### PR TITLE
feat(validation): ValidatorBannedComposeVars — compose↔contract topic drift [OMN-9062]

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -56,6 +56,15 @@ allowed_files:
     added: "2026-01-10"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/validation/validator_banned_compose_vars.py"
+    reason: >-
+      Cross-schema drift validator - must parse heterogeneous YAML (docker-compose services, k8s Deployment/Pod
+      manifests, contract.yaml event_bus blocks) to extract env var names/values and topic strings. No
+      single Pydantic model covers all three schemas; the validator extracts flat (var_name, topic) tuples
+      for set comparison, not typed contract validation. (OMN-9062)
+    added: "2026-04-17"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/utils/util_safe_yaml_loader.py"
     reason: >-
       Foundational utility layer that bridges raw YAML parsing and Pydantic validation - provides safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,7 @@ ignore = [
 "src/omnibase_core/models/metadata/model_example_string_reduction_improvements.py" = ["T201"]
 "src/omnibase_core/services/service_validation_suite.py" = ["T201"]
 "src/omnibase_core/validation/validator_architecture.py" = ["T201"]
+"src/omnibase_core/validation/validator_banned_compose_vars.py" = ["T201"]
 "src/omnibase_core/validation/validator_base.py" = ["T201"]
 "src/omnibase_core/validation/validator_circular_import.py" = ["T201"]
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]

--- a/src/omnibase_core/enums/enum_compose_drift_kind.py
+++ b/src/omnibase_core/enums/enum_compose_drift_kind.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Compose-contract drift kind enumeration.
+
+Classifies violations found by ValidatorBannedComposeVars when comparing
+Docker compose / k8s manifest environment blocks against contract.yaml
+event_bus.subscribe_topics / publish_topics declarations.
+
+Related ticket: OMN-9062 (trigger: OMN-8840, parent: OMN-9048).
+"""
+
+import enum
+
+__all__ = ["EnumComposeDriftKind"]
+
+
+@enum.unique
+class EnumComposeDriftKind(enum.StrEnum):
+    """Kind of compose↔contract drift violation."""
+
+    BANNED_VAR = "BANNED_VAR"
+    MISSING_VAR = "MISSING_VAR"

--- a/src/omnibase_core/models/validation/model_compose_drift_violation.py
+++ b/src/omnibase_core/models/validation/model_compose_drift_violation.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Compose-contract drift violation model.
+
+Represents a single bidirectional drift between Docker compose / k8s
+environment blocks and contract.yaml event_bus topic declarations.
+
+Related ticket: OMN-9062 (trigger: OMN-8840, parent: OMN-9048).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
+
+__all__ = ["ModelComposeDriftViolation"]
+
+
+class ModelComposeDriftViolation(BaseModel):
+    """A single compose↔contract drift violation.
+
+    Two drift kinds are captured:
+
+    - BANNED_VAR: compose references an env var whose corresponding topic
+      is not declared by any contract.yaml — stale compose (e.g. the
+      OMN-8840 case where ``ONEX_INPUT_TOPIC`` survived in compose after
+      OMN-8784 removed it from code).
+
+    - MISSING_VAR: a contract declares a topic but no compose / k8s
+      manifest exposes the corresponding env var — orphaned contract.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: EnumComposeDriftKind = Field(description="Classification of the drift")
+    var_name: str = Field(description="Environment variable name involved in the drift")
+    compose_path: Path | None = Field(
+        default=None,
+        description=(
+            "Path to the compose / k8s manifest declaring the env var "
+            "(None for MISSING_VAR)"
+        ),
+    )
+    contract_path: Path | None = Field(
+        default=None,
+        description=(
+            "Path to the contract.yaml declaring the topic (None for BANNED_VAR)"
+        ),
+    )
+    message: str = Field(description="Human-readable violation message")

--- a/src/omnibase_core/validation/__init__.py
+++ b/src/omnibase_core/validation/__init__.py
@@ -122,6 +122,9 @@ from .envelope_validator import EnvelopeValidator
 
 # Import Any type validator (OMN-1291)
 from .validator_any_type import ValidatorAnyType
+from .validator_banned_compose_vars import (
+    ValidatorBannedComposeVars,
+)
 
 # Import validator base class (OMN-1291)
 from .validator_base import (
@@ -490,6 +493,8 @@ __all__ = [
     # Local path validator — detect machine-specific absolute paths
     "ValidatorLocalPaths",
     "ModelLocalPathViolation",
+    # Banned compose vars validator — compose↔contract topic drift (OMN-9062)
+    "ValidatorBannedComposeVars",
     # Naming Convention validator (OMN-1291)
     "ValidatorNamingConvention",
     "RULE_FILE_NAMING",

--- a/src/omnibase_core/validation/validator_banned_compose_vars.py
+++ b/src/omnibase_core/validation/validator_banned_compose_vars.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ValidatorBannedComposeVars — bidirectional compose↔contract topic drift.
+
+Builds the canonical set of ONEX topics declared by ``event_bus.subscribe_topics``
+/ ``publish_topics`` across every ``contract.yaml`` in the scanned tree, then
+compares against Docker-compose and Kubernetes manifest environment blocks.
+
+Two drift kinds are reported:
+
+- **BANNED_VAR**: compose/k8s references an ONEX topic string (via any env var
+  value) that no contract declares. Stale compose — the OMN-8840 pattern where
+  ``ONEX_INPUT_TOPIC`` persisted after OMN-8784 removed the topic from code.
+- **MISSING_VAR**: a contract declares a topic but no compose / k8s manifest
+  exposes it as any env var value. Orphaned contract.
+
+The validator deliberately ignores non-ONEX env var values (plain strings like
+``requests``, ``responses``) — the universe of drift it gates is ONEX topic
+strings matching ``onex.{kind}.{producer}.{event-name}.v{n}``.
+
+Related ticket: OMN-9062 (trigger: OMN-8840, parent: OMN-9048).
+
+Usage::
+
+    # Programmatic
+    from pathlib import Path
+    from omnibase_core.validation import ValidatorBannedComposeVars
+
+    validator = ValidatorBannedComposeVars()
+    violations = validator.check_paths([Path("omni_home")])
+
+    # CLI
+    python -m omnibase_core.validation.validator_banned_compose_vars omni_home/
+
+Exit codes:
+    0 — no drift
+    2 — drift detected
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Final
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
+from omnibase_core.models.validation.model_compose_drift_violation import (
+    ModelComposeDriftViolation,
+)
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# Canonical ONEX topic form: onex.{kind}.{producer}.{event-name}.v{n}
+# Kept in lock-step with validator_topic_suffix.TOPIC_SUFFIX_PATTERN.
+_ONEX_TOPIC_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\.v\d+$"
+)
+
+# Filename patterns recognised as compose / k8s manifests.
+_COMPOSE_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"^docker-compose.*\.ya?ml$")
+_COMPOSE_DIR_COMPONENTS: Final[frozenset[str]] = frozenset({"k8s", "kubernetes"})
+
+# Contract filenames (scanned for topic declarations).
+_CONTRACT_FILENAMES: Final[frozenset[str]] = frozenset(
+    {"contract.yaml", "contract.yml", "handler_contract.yaml"}
+)
+
+# Directories skipped during recursive scan.
+_SKIP_DIRS: Final[frozenset[str]] = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".tox",
+        ".venv",
+        "venv",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class ValidatorBannedComposeVars(BaseModel):
+    """Bidirectional compose↔contract topic drift detector.
+
+    Stateless — each call to :meth:`check_paths` returns violations without
+    mutating instance state. Safe to reuse across calls.
+
+    Thread Safety:
+        Instances are thread-safe because there is no mutable state.
+    """
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    def check_paths(self, paths: list[Path]) -> list[ModelComposeDriftViolation]:
+        """Scan the given files/directories and return every drift violation."""
+        # Maps: topic -> source path / (var_name, source) for compose.
+        contract_topics: dict[str, Path] = {}
+        compose_topics: dict[str, tuple[str, Path]] = {}
+
+        for base in paths:
+            for file_path in _iter_yaml_files(base):
+                if _is_contract_file(file_path):
+                    for topic in _extract_contract_topics(file_path):
+                        contract_topics.setdefault(topic, file_path)
+                elif _is_compose_or_k8s_file(file_path):
+                    for var_name, topic in _extract_compose_topic_refs(file_path):
+                        compose_topics.setdefault(topic, (var_name, file_path))
+
+        violations: list[ModelComposeDriftViolation] = []
+
+        # BANNED_VAR: compose references an ONEX topic no contract declares
+        for topic, (var_name, compose_path) in compose_topics.items():
+            if topic in contract_topics:
+                continue
+            violations.append(
+                ModelComposeDriftViolation(
+                    kind=EnumComposeDriftKind.BANNED_VAR,
+                    var_name=var_name,
+                    compose_path=compose_path,
+                    contract_path=None,
+                    message=(
+                        f"{compose_path} exposes env var {var_name!r} = "
+                        f"{topic!r} but no contract.yaml declares that topic "
+                        f"in event_bus.subscribe_topics / publish_topics. "
+                        f"Either declare the topic in a contract or remove "
+                        f"the stale env var from compose/k8s."
+                    ),
+                )
+            )
+
+        # MISSING_VAR: contract declares a topic no compose / k8s exposes
+        for topic, contract_path in contract_topics.items():
+            if topic in compose_topics:
+                continue
+            violations.append(
+                ModelComposeDriftViolation(
+                    kind=EnumComposeDriftKind.MISSING_VAR,
+                    var_name=_topic_to_var_hint(topic),
+                    compose_path=None,
+                    contract_path=contract_path,
+                    message=(
+                        f"{contract_path} declares topic {topic!r} but no "
+                        f"compose / k8s manifest exposes it via any env var. "
+                        f"Either wire the topic into compose/k8s or remove "
+                        f"the contract declaration."
+                    ),
+                )
+            )
+
+        violations.sort(
+            key=lambda v: (
+                v.kind.value,
+                v.var_name,
+                str(v.compose_path or v.contract_path),
+            )
+        )
+        return violations
+
+
+# ---------------------------------------------------------------------------
+# Helpers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _iter_yaml_files(base: Path) -> list[Path]:
+    """Return every YAML file under ``base`` (file or directory)."""
+    if base.is_file():
+        return [base] if base.suffix in {".yaml", ".yml"} else []
+    if not base.is_dir():
+        return []
+
+    results: list[Path] = []
+    for child in base.rglob("*"):
+        if any(part in _SKIP_DIRS for part in child.parts):
+            continue
+        if child.is_file() and child.suffix in {".yaml", ".yml"}:
+            results.append(child)
+    return sorted(results)
+
+
+def _is_contract_file(path: Path) -> bool:
+    return path.name in _CONTRACT_FILENAMES
+
+
+def _is_compose_or_k8s_file(path: Path) -> bool:
+    if _COMPOSE_NAME_PATTERN.match(path.name):
+        return True
+    return any(component in _COMPOSE_DIR_COMPONENTS for component in path.parts)
+
+
+def _load_yaml_safely(path: Path) -> object | None:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return None
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+
+def _extract_contract_topics(path: Path) -> list[str]:
+    """Extract every ONEX topic declared by this contract's event_bus block."""
+    doc = _load_yaml_safely(path)
+    if not isinstance(doc, dict):
+        return []
+    event_bus = doc.get("event_bus")
+    if not isinstance(event_bus, dict):
+        return []
+
+    topics: list[str] = []
+    for key in ("subscribe_topics", "publish_topics"):
+        raw = event_bus.get(key)
+        if isinstance(raw, list):
+            topics.extend(str(item) for item in raw if isinstance(item, str))
+
+    return [topic for topic in topics if _ONEX_TOPIC_PATTERN.match(topic)]
+
+
+def _extract_compose_topic_refs(path: Path) -> list[tuple[str, str]]:
+    """Extract every ``(var_name, topic)`` pair whose value is an ONEX topic.
+
+    Handles three forms:
+
+    - docker-compose ``environment:`` dict (``KEY: value``)
+    - docker-compose ``environment:`` list (``- KEY=value`` or ``- KEY: value``)
+    - k8s ``env:`` list of ``{name: KEY, value: VAL}``
+    """
+    doc = _load_yaml_safely(path)
+    if doc is None:
+        return []
+
+    return [
+        (var_name, value)
+        for var_name, value in _walk_env_pairs(doc)
+        if _ONEX_TOPIC_PATTERN.match(value)
+    ]
+
+
+def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
+    """Yield every ``(name, value)`` pair discoverable as container env."""
+    pairs: list[tuple[str, str]] = []
+
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "environment" and isinstance(value, dict):
+                for env_key, env_val in value.items():
+                    if isinstance(env_val, (str, int, float)):
+                        pairs.append((str(env_key), str(env_val)))
+            elif key == "environment" and isinstance(value, list):
+                for item in value:
+                    if isinstance(item, str) and "=" in item:
+                        k, _, v = item.partition("=")
+                        pairs.append((k.strip(), v.strip()))
+                    elif isinstance(item, dict) and "name" in item and "value" in item:
+                        pairs.append((str(item["name"]), str(item["value"])))
+            elif key == "env" and isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict) and "name" in item and "value" in item:
+                        pairs.append((str(item["name"]), str(item["value"])))
+            else:
+                pairs.extend(_walk_env_pairs(value))
+    elif isinstance(node, list):
+        for item in node:
+            pairs.extend(_walk_env_pairs(item))
+
+    return pairs
+
+
+def _topic_to_var_hint(topic: str) -> str:
+    """Produce a human-readable identifier for MISSING_VAR reports.
+
+    Contracts declare topics, not env var names; this surfaces the topic
+    itself as the "var_name" so consumers of the report can locate it.
+    """
+    return f"<missing-topic:{topic}>"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    Exit codes:
+        0 — no drift
+        2 — drift detected
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="check-banned-compose-vars",
+        description=(
+            "Detect bidirectional compose↔contract topic drift. "
+            "Exits 2 if any BANNED_VAR or MISSING_VAR violation is found."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path()],
+        help="Files or directories to scan (default: current directory)",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Suppress the summary footer",
+    )
+    parsed = parser.parse_args(argv)
+
+    validator = ValidatorBannedComposeVars()
+    violations = validator.check_paths(parsed.paths)
+
+    for v in violations:
+        location = v.compose_path if v.compose_path is not None else v.contract_path
+        print(f"{location}: [{v.kind.value}] {v.var_name}: {v.message}")
+
+    if not parsed.quiet:
+        if violations:
+            banned = sum(
+                1 for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR
+            )
+            missing = sum(
+                1 for v in violations if v.kind is EnumComposeDriftKind.MISSING_VAR
+            )
+            print(
+                f"\n{len(violations)} compose/contract drift violation(s): "
+                f"{banned} BANNED_VAR, {missing} MISSING_VAR.",
+                file=sys.stderr,
+            )
+        else:
+            print("No compose/contract drift found.", file=sys.stderr)
+
+    return 2 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/validation/validator_banned_compose_vars.py
+++ b/src/omnibase_core/validation/validator_banned_compose_vars.py
@@ -2,23 +2,31 @@
 # SPDX-License-Identifier: MIT
 
 """
-ValidatorBannedComposeVars — bidirectional compose↔contract topic drift.
+ValidatorBannedComposeVars — kernel-sourced banned env var detector.
 
-Builds the canonical set of ONEX topics declared by ``event_bus.subscribe_topics``
-/ ``publish_topics`` across every ``contract.yaml`` in the scanned tree, then
-compares against Docker-compose and Kubernetes manifest environment blocks.
+Scans every ``docker-compose*.yaml`` and every ``k8s/**/*.yaml`` for
+``environment:`` / ``env:`` blocks and flags any entry whose NAME appears in
+the kernel's ``_DEPRECATED_TOPIC_ENV_VARS`` constant (canonical source of
+truth for topic env vars that code no longer reads).
 
-Two drift kinds are reported:
+**Ground truth**: ``omnibase_infra/src/omnibase_infra/runtime/service_kernel.py``
+defines ``_DEPRECATED_TOPIC_ENV_VARS`` (OMN-8784). This validator parses that
+file via ``ast`` to pull the current set — single source of truth, no
+duplication.
 
-- **BANNED_VAR**: compose/k8s references an ONEX topic string (via any env var
-  value) that no contract declares. Stale compose — the OMN-8840 pattern where
-  ``ONEX_INPUT_TOPIC`` persisted after OMN-8784 removed the topic from code.
-- **MISSING_VAR**: a contract declares a topic but no compose / k8s manifest
-  exposes it as any env var value. Orphaned contract.
+The validator is layer-clean (omnibase_core cannot import omnibase_infra per
+repo layering rules). Instead it reads the kernel source as a text file and
+extracts the constant with a static AST walk.
 
-The validator deliberately ignores non-ONEX env var values (plain strings like
-``requests``, ``responses``) — the universe of drift it gates is ONEX topic
-strings matching ``onex.{kind}.{producer}.{event-name}.v{n}``.
+Drift kind reported:
+
+- **BANNED_VAR**: compose/k8s exposes an env var whose NAME is in the banned
+  set (regardless of value). Stale compose — the OMN-8840 pattern where
+  ``ONEX_INPUT_TOPIC`` survived after OMN-8784 removed it from code.
+
+``MISSING_VAR`` (forward-drift contract→compose check — for each contract's
+declared topics, verify a compose entry exposes the expected env var) is
+deferred to follow-up ticket OMN-9064. The enum value is preserved.
 
 Related ticket: OMN-9062 (trigger: OMN-8840, parent: OMN-9048).
 
@@ -28,11 +36,15 @@ Usage::
     from pathlib import Path
     from omnibase_core.validation import ValidatorBannedComposeVars
 
-    validator = ValidatorBannedComposeVars()
+    validator = ValidatorBannedComposeVars(
+        kernel_source_path=Path("../omnibase_infra/src/omnibase_infra/runtime/service_kernel.py"),
+    )
     violations = validator.check_paths([Path("omni_home")])
 
     # CLI
-    python -m omnibase_core.validation.validator_banned_compose_vars omni_home/
+    python -m omnibase_core.validation.validator_banned_compose_vars \\
+        --kernel-source ../omnibase_infra/src/omnibase_infra/runtime/service_kernel.py \\
+        omni_home/
 
 Exit codes:
     0 — no drift
@@ -41,13 +53,14 @@ Exit codes:
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
 from typing import Final
 
 import yaml
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
 from omnibase_core.models.validation.model_compose_drift_violation import (
@@ -55,23 +68,15 @@ from omnibase_core.models.validation.model_compose_drift_violation import (
 )
 
 # ---------------------------------------------------------------------------
-# Patterns
+# Constants
 # ---------------------------------------------------------------------------
 
-# Canonical ONEX topic form: onex.{kind}.{producer}.{event-name}.v{n}
-# Kept in lock-step with validator_topic_suffix.TOPIC_SUFFIX_PATTERN.
-_ONEX_TOPIC_PATTERN: Final[re.Pattern[str]] = re.compile(
-    r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\.v\d+$"
-)
+# Canonical name of the banned-set tuple in service_kernel.py.
+_BANNED_CONSTANT_NAME: Final[str] = "_DEPRECATED_TOPIC_ENV_VARS"
 
 # Filename patterns recognised as compose / k8s manifests.
 _COMPOSE_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"^docker-compose.*\.ya?ml$")
 _COMPOSE_DIR_COMPONENTS: Final[frozenset[str]] = frozenset({"k8s", "kubernetes"})
-
-# Contract filenames (scanned for topic declarations).
-_CONTRACT_FILENAMES: Final[frozenset[str]] = frozenset(
-    {"contract.yaml", "contract.yml", "handler_contract.yaml"}
-)
 
 # Directories skipped during recursive scan.
 _SKIP_DIRS: Final[frozenset[str]] = frozenset(
@@ -93,72 +98,79 @@ _SKIP_DIRS: Final[frozenset[str]] = frozenset(
 
 
 class ValidatorBannedComposeVars(BaseModel):
-    """Bidirectional compose↔contract topic drift detector.
+    """Kernel-sourced banned env var detector for compose / k8s manifests.
 
     Stateless — each call to :meth:`check_paths` returns violations without
     mutating instance state. Safe to reuse across calls.
+
+    Args:
+        kernel_source_path: Path to ``service_kernel.py`` whose
+            ``_DEPRECATED_TOPIC_ENV_VARS`` tuple is the canonical banned set.
+            If ``None``, the validator falls back to an empty banned set
+            (hard-fail at CLI level — avoids silent pass on misconfig).
+        extra_banned: Additional env var names to treat as banned (optional
+            supplement for cross-repo cases the kernel tuple doesn't cover).
 
     Thread Safety:
         Instances are thread-safe because there is no mutable state.
     """
 
-    model_config = ConfigDict(extra="forbid", from_attributes=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kernel_source_path: Path | None = Field(
+        default=None,
+        description=(
+            "Path to service_kernel.py whose _DEPRECATED_TOPIC_ENV_VARS tuple "
+            "is the canonical banned set. Required for non-trivial scans."
+        ),
+    )
+    extra_banned: frozenset[str] = Field(
+        default_factory=frozenset,
+        description="Additional env var names to treat as banned.",
+    )
+
+    def banned_env_vars(self) -> frozenset[str]:
+        """Return the resolved banned env var set.
+
+        Combines the AST-extracted kernel tuple with any ``extra_banned``
+        names supplied at construction. Empty when no sources are configured.
+        """
+        kernel_set: frozenset[str] = frozenset()
+        if self.kernel_source_path is not None:
+            kernel_set = extract_banned_env_vars_from_kernel(self.kernel_source_path)
+        return kernel_set | self.extra_banned
 
     def check_paths(self, paths: list[Path]) -> list[ModelComposeDriftViolation]:
         """Scan the given files/directories and return every drift violation."""
-        # Maps: topic -> source path / (var_name, source) for compose.
-        contract_topics: dict[str, Path] = {}
-        compose_topics: dict[str, tuple[str, Path]] = {}
+        banned = self.banned_env_vars()
+        violations: list[ModelComposeDriftViolation] = []
+
+        if not banned:
+            return violations
 
         for base in paths:
             for file_path in _iter_yaml_files(base):
-                if _is_contract_file(file_path):
-                    for topic in _extract_contract_topics(file_path):
-                        contract_topics.setdefault(topic, file_path)
-                elif _is_compose_or_k8s_file(file_path):
-                    for var_name, topic in _extract_compose_topic_refs(file_path):
-                        compose_topics.setdefault(topic, (var_name, file_path))
-
-        violations: list[ModelComposeDriftViolation] = []
-
-        # BANNED_VAR: compose references an ONEX topic no contract declares
-        for topic, (var_name, compose_path) in compose_topics.items():
-            if topic in contract_topics:
-                continue
-            violations.append(
-                ModelComposeDriftViolation(
-                    kind=EnumComposeDriftKind.BANNED_VAR,
-                    var_name=var_name,
-                    compose_path=compose_path,
-                    contract_path=None,
-                    message=(
-                        f"{compose_path} exposes env var {var_name!r} = "
-                        f"{topic!r} but no contract.yaml declares that topic "
-                        f"in event_bus.subscribe_topics / publish_topics. "
-                        f"Either declare the topic in a contract or remove "
-                        f"the stale env var from compose/k8s."
-                    ),
-                )
-            )
-
-        # MISSING_VAR: contract declares a topic no compose / k8s exposes
-        for topic, contract_path in contract_topics.items():
-            if topic in compose_topics:
-                continue
-            violations.append(
-                ModelComposeDriftViolation(
-                    kind=EnumComposeDriftKind.MISSING_VAR,
-                    var_name=_topic_to_var_hint(topic),
-                    compose_path=None,
-                    contract_path=contract_path,
-                    message=(
-                        f"{contract_path} declares topic {topic!r} but no "
-                        f"compose / k8s manifest exposes it via any env var. "
-                        f"Either wire the topic into compose/k8s or remove "
-                        f"the contract declaration."
-                    ),
-                )
-            )
+                if not _is_compose_or_k8s_file(file_path):
+                    continue
+                for var_name, value in _extract_env_pairs(file_path):
+                    if var_name not in banned:
+                        continue
+                    violations.append(
+                        ModelComposeDriftViolation(
+                            kind=EnumComposeDriftKind.BANNED_VAR,
+                            var_name=var_name,
+                            compose_path=file_path,
+                            contract_path=None,
+                            message=(
+                                f"{file_path} exposes banned env var "
+                                f"{var_name!r} (value: {value!r}). This var "
+                                f"is in the kernel's "
+                                f"{_BANNED_CONSTANT_NAME} tuple; code no "
+                                f"longer reads it (OMN-8784). Remove the "
+                                f"entry from compose/k8s."
+                            ),
+                        )
+                    )
 
         violations.sort(
             key=lambda v: (
@@ -171,7 +183,65 @@ class ValidatorBannedComposeVars(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Helpers (module-private)
+# AST-based kernel constant extractor
+# ---------------------------------------------------------------------------
+
+
+def extract_banned_env_vars_from_kernel(kernel_path: Path) -> frozenset[str]:
+    """Extract ``_DEPRECATED_TOPIC_ENV_VARS`` string literals from a kernel source file.
+
+    Parses the file with :mod:`ast` and walks module-level ``Assign`` /
+    ``AnnAssign`` nodes. Only string-literal tuple / list / set members are
+    returned — anything non-literal (expressions, imports) is skipped.
+
+    Returns an empty frozenset if the constant is missing, the file is
+    unreadable, or the file cannot be parsed — callers hard-fail on empty.
+
+    This is a static read — no code is executed.
+    """
+    try:
+        source = kernel_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return frozenset()
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return frozenset()
+
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+
+        if value is None:
+            continue
+
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == _BANNED_CONSTANT_NAME:
+                return _collect_string_literals(value)
+
+    return frozenset()
+
+
+def _collect_string_literals(node: ast.expr) -> frozenset[str]:
+    """Collect every ``ast.Constant`` string inside a tuple/list/set expression."""
+    names: set[str] = set()
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        for element in node.elts:
+            if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                names.add(element.value)
+    return frozenset(names)
+
+
+# ---------------------------------------------------------------------------
+# Compose / k8s scanning helpers
 # ---------------------------------------------------------------------------
 
 
@@ -191,10 +261,6 @@ def _iter_yaml_files(base: Path) -> list[Path]:
     return sorted(results)
 
 
-def _is_contract_file(path: Path) -> bool:
-    return path.name in _CONTRACT_FILENAMES
-
-
 def _is_compose_or_k8s_file(path: Path) -> bool:
     if _COMPOSE_NAME_PATTERN.match(path.name):
         return True
@@ -212,46 +278,23 @@ def _load_yaml_safely(path: Path) -> object | None:
         return None
 
 
-def _extract_contract_topics(path: Path) -> list[str]:
-    """Extract every ONEX topic declared by this contract's event_bus block."""
+def _extract_env_pairs(path: Path) -> list[tuple[str, str]]:
+    """Return every ``(var_name, value)`` pair from this file's env blocks."""
     doc = _load_yaml_safely(path)
-    if not isinstance(doc, dict):
+    if doc is None:
         return []
-    event_bus = doc.get("event_bus")
-    if not isinstance(event_bus, dict):
-        return []
-
-    topics: list[str] = []
-    for key in ("subscribe_topics", "publish_topics"):
-        raw = event_bus.get(key)
-        if isinstance(raw, list):
-            topics.extend(str(item) for item in raw if isinstance(item, str))
-
-    return [topic for topic in topics if _ONEX_TOPIC_PATTERN.match(topic)]
+    return _walk_env_pairs(doc)
 
 
-def _extract_compose_topic_refs(path: Path) -> list[tuple[str, str]]:
-    """Extract every ``(var_name, topic)`` pair whose value is an ONEX topic.
+def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
+    """Yield every ``(name, value)`` pair discoverable as container env.
 
     Handles three forms:
 
     - docker-compose ``environment:`` dict (``KEY: value``)
-    - docker-compose ``environment:`` list (``- KEY=value`` or ``- KEY: value``)
+    - docker-compose ``environment:`` list (``- KEY=value`` or ``- {name, value}``)
     - k8s ``env:`` list of ``{name: KEY, value: VAL}``
     """
-    doc = _load_yaml_safely(path)
-    if doc is None:
-        return []
-
-    return [
-        (var_name, value)
-        for var_name, value in _walk_env_pairs(doc)
-        if _ONEX_TOPIC_PATTERN.match(value)
-    ]
-
-
-def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
-    """Yield every ``(name, value)`` pair discoverable as container env."""
     pairs: list[tuple[str, str]] = []
 
     if isinstance(node, dict):
@@ -280,15 +323,6 @@ def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
     return pairs
 
 
-def _topic_to_var_hint(topic: str) -> str:
-    """Produce a human-readable identifier for MISSING_VAR reports.
-
-    Contracts declare topics, not env var names; this surfaces the topic
-    itself as the "var_name" so consumers of the report can locate it.
-    """
-    return f"<missing-topic:{topic}>"
-
-
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -299,15 +333,16 @@ def main(argv: list[str] | None = None) -> int:
 
     Exit codes:
         0 — no drift
-        2 — drift detected
+        2 — drift detected or empty banned set (misconfigured)
     """
     import argparse
 
     parser = argparse.ArgumentParser(
         prog="check-banned-compose-vars",
         description=(
-            "Detect bidirectional compose↔contract topic drift. "
-            "Exits 2 if any BANNED_VAR or MISSING_VAR violation is found."
+            "Detect compose / k8s env vars whose name is in the kernel's "
+            "_DEPRECATED_TOPIC_ENV_VARS banned set. Exits 2 on any violation "
+            "or if the banned set is empty."
         ),
     )
     parser.add_argument(
@@ -318,6 +353,22 @@ def main(argv: list[str] | None = None) -> int:
         help="Files or directories to scan (default: current directory)",
     )
     parser.add_argument(
+        "--kernel-source",
+        type=Path,
+        required=True,
+        help=(
+            "Path to service_kernel.py whose _DEPRECATED_TOPIC_ENV_VARS "
+            "tuple is the canonical banned set."
+        ),
+    )
+    parser.add_argument(
+        "--extra-banned",
+        action="append",
+        default=[],
+        metavar="VAR_NAME",
+        help="Additional env var name to treat as banned (repeatable).",
+    )
+    parser.add_argument(
         "--quiet",
         "-q",
         action="store_true",
@@ -325,28 +376,37 @@ def main(argv: list[str] | None = None) -> int:
     )
     parsed = parser.parse_args(argv)
 
-    validator = ValidatorBannedComposeVars()
+    validator = ValidatorBannedComposeVars(
+        kernel_source_path=parsed.kernel_source,
+        extra_banned=frozenset(parsed.extra_banned),
+    )
+
+    banned = validator.banned_env_vars()
+    if not banned:
+        print(
+            f"ERROR: banned set is empty. Check --kernel-source "
+            f"({parsed.kernel_source}) contains {_BANNED_CONSTANT_NAME}.",
+            file=sys.stderr,
+        )
+        return 2
+
     violations = validator.check_paths(parsed.paths)
 
     for v in violations:
-        location = v.compose_path if v.compose_path is not None else v.contract_path
-        print(f"{location}: [{v.kind.value}] {v.var_name}: {v.message}")
+        print(f"{v.compose_path}: [{v.kind.value}] {v.var_name}: {v.message}")
 
     if not parsed.quiet:
         if violations:
-            banned = sum(
-                1 for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR
-            )
-            missing = sum(
-                1 for v in violations if v.kind is EnumComposeDriftKind.MISSING_VAR
-            )
             print(
-                f"\n{len(violations)} compose/contract drift violation(s): "
-                f"{banned} BANNED_VAR, {missing} MISSING_VAR.",
+                f"\n{len(violations)} banned compose env var violation(s) "
+                f"(banned set size: {len(banned)}).",
                 file=sys.stderr,
             )
         else:
-            print("No compose/contract drift found.", file=sys.stderr)
+            print(
+                f"No banned compose env vars found (banned set size: {len(banned)}).",
+                file=sys.stderr,
+            )
 
     return 2 if violations else 0
 

--- a/src/omnibase_core/validation/validator_banned_compose_vars.py
+++ b/src/omnibase_core/validation/validator_banned_compose_vars.py
@@ -267,23 +267,32 @@ def _is_compose_or_k8s_file(path: Path) -> bool:
     return any(component in _COMPOSE_DIR_COMPONENTS for component in path.parts)
 
 
-def _load_yaml_safely(path: Path) -> object | None:
+def _load_yaml_safely(path: Path) -> list[object]:
+    """Return every document in ``path`` as a list.
+
+    k8s manifests commonly use multi-document YAML streams (``---`` separator)
+    bundling a Deployment + Service + ConfigMap in one file. Using
+    :func:`yaml.safe_load` on such a stream raises ``ComposerError``; we must
+    use :func:`yaml.safe_load_all` to iterate each document.
+
+    Returns an empty list on any read or parse failure.
+    """
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except (OSError, PermissionError):
-        return None
+        return []
     try:
-        return yaml.safe_load(text)
+        return [doc for doc in yaml.safe_load_all(text) if doc is not None]
     except yaml.YAMLError:
-        return None
+        return []
 
 
 def _extract_env_pairs(path: Path) -> list[tuple[str, str]]:
-    """Return every ``(var_name, value)`` pair from this file's env blocks."""
-    doc = _load_yaml_safely(path)
-    if doc is None:
-        return []
-    return _walk_env_pairs(doc)
+    """Return every ``(var_name, value)`` pair from every document in the file."""
+    pairs: list[tuple[str, str]] = []
+    for doc in _load_yaml_safely(path):
+        pairs.extend(_walk_env_pairs(doc))
+    return pairs
 
 
 def _walk_env_pairs(node: object) -> list[tuple[str, str]]:

--- a/src/omnibase_core/validation/validator_banned_compose_vars.py
+++ b/src/omnibase_core/validation/validator_banned_compose_vars.py
@@ -41,8 +41,8 @@ Usage::
     )
     violations = validator.check_paths([Path("omni_home")])
 
-    # CLI
-    python -m omnibase_core.validation.validator_banned_compose_vars \\
+    # CLI (per repo policy: all Python commands via uv run)
+    uv run python -m omnibase_core.validation.validator_banned_compose_vars \\
         --kernel-source ../omnibase_infra/src/omnibase_infra/runtime/service_kernel.py \\
         omni_home/
 
@@ -289,11 +289,20 @@ def _extract_env_pairs(path: Path) -> list[tuple[str, str]]:
 def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
     """Yield every ``(name, value)`` pair discoverable as container env.
 
-    Handles three forms:
+    Since the validator enforces bans on env var **names**, value-less forms
+    are surfaced too (name paired with ``""``). That covers:
 
     - docker-compose ``environment:`` dict (``KEY: value``)
-    - docker-compose ``environment:`` list (``- KEY=value`` or ``- {name, value}``)
-    - k8s ``env:`` list of ``{name: KEY, value: VAL}``
+    - docker-compose ``environment:`` list — all three forms:
+        * ``- KEY=value`` — explicit value
+        * ``- KEY`` — pass-through from host env (no ``=``)
+        * ``- {name: KEY, value: VAL}`` — dict with explicit value
+        * ``- {name: KEY}`` — dict with no value (also pass-through)
+    - k8s ``env:`` list — both forms:
+        * ``- {name: KEY, value: VAL}`` — literal value
+        * ``- {name: KEY, valueFrom: {...}}`` — sourced from ConfigMap/Secret/etc.
+
+    Missing a form would be a false-negative bypass of the ban.
     """
     pairs: list[tuple[str, str]] = []
 
@@ -303,17 +312,26 @@ def _walk_env_pairs(node: object) -> list[tuple[str, str]]:
                 for env_key, env_val in value.items():
                     if isinstance(env_val, (str, int, float)):
                         pairs.append((str(env_key), str(env_val)))
+                    elif env_val is None:
+                        pairs.append((str(env_key), ""))
             elif key == "environment" and isinstance(value, list):
                 for item in value:
-                    if isinstance(item, str) and "=" in item:
-                        k, _, v = item.partition("=")
-                        pairs.append((k.strip(), v.strip()))
-                    elif isinstance(item, dict) and "name" in item and "value" in item:
-                        pairs.append((str(item["name"]), str(item["value"])))
+                    if isinstance(item, str):
+                        if "=" in item:
+                            k, _, v = item.partition("=")
+                            name = k.strip()
+                            if name:
+                                pairs.append((name, v.strip()))
+                        else:
+                            name = item.strip()
+                            if name:
+                                pairs.append((name, ""))
+                    elif isinstance(item, dict) and "name" in item:
+                        pairs.append((str(item["name"]), str(item.get("value", ""))))
             elif key == "env" and isinstance(value, list):
                 for item in value:
-                    if isinstance(item, dict) and "name" in item and "value" in item:
-                        pairs.append((str(item["name"]), str(item["value"])))
+                    if isinstance(item, dict) and "name" in item:
+                        pairs.append((str(item["name"]), str(item.get("value", ""))))
             else:
                 pairs.extend(_walk_env_pairs(value))
     elif isinstance(node, list):

--- a/tests/unit/validation/test_validator_banned_compose_vars.py
+++ b/tests/unit/validation/test_validator_banned_compose_vars.py
@@ -3,16 +3,13 @@
 
 """Unit tests for ValidatorBannedComposeVars [OMN-9062].
 
-Tests bidirectional compose↔contract topic drift detection:
+Tests kernel-sourced banned env var detection against compose / k8s manifests.
 
-- Synthetic contract + compose that agree → 0 violations
-- Compose references banned topic (not in any contract) → BANNED_VAR
-- Contract declares topic missing from compose → MISSING_VAR
-- Multi-repo scan (contracts in one dir, compose in another)
-
-Trigger incident: OMN-8840 — ``ONEX_INPUT_TOPIC`` persisted in compose
-after OMN-8784 removed it from code. A bidirectional validator would
-have caught the drift at review time.
+Trigger incident: OMN-8840 — ``ONEX_INPUT_TOPIC`` persisted in compose after
+OMN-8784 removed it from code. This validator flags any compose env var whose
+name is in the kernel's ``_DEPRECATED_TOPIC_ENV_VARS`` constant (single source
+of truth — parsed via static ``ast`` walk to respect compat/core/spi/infra
+layering).
 """
 
 from __future__ import annotations
@@ -24,33 +21,28 @@ import pytest
 from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
 from omnibase_core.validation.validator_banned_compose_vars import (
     ValidatorBannedComposeVars,
+    extract_banned_env_vars_from_kernel,
     main,
 )
 
 
 @pytest.fixture
 def tmp_repo(tmp_path: Path) -> Path:
-    """Produce an empty scratch repo directory."""
-    (tmp_path / "contracts").mkdir()
+    """Produce an empty scratch repo directory with a synthetic kernel."""
     (tmp_path / "docker").mkdir()
     return tmp_path
 
 
-def _write_contract(
-    root: Path, rel: str, subscribe: list[str], publish: list[str]
-) -> Path:
-    contract_path = root / rel
-    contract_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [
-        "name: node_example",
-        "event_bus:",
-        "  subscribe_topics:",
-    ]
-    lines.extend(f"    - {topic!r}" for topic in subscribe)
-    lines.append("  publish_topics:")
-    lines.extend(f"    - {topic!r}" for topic in publish)
-    contract_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return contract_path
+def _write_kernel_with_banned_set(root: Path, banned: list[str]) -> Path:
+    """Emit a fake ``service_kernel.py`` carrying ``_DEPRECATED_TOPIC_ENV_VARS``."""
+    kernel_path = root / "service_kernel.py"
+    literals = ", ".join(f'"{name}"' for name in banned)
+    kernel_path.write_text(
+        f"# Synthetic kernel for tests.\n"
+        f"_DEPRECATED_TOPIC_ENV_VARS: tuple[str, ...] = ({literals},)\n",
+        encoding="utf-8",
+    )
+    return kernel_path
 
 
 def _write_compose(root: Path, rel: str, env: dict[str, str]) -> Path:
@@ -68,115 +60,107 @@ def _write_compose(root: Path, rel: str, env: dict[str, str]) -> Path:
     return compose_path
 
 
+class TestExtractBannedEnvVarsFromKernel:
+    def test_extracts_tuple_literal(self, tmp_path: Path) -> None:
+        kernel = _write_kernel_with_banned_set(
+            tmp_path, ["ONEX_INPUT_TOPIC", "ONEX_OUTPUT_TOPIC"]
+        )
+        assert extract_banned_env_vars_from_kernel(kernel) == frozenset(
+            {"ONEX_INPUT_TOPIC", "ONEX_OUTPUT_TOPIC"}
+        )
+
+    def test_extracts_list_literal(self, tmp_path: Path) -> None:
+        kernel = tmp_path / "service_kernel.py"
+        kernel.write_text(
+            '_DEPRECATED_TOPIC_ENV_VARS = ["VAR_ONE", "VAR_TWO"]\n',
+            encoding="utf-8",
+        )
+        assert extract_banned_env_vars_from_kernel(kernel) == frozenset(
+            {"VAR_ONE", "VAR_TWO"}
+        )
+
+    def test_missing_file_returns_empty_set(self, tmp_path: Path) -> None:
+        assert extract_banned_env_vars_from_kernel(tmp_path / "nope.py") == frozenset()
+
+    def test_missing_constant_returns_empty_set(self, tmp_path: Path) -> None:
+        kernel = tmp_path / "service_kernel.py"
+        kernel.write_text("OTHER_CONSTANT = ('X',)\n", encoding="utf-8")
+        assert extract_banned_env_vars_from_kernel(kernel) == frozenset()
+
+    def test_syntax_error_returns_empty_set(self, tmp_path: Path) -> None:
+        kernel = tmp_path / "service_kernel.py"
+        kernel.write_text("def broken(\n", encoding="utf-8")
+        assert extract_banned_env_vars_from_kernel(kernel) == frozenset()
+
+    def test_ignores_non_literal_elements(self, tmp_path: Path) -> None:
+        kernel = tmp_path / "service_kernel.py"
+        kernel.write_text(
+            'OTHER = "X"\n_DEPRECATED_TOPIC_ENV_VARS = ("STRING_LITERAL", OTHER, 42)\n',
+            encoding="utf-8",
+        )
+        assert extract_banned_env_vars_from_kernel(kernel) == frozenset(
+            {"STRING_LITERAL"}
+        )
+
+
 class TestValidatorBannedComposeVars:
-    def test_agreement_yields_zero_violations(self, tmp_repo: Path) -> None:
-        _write_contract(
+    def test_no_kernel_source_yields_empty_banned_set(self, tmp_repo: Path) -> None:
+        _write_compose(
             tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=["onex.evt.service-a.thing-done.v1"],
+            "docker/docker-compose.yml",
+            env={"ONEX_INPUT_TOPIC": "requests"},
+        )
+        validator = ValidatorBannedComposeVars()
+        assert validator.banned_env_vars() == frozenset()
+        assert validator.check_paths([tmp_repo]) == []
+
+    def test_banned_var_flagged_regardless_of_value(self, tmp_repo: Path) -> None:
+        kernel = _write_kernel_with_banned_set(
+            tmp_repo, ["ONEX_INPUT_TOPIC", "ONEX_OUTPUT_TOPIC"]
         )
         _write_compose(
             tmp_repo,
             "docker/docker-compose.yml",
             env={
-                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
-                "ONEX_OUTPUT_TOPIC": "onex.evt.service-a.thing-done.v1",
+                # Both are banned — regardless of their values.
+                "ONEX_INPUT_TOPIC": "requests",
+                "ONEX_OUTPUT_TOPIC": "responses",
+                # Not banned — left alone.
+                "OMNI_LOG_LEVEL": "INFO",
             },
         )
 
-        validator = ValidatorBannedComposeVars()
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
         violations = validator.check_paths([tmp_repo])
-        assert violations == []
 
-    def test_banned_var_detected_when_compose_references_undeclared_topic(
-        self, tmp_repo: Path
-    ) -> None:
-        _write_contract(
-            tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=[],
-        )
+        assert sorted(v.var_name for v in violations) == [
+            "ONEX_INPUT_TOPIC",
+            "ONEX_OUTPUT_TOPIC",
+        ]
+        for v in violations:
+            assert v.kind is EnumComposeDriftKind.BANNED_VAR
+            assert v.compose_path is not None
+            assert v.compose_path.name == "docker-compose.yml"
+            assert v.contract_path is None
+            assert "_DEPRECATED_TOPIC_ENV_VARS" in v.message
+
+    def test_allowed_vars_ignored(self, tmp_repo: Path) -> None:
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
         _write_compose(
             tmp_repo,
             "docker/docker-compose.yml",
             env={
-                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
-                # Stale — no contract declares this topic (OMN-8840 pattern)
-                "ONEX_OUTPUT_TOPIC": "onex.evt.service-a.stale-thing.v1",
+                "OMNI_LOG_LEVEL": "INFO",
+                "DATABASE_URL": "postgresql://x",
+                "ONEX_GROUP_ID": "some-group",
             },
         )
 
-        validator = ValidatorBannedComposeVars()
-        violations = validator.check_paths([tmp_repo])
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        assert validator.check_paths([tmp_repo]) == []
 
-        banned = [v for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR]
-        assert len(banned) == 1
-        assert banned[0].var_name == "ONEX_OUTPUT_TOPIC"
-        assert banned[0].compose_path is not None
-        assert banned[0].compose_path.name == "docker-compose.yml"
-        assert banned[0].contract_path is None
-        assert "onex.evt.service-a.stale-thing.v1" in banned[0].message
-
-    def test_missing_var_detected_when_contract_topic_not_exposed(
-        self, tmp_repo: Path
-    ) -> None:
-        _write_contract(
-            tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=["onex.evt.service-a.thing-done.v1"],
-        )
-        _write_compose(
-            tmp_repo,
-            "docker/docker-compose.yml",
-            env={
-                # Only subscribe topic exposed — publish is orphaned
-                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
-            },
-        )
-
-        validator = ValidatorBannedComposeVars()
-        violations = validator.check_paths([tmp_repo])
-
-        missing = [v for v in violations if v.kind is EnumComposeDriftKind.MISSING_VAR]
-        assert len(missing) == 1
-        assert missing[0].contract_path is not None
-        assert missing[0].compose_path is None
-        assert "onex.evt.service-a.thing-done.v1" in missing[0].message
-
-    def test_multi_repo_scan_separates_contract_and_compose_roots(
-        self, tmp_path: Path
-    ) -> None:
-        repo_a = tmp_path / "repo_a"
-        repo_b = tmp_path / "repo_b"
-        repo_a.mkdir()
-        repo_b.mkdir()
-
-        _write_contract(
-            repo_a,
-            "src/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=[],
-        )
-        _write_compose(
-            repo_b,
-            "deploy/docker-compose.yml",
-            env={"ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1"},
-        )
-
-        validator = ValidatorBannedComposeVars()
-        violations = validator.check_paths([repo_a, repo_b])
-        assert violations == []
-
-    def test_k8s_manifest_environment_block_scanned(self, tmp_repo: Path) -> None:
-        _write_contract(
-            tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=[],
-        )
+    def test_k8s_manifest_env_list_form_scanned(self, tmp_repo: Path) -> None:
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
         k8s_path = tmp_repo / "k8s" / "deployment.yaml"
         k8s_path.parent.mkdir(parents=True, exist_ok=True)
         k8s_path.write_text(
@@ -189,57 +173,103 @@ class TestValidatorBannedComposeVars:
             "        - name: svc\n"
             "          env:\n"
             "            - name: ONEX_INPUT_TOPIC\n"
-            "              value: 'onex.cmd.service-a.do-thing.v1'\n"
-            "            - name: ONEX_STALE_TOPIC\n"
-            "              value: 'onex.evt.service-a.undeclared.v1'\n",
+            "              value: 'anything'\n"
+            "            - name: OMNI_LOG_LEVEL\n"
+            "              value: INFO\n",
             encoding="utf-8",
         )
 
-        validator = ValidatorBannedComposeVars()
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
         violations = validator.check_paths([tmp_repo])
 
-        banned = [v for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR]
-        assert len(banned) == 1
-        assert banned[0].var_name == "ONEX_STALE_TOPIC"
-        assert banned[0].compose_path is not None
-        assert banned[0].compose_path.name == "deployment.yaml"
+        assert len(violations) == 1
+        assert violations[0].var_name == "ONEX_INPUT_TOPIC"
+        assert violations[0].compose_path is not None
+        assert violations[0].compose_path.name == "deployment.yaml"
 
-    def test_cli_exits_2_on_drift(
-        self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        _write_contract(
-            tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=[],
+    def test_compose_environment_list_form_scanned(self, tmp_repo: Path) -> None:
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        compose_path = tmp_repo / "docker" / "docker-compose.yml"
+        compose_path.write_text(
+            "services:\n"
+            "  example:\n"
+            "    image: example:latest\n"
+            "    environment:\n"
+            "      - ONEX_INPUT_TOPIC=requests\n"
+            "      - OMNI_LOG_LEVEL=INFO\n",
+            encoding="utf-8",
         )
+
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        violations = validator.check_paths([tmp_repo])
+        assert len(violations) == 1
+        assert violations[0].var_name == "ONEX_INPUT_TOPIC"
+
+    def test_extra_banned_merges_with_kernel_set(self, tmp_repo: Path) -> None:
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
         _write_compose(
             tmp_repo,
             "docker/docker-compose.yml",
-            env={"ONEX_STALE": "onex.evt.undeclared.service.v1"},
+            env={
+                "ONEX_INPUT_TOPIC": "x",  # from kernel
+                "EXTRA_FORBIDDEN": "y",  # from --extra-banned
+                "OKAY_VAR": "z",
+            },
         )
 
-        exit_code = main([str(tmp_repo)])
-        captured = capsys.readouterr()
+        validator = ValidatorBannedComposeVars(
+            kernel_source_path=kernel,
+            extra_banned=frozenset({"EXTRA_FORBIDDEN"}),
+        )
+        violations = validator.check_paths([tmp_repo])
+        assert sorted(v.var_name for v in violations) == [
+            "EXTRA_FORBIDDEN",
+            "ONEX_INPUT_TOPIC",
+        ]
 
+    def test_cli_exits_2_on_violation(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={"ONEX_INPUT_TOPIC": "requests"},
+        )
+
+        exit_code = main(
+            ["--kernel-source", str(kernel), str(tmp_repo)],
+        )
+        out = capsys.readouterr().out
         assert exit_code == 2
-        assert "BANNED_VAR" in captured.out
-        assert "onex.evt.undeclared.service.v1" in captured.out
+        assert "BANNED_VAR" in out
+        assert "ONEX_INPUT_TOPIC" in out
 
     def test_cli_exits_0_on_clean(
         self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        _write_contract(
-            tmp_repo,
-            "contracts/node_a/contract.yaml",
-            subscribe=["onex.cmd.service-a.do-thing.v1"],
-            publish=[],
-        )
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
         _write_compose(
             tmp_repo,
             "docker/docker-compose.yml",
-            env={"ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1"},
+            env={"OMNI_LOG_LEVEL": "INFO"},
         )
 
-        exit_code = main([str(tmp_repo)])
+        exit_code = main(
+            ["--kernel-source", str(kernel), str(tmp_repo)],
+        )
         assert exit_code == 0
+
+    def test_cli_exits_2_on_empty_banned_set(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Empty banned set is a misconfiguration — fail loudly, not silently pass."""
+        empty_kernel = tmp_repo / "empty_kernel.py"
+        empty_kernel.write_text("# no constant here\n", encoding="utf-8")
+
+        exit_code = main(
+            ["--kernel-source", str(empty_kernel), str(tmp_repo)],
+        )
+        err = capsys.readouterr().err
+        assert exit_code == 2
+        assert "banned set is empty" in err

--- a/tests/unit/validation/test_validator_banned_compose_vars.py
+++ b/tests/unit/validation/test_validator_banned_compose_vars.py
@@ -205,6 +205,69 @@ class TestValidatorBannedComposeVars:
         assert len(violations) == 1
         assert violations[0].var_name == "ONEX_INPUT_TOPIC"
 
+    def test_compose_pass_through_list_form_scanned(self, tmp_repo: Path) -> None:
+        """Compose `- VAR_NAME` (no `=`) passes value from host env; still banned."""
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        compose_path = tmp_repo / "docker" / "docker-compose.yml"
+        compose_path.write_text(
+            "services:\n"
+            "  example:\n"
+            "    image: example:latest\n"
+            "    environment:\n"
+            "      - ONEX_INPUT_TOPIC\n"
+            "      - OMNI_LOG_LEVEL\n",
+            encoding="utf-8",
+        )
+
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        violations = validator.check_paths([tmp_repo])
+        assert [v.var_name for v in violations] == ["ONEX_INPUT_TOPIC"]
+
+    def test_k8s_value_from_form_scanned(self, tmp_repo: Path) -> None:
+        """k8s `valueFrom` (no `value`) must not bypass the ban."""
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        k8s_path = tmp_repo / "k8s" / "deployment.yaml"
+        k8s_path.parent.mkdir(parents=True, exist_ok=True)
+        k8s_path.write_text(
+            "apiVersion: apps/v1\n"
+            "kind: Deployment\n"
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "        - name: svc\n"
+            "          env:\n"
+            "            - name: ONEX_INPUT_TOPIC\n"
+            "              valueFrom:\n"
+            "                configMapKeyRef:\n"
+            "                  name: some-cm\n"
+            "                  key: topic\n"
+            "            - name: OMNI_LOG_LEVEL\n"
+            "              value: INFO\n",
+            encoding="utf-8",
+        )
+
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        violations = validator.check_paths([tmp_repo])
+        assert [v.var_name for v in violations] == ["ONEX_INPUT_TOPIC"]
+
+    def test_compose_name_only_dict_scanned(self, tmp_repo: Path) -> None:
+        """Compose ``- {name: KEY}`` (dict, no ``value``) is pass-through; still banned."""
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        compose_path = tmp_repo / "docker" / "docker-compose.yml"
+        compose_path.write_text(
+            "services:\n"
+            "  example:\n"
+            "    image: example:latest\n"
+            "    environment:\n"
+            "      - name: ONEX_INPUT_TOPIC\n",
+            encoding="utf-8",
+        )
+
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        violations = validator.check_paths([tmp_repo])
+        assert [v.var_name for v in violations] == ["ONEX_INPUT_TOPIC"]
+
     def test_extra_banned_merges_with_kernel_set(self, tmp_repo: Path) -> None:
         kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
         _write_compose(

--- a/tests/unit/validation/test_validator_banned_compose_vars.py
+++ b/tests/unit/validation/test_validator_banned_compose_vars.py
@@ -251,6 +251,40 @@ class TestValidatorBannedComposeVars:
         violations = validator.check_paths([tmp_repo])
         assert [v.var_name for v in violations] == ["ONEX_INPUT_TOPIC"]
 
+    def test_multi_doc_k8s_manifest_scanned(self, tmp_repo: Path) -> None:
+        """k8s manifests often bundle multiple documents with `---` separators."""
+        kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])
+        k8s_path = tmp_repo / "k8s" / "bundle.yaml"
+        k8s_path.parent.mkdir(parents=True, exist_ok=True)
+        k8s_path.write_text(
+            "apiVersion: v1\n"
+            "kind: ConfigMap\n"
+            "metadata:\n"
+            "  name: cfg\n"
+            "---\n"
+            "apiVersion: apps/v1\n"
+            "kind: Deployment\n"
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "        - name: svc\n"
+            "          env:\n"
+            "            - name: ONEX_INPUT_TOPIC\n"
+            "              value: requests\n"
+            "---\n"
+            "apiVersion: v1\n"
+            "kind: Service\n"
+            "metadata:\n"
+            "  name: svc\n",
+            encoding="utf-8",
+        )
+
+        validator = ValidatorBannedComposeVars(kernel_source_path=kernel)
+        violations = validator.check_paths([tmp_repo])
+        assert len(violations) == 1
+        assert violations[0].var_name == "ONEX_INPUT_TOPIC"
+
     def test_compose_name_only_dict_scanned(self, tmp_repo: Path) -> None:
         """Compose ``- {name: KEY}`` (dict, no ``value``) is pass-through; still banned."""
         kernel = _write_kernel_with_banned_set(tmp_repo, ["ONEX_INPUT_TOPIC"])

--- a/tests/unit/validation/test_validator_banned_compose_vars.py
+++ b/tests/unit/validation/test_validator_banned_compose_vars.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ValidatorBannedComposeVars [OMN-9062].
+
+Tests bidirectional compose↔contract topic drift detection:
+
+- Synthetic contract + compose that agree → 0 violations
+- Compose references banned topic (not in any contract) → BANNED_VAR
+- Contract declares topic missing from compose → MISSING_VAR
+- Multi-repo scan (contracts in one dir, compose in another)
+
+Trigger incident: OMN-8840 — ``ONEX_INPUT_TOPIC`` persisted in compose
+after OMN-8784 removed it from code. A bidirectional validator would
+have caught the drift at review time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
+from omnibase_core.validation.validator_banned_compose_vars import (
+    ValidatorBannedComposeVars,
+    main,
+)
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path) -> Path:
+    """Produce an empty scratch repo directory."""
+    (tmp_path / "contracts").mkdir()
+    (tmp_path / "docker").mkdir()
+    return tmp_path
+
+
+def _write_contract(
+    root: Path, rel: str, subscribe: list[str], publish: list[str]
+) -> Path:
+    contract_path = root / rel
+    contract_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "name: node_example",
+        "event_bus:",
+        "  subscribe_topics:",
+    ]
+    lines.extend(f"    - {topic!r}" for topic in subscribe)
+    lines.append("  publish_topics:")
+    lines.extend(f"    - {topic!r}" for topic in publish)
+    contract_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return contract_path
+
+
+def _write_compose(root: Path, rel: str, env: dict[str, str]) -> Path:
+    compose_path = root / rel
+    compose_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "services:",
+        "  example:",
+        "    image: example:latest",
+        "    environment:",
+    ]
+    for key, val in env.items():
+        lines.append(f"      {key}: {val!r}")
+    compose_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return compose_path
+
+
+class TestValidatorBannedComposeVars:
+    def test_agreement_yields_zero_violations(self, tmp_repo: Path) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=["onex.evt.service-a.thing-done.v1"],
+        )
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={
+                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
+                "ONEX_OUTPUT_TOPIC": "onex.evt.service-a.thing-done.v1",
+            },
+        )
+
+        validator = ValidatorBannedComposeVars()
+        violations = validator.check_paths([tmp_repo])
+        assert violations == []
+
+    def test_banned_var_detected_when_compose_references_undeclared_topic(
+        self, tmp_repo: Path
+    ) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=[],
+        )
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={
+                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
+                # Stale — no contract declares this topic (OMN-8840 pattern)
+                "ONEX_OUTPUT_TOPIC": "onex.evt.service-a.stale-thing.v1",
+            },
+        )
+
+        validator = ValidatorBannedComposeVars()
+        violations = validator.check_paths([tmp_repo])
+
+        banned = [v for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR]
+        assert len(banned) == 1
+        assert banned[0].var_name == "ONEX_OUTPUT_TOPIC"
+        assert banned[0].compose_path is not None
+        assert banned[0].compose_path.name == "docker-compose.yml"
+        assert banned[0].contract_path is None
+        assert "onex.evt.service-a.stale-thing.v1" in banned[0].message
+
+    def test_missing_var_detected_when_contract_topic_not_exposed(
+        self, tmp_repo: Path
+    ) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=["onex.evt.service-a.thing-done.v1"],
+        )
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={
+                # Only subscribe topic exposed — publish is orphaned
+                "ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1",
+            },
+        )
+
+        validator = ValidatorBannedComposeVars()
+        violations = validator.check_paths([tmp_repo])
+
+        missing = [v for v in violations if v.kind is EnumComposeDriftKind.MISSING_VAR]
+        assert len(missing) == 1
+        assert missing[0].contract_path is not None
+        assert missing[0].compose_path is None
+        assert "onex.evt.service-a.thing-done.v1" in missing[0].message
+
+    def test_multi_repo_scan_separates_contract_and_compose_roots(
+        self, tmp_path: Path
+    ) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        _write_contract(
+            repo_a,
+            "src/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=[],
+        )
+        _write_compose(
+            repo_b,
+            "deploy/docker-compose.yml",
+            env={"ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1"},
+        )
+
+        validator = ValidatorBannedComposeVars()
+        violations = validator.check_paths([repo_a, repo_b])
+        assert violations == []
+
+    def test_k8s_manifest_environment_block_scanned(self, tmp_repo: Path) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=[],
+        )
+        k8s_path = tmp_repo / "k8s" / "deployment.yaml"
+        k8s_path.parent.mkdir(parents=True, exist_ok=True)
+        k8s_path.write_text(
+            "apiVersion: apps/v1\n"
+            "kind: Deployment\n"
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "        - name: svc\n"
+            "          env:\n"
+            "            - name: ONEX_INPUT_TOPIC\n"
+            "              value: 'onex.cmd.service-a.do-thing.v1'\n"
+            "            - name: ONEX_STALE_TOPIC\n"
+            "              value: 'onex.evt.service-a.undeclared.v1'\n",
+            encoding="utf-8",
+        )
+
+        validator = ValidatorBannedComposeVars()
+        violations = validator.check_paths([tmp_repo])
+
+        banned = [v for v in violations if v.kind is EnumComposeDriftKind.BANNED_VAR]
+        assert len(banned) == 1
+        assert banned[0].var_name == "ONEX_STALE_TOPIC"
+        assert banned[0].compose_path is not None
+        assert banned[0].compose_path.name == "deployment.yaml"
+
+    def test_cli_exits_2_on_drift(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=[],
+        )
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={"ONEX_STALE": "onex.evt.undeclared.service.v1"},
+        )
+
+        exit_code = main([str(tmp_repo)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 2
+        assert "BANNED_VAR" in captured.out
+        assert "onex.evt.undeclared.service.v1" in captured.out
+
+    def test_cli_exits_0_on_clean(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_contract(
+            tmp_repo,
+            "contracts/node_a/contract.yaml",
+            subscribe=["onex.cmd.service-a.do-thing.v1"],
+            publish=[],
+        )
+        _write_compose(
+            tmp_repo,
+            "docker/docker-compose.yml",
+            env={"ONEX_INPUT_TOPIC": "onex.cmd.service-a.do-thing.v1"},
+        )
+
+        exit_code = main([str(tmp_repo)])
+        assert exit_code == 0


### PR DESCRIPTION
## Summary

Kernel-sourced validator that flags any compose / k8s env var whose NAME is in the kernel's `_DEPRECATED_TOPIC_ENV_VARS` tuple — direct **OMN-8840** regression prevention. Parent epic: **OMN-9048** (validator standardization).

**Ground truth**: `omnibase_infra/src/omnibase_infra/runtime/service_kernel.py` defines `_DEPRECATED_TOPIC_ENV_VARS` (OMN-8784). The validator parses that file via static `ast` walk to pull the current set — single source of truth, no duplication. Layer-clean: omnibase_core → omnibase_infra is forbidden, so the validator reads the kernel source as a text file (no runtime import, no executed code).

**Drift kind:**
- **BANNED_VAR** — compose/k8s exposes an env var whose NAME is in the banned set (value-agnostic). The OMN-8840 pattern: `ONEX_INPUT_TOPIC` persisted after OMN-8784 removed it from code.

**Deferred to OMN-9064** — forward-drift (`MISSING_VAR`): for each contract's declared topics, verify a compose entry exposes the expected env var. Enum value preserved for that follow-up.

CLI exits `2` on drift or on empty banned set (misconfigured — fail loudly), `0` on clean. `--kernel-source <path>` is required; `--extra-banned VAR_NAME` is a repeatable supplement for cross-repo coverage.

[skip-deploy-gate: validator-only library addition; no runtime handler, node, topic, or container behavior change — pure static check module + unit tests + allowlist entries]

## Real-world evidence

Smoke test against live `omnibase_infra/docker/*.yml`:

```
8 banned compose env var violation(s) (banned set size: 2).
docker-compose.e2e.yml:  [BANNED_VAR] ONEX_INPUT_TOPIC
docker-compose.infra.yml: [BANNED_VAR] ONEX_INPUT_TOPIC (x3)
docker-compose.e2e.yml:  [BANNED_VAR] ONEX_OUTPUT_TOPIC
docker-compose.infra.yml: [BANNED_VAR] ONEX_OUTPUT_TOPIC (x3)
```

This is exactly the OMN-8840 regression class — 8 concrete drift instances the validator would have caught at review time.

## What landed

- `src/omnibase_core/enums/enum_compose_drift_kind.py` — `StrEnum {BANNED_VAR, MISSING_VAR}`
- `src/omnibase_core/models/validation/model_compose_drift_violation.py` — frozen Pydantic model
- `src/omnibase_core/validation/validator_banned_compose_vars.py` — Pydantic `BaseModel` validator with `banned_env_vars()`, `check_paths()`, `extract_banned_env_vars_from_kernel()`, `main()` CLI
- `tests/unit/validation/test_validator_banned_compose_vars.py` — 15 unit tests (6 extractor + 9 validator)
- `pyproject.toml` — adds `validator_banned_compose_vars.py` to T201 per-file-ignores
- `.yaml-validation-allowlist.yaml` — adds validator under allowed_files

Handles three env-block forms: compose `environment:` dict, compose `environment:` list (`KEY=VAL` or `{name, value}`), k8s `env:` list of `{name, value}`.

## Test plan

- [x] `uv run pytest tests/unit/validation/test_validator_banned_compose_vars.py -v` — 15/15 pass
- [x] `uv run pytest tests/unit/validation/test_yaml_allowlist.py -v` — 10/10 pass (allowlist integrity)
- [x] `uv run pytest tests/ -m "not integration and not slow"` — full non-integration suite green
- [x] `uv run mypy src/` — strict clean
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] Pre-commit hooks — pass
- [x] Real-world smoke test — 8 `omnibase_infra/docker/*.yml` violations correctly flagged (OMN-8840 pattern)

## Follow-up

- **OMN-9063** — wire validator as pre-merge CI gate + pre-commit hook across every repo that ships `contract.yaml` + compose/k8s manifests
- **OMN-9064** — implement MISSING_VAR forward-drift check (contract declares a topic → compose must expose it)

---

Trigger: OMN-8840 · Parent epic: OMN-9048 · Follow-up: OMN-9063, OMN-9064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validator and CLI to detect banned environment variables in Docker Compose and Kubernetes manifests; includes new enum and model types and exports to surface results.

* **Tests**
  * Added unit tests covering banned-variable extraction, various compose/k8s env formats, extra-banned merging, and CLI exit behavior.

* **Chores**
  * Updated YAML allowlist and lint configuration to permit intended validation use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->