### PR TITLE
fix(compliance): eliminate HARDCODED_TOPIC violations in omnibase_core (OMN-8635)

### DIFF
--- a/src/omnibase_core/constants/constants_event_types.py
+++ b/src/omnibase_core/constants/constants_event_types.py
@@ -55,6 +55,19 @@ TOPIC_GITHUB_PR_STATUS_EVENT = "onex.evt.platform.github-pr-status.v1"
 TOPIC_GIT_HOOK_EVENT = "onex.evt.platform.git-hook.v1"
 TOPIC_LINEAR_SNAPSHOT_EVENT = "onex.evt.platform.linear-snapshot.v1"
 
+# Runtime event type alias strings used in legacy payload migration (OMN-8635)
+# These are NOT Kafka topic names — they are legacy event-type identifiers used as
+# lookup keys to map wire-format strings to typed payload classes.
+EVENT_TYPE_ALIAS_NODE_REGISTERED = "onex.runtime.node.registered"
+EVENT_TYPE_ALIAS_NODE_UNREGISTERED = "onex.runtime.node.unregistered"
+EVENT_TYPE_ALIAS_SUBSCRIPTION_CREATED = "onex.runtime.subscription.created"
+EVENT_TYPE_ALIAS_SUBSCRIPTION_FAILED = "onex.runtime.subscription.failed"
+EVENT_TYPE_ALIAS_SUBSCRIPTION_REMOVED = "onex.runtime.subscription.removed"
+EVENT_TYPE_ALIAS_RUNTIME_READY = "onex.runtime.ready"
+EVENT_TYPE_ALIAS_NODE_GRAPH_READY = "onex.runtime.node_graph.ready"
+EVENT_TYPE_ALIAS_WIRING_RESULT = "onex.runtime.wiring.result"
+EVENT_TYPE_ALIAS_WIRING_ERROR = "onex.runtime.wiring.error"
+
 
 def normalize_legacy_event_type(event_type: str | TypedDictEventType | object) -> str:
     """Normalize legacy event types to consistent string format.

--- a/src/omnibase_core/models/core/model_event_channels.py
+++ b/src/omnibase_core/models/core/model_event_channels.py
@@ -20,22 +20,4 @@ class ModelEventChannels(BaseModel):
         description="Event channels this node publishes events to",
     )
 
-    model_config = ConfigDict(
-        extra="forbid",
-        json_schema_extra={
-            "examples": [
-                {
-                    "subscribes_to": [
-                        "onex.discovery.commands",
-                        "onex.registry.query",
-                        "onex.node.health_check",
-                    ],
-                    "publishes_to": [
-                        "onex.discovery.events",
-                        "onex.registry.update",
-                        "onex.node.status",
-                    ],
-                },
-            ],
-        },
-    )
+    model_config = ConfigDict(extra="forbid")

--- a/src/omnibase_core/utils/util_payload_migration.py
+++ b/src/omnibase_core/utils/util_payload_migration.py
@@ -27,6 +27,17 @@ See Also:
 
 from uuid import UUID
 
+from omnibase_core.constants.constants_event_types import (
+    EVENT_TYPE_ALIAS_NODE_GRAPH_READY,
+    EVENT_TYPE_ALIAS_NODE_REGISTERED,
+    EVENT_TYPE_ALIAS_NODE_UNREGISTERED,
+    EVENT_TYPE_ALIAS_RUNTIME_READY,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_CREATED,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_FAILED,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_REMOVED,
+    EVENT_TYPE_ALIAS_WIRING_ERROR,
+    EVENT_TYPE_ALIAS_WIRING_RESULT,
+)
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.errors.exception_groups import PYDANTIC_MODEL_ERRORS
 
@@ -52,26 +63,26 @@ from omnibase_core.models.events.payloads.model_event_payload_union import (
 _EVENT_TYPE_TO_PAYLOAD_CLASS: dict[str, type[ModelEventPayloadUnion]] = {
     # Node lifecycle events
     "NODE_REGISTERED": ModelNodeRegisteredEvent,
-    "onex.runtime.node.registered": ModelNodeRegisteredEvent,
+    EVENT_TYPE_ALIAS_NODE_REGISTERED: ModelNodeRegisteredEvent,
     "NODE_UNREGISTERED": ModelNodeUnregisteredEvent,
-    "onex.runtime.node.unregistered": ModelNodeUnregisteredEvent,
+    EVENT_TYPE_ALIAS_NODE_UNREGISTERED: ModelNodeUnregisteredEvent,
     # Subscription events
     "SUBSCRIPTION_CREATED": ModelSubscriptionCreatedEvent,
-    "onex.runtime.subscription.created": ModelSubscriptionCreatedEvent,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_CREATED: ModelSubscriptionCreatedEvent,
     "SUBSCRIPTION_FAILED": ModelSubscriptionFailedEvent,
-    "onex.runtime.subscription.failed": ModelSubscriptionFailedEvent,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_FAILED: ModelSubscriptionFailedEvent,
     "SUBSCRIPTION_REMOVED": ModelSubscriptionRemovedEvent,
-    "onex.runtime.subscription.removed": ModelSubscriptionRemovedEvent,
+    EVENT_TYPE_ALIAS_SUBSCRIPTION_REMOVED: ModelSubscriptionRemovedEvent,
     # Runtime status events
     "RUNTIME_READY": ModelRuntimeReadyEvent,
-    "onex.runtime.ready": ModelRuntimeReadyEvent,
+    EVENT_TYPE_ALIAS_RUNTIME_READY: ModelRuntimeReadyEvent,
     "NODE_GRAPH_READY": ModelNodeGraphReadyEvent,
-    "onex.runtime.node_graph.ready": ModelNodeGraphReadyEvent,
+    EVENT_TYPE_ALIAS_NODE_GRAPH_READY: ModelNodeGraphReadyEvent,
     # Wiring events
     "WIRING_RESULT": ModelWiringResultEvent,
-    "onex.runtime.wiring.result": ModelWiringResultEvent,
+    EVENT_TYPE_ALIAS_WIRING_RESULT: ModelWiringResultEvent,
     "WIRING_ERROR": ModelWiringErrorEvent,
-    "onex.runtime.wiring.error": ModelWiringErrorEvent,
+    EVENT_TYPE_ALIAS_WIRING_ERROR: ModelWiringErrorEvent,
 }
 
 # Common field name patterns that help identify payload types


### PR DESCRIPTION
## Summary

- Add `EVENT_TYPE_ALIAS_*` constants to `constants_event_types.py` for the 9 legacy runtime event type identifier strings used in `util_payload_migration.py`
- Update `util_payload_migration.py` to import those constants instead of inline string literals in `_EVENT_TYPE_TO_PAYLOAD_CLASS` dict
- Remove `json_schema_extra` topic examples from `ModelEventChannels` to eliminate 6 hardcoded topic strings from schema documentation

Closes OMN-8635. Sub-ticket of OMN-8605.

## Files changed

- `src/omnibase_core/constants/constants_event_types.py` — 9 new `EVENT_TYPE_ALIAS_*` constants
- `src/omnibase_core/utils/util_payload_migration.py` — import + use constants
- `src/omnibase_core/models/core/model_event_channels.py` — remove hardcoded topic examples

## Test plan

- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues (3 files)
- [x] `pytest tests/unit/constants/test_event_types.py tests/unit/constants/test_topic_naming.py` — 46 passed
- [x] `pytest tests/unit/utils/test_util_payload_migration.py` — 42 passed