### PR TITLE
feat: register onex.nodes entry points for auto-wiring discovery (OMN-8538 Wave A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,14 @@ env_vars = "omnibase_core.doctor.checks.check_env_vars:CheckEnvVars"
 python_version = "omnibase_core.doctor.checks.check_python_version:CheckPythonVersion"
 js_runtime = "omnibase_core.doctor.checks.check_js_runtime:CheckJsRuntime"
 
+[project.entry-points."onex.nodes"]
+node_compliance_evidence_effect = "omnibase_core.nodes.node_compliance_evidence_effect"
+node_compliance_orchestrator = "omnibase_core.nodes.node_compliance_orchestrator"
+node_compliance_report_reducer = "omnibase_core.nodes.node_compliance_report_reducer"
+node_compliance_scan_compute = "omnibase_core.nodes.node_compliance_scan_compute"
+node_contract_resolve_compute = "omnibase_core.nodes.node_contract_resolve_compute"
+node_contract_verify_replay_compute = "omnibase_core.nodes.node_contract_verify_replay_compute"
+
 [project.optional-dependencies]
 spi = ["omnibase-spi>=0.20.2"]
 cli = ["psutil>=7.2.1"]


### PR DESCRIPTION
## Summary

- Adds `[project.entry-points."onex.nodes"]` section to `pyproject.toml` so the ONEX runtime can discover omnibase_core's 6 nodes via `importlib.metadata.entry_points(group="onex.nodes")` instead of requiring manual registration
- This is Wave A of OMN-8538 (4-repo series): omnibase_core → omniintelligence → omniclaude → omnibase_infra
- Follows the exact pattern already in use by omnimarket

## Nodes registered (6)

- `node_compliance_evidence_effect`
- `node_compliance_orchestrator`
- `node_compliance_report_reducer`
- `node_compliance_scan_compute`
- `node_contract_resolve_compute`
- `node_contract_verify_replay_compute`

Note: `node_validation_orchestrator/` directory was intentionally excluded — it contains only Python files with no `contract.yaml`.

## Test plan

- [ ] CI passes (pyproject.toml-only change, no Python code modified)
- [ ] After merge + install, verify: `python -c "from importlib.metadata import entry_points; print([ep.name for ep in entry_points(group='onex.nodes') if 'omnibase_core' in ep.value])"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered six new processing nodes for compliance and contract workflows, providing support for evidence effects, orchestration, compliance report reduction, scanning operations, contract resolution, and contract verification replay—enabling enhanced workflow automation and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->