### PR TITLE
fix: replace hardcoded /Volumes/PRO-G40 fallback with cross-machine default (OMN-8592)

### DIFF
--- a/src/omnibase_core/doctor/checks/check_repos_synced.py
+++ b/src/omnibase_core/doctor/checks/check_repos_synced.py
@@ -13,7 +13,8 @@ from omnibase_core.models.doctor.model_doctor_check_result import ModelDoctorChe
 
 
 def _get_omni_home() -> Path:
-    return Path(os.environ.get("OMNI_HOME", "/Volumes/PRO-G40/Code/omni_home"))
+    default = str(Path.home() / "Code" / "omni_home")
+    return Path(os.environ.get("OMNI_HOME", default))
 
 
 class CheckReposSynced(DoctorCheckBase):


### PR DESCRIPTION
## Summary

- Replaces `"/Volumes/PRO-G40/Code/omni_home"` hardcoded fallback in `_get_omni_home()` with `str(Path.home() / "Code" / "omni_home")`
- No other files in `omnibase_core/src/` had the same pattern (grep confirmed)

Closes OMN-8592
Part of OMN-8573

## Test plan
- [ ] `tests/test_doctor/test_checks_repos.py` — 2 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default data directory path resolution to use the user's home directory instead of a hardcoded system path, enhancing portability across different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->