### PR TITLE
fix(ci): use gh pr merge --merge for merge-queue compatibility [OMN-8653]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -83,11 +83,11 @@ jobs:
           set -euo pipefail
           # "already enqueued" race is benign — treat as success.
           # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --merge 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi
-          if echo "$output" | grep -qiE "already|enqueued"; then
+          if echo "$output" | grep -qiE "already enqueued|already queued|auto-merge already enabled"; then
             echo "auto-merge not newly enabled (expected): $output"
             exit 0
           fi

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -83,7 +83,7 @@ jobs:
           set -euo pipefail
           # "already enqueued" race is benign — treat as success.
           # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --merge 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --merge 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Replace \`gh pr merge --merge\` for merge-queue compatibility. The previous command (\`--auto\` / \`--auto --squash\`) silently exits 0 on merge-queue-enforced branches while logging "The merge strategy for main is set by the merge queue" — resulting in PRs that sit CLEAN indefinitely without draining.

- Replace \`--auto\` / \`--auto --squash\` with \`--merge\`, which correctly enrolls PRs into the merge queue
- Squash behavior is controlled by branch protection policy, not the CLI flag

Part of OMN-8653 (follow-up to OMN-8432).

## Test plan

- [ ] PR auto-merge workflow triggers on open/reopen
- [ ] PR is enrolled in merge queue (not silently skipped)