### PR TITLE
feat(agents): add is_verifier + dispatch_category to ModelAgentDefinition (OMN-8926)

### DIFF
--- a/src/omnibase_core/models/agents/model_agent_definition.py
+++ b/src/omnibase_core/models/agents/model_agent_definition.py
@@ -87,6 +87,15 @@ class ModelAgentDefinition(BaseModel):
     success_metrics: ModelSuccessMetrics | None = None
     integration_points: ModelIntegrationPoints | None = None
     transformation_context: ModelTransformationContext | None = None
+    # Dispatch-claim registry fields (OMN-8921)
+    is_verifier: bool = Field(
+        default=False,
+        description="When True, this agent is a verification-only agent and may not dispatch further Agent() calls",
+    )
+    dispatch_category: str | None = Field(
+        default=None,
+        description="Optional category tag for dispatch claim deduplication (e.g. 'fix_containers', 'merge_sweep')",
+    )
 
 
 __all__ = ["ModelAgentDefinition"]


### PR DESCRIPTION
## Summary

- Adds `is_verifier: bool = False` to `ModelAgentDefinition` — when True, agent may not dispatch further `Agent()` calls
- Adds `dispatch_category: str | None = None` — optional category tag for claim deduplication
- Both fields are optional with defaults; all existing YAML configs validate cleanly with `extra="ignore"`

## Test plan

- [x] All 59 existing `ModelAgentDefinition` tests pass (no regression)
- [x] All pre-commit hooks pass
- [ ] CI green

Part of OMN-8926 (omnibase_core side). Omniclaude YAML updates are in a companion PR. Part of OMN-8921 epic.