### PR TITLE
fix(ci): replace dead run_contract_compliance_check.py ref [OMN-8808]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -961,17 +961,13 @@ jobs:
       - uses: actions/checkout@v6
       - name: Clone onex_change_control
         run: git clone --depth=1 https://github.com/OmniNode-ai/onex_change_control.git /tmp/onex_change_control
-      - name: Install pyyaml
-        run: pip install pyyaml
-      - name: Run contract compliance check
-        run: |
-          python /tmp/onex_change_control/scripts/ci/run_contract_compliance_check.py \
-            --pr ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --contracts-dir /tmp/onex_change_control/contracts
-        env:
-          EMERGENCY_BYPASS: ${{ secrets.EMERGENCY_BYPASS || '' }}
-          GH_TOKEN: ${{ github.token }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.3"
+      - name: Validate all ticket contracts (OMN-8808 — replaces dead run_contract_compliance_check.py ref)
+        working-directory: /tmp/onex_change_control
+        run: uv run validate-yaml contracts/OMN-*.yaml
 
   ci-summary:
     name: CI Summary


### PR DESCRIPTION
## Summary

- Removes the dead reference to `scripts/ci/run_contract_compliance_check.py` in the `contract-compliance` CI job — that script path never existed in `onex_change_control`
- Replaces it with `uv run validate-yaml contracts/OMN-*.yaml` from onex_change_control, the canonical CLI for contract schema validation (shipped as part of OMN-8808)

## Motivating Incident

OMN-8606: Malformed contract YAML shipped to main. OMN-8808 wires the validation gate in onex_change_control; this PR removes the broken placeholder that was providing false confidence in omnibase_core.

## Test plan

- [ ] CI `contract-compliance` job runs `uv run validate-yaml contracts/OMN-*.yaml` from cloned onex_change_control
- [ ] No Python scripts required — uses the published `validate-yaml` CLI entrypoint via uv