### PR TITLE
ci: canary PR to verify cr-thread-gate caller fix

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -18,3 +18,4 @@ jobs:
       pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
     secrets:
       github-token: ${{ secrets.CROSS_REPO_PAT }}
+


### PR DESCRIPTION
Trivial trailing-newline change. Verifies OMN-8829 follow-up fix (#814) actually causes cr-thread-gate to run cleanly on a real PR.

## Test plan
- [ ] cr-thread-gate runs and completes (not startup_failure)
- [ ] All other CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal workflow formatting update with no functional impact to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->