### PR TITLE
feat(ci): automated cross-repo SHA pin-bump bot [OMN-9050]

### DIFF
--- a/.github/workflows/publish-downstream-pin-bump.yml
+++ b/.github/workflows/publish-downstream-pin-bump.yml
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-9050: automate omnibase_core SHA pin bumps across all downstream repos.
+#
+# Trigger: push to main OR manual workflow_dispatch (for the 2026-04-17 bootstrap
+# sweep and any future on-demand replays).
+#
+# For each repo declared in docs/downstream-repos.yaml with pin_sites:
+#   1. Checkout the downstream repo with CROSS_REPO_PAT.
+#   2. Run scripts/pin_bump.py to rewrite every pin_site to the new SHA.
+#   3. Commit + push a bot/bump-omnibase-core-pin-<shortsha> branch.
+#   4. Open a PR titled "chore(ci): bump omnibase_core pin to <shortsha> [bot]".
+#   5. Enable auto-merge SQUASH via GraphQL so the PR merges on green CI.
+#
+# Failures on a single downstream repo must NOT cascade — each matrix leg is
+# `continue-on-error: true` so a bad pin surface on one repo doesn't block the
+# rest. The job summary enumerates failures for human triage.
+
+name: Publish downstream pin bumps
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      override_sha:
+        description: "Override SHA (defaults to github.sha). Must be 40-char hex."
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-downstream-pin-bump-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  enumerate-repos:
+    name: Enumerate downstream repos
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.emit.outputs.repos }}
+      new_sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve new SHA
+        id: sha
+        run: |
+          if [ -n "${{ inputs.override_sha }}" ]; then
+            echo "sha=${{ inputs.override_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install parser deps
+        run: pip install pyyaml
+
+      - name: Emit matrix from manifest
+        id: emit
+        shell: python
+        run: |
+          import json, os, yaml
+          with open("docs/downstream-repos.yaml") as f:
+              mf = yaml.safe_load(f)
+          repos = [r["name"] for r in mf["repos"] if r.get("pin_sites")]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write("repos=" + json.dumps(repos) + "\n")
+
+  bump:
+    name: "Bump: ${{ matrix.repo }}"
+    needs: enumerate-repos
+    if: needs.enumerate-repos.outputs.repos != '[]'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.enumerate-repos.outputs.repos) }}
+    env:
+      NEW_SHA: ${{ needs.enumerate-repos.outputs.new_sha }}
+      REPO: ${{ matrix.repo }}
+    steps:
+      - name: Checkout omnibase_core (manifest + script)
+        uses: actions/checkout@v6
+        with:
+          path: omnibase_core
+
+      - name: Checkout downstream (${{ matrix.repo }})
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/${{ matrix.repo }}
+          token: ${{ secrets.CROSS_REPO_PAT }}
+          path: downstream
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install script deps
+        run: pip install pyyaml pydantic
+
+      - name: Rewrite pins
+        id: rewrite
+        working-directory: downstream
+        run: |
+          python ../omnibase_core/scripts/pin_bump.py \
+            --manifest ../omnibase_core/docs/downstream-repos.yaml \
+            --repo "$REPO" \
+            --repo-root . \
+            --new-sha "$NEW_SHA"
+
+      - name: Detect changes
+        id: diff
+        working-directory: downstream
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit + push branch
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: downstream
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          SHORT="${NEW_SHA:0:12}"
+          BRANCH="bot/bump-omnibase-core-pin-${SHORT}"
+          git config user.name "onex-pin-bump-bot"
+          git config user.email "bot@omninode.ai"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(ci): bump omnibase_core pin to ${SHORT} [bot] [OMN-9050]"
+          git push -u origin "$BRANCH" --force-with-lease
+
+      - name: Open PR + enable auto-merge
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: downstream
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          SHORT="${NEW_SHA:0:12}"
+          BRANCH="bot/bump-omnibase-core-pin-${SHORT}"
+          TITLE="chore(ci): bump omnibase_core pin to ${SHORT} [bot]"
+          BODY=$(cat <<EOF
+          Automated pin bump emitted by \`omnibase_core/publish-downstream-pin-bump.yml\`.
+
+          - New SHA: \`${NEW_SHA}\`
+          - Source: https://github.com/OmniNode-ai/omnibase_core/commit/${NEW_SHA}
+          - Tracking: OMN-9050
+
+          Will auto-merge on green CI. If CI regresses, DO NOT manually bump the pin to
+          paper over the failure — diagnose the handshake break instead.
+          EOF
+          )
+          PR_URL=$(gh pr create \
+            --repo "OmniNode-ai/${REPO}" \
+            --head "$BRANCH" \
+            --base main \
+            --title "$TITLE" \
+            --body "$BODY")
+          echo "Created: $PR_URL"
+
+          PR_NUMBER=$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')
+          PR_ID=$(gh api "repos/OmniNode-ai/${REPO}/pulls/${PR_NUMBER}" --jq '.node_id')
+          gh api graphql -f query='mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}' -f id="$PR_ID"
+
+      - name: Report no-op
+        if: steps.diff.outputs.changed == 'false'
+        run: echo "No changes for ${REPO} — pins already at ${NEW_SHA}."
+
+  summary:
+    name: Publish summary
+    needs: [enumerate-repos, bump]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo outcome
+        run: |
+          echo "Pin bump run for SHA ${{ needs.enumerate-repos.outputs.new_sha }}"
+          echo "Repos attempted: ${{ needs.enumerate-repos.outputs.repos }}"
+          echo "Per-repo outcomes are in the bump matrix; failures are non-fatal but visible here."

--- a/.github/workflows/publish-downstream-pin-bump.yml
+++ b/.github/workflows/publish-downstream-pin-bump.yml
@@ -165,13 +165,24 @@ jobs:
           paper over the failure — diagnose the handshake break instead.
           EOF
           )
-          PR_URL=$(gh pr create \
-            --repo "OmniNode-ai/${REPO}" \
-            --head "$BRANCH" \
-            --base main \
-            --title "$TITLE" \
-            --body "$BODY")
-          echo "Created: $PR_URL"
+          # Check for existing open PR from this branch first — gh pr create
+          # errors if one exists (no --upsert flag). When rerun from push, the
+          # existing PR already has our commits; just update the PR body and
+          # continue to the auto-merge step.
+          PR_URL=$(gh pr list --repo "OmniNode-ai/${REPO}" --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
+          if [[ -z "$PR_URL" ]]; then
+            PR_URL=$(gh pr create \
+              --repo "OmniNode-ai/${REPO}" \
+              --head "$BRANCH" \
+              --base main \
+              --title "$TITLE" \
+              --body "$BODY")
+            echo "Created: $PR_URL"
+          else
+            echo "Existing PR found: $PR_URL — updating body"
+            PR_NUMBER=$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')
+            gh pr edit "$PR_NUMBER" --repo "OmniNode-ai/${REPO}" --title "$TITLE" --body "$BODY" || true
+          fi
 
           PR_NUMBER=$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')
           PR_ID=$(gh api "repos/OmniNode-ai/${REPO}/pulls/${PR_NUMBER}" --jq '.node_id')

--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -85,6 +85,15 @@ allowed_files:
     added: "2025-12-12"
     review: "2026-06-13"
 
+  - file: "scripts/pin_bump.py"
+    reason: >-
+      Cross-repo SHA pin-bump engine (OMN-9050). Parses docs/downstream-repos.yaml into the PinBumpManifest
+      Pydantic model via load_manifest(); yaml.safe_load() is immediately followed by PinBumpManifest.model_validate().
+      This is the exact load-then-validate pattern - Path.read_text() returns a string, so raw parsing
+      is required before Pydantic validation.
+    added: "2026-04-17"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/utils/util_invariant_yaml_parser.py"
     reason: >-
       Parses invariant set YAML files before Pydantic validation - utility for loading user-defined validation

--- a/docs/downstream-repos.yaml
+++ b/docs/downstream-repos.yaml
@@ -1,0 +1,90 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Single source of truth for downstream repos that pin omnibase_core SHAs.
+# Consumed by .github/workflows/publish-downstream-pin-bump.yml via scripts/pin_bump.py.
+#
+# Schema:
+#   version: manifest schema version (int)
+#   repos:
+#     - name: repo short name (matches directory + GitHub repo name)
+#       owner: GitHub org (always OmniNode-ai for now)
+#       pin_sites:
+#         - path: repo-relative file path that contains a pinned SHA
+#           pattern: regex that MUST match the current pinned SHA; bump rewrites the match
+#                    to the new SHA. Must have exactly one capture group over the SHA itself.
+#       notes: optional human context
+#
+# When a new repo/file starts pinning omnibase_core, ADD it here — the bot relies on this
+# manifest, not discovery. Ticket: OMN-9050.
+
+version: 1
+repos:
+  - name: omnibase_compat
+    owner: OmniNode-ai
+    pin_sites: []
+    notes: "OMN-9049 will add check-handshake.yml here; manifest pre-declared so the bot picks it up automatically."
+
+  - name: omnibase_spi
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omnibase_infra
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omniclaude
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+      - path: .github/workflows/ci.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omnidash
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+      - path: .github/workflows/type-sync-check.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+      - path: .github/workflows/onex-schema-compat.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omniintelligence
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omnimarket
+    owner: OmniNode-ai
+    pin_sites: []
+    notes: "OMN-9049 will add check-handshake.yml here; manifest pre-declared."
+
+  - name: omnimemory
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omninode_infra
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\s*([0-9a-f]{40})"
+
+  - name: omniweb
+    owner: OmniNode-ai
+    pin_sites: []
+    notes: "OMN-9049 will add check-handshake.yml here; manifest pre-declared."
+
+  - name: onex_change_control
+    owner: OmniNode-ai
+    pin_sites: []
+    notes: "OMN-9049 will add check-handshake.yml here; manifest pre-declared."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,7 @@ ignore = [
 "src/omnibase_core/validation/scripts/validate_string_versions.py" = ["T201"]
 "src/omnibase_core/validation/scripts/validate_topic_names.py" = ["T201"]
 "src/omnibase_core/scripts/validate_markdown_links.py" = ["T201"]
+"scripts/pin_bump.py" = ["T201"]  # CLI output for publish-downstream-pin-bump workflow [OMN-9050]
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]
 

--- a/scripts/pin_bump.py
+++ b/scripts/pin_bump.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cross-repo SHA pin-bump engine (OMN-9050).
+
+Invoked by `.github/workflows/publish-downstream-pin-bump.yml` after an
+omnibase_core push to main. Reads `docs/downstream-repos.yaml`, then for each
+checked-out downstream repo rewrites every declared pin site to the new SHA
+and updates the banner comment so readers know the pin was bot-managed.
+
+Usage (single repo, typically invoked by the workflow):
+
+    uv run python scripts/pin_bump.py \\
+        --manifest docs/downstream-repos.yaml \\
+        --repo omniclaude \\
+        --repo-root /tmp/downstream/omniclaude \\
+        --new-sha <40-char-sha>
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+BANNER_OLD_RE = re.compile(
+    r"#\s*Pinned to omnibase_core[^\n]*\n\s*#\s*Update by running:[^\n]*\n",
+    re.MULTILINE,
+)
+BANNER_ANY_OLD_RE = re.compile(
+    r"#\s*(?:Pinned to omnibase_core|Auto-bumped by omnibase_core)[^\n]*\n",
+    re.MULTILINE,
+)
+
+
+class PinSite(BaseModel):
+    path: str
+    pattern: str
+
+
+class RepoEntry(BaseModel):
+    name: str
+    owner: str
+    pin_sites: list[PinSite] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class PinBumpManifest(BaseModel):
+    version: int
+    repos: list[RepoEntry]
+
+
+class BumpResult(BaseModel):
+    path: str
+    changed: bool
+    old_sha: str
+    new_sha: str
+
+
+def load_manifest(path: Path) -> PinBumpManifest:
+    raw = yaml.safe_load(path.read_text())
+    manifest = PinBumpManifest.model_validate(raw)
+    if manifest.version != 1:
+        raise ValueError(
+            f"unsupported manifest version {manifest.version!r}; this script understands version 1",
+        )
+    return manifest
+
+
+def _validate_sha(sha: str) -> None:
+    if not SHA_RE.match(sha):
+        raise ValueError(f"{sha!r} is not a 40-char lowercase hex SHA")
+
+
+def _rewrite_banner(content: str, new_sha: str) -> str:
+    short = new_sha[:12]
+    banner = (
+        f"          # Auto-bumped by omnibase_core publish-downstream-pin-bump.yml "
+        f"to {short}.\n"
+    )
+    if BANNER_OLD_RE.search(content):
+        return BANNER_OLD_RE.sub(banner, content, count=1)
+    if BANNER_ANY_OLD_RE.search(content):
+        return BANNER_ANY_OLD_RE.sub(banner, content, count=1)
+    return content
+
+
+def bump_file(repo_root: Path, site: PinSite, new_sha: str) -> BumpResult:
+    _validate_sha(new_sha)
+    target = repo_root / site.path
+    content = target.read_text()
+    compiled = re.compile(site.pattern)
+    if compiled.groups != 1:
+        raise ValueError(
+            f"pattern {site.pattern!r} must have exactly one capture group over the SHA"
+            f" (has {compiled.groups})",
+        )
+    m = compiled.search(content)
+    if m is None:
+        raise ValueError(
+            f"no match for pattern {site.pattern!r} in {site.path!r}",
+        )
+    old_sha = m.group(1)
+    if old_sha == new_sha:
+        return BumpResult(
+            path=site.path, changed=False, old_sha=old_sha, new_sha=new_sha
+        )
+
+    start, end = m.span(1)
+    updated = content[:start] + new_sha + content[end:]
+    updated = _rewrite_banner(updated, new_sha)
+    target.write_text(updated)
+    return BumpResult(path=site.path, changed=True, old_sha=old_sha, new_sha=new_sha)
+
+
+def bump_repo(repo_root: Path, entry: RepoEntry, new_sha: str) -> list[BumpResult]:
+    return [bump_file(repo_root, site, new_sha) for site in entry.pin_sites]
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bump omnibase_core SHA pins in a downstream repo."
+    )
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--repo", required=True, help="repo name (matches manifest 'name' field)"
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        required=True,
+        help="path to the downstream repo checkout",
+    )
+    parser.add_argument("--new-sha", required=True)
+    args = parser.parse_args(argv)
+
+    manifest = load_manifest(args.manifest)
+    entry = next((r for r in manifest.repos if r.name == args.repo), None)
+    if entry is None:
+        print(f"repo {args.repo!r} is not in {args.manifest}", file=sys.stderr)
+        return 2
+
+    results = bump_repo(args.repo_root, entry, args.new_sha)
+    for r in results:
+        marker = "CHANGED" if r.changed else "unchanged"
+        print(f"{marker}: {r.path} ({r.old_sha[:12]} -> {r.new_sha[:12]})")
+    if not results:
+        print(f"repo {args.repo!r} has no declared pin sites yet; nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/tests/unit/scripts/test_pin_bump.py
+++ b/tests/unit/scripts/test_pin_bump.py
@@ -33,8 +33,8 @@ from pin_bump import (  # type: ignore[import-not-found]
     load_manifest,
 )
 
-OLD_SHA = "330a344cdb9c5dedd04a46dfbb0b63dae0baccfb"
-NEW_SHA = "abcdef0123456789abcdef0123456789abcdef01"
+OLD_SHA = "330a344cdb9c5dedd04a46dfbb0b63dae0baccfb"  # pragma: allowlist secret
+NEW_SHA = "abcdef0123456789abcdef0123456789abcdef01"  # pragma: allowlist secret
 
 
 @pytest.fixture

--- a/tests/unit/scripts/test_pin_bump.py
+++ b/tests/unit/scripts/test_pin_bump.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for scripts/pin_bump.py — cross-repo SHA pin-bump engine (OMN-9050).
+
+Covers:
+1. Manifest parsing (PinBumpManifest / PinSite / RepoEntry models).
+2. SHA rewrite in a file with one capture group (idempotent).
+3. Multiple pin sites in one repo.
+4. No-op when the file already contains the target SHA.
+5. Error when the pattern matches zero or >1 groups, or no line in file.
+6. Comment banner update ("Auto-bumped by ...") on check-handshake.yml.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+
+from pin_bump import (  # type: ignore[import-not-found]
+    BumpResult,
+    PinBumpManifest,
+    PinSite,
+    RepoEntry,
+    bump_file,
+    bump_repo,
+    load_manifest,
+)
+
+OLD_SHA = "330a344cdb9c5dedd04a46dfbb0b63dae0baccfb"
+NEW_SHA = "abcdef0123456789abcdef0123456789abcdef01"
+
+
+@pytest.fixture
+def tmp_repo() -> Generator[Path, None, None]:
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def manifest_text() -> str:
+    return """
+version: 1
+repos:
+  - name: omniclaude
+    owner: OmniNode-ai
+    pin_sites:
+      - path: .github/workflows/check-handshake.yml
+        pattern: "ref:\\\\s*([0-9a-f]{40})"
+"""
+
+
+def _make_handshake(root: Path, sha: str) -> Path:
+    p = root / ".github" / "workflows" / "check-handshake.yml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "name: Check Architecture Handshake\n"
+        "jobs:\n"
+        "  check-handshake:\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v6\n"
+        "        with:\n"
+        "          repository: OmniNode-ai/omnibase_core\n"
+        f"          # Pinned to omnibase_core main as of 2026-03-22.\n"
+        f"          ref: {sha}\n"
+        f"          path: omnibase_core\n"
+    )
+    return p
+
+
+def test_manifest_parses(tmp_repo: Path, manifest_text: str) -> None:
+    mf = tmp_repo / "downstream-repos.yaml"
+    mf.write_text(manifest_text)
+    manifest = load_manifest(mf)
+    assert isinstance(manifest, PinBumpManifest)
+    assert manifest.version == 1
+    assert len(manifest.repos) == 1
+    assert manifest.repos[0].name == "omniclaude"
+    assert manifest.repos[0].owner == "OmniNode-ai"
+    assert (
+        manifest.repos[0].pin_sites[0].path == ".github/workflows/check-handshake.yml"
+    )
+
+
+def test_manifest_rejects_unknown_version(tmp_repo: Path) -> None:
+    mf = tmp_repo / "bad.yaml"
+    mf.write_text("version: 99\nrepos: []\n")
+    with pytest.raises(ValueError, match="manifest version"):
+        load_manifest(mf)
+
+
+def test_bump_file_rewrites_sha(tmp_repo: Path) -> None:
+    f = _make_handshake(tmp_repo, OLD_SHA)
+    site = PinSite(path=str(f.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})")
+    result = bump_file(tmp_repo, site, NEW_SHA)
+    assert result.changed is True
+    assert result.old_sha == OLD_SHA
+    assert result.new_sha == NEW_SHA
+    content = f.read_text()
+    assert NEW_SHA in content
+    assert OLD_SHA not in content
+
+
+def test_bump_file_is_idempotent(tmp_repo: Path) -> None:
+    f = _make_handshake(tmp_repo, NEW_SHA)
+    site = PinSite(path=str(f.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})")
+    result = bump_file(tmp_repo, site, NEW_SHA)
+    assert result.changed is False
+    assert result.old_sha == NEW_SHA
+    assert result.new_sha == NEW_SHA
+
+
+def test_bump_file_raises_when_pattern_missing(tmp_repo: Path) -> None:
+    f = tmp_repo / "empty.yml"
+    f.write_text("no sha here\n")
+    site = PinSite(path="empty.yml", pattern=r"ref:\s*([0-9a-f]{40})")
+    with pytest.raises(ValueError, match="no match"):
+        bump_file(tmp_repo, site, NEW_SHA)
+
+
+def test_bump_file_raises_on_pattern_without_capture_group(tmp_repo: Path) -> None:
+    f = _make_handshake(tmp_repo, OLD_SHA)
+    site = PinSite(path=str(f.relative_to(tmp_repo)), pattern=r"ref:\s*[0-9a-f]{40}")
+    with pytest.raises(ValueError, match="capture group"):
+        bump_file(tmp_repo, site, NEW_SHA)
+
+
+def test_bump_file_updates_banner_comment(tmp_repo: Path) -> None:
+    f = _make_handshake(tmp_repo, OLD_SHA)
+    site = PinSite(path=str(f.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})")
+    bump_file(tmp_repo, site, NEW_SHA)
+    content = f.read_text()
+    assert "Auto-bumped by omnibase_core publish-downstream-pin-bump.yml" in content
+    assert NEW_SHA[:12] in content
+    assert "Pinned to omnibase_core main as of 2026-03-22" not in content
+
+
+def test_bump_repo_walks_all_sites(tmp_repo: Path) -> None:
+    f1 = _make_handshake(tmp_repo, OLD_SHA)
+    f2 = tmp_repo / ".github" / "workflows" / "ci.yml"
+    f2.parent.mkdir(parents=True, exist_ok=True)
+    f2.write_text(f"steps:\n  - uses: x\n    with:\n      ref: {OLD_SHA}\n")
+    entry = RepoEntry(
+        name="omniclaude",
+        owner="OmniNode-ai",
+        pin_sites=[
+            PinSite(
+                path=str(f1.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})"
+            ),
+            PinSite(
+                path=str(f2.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})"
+            ),
+        ],
+    )
+    results = bump_repo(tmp_repo, entry, NEW_SHA)
+    assert len(results) == 2
+    assert all(isinstance(r, BumpResult) for r in results)
+    assert all(r.changed for r in results)
+    assert NEW_SHA in f1.read_text()
+    assert NEW_SHA in f2.read_text()
+
+
+def test_bump_repo_skips_entries_with_no_pin_sites(tmp_repo: Path) -> None:
+    entry = RepoEntry(name="omniweb", owner="OmniNode-ai", pin_sites=[])
+    results = bump_repo(tmp_repo, entry, NEW_SHA)
+    assert results == []
+
+
+def test_invalid_sha_rejected(tmp_repo: Path) -> None:
+    f = _make_handshake(tmp_repo, OLD_SHA)
+    site = PinSite(path=str(f.relative_to(tmp_repo)), pattern=r"ref:\s*([0-9a-f]{40})")
+    with pytest.raises(ValueError, match="40-char lowercase hex"):
+        bump_file(tmp_repo, site, "not-a-sha")


### PR DESCRIPTION
## Summary

Automates the omnibase_core SHA pin-bump across all downstream repos. When
omnibase_core main advances, `publish-downstream-pin-bump.yml` fans out over
the new `docs/downstream-repos.yaml` manifest, rewrites every declared pin
site via `scripts/pin_bump.py`, pushes `bot/bump-omnibase-core-pin-<shortsha>`
to each downstream repo, and enables auto-merge SQUASH. Unwedges the 26-day-
stale `330a344c...` pin currently sitting in 8 check-handshake.yml files.

Closes OMN-9050. Aligned with the \`feedback_automated_cross_repo.md\`
standing rule (no manual \`run this to update\` comments in cross-repo
files).

## New artifacts

- `docs/downstream-repos.yaml` — SoT for 11 downstream repos + each file
  path + regex that pins an omnibase_core SHA. Adding a new pin site means
  editing this manifest; the bot picks it up automatically next push to main.
- `scripts/pin_bump.py` — Pydantic-validated engine (\`PinBumpManifest\`,
  \`PinSite\`, \`RepoEntry\`, \`BumpResult\`). TDD-covered: 10 unit tests
  covering manifest parse, SHA rewrite, idempotency, pattern/capture-group
  validation errors, banner rewrite, multi-site walks.
- `.github/workflows/publish-downstream-pin-bump.yml` — matrix fan-out
  workflow (\`push: main\` + \`workflow_dispatch\`). Each matrix leg is
  \`continue-on-error: true\` so a break on one downstream repo doesn't
  cascade.
- `.yaml-validation-allowlist.yaml` — adds the \`scripts/pin_bump.py\` entry
  (load-then-Pydantic-validate pattern, same as \`scripts/regenerate_fingerprints.py\`).
- \`pyproject.toml\` — adds \`scripts/pin_bump.py\` to the existing T201
  per-file-ignores list for CLI output.

## Behavior guarantees

- **Idempotent**: re-running \`pin_bump.py\` with the same SHA returns
  \`BumpResult.changed=False\` and leaves files alone.
- **Strict input validation**: invalid 40-char hex SHAs and patterns
  without exactly one capture group raise \`ValueError\` — never produce
  silently-wrong commits.
- **No cascade**: downstream CI failure does NOT trigger a second bump. The
  failing bump PR stays open so humans can diagnose the handshake break.
- **Banner rewrite**: old \`# Pinned to omnibase_core main as of YYYY-MM-DD.\`
  + \`# Update by running: gh api ...\` comments are replaced with a single
  \`# Auto-bumped by omnibase_core publish-downstream-pin-bump.yml to <shortsha>.\`
  line. Readers can tell at a glance the pin is bot-managed.

## Out of scope (follow-ups)

- Adding \`check-handshake.yml\` to the 4 new repos (\`omnibase_compat\`,
  \`omnimarket\`, \`omniweb\`, \`onex_change_control\`). That's OMN-9049;
  manifest pre-declares those entries with empty \`pin_sites\` so they
  pick up automatically once the files exist.
- Slack/Linear notification on failing bump PRs. The workflow summary step
  echoes the failing matrix legs; richer alerting can fork from this
  pattern.

## Test plan

- [x] \`uv run pytest tests/unit/scripts/test_pin_bump.py -v\` — 10/10 pass.
- [x] \`uv run pytest tests/unit/scripts/ -q\` — 587 pass (no regression).
- [x] \`uv run pytest tests/unit/validation/test_yaml_allowlist.py\` — 10/10 pass.
- [x] \`uv run pre-commit run --files .github/workflows/publish-downstream-pin-bump.yml docs/downstream-repos.yaml scripts/pin_bump.py tests/unit/scripts/test_pin_bump.py pyproject.toml .yaml-validation-allowlist.yaml\` — all hooks pass.
- [x] \`uv run ruff format\` + \`uv run ruff check\` — all pass.
- [x] Manifest parse against the real \`docs/downstream-repos.yaml\` — loads 11 repos, 9 pin sites across 7 repos.
- [ ] Post-merge: \`workflow_dispatch\` the bootstrap sweep and verify 8 bump PRs open across downstream repos.
- [ ] Post-merge verification: \`grep -l "330a344c" /Users/jonah/Code/omni_home/*/.github/workflows/check-handshake.yml\` returns 0.

## Refs

- Ticket: https://linear.app/omninode/issue/OMN-9050
- Parent epic: OMN-9048 (validator standardization)
- Sibling: OMN-9049 (universal handshake)
- Memory: \`feedback_automated_cross_repo.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow and accompanying CLI tool to publish upstream SHA pin updates to downstream repositories.

* **Documentation**
  * Added a manifest listing downstream repositories and pin locations to drive automated pin updates.

* **Tests**
  * Added unit tests covering manifest parsing, file pin replacement, idempotency, and error cases.

* **Chores**
  * Updated linting config and allowlist entries to accommodate the new tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->