### PR TITLE
docs: cross-reference omnibase_compat.types.type_json (OMN-8553)

### DIFF
--- a/src/omnibase_core/types/type_json.py
+++ b/src/omnibase_core/types/type_json.py
@@ -44,6 +44,7 @@ See Also:
     - omnibase_core.types.type_effect_result: Effect-specific type aliases
     - omnibase_core.utils.compute_transformations: JSON transformation utilities
     - docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md: Node architecture patterns
+    - omnibase_compat.types.type_json: Equivalent definitions for compat consumers
 """
 
 from datetime import datetime


### PR DESCRIPTION
## Summary
- Adds a `See Also` docstring note in `omnibase_core/types/type_json.py` pointing to the new `omnibase_compat.types.type_json` equivalent

## Note
The types remain defined in omnibase_core (not re-imported from compat) because `omnibase-compat` is in the SDK boundary blocklist in `test_no_internal_deps.py`. No functional change.

Companion to omnibase_compat#47 (OMN-8553)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated type documentation with an additional reference to equivalent JSON type definitions for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->