### PR TITLE
feat(contracts): ModelTicketContract Pydantic model + Linear DoD validator (OMN-8916)

### DIFF
--- a/scripts/validate-pr-tickets.sh
+++ b/scripts/validate-pr-tickets.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# validate-pr-tickets.sh — CI gate for OMN-8916
+#
+# Parses a PR for OMN-XXXX ticket IDs, fetches each from Linear via GH CLI
+# GraphQL, validates against ModelTicketContract, exits non-zero on any failure.
+#
+# Usage:
+#   PR_NUMBER=123 REPO=OmniNode-ai/omnibase_core bash scripts/validate-pr-tickets.sh
+#   Or:  bash scripts/validate-pr-tickets.sh [pr_number]
+
+set -euo pipefail
+
+PR_NUMBER="${1:-${PR_NUMBER:-}}"
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")}"
+LINEAR_API_KEY="${LINEAR_API_KEY:-}"
+SKIP_LABEL="skip-contract-gate"
+
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "[validate-pr-tickets] ERROR: PR_NUMBER not set" >&2
+  exit 1
+fi
+
+# Fetch PR metadata
+PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json title,body,headRefName,labels 2>/dev/null) || {
+  echo "[validate-pr-tickets] ERROR: Could not fetch PR #$PR_NUMBER from $REPO" >&2
+  exit 1
+}
+
+# Check for skip label
+LABELS=$(echo "$PR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(l['name'] for l in d.get('labels',[])))")
+if echo "$LABELS" | grep -qw "$SKIP_LABEL"; then
+  echo "[validate-pr-tickets] Skipping: label '$SKIP_LABEL' present"
+  exit 0
+fi
+
+# Extract OMN-\d+ ticket IDs from branch, title, body
+ALL_TEXT=$(echo "$PR_JSON" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('headRefName','') + ' ' + d.get('title','') + ' ' + d.get('body',''))
+")
+
+TICKET_IDS=$(echo "$ALL_TEXT" | grep -oE 'OMN-[0-9]+' | sort -u || true)
+
+if [[ -z "$TICKET_IDS" ]]; then
+  echo "[validate-pr-tickets] No OMN-XXXX tickets found — skipping gate"
+  exit 0
+fi
+
+echo "[validate-pr-tickets] Found tickets: $(echo "$TICKET_IDS" | tr '\n' ' ')"
+
+# Validate each ticket
+FAILED=0
+for TICKET_ID in $TICKET_IDS; do
+  echo "[validate-pr-tickets] Validating $TICKET_ID ..."
+
+  # Fetch from Linear via GraphQL
+  if [[ -z "$LINEAR_API_KEY" ]]; then
+    echo "[validate-pr-tickets] WARNING: LINEAR_API_KEY not set, skipping Linear fetch for $TICKET_ID" >&2
+    continue
+  fi
+
+  TICKET_JSON=$(curl -s -X POST "https://api.linear.app/graphql" \
+    -H "Authorization: $LINEAR_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"query\": \"{ issue(id: \\\"$TICKET_ID\\\") { identifier title description } }\"}" \
+    2>/dev/null) || {
+    echo "[validate-pr-tickets] ERROR: Linear API call failed for $TICKET_ID" >&2
+    FAILED=1
+    continue
+  }
+
+  # Run Python validator inline
+  RESULT=$(python3 - <<PYEOF
+import sys, json
+try:
+    from omnibase_core.contracts.validators.validate_ticket_contract import validate_ticket_contract
+
+    raw = json.loads('''${TICKET_JSON}''')
+    issue = raw.get("data", {}).get("issue") or {}
+    desc = issue.get("description", "")
+
+    import re, yaml as _yaml
+
+    # Extract YAML contract block from description
+    contract_match = re.search(r'```yaml\n(.*?)```', desc, re.DOTALL)
+    if not contract_match:
+        print(json.dumps({"valid": False, "errors": ["No YAML contract block found in ticket description"]}))
+        sys.exit(0)
+
+    contract_dict = _yaml.safe_load(contract_match.group(1))
+    contract_dict.setdefault("ticket_id", issue.get("identifier", ""))
+    contract_dict.setdefault("title", issue.get("title", ""))
+
+    result = validate_ticket_contract(contract_dict)
+    print(json.dumps({"valid": result.valid, "errors": result.errors}))
+except Exception as e:
+    print(json.dumps({"valid": False, "errors": [str(e)]}))
+PYEOF
+)
+
+  VALID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['valid'])")
+  ERRORS=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print('\n'.join(d['errors']))")
+
+  if [[ "$VALID" != "True" ]]; then
+    echo "[validate-pr-tickets] FAIL $TICKET_ID:"
+    echo "$ERRORS" | sed 's/^/  /'
+    FAILED=1
+  else
+    echo "[validate-pr-tickets] PASS $TICKET_ID"
+  fi
+done
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo ""
+  echo "[validate-pr-tickets] CONTRACT GATE FAILED — one or more tickets have incomplete contracts."
+  echo "Fix dod_evidence, golden_path, or deploy_step in the Linear ticket description."
+  exit 1
+fi
+
+echo "[validate-pr-tickets] All tickets passed contract validation."
+exit 0

--- a/src/omnibase_core/contracts/validators/__init__.py
+++ b/src/omnibase_core/contracts/validators/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/contracts/validators/validate_ticket_contract.py
+++ b/src/omnibase_core/contracts/validators/validate_ticket_contract.py
@@ -15,10 +15,9 @@ from omnibase_core.contracts.validators.validation_result import ValidationResul
 from omnibase_core.models.contracts.ticket.model_linear_ticket_contract import (
     ModelTicketContract,
 )
-from omnibase_core.types.typed_dict_ticket_input import TypedDictTicketInput
 
 
-def validate_ticket_contract(ticket: TypedDictTicketInput) -> ValidationResult:
+def validate_ticket_contract(ticket: object) -> ValidationResult:
     """Validate a Linear ticket dict against ModelTicketContract.
 
     Args:
@@ -29,7 +28,7 @@ def validate_ticket_contract(ticket: TypedDictTicketInput) -> ValidationResult:
         or valid=False with a list of human-readable error strings on failure.
     """
     try:
-        ModelTicketContract(**ticket)
+        ModelTicketContract.model_validate(ticket)
         return ValidationResult(valid=True)
     except ValidationError as exc:
         errors = [

--- a/src/omnibase_core/contracts/validators/validate_ticket_contract.py
+++ b/src/omnibase_core/contracts/validators/validate_ticket_contract.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+validate_ticket_contract — validate a Linear ticket dict against ModelTicketContract.
+
+OMN-8916
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from omnibase_core.contracts.validators.validation_result import ValidationResult
+from omnibase_core.models.contracts.ticket.model_linear_ticket_contract import (
+    ModelTicketContract,
+)
+from omnibase_core.types.typed_dict_ticket_input import TypedDictTicketInput
+
+
+def validate_ticket_contract(ticket: TypedDictTicketInput) -> ValidationResult:
+    """Validate a Linear ticket dict against ModelTicketContract.
+
+    Args:
+        ticket: Typed dict from Linear API or test fixture.
+
+    Returns:
+        ValidationResult with valid=True and empty errors on success,
+        or valid=False with a list of human-readable error strings on failure.
+    """
+    try:
+        ModelTicketContract(**ticket)
+        return ValidationResult(valid=True)
+    except ValidationError as exc:
+        errors = [
+            f"{'.'.join(str(loc) for loc in e['loc'])}: {e['msg']}"
+            for e in exc.errors()
+        ]
+        return ValidationResult(valid=False, errors=errors)
+    except TypeError as exc:
+        return ValidationResult(valid=False, errors=[str(exc)])
+
+
+__all__ = ["validate_ticket_contract"]

--- a/src/omnibase_core/contracts/validators/validation_result.py
+++ b/src/omnibase_core/contracts/validators/validation_result.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidationResult — structured output of ticket contract validation. OMN-8916"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ValidationResult:
+    """Structured result of validate_ticket_contract."""
+
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+
+
+__all__ = ["ValidationResult"]

--- a/src/omnibase_core/models/contracts/ticket/__init__.py
+++ b/src/omnibase_core/models/contracts/ticket/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/models/contracts/ticket/model_dod_evidence_check.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_evidence_check.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodEvidenceCheck — a single check entry within a DoD evidence item. OMN-8916"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDodEvidenceCheck(BaseModel):
+    """A single verifiable check within a DoD evidence item."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    check_type: str = Field(..., min_length=1)
+    check_value: str = Field(..., min_length=1)
+
+
+__all__ = ["ModelDodEvidenceCheck"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodEvidenceItem — a single DoD evidence entry for a Linear ticket. OMN-8916"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.ticket.model_dod_evidence_check import (
+    ModelDodEvidenceCheck,
+)
+
+
+class ModelDodEvidenceItem(BaseModel):
+    """A single DoD evidence entry declaring what must be verified before Done."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    checks: list[ModelDodEvidenceCheck] = Field(default_factory=list)
+
+
+__all__ = ["ModelDodEvidenceItem"]

--- a/src/omnibase_core/models/contracts/ticket/model_linear_ticket_contract.py
+++ b/src/omnibase_core/models/contracts/ticket/model_linear_ticket_contract.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelTicketContract — Pydantic v2 schema for Linear ticket contracts.
+
+Validates that every ticket cited in a PR has a complete, non-empty contract
+with dod_evidence, golden_path, and deploy_step when the ticket touches runtime.
+
+OMN-8916
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.models.contracts.ticket.model_dod_evidence_item import (
+    ModelDodEvidenceItem,
+)
+
+_TICKET_ID_RE = re.compile(r"^OMN-\d+$")
+
+
+class ModelTicketContract(BaseModel):
+    """Canonical contract for a Linear ticket cited in a PR.
+
+    Enforces that dod_evidence and golden_path are non-empty, and that
+    runtime-touching tickets declare a deploy_step.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ticket_id: str = Field(..., description="Linear ticket ID matching OMN-\\d+")
+    title: str = Field(..., min_length=1)
+    dod_evidence: list[ModelDodEvidenceItem] = Field(..., min_length=1)
+    golden_path: str = Field(..., min_length=1)
+    runtime_change: bool = Field(default=False)
+    deploy_step: str | None = Field(default=None)
+
+    @field_validator("ticket_id")
+    @classmethod
+    def validate_ticket_id(cls, v: str) -> str:
+        if not _TICKET_ID_RE.match(v):
+            raise ValueError(f"ticket_id must match OMN-\\d+, got: {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def validate_deploy_step_when_runtime_change(self) -> ModelTicketContract:
+        if self.runtime_change and not self.deploy_step:
+            raise ValueError("deploy_step is required when runtime_change=True")
+        return self
+
+
+__all__ = ["ModelTicketContract"]

--- a/src/omnibase_core/types/typed_dict_ticket_input.py
+++ b/src/omnibase_core/types/typed_dict_ticket_input.py
@@ -7,13 +7,20 @@ from __future__ import annotations
 
 from typing import Required, TypedDict
 
+from omnibase_core.models.contracts.ticket.model_dod_evidence_item import (
+    ModelDodEvidenceItem,
+)
+
 
 class TypedDictTicketInput(TypedDict, total=False):
-    """Typed shape of the ticket dict accepted by validate_ticket_contract."""
+    """Typed shape of the structured ticket dict for validate_ticket_contract.
+
+    dod_evidence accepts ModelDodEvidenceItem instances or raw dicts (Pydantic coerces).
+    """
 
     ticket_id: Required[str]
     title: Required[str]
-    dod_evidence: Required[list[object]]
+    dod_evidence: Required[list[ModelDodEvidenceItem | object]]
     golden_path: Required[str]
     runtime_change: bool
     deploy_step: str | None

--- a/src/omnibase_core/types/typed_dict_ticket_input.py
+++ b/src/omnibase_core/types/typed_dict_ticket_input.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TypedDictTicketInput — typed input shape for validate_ticket_contract. OMN-8916"""
+
+from __future__ import annotations
+
+from typing import Required, TypedDict
+
+
+class TypedDictTicketInput(TypedDict, total=False):
+    """Typed shape of the ticket dict accepted by validate_ticket_contract."""
+
+    ticket_id: Required[str]
+    title: Required[str]
+    dod_evidence: Required[list[object]]
+    golden_path: Required[str]
+    runtime_change: bool
+    deploy_step: str | None
+
+
+__all__ = ["TypedDictTicketInput"]

--- a/tests/unit/models/contracts/test_model_ticket_contract.py
+++ b/tests/unit/models/contracts/test_model_ticket_contract.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for ModelTicketContract.
+
+TDD tests for OMN-8916: ModelTicketContract Pydantic model + Linear DoD validator.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.contracts.validators.validate_ticket_contract import (
+    validate_ticket_contract,
+)
+from omnibase_core.contracts.validators.validation_result import ValidationResult
+from omnibase_core.models.contracts.ticket.model_linear_ticket_contract import (
+    ModelTicketContract,
+)
+
+VALID_TICKET = {
+    "ticket_id": "OMN-1234",
+    "title": "Add foo feature",
+    "dod_evidence": [
+        {
+            "id": "dod-001",
+            "description": "Test passes",
+            "checks": [
+                {
+                    "check_type": "test_passes",
+                    "check_value": "tests/test_foo.py::test_bar",
+                }
+            ],
+        }
+    ],
+    "golden_path": "Emit event → handler processes → row in DB",
+}
+
+
+class TestModelTicketContractValidField:
+    def test_accepts_valid_ticket(self) -> None:
+        contract = ModelTicketContract(**VALID_TICKET)
+        assert contract.ticket_id == "OMN-1234"
+        assert contract.title == "Add foo feature"
+        assert len(contract.dod_evidence) == 1
+        assert contract.golden_path == "Emit event → handler processes → row in DB"
+        assert contract.runtime_change is False
+        assert contract.deploy_step is None
+
+    def test_accepts_valid_ticket_with_runtime_change_and_deploy_step(self) -> None:
+        contract = ModelTicketContract(
+            **VALID_TICKET,
+            runtime_change=True,
+            deploy_step="trigger deploy-agent rebuild via Kafka",
+        )
+        assert contract.runtime_change is True
+        assert contract.deploy_step == "trigger deploy-agent rebuild via Kafka"
+
+    def test_ticket_id_regex_rejects_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="ticket_id"):
+            ModelTicketContract(**{**VALID_TICKET, "ticket_id": "LIN-123"})
+
+    def test_ticket_id_regex_rejects_no_prefix(self) -> None:
+        with pytest.raises(ValidationError, match="ticket_id"):
+            ModelTicketContract(**{**VALID_TICKET, "ticket_id": "8916"})
+
+
+class TestModelTicketContractRejectsMissingFields:
+    def test_rejects_missing_dod_evidence(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTicketContract(
+                ticket_id="OMN-1234",
+                title="Add foo feature",
+                golden_path="Emit event → handler processes → row in DB",
+            )
+
+    def test_rejects_empty_dod_evidence(self) -> None:
+        with pytest.raises(ValidationError, match="dod_evidence"):
+            ModelTicketContract(**{**VALID_TICKET, "dod_evidence": []})
+
+    def test_rejects_missing_golden_path(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTicketContract(
+                ticket_id="OMN-1234",
+                title="Add foo feature",
+                dod_evidence=VALID_TICKET["dod_evidence"],
+            )
+
+    def test_rejects_empty_golden_path(self) -> None:
+        with pytest.raises(ValidationError, match="golden_path"):
+            ModelTicketContract(**{**VALID_TICKET, "golden_path": ""})
+
+    def test_rejects_runtime_change_true_without_deploy_step(self) -> None:
+        with pytest.raises(ValidationError, match="deploy_step"):
+            ModelTicketContract(**{**VALID_TICKET, "runtime_change": True})
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTicketContract(**{**VALID_TICKET, "unknown_field": "value"})
+
+    def test_is_frozen(self) -> None:
+        contract = ModelTicketContract(**VALID_TICKET)
+        with pytest.raises((ValidationError, TypeError)):
+            contract.title = "mutated"  # type: ignore[misc]
+
+
+class TestValidateTicketContractFunction:
+    def test_returns_valid_for_complete_ticket(self) -> None:
+        result = validate_ticket_contract(VALID_TICKET)
+        assert isinstance(result, ValidationResult)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_returns_invalid_for_empty_dod_evidence(self) -> None:
+        result = validate_ticket_contract({**VALID_TICKET, "dod_evidence": []})
+        assert result.valid is False
+        assert len(result.errors) > 0
+
+    def test_returns_invalid_for_missing_golden_path(self) -> None:
+        bad = {k: v for k, v in VALID_TICKET.items() if k != "golden_path"}
+        result = validate_ticket_contract(bad)
+        assert result.valid is False
+        assert len(result.errors) > 0
+
+    def test_returns_invalid_for_runtime_change_without_deploy_step(self) -> None:
+        result = validate_ticket_contract({**VALID_TICKET, "runtime_change": True})
+        assert result.valid is False
+        assert any("deploy_step" in e for e in result.errors)
+
+    def test_error_messages_are_strings(self) -> None:
+        result = validate_ticket_contract({**VALID_TICKET, "dod_evidence": []})
+        assert all(isinstance(e, str) for e in result.errors)


### PR DESCRIPTION
## Summary

- `ModelLinearTicketContract` (Pydantic v2, frozen, extra=forbid): enforces `ticket_id` matching `OMN-\d+`, non-empty `dod_evidence`, non-empty `golden_path`, `deploy_step` required when `runtime_change=True`
- `ModelDodEvidenceItem` + `ModelDodEvidenceCheck`: typed DoD evidence schema (one class per file)
- `ValidationResult` dataclass + `validate_ticket_contract()` function accepting `object`, returns structured result
- `TypedDictTicketInput` in `types/` per repo conventions
- `scripts/validate-pr-tickets.sh`: CI wrapper extracting `OMN-XXXX` from PR branch/title/body, fetching from Linear, validating, exiting non-zero on failure
- 16 TDD tests — all green; mypy + all pre-commit hooks pass

## Linear

Closes OMN-8916 (child of OMN-8908)

## Test plan

- [x] `test_accepts_valid_ticket` — well-formed ticket passes
- [x] `test_rejects_missing_dod_evidence` — missing field rejected
- [x] `test_rejects_empty_dod_evidence` — empty list rejected
- [x] `test_rejects_missing_golden_path` — missing field rejected
- [x] `test_rejects_empty_golden_path` — empty string rejected
- [x] `test_rejects_runtime_change_true_without_deploy_step` — cross-field validation
- [x] `test_rejects_extra_fields` — extra=forbid enforced
- [x] `test_is_frozen` — mutation attempt raises
- [x] `validate_ticket_contract` returns `ValidationResult(valid=True)` for valid input
- [x] `validate_ticket_contract` returns structured errors for invalid input
- [x] mypy strict — no errors