### PR TITLE
ci(handshake): drop path filter so gate runs on every PR [OMN-9049]

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -6,16 +6,9 @@ name: Check Architecture Handshake
 on:
   push:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - 'architecture-handshakes/**'
-      - '.github/workflows/check-handshake.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - 'architecture-handshakes/**'
-      - '.github/workflows/check-handshake.yml'
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Drop the `paths:` filter on `on.push` and `on.pull_request` in `.github/workflows/check-handshake.yml` so the architecture handshake gate fires on every PR, not just PRs that touch `.claude/architecture-handshake.md` or `architecture-handshakes/**`.
- Add `merge_group:` trigger so the gate also runs in the merge queue context.
- `workflow_dispatch:` trigger is preserved.

## Why

The gate existed but only fired when the handshake file itself changed, so it never actually blocked PRs that drifted from the architecture contract. This makes it universal: every PR now proves its handshake is current. omnibase_core is the source-of-truth repo (no remote checkout needed), but the gate needs to run universally here too for PRs that modify `architecture-handshakes/` and anywhere else.

## Test plan

- [x] YAML parses cleanly, `merge_group` trigger present, `paths` key absent
- [ ] On PR open, `Check Architecture Handshake / check-handshake` context fires in Actions

## Ticket

- Ticket: [OMN-9049](https://linear.app/omninode/issue/OMN-9049)
- Parent epic: OMN-9048
- Companion: OMN-9050 (automated SHA bump bot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow trigger configuration to run on merge queue events and all push/pull request events, ensuring broader validation coverage regardless of changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->