### PR TITLE
fix(enums): remove TASK_OUTPUT from EnumClaudeCodeToolName (OMN-8875)

### DIFF
--- a/src/omnibase_core/enums/hooks/claude_code/enum_claude_code_tool_name.py
+++ b/src/omnibase_core/enums/hooks/claude_code/enum_claude_code_tool_name.py
@@ -26,8 +26,7 @@ class EnumClaudeCodeToolName(StrValueHelper, str, Enum):
         - Execution: BASH, BASH_OUTPUT, TASK, KILL_SHELL
         - Web operations: WEB_FETCH, WEB_SEARCH
         - Notebook: NOTEBOOK_EDIT, NOTEBOOK_READ
-        - Task management: TASK_CREATE, TASK_GET, TASK_UPDATE, TASK_LIST,
-            TASK_STOP, TASK_OUTPUT
+        - Task management: TASK_CREATE, TASK_GET, TASK_UPDATE, TASK_LIST, TASK_STOP
         - User interaction: ASK_USER_QUESTION
         - Plan mode: ENTER_PLAN_MODE, EXIT_PLAN_MODE
         - Skills: SKILL
@@ -96,9 +95,6 @@ class EnumClaudeCodeToolName(StrValueHelper, str, Enum):
 
     TASK_STOP = "TaskStop"
     """Stop a running background task."""
-
-    TASK_OUTPUT = "TaskOutput"
-    """Get output from a task."""
 
     # User interaction
     ASK_USER_QUESTION = "AskUserQuestion"
@@ -183,7 +179,6 @@ class EnumClaudeCodeToolName(StrValueHelper, str, Enum):
             cls.TASK_UPDATE,
             cls.TASK_LIST,
             cls.TASK_STOP,
-            cls.TASK_OUTPUT,
         }
 
     @classmethod

--- a/tests/unit/enums/hooks/claude_code/test_enum_claude_code_tool_name.py
+++ b/tests/unit/enums/hooks/claude_code/test_enum_claude_code_tool_name.py
@@ -58,10 +58,6 @@ class TestEnumClaudeCodeToolNameValues:
         """Test TaskStop tool value."""
         assert EnumClaudeCodeToolName.TASK_STOP.value == "TaskStop"
 
-    def test_task_output_value(self) -> None:
-        """Test TaskOutput tool value."""
-        assert EnumClaudeCodeToolName.TASK_OUTPUT.value == "TaskOutput"
-
     def test_bash_output_value(self) -> None:
         """Test BashOutput tool value."""
         assert EnumClaudeCodeToolName.BASH_OUTPUT.value == "BashOutput"
@@ -112,9 +108,9 @@ class TestEnumClaudeCodeToolNameValues:
         assert EnumClaudeCodeToolName.UNKNOWN.value == "Unknown"
 
     def test_enum_count(self) -> None:
-        """Test that enum has at least 26 values (minimum baseline)."""
+        """Test that enum has at least 25 values (minimum baseline)."""
         values = list(EnumClaudeCodeToolName)
-        assert len(values) >= 26, f"Expected at least 26 enum values, got {len(values)}"
+        assert len(values) >= 25, f"Expected at least 25 enum values, got {len(values)}"
 
     def test_all_expected_values_present(self) -> None:
         """Test that all expected values are present."""
@@ -129,7 +125,6 @@ class TestEnumClaudeCodeToolNameValues:
             "BashOutput",
             "Task",
             "TaskStop",
-            "TaskOutput",
             "KillShell",
             "WebFetch",
             "WebSearch",
@@ -313,10 +308,6 @@ class TestEnumClaudeCodeToolNameFromString:
             == EnumClaudeCodeToolName.TASK_STOP
         )
         assert (
-            EnumClaudeCodeToolName.from_string("TaskOutput")
-            == EnumClaudeCodeToolName.TASK_OUTPUT
-        )
-        assert (
             EnumClaudeCodeToolName.from_string("BashOutput")
             == EnumClaudeCodeToolName.BASH_OUTPUT
         )
@@ -425,7 +416,6 @@ class TestEnumClaudeCodeToolNameIsFileOperation:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -489,7 +479,6 @@ class TestEnumClaudeCodeToolNameIsSearchOperation:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -553,7 +542,6 @@ class TestEnumClaudeCodeToolNameIsExecutionTool:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -617,7 +605,6 @@ class TestEnumClaudeCodeToolNameIsWebOperation:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -657,7 +644,6 @@ class TestEnumClaudeCodeToolNameIsTaskManagement:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
         ]
 
         for tool in task_mgmt_tools:
@@ -696,13 +682,13 @@ class TestEnumClaudeCodeToolNameIsTaskManagement:
             )
 
     def test_task_management_count(self) -> None:
-        """Test that exactly 6 tools are task management tools."""
+        """Test that exactly 5 tools are task management tools."""
         count = sum(
             1
             for tool in EnumClaudeCodeToolName
             if EnumClaudeCodeToolName.is_task_management(tool)
         )
-        assert count == 6
+        assert count == 5
 
 
 # ============================================================================
@@ -745,7 +731,6 @@ class TestEnumClaudeCodeToolNameIsNotebookOperation:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -808,7 +793,6 @@ class TestEnumClaudeCodeToolNameIsUserInteraction:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
             EnumClaudeCodeToolName.SKILL,
@@ -873,7 +857,6 @@ class TestEnumClaudeCodeToolNameIsPlanMode:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.SKILL,
             EnumClaudeCodeToolName.MCP,
@@ -982,7 +965,6 @@ class TestEnumClaudeCodeToolNameCategoryExclusivity:
             EnumClaudeCodeToolName.TASK_UPDATE,
             EnumClaudeCodeToolName.TASK_LIST,
             EnumClaudeCodeToolName.TASK_STOP,
-            EnumClaudeCodeToolName.TASK_OUTPUT,
             EnumClaudeCodeToolName.ASK_USER_QUESTION,
             EnumClaudeCodeToolName.ENTER_PLAN_MODE,
             EnumClaudeCodeToolName.EXIT_PLAN_MODE,
@@ -1086,6 +1068,29 @@ class TestEnumClaudeCodeToolNameImport:
         from omnibase_core.enums.hooks import claude_code
 
         assert "EnumClaudeCodeToolName" in claude_code.__all__
+
+
+# ============================================================================
+# Test: OMN-8875 — TaskOutput removed in cc 2.1.83
+# ============================================================================
+
+
+class TestTaskOutputRemoved:
+    """Verify TASK_OUTPUT was removed from the enum (OMN-8875)."""
+
+    def test_task_output_not_in_enum_values(self) -> None:
+        """TaskOutput must not appear in any enum member value."""
+        values = {member.value for member in EnumClaudeCodeToolName}
+        assert "TaskOutput" not in values
+
+    def test_task_output_attr_absent(self) -> None:
+        """TASK_OUTPUT attribute must not exist on the enum class."""
+        assert not hasattr(EnumClaudeCodeToolName, "TASK_OUTPUT")
+
+    def test_from_string_task_output_returns_unknown(self) -> None:
+        """from_string('TaskOutput') must return UNKNOWN, not a valid member."""
+        result = EnumClaudeCodeToolName.from_string("TaskOutput")
+        assert result == EnumClaudeCodeToolName.UNKNOWN
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Removes `TASK_OUTPUT = "TaskOutput"` enum member — tool no longer exists in cc 2.1.83
- Removes `TASK_OUTPUT` from `is_task_management()` helper set
- Scrubs all test assertions referencing `TASK_OUTPUT`; adjusts count assertions (26→25 members, 6→5 task-mgmt tools)
- Adds `TestTaskOutputRemoved` integration test class with 3 guards against regression

Closes OMN-8875

## Test plan
- [x] `uv run pytest tests/unit/enums/hooks/claude_code/test_enum_claude_code_tool_name.py` — 72 passed
- [x] `from_string("TaskOutput")` now returns `UNKNOWN`
- [x] `TASK_OUTPUT` attribute absent from enum class