### PR TITLE
feat(plan): extend ModelPlanContract with enforcement-chain fields (OMN-8421)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,10 @@ When spawning polymorphic agents or AI assistants:
 
 **Mutable defaults**: ALWAYS use `default_factory` — e.g. `items: list[str] = Field(default_factory=list)`
 
+### Plan Contract Enforcement Fields (OMN-8421)
+
+`ModelPlanContract` carries plan-level enforcement metadata for the OMN-8416 plan → epic → tickets → PR → dogfood chain. When adding a new plan, set `epic_id` (Linear epic in `^OMN-\d+$` format), `plan_phases`, `success_criteria` (via `ModelDoDItem`), and `halt_conditions` at the top level — not in `context`. The existing `phase: EnumPlanPhase` lifecycle field is distinct from `plan_phases: list[str]` and must not be confused.
+
 **See**: [Pydantic Best Practices](docs/conventions/PYDANTIC_BEST_PRACTICES.md)
 
 ---

--- a/src/omnibase_core/models/plan/__init__.py
+++ b/src/omnibase_core/models/plan/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+from omnibase_core.models.plan.model_dod_item import DoDItem, ModelDoDItem
 from omnibase_core.models.plan.model_plan_contract import (
     ModelPlanContract,
     PlanContract,
@@ -21,6 +22,8 @@ from omnibase_core.models.plan.model_plan_ticket_link import (
 )
 
 __all__ = [
+    "DoDItem",
+    "ModelDoDItem",
     "ModelPlanContract",
     "ModelPlanDocument",
     "ModelPlanEntry",

--- a/src/omnibase_core/models/plan/model_dod_item.py
+++ b/src/omnibase_core/models/plan/model_dod_item.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Minimal DoD item model for plan success criteria.
+
+Used by ModelPlanContract.success_criteria as the type-safe representation
+of a single definition-of-done item. Structured evidence types and richer
+lifecycle live in ModelProofRequirement (ticket contract territory); this
+model is deliberately flat.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelDoDItem", "DoDItem"]
+
+
+class ModelDoDItem(BaseModel):
+    """A single definition-of-done item on a plan contract.
+
+    Flat, frozen, append-only. For richer evidence semantics see
+    ModelProofRequirement on ticket contracts.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    id: str = Field(..., min_length=1, description="Stable DoD item identifier.")
+    description: str = Field(
+        ..., min_length=1, description="Human-readable DoD statement."
+    )
+    evidence_type: str | None = Field(
+        default=None,
+        description=(
+            "Evidence kind expected to satisfy this item "
+            "(e.g. 'rendered_output', 'integration_test', 'screenshot'). "
+            "None means unspecified."
+        ),
+    )
+    satisfied: bool = Field(
+        default=False, description="Whether this DoD item has been satisfied."
+    )
+
+
+DoDItem = ModelDoDItem

--- a/src/omnibase_core/models/plan/model_plan_contract.py
+++ b/src/omnibase_core/models/plan/model_plan_contract.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from datetime import UTC, datetime
 from typing import Any, ClassVar
 
@@ -34,11 +35,14 @@ from omnibase_core.enums.plan import (
     EnumPlanPhase,
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.plan.model_dod_item import ModelDoDItem
 from omnibase_core.models.plan.model_plan_document import ModelPlanDocument
 from omnibase_core.models.plan.model_plan_entry import ModelPlanEntry
 from omnibase_core.models.plan.model_plan_review_result import ModelPlanReviewResult
 from omnibase_core.models.plan.model_plan_ticket_link import ModelPlanTicketLink
 from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
+
+_EPIC_ID_PATTERN = re.compile(r"^OMN-\d+$")
 
 
 @allow_string_id(reason="Plan ID is an external identifier (e.g., PLAN-OMN-5971)")
@@ -93,6 +97,56 @@ class ModelPlanContract(BaseModel):
         description="Non-core extensibility metadata (orchestration, session, etc.)",
     )
 
+    # -------------------------------------------------------------------------
+    # Enforcement-chain metadata (OMN-8421)
+    # -------------------------------------------------------------------------
+    # These fields support the plan -> epic -> tickets -> PR -> dogfood
+    # enforcement chain (OMN-8416). They live at the top level (not in
+    # context) so downstream hooks and skills get type-safe access.
+    #
+    # NAMING: `plan_phases` (plural, list) is distinct from the existing
+    # `phase: EnumPlanPhase` field above, which tracks lifecycle state
+    # (DRAFT -> REVIEWED -> TICKETED -> EXECUTING -> CLOSED). `plan_phases`
+    # is the ordered list of plan-defined phase IDs (e.g. ["P0", "P1", "P2"])
+    # that the plan decomposes its work into. They are different concepts.
+    epic_id: str | None = Field(
+        default=None,
+        description=(
+            "Linear epic identifier that this plan is realized under "
+            "(e.g. 'OMN-8416'). Must match `^OMN-\\d+$`."
+        ),
+    )
+    plan_phases: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list of plan-defined phase IDs. Distinct from "
+            "`phase: EnumPlanPhase` lifecycle state."
+        ),
+    )
+    dependencies: list[str] = Field(
+        default_factory=list,
+        description="Plan IDs that must complete before this plan starts.",
+    )
+    success_criteria: list[ModelDoDItem] = Field(
+        default_factory=list,
+        description="Definition-of-done items for this plan.",
+    )
+    halt_conditions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Plain-string halt conditions. Structured ModelHaltCondition "
+            "support is deferred to OMN-8375 territory."
+        ),
+    )
+    supersedes: list[str] = Field(
+        default_factory=list,
+        description="Plan IDs that this plan replaces.",
+    )
+    superseded_by: str | None = Field(
+        default=None,
+        description="Plan ID that replaces this plan, if any.",
+    )
+
     # Fingerprinting and timestamps
     contract_fingerprint: str | None = Field(
         default=None, description="SHA256 fingerprint of contract state"
@@ -122,6 +176,18 @@ class ModelPlanContract(BaseModel):
     # =========================================================================
     # Validators
     # =========================================================================
+
+    @field_validator("epic_id", mode="after")
+    @classmethod
+    def _validate_epic_id(cls, v: str | None) -> str | None:
+        """Enforce OMN-<digits> format on epic_id when set."""
+        if v is None:
+            return v
+        if not _EPIC_ID_PATTERN.match(v):
+            raise ValueError(  # error-ok: Pydantic field_validator requires ValueError
+                f"epic_id {v!r} does not match required pattern '^OMN-\\d+$'"
+            )
+        return v
 
     @field_validator("created_at", "updated_at", mode="before")
     @classmethod
@@ -526,6 +592,38 @@ class ModelPlanContract(BaseModel):
                 seen.add(link.ticket_id)
                 result.append(link.ticket_id)
         return result
+
+    def is_transitively_superseded(
+        self, resolver: dict[str, ModelPlanContract]
+    ) -> bool:
+        """Walk the superseded_by chain and detect supersession.
+
+        Pure function: caller supplies the plan_id -> contract resolver.
+        Follows superseded_by pointers until one is None or a cycle is
+        detected. A cycle is treated as superseded (the chain terminates
+        abnormally).
+
+        Args:
+            resolver: Mapping of plan_id to ModelPlanContract, used to walk
+                the superseded_by chain beyond the immediate successor.
+
+        Returns:
+            True if this plan has any superseded_by pointer (directly or
+            transitively). False only when this plan has no successor.
+        """
+        if self.superseded_by is None:
+            return False
+        visited: set[str] = {self.plan_id}
+        cursor: str | None = self.superseded_by
+        while cursor is not None:
+            if cursor in visited:
+                return True
+            visited.add(cursor)
+            next_contract = resolver.get(cursor)
+            if next_contract is None:
+                return True
+            cursor = next_contract.superseded_by
+        return True
 
     def link_for_entry(self, entry_id: str) -> ModelPlanTicketLink | None:
         """Look up the ticket link for a given entry ID.

--- a/tests/unit/models/plan/test_model_dod_item.py
+++ b/tests/unit/models/plan/test_model_dod_item.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.plan import ModelDoDItem
+
+
+@pytest.mark.unit
+class TestModelDoDItem:
+    def test_construct_minimal(self) -> None:
+        item = ModelDoDItem(id="dod-1", description="Must render output correctly")
+        assert item.id == "dod-1"
+        assert item.description == "Must render output correctly"
+        assert item.evidence_type is None
+        assert item.satisfied is False
+
+    def test_construct_full(self) -> None:
+        item = ModelDoDItem(
+            id="dod-2",
+            description="Screenshot attached to PR",
+            evidence_type="screenshot",
+            satisfied=True,
+        )
+        assert item.evidence_type == "screenshot"
+        assert item.satisfied is True
+
+    def test_frozen(self) -> None:
+        item = ModelDoDItem(id="dod-3", description="x")
+        with pytest.raises(ValidationError):
+            item.satisfied = True  # type: ignore[misc]
+
+    def test_extra_forbid(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDoDItem(id="dod-4", description="x", extra_field="nope")  # type: ignore[call-arg]
+
+    def test_id_and_description_required_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDoDItem(id="", description="x")
+        with pytest.raises(ValidationError):
+            ModelDoDItem(id="dod-5", description="")
+
+    def test_round_trip_json(self) -> None:
+        original = ModelDoDItem(
+            id="dod-6",
+            description="Integration test green",
+            evidence_type="integration_test",
+            satisfied=True,
+        )
+        restored = ModelDoDItem.model_validate_json(original.model_dump_json())
+        assert restored == original

--- a/tests/unit/models/plan/test_model_plan_contract_enforcement_fields.py
+++ b/tests/unit/models/plan/test_model_plan_contract_enforcement_fields.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for OMN-8421 enforcement-chain fields on ModelPlanContract.
+
+Covers the 7 fields added for the OMN-8416 plan -> epic -> tickets -> PR
+-> dogfood enforcement chain: epic_id, plan_phases, dependencies,
+success_criteria, halt_conditions, supersedes, superseded_by.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_plan_structure_type import EnumPlanStructureType
+from omnibase_core.models.plan import (
+    ModelDoDItem,
+    ModelPlanContract,
+    ModelPlanDocument,
+    ModelPlanEntry,
+)
+
+
+def _doc() -> ModelPlanDocument:
+    return ModelPlanDocument(
+        title="Enforcement Test Plan",
+        structure_type=EnumPlanStructureType.TASK_SECTIONS,
+        entries=[
+            ModelPlanEntry(id="P1", title="Task 1: item", content="body"),
+            ModelPlanEntry(id="P2", title="Task 2: item", content="body"),
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestEnforcementFieldDefaults:
+    def test_all_new_fields_default_empty(self) -> None:
+        c = ModelPlanContract(plan_id="PLAN-TEST-DEFAULTS", document=_doc())
+        assert c.epic_id is None
+        assert c.plan_phases == []
+        assert c.dependencies == []
+        assert c.success_criteria == []
+        assert c.halt_conditions == []
+        assert c.supersedes == []
+        assert c.superseded_by is None
+
+    def test_backwards_compat_minimal_construction(self) -> None:
+        """A pre-OMN-8421 contract constructor call must still work unchanged."""
+        c = ModelPlanContract(plan_id="PLAN-BWC-1", document=_doc())
+        # Roundtrip via YAML to simulate reading an old persisted contract
+        restored = ModelPlanContract.from_yaml(c.to_yaml())
+        assert restored.plan_id == c.plan_id
+        assert restored.epic_id is None
+        assert restored.plan_phases == []
+
+
+@pytest.mark.unit
+class TestEpicIdValidator:
+    def test_valid_epic_id(self) -> None:
+        c = ModelPlanContract(
+            plan_id="PLAN-EPIC-1", document=_doc(), epic_id="OMN-8416"
+        )
+        assert c.epic_id == "OMN-8416"
+
+    def test_none_allowed(self) -> None:
+        c = ModelPlanContract(plan_id="PLAN-EPIC-2", document=_doc(), epic_id=None)
+        assert c.epic_id is None
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "foo-123",
+            "OMN-",
+            "",
+            "OMN-abc",
+            "omn-123",
+            " OMN-8416 ",
+        ],
+    )
+    def test_invalid_epic_id_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            ModelPlanContract(plan_id="PLAN-EPIC-X", document=_doc(), epic_id=bad)
+
+
+@pytest.mark.unit
+class TestSuccessCriteriaField:
+    def test_with_dod_items(self) -> None:
+        items = [
+            ModelDoDItem(id="d1", description="Tests pass"),
+            ModelDoDItem(
+                id="d2",
+                description="Rendered output verified",
+                evidence_type="rendered_output",
+            ),
+        ]
+        c = ModelPlanContract(
+            plan_id="PLAN-DOD-1", document=_doc(), success_criteria=items
+        )
+        assert len(c.success_criteria) == 2
+        assert c.success_criteria[0].id == "d1"
+        assert c.success_criteria[1].evidence_type == "rendered_output"
+
+
+@pytest.mark.unit
+class TestYAMLRoundTrip:
+    def test_all_fields_round_trip(self) -> None:
+        original = ModelPlanContract(
+            plan_id="PLAN-YAML-1",
+            document=_doc(),
+            epic_id="OMN-8416",
+            plan_phases=["P0", "P1", "P2"],
+            dependencies=["PLAN-YAML-0"],
+            success_criteria=[
+                ModelDoDItem(id="d1", description="Green CI", satisfied=True),
+                ModelDoDItem(id="d2", description="Screenshot"),
+            ],
+            halt_conditions=["diagnosis_required", "two_strike"],
+            supersedes=["PLAN-OLD-A", "PLAN-OLD-B"],
+            superseded_by=None,
+        )
+        restored = ModelPlanContract.from_yaml(original.to_yaml())
+        assert restored.epic_id == "OMN-8416"
+        assert restored.plan_phases == ["P0", "P1", "P2"]
+        assert restored.dependencies == ["PLAN-YAML-0"]
+        assert len(restored.success_criteria) == 2
+        assert restored.success_criteria[0].satisfied is True
+        assert restored.halt_conditions == ["diagnosis_required", "two_strike"]
+        assert restored.supersedes == ["PLAN-OLD-A", "PLAN-OLD-B"]
+        assert restored.superseded_by is None
+
+
+@pytest.mark.unit
+class TestSupersededByChain:
+    def test_no_successor_is_not_superseded(self) -> None:
+        c = ModelPlanContract(plan_id="PLAN-A", document=_doc(), superseded_by=None)
+        assert c.is_transitively_superseded({}) is False
+
+    def test_direct_successor_present_in_resolver(self) -> None:
+        b = ModelPlanContract(plan_id="PLAN-B", document=_doc(), superseded_by=None)
+        a = ModelPlanContract(plan_id="PLAN-A", document=_doc(), superseded_by="PLAN-B")
+        assert a.is_transitively_superseded({"PLAN-B": b}) is True
+
+    def test_transitive_chain(self) -> None:
+        c = ModelPlanContract(plan_id="PLAN-C", document=_doc(), superseded_by=None)
+        b = ModelPlanContract(plan_id="PLAN-B", document=_doc(), superseded_by="PLAN-C")
+        a = ModelPlanContract(plan_id="PLAN-A", document=_doc(), superseded_by="PLAN-B")
+        resolver = {"PLAN-B": b, "PLAN-C": c}
+        assert a.is_transitively_superseded(resolver) is True
+
+    def test_cycle_treated_as_superseded(self) -> None:
+        b = ModelPlanContract(plan_id="PLAN-B", document=_doc(), superseded_by="PLAN-A")
+        a = ModelPlanContract(plan_id="PLAN-A", document=_doc(), superseded_by="PLAN-B")
+        assert a.is_transitively_superseded({"PLAN-B": b}) is True
+
+    def test_unresolvable_successor_treated_as_superseded(self) -> None:
+        """If the chain points at a plan_id the resolver doesn't know, stop walking."""
+        a = ModelPlanContract(
+            plan_id="PLAN-A", document=_doc(), superseded_by="PLAN-UNKNOWN"
+        )
+        assert a.is_transitively_superseded({}) is True
+
+
+@pytest.mark.unit
+class TestFingerprintIncludesNewFields:
+    def test_epic_id_change_changes_fingerprint(self) -> None:
+        a = ModelPlanContract(plan_id="PLAN-FP-1", document=_doc(), epic_id="OMN-1")
+        b = ModelPlanContract(plan_id="PLAN-FP-1", document=_doc(), epic_id="OMN-2")
+        assert a.compute_fingerprint() != b.compute_fingerprint()
+
+    def test_plan_phases_change_changes_fingerprint(self) -> None:
+        a = ModelPlanContract(plan_id="PLAN-FP-2", document=_doc(), plan_phases=["P0"])
+        b = ModelPlanContract(
+            plan_id="PLAN-FP-2", document=_doc(), plan_phases=["P0", "P1"]
+        )
+        assert a.compute_fingerprint() != b.compute_fingerprint()


### PR DESCRIPTION
## Summary

Extends the existing `ModelPlanContract` with 7 top-level metadata fields so the OMN-8416 enforcement-chain hooks and skills (OMN-8417 plan-existence hook, OMN-8418 plan-epic linkage, OMN-8420 plan_audit) get type-safe access to plan metadata instead of stashing everything in `context: dict[str, Any]`.

Closes OMN-8421. Parent epic OMN-8416.

## Fields added

- `epic_id: str | None` — Linear epic identifier, regex-constrained to `^OMN-\d+$`
- `plan_phases: list[str]` — ordered list of plan phase IDs (distinct from the existing `phase: EnumPlanPhase` lifecycle field — documented in a class-level comment so the naming collision is unambiguous)
- `dependencies: list[str]` — plan IDs this plan depends on
- `success_criteria: list[ModelDoDItem]` — DoD items using a new minimal sibling model
- `halt_conditions: list[str]` — flat string list for now; structured `ModelHaltCondition` is OMN-8375 territory and out of scope
- `supersedes: list[str]` — plan IDs this plan replaces
- `superseded_by: str | None` — with `is_transitively_superseded(resolver)` helper that walks the chain and treats cycles or unresolvable successors as superseded

All new fields default to `None` or `[]`. A backwards-compat test round-trips a minimal `ModelPlanContract` through YAML to prove existing consumers load unchanged.

## Reality check notes

OMN-8421 was originally filed as "create `ModelPlanContract` pydantic type parallel to ModelNodeContract / ModelTicketContract / ModelWorkerContract." Preflight discovered the model ALREADY EXISTS as a 683-line mature implementation with phase state machine, ticket linkage, fingerprinting, YAML persistence, and a grace period for the bootstrap paradox. Creating a new model would have collided or overwritten.

Scope was rewritten to "extend, not create" by team-lead decision. Friction event logged at `.onex_state/friction/2026-04-11-omn-8421-preflight-catch.md` as training signal for OMN-8411 (automated preflight reality-check gate).

## Test plan

- [x] 124 unit tests pass in `tests/unit/models/plan/` (25 new + 99 pre-existing backwards-compat)
- [x] `uv run mypy src/omnibase_core/models/plan/ --strict` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` — clean
- [x] Pre-commit hooks — all pass (initially flagged a local variable named `current_id` by the ID-type linter; renamed to `cursor`)
- [ ] CI green (in progress)
- [ ] Downstream enforcement-chain tickets (OMN-8417 / OMN-8418 / OMN-8420) can import and type-check against the extended model