### PR TITLE
fix: RuntimeLocal input model resolution and env injection [OMN-7476]

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -727,6 +727,15 @@
         "line_number": 464
       }
     ],
+    "src/omnibase_core/runtime/runtime_local.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/omnibase_core/runtime/runtime_local.py",
+        "hashed_secret": "893514f22d846e9c952f7232d0e9dc9a584737ac",
+        "is_verified": false,
+        "line_number": 249
+      }
+    ],
     "src/omnibase_core/services/replay/service_config_override_injector.py": [
       {
         "type": "Secret Keyword",
@@ -2218,5 +2227,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T20:39:16Z"
+  "generated_at": "2026-04-04T15:15:03Z"
 }

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -243,7 +243,22 @@ class RuntimeLocal:
             self._write_state()
             return self._result
 
-        handler_instance = handler_cls()
+        import os as _os
+
+        _env_kwarg_map = {
+            "linear_api_key": "LINEAR_API_KEY",
+        }
+        _handler_kwargs: dict[str, Any] = {}
+        try:
+            import inspect as _inspect
+
+            _sig = _inspect.signature(handler_cls.__init__)
+            for param_name, env_name in _env_kwarg_map.items():
+                if param_name in _sig.parameters and _os.environ.get(env_name):
+                    _handler_kwargs[param_name] = _os.environ[env_name]
+        except (ValueError, TypeError):
+            pass
+        handler_instance = handler_cls(**_handler_kwargs)
         logger.info(
             "RuntimeLocal: resolved handler %s.%s",
             handler_module_name,
@@ -251,7 +266,10 @@ class RuntimeLocal:
         )
 
         # 5. Build initial payload from contract input spec
-        initial_payload = self._build_initial_payload(self._contract.get("input", {}))
+        input_spec = handler_spec.get("input_model", {}) or self._contract.get(
+            "input", {}
+        )
+        initial_payload = self._build_initial_payload(input_spec)
 
         # 6. Invoke handler
         try:
@@ -290,7 +308,24 @@ class RuntimeLocal:
         try:
             mod = importlib.import_module(model_module)
             cls = getattr(mod, model_class)
-            return cls()
+            try:
+                return cls()
+            except (TypeError, ValueError):
+                import uuid
+                from datetime import UTC
+                from datetime import datetime as _dt
+
+                defaults: dict[str, Any] = {}
+                for field_name, field_info in cls.model_fields.items():
+                    if field_info.is_required():
+                        ann = field_info.annotation
+                        if ann is uuid.UUID or (
+                            hasattr(ann, "__origin__") and ann.__origin__ is uuid.UUID
+                        ):
+                            defaults[field_name] = uuid.uuid4()
+                        elif ann is _dt:
+                            defaults[field_name] = _dt.now(UTC)
+                return cls(**defaults)
         except (ImportError, AttributeError, TypeError) as exc:
             logger.warning(
                 "RuntimeLocal: could not build input payload from %s.%s: %s",


### PR DESCRIPTION
## Summary
- Fix input model lookup to read from `handler.input_model` (canonical location in workflow contracts)
- Auto-fill required UUID and datetime fields when instantiating input models with defaults
- Inject env vars (e.g. `LINEAR_API_KEY`) into handler constructors that accept matching kwargs

All three bugs were discovered during proof-of-life testing of the build loop workflow (OMN-7468).

Fixes OMN-7476

## Test plan
- [ ] Existing runtime_local tests pass
- [ ] `onex run` with build_loop_workflow.yaml completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handler now automatically reads API keys from environment variables when available, simplifying configuration.

* **Bug Fixes**
  * Model instantiation now auto-generates sensible defaults for required UUID and datetime fields to reduce initialization failures.
  * Input model selection improved with fallback logic for more robust payload construction and fewer configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->