### PR TITLE
ci(receipt-gate): wire omnibase_core caller [OMN-9074]

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Caller workflow that invokes the reusable receipt-gate on every PR targeting main.
+#
+# Receipt-gate (omnibase_core's .github/workflows/receipt-gate.yml) enforces
+# "Enforcement by Receipt" (OMN-TBD): every PR must cite a Linear ticket whose
+# dod_evidence items all have PASS ModelDodReceipt artifacts at the canonical
+# path on onex_change_control. Missing or failing receipts block merge.
+#
+# Required-status-check name (for branch-protection): `receipt-gate / verify`.
+# Branch-protection update happens after this workflow runs cleanly on a few
+# PRs — see follow-up ticket OMN-TBD for the protection flip.
+#
+# Eats its own dogfood: this PR itself is gated by the same receipt-gate once
+# the reusable workflow is present on main (PR #834).
+
+name: Receipt Gate
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify:
+    uses: ./.github/workflows/receipt-gate.yml


### PR DESCRIPTION
## Summary

Companion to [PR #834](https://github.com/OmniNode-ai/omnibase_core/pull/834) (reusable receipt-gate workflow).

\#834 ships the gate logic. This PR wires it as an actual CI check that runs on every \`pull_request\` → main + \`merge_group\` event, delegating to the reusable workflow via \`uses: ./.github/workflows/receipt-gate.yml\`.

Without this caller, \#834's reusable workflow exists but executes on nothing. Reusable workflows only run when invoked.

## Dependency

Must merge AFTER #834 lands on main. Will CI-fail here until that workflow exists on main (the \`uses:\` path resolves from the caller's ref).

## Follow-up (not this PR)

Branch-protection update to make \`receipt-gate / verify\` a required status check:

\`\`\`
python3 scripts/audit-branch-protection.py --repos omnibase_core    # precheck per OMN-9038
gh api repos/OmniNode-ai/omnibase_core/branches/main/protection ... # add required check
\`\`\`

Until the required-check flip lands, the gate runs as advisory (visible but not blocking). That's the final step that makes \"merge impossible without receipts\" structurally true.

## Fan-out

Same caller template lands in 11 other OmniNode repos following the OMN-8828 cr-thread-gate precedent (one caller per repo, all calling the same reusable workflow hosted here in omnibase_core).

## Test plan

- [ ] CI runs \`receipt-gate / verify\` on this PR (will fail until #834 merges)
- [ ] After #834 merges + rebase: \`receipt-gate / verify\` appears in status rollup
- [ ] Merge queue picks up clean
- [ ] Fan-out PRs open in 11 other repos
- [ ] Branch-protection update follow-up PR flips to required-check

## Override

This PR itself bypasses the gate (it adds the gate — bootstrap paradox).

\`\`\`
[skip-receipt-gate: bootstrap — wiring the receipt-gate caller itself; first receipts produced on next PR post-merge per follow-up ticket]
\`\`\`