### PR TITLE
docs: cross-reference omnibase_compat.utils.util_str_enum_base (OMN-8554)

### DIFF
--- a/src/omnibase_core/utils/util_str_enum_base.py
+++ b/src/omnibase_core/utils/util_str_enum_base.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""StrValueHelper mixin providing standard __str__ for string enums."""
+"""StrValueHelper mixin providing standard __str__ for string enums.
+
+See Also:
+    - omnibase_compat.utils.util_str_enum_base: Equivalent definition for compat consumers
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Adds a `See Also` docstring note in `omnibase_core/utils/util_str_enum_base.py` pointing to the new `omnibase_compat.utils.util_str_enum_base` equivalent
- No functional change

Companion to omnibase_compat#48 (OMN-8554)