### PR TITLE
fix(validation): re-wire ValidatorBannedComposeVars (never actually landed under OMN-9062) [OMN-9113]

### DIFF
--- a/.github/workflows/validator-banned-compose-vars.yml
+++ b/.github/workflows/validator-banned-compose-vars.yml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Compose Drift — ValidatorBannedComposeVars gate [OMN-9113]
+#
+# Canonical CI gate for `omnibase_core.validation.validator_banned_compose_vars`.
+# Required status check context: "Compose Drift / validate" — matches
+# architecture-handshakes/validator-requirements.yaml::banned-compose-env-vars.
+#
+# This workflow runs on omnibase_core itself:
+#   1. unit + integration pytest for the validator (regression guard)
+#   2. self-scan of omnibase_core's own compose/k8s YAMLs against a synthetic
+#      kernel tuple sourced from the omnibase_infra kernel constant, proving
+#      the CLI is resolvable and the check is green on this repo's own tree.
+#
+# Consumer repos (omnibase_infra, omninode_infra per validator-requirements.yaml)
+# wire this by adding the hook entry to their own .pre-commit-config.yaml and
+# mirroring the `validate` job in their own CI, pointing --kernel-source at
+# their local copy of service_kernel.py.
+
+name: Compose Drift
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: compose-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ValidatorBannedComposeVars unit + integration tests
+        run: |
+          uv run pytest \
+            tests/unit/validation/test_validator_banned_compose_vars.py \
+            tests/integration/test_validator_banned_compose_vars_integration.py \
+            -v
+
+      - name: Self-scan omnibase_core repo for banned compose env vars
+        run: |
+          # Synthetic kernel mirrors the current `_DEPRECATED_TOPIC_ENV_VARS`
+          # tuple in omnibase_infra/src/omnibase_infra/runtime/service_kernel.py
+          # (OMN-8784). omnibase_core has no legitimate consumer of those vars,
+          # so the scan must exit 0. If omnibase_core ever adds a real compose
+          # manifest that uses them, this gate catches it before merge.
+          cat > /tmp/synthetic_kernel.py <<'EOF'
+          # Mirror of omnibase_infra service_kernel._DEPRECATED_TOPIC_ENV_VARS.
+          _DEPRECATED_TOPIC_ENV_VARS: tuple[str, ...] = (
+              "ONEX_INPUT_TOPIC",
+              "ONEX_OUTPUT_TOPIC",
+          )
+          EOF
+          uv run python -m omnibase_core.validation.validator_banned_compose_vars \
+            --kernel-source /tmp/synthetic_kernel.py \
+            .

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,3 +40,17 @@
   types: [python]
   exclude: ^(tests/|archived/|archive/|examples/prototypes/).*\.py$
   stages: [pre-commit]
+
+- id: validator-banned-compose-vars
+  name: ValidatorBannedComposeVars (kernel-sourced banned env vars in compose/k8s)
+  description: >
+    Flags any docker-compose or k8s manifest that exposes an env var whose NAME appears in the kernel's
+    `_DEPRECATED_TOPIC_ENV_VARS` tuple (OMN-8784 canonical source). Direct OMN-8840 regression guard —
+    ONEX_INPUT_TOPIC persisted in compose after code removal. Consumer repos MUST override `args:` to
+    pass `--kernel-source` pointing at their vendored/checked-out service_kernel.py path.
+  language: python
+  entry: python -m omnibase_core.validation.validator_banned_compose_vars
+  files: (docker-compose.*\.ya?ml|k8s/.*\.ya?ml|kubernetes/.*\.ya?ml)$
+  pass_filenames: true
+  require_serial: true
+  stages: [pre-commit]

--- a/tests/integration/test_validator_banned_compose_vars_integration.py
+++ b/tests/integration/test_validator_banned_compose_vars_integration.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for ValidatorBannedComposeVars wiring [OMN-9113].
+
+Unit tests synthesize minimal kernels; this suite proves the wiring story end
+to end:
+
+* CLI entrypoint is resolvable as a module (what the pre-commit hook invokes).
+* A realistic docker-compose.yml containing ``ONEX_INPUT_TOPIC`` is flagged
+  against a real kernel tuple (OMN-8840 regression prevention).
+* The hook contract declared in ``.pre-commit-hooks.yaml`` advertises the CLI
+  entry the integration test just exercised.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.integration
+def test_cli_module_is_importable() -> None:
+    """`uv run python -m ...` must resolve — pre-commit hooks rely on it."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_banned_compose_vars",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--kernel-source" in result.stdout
+
+
+@pytest.mark.integration
+def test_realistic_compose_with_onex_input_topic_is_flagged(tmp_path: Path) -> None:
+    """A real docker-compose.yml with ONEX_INPUT_TOPIC must fire the validator."""
+    kernel = tmp_path / "service_kernel.py"
+    kernel.write_text(
+        '_DEPRECATED_TOPIC_ENV_VARS: tuple[str, ...] = ("ONEX_INPUT_TOPIC", "ONEX_OUTPUT_TOPIC")\n',
+        encoding="utf-8",
+    )
+
+    compose = tmp_path / "docker-compose.yml"
+    compose.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "runtime-effects": {
+                        "image": "omninode-runtime-effects:latest",
+                        "environment": {
+                            "KAFKA_BOOTSTRAP_SERVERS": "redpanda:9092",
+                            "ONEX_INPUT_TOPIC": "onex.cmd.runtime.request.v1",
+                            "LOG_LEVEL": "INFO",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from omnibase_core.enums.enum_compose_drift_kind import EnumComposeDriftKind
+    from omnibase_core.validation.validator_banned_compose_vars import (
+        ValidatorBannedComposeVars,
+    )
+
+    violations = ValidatorBannedComposeVars(kernel_source_path=kernel).check_paths(
+        [tmp_path]
+    )
+
+    flagged = {v.var_name for v in violations}
+    assert "ONEX_INPUT_TOPIC" in flagged
+    assert all(v.kind is EnumComposeDriftKind.BANNED_VAR for v in violations)
+
+
+@pytest.mark.integration
+def test_pre_commit_hook_declaration_matches_cli_entry() -> None:
+    """Hook id + entry in .pre-commit-hooks.yaml must reference the real module."""
+    hooks_file = REPO_ROOT / ".pre-commit-hooks.yaml"
+    hooks = yaml.safe_load(hooks_file.read_text(encoding="utf-8"))
+    ids = {hook["id"] for hook in hooks}
+    assert "validator-banned-compose-vars" in ids, (
+        "hook id 'validator-banned-compose-vars' missing from .pre-commit-hooks.yaml"
+    )
+    hook = next(h for h in hooks if h["id"] == "validator-banned-compose-vars")
+    assert "omnibase_core.validation.validator_banned_compose_vars" in hook["entry"]


### PR DESCRIPTION
## Summary

[OMN-9062](https://linear.app/omninode/issue/OMN-9062) shipped the validator source + enum + model + 19 unit tests on main (PR #831) but left the actual **wiring** off main. The dogfood audit on 2026-04-17 proved:

- `pre-commit run validator-banned-compose-vars` → `No hook with id`
- Zero entries in `.pre-commit-hooks.yaml`
- No CI workflow emits the `Compose Drift / validate` context the spec at `architecture-handshakes/validator-requirements.yaml:355` requires

Validators are enforcement, not detection (`feedback_no_informational_gates.md`). A closed ticket with no on-main wiring is worse than an open ticket.

## Three-way wire

1. **`.pre-commit-hooks.yaml`** — adds `validator-banned-compose-vars` hook entry that consumer repos (`omnibase_infra`, `omninode_infra` per `validator-requirements.yaml::applies_to_repos`) reference, overriding `args:` with their local `--kernel-source` path.

2. **`.github/workflows/validator-banned-compose-vars.yml`** — new `Compose Drift` workflow with `validate` job matching the required-check context `"Compose Drift / validate"`. Runs the validator's pytest suite plus a self-scan of omnibase_core's own tree against a synthetic kernel mirroring `_DEPRECATED_TOPIC_ENV_VARS`. Exits non-zero if omnibase_core ever grows a compose/k8s manifest with a banned var.

3. **Integration tests (TDD-first)** — hook-declaration test was red before the hook entry was added:
   - CLI module is resolvable via `python -m ...` (pre-commit hook contract)
   - Realistic docker-compose.yml with `ONEX_INPUT_TOPIC` → `BANNED_VAR` violation (OMN-8840 regression class)
   - `.pre-commit-hooks.yaml` declares id + entry targeting the real module

## Evidence

- `pre-commit run --files .pre-commit-hooks.yaml ...` → clean
- `uv run pytest tests/unit/validation/ tests/integration/test_validator_banned_compose_vars_integration.py` → **3596 passed, 4 skipped**
- `uv run mypy src/ --config-file=mypy.ini` → Success: no issues found in 3371 source files
- `uv run ruff check src/ tests/` → All checks passed
- Self-scan: `uv run python -m omnibase_core.validation.validator_banned_compose_vars --kernel-source /tmp/synthetic .` → exit 0

## Follow-up

- Propagation to consumer repos (`omnibase_infra`, `omninode_infra`) via OMN-9050 pin-bump bot (separate ticket)
- Branch-protection required-status-check addition for `"Compose Drift / validate"` via the standard audit tool after first green run on main

[skip-deploy-gate: pure validation wiring — no runtime handler, node, topic, or container behavior change]

---

Parent epic: OMN-9048 (validator standardization)
Trigger: OMN-8840 (ONEX_INPUT_TOPIC compose persistence)
Fixes: OMN-9113 (OMN-9062 re-wire)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated validation for Docker Compose and Kubernetes YAML files to detect banned environment variables in CI/CD pipelines and as a pre-commit hook for local development.

* **Chores**
  * Configured GitHub Actions workflow for continuous validation on push, pull requests, and merges.
  * Added integration tests to ensure validator functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->