### PR TITLE
ci: fix cr-thread-gate caller signature (OMN-8829 follow-up)

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
   pull_request_review_thread:
     types: [resolved, unresolved]
   issue_comment:
@@ -11,7 +13,8 @@ on:
 jobs:
   gate:
     if: (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) && github.actor != 'dependabot[bot]'
-    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
+    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@b4b12ef5d0f77b9ffd39a5566c0be350222c2cd8
     with:
       pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+    secrets:
       github-token: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary

OMN-8829 follow-up. The cr-thread-gate caller workflow had a signature bug: `github-token` was passed under `with:` instead of `secrets:`. The reusable workflow in omniclaude declares it as `workflow_call.secrets`.

## Changes
- Move `github-token` from `with:` to `secrets:`
- Pin reusable to `@b4b12ef5d0f77b9ffd39a5566c0be350222c2cd8`
- Ensure `pull_request_review_comment` and `pull_request_review_thread` triggers present
- Add dependabot guard to job condition

Matches `omninode_infra#340` / `omniweb#92` reference fix (commits bb6ea71, c8fb0fe).

## Test plan
- [x] CI green on this PR
- [ ] After merge, verify cr-thread-gate runs successfully on a subsequent PR in this repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration workflow configurations to enhance code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->