### PR TITLE
feat(cli): onex run accepts node names, not just workflow paths

### DIFF
--- a/src/omnibase_core/cli/cli_run.py
+++ b/src/omnibase_core/cli/cli_run.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""``onex run`` — execute a contract-declared workflow on the local runtime."""
+"""``onex run`` — execute a workflow or dispatch a deterministic node."""
 
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -17,27 +19,41 @@ from omnibase_core.runtime.runtime_local import (
     parse_backend_overrides,
 )
 
+_OMNIMARKET_PATH_DEFAULT = "/Volumes/PRO-G40/Code/omni_home/omnimarket"
 
-@click.command("run")
-@click.argument("workflow_path", type=click.Path(path_type=Path))
+
+def _is_yaml_path(value: str) -> bool:
+    """Return True if value looks like a file path to a YAML workflow."""
+    return value.endswith((".yaml", ".yml")) or Path(value).exists()
+
+
+def _resolve_omnimarket_path() -> Path:
+    raw = os.environ.get("OMNIMARKET_PATH", _OMNIMARKET_PATH_DEFAULT)
+    return Path(raw)
+
+
+@click.command(
+    "run", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+@click.argument("target")
 @click.option(
     "--state-root",
     type=click.Path(path_type=Path),
     default=".onex_state",
     show_default=True,
-    help="Root directory for disk state.",
+    help="Root directory for disk state (workflow mode only).",
 )
 @click.option(
     "--backend",
     multiple=True,
-    help="Override backend: --backend event_bus=inmemory",
+    help="Override backend: --backend event_bus=inmemory (workflow mode only).",
 )
 @click.option(
     "--timeout",
     type=int,
     default=300,
     show_default=True,
-    help="Max execution time in seconds.",
+    help="Max execution time in seconds (workflow mode only).",
 )
 @click.option(
     "--verbose",
@@ -46,31 +62,62 @@ from omnibase_core.runtime.runtime_local import (
     default=False,
     help="Enable DEBUG-level logging (default is INFO).",
 )
+@click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 def run_workflow(
+    target: str,
+    state_root: Path,
+    backend: tuple[str, ...],
+    timeout: int,
+    verbose: bool,
+    extra_args: tuple[str, ...],
+) -> None:
+    """Run a workflow YAML or dispatch a deterministic node by name.
+
+    TARGET is either:
+
+    \b
+      - A path to a workflow contract YAML file, OR
+      - A node name (e.g. merge_sweep, coderabbit_triage)
+
+    \b
+    Node invocation (passes extra args directly to the node):
+        onex run merge_sweep --repos OmniNode-ai/omni_home --dry-run
+        onex run coderabbit_triage --repo OmniNode-ai/omniclaude --pr 1332
+
+    \b
+    Workflow invocation (existing behaviour):
+        onex run workflow.yaml
+        onex run workflow.yaml --timeout 60 --backend event_bus=inmemory
+
+    \b
+    Exit codes (node mode):
+        Forwarded from the node process.
+
+    \b
+    Exit codes (workflow mode):
+        0  COMPLETED — terminal event received, evidence written
+        1  FAILED / TIMEOUT — terminal event with failure or timeout exceeded
+        2  PARTIAL — evidence written but no terminal event
+    """
+    if _is_yaml_path(target):
+        _run_workflow_yaml(
+            workflow_path=Path(target),
+            state_root=state_root,
+            backend=backend,
+            timeout=timeout,
+            verbose=verbose,
+        )
+    else:
+        _run_node(node_name=target, extra_args=extra_args, verbose=verbose)
+
+
+def _run_workflow_yaml(
     workflow_path: Path,
     state_root: Path,
     backend: tuple[str, ...],
     timeout: int,
     verbose: bool,
 ) -> None:
-    """Run a contract-declared workflow on the local runtime.
-
-    WORKFLOW_PATH is the path to a workflow contract YAML file. The contract
-    must declare a ``terminal_event`` topic that signals workflow completion.
-
-    \b
-    Exit codes:
-        0  COMPLETED — terminal event received, evidence written
-        1  FAILED / TIMEOUT — terminal event with failure or timeout exceeded
-        2  PARTIAL — evidence written but no terminal event
-
-    \b
-    Examples:
-        onex run workflow.yaml
-        onex run workflow.yaml --timeout 60
-        onex run workflow.yaml --backend event_bus=inmemory --state-root ./state
-    """
-    # Configure logging so runtime diagnostics are visible
     log_level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(
         level=log_level,
@@ -78,12 +125,10 @@ def run_workflow(
         datefmt="%H:%M:%S",
     )
 
-    # Validate workflow path exists
     if not workflow_path.exists():
         click.echo(f"Error: Workflow contract not found: {workflow_path}", err=True)
         sys.exit(1)
 
-    # Validate backend overrides
     try:
         backend_overrides = parse_backend_overrides(backend)
     except ModelOnexError as exc:
@@ -96,6 +141,29 @@ def run_workflow(
         backend_overrides=backend_overrides,
         timeout=timeout,
     )
-
     runtime.run()
     sys.exit(runtime.exit_code)
+
+
+def _run_node(node_name: str, extra_args: tuple[str, ...], verbose: bool) -> None:
+    omnimarket = _resolve_omnimarket_path()
+    if not omnimarket.exists():
+        click.echo(
+            f"Error: omnimarket not found at {omnimarket}. "
+            "Set OMNIMARKET_PATH to override.",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Normalise: strip leading node_ prefix if user accidentally included it
+    if node_name.startswith("node_"):
+        module_name = f"omnimarket.nodes.{node_name}"
+    else:
+        module_name = f"omnimarket.nodes.node_{node_name}"
+
+    if verbose:
+        click.echo(f"Dispatching node: {module_name}", err=True)
+
+    cmd = [sys.executable, "-m", module_name, *extra_args]
+    result = subprocess.run(cmd, cwd=str(omnimarket), check=False)
+    sys.exit(result.returncode)


### PR DESCRIPTION
## Summary

- `onex run <node_name> [args]` now dispatches the named omnimarket deterministic node directly
- If TARGET ends in `.yaml`/`.yml` or resolves to an existing file, existing workflow execution runs unchanged
- Otherwise TARGET is treated as a node name: `python -m omnimarket.nodes.node_<name> [extra_args...]`
- `OMNIMARKET_PATH` env var overrides the default omnimarket path
- Exit code is forwarded from the node subprocess

## Test plan

- [ ] `onex run merge_sweep --dry-run` → dispatches node, returns node output
- [ ] `onex run coderabbit_triage --repo OmniNode-ai/omniclaude --pr 1332 --dry-run` → dispatches node
- [ ] `onex run some-workflow.yaml` (missing file) → `Error: Workflow contract not found`
- [ ] `onex run --help` → shows updated docstring with both usage modes
- [ ] All pre-commit hooks pass (verified in commit)
- [ ] mypy strict passes (verified in commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `onex run` command now accepts a flexible `target` argument that automatically routes to either workflow file execution or node dispatch based on the input.
  * Added support for trailing arguments that pass directly through to the executed workflow or node command.
  * Enabled node dispatch execution allowing modules to be invoked from the omnimarket directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->