### PR TITLE
feat(cli): load onex.cli entry-point extensions dynamically (OMN-8435)

### DIFF
--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -633,6 +633,19 @@ from omnibase_core.cli.cli_port_openclaw import cli_port_openclaw
 
 cli.add_command(cli_port_openclaw)
 
+# Load CLI extension groups registered by other packages via the onex.cli entry-point group.
+# Each entry point must expose a click.Group or click.Command.
+# This enables infra packages (e.g. omnibase_infra) to contribute subcommands
+# (e.g. `onex kafka`) without creating circular imports in omnibase_core.
+import importlib.metadata
+
+for _ep in importlib.metadata.entry_points(group="onex.cli"):
+    try:
+        _cmd = _ep.load()
+        if callable(_cmd):
+            cli.add_command(_cmd, _ep.name)
+    except Exception:  # noqa: BLE001 — extension load failures must not crash the CLI
+        pass
 
 if __name__ == "__main__":
     cli()

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -637,15 +637,27 @@ cli.add_command(cli_port_openclaw)
 # Each entry point must expose a click.Group or click.Command.
 # This enables infra packages (e.g. omnibase_infra) to contribute subcommands
 # (e.g. `onex kafka`) without creating circular imports in omnibase_core.
+#
+# Security note: entry points are resolved from pip-installed packages, whose
+# trust boundary is the Python environment itself. Loading is limited to the
+# installed package set — no arbitrary code is executed from untrusted sources.
 import importlib.metadata
+import logging as _logging
+
+_extension_log = _logging.getLogger(__name__)
 
 for _ep in importlib.metadata.entry_points(group="onex.cli"):
     try:
         _cmd = _ep.load()
         if callable(_cmd):
             cli.add_command(_cmd, _ep.name)
-    except Exception:  # noqa: BLE001 — extension load failures must not crash the CLI
-        pass
+    except (ImportError, ModuleNotFoundError, AttributeError, TypeError) as _ext_err:
+        # Narrow catch: expected failure modes when loading a broken/missing extension.
+        # Other exception types (RuntimeError, etc.) are NOT caught here — they propagate
+        # so they are visible rather than silently swallowed.
+        _extension_log.warning(
+            "onex.cli extension %r failed to load: %s", _ep.name, _ext_err
+        )
 
 if __name__ == "__main__":
     cli()

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -649,12 +649,15 @@ _extension_log = _logging.getLogger(__name__)
 for _ep in importlib.metadata.entry_points(group="onex.cli"):
     try:
         _cmd = _ep.load()
-        # Trust boundary: entry points are provided by pip-installed packages.
-        # The installer (pip/uv) is the security boundary — this is the same
-        # model used by pytest plugins, Babel extractors, and other Python
-        # extension ecosystems. Only accept valid click.BaseCommand instances.
+        # boundary-ok: entry points are provided by pip-installed packages.
         if isinstance(_cmd, (click.Command, click.Group)):
-            cli.add_command(_cmd, _ep.name)
+            if _ep.name in cli.commands:
+                _extension_log.warning(
+                    "onex.cli extension %r conflicts with an existing command, skipping",
+                    _ep.name,
+                )
+            else:
+                cli.add_command(_cmd, _ep.name)
         else:
             _extension_log.warning(
                 "onex.cli extension %r is not a click.Command or click.Group (got %s), skipping",

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -653,11 +653,11 @@ for _ep in importlib.metadata.entry_points(group="onex.cli"):
         # The installer (pip/uv) is the security boundary — this is the same
         # model used by pytest plugins, Babel extractors, and other Python
         # extension ecosystems. Only accept valid click.BaseCommand instances.
-        if isinstance(_cmd, click.BaseCommand):
+        if isinstance(_cmd, (click.Command, click.Group)):
             cli.add_command(_cmd, _ep.name)
         else:
             _extension_log.warning(
-                "onex.cli extension %r is not a click.BaseCommand (got %s), skipping",
+                "onex.cli extension %r is not a click.Command or click.Group (got %s), skipping",
                 _ep.name,
                 type(_cmd).__name__,
             )

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -641,12 +641,12 @@ cli.add_command(cli_port_openclaw)
 # Security note: entry points are resolved from pip-installed packages, whose
 # trust boundary is the Python environment itself. Loading is limited to the
 # installed package set — no arbitrary code is executed from untrusted sources.
-import importlib.metadata
 import logging as _logging
+from importlib.metadata import entry_points as _entry_points
 
 _extension_log = _logging.getLogger(__name__)
 
-for _ep in importlib.metadata.entry_points(group="onex.cli"):
+for _ep in _entry_points(group="onex.cli"):
     try:
         _cmd = _ep.load()
         # boundary-ok: entry points are provided by pip-installed packages.

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -649,12 +649,22 @@ _extension_log = _logging.getLogger(__name__)
 for _ep in importlib.metadata.entry_points(group="onex.cli"):
     try:
         _cmd = _ep.load()
-        if callable(_cmd):
+        # Trust boundary: entry points are provided by pip-installed packages.
+        # The installer (pip/uv) is the security boundary — this is the same
+        # model used by pytest plugins, Babel extractors, and other Python
+        # extension ecosystems. Only accept valid click.BaseCommand instances.
+        if isinstance(_cmd, click.BaseCommand):
             cli.add_command(_cmd, _ep.name)
+        else:
+            _extension_log.warning(
+                "onex.cli extension %r is not a click.BaseCommand (got %s), skipping",
+                _ep.name,
+                type(_cmd).__name__,
+            )
     except (ImportError, ModuleNotFoundError, AttributeError, TypeError) as _ext_err:
         # Narrow catch: expected failure modes when loading a broken/missing extension.
-        # Other exception types (RuntimeError, etc.) are NOT caught here — they propagate
-        # so they are visible rather than silently swallowed.
+        # RuntimeError and other unexpected exceptions are NOT caught — they propagate
+        # and remain visible rather than being silently swallowed.
         _extension_log.warning(
             "onex.cli extension %r failed to load: %s", _ep.name, _ext_err
         )

--- a/tests/unit/cli/test_cli_kafka.py
+++ b/tests/unit/cli/test_cli_kafka.py
@@ -125,7 +125,7 @@ class TestOnexCliExtensionLoading:
         importlib.reload(mod)
         # Pick any command already registered in the CLI after a clean reload.
         existing_name = next(iter(mod.cli.commands))
-        original_cmd = mod.cli.commands[existing_name]
+        _original_cmd = mod.cli.commands[existing_name]
 
         hijack_group = click.Group(existing_name, help="Hijack attempt")
         mock_ep: MagicMock = MagicMock(spec=EntryPoint)

--- a/tests/unit/cli/test_cli_kafka.py
+++ b/tests/unit/cli/test_cli_kafka.py
@@ -114,3 +114,31 @@ class TestOnexCliExtensionLoading:
         result = runner.invoke(reloaded_cli, ["--help"])
         assert result.exit_code == 0
         assert "onex" in result.output.lower() or "cli" in result.output.lower()
+
+    def test_duplicate_extension_name_does_not_overwrite_builtin(self) -> None:
+        """An entry-point whose name collides with an existing built-in command must
+        be skipped, not silently overwrite the built-in."""
+        import importlib
+
+        import omnibase_core.cli.cli_commands as mod
+
+        importlib.reload(mod)
+        # Pick any command already registered in the CLI after a clean reload.
+        existing_name = next(iter(mod.cli.commands))
+        original_cmd = mod.cli.commands[existing_name]
+
+        hijack_group = click.Group(existing_name, help="Hijack attempt")
+        mock_ep: MagicMock = MagicMock(spec=EntryPoint)
+        mock_ep.name = existing_name
+        mock_ep.load.return_value = hijack_group
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        # The built-in must not be replaced by the extension.
+        assert reloaded_cli.commands.get(existing_name) is not hijack_group
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0

--- a/tests/unit/cli/test_cli_kafka.py
+++ b/tests/unit/cli/test_cli_kafka.py
@@ -125,7 +125,6 @@ class TestOnexCliExtensionLoading:
         importlib.reload(mod)
         # Pick any command already registered in the CLI after a clean reload.
         existing_name = next(iter(mod.cli.commands))
-        _original_cmd = mod.cli.commands[existing_name]
 
         hijack_group = click.Group(existing_name, help="Hijack attempt")
         mock_ep: MagicMock = MagicMock(spec=EntryPoint)

--- a/tests/unit/cli/test_cli_kafka.py
+++ b/tests/unit/cli/test_cli_kafka.py
@@ -60,6 +60,29 @@ class TestOnexCliExtensionLoading:
         result = runner.invoke(reloaded_cli, ["--help"])
         assert result.exit_code == 0
 
+    def test_non_basecommand_extension_is_rejected(self) -> None:
+        """Non-click.BaseCommand callables (e.g. malicious functions) are rejected."""
+        mock_ep: MagicMock = MagicMock(spec=EntryPoint)
+        mock_ep.name = "malicious"
+
+        def _malicious_callable() -> None:
+            pass  # A callable but NOT a click.BaseCommand
+
+        mock_ep.load.return_value = _malicious_callable
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            import importlib
+
+            import omnibase_core.cli.cli_commands as mod
+
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0
+        assert "malicious" not in result.output
+
     def test_non_callable_extension_is_skipped(self) -> None:
         mock_ep: MagicMock = MagicMock(spec=EntryPoint)
         mock_ep.name = "notcallable"

--- a/tests/unit/cli/test_cli_kafka.py
+++ b/tests/unit/cli/test_cli_kafka.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for onex.cli dynamic extension loading (OMN-8435).
+
+Tests that cli_commands.py correctly loads click Groups registered via the
+onex.cli entry-point group. The kafka produce subcommand implementation lives
+in omnibase_infra; these tests verify the loading contract only.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+
+
+class TestOnexCliExtensionLoading:
+    """Tests for dynamic onex.cli entry-point extension loading."""
+
+    def test_extension_group_is_added_to_cli(self) -> None:
+        mock_group = click.Group("testpkg", help="Test extension group")
+        mock_ep: MagicMock = MagicMock(spec=EntryPoint)
+        mock_ep.name = "testpkg"
+        mock_ep.load.return_value = mock_group
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            # Reload the cli with the patched entry points
+            import importlib
+
+            import omnibase_core.cli.cli_commands as mod
+
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0
+        assert "testpkg" in result.output
+
+    def test_broken_extension_does_not_crash_cli(self) -> None:
+        mock_ep: MagicMock = MagicMock(spec=EntryPoint)
+        mock_ep.name = "broken"
+        mock_ep.load.side_effect = ImportError("simulated failure")
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            import importlib
+
+            import omnibase_core.cli.cli_commands as mod
+
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0
+
+    def test_non_callable_extension_is_skipped(self) -> None:
+        mock_ep: MagicMock = MagicMock(spec=EntryPoint)
+        mock_ep.name = "notcallable"
+        mock_ep.load.return_value = "not a click command"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            import importlib
+
+            import omnibase_core.cli.cli_commands as mod
+
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0
+        assert "notcallable" not in result.output
+
+    def test_cli_help_still_works_with_no_extensions(self) -> None:
+        with patch("importlib.metadata.entry_points", return_value=[]):
+            import importlib
+
+            import omnibase_core.cli.cli_commands as mod
+
+            importlib.reload(mod)
+            reloaded_cli = mod.cli
+
+        runner = CliRunner()
+        result = runner.invoke(reloaded_cli, ["--help"])
+        assert result.exit_code == 0
+        assert "onex" in result.output.lower() or "cli" in result.output.lower()


### PR DESCRIPTION
## Summary

- Adds dynamic loading of click Groups/Commands registered via the `onex.cli` entry-point group into the root `onex` CLI
- This enables infrastructure packages (e.g. `omnibase_infra`) to contribute subcommands without creating circular imports in `omnibase_core`
- Load failures are silently swallowed so a broken extension never prevents the rest of the CLI from starting
- Part of OMN-8435: the `kafka` subcommand ships in omnibase_infra PR

## Test plan

- [ ] `test_extension_group_is_added_to_cli` — mock entry point is mounted on the CLI
- [ ] `test_broken_extension_does_not_crash_cli` — ImportError is swallowed
- [ ] `test_non_callable_extension_is_skipped` — non-callable load result is ignored
- [ ] `test_cli_help_still_works_with_no_extensions` — empty entry point list is safe

## Related

- Linear: OMN-8435
- omnibase_infra PR: the `kafka produce` implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now dynamically loads external command extensions; invalid or failing extensions are skipped with warnings and cannot overwrite built-in commands.
* **Tests**
  * Added tests validating extension loading, robustness against failing/invalid extensions, collision protection, and consistent CLI help/exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->