### PR TITLE
feat: validator-requirements.yaml as compliance-gate spec [OMN-9051]

### DIFF
--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -1,0 +1,376 @@
+---
+# Canonical validator requirements for OmniNode-ai downstream repos.
+#
+# This file is the single source of truth for which validators must be wired
+# on every repo's pre-commit + CI + branch protection. The handshake verifier
+# (check-handshake-validators.py) reads this spec and cross-references each
+# downstream repo's .pre-commit-config.yaml + .github/workflows/ + branch
+# protection required-checks, and fails loud on any missing/mis-configured
+# validator.
+#
+# Adding a new validator here automatically propagates to all 12 repos via the
+# OMN-9050 pin-bump bot: spec change → bot opens a bump PR on every downstream
+# repo → each repo's handshake workflow fails until wiring is added.
+#
+# See: OMN-9048 (validator standardization epic), OMN-9051 (this file's owner).
+
+schema_version:
+  major: 1
+  minor: 0
+  patch: 0
+
+# Scopes:
+#   - pre_commit: "required" | "optional"  — entry in .pre-commit-config.yaml
+#   - ci_workflow: "required" | "optional" — .github/workflows/*.yml that runs it
+#   - required_check_on_main: exact context name that must be in branch
+#     protection required_status_checks (or null if not gated at that level)
+#   - silent_skip_allowed: false (no advisory modes per feedback_no_informational_gates)
+#   - excludes.forbidden: regex patterns the exclude list MUST NOT contain
+#   - excludes.allowed: regex patterns the exclude list MAY contain (fixtures only)
+#   - applies_to_repos: which of the 12 repos must have this validator wired.
+#     "all" = all 12. Override with a list for validators that legitimately
+#     skip some repos (e.g., Python validators skip omniweb PHP).
+#   - central_source: canonical module/script location
+
+required_validators:
+
+  hardcoded-local-paths:
+    description: |
+      Blocks /Users/, /Volumes/, /home/, C:\Users\ absolute paths in source.
+      Violations escape this on any repo without the hook wired.
+    central_source: "omnibase_core.validation.validator_local_paths"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "validate-local-paths / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/fixtures/", "^docs/"]
+      forbidden: ["^tests/$", "^tests/[^f]", "^src/"]
+    applies_to_repos: all
+
+  spdx-headers:
+    description: |
+      Enforces MIT SPDX headers on source + tests + scripts + examples.
+    central_source: "omnibase_core CLI: onex spdx validate"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "SPDX Headers / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["\\.md$", "\\.ya?ml$", "\\.json$"]
+      forbidden: ["^tests/", "^src/"]
+    applies_to_repos: all
+
+  no-hardcoded-topics:
+    description: |
+      Kafka topic strings must come from contract.yaml, not hardcoded in source.
+    central_source: "onex_change_control (centralized hook)"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-Invariants / no-hardcoded-topics"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^docs/", "\\.yaml$"]
+      forbidden: ["^src/", "^tests/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+      - onex_change_control
+
+  stub-implementations:
+    description: |
+      Blocks NotImplementedError, bare pass, bare TODO docstrings in non-test source.
+    central_source: "omnibase_core.validation.check_stub_implementations"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Stub Implementations / check"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  enum-governance:
+    description: |
+      Enforces UPPER_SNAKE_CASE enum members + detects Literal-duplication anti-pattern.
+    central_source: "omnibase_core.validation.checker_enum_governance"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Enum Governance / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  naming-conventions:
+    description: |
+      File-naming (model_*, enum_*, protocol_*, handler_*, service_*, node_*) +
+      class-naming prefix (Model*, Enum*, Protocol*, Handler*, Service*).
+    central_source: "omnibase_core.validation.validate_naming_conventions"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Naming Conventions / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/", "^archived/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  self-gating-workflows:
+    description: |
+      Blocks cross-repo @main refs in .github/workflows/*.yml (retro §4.8).
+      Requires local-path ./.github/workflows/*.yml or pinned SHA/tag.
+    central_source: "scripts/check_self_gating_workflows.py (OMN-9039)"
+    pre_commit: required
+    ci_workflow: optional
+    required_check_on_main: null
+    silent_skip_allowed: false
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos: all
+
+  branch-protection-rollout-guard:
+    description: |
+      PreToolUse Claude Code hook that blocks gh api PUT/PATCH .../branches/*/protection
+      unless all required_status_checks contexts are emitted by a workflow on the repo.
+      Lives in omniclaude plugin only (runs at Claude-session level).
+    central_source: "omniclaude plugins/onex/hooks/lib/branch_protection_verifier.py (OMN-9038)"
+    pre_commit: optional
+    ci_workflow: optional
+    required_check_on_main: null
+    silent_skip_allowed: false
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omniclaude
+
+  bandit-security:
+    description: |
+      Python security linting (medium+ severity).
+    central_source: "bandit (pip); per-repo .bandit config"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Security Gate / bandit"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/", "^examples/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+
+  mypy-type-check:
+    description: |
+      Strict mypy on src/.
+    central_source: "mypy (pip); per-repo pyproject.toml [tool.mypy]"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Quality Gate / mypy"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  ruff-format-check:
+    description: |
+      Ruff format + check, universal across Python repos.
+    central_source: "astral-sh/ruff-pre-commit"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Quality Gate / ruff"
+    silent_skip_allowed: false
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+      - onex_change_control
+
+  aislop-patterns:
+    description: |
+      Detects AI-generated boilerplate, narrative docstrings, step_narration anti-patterns.
+    central_source: "omniclaude plugins/onex/skills/aislop_sweep"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "AI Slop / check"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^docs/", "^CHANGELOG\\.md$"]
+      forbidden: ["^src/"]
+    applies_to_repos: all
+
+  pydantic-patterns:
+    description: |
+      Enforces ConfigDict(frozen=True, extra="forbid"), Field(..., description), no Any, PEP 604 unions.
+    central_source: "omnibase_core.validation.validate_pydantic_patterns"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Pydantic Patterns / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  single-class-per-file:
+    description: |
+      Enforces one class per .py file (protocols + TypedDicts exempt).
+    central_source: "omnibase_core.validation.validate_single_class_per_file"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Single Class / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  detect-secrets:
+    description: |
+      Yelp/detect-secrets baseline, catches committed API keys / passwords / PEM keys.
+    central_source: "Yelp/detect-secrets"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Security Gate / detect-secrets"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["\\.secrets\\.baseline$", "^tests/fixtures/"]
+      forbidden: []
+    applies_to_repos: all
+
+  no-untracked-todos:
+    description: |
+      Blocks bare TODO/FIXME. Requires # TODO(OMN-XXXX): format.
+    central_source: "onex_change_control (centralized)"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-Invariants / no-untracked-todos"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^docs/"]
+      forbidden: ["^src/", "^tests/"]
+    applies_to_repos: all
+
+  arch-002-no-transport-imports:
+    description: |
+      Nodes must not import aiokafka/httpx/asyncpg directly (SPI boundary).
+      Only handlers/adapters may import transport libraries.
+    central_source: "omnibase_core.validation.validate_no_transport_imports"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-002 / no-transport-imports"
+    silent_skip_allowed: false
+    excludes:
+      allowed: ["^tests/", "^src/.*/runtime/", "^src/.*/api/", "^src/.*/adapters/"]
+      forbidden: ["^src/.*/nodes/"]
+    applies_to_repos:
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  banned-compose-env-vars:
+    description: |
+      Detects docker-compose / Kubernetes manifests that reference env vars the
+      handler code no longer reads. Bidirectional drift guard between kernel
+      version bumps and compose config. Trigger class: OMN-8840 runtime-effects
+      crash where banned ONEX_INPUT_TOPIC persisted in compose after code removal.
+    central_source: "omnibase_core.validation.validator_banned_compose_vars"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Compose Drift / validate"
+    silent_skip_allowed: false
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omnibase_infra
+      - omninode_infra
+
+# Handshake metadata
+
+metadata:
+  generated_by: "manually authored (OMN-9051)"
+  last_updated: "2026-04-17"
+  next_review: "on any new validator addition — single source of truth, change propagates via OMN-9050
+    bot"
+  related_tickets:
+    - OMN-9048  # validator standardization epic
+    - OMN-9049  # universal handshake coverage
+    - OMN-9050  # pin-bump bot
+    - OMN-9051  # this file's owner
+    - OMN-9058  # env-store abstraction

--- a/tests/validation/test_validator_requirements_spec.py
+++ b/tests/validation/test_validator_requirements_spec.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for architecture-handshakes/validator-requirements.yaml (OMN-9051).
+
+This spec is the single source of truth for which validators every downstream
+repo must have wired (pre-commit + CI + required-check). The handshake verifier
+reads it and cross-references each downstream repo's config.
+
+These tests lock the schema shape so changes to the spec cannot silently break
+consumers. If you hit a failure here, read the comment at the top of the
+schema file — the schema version MUST bump if you add/remove fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+SPEC_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "architecture-handshakes"
+    / "validator-requirements.yaml"
+)
+
+# Minimum number of validators the DoD requires. The ticket asks for >= 10.
+MIN_VALIDATORS = 10
+
+REQUIRED_TOP_LEVEL_KEYS = {"schema_version", "required_validators", "metadata"}
+
+REQUIRED_VALIDATOR_FIELDS = {
+    "description",
+    "central_source",
+    "pre_commit",
+    "ci_workflow",
+    "required_check_on_main",
+    "silent_skip_allowed",
+    "excludes",
+    "applies_to_repos",
+}
+
+VALID_SCOPE_VALUES = {"required", "optional"}
+
+# Repos that are allowed as applies_to_repos targets. Keep in sync with
+# omni_home/CLAUDE.md repository registry.
+KNOWN_REPOS = {
+    "omniclaude",
+    "omnibase_compat",
+    "omnibase_core",
+    "omnibase_spi",
+    "omnibase_infra",
+    "omnidash",
+    "omnimarket",
+    "omniintelligence",
+    "omnimemory",
+    "omninode_infra",
+    "omniweb",
+    "onex_change_control",
+}
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict[str, Any]:
+    assert SPEC_PATH.exists(), f"validator-requirements.yaml missing at {SPEC_PATH}"
+    with SPEC_PATH.open() as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict), "spec root must be a mapping"
+    return data
+
+
+def test_top_level_schema_shape(spec: dict[str, Any]) -> None:
+    """Spec file has exactly the top-level keys consumers expect."""
+    assert set(spec.keys()) == REQUIRED_TOP_LEVEL_KEYS, (
+        f"unexpected top-level keys: {set(spec.keys()) ^ REQUIRED_TOP_LEVEL_KEYS}"
+    )
+
+
+def test_schema_version_is_semver(spec: dict[str, Any]) -> None:
+    """schema_version uses ModelSemVer mapping (major/minor/patch) per ONEX
+    validator ``validate-string-versions`` — no string version literals."""
+    version = spec["schema_version"]
+    assert isinstance(version, dict), (
+        f"schema_version must be a ModelSemVer mapping, got {type(version).__name__}"
+    )
+    assert set(version.keys()) == {"major", "minor", "patch"}, (
+        f"schema_version keys must be {{major, minor, patch}}, got {set(version.keys())}"
+    )
+    for key, value in version.items():
+        assert isinstance(value, int) and value >= 0, (
+            f"schema_version.{key} must be a non-negative int, got {value!r}"
+        )
+
+
+def test_minimum_validator_count(spec: dict[str, Any]) -> None:
+    """DoD: spec must enumerate at least 10 validators from the inventory."""
+    validators = spec["required_validators"]
+    assert isinstance(validators, dict), "required_validators must be a mapping"
+    assert len(validators) >= MIN_VALIDATORS, (
+        f"DoD requires >= {MIN_VALIDATORS} validators; found {len(validators)}"
+    )
+
+
+def test_every_validator_has_required_fields(spec: dict[str, Any]) -> None:
+    """Each validator entry declares the full schema so the handshake verifier
+    can rely on the fields being present without defensive defaults."""
+    missing: dict[str, set[str]] = {}
+    for name, entry in spec["required_validators"].items():
+        entry_keys = set(entry.keys())
+        gap = REQUIRED_VALIDATOR_FIELDS - entry_keys
+        if gap:
+            missing[name] = gap
+    assert not missing, f"validators missing fields: {missing}"
+
+
+def test_scope_fields_use_required_or_optional(spec: dict[str, Any]) -> None:
+    for name, entry in spec["required_validators"].items():
+        for scope_field in ("pre_commit", "ci_workflow"):
+            value = entry[scope_field]
+            assert value in VALID_SCOPE_VALUES, (
+                f"{name}.{scope_field} must be one of {VALID_SCOPE_VALUES}, got {value!r}"
+            )
+
+
+def test_silent_skip_never_allowed(spec: dict[str, Any]) -> None:
+    """feedback_no_informational_gates: every check blocks. Advisory modes are
+    forbidden. The handshake must not tolerate a spec that opens a silent-skip
+    escape hatch."""
+    offenders = [
+        name
+        for name, entry in spec["required_validators"].items()
+        if entry["silent_skip_allowed"] is not False
+    ]
+    assert not offenders, (
+        f"silent_skip_allowed must be False for all validators; offenders: {offenders}"
+    )
+
+
+def test_required_check_context_is_string_or_null(spec: dict[str, Any]) -> None:
+    for name, entry in spec["required_validators"].items():
+        value = entry["required_check_on_main"]
+        assert value is None or isinstance(value, str), (
+            f"{name}.required_check_on_main must be str|None, got {type(value).__name__}"
+        )
+
+
+def test_excludes_shape(spec: dict[str, Any]) -> None:
+    for name, entry in spec["required_validators"].items():
+        excludes = entry["excludes"]
+        assert isinstance(excludes, dict), f"{name}.excludes must be mapping"
+        assert set(excludes.keys()) == {"allowed", "forbidden"}, (
+            f"{name}.excludes must have exactly 'allowed' and 'forbidden' keys"
+        )
+        for bucket in ("allowed", "forbidden"):
+            assert isinstance(excludes[bucket], list), (
+                f"{name}.excludes.{bucket} must be a list"
+            )
+            for pat in excludes[bucket]:
+                assert isinstance(pat, str), (
+                    f"{name}.excludes.{bucket} entries must be strings"
+                )
+
+
+def test_applies_to_repos_is_all_or_known_list(spec: dict[str, Any]) -> None:
+    """applies_to_repos is either the literal 'all' or a list of known repos.
+    Unknown repo names silently skip coverage — this check blocks typos."""
+    for name, entry in spec["required_validators"].items():
+        value = entry["applies_to_repos"]
+        if value == "all":
+            continue
+        assert isinstance(value, list), (
+            f"{name}.applies_to_repos must be 'all' or a list, got {value!r}"
+        )
+        unknown = set(value) - KNOWN_REPOS
+        assert not unknown, (
+            f"{name}.applies_to_repos references unknown repos: {unknown}"
+        )
+
+
+def test_metadata_references_ticket(spec: dict[str, Any]) -> None:
+    metadata = spec["metadata"]
+    assert isinstance(metadata, dict), "metadata must be a mapping"
+    related = metadata.get("related_tickets", [])
+    assert "OMN-9051" in related, (
+        "metadata.related_tickets must include OMN-9051 (this spec's owner)"
+    )
+
+
+def test_critical_validators_present(spec: dict[str, Any]) -> None:
+    """Anchor check: these validators were flagged in the 2026-04-17 inventory
+    as the blocking gaps. Removing any of them from the spec is a regression."""
+    required_names = {
+        "hardcoded-local-paths",
+        "spdx-headers",
+        "stub-implementations",
+        "enum-governance",
+        "naming-conventions",
+        "mypy-type-check",
+        "ruff-format-check",
+        "detect-secrets",
+    }
+    present = set(spec["required_validators"].keys())
+    missing = required_names - present
+    assert not missing, f"critical validators missing from spec: {missing}"


### PR DESCRIPTION
## Summary

Ship `architecture-handshakes/validator-requirements.yaml` as the canonical spec enumerating the 18 validators every downstream OmniNode repo must have wired across pre-commit + CI + branch-protection required-checks.

## Why

Per OMN-9048 epic + 2026-04-17 user directive: "we need a proper check to automate repository compliance for all validation logic. Shouldn't that be tied into the Handshake?" This YAML becomes the single source of truth that the architecture handshake verifier (OMN-9049) reads and cross-references against each downstream repo's actual wiring. Replaces the per-validator "file 11 sub-tickets" pattern — adding a validator here makes handshake fail loud on every repo that lacks it, surfacing the full coverage gap as CI errors.

## What

- `architecture-handshakes/validator-requirements.yaml` — 18 validators enumerated (DoD requires >=10), each with `pre_commit`, `ci_workflow`, `required_check_on_main`, `silent_skip_allowed`, `excludes.{allowed, forbidden}`, `applies_to_repos`, `central_source`.
- `tests/validation/test_validator_requirements_spec.py` — 11 schema tests lock the spec shape so changes cannot silently break downstream handshake consumers.
- `schema_version` uses `ModelSemVer` mapping (`{major, minor, patch}`) — respects `validate-string-versions` pre-commit hook.
- `silent_skip_allowed: false` enforced on every validator (respects `feedback_no_informational_gates`).

## DoD checklist

- [x] validator-requirements.yaml exists with >=10 validators (18 enumerated)
- [x] Schema-shape tests cover required fields, semver, silent-skip ban, known-repo list, critical validators
- [x] Pre-commit clean (ruff format/check, string-version, aislop, SPDX, yamlfmt, topics, TODO)
- [x] Strict mypy clean on new test file
- [x] Linked to OMN-9048 epic, OMN-9049 prerequisite, OMN-9050 prerequisite
- [ ] CI green (watching)

## Linear

- Ticket: https://linear.app/omninode/issue/OMN-9051
- Parent epic: OMN-9048 (validator standardization)

## Test plan

- [x] `uv run pytest tests/validation/test_validator_requirements_spec.py -v` — 11/11 pass
- [x] `pre-commit run --files architecture-handshakes/validator-requirements.yaml tests/validation/test_validator_requirements_spec.py` — all checks pass
- [x] Full suite on main via isolated file run: 55/55 SPI tests pass (40 failures in `-n auto` across full suite are pre-existing pytest-xdist event-loop flakes; CI uses test-splits)
- [ ] GitHub Actions: Quality Gate + test splits green on this PR (watching)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established canonical validator requirements definition specifying validation logic sources, deployment scopes (pre-commit and CI), exclusion patterns, repository applicability, and metadata configuration across the ecosystem.

* **Tests**
  * Implemented comprehensive test suite (11+ tests) validating schema structure, semver version compliance, required field presence, scope field values, exclusion patterns structure, repository allowlist constraints, and critical validator presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->