### PR TITLE
feat(runtime): ProtocolStateStore as reducer sink in RuntimeLocal [OMN-8946]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,11 +155,13 @@ When spawning polymorphic agents or AI assistants:
 Synchronous-return handlers invoked via `RuntimeLocal._run_single_handler` receive
 a **runtime-synthesized terminal event** after successful result classification.
 The runtime publishes to the contract's declared `terminal_event` topic with
-payload::
+payload:
 
-    {"status": "success" | "failure",
-     "correlation_id": "<uuid>",
-     "source": "runtime_local"}
+```json
+{"status": "success" | "failure",
+ "correlation_id": "<uuid>",
+ "source": "runtime_local"}
+```
 
 The `source: "runtime_local"` field lets consumers distinguish runtime-synthesized
 terminals from handler-published ones. This semantics applies **only** to the

--- a/src/omnibase_core/cli/cli_node.py
+++ b/src/omnibase_core/cli/cli_node.py
@@ -135,7 +135,7 @@ def run_node_by_name(
     Exit codes:
         0  COMPLETED — terminal event received, evidence written
         1  FAILED / TIMEOUT — terminal event with failure or timeout exceeded
-        2  PARTIAL — evidence written but no terminal event
+        3  PARTIAL — evidence written but no terminal event
 
     \b
     Examples:
@@ -165,5 +165,10 @@ def run_node_by_name(
         input_path=input_path,
         timeout=timeout,
     )
-    runtime.run()
+    # boundary-ok: catch all runtime errors (contract-load, bootstrap, input-validation) at the CLI boundary.
+    try:
+        runtime.run()
+    except Exception as exc:  # noqa: BLE001 — CLI boundary, all errors become exit 1
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
     sys.exit(runtime.exit_code)

--- a/src/omnibase_core/cli/cli_node.py
+++ b/src/omnibase_core/cli/cli_node.py
@@ -151,6 +151,7 @@ def run_node_by_name(
 
     resolved_contract = contract_path or _resolve_packaged_contract(node_name)
 
+    # boundary-ok: CLI boundary converts backend validation failures into user-facing stderr + exit code.
     try:
         backend_overrides = parse_backend_overrides(backend)
     except ModelOnexError as exc:

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -426,6 +426,10 @@ class RuntimeLocal:
         # of None.
         if result_obj is not None:
             self._result = self._classify_result(result_obj)
+            # NOTE(OMN-8946): Fail-loud policy — no try/except here. If state_store.put()
+            # raises, the exception propagates and the runtime fails. Silent persistence
+            # failures defeat the purpose of this sink (user decision: "No fucking fallbacks.
+            # The runtime either works or doesn't.").
             await self._persist_reducer_projection_if_applicable(result_obj)
             await self._publish_synthesized_terminal(bus, terminal_topic)
             logger.info("RuntimeLocal: handler returned, result=%s", self._result.value)
@@ -1008,7 +1012,8 @@ class RuntimeLocal:
         is_reducer_output_shape = (
             isinstance(result_obj, dict)
             and "state" in result_obj
-            and isinstance(result_obj.get("intents", []), list)
+            and "intents" in result_obj
+            and isinstance(result_obj["intents"], list)
         )
 
         if not is_reducer_output_shape:

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -44,6 +44,11 @@ KNOWN_BACKEND_KEYS: frozenset[str] = frozenset(
 )
 
 
+class _StatePersistenceError(BaseException):
+    """Raised when ProtocolStateStore.put() fails; inherits BaseException so it
+    escapes broad `except Exception` handlers and surfaces as a hard failure."""
+
+
 @dataclass(frozen=True)
 class _ResolvedRoutingEntry:
     """A single resolved handler routing entry with concrete topics."""
@@ -426,11 +431,13 @@ class RuntimeLocal:
         # of None.
         if result_obj is not None:
             self._result = self._classify_result(result_obj)
-            # NOTE(OMN-8946): Fail-loud policy — no try/except here. If state_store.put()
-            # raises, the exception propagates and the runtime fails. Silent persistence
-            # failures defeat the purpose of this sink (user decision: "No fucking fallbacks.
-            # The runtime either works or doesn't.").
-            await self._persist_reducer_projection_if_applicable(result_obj)
+            # Fail-loud policy (OMN-8946): persistence errors must escape the broad
+            # except Exception blocks in run_async(). Wrap in _StatePersistenceError
+            # (BaseException subclass) so they are never silently downgraded to FAILED.
+            try:
+                await self._persist_reducer_projection_if_applicable(result_obj)
+            except Exception as _persist_exc:
+                raise _StatePersistenceError(str(_persist_exc)) from _persist_exc
             await self._publish_synthesized_terminal(bus, terminal_topic)
             logger.info("RuntimeLocal: handler returned, result=%s", self._result.value)
             return
@@ -951,7 +958,10 @@ class RuntimeLocal:
         )
 
         self._result = self._classify_result(result_obj)
-        await self._persist_reducer_projection_if_applicable(result_obj)
+        try:
+            await self._persist_reducer_projection_if_applicable(result_obj)
+        except Exception as _persist_exc:
+            raise _StatePersistenceError(str(_persist_exc)) from _persist_exc
         logger.info(
             "RuntimeLocal: compute handler returned, result=%s", self._result.value
         )
@@ -1149,6 +1159,8 @@ class RuntimeLocal:
         except Exception:
             logger.exception("RuntimeLocal: unhandled exception during execution")
             self._result = EnumWorkflowResult.FAILED
+        # _StatePersistenceError (BaseException) intentionally not caught here — it
+        # escapes to the CLI boundary so state-store failures are loud, not silent FAILED.
         finally:
             await bus.close()
             self._write_state()
@@ -1230,7 +1242,9 @@ class RuntimeLocal:
                     else:
                         # Handle tuple[T, ...] and list[T] with empty default
                         origin = typing.get_origin(ann)
-                        if origin is tuple or origin is list:
+                        if origin is list:
+                            defaults[field_name] = []
+                        elif origin is tuple:
                             defaults[field_name] = ()
             try:
                 return cls(**defaults)

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -186,6 +186,9 @@ class RuntimeLocal:
         self._last_error: str | None = None
         self._handlers_wired: list[str] = []
 
+        # ProtocolStateStore (resolved via DI in run_async). None if registry bootstrap fails.
+        self._state_store: Any = None
+
     # ONEX_EXCLUDE: dict_str_any — event bus payload
     def _on_terminal_event(self, payload: dict[str, Any]) -> None:
         """Callback invoked when a message arrives on the terminal_event topic."""
@@ -423,6 +426,7 @@ class RuntimeLocal:
         # of None.
         if result_obj is not None:
             self._result = self._classify_result(result_obj)
+            await self._persist_reducer_projection_if_applicable(result_obj)
             await self._publish_synthesized_terminal(bus, terminal_topic)
             logger.info("RuntimeLocal: handler returned, result=%s", self._result.value)
             return
@@ -943,8 +947,112 @@ class RuntimeLocal:
         )
 
         self._result = self._classify_result(result_obj)
+        await self._persist_reducer_projection_if_applicable(result_obj)
         logger.info(
             "RuntimeLocal: compute handler returned, result=%s", self._result.value
+        )
+
+    async def _bootstrap_state_store(self) -> None:
+        """Resolve ProtocolStateStore from the DI container (OMN-8946).
+
+        NO fallbacks. NO silent degrade. NO try/except.
+
+        The runtime either bootstraps a working state store or it does not run.
+        Failure modes (ImportError, ModelOnexError, registry errors) propagate
+        unmodified so callers see real problems instead of reducer projections
+        silently disappearing.
+
+        Uses the public `auto_configure_registry(container)` API so the
+        instance is not hardcoded — ServiceStateDisk (or whichever backend
+        wins probe resolution) is wired via entry points + local defaults at
+        `container/container_auto_config.py`.
+        """
+        from omnibase_core.container.container_auto_config import (
+            auto_configure_registry,
+        )
+        from omnibase_core.models.container.model_onex_container import (
+            ModelONEXContainer,
+        )
+        from omnibase_core.protocols.storage.protocol_state_store import (
+            ProtocolStateStore,
+        )
+
+        container = ModelONEXContainer(enable_service_registry=True)
+        await auto_configure_registry(container, state_root=self.state_root)
+        self._state_store = await container.service_registry.resolve_service(
+            ProtocolStateStore,
+        )
+        logger.info("RuntimeLocal: ProtocolStateStore resolved via DI container")
+
+    async def _persist_reducer_projection_if_applicable(
+        self,
+        result_obj: Any,
+    ) -> None:
+        """Persist reducer handler output to ProtocolStateStore when applicable.
+
+        Authority model (OMN-8946):
+            - Contract MUST declare `node_type: reducer` (authority: contract, not shape).
+            - Handler output MUST be a dict with `"state"` key AND (optionally)
+              `"intents"` as a list — matching the real reducer convention at
+              node_loop_state_reducer/handlers/handler_loop_state.py:96-110.
+
+        A dict-with-state output from a non-reducer contract is logged but NOT
+        persisted. This closes the "accidental-dict-trigger" bug class.
+
+        NO try/except around state_store.put(). If persistence fails, the
+        error propagates — silent persist failures would reintroduce exactly
+        the class of bug this task exists to fix.
+        """
+        contract_node_type = str(self._contract.get("node_type", "")).strip().lower()
+        is_reducer_contract = contract_node_type == "reducer"
+        is_reducer_output_shape = (
+            isinstance(result_obj, dict)
+            and "state" in result_obj
+            and isinstance(result_obj.get("intents", []), list)
+        )
+
+        if not is_reducer_output_shape:
+            return
+
+        if not is_reducer_contract:
+            logger.debug(
+                "RuntimeLocal: dict-with-state output ignored — contract "
+                "node_type=%r is not 'reducer' (accidental-shape-match guard)",
+                contract_node_type,
+            )
+            return
+
+        from datetime import UTC, datetime
+
+        from omnibase_core.models.state.model_state_envelope import ModelStateEnvelope
+
+        declared_node_id = (self._contract.get("node_identity") or {}).get("node_id")
+        contract_name = self._contract.get("name", "unknown_reducer")
+        node_id = declared_node_id or (
+            contract_name
+            if str(contract_name).startswith("node_")
+            else f"node_{contract_name}"
+        )
+        scope_id = (self._contract.get("node_identity") or {}).get(
+            "scope_id", "default"
+        )
+
+        # ModelStateEnvelope schema per models/state/model_state_envelope.py:
+        #   node_id, scope_id, data (dict), written_at, contract_fingerprint.
+        # The reducer's `handle()` returns `{"state": ..., "intents": ...}` — the
+        # `"state"` portion becomes `data`. The `"intents"` portion is not persisted
+        # here (intents are for downstream emission, outside the state projection).
+        envelope = ModelStateEnvelope(
+            node_id=node_id,
+            scope_id=scope_id,
+            data=result_obj["state"],
+            written_at=datetime.now(UTC),
+        )
+        await self._state_store.put(envelope)
+        logger.info(
+            "RuntimeLocal: persisted reducer projection node_id=%s scope_id=%s",
+            envelope.node_id,
+            envelope.scope_id,
         )
 
     # ------------------------------------------------------------------
@@ -962,6 +1070,12 @@ class RuntimeLocal:
         # ONEX_STATE_ROOT — they receive state via ProtocolStateStore DI.
         # See OMN-8938 plan Task 3 Step 6.
         os.environ["ONEX_STATE_ROOT"] = str(self.state_root)
+
+        # 0. Resolve ProtocolStateStore via DI (OMN-8946). Runtime now uses the
+        # registered ServiceStateDisk as a reducer sink (was previously only
+        # registered, never consumed). Gracefully degrades to None if the
+        # container cannot bootstrap.
+        await self._bootstrap_state_store()
 
         # 1. Load contract
         self._contract = load_workflow_contract(self.workflow_path)

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -1088,8 +1088,7 @@ class RuntimeLocal:
 
         # 0. Resolve ProtocolStateStore via DI (OMN-8946). Runtime now uses the
         # registered ServiceStateDisk as a reducer sink (was previously only
-        # registered, never consumed). Gracefully degrades to None if the
-        # container cannot bootstrap.
+        # registered, never consumed). NO fallbacks — failures propagate.
         await self._bootstrap_state_store()
 
         # 1. Load contract

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -492,6 +492,7 @@ class RuntimeLocal:
                 }
             ).encode("utf-8"),
         )
+        self._record_event("(terminal)")
 
     # ------------------------------------------------------------------
     # Event-driven execution path

--- a/tests/fixtures/handler_proof_reducer.py
+++ b/tests/fixtures/handler_proof_reducer.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Test-only reducer fixture for OMN-8946 state-sink wiring.
+
+Mirrors the real reducer handler convention in
+omnimarket/src/omnimarket/nodes/node_loop_state_reducer/handlers/handler_loop_state.py:96-110:
+- pure `delta(state, event) -> (new_state, intents[])`
+- `handle()` is a RuntimeLocal-protocol shim that wraps the tuple in a dict
+
+This fixture is test-only. Production handlers MUST NOT import from it.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ModelProofReducerInput(BaseModel):
+    """Test-only input. Not a production type."""
+
+    counter_delta: int = 0
+
+
+class ModelProofReducerState(BaseModel):
+    """Test-only state. Not a production type."""
+
+    counter: int = 0
+
+
+class HandlerProofReducer:
+    """Test-only reducer. Pure delta, dict-shape handle() shim."""
+
+    def delta(
+        self,
+        state: ModelProofReducerState,
+        event: ModelProofReducerInput,
+    ) -> tuple[ModelProofReducerState, list[dict]]:
+        """Pure: no I/O, no env reads, no bus publishes."""
+        new_state = ModelProofReducerState(counter=state.counter + event.counter_delta)
+        return new_state, []
+
+    def handle(self, request: ModelProofReducerInput) -> dict:
+        """RuntimeLocal-protocol shim. Wraps delta() tuple in dict convention."""
+        initial = ModelProofReducerState(counter=0)
+        new_state, intents = self.delta(initial, request)
+        return {
+            "state": new_state.model_dump(mode="json"),
+            "intents": intents,
+        }

--- a/tests/test_runtime_local_input_flag.py
+++ b/tests/test_runtime_local_input_flag.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+
+pytestmark = pytest.mark.unit
 from omnibase_core.runtime.runtime_local import RuntimeLocal
 
 

--- a/tests/test_runtime_local_reducer_state_sink.py
+++ b/tests/test_runtime_local_reducer_state_sink.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
 from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+
+pytestmark = pytest.mark.unit
 from omnibase_core.runtime.runtime_local import RuntimeLocal
 
 

--- a/tests/test_runtime_local_reducer_state_sink.py
+++ b/tests/test_runtime_local_reducer_state_sink.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Test that RuntimeLocal persists reducer projections to ServiceStateDisk (OMN-8946).
+
+Gating: persistence fires only when contract declares `node_type: reducer` AND
+handler output is a dict with `"state"` key. State store layout per
+service_state_disk.py:38-39 is `<state_root>/<node_id>/<scope_id>/state.yaml`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_core.runtime.runtime_local import RuntimeLocal
+
+
+def test_reducer_projection_persists_to_state_store(tmp_path: Path) -> None:
+    """Reducer handler output is persisted via ProtocolStateStore.put()."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(
+        "---\n"
+        "name: proof_reducer\n"
+        "node_type: reducer\n"
+        "handler:\n"
+        "  module: tests.fixtures.handler_proof_reducer\n"
+        "  class: HandlerProofReducer\n"
+        "  input_model: tests.fixtures.handler_proof_reducer.ModelProofReducerInput\n"
+        "handler_routing:\n"
+        "  default_handler: tests.fixtures.handler_proof_reducer:HandlerProofReducer\n",
+        encoding="utf-8",
+    )
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"counter_delta": 7}), encoding="utf-8")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        input_path=input_path,
+        timeout=10,
+    )
+    result = runtime.run()
+
+    assert result == EnumWorkflowResult.COMPLETED
+    # Layout: <state_root>/<node_id>/<scope_id>/state.yaml
+    # node_id derived from contract `name` with node_ prefix.
+    state_yaml = tmp_path / "state" / "node_proof_reducer" / "default" / "state.yaml"
+    assert state_yaml.exists(), f"state projection missing at {state_yaml}"
+    envelope = yaml.safe_load(state_yaml.read_text(encoding="utf-8"))
+    assert envelope["node_id"] == "node_proof_reducer"
+    assert envelope["scope_id"] == "default"
+    # ModelStateEnvelope field is `data`, not `state` (see model_state_envelope.py:28).
+    assert envelope["data"]["counter"] == 7
+    assert "written_at" in envelope
+
+
+def test_non_reducer_contract_with_dict_state_does_not_persist(tmp_path: Path) -> None:
+    """Dict-shape output from a non-reducer contract must NOT trigger persistence.
+
+    Guards the 'accidental-dict-trigger' class of bugs the reviewer flagged.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    # Note: node_type is "compute", not "reducer".
+    contract_path.write_text(
+        "---\n"
+        "name: proof_compute\n"
+        "node_type: compute\n"
+        "handler:\n"
+        "  module: tests.fixtures.handler_proof_reducer\n"
+        "  class: HandlerProofReducer\n"
+        "  input_model: tests.fixtures.handler_proof_reducer.ModelProofReducerInput\n"
+        "handler_routing:\n"
+        "  default_handler: tests.fixtures.handler_proof_reducer:HandlerProofReducer\n",
+        encoding="utf-8",
+    )
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"counter_delta": 7}), encoding="utf-8")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        input_path=input_path,
+        timeout=10,
+    )
+    runtime.run()
+
+    # State dir may exist for workflow_result.json but no reducer projection.
+    projection = tmp_path / "state" / "node_proof_compute" / "default" / "state.yaml"
+    assert not projection.exists(), (
+        "Non-reducer contract produced persisted state — authority gate failed"
+    )

--- a/tests/unit/cli/test_cli_node.py
+++ b/tests/unit/cli/test_cli_node.py
@@ -21,6 +21,8 @@ from click.testing import CliRunner
 
 from omnibase_core.cli.cli_node import _resolve_packaged_contract, run_node_by_name
 
+pytestmark = pytest.mark.unit
+
 
 def test_unknown_node_name_reports_known_names() -> None:
     """Unknown name errors with the list of known names."""
@@ -31,17 +33,38 @@ def test_unknown_node_name_reports_known_names() -> None:
     assert "Unknown node 'definitely_not_a_real_node'" in combined
 
 
-def test_valid_node_name_resolves_packaged_contract() -> None:
-    """A real onex.nodes entry point resolves to a packaged contract.yaml.
+def test_valid_node_name_resolves_packaged_contract(tmp_path: Path) -> None:
+    """A known onex.nodes entry point resolves to a packaged contract.yaml.
 
-    Skipped if no onex.nodes entry points are registered in the test env.
+    Stubs entry_points and importlib.import_module so the test owns the registry
+    and does not depend on which packages are installed in the environment.
     """
-    from importlib.metadata import entry_points
+    fake_pkg = tmp_path / "fake_node_pkg"
+    fake_pkg.mkdir()
+    contract_file = fake_pkg / "contract.yaml"
+    contract_file.write_text("name: test_node\n", encoding="utf-8")
 
-    available = [ep.name for ep in entry_points(group="onex.nodes")]
-    if not available:
-        pytest.skip("No onex.nodes entry points registered in this env")
-    contract = _resolve_packaged_contract(available[0])
+    import types
+
+    fake_module = types.ModuleType("fake_node_pkg")
+    fake_module.__file__ = str(fake_pkg / "__init__.py")
+
+    class _FakeEP:
+        name = "test.node"
+        value = "fake_node_pkg"
+        dist = "local-fake"
+
+    with (
+        patch(
+            "omnibase_core.cli.cli_node.entry_points",
+            return_value=[_FakeEP()],
+        ),
+        patch(
+            "omnibase_core.cli.cli_node.importlib.import_module",
+            return_value=fake_module,
+        ),
+    ):
+        contract = _resolve_packaged_contract("test.node")
     assert contract.name == "contract.yaml"
     assert contract.exists()
 
@@ -49,18 +72,12 @@ def test_valid_node_name_resolves_packaged_contract() -> None:
 def test_contract_override_wins_over_packaged(tmp_path: Path) -> None:
     """``--contract <path>`` takes precedence over the packaged contract.
 
-    Proves the override was honored by confirming the CLI processes the
-    override's contract path (not the packaged one): we point --contract
-    at a well-formed YAML whose handler module does not exist. The runtime
-    attempts to resolve that bogus handler, fails, and exits non-zero.
-    A FAILED exit with the handler-not-found log confirms override wins.
+    Proves the override was honored: we point --contract at a well-formed YAML
+    whose handler module does not exist. The runtime attempts to resolve that
+    bogus handler, fails, and exits non-zero — confirming the override was used,
+    not the packaged contract. Uses a dummy node name to avoid any dependency on
+    installed onex.nodes entry points.
     """
-    from importlib.metadata import entry_points
-
-    available = [ep.name for ep in entry_points(group="onex.nodes")]
-    if not available:
-        pytest.skip("No onex.nodes entry points registered in this env")
-
     override = tmp_path / "custom_contract.yaml"
     override.write_text(
         "---\n"
@@ -75,7 +92,7 @@ def test_contract_override_wins_over_packaged(tmp_path: Path) -> None:
     result = runner.invoke(
         run_node_by_name,
         [
-            available[0],
+            "unused-node-name",
             "--contract",
             str(override),
             "--state-root",
@@ -85,8 +102,8 @@ def test_contract_override_wins_over_packaged(tmp_path: Path) -> None:
         ],
     )
     # Exit code 1 = FAILED (handler could not be resolved from override). If the
-    # override had been ignored and the packaged contract loaded instead, the
-    # well-formed packaged handler would have succeeded or hit a different error.
+    # override had been ignored and packaged resolution ran, it would have raised
+    # a ClickException for the unknown node — a different failure mode.
     assert result.exit_code == 1
 
 

--- a/tests/unit/cli/test_cli_node.py
+++ b/tests/unit/cli/test_cli_node.py
@@ -76,7 +76,8 @@ def test_contract_override_wins_over_packaged(tmp_path: Path) -> None:
     whose handler module does not exist. The runtime attempts to resolve that
     bogus handler, fails, and exits non-zero — confirming the override was used,
     not the packaged contract. Uses a dummy node name to avoid any dependency on
-    installed onex.nodes entry points.
+    installed onex.nodes entry points. Asserts _resolve_packaged_contract was
+    never consulted (the override path must short-circuit it entirely).
     """
     override = tmp_path / "custom_contract.yaml"
     override.write_text(
@@ -89,21 +90,28 @@ def test_contract_override_wins_over_packaged(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     runner = CliRunner()
-    result = runner.invoke(
-        run_node_by_name,
-        [
-            "unused-node-name",
-            "--contract",
-            str(override),
-            "--state-root",
-            str(tmp_path / "state"),
-            "--timeout",
-            "5",
-        ],
-    )
+    with patch(
+        "omnibase_core.cli.cli_node._resolve_packaged_contract",
+        side_effect=AssertionError(
+            "_resolve_packaged_contract must not be called when --contract is provided"
+        ),
+    ) as mock_resolve:
+        result = runner.invoke(
+            run_node_by_name,
+            [
+                "unused-node-name",
+                "--contract",
+                str(override),
+                "--state-root",
+                str(tmp_path / "state"),
+                "--timeout",
+                "5",
+            ],
+        )
+    mock_resolve.assert_not_called()
     # Exit code 1 = FAILED (handler could not be resolved from override). If the
     # override had been ignored and packaged resolution ran, it would have raised
-    # a ClickException for the unknown node — a different failure mode.
+    # AssertionError above — a different failure mode.
     assert result.exit_code == 1
 
 


### PR DESCRIPTION
## Summary

Fixes the core architectural gap surfaced by OMN-8935: `ProtocolStateStore` is DI-registered via `container_auto_config._register_local_defaults` but `RuntimeLocal` never called `state_store.put()`. **Reducer projections have never persisted.** This PR wires the sink.

## Authority model

Persistence requires BOTH:
1. Contract declares `node_type: reducer` (contract authority, not output shape)
2. Handler output is dict with `"state"` key and `"intents"` list

Defensive log for dict-shape output from non-reducer contract — closes the "accidental-dict-trigger" bug class.

## No fallbacks

`_bootstrap_state_store` has no try/except. ImportError, ModelOnexError, registry failures all propagate — silent degrade would reintroduce exactly the bug class this PR exists to fix. Per CLAUDE.md "Fail-fast on missing env, not silent fallback".

## Ticket references

- Epic: OMN-8943 — Prove Full Four-Node ONEX Pattern End-to-End
- OMN-8946 (Task 3: substrate fix)
- Plan: https://github.com/OmniNode-ai/omni_home/blob/jonah/session-handoff-2026-04-16-morning/docs/plans/2026-04-16-prove-full-four-node-pattern-end-to-end.md
- Proof receipt: https://github.com/OmniNode-ai/omni_home/blob/jonah/session-handoff-2026-04-16-morning/docs/proofs/2026-04-16-four-node-proof.md

## Depends on

- omnibase_core#825 (OMN-8938 `onex node` CLI rename) — this branch is stacked on jonah/omn-runtime-proof until #825 merges; will rebase to main after.

## Paired PR

- omnimarket four-node-proof — builds 4 ledger nodes + PoL script that exercise this sink.

## Test plan

- [x] 2 new tests in `tests/test_runtime_local_reducer_state_sink.py`: persist + defensive non-reducer guard
- [x] 363 runtime+cli tests pass locally
- [x] PoL script (paired omnimarket PR): `uv run onex node node_ledger_state_reducer --input fixtures/ledger_hash_computed.json` produces on-disk YAML with field-level assertion
- [ ] CI full suite (gate on this PR)

## Standalone Proof Boundary

Per plan: canonical local-runtime shape coverage, not broker-parity. DLQ + `consumer_group` remain documented local-mode exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reducer nodes can now persist state to the configured state store.

* **Bug Fixes**
  * CLI now emits clearer error messages and exits consistently for runtime failures; adjusted exit code for a partial-result case.

* **Documentation**
  * Clarified terminal event payload example formatting in docs.

* **Tests**
  * Added unit tests covering reducer state persistence and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[skip-deploy-gate: Deploy-agent inactive (OMN-8841) — diff is pure Python library code in runtime_local.py, no container paths changed]