### PR TITLE
fix: onex discover handler-based node recognition + introspection [OMN-8104]

### DIFF
--- a/src/omnibase_core/mixins/mixin_introspection_publisher.py
+++ b/src/omnibase_core/mixins/mixin_introspection_publisher.py
@@ -372,6 +372,7 @@ class MixinIntrospectionPublisher:
                         "health_check",
                         "validate",
                         "process",
+                        "handle",
                         "configure",
                     ]:
                         actions.append(method_name)

--- a/tests/unit/discovery/test_discovery_external_nodes.py
+++ b/tests/unit/discovery/test_discovery_external_nodes.py
@@ -144,8 +144,20 @@ class TestDiscoverExternalNodes:
         assert "typed_node" in result
 
     @pytest.mark.unit
-    def test_discover_rejects_class_without_process_or_contract(self) -> None:
-        """A plain class with no process/contract_path/__onex_node_type__ is rejected."""
+    def test_discover_accepts_handle_node(self) -> None:
+        """A class with a handle method (handler-based node) should be accepted."""
+        node_cls = type("HandlerNode", (), {"handle": lambda self, msg: None})
+        ep = _make_entry_point("handler_node", load_return=node_cls)
+
+        with patch(_EP_MODULE, return_value=[ep]):
+            result = discover_external_nodes()
+
+        assert "handler_node" in result
+        assert result["handler_node"].node_class is node_cls
+
+    @pytest.mark.unit
+    def test_discover_rejects_class_without_process_handle_or_contract(self) -> None:
+        """A plain class with no process/handle/contract_path/__onex_node_type__ is rejected."""
         node_cls = type("PlainClass", (), {})
         ep = _make_entry_point("plain_node", load_return=node_cls)
 


### PR DESCRIPTION
## Summary

- Add `test_discover_accepts_handle_node` — covers the handler-based node path (`handle()` method) that was previously untested in `discover_external_nodes`
- Fix `mixin_introspection_publisher` action detection to include `handle` alongside `process`, so handler nodes report their supported actions correctly

The core validation fix (`_is_valid_node_class` accepting `handle`) was already merged in #790 (OMN-7808), but test coverage and the introspection mixin were missed.

Closes OMN-8104

## Test plan

- [x] `test_discover_accepts_handle_node` passes — handler-based nodes are discovered
- [x] All existing discovery tests pass (no regression on `process`-based nodes)
- [x] `tests/unit/mixins/` — 832 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced node discovery to recognize and validate nodes implementing handle methods.
  * Improved validation logic to ensure discovered nodes meet all required method and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->