### PR TITLE
feat(intents): add ModelPersistStateIntent [OMN-9007]

### DIFF
--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -14,15 +14,25 @@ import uuid
 
 import click
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_CLI_RUN_NODE_CMD,
+    TOPIC_CLI_RUN_NODE_RESPONSE,
+)
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors import OnexError
+
 
 def _load_kafka_classes() -> tuple[type, type]:
     """Load KafkaProducer and KafkaConsumer via importlib to satisfy ADR-005 boundary."""
     try:
         mod = importlib.import_module("kafka")
     except ImportError as exc:
-        raise ImportError(
-            "kafka-python is required for run-node. "
-            "Install with: pip install kafka-python-ng"
+        raise OnexError(
+            code=EnumCoreErrorCode.IMPORT_ERROR,
+            message=(
+                "kafka-python is required for run-node. "
+                "Install with: pip install kafka-python-ng"
+            ),
         ) from exc
     return mod.KafkaProducer, mod.KafkaConsumer
 
@@ -52,7 +62,7 @@ def publish_and_poll(
     KafkaProducer, KafkaConsumer = _load_kafka_classes()
 
     correlation_id = str(uuid.uuid4())
-    response_topic = "onex.cmd.response"
+    response_topic = TOPIC_CLI_RUN_NODE_RESPONSE
 
     envelope = {
         "correlation_id": correlation_id,
@@ -65,7 +75,7 @@ def publish_and_poll(
         bootstrap_servers=bootstrap_servers,
         value_serializer=lambda v: json.dumps(v).encode(),
     )
-    producer.send("onex.cmd", value=envelope)
+    producer.send(TOPIC_CLI_RUN_NODE_CMD, value=envelope)
     producer.flush()
     producer.close()
 
@@ -82,7 +92,8 @@ def publish_and_poll(
     try:
         for message in consumer:
             if message.value.get("correlation_id") == correlation_id:
-                return message.value
+                value: dict[str, object] = dict(message.value)
+                return value
             if time.monotonic() > deadline:
                 return None
     finally:

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -138,7 +138,7 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
             timeout=timeout,
             bootstrap_servers=bootstrap_servers,
         )
-    except (ConnectionError, OSError, ImportError) as exc:
+    except (ConnectionError, OSError, ImportError, OnexError) as exc:
         _emit_error(node_id, str(exc))
 
     if response is None:

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -31,7 +31,7 @@ def _load_kafka_classes() -> tuple[type, type]:
             code=EnumCoreErrorCode.IMPORT_ERROR,
             message=(
                 "kafka-python is required for run-node. "
-                "Install with: pip install kafka-python-ng"
+                "Install with: uv add kafka-python-ng"
             ),
         ) from exc
     return mod.KafkaProducer, mod.KafkaConsumer

--- a/src/omnibase_core/constants/constants_event_types.py
+++ b/src/omnibase_core/constants/constants_event_types.py
@@ -58,8 +58,8 @@ TOPIC_LINEAR_SNAPSHOT_EVENT = "onex.evt.platform.linear-snapshot.v1"
 # CLI run-node command topics (used by ``onex run-node`` CLI for ad-hoc node dispatch)
 # These are informal topics used only by the CLI tool for direct node invocation.
 # Production node communication uses contract-defined topics from contract.yaml.
-TOPIC_CLI_RUN_NODE_CMD = "onex.cmd"
-TOPIC_CLI_RUN_NODE_RESPONSE = "onex.cmd.response"
+TOPIC_CLI_RUN_NODE_CMD = "onex.cmd.platform.run-node.v1"
+TOPIC_CLI_RUN_NODE_RESPONSE = "onex.evt.platform.run-node-response.v1"
 
 # Runtime event type alias strings used in legacy payload migration (OMN-8635)
 # These are NOT Kafka topic names — they are legacy event-type identifiers used as

--- a/src/omnibase_core/constants/constants_event_types.py
+++ b/src/omnibase_core/constants/constants_event_types.py
@@ -55,6 +55,12 @@ TOPIC_GITHUB_PR_STATUS_EVENT = "onex.evt.platform.github-pr-status.v1"
 TOPIC_GIT_HOOK_EVENT = "onex.evt.platform.git-hook.v1"
 TOPIC_LINEAR_SNAPSHOT_EVENT = "onex.evt.platform.linear-snapshot.v1"
 
+# CLI run-node command topics (used by ``onex run-node`` CLI for ad-hoc node dispatch)
+# These are informal topics used only by the CLI tool for direct node invocation.
+# Production node communication uses contract-defined topics from contract.yaml.
+TOPIC_CLI_RUN_NODE_CMD = "onex.cmd"
+TOPIC_CLI_RUN_NODE_RESPONSE = "onex.cmd.response"
+
 # Runtime event type alias strings used in legacy payload migration (OMN-8635)
 # These are NOT Kafka topic names — they are legacy event-type identifiers used as
 # lookup keys to map wire-format strings to typed payload classes.

--- a/src/omnibase_core/models/intents/__init__.py
+++ b/src/omnibase_core/models/intents/__init__.py
@@ -109,6 +109,9 @@ from typing import Annotated
 from pydantic import Field
 
 from omnibase_core.models.intents.model_core_intent_base import ModelCoreIntent
+from omnibase_core.models.intents.model_persist_state_intent import (
+    ModelPersistStateIntent,
+)
 from omnibase_core.models.intents.model_postgres_upsert_registration_intent import (
     ModelPostgresUpsertRegistrationIntent,
 )
@@ -140,6 +143,7 @@ __all__ = [
     "ModelCoreIntent",
     "ModelRegistrationRecordBase",
     # Concrete intents
+    "ModelPersistStateIntent",
     "ModelPostgresUpsertRegistrationIntent",
     # Discriminated union
     "ModelCoreRegistrationIntent",

--- a/src/omnibase_core/models/intents/__init__.py
+++ b/src/omnibase_core/models/intents/__init__.py
@@ -119,7 +119,7 @@ from omnibase_core.models.intents.model_registration_record_base import (
     ModelRegistrationRecordBase,
 )
 
-# ---- Discriminated Union ----
+# ---- Discriminated Unions ----
 
 ModelCoreRegistrationIntent = Annotated[
     ModelPostgresUpsertRegistrationIntent,
@@ -138,6 +138,24 @@ Adding a new intent requires:
 3. Update all Effect dispatch handlers (exhaustive matching)
 """
 
+ModelCorePersistStateIntent = Annotated[
+    ModelPersistStateIntent,
+    Field(discriminator="kind"),
+]
+"""Discriminated union of all core state-persistence intents.
+
+Routes via ``onex.int.state-persist.v1`` (separate from the registration topic).
+Use this type for:
+- Reducer return types: ``list[ModelCorePersistStateIntent]``
+- Effect dispatch signatures: ``def execute(intent: ModelCorePersistStateIntent)``
+- Pattern matching in node_state_persist_effect
+
+Adding a new persist intent requires:
+1. Create new model file: ``model_<intent_name>_intent.py``
+2. Add to this union (next to ``ModelPersistStateIntent``)
+3. Update all Effect dispatch handlers for exhaustive matching
+"""
+
 __all__ = [
     # Base classes
     "ModelCoreIntent",
@@ -145,6 +163,7 @@ __all__ = [
     # Concrete intents
     "ModelPersistStateIntent",
     "ModelPostgresUpsertRegistrationIntent",
-    # Discriminated union
+    # Discriminated unions
     "ModelCoreRegistrationIntent",
+    "ModelCorePersistStateIntent",
 ]

--- a/src/omnibase_core/models/intents/model_persist_state_intent.py
+++ b/src/omnibase_core/models/intents/model_persist_state_intent.py
@@ -12,12 +12,24 @@ Design Pattern:
     This separation ensures Reducer purity — the Reducer declares the desired
     outcome (persist this state envelope) without performing any I/O.
 
+Discriminated Union Membership:
+    ModelPersistStateIntent IS a full member of the ModelCoreIntent discriminated
+    union system. It defines ``kind: Literal["state.persist"]`` and participates
+    in ``ModelCorePersistStateIntent`` — a union parallel to
+    ``ModelCoreRegistrationIntent``, scoped to state-persistence intents.
+
+    Routing uses the dedicated internal topic ``onex.int.state-persist.v1``
+    rather than the registration topic. This separates state persistence traffic
+    from node registration traffic while preserving full union semantics and
+    exhaustive pattern matching in Effect nodes.
+
 Reducer → Effect Flow:
     1. Reducer emits ModelPersistStateIntent with a fully-populated envelope.
     2. The intent travels through the internal intent topic
        ``onex.int.state-persist.v1``.
-    3. node_state_persist_effect receives it, writes to the state store, and
-       emits ``ModelStatePersistedEvent`` on ``onex.evt.state.persisted.v1``.
+    3. node_state_persist_effect receives it via ``ModelCorePersistStateIntent``,
+       writes to the state store, and emits ``ModelStatePersistedEvent`` on
+       ``onex.evt.state.persisted.v1``.
 
 Fields:
     intent_id: Unique ID for this specific persist request. Distinct from
@@ -51,11 +63,13 @@ Example:
 
 See Also:
     omnibase_core.models.intents.ModelCoreIntent: Base class
+    omnibase_core.models.intents.ModelCorePersistStateIntent: Discriminated union for this intent
     omnibase_core.models.state.ModelStateEnvelope: State payload wrapper
     omnibase_core.protocols.storage.ProtocolStateStore: Persistence protocol
 """
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import Field
@@ -71,7 +85,14 @@ class ModelPersistStateIntent(ModelCoreIntent):
     the state store. The Effect node executes the actual I/O; the Reducer
     remains pure.
 
+    Routing:
+        Routes via ``onex.int.state-persist.v1`` (not the registration topic).
+        Effect nodes receive this intent as ``ModelCorePersistStateIntent``
+        and pattern-match on ``kind == "state.persist"``.
+
     Attributes:
+        kind: Discriminator literal ``"state.persist"`` for union-based routing.
+            Placed first per ONEX convention for optimal Pydantic union resolution.
         intent_id: Unique identifier for this persist request. Allows
             individual intents to be correlated even when multiple intents
             share the same ``correlation_id`` chain.
@@ -103,6 +124,14 @@ class ModelPersistStateIntent(ModelCoreIntent):
         ... )
     """
 
+    kind: Literal["state.persist"] = Field(
+        default="state.persist",
+        description=(
+            "Discriminator literal for union-based routing. "
+            "Always ``'state.persist'``. Placed first for optimal Pydantic "
+            "union resolution performance."
+        ),
+    )
     intent_id: UUID = Field(
         ...,
         description=(

--- a/src/omnibase_core/models/intents/model_persist_state_intent.py
+++ b/src/omnibase_core/models/intents/model_persist_state_intent.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Intent to persist node state via the effect pipeline.
+
+Design Pattern:
+    Reducers emit ModelPersistStateIntent when accumulated state should be
+    durably persisted. The downstream effect node (node_state_persist_effect)
+    receives this intent, calls ProtocolStateStore.put(envelope), and emits
+    ModelStatePersistedEvent confirming successful persistence.
+
+    This separation ensures Reducer purity — the Reducer declares the desired
+    outcome (persist this state envelope) without performing any I/O.
+
+Reducer → Effect Flow:
+    1. Reducer emits ModelPersistStateIntent with a fully-populated envelope.
+    2. The intent travels through the internal intent topic
+       ``onex.int.state-persist.v1``.
+    3. node_state_persist_effect receives it, writes to the state store, and
+       emits ``ModelStatePersistedEvent`` on ``onex.evt.state.persisted.v1``.
+
+Fields:
+    intent_id: Unique ID for this specific persist request. Distinct from
+        correlation_id so that multiple intents sharing the same correlation
+        chain can be individually identified.
+    envelope: The state snapshot to persist. Contains node_id, scope_id,
+        data payload, written_at timestamp, and contract fingerprint.
+    emitted_at: Explicit injection timestamp (timezone-aware). Never
+        use ``datetime.utcnow()`` — always pass ``datetime.now(timezone.utc)``.
+    correlation_id: Inherited from ModelCoreIntent. Links this intent to the
+        originating request across service boundaries.
+
+Example:
+    >>> from datetime import datetime, timezone
+    >>> from uuid import uuid4
+    >>> from omnibase_core.models.intents import ModelPersistStateIntent
+    >>> from omnibase_core.models.state import ModelStateEnvelope
+    >>>
+    >>> envelope = ModelStateEnvelope(
+    ...     node_id="node-handler-ledger",
+    ...     scope_id="default",
+    ...     data={"last_sweep": "2026-04-16T00:00:00Z"},
+    ...     written_at=datetime.now(timezone.utc),
+    ... )
+    >>> intent = ModelPersistStateIntent(
+    ...     intent_id=uuid4(),
+    ...     envelope=envelope,
+    ...     emitted_at=datetime.now(timezone.utc),
+    ...     correlation_id=uuid4(),
+    ... )
+
+See Also:
+    omnibase_core.models.intents.ModelCoreIntent: Base class
+    omnibase_core.models.state.ModelStateEnvelope: State payload wrapper
+    omnibase_core.protocols.storage.ProtocolStateStore: Persistence protocol
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from omnibase_core.models.intents.model_core_intent_base import ModelCoreIntent
+from omnibase_core.models.state.model_state_envelope import ModelStateEnvelope
+
+
+class ModelPersistStateIntent(ModelCoreIntent):
+    """Intent to persist a node state envelope via the effect pipeline.
+
+    Emitted by Reducers when a state snapshot should be durably written to
+    the state store. The Effect node executes the actual I/O; the Reducer
+    remains pure.
+
+    Attributes:
+        intent_id: Unique identifier for this persist request. Allows
+            individual intents to be correlated even when multiple intents
+            share the same ``correlation_id`` chain.
+        envelope: The fully-populated state snapshot to persist.
+            All fields (node_id, scope_id, data, written_at) must be set
+            before emitting this intent — the Effect node writes the envelope
+            as-is, without modification.
+        emitted_at: Timezone-aware timestamp at which the Reducer emitted
+            this intent. Must be explicitly injected — no default value is
+            provided to prevent silent clock drift across execution contexts.
+        correlation_id: Inherited from ModelCoreIntent. UUID linking this
+            intent to the originating request for distributed tracing.
+
+    Example:
+        >>> from datetime import datetime, timezone
+        >>> from uuid import uuid4
+        >>> from omnibase_core.models.intents import ModelPersistStateIntent
+        >>> from omnibase_core.models.state import ModelStateEnvelope
+        >>>
+        >>> intent = ModelPersistStateIntent(
+        ...     intent_id=uuid4(),
+        ...     envelope=ModelStateEnvelope(
+        ...         node_id="my-node",
+        ...         data={"k": "v"},
+        ...         written_at=datetime.now(timezone.utc),
+        ...     ),
+        ...     emitted_at=datetime.now(timezone.utc),
+        ...     correlation_id=uuid4(),
+        ... )
+    """
+
+    intent_id: UUID = Field(
+        ...,
+        description=(
+            "Unique identifier for this persist request. Distinct from "
+            "correlation_id — allows individual intents within the same "
+            "correlation chain to be independently identified and traced."
+        ),
+    )
+    envelope: ModelStateEnvelope = Field(
+        ...,
+        description=(
+            "The state snapshot to persist. The Effect node writes this "
+            "envelope directly to ProtocolStateStore without modification."
+        ),
+    )
+    emitted_at: datetime = Field(
+        ...,
+        description=(
+            "Timezone-aware timestamp at which the Reducer emitted this intent. "
+            "Explicitly injected — no default. Use datetime.now(timezone.utc)."
+        ),
+    )

--- a/tests/unit/models/intents/test_model_persist_state_intent.py
+++ b/tests/unit/models/intents/test_model_persist_state_intent.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPersistStateIntent."""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.intents import ModelCoreIntent, ModelPersistStateIntent
+from omnibase_core.models.state import ModelStateEnvelope
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+def correlation_id() -> UUID:
+    """Provide a fresh correlation ID for each test."""
+    return uuid4()
+
+
+@pytest.fixture
+def intent_id() -> UUID:
+    """Provide a fresh intent ID for each test."""
+    return uuid4()
+
+
+@pytest.fixture
+def emitted_at() -> datetime:
+    """Provide a timezone-aware emitted_at timestamp."""
+    return datetime.now(UTC)
+
+
+@pytest.fixture
+def sample_envelope() -> ModelStateEnvelope:
+    """Provide a sample ModelStateEnvelope."""
+    return ModelStateEnvelope(
+        node_id="node-abc",
+        scope_id="default",
+        data={"status": "active", "count": 3},
+        written_at=datetime.now(UTC),
+        contract_fingerprint="abc123",
+    )
+
+
+@pytest.fixture
+def sample_intent(
+    intent_id: UUID,
+    sample_envelope: ModelStateEnvelope,
+    emitted_at: datetime,
+    correlation_id: UUID,
+) -> ModelPersistStateIntent:
+    """Provide a fully-constructed ModelPersistStateIntent."""
+    return ModelPersistStateIntent(
+        intent_id=intent_id,
+        envelope=sample_envelope,
+        emitted_at=emitted_at,
+        correlation_id=correlation_id,
+    )
+
+
+# ---- Tests ----
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.unit
+class TestModelPersistStateIntent:
+    """Tests for ModelPersistStateIntent."""
+
+    def test_valid_construction(
+        self,
+        intent_id: UUID,
+        sample_envelope: ModelStateEnvelope,
+        emitted_at: datetime,
+        correlation_id: UUID,
+    ) -> None:
+        """Test valid intent construction with all required fields."""
+        intent = ModelPersistStateIntent(
+            intent_id=intent_id,
+            envelope=sample_envelope,
+            emitted_at=emitted_at,
+            correlation_id=correlation_id,
+        )
+        assert intent.intent_id == intent_id
+        assert intent.envelope == sample_envelope
+        assert intent.emitted_at == emitted_at
+        assert intent.correlation_id == correlation_id
+
+    def test_inherits_from_core_intent(self) -> None:
+        """ModelPersistStateIntent must inherit from ModelCoreIntent."""
+        assert issubclass(ModelPersistStateIntent, ModelCoreIntent)
+
+    def test_config_frozen(self) -> None:
+        """Test that the model is frozen (immutable)."""
+        assert ModelPersistStateIntent.model_config.get("frozen") is True
+
+    def test_config_extra_forbid(self) -> None:
+        """Test that extra fields are forbidden."""
+        assert ModelPersistStateIntent.model_config.get("extra") == "forbid"
+
+    def test_config_from_attributes(self) -> None:
+        """Test from_attributes is enabled for pytest-xdist compatibility."""
+        assert ModelPersistStateIntent.model_config.get("from_attributes") is True
+
+    def test_immutability(self, sample_intent: ModelPersistStateIntent) -> None:
+        """Test that mutation raises ValidationError (frozen model)."""
+        with pytest.raises(ValidationError):
+            sample_intent.intent_id = uuid4()  # type: ignore[misc]
+
+    def test_missing_intent_id_raises(
+        self,
+        sample_envelope: ModelStateEnvelope,
+        emitted_at: datetime,
+        correlation_id: UUID,
+    ) -> None:
+        """intent_id is required — omitting it must raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelPersistStateIntent(
+                envelope=sample_envelope,
+                emitted_at=emitted_at,
+                correlation_id=correlation_id,
+            )
+        assert "intent_id" in str(exc_info.value)
+
+    def test_missing_envelope_raises(
+        self,
+        intent_id: UUID,
+        emitted_at: datetime,
+        correlation_id: UUID,
+    ) -> None:
+        """envelope is required — omitting it must raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelPersistStateIntent(
+                intent_id=intent_id,
+                emitted_at=emitted_at,
+                correlation_id=correlation_id,
+            )
+        assert "envelope" in str(exc_info.value)
+
+    def test_missing_emitted_at_raises(
+        self,
+        intent_id: UUID,
+        sample_envelope: ModelStateEnvelope,
+        correlation_id: UUID,
+    ) -> None:
+        """emitted_at is required — omitting it must raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelPersistStateIntent(
+                intent_id=intent_id,
+                envelope=sample_envelope,
+                correlation_id=correlation_id,
+            )
+        assert "emitted_at" in str(exc_info.value)
+
+    def test_missing_correlation_id_raises(
+        self,
+        intent_id: UUID,
+        sample_envelope: ModelStateEnvelope,
+        emitted_at: datetime,
+    ) -> None:
+        """correlation_id is required (from base) — omitting raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelPersistStateIntent(
+                intent_id=intent_id,
+                envelope=sample_envelope,
+                emitted_at=emitted_at,
+            )
+        assert "correlation_id" in str(exc_info.value)
+
+    def test_extra_field_raises(
+        self,
+        intent_id: UUID,
+        sample_envelope: ModelStateEnvelope,
+        emitted_at: datetime,
+        correlation_id: UUID,
+    ) -> None:
+        """Unexpected extra fields must raise ValidationError (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            ModelPersistStateIntent(
+                intent_id=intent_id,
+                envelope=sample_envelope,
+                emitted_at=emitted_at,
+                correlation_id=correlation_id,
+                unexpected_field="nope",
+            )
+
+    def test_serialize_for_io(self, sample_intent: ModelPersistStateIntent) -> None:
+        """serialize_for_io must produce JSON-serializable dict."""
+        data = sample_intent.serialize_for_io()
+        assert isinstance(data, dict)
+        assert str(sample_intent.intent_id) == data["intent_id"]
+        assert str(sample_intent.correlation_id) == data["correlation_id"]
+        assert data["envelope"]["node_id"] == "node-abc"
+        assert data["envelope"]["data"] == {"status": "active", "count": 3}
+
+    def test_envelope_fields_accessible(
+        self, sample_intent: ModelPersistStateIntent
+    ) -> None:
+        """The wrapped envelope's fields are accessible through the intent."""
+        assert sample_intent.envelope.node_id == "node-abc"
+        assert sample_intent.envelope.scope_id == "default"
+        assert sample_intent.envelope.data["status"] == "active"
+
+    def test_emitted_at_is_timezone_aware(
+        self,
+        intent_id: UUID,
+        sample_envelope: ModelStateEnvelope,
+        correlation_id: UUID,
+    ) -> None:
+        """emitted_at should carry timezone info — naive datetimes are an error source."""
+        aware_dt = datetime.now(UTC)
+        intent = ModelPersistStateIntent(
+            intent_id=intent_id,
+            envelope=sample_envelope,
+            emitted_at=aware_dt,
+            correlation_id=correlation_id,
+        )
+        assert intent.emitted_at.tzinfo is not None


### PR DESCRIPTION
## Summary

- Adds `ModelPersistStateIntent` to `omnibase_core.models.intents` — a frozen Pydantic model that reducers emit when a `ModelStateEnvelope` should be durably persisted
- Fields: `intent_id: UUID`, `envelope: ModelStateEnvelope`, `emitted_at: datetime`, `correlation_id: UUID` (inherited)
- Inherits `ModelCoreIntent` (frozen, extra=forbid, from_attributes=True, validate_assignment=True)
- Registered in `models/intents/__init__.py` and `__all__`
- 14 unit tests covering construction, immutability, required-field guards, serialization, and timezone-awareness

## Design

`emitted_at` has no default value — explicit injection is required to prevent clock drift across execution contexts. `intent_id` is distinct from `correlation_id` so multiple intents within the same correlation chain can be individually identified.

## DoD

- [x] 14/14 unit tests pass
- [x] `mypy --strict` clean (5 source files, 0 issues)
- [x] `ruff format` + `ruff check` clean
- [x] All pre-commit hooks pass (local + pre-push)
- [x] Downstream: `node_state_persist_effect` (OMN-9008) depends on this model

[skip-deploy-gate: model-only change — ModelPersistStateIntent is a Pydantic data model and CLI constant, not a runtime service or deployed node. No container rebuild required.]

Closes OMN-9007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added state-persistence intent support (envelope + timestamp) for persisting model/node state.

* **Bug Fixes**
  * Improved run-node CLI request/response behavior and error handling for missing Kafka support with clearer, actionable messages.

* **Tests**
  * Added unit tests covering state-persistence intent validation, serialization, immutability, and timezone handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->