### PR TITLE
feat(handshake): wire validator-requirements.yaml consumer (OMN-9051 shipped spec, not enforcement) [OMN-9115]

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -24,7 +24,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo
@@ -36,3 +36,18 @@ jobs:
 
       - name: Check architecture handshake
         run: bash architecture-handshakes/check-handshake.sh .
+
+      # OMN-9115: Enforce validator-requirements.yaml so the compliance-gate
+      # spec shipped by OMN-9051 is actually consumed. Runs against
+      # omnibase_core itself; downstream repos copy this workflow and change
+      # --repo accordingly (OMN-9049 universal rollout).
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Enforce validator-requirements.yaml
+        run: |
+          uv sync --all-extras
+          uv run python -m omnibase_core.validation.validator_requirements_consumer \
+            --repo omnibase_core \
+            --repo-root . \
+            --baseline architecture-handshakes/validator-requirements-baseline.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -275,7 +275,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 
@@ -717,6 +717,19 @@ repos:
       - id: check-forbidden-patterns
         name: Decommissioned Pattern Scanner
         entry: bash scripts/check_forbidden_patterns.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
+      # OMN-9115: Enforce architecture-handshakes/validator-requirements.yaml
+      # Runs the consumer in baseline mode; blocks on any new gap relative to
+      # validator-requirements-baseline.yaml. feedback_no_informational_gates:
+      # ratchet pattern (established precedent: validate-dict-any-usage).
+      - id: validate-validator-requirements
+        name: Enforce validator-requirements.yaml (OMN-9115)
+        entry: uv run python -m omnibase_core.validation.validator_requirements_consumer --repo omnibase_core
+          --repo-root . --baseline architecture-handshakes/validator-requirements-baseline.yaml
         language: system
         pass_filenames: false
         always_run: true

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -1,0 +1,63 @@
+---
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Accepted validator-requirement gaps for omnibase_core.
+#
+# This file is the ratchet baseline for validator_requirements_consumer.py.
+# Each entry is a gap the consumer would otherwise report against
+# architecture-handshakes/validator-requirements.yaml. The handshake gate
+# blocks:
+#
+#   - any NEW gap not listed here (regression)
+#   - any entry here that the consumer no longer reproduces (stale baseline;
+#     must be removed once the validator is wired)
+#
+# Individual entries close as OMN-9048 sub-tickets land. Remove each entry
+# when the corresponding wiring work lands in this repo. See
+# docs/audits/2026-04-17-validator-inventory.md for the per-validator roadmap.
+#
+# Spec consumer: OMN-9115. Baseline pattern mirrors validate-dict-any-usage
+# (pre-commit-config --max-violations), which is the established ratchet
+# precedent in this repo.
+- repo: omnibase_core
+  validator: bandit-security
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: bandit-security
+  kind: MISSING_PRE_COMMIT
+- repo: omnibase_core
+  validator: detect-secrets
+  kind: MISSING_PRE_COMMIT
+- repo: omnibase_core
+  validator: enum-governance
+  kind: SILENT_SKIP_WRAPPER
+- repo: omnibase_core
+  validator: hardcoded-local-paths
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: hardcoded-local-paths
+  kind: MISSING_PRE_COMMIT
+- repo: omnibase_core
+  validator: naming-conventions
+  kind: SILENT_SKIP_WRAPPER
+- repo: omnibase_core
+  validator: no-hardcoded-topics
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: no-untracked-todos
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: pydantic-patterns
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: self-gating-workflows
+  kind: MISSING_PRE_COMMIT
+- repo: omnibase_core
+  validator: single-class-per-file
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: spdx-headers
+  kind: MISSING_CI_WORKFLOW
+- repo: omnibase_core
+  validator: stub-implementations
+  kind: MISSING_CI_WORKFLOW

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -3,8 +3,8 @@
 #
 # This file is the single source of truth for which validators must be wired
 # on every repo's pre-commit + CI + branch protection. The handshake verifier
-# (check-handshake-validators.py) reads this spec and cross-references each
-# downstream repo's .pre-commit-config.yaml + .github/workflows/ + branch
+# (validator_requirements_consumer.py) reads this spec and cross-references
+# each downstream repo's .pre-commit-config.yaml + .github/workflows/ + branch
 # protection required-checks, and fails loud on any missing/mis-configured
 # validator.
 #
@@ -12,11 +12,12 @@
 # OMN-9050 pin-bump bot: spec change → bot opens a bump PR on every downstream
 # repo → each repo's handshake workflow fails until wiring is added.
 #
-# See: OMN-9048 (validator standardization epic), OMN-9051 (this file's owner).
+# See: OMN-9048 (validator standardization epic), OMN-9051 (spec),
+#      OMN-9115 (spec consumer + enforcement wiring).
 
 schema_version:
   major: 1
-  minor: 0
+  minor: 1
   patch: 0
 
 # Scopes:
@@ -31,6 +32,12 @@ schema_version:
 #     "all" = all 12. Override with a list for validators that legitimately
 #     skip some repos (e.g., Python validators skip omniweb PHP).
 #   - central_source: canonical module/script location
+#   - pre_commit_hook_ids: list of acceptable pre-commit hook id substrings.
+#     The consumer accepts any repo whose .pre-commit-config.yaml contains at
+#     least one hook whose id matches one of these substrings.
+#   - ci_workflow_keywords: list of acceptable CI workflow step-name / run-line
+#     substrings. The consumer accepts any repo whose .github/workflows/*.yml
+#     contains at least one step mentioning one of these keywords.
 
 required_validators:
 
@@ -43,6 +50,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "validate-local-paths / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-local-paths"
+      - "check-local-paths"
+    ci_workflow_keywords:
+      - "validator_local_paths"
+      - "validate-local-paths"
     excludes:
       allowed: ["^tests/fixtures/", "^docs/"]
       forbidden: ["^tests/$", "^tests/[^f]", "^src/"]
@@ -56,6 +69,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "SPDX Headers / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-spdx-headers"
+      - "spdx-headers"
+    ci_workflow_keywords:
+      - "spdx"
+      - "onex spdx validate"
     excludes:
       allowed: ["\\.md$", "\\.ya?ml$", "\\.json$"]
       forbidden: ["^tests/", "^src/"]
@@ -69,6 +88,11 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "ARCH-Invariants / no-hardcoded-topics"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "no-hardcoded-topics"
+    ci_workflow_keywords:
+      - "no-hardcoded-topics"
+      - "hardcoded-topics"
     excludes:
       allowed: ["^docs/", "\\.yaml$"]
       forbidden: ["^src/", "^tests/"]
@@ -91,6 +115,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Stub Implementations / check"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-stub-implementations"
+      - "stub-implementations"
+    ci_workflow_keywords:
+      - "check_stub_implementations"
+      - "stub-implementations"
     excludes:
       allowed: ["^tests/"]
       forbidden: ["^src/"]
@@ -111,6 +141,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Enum Governance / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-enum-governance"
+      - "enum-governance"
+    ci_workflow_keywords:
+      - "checker_enum_governance"
+      - "enum-governance"
     excludes:
       allowed: ["^tests/"]
       forbidden: ["^src/"]
@@ -133,6 +169,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Naming Conventions / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-naming-conventions"
+      - "validate-file-naming-conventions"
+    ci_workflow_keywords:
+      - "naming-conventions"
+      - "validate_naming"
     excludes:
       allowed: ["^tests/", "^archived/"]
       forbidden: ["^src/"]
@@ -155,6 +197,12 @@ required_validators:
     ci_workflow: optional
     required_check_on_main: null
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-self-gating-workflows"
+      - "self-gating-workflows"
+    ci_workflow_keywords:
+      - "check_self_gating_workflows"
+      - "self-gating"
     excludes:
       allowed: []
       forbidden: []
@@ -170,6 +218,10 @@ required_validators:
     ci_workflow: optional
     required_check_on_main: null
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "branch-protection-rollout-guard"
+    ci_workflow_keywords:
+      - "branch_protection_verifier"
     excludes:
       allowed: []
       forbidden: []
@@ -184,6 +236,10 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Security Gate / bandit"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "bandit"
+    ci_workflow_keywords:
+      - "bandit"
     excludes:
       allowed: ["^tests/", "^examples/"]
       forbidden: ["^src/"]
@@ -206,6 +262,11 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Quality Gate / mypy"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "mypy-type-check"
+      - "mypy"
+    ci_workflow_keywords:
+      - "mypy"
     excludes:
       allowed: ["^tests/"]
       forbidden: ["^src/"]
@@ -227,6 +288,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Quality Gate / ruff"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "ruff-format"
+      - "ruff-fix"
+      - "ruff"
+    ci_workflow_keywords:
+      - "ruff"
     excludes:
       allowed: []
       forbidden: []
@@ -250,6 +317,13 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "AI Slop / check"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-ai-slop"
+      - "aislop"
+    ci_workflow_keywords:
+      - "aislop"
+      - "ai-slop"
+      - "check_ai_slop"
     excludes:
       allowed: ["^docs/", "^CHANGELOG\\.md$"]
       forbidden: ["^src/"]
@@ -263,6 +337,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Pydantic Patterns / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-pydantic-patterns"
+      - "validate-pydantic-conventions"
+      - "pydantic-patterns"
+    ci_workflow_keywords:
+      - "pydantic"
     excludes:
       allowed: ["^tests/"]
       forbidden: ["^src/"]
@@ -284,6 +364,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Single Class / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "onex-single-class-per-file"
+      - "single-class-per-file"
+    ci_workflow_keywords:
+      - "single-class-per-file"
+      - "single_class"
     excludes:
       allowed: ["^tests/"]
       forbidden: ["^src/"]
@@ -305,6 +391,11 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Security Gate / detect-secrets"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "detect-secrets"
+    ci_workflow_keywords:
+      - "detect-secrets"
+      - "detect_secrets"
     excludes:
       allowed: ["\\.secrets\\.baseline$", "^tests/fixtures/"]
       forbidden: []
@@ -318,6 +409,11 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "ARCH-Invariants / no-untracked-todos"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "no-untracked-todos"
+    ci_workflow_keywords:
+      - "no-untracked-todos"
+      - "untracked-todos"
     excludes:
       allowed: ["^docs/"]
       forbidden: ["^src/", "^tests/"]
@@ -332,6 +428,12 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "ARCH-002 / no-transport-imports"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-no-transport-imports"
+      - "no-transport-imports"
+    ci_workflow_keywords:
+      - "validate_no_transport_imports"
+      - "no-transport-imports"
     excludes:
       allowed: ["^tests/", "^src/.*/runtime/", "^src/.*/api/", "^src/.*/adapters/"]
       forbidden: ["^src/.*/nodes/"]
@@ -354,6 +456,14 @@ required_validators:
     ci_workflow: required
     required_check_on_main: "Compose Drift / validate"
     silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validator-banned-compose-vars"
+      - "banned-compose-vars"
+      - "banned-compose-env-vars"
+    ci_workflow_keywords:
+      - "validator_banned_compose_vars"
+      - "banned-compose-vars"
+      - "banned-compose-env-vars"
     excludes:
       allowed: []
       forbidden: []
@@ -364,7 +474,7 @@ required_validators:
 # Handshake metadata
 
 metadata:
-  generated_by: "manually authored (OMN-9051)"
+  generated_by: "manually authored (OMN-9051); consumer added OMN-9115"
   last_updated: "2026-04-17"
   next_review: "on any new validator addition — single source of truth, change propagates via OMN-9050
     bot"
@@ -372,5 +482,6 @@ metadata:
     - OMN-9048  # validator standardization epic
     - OMN-9049  # universal handshake coverage
     - OMN-9050  # pin-bump bot
-    - OMN-9051  # this file's owner
+    - OMN-9051  # spec file owner
     - OMN-9058  # env-store abstraction
+    - OMN-9115  # spec consumer + enforcement wiring

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -17,8 +17,26 @@
 
 schema_version:
   major: 1
-  minor: 1
+  minor: 2
   patch: 0
+
+# Canonical list of all OmniNode repos governed by this spec. The consumer
+# uses this list to reject typos in repo arguments. Keep in sync when
+# onboarding/offboarding a repo; adding a repo here without wiring its
+# validators will surface as gaps on the next handshake run.
+known_repos:
+  - omniclaude
+  - omnibase_compat
+  - omnibase_core
+  - omnibase_spi
+  - omnibase_infra
+  - omnidash
+  - omnimarket
+  - omniintelligence
+  - omnimemory
+  - omninode_infra
+  - omniweb
+  - onex_change_control
 
 # Scopes:
 #   - pre_commit: "required" | "optional"  — entry in .pre-commit-config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ ignore = [
 "src/omnibase_core/services/service_validation_suite.py" = ["T201"]
 "src/omnibase_core/validation/validator_architecture.py" = ["T201"]
 "src/omnibase_core/validation/validator_banned_compose_vars.py" = ["T201"]
+"src/omnibase_core/validation/validator_requirements_consumer.py" = ["T201"]
 "src/omnibase_core/validation/validator_base.py" = ["T201"]
 "src/omnibase_core/validation/validator_circular_import.py" = ["T201"]
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]

--- a/src/omnibase_core/enums/enum_validator_requirement_gap_kind.py
+++ b/src/omnibase_core/enums/enum_validator_requirement_gap_kind.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validator-requirement compliance gap kind enumeration.
+
+Classifies violations found by ValidatorRequirementsConsumer when comparing
+a repo's ``.pre-commit-config.yaml`` + ``.github/workflows/*.yml`` against
+``architecture-handshakes/validator-requirements.yaml``.
+
+Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
+"""
+
+import enum
+
+__all__ = ["EnumValidatorRequirementGapKind"]
+
+
+@enum.unique
+class EnumValidatorRequirementGapKind(enum.StrEnum):
+    """Kind of validator-requirement compliance gap."""
+
+    MISSING_PRE_COMMIT = "MISSING_PRE_COMMIT"
+    MISSING_CI_WORKFLOW = "MISSING_CI_WORKFLOW"
+    SILENT_SKIP_WRAPPER = "SILENT_SKIP_WRAPPER"

--- a/src/omnibase_core/enums/enum_validator_requirement_scope.py
+++ b/src/omnibase_core/enums/enum_validator_requirement_scope.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validator-requirement scope enumeration.
+
+Constrains the ``pre_commit`` and ``ci_workflow`` scope fields on
+``ModelValidatorRequirementEntry`` so that a spec typo (e.g. ``requird``)
+surfaces as a Pydantic validation error at load time rather than silently
+bypassing enforcement.
+
+Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
+"""
+
+import enum
+
+__all__ = ["EnumValidatorRequirementScope"]
+
+
+@enum.unique
+class EnumValidatorRequirementScope(enum.StrEnum):
+    """Scope of a validator requirement.
+
+    ``REQUIRED`` — repos matching ``applies_to_repos`` MUST wire this
+    validator; a gap is reported if absent.
+    ``OPTIONAL`` — repos MAY skip this validator without producing a gap.
+    """
+
+    REQUIRED = "required"
+    OPTIONAL = "optional"

--- a/src/omnibase_core/models/validation/model_validator_requirement_entry.py
+++ b/src/omnibase_core/models/validation/model_validator_requirement_entry.py
@@ -9,6 +9,11 @@ reads the spec, constructs one of these per validator, and uses the typed
 fields rather than raw ``dict[str, Any]`` access so that any schema drift
 surfaces as a Pydantic validation error rather than a ``KeyError``.
 
+The model mirrors the full spec shape (``extra="forbid"``) so unknown
+fields fail loud, and ``pre_commit``/``ci_workflow`` use
+``EnumValidatorRequirementScope`` so scope typos (e.g. ``requird``) cannot
+silently bypass enforcement.
+
 Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
 """
 
@@ -16,24 +21,52 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.enums.enum_validator_requirement_scope import (
+    EnumValidatorRequirementScope,
+)
+from omnibase_core.models.validation.model_validator_requirement_excludes import (
+    ModelValidatorRequirementExcludes,
+)
+
 __all__ = ["ModelValidatorRequirementEntry"]
 
 
 class ModelValidatorRequirementEntry(BaseModel):
     """Typed view over a single ``required_validators[*]`` entry."""
 
-    model_config = ConfigDict(frozen=True, extra="ignore", from_attributes=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    pre_commit: str = Field(
+    description: str = Field(
+        description="Human-readable summary of what the validator enforces."
+    )
+    central_source: str = Field(
         description=(
-            "pre-commit scope: 'required' means repos must wire the hook; "
-            "'optional' means repos may skip without producing a gap."
+            "Canonical source module / CLI that hosts the validator "
+            "implementation (e.g. 'omnibase_core.validation.validator_x')."
         )
     )
-    ci_workflow: str = Field(
+    pre_commit: EnumValidatorRequirementScope = Field(
         description=(
-            "CI workflow scope: 'required' means a step must exist; "
-            "'optional' means CI coverage is a nice-to-have."
+            "pre-commit scope: REQUIRED means repos must wire the hook; "
+            "OPTIONAL means repos may skip without producing a gap."
+        )
+    )
+    ci_workflow: EnumValidatorRequirementScope = Field(
+        description=(
+            "CI workflow scope: REQUIRED means a step must exist; "
+            "OPTIONAL means CI coverage is a nice-to-have."
+        )
+    )
+    required_check_on_main: str | None = Field(
+        description=(
+            "GitHub required-check context name protecting main (e.g. "
+            "'SPDX Headers / validate'), or null if not yet wired."
+        )
+    )
+    silent_skip_allowed: bool = Field(
+        description=(
+            "Must be False; feedback_no_informational_gates forbids advisory "
+            "modes. Kept as a field so the spec test can enforce the invariant."
         )
     )
     pre_commit_hook_ids: list[str] = Field(
@@ -49,6 +82,12 @@ class ModelValidatorRequirementEntry(BaseModel):
             "Substrings accepted anywhere in .github/workflows/*.yml as "
             "evidence that this validator runs in CI."
         ),
+    )
+    excludes: ModelValidatorRequirementExcludes = Field(
+        description=(
+            "Allow/forbid path-regex buckets constraining where the "
+            "validator is permitted to skip."
+        )
     )
     applies_to_repos: list[str] | str = Field(
         description=(

--- a/src/omnibase_core/models/validation/model_validator_requirement_entry.py
+++ b/src/omnibase_core/models/validation/model_validator_requirement_entry.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed spec entry for validator-requirements.yaml.
+
+Each key under ``required_validators`` in the spec maps to a
+``ModelValidatorRequirementEntry``. The enforcement consumer (OMN-9115)
+reads the spec, constructs one of these per validator, and uses the typed
+fields rather than raw ``dict[str, Any]`` access so that any schema drift
+surfaces as a Pydantic validation error rather than a ``KeyError``.
+
+Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelValidatorRequirementEntry"]
+
+
+class ModelValidatorRequirementEntry(BaseModel):
+    """Typed view over a single ``required_validators[*]`` entry."""
+
+    model_config = ConfigDict(frozen=True, extra="ignore", from_attributes=True)
+
+    pre_commit: str = Field(
+        description=(
+            "pre-commit scope: 'required' means repos must wire the hook; "
+            "'optional' means repos may skip without producing a gap."
+        )
+    )
+    ci_workflow: str = Field(
+        description=(
+            "CI workflow scope: 'required' means a step must exist; "
+            "'optional' means CI coverage is a nice-to-have."
+        )
+    )
+    pre_commit_hook_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Substrings accepted as pre-commit hook ids for this validator. "
+            "At least one must match an entry in .pre-commit-config.yaml."
+        ),
+    )
+    ci_workflow_keywords: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Substrings accepted anywhere in .github/workflows/*.yml as "
+            "evidence that this validator runs in CI."
+        ),
+    )
+    applies_to_repos: list[str] | str = Field(
+        description=(
+            "Either the literal string 'all' (every repo) or a list of repo "
+            "names. Unknown names are a spec typo, caught by the shape tests."
+        )
+    )

--- a/src/omnibase_core/models/validation/model_validator_requirement_excludes.py
+++ b/src/omnibase_core/models/validation/model_validator_requirement_excludes.py
@@ -23,10 +23,8 @@ class ModelValidatorRequirementExcludes(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     allowed: list[str] = Field(
-        default_factory=list,
         description="Path regex patterns that this validator SKIPS by design.",
     )
     forbidden: list[str] = Field(
-        default_factory=list,
         description="Path regex patterns that are NEVER allowed in 'allowed'.",
     )

--- a/src/omnibase_core/models/validation/model_validator_requirement_excludes.py
+++ b/src/omnibase_core/models/validation/model_validator_requirement_excludes.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed view over the ``excludes`` block of a validator-requirements entry.
+
+Carries the two canonical buckets (``allowed`` path-regex patterns, and
+``forbidden`` path-regex patterns). Kept as a frozen Pydantic model so spec
+drift surfaces as a validation error rather than silently losing a bucket.
+
+Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelValidatorRequirementExcludes"]
+
+
+class ModelValidatorRequirementExcludes(BaseModel):
+    """Allow/forbid path-regex buckets for a validator's exclusion policy."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    allowed: list[str] = Field(
+        default_factory=list,
+        description="Path regex patterns that this validator SKIPS by design.",
+    )
+    forbidden: list[str] = Field(
+        default_factory=list,
+        description="Path regex patterns that are NEVER allowed in 'allowed'.",
+    )

--- a/src/omnibase_core/models/validation/model_validator_requirement_gap.py
+++ b/src/omnibase_core/models/validation/model_validator_requirement_gap.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validator-requirement compliance gap model.
+
+Represents a single gap between the validator-requirements.yaml spec and a
+repo's live ``.pre-commit-config.yaml`` + ``.github/workflows/`` state.
+
+Related ticket: OMN-9115 (consumer), OMN-9051 (spec), parent OMN-9048.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_validator_requirement_gap_kind import (
+    EnumValidatorRequirementGapKind,
+)
+
+__all__ = ["ModelValidatorRequirementGap"]
+
+
+class ModelValidatorRequirementGap(BaseModel):
+    """A single validator-requirement compliance gap."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str = Field(description="Target repo whose configuration is being scanned")
+    validator: str = Field(
+        description="Validator logical name (top-level key in validator-requirements.yaml)"
+    )
+    kind: EnumValidatorRequirementGapKind = Field(
+        description="Classification of the compliance gap"
+    )
+    detail: str = Field(description="Human-readable detail describing the gap")

--- a/src/omnibase_core/validation/validator_requirements_consumer.py
+++ b/src/omnibase_core/validation/validator_requirements_consumer.py
@@ -42,6 +42,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -67,34 +68,15 @@ _CANONICAL_SPEC_PATH: Final[Path] = (
     / "validator-requirements.yaml"
 )
 
-# Patterns that indicate a silent-skip wrapper in a pre-commit hook entry.
-# feedback_no_informational_gates: every check blocks. ``|| true`` / ``; exit 0``
-# / ``|| exit 0`` turn a failure into a pass and are forbidden.
-_SILENT_SKIP_MARKERS: Final[tuple[str, ...]] = (
-    "|| true",
-    "|| exit 0",
-    "; exit 0",
-    "; true",
+# Regex matching silent-skip wrappers in a pre-commit hook entry. Catches
+# formatting variants: ``|| true``, ``||true``, ``|| exit 0``, ``;exit 0``,
+# ``&& : || true`` etc. feedback_no_informational_gates: every check blocks;
+# any of these turn a failure into a pass and are forbidden.
+_SILENT_SKIP_RE: Final[re.Pattern[str]] = re.compile(
+    r"(\|\||;)\s*(true\b|exit\s*0\b|:(?:\s|$|[^A-Za-z0-9_]))",
 )
 
 _SCOPE_REQUIRED: Final[str] = "required"
-
-_KNOWN_REPOS: Final[frozenset[str]] = frozenset(
-    {
-        "omniclaude",
-        "omnibase_compat",
-        "omnibase_core",
-        "omnibase_spi",
-        "omnibase_infra",
-        "omnidash",
-        "omnimarket",
-        "omniintelligence",
-        "omnimemory",
-        "omninode_infra",
-        "omniweb",
-        "onex_change_control",
-    }
-)
 
 
 # Internal carrier for a single ``repos[*].hooks[*]`` entry from
@@ -104,7 +86,7 @@ _PreCommitHook = tuple[str, str]
 
 
 def _hook_is_silent_skip(hook: _PreCommitHook) -> bool:
-    return any(marker in hook[1] for marker in _SILENT_SKIP_MARKERS)
+    return _SILENT_SKIP_RE.search(hook[1]) is not None
 
 
 class ValidatorRequirementsConsumer:
@@ -116,8 +98,13 @@ class ValidatorRequirementsConsumer:
     a worktree or downstream checkout.
     """
 
-    def __init__(self, validators: dict[str, ModelValidatorRequirementEntry]) -> None:
+    def __init__(
+        self,
+        validators: dict[str, ModelValidatorRequirementEntry],
+        known_repos: frozenset[str] = frozenset(),
+    ) -> None:
         self.validators = validators
+        self._known_repos = known_repos
 
     # ---------------------------------------------------------------
     # Constructors
@@ -156,7 +143,14 @@ class ValidatorRequirementsConsumer:
             name: ModelValidatorRequirementEntry.model_validate(entry)
             for name, entry in raw_validators.items()
         }
-        return cls(validators=typed)
+        # known_repos is the canonical governed-repo list. Missing => permissive.
+        raw_known = raw.get("known_repos")
+        known: frozenset[str]
+        if isinstance(raw_known, list) and all(isinstance(r, str) for r in raw_known):
+            known = frozenset(raw_known)
+        else:
+            known = frozenset()
+        return cls(validators=typed, known_repos=known)
 
     # ---------------------------------------------------------------
     # Scan entry point
@@ -171,12 +165,14 @@ class ValidatorRequirementsConsumer:
         """Scan a target repo's pre-commit and CI configuration.
 
         Raises:
-            ValueError: If ``repo_name`` is not a known OmniNode repo.
-                Unknown repos are a typo class — fail loudly.
+            ValueError: If ``repo_name`` is not listed in the spec's
+                ``known_repos`` (typos fail loud). When the spec omits that
+                key the check is permissive.
         """
-        if repo_name not in _KNOWN_REPOS:
+        if self._known_repos and repo_name not in self._known_repos:
             raise ValueError(  # error-ok: CLI argument validation at call boundary
-                f"unknown repo {repo_name!r}; expected one of {sorted(_KNOWN_REPOS)}"
+                f"unknown repo {repo_name!r}; expected one of "
+                f"{sorted(self._known_repos)}"
             )
 
         pre_commit_hooks = self._load_pre_commit_hooks(repo_root)

--- a/src/omnibase_core/validation/validator_requirements_consumer.py
+++ b/src/omnibase_core/validation/validator_requirements_consumer.py
@@ -49,9 +49,13 @@ from pathlib import Path
 from typing import Final
 
 import yaml
+from pydantic import ValidationError
 
 from omnibase_core.enums.enum_validator_requirement_gap_kind import (
     EnumValidatorRequirementGapKind,
+)
+from omnibase_core.enums.enum_validator_requirement_scope import (
+    EnumValidatorRequirementScope,
 )
 from omnibase_core.models.validation.model_validator_requirement_entry import (
     ModelValidatorRequirementEntry,
@@ -75,9 +79,6 @@ _CANONICAL_SPEC_PATH: Final[Path] = (
 _SILENT_SKIP_RE: Final[re.Pattern[str]] = re.compile(
     r"(\|\||;)\s*(true\b|exit\s*0\b|:(?:\s|$|[^A-Za-z0-9_]))",
 )
-
-_SCOPE_REQUIRED: Final[str] = "required"
-
 
 # Internal carrier for a single ``repos[*].hooks[*]`` entry from
 # ``.pre-commit-config.yaml``. Kept as a plain tuple (hook_id, entry) so the
@@ -139,10 +140,14 @@ class ValidatorRequirementsConsumer:
             raise ValueError(  # error-ok: spec shape validation at load boundary
                 "spec.required_validators must be a mapping"
             )
-        typed: dict[str, ModelValidatorRequirementEntry] = {
-            name: ModelValidatorRequirementEntry.model_validate(entry)
-            for name, entry in raw_validators.items()
-        }
+        typed: dict[str, ModelValidatorRequirementEntry] = {}
+        for name, entry in raw_validators.items():
+            try:
+                typed[name] = ModelValidatorRequirementEntry.model_validate(entry)
+            except ValidationError as exc:
+                raise ValueError(  # error-ok: spec shape validation at load boundary
+                    f"spec.required_validators[{name!r}] is malformed: {exc}"
+                ) from exc
         # known_repos is the canonical governed-repo list. Missing => permissive.
         raw_known = raw.get("known_repos")
         known: frozenset[str]
@@ -253,7 +258,7 @@ def _check_validator(
 
     matched_hooks = [h for h in pre_commit_hooks if _any_substring(h[0], hook_ids)]
 
-    if entry.pre_commit == _SCOPE_REQUIRED and not matched_hooks:
+    if entry.pre_commit is EnumValidatorRequirementScope.REQUIRED and not matched_hooks:
         yield ModelValidatorRequirementGap(
             repo=repo_name,
             validator=validator_name,
@@ -275,8 +280,9 @@ def _check_validator(
                 ),
             )
 
-    if entry.ci_workflow == _SCOPE_REQUIRED and not _any_substring(
-        ci_haystack, ci_keywords
+    if (
+        entry.ci_workflow is EnumValidatorRequirementScope.REQUIRED
+        and not _any_substring(ci_haystack, ci_keywords)
     ):
         yield ModelValidatorRequirementGap(
             repo=repo_name,

--- a/src/omnibase_core/validation/validator_requirements_consumer.py
+++ b/src/omnibase_core/validation/validator_requirements_consumer.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorRequirementsConsumer — enforcement consumer for validator-requirements.yaml.
+
+OMN-9051 shipped ``architecture-handshakes/validator-requirements.yaml`` as the
+single source of truth for which validators every repo must have wired on
+pre-commit + CI. OMN-9115 wires this consumer so the spec is actually
+enforced rather than a paper spec.
+
+The consumer reads the spec and, for a given target repo directory, scans:
+
+  - ``.pre-commit-config.yaml`` for every validator whose ``applies_to_repos``
+    includes the target repo and whose ``pre_commit: required``.
+  - ``.github/workflows/*.yml`` step names / run lines for every validator
+    whose ``ci_workflow: required``.
+
+Any missing registration, or any hook wrapped in a ``|| true`` / ``; exit 0``
+silent-skip shim, is reported as a ``ModelValidatorRequirementGap``. The CLI
+exits non-zero when any gap is found (blocking gate per
+``feedback_no_informational_gates``).
+
+Usage::
+
+    # Programmatic
+    from omnibase_core.validation.validator_requirements_consumer import (
+        ValidatorRequirementsConsumer,
+    )
+
+    consumer = ValidatorRequirementsConsumer.from_canonical()
+    gaps = consumer.scan_repo(repo_name="omnibase_core", repo_root=Path("."))
+
+    # CLI
+    uv run python -m omnibase_core.validation.validator_requirements_consumer \\
+        --repo omnibase_core --repo-root .
+
+Exit codes:
+    0 — no gaps
+    2 — one or more gaps detected
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+from omnibase_core.enums.enum_validator_requirement_gap_kind import (
+    EnumValidatorRequirementGapKind,
+)
+from omnibase_core.models.validation.model_validator_requirement_entry import (
+    ModelValidatorRequirementEntry,
+)
+from omnibase_core.models.validation.model_validator_requirement_gap import (
+    ModelValidatorRequirementGap,
+)
+
+__all__ = ["ValidatorRequirementsConsumer"]
+
+_CANONICAL_SPEC_PATH: Final[Path] = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "architecture-handshakes"
+    / "validator-requirements.yaml"
+)
+
+# Patterns that indicate a silent-skip wrapper in a pre-commit hook entry.
+# feedback_no_informational_gates: every check blocks. ``|| true`` / ``; exit 0``
+# / ``|| exit 0`` turn a failure into a pass and are forbidden.
+_SILENT_SKIP_MARKERS: Final[tuple[str, ...]] = (
+    "|| true",
+    "|| exit 0",
+    "; exit 0",
+    "; true",
+)
+
+_SCOPE_REQUIRED: Final[str] = "required"
+
+_KNOWN_REPOS: Final[frozenset[str]] = frozenset(
+    {
+        "omniclaude",
+        "omnibase_compat",
+        "omnibase_core",
+        "omnibase_spi",
+        "omnibase_infra",
+        "omnidash",
+        "omnimarket",
+        "omniintelligence",
+        "omnimemory",
+        "omninode_infra",
+        "omniweb",
+        "onex_change_control",
+    }
+)
+
+
+# Internal carrier for a single ``repos[*].hooks[*]`` entry from
+# ``.pre-commit-config.yaml``. Kept as a plain tuple (hook_id, entry) so the
+# enforcement consumer file stays single-class (per onex-single-class-per-file).
+_PreCommitHook = tuple[str, str]
+
+
+def _hook_is_silent_skip(hook: _PreCommitHook) -> bool:
+    return any(marker in hook[1] for marker in _SILENT_SKIP_MARKERS)
+
+
+class ValidatorRequirementsConsumer:
+    """Read validator-requirements.yaml and enforce repo compliance.
+
+    This is the OMN-9115 consumer for the OMN-9051 spec. Prefer
+    ``ValidatorRequirementsConsumer.from_canonical()`` when scanning from
+    omnibase_core itself; use ``from_spec_path()`` when the spec lives under
+    a worktree or downstream checkout.
+    """
+
+    def __init__(self, validators: dict[str, ModelValidatorRequirementEntry]) -> None:
+        self.validators = validators
+
+    # ---------------------------------------------------------------
+    # Constructors
+    # ---------------------------------------------------------------
+
+    @classmethod
+    def from_canonical(cls) -> ValidatorRequirementsConsumer:
+        """Construct from the canonical spec under this repo's
+        ``architecture-handshakes/`` directory."""
+        return cls.from_spec_path(_CANONICAL_SPEC_PATH)
+
+    @classmethod
+    def from_spec_path(cls, spec_path: Path) -> ValidatorRequirementsConsumer:
+        """Construct from an arbitrary spec path.
+
+        Raises:
+            FileNotFoundError: If ``spec_path`` does not exist.
+            ValueError: If the spec is malformed.
+        """
+        if not spec_path.exists():
+            raise FileNotFoundError(  # error-ok: standard stdlib for missing file
+                f"validator-requirements.yaml missing at {spec_path}"
+            )
+        with spec_path.open() as fh:
+            raw = yaml.safe_load(fh)
+        if not isinstance(raw, dict):
+            raise ValueError(  # error-ok: spec shape validation at load boundary
+                "spec root must be a mapping"
+            )
+        raw_validators = raw.get("required_validators")
+        if not isinstance(raw_validators, dict):
+            raise ValueError(  # error-ok: spec shape validation at load boundary
+                "spec.required_validators must be a mapping"
+            )
+        typed: dict[str, ModelValidatorRequirementEntry] = {
+            name: ModelValidatorRequirementEntry.model_validate(entry)
+            for name, entry in raw_validators.items()
+        }
+        return cls(validators=typed)
+
+    # ---------------------------------------------------------------
+    # Scan entry point
+    # ---------------------------------------------------------------
+
+    def scan_repo(
+        self,
+        *,
+        repo_name: str,
+        repo_root: Path,
+    ) -> list[ModelValidatorRequirementGap]:
+        """Scan a target repo's pre-commit and CI configuration.
+
+        Raises:
+            ValueError: If ``repo_name`` is not a known OmniNode repo.
+                Unknown repos are a typo class — fail loudly.
+        """
+        if repo_name not in _KNOWN_REPOS:
+            raise ValueError(  # error-ok: CLI argument validation at call boundary
+                f"unknown repo {repo_name!r}; expected one of {sorted(_KNOWN_REPOS)}"
+            )
+
+        pre_commit_hooks = self._load_pre_commit_hooks(repo_root)
+        ci_haystack = self._load_ci_haystack(repo_root)
+
+        gaps: list[ModelValidatorRequirementGap] = []
+        for validator_name, entry in self.validators.items():
+            if not _applies_to(entry, repo_name):
+                continue
+            gaps.extend(
+                _check_validator(
+                    repo_name=repo_name,
+                    validator_name=validator_name,
+                    entry=entry,
+                    pre_commit_hooks=pre_commit_hooks,
+                    ci_haystack=ci_haystack,
+                )
+            )
+        return gaps
+
+    # ---------------------------------------------------------------
+    # Internals
+    # ---------------------------------------------------------------
+
+    def _load_pre_commit_hooks(self, repo_root: Path) -> list[_PreCommitHook]:
+        config_path = repo_root / ".pre-commit-config.yaml"
+        if not config_path.exists():
+            return []
+        with config_path.open() as fh:
+            raw = yaml.safe_load(fh) or {}
+        if not isinstance(raw, dict):
+            return []
+        hooks: list[_PreCommitHook] = []
+        for block in raw.get("repos", []) or []:
+            if not isinstance(block, dict):
+                continue
+            for hook in block.get("hooks", []) or []:
+                if not isinstance(hook, dict):
+                    continue
+                hook_id = hook.get("id")
+                if not isinstance(hook_id, str):
+                    continue
+                raw_entry = hook.get("entry", "") or ""
+                entry_text = raw_entry if isinstance(raw_entry, str) else str(raw_entry)
+                hooks.append((hook_id, entry_text))
+        return hooks
+
+    def _load_ci_haystack(self, repo_root: Path) -> str:
+        workflows_dir = repo_root / ".github" / "workflows"
+        if not workflows_dir.is_dir():
+            return ""
+        chunks: list[str] = []
+        for path in sorted(workflows_dir.glob("*.y*ml")):
+            try:
+                chunks.append(path.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+        return "\n".join(chunks)
+
+
+def _applies_to(entry: ModelValidatorRequirementEntry, repo_name: str) -> bool:
+    applies = entry.applies_to_repos
+    if isinstance(applies, str):
+        return applies == "all"
+    return repo_name in applies
+
+
+def _check_validator(
+    *,
+    repo_name: str,
+    validator_name: str,
+    entry: ModelValidatorRequirementEntry,
+    pre_commit_hooks: list[_PreCommitHook],
+    ci_haystack: str,
+) -> Iterable[ModelValidatorRequirementGap]:
+    hook_ids = entry.pre_commit_hook_ids
+    ci_keywords = entry.ci_workflow_keywords
+
+    matched_hooks = [h for h in pre_commit_hooks if _any_substring(h[0], hook_ids)]
+
+    if entry.pre_commit == _SCOPE_REQUIRED and not matched_hooks:
+        yield ModelValidatorRequirementGap(
+            repo=repo_name,
+            validator=validator_name,
+            kind=EnumValidatorRequirementGapKind.MISSING_PRE_COMMIT,
+            detail=f"no .pre-commit-config.yaml hook id matched any of {hook_ids}",
+        )
+
+    # Silent-skip wrappers are a violation regardless of pre_commit scope
+    # (feedback_no_informational_gates — no advisory modes).
+    for hook_id, hook_entry in matched_hooks:
+        if _hook_is_silent_skip((hook_id, hook_entry)):
+            yield ModelValidatorRequirementGap(
+                repo=repo_name,
+                validator=validator_name,
+                kind=EnumValidatorRequirementGapKind.SILENT_SKIP_WRAPPER,
+                detail=(
+                    f"pre-commit hook {hook_id!r} wraps execution in a "
+                    f"silent-skip shim: {hook_entry!r}"
+                ),
+            )
+
+    if entry.ci_workflow == _SCOPE_REQUIRED and not _any_substring(
+        ci_haystack, ci_keywords
+    ):
+        yield ModelValidatorRequirementGap(
+            repo=repo_name,
+            validator=validator_name,
+            kind=EnumValidatorRequirementGapKind.MISSING_CI_WORKFLOW,
+            detail=f"no .github/workflows/*.yml referenced any of {ci_keywords}",
+        )
+
+
+def _any_substring(haystack: str, needles: list[str]) -> bool:
+    return any(needle and needle in haystack for needle in needles)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_gaps(gaps: list[ModelValidatorRequirementGap]) -> str:
+    lines = [f"{len(gaps)} validator-requirement gap(s):"]
+    for gap in gaps:
+        lines.append(
+            f"  [{gap.kind.value}] {gap.repo} :: {gap.validator} — {gap.detail}"
+        )
+    return "\n".join(lines)
+
+
+def _load_baseline(path: Path) -> set[tuple[str, str, str]]:
+    """Load an accepted-gap baseline as a set of ``(repo, validator, kind)`` tuples.
+
+    The baseline is YAML shaped as a list of mapping entries. Unknown kind
+    values fail loudly to prevent silent drift.
+    """
+    if not path.exists():
+        return set()
+    with path.open() as fh:
+        raw = yaml.safe_load(fh) or []
+    if not isinstance(raw, list):
+        raise ValueError(  # error-ok: baseline shape validation at load boundary
+            f"baseline {path} must be a list of mappings"
+        )
+    accepted: set[tuple[str, str, str]] = set()
+    valid_kinds = {k.value for k in EnumValidatorRequirementGapKind}
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(  # error-ok: baseline shape validation at load boundary
+                f"baseline[{idx}] must be a mapping"
+            )
+        try:
+            repo = str(item["repo"])
+            validator = str(item["validator"])
+            kind = str(item["kind"])
+        except KeyError as exc:
+            raise ValueError(  # error-ok: baseline shape validation at load boundary
+                f"baseline[{idx}] missing field: {exc}"
+            ) from exc
+        if kind not in valid_kinds:
+            raise ValueError(  # error-ok: baseline shape validation at load boundary
+                f"baseline[{idx}].kind invalid: {kind}"
+            )
+        accepted.add((repo, validator, kind))
+    return accepted
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce validator-requirements.yaml (OMN-9115)."
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="Target repo name (must match a key in validator-requirements.yaml applies_to_repos)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to target repo's working tree (default: cwd)",
+    )
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        default=None,
+        help="Path to validator-requirements.yaml (default: canonical path under omnibase_core)",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Optional baseline YAML listing accepted gaps as "
+            "[{repo, validator, kind}, ...]. Any gap NOT in the baseline fails "
+            "the check. Baseline entries NOT reproduced by the scan also fail "
+            "(stale baseline). Mirrors the validate-dict-any-usage ratchet."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    spec_path = args.spec or _CANONICAL_SPEC_PATH
+    consumer = ValidatorRequirementsConsumer.from_spec_path(spec_path)
+    gaps = consumer.scan_repo(repo_name=args.repo, repo_root=args.repo_root)
+
+    if args.baseline is None:
+        if not gaps:
+            print(
+                f"validator-requirements: OK ({args.repo} @ {args.repo_root})",
+                file=sys.stderr,
+            )
+            return 0
+        print(_format_gaps(gaps), file=sys.stderr)
+        return 2
+
+    accepted = _load_baseline(args.baseline)
+    observed = {(g.repo, g.validator, g.kind.value) for g in gaps}
+    new_gaps = observed - accepted
+    stale_entries = accepted - observed
+
+    if not new_gaps and not stale_entries:
+        print(
+            f"validator-requirements: baseline-clean ({args.repo} — "
+            f"{len(observed)} accepted gap(s))",
+            file=sys.stderr,
+        )
+        return 0
+
+    if new_gaps:
+        print("New validator-requirement gaps not in baseline:", file=sys.stderr)
+        for repo, validator, kind in sorted(new_gaps):
+            print(f"  + [{kind}] {repo} :: {validator}", file=sys.stderr)
+    if stale_entries:
+        print(
+            "Baseline entries no longer reproduced (remove from baseline):",
+            file=sys.stderr,
+        )
+        for repo, validator, kind in sorted(stale_entries):
+            print(f"  - [{kind}] {repo} :: {validator}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: standard CLI entry-point idiom

--- a/tests/validation/test_validator_requirements_consumer.py
+++ b/tests/validation/test_validator_requirements_consumer.py
@@ -199,6 +199,32 @@ def test_scan_flags_warning_mode_wrapper(tmp_path: Path) -> None:
     ) in kinds
 
 
+def test_scan_flags_silent_skip_formatting_variants(tmp_path: Path) -> None:
+    """The silent-skip detector must catch formatting variants without spaces
+    or with alternative no-op commands (``||true``, ``;exit 0``, ``&& :``)."""
+    from omnibase_core.validation.validator_requirements_consumer import (
+        _hook_is_silent_skip,
+    )
+
+    variants = [
+        ("validate-local-paths", "bash -c 'run-x ||true'"),
+        ("validate-local-paths", "bash -c 'run-x ||exit 0'"),
+        ("validate-local-paths", "bash -c 'run-x ;exit 0'"),
+        ("validate-local-paths", "bash -c 'run-x ;true'"),
+        ("validate-local-paths", "bash -c 'run-x || :'"),
+    ]
+    for hid, entry in variants:
+        assert _hook_is_silent_skip((hid, entry)), (
+            f"Silent-skip detector missed variant: {entry!r}"
+        )
+
+    # Negative control: not a silent-skip wrapper (``&&`` propagates failures,
+    # ``|| false`` still returns non-zero on failure).
+    assert not _hook_is_silent_skip(("validate", "bash -c 'run-x && verify'"))
+    assert not _hook_is_silent_skip(("validate", "bash -c 'run-x || false'"))
+    assert not _hook_is_silent_skip(("validate", "run-x"))
+
+
 def test_scan_respects_applies_to_repos(tmp_path: Path) -> None:
     """A validator that does not apply to the target repo must NOT produce
     gaps even if its pre-commit hook id is absent. For example, omniweb (PHP)

--- a/tests/validation/test_validator_requirements_consumer.py
+++ b/tests/validation/test_validator_requirements_consumer.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the validator-requirements.yaml enforcement consumer (OMN-9115).
+
+OMN-9051 shipped the spec file; OMN-9115 wires the enforcement consumer. These
+tests verify the consumer:
+
+1. Loads the spec and detects missing pre-commit registrations per repo.
+2. Detects missing CI workflows / workflow steps per repo.
+3. Detects silent-skip advisory modes (`|| true`, warning-mode wrappers).
+4. Exits non-zero when any required validator is unwired (blocking gate per
+   feedback_no_informational_gates.md).
+5. Self-validates this repo (omnibase_core) at import time so the spec's own
+   host repo cannot regress.
+
+These are unit tests — they run against synthetic repo fixtures in ``tmp_path``
+to exercise the detection logic without coupling to the live state of other
+repos (which is covered by the on-repo pre-commit hook + CI workflow step).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.enum_validator_requirement_gap_kind import (
+    EnumValidatorRequirementGapKind,
+)
+from omnibase_core.models.validation.model_validator_requirement_gap import (
+    ModelValidatorRequirementGap,
+)
+from omnibase_core.validation.validator_requirements_consumer import (
+    ValidatorRequirementsConsumer,
+)
+
+SPEC_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "architecture-handshakes"
+    / "validator-requirements.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def spec_data() -> dict:
+    with SPEC_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def _write_precommit(
+    root: Path, hook_ids: list[str], *, warn_ids: list[str] | None = None
+) -> None:
+    warn_ids = warn_ids or []
+    blocks: list[dict] = [
+        {
+            "repo": "local",
+            "hooks": [
+                {"id": hid, "name": hid, "entry": f"run-{hid}", "language": "system"}
+                for hid in hook_ids
+            ]
+            + [
+                {
+                    "id": hid,
+                    "name": hid,
+                    # Warning-mode wrapper — the consumer must flag this as a silent-skip.
+                    "entry": f"bash -c 'run-{hid} || true'",
+                    "language": "system",
+                }
+                for hid in warn_ids
+            ],
+        }
+    ]
+    (root / ".pre-commit-config.yaml").write_text(yaml.safe_dump({"repos": blocks}))
+
+
+def _write_workflow(root: Path, filename: str, step_names: list[str]) -> None:
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / filename).write_text(
+        yaml.safe_dump(
+            {
+                "name": filename.rsplit(".", 1)[0],
+                "on": {"pull_request": {}, "push": {"branches": ["main"]}},
+                "jobs": {
+                    "check": {
+                        "runs-on": "ubuntu-latest",
+                        "steps": [
+                            {"name": step, "run": f"echo {step}"} for step in step_names
+                        ],
+                    }
+                },
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec loading
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_loads_spec_from_canonical_path() -> None:
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    assert consumer.validators, "consumer must expose the required_validators map"
+    assert "hardcoded-local-paths" in consumer.validators
+
+
+def test_consumer_rejects_missing_spec(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yaml"
+    with pytest.raises(FileNotFoundError):
+        ValidatorRequirementsConsumer.from_spec_path(missing)
+
+
+def test_consumer_rejects_malformed_spec(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("not-a-mapping")
+    with pytest.raises(ValueError, match="spec root must be a mapping"):
+        ValidatorRequirementsConsumer.from_spec_path(bad)
+
+
+# ---------------------------------------------------------------------------
+# Per-repo compliance scanning
+# ---------------------------------------------------------------------------
+
+
+def test_scan_reports_missing_pre_commit_registration(tmp_path: Path) -> None:
+    """If a required validator is missing from .pre-commit-config.yaml, the
+    consumer must emit a MISSING_PRE_COMMIT gap."""
+    # Simulate omnibase_compat with only ruff + spdx wired; missing detect-secrets.
+    _write_precommit(
+        tmp_path, ["ruff-format", "validate-spdx-headers", "check-ai-slop"]
+    )
+    _write_workflow(tmp_path, "ci.yml", ["ruff", "spdx", "aislop"])
+
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    gaps = consumer.scan_repo(repo_name="omnibase_compat", repo_root=tmp_path)
+
+    kinds = {(g.validator, g.kind) for g in gaps}
+    assert (
+        "detect-secrets",
+        EnumValidatorRequirementGapKind.MISSING_PRE_COMMIT,
+    ) in kinds
+
+
+def test_scan_reports_missing_ci_workflow(tmp_path: Path) -> None:
+    """If a required validator has no CI workflow step anywhere, the consumer
+    must emit a MISSING_CI_WORKFLOW gap."""
+    _write_precommit(
+        tmp_path,
+        [
+            "ruff-format",
+            "validate-spdx-headers",
+            "detect-secrets",
+            "check-ai-slop",
+            "validate-local-paths",
+        ],
+    )
+    # Workflow only mentions ruff — SPDX has no CI step.
+    _write_workflow(tmp_path, "ci.yml", ["ruff"])
+
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    gaps = consumer.scan_repo(repo_name="omnibase_compat", repo_root=tmp_path)
+
+    kinds = {(g.validator, g.kind) for g in gaps}
+    assert (
+        "spdx-headers",
+        EnumValidatorRequirementGapKind.MISSING_CI_WORKFLOW,
+    ) in kinds
+
+
+def test_scan_flags_warning_mode_wrapper(tmp_path: Path) -> None:
+    """A hook wrapped in ``|| true`` is a silent-skip violation. feedback
+    no_informational_gates forbids advisory modes."""
+    _write_precommit(
+        tmp_path,
+        ["validate-spdx-headers", "ruff-format", "detect-secrets", "check-ai-slop"],
+        warn_ids=["validate-local-paths"],
+    )
+    _write_workflow(
+        tmp_path,
+        "ci.yml",
+        ["spdx", "ruff", "detect-secrets", "aislop", "validate-local-paths"],
+    )
+
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    gaps = consumer.scan_repo(repo_name="omnibase_compat", repo_root=tmp_path)
+
+    kinds = {(g.validator, g.kind) for g in gaps}
+    assert (
+        "hardcoded-local-paths",
+        EnumValidatorRequirementGapKind.SILENT_SKIP_WRAPPER,
+    ) in kinds
+
+
+def test_scan_respects_applies_to_repos(tmp_path: Path) -> None:
+    """A validator that does not apply to the target repo must NOT produce
+    gaps even if its pre-commit hook id is absent. For example, omniweb (PHP)
+    should not be required to wire Python validators."""
+    # omniweb has nothing Python.
+    _write_precommit(tmp_path, [])
+    _write_workflow(tmp_path, "ci.yml", [])
+
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    gaps = consumer.scan_repo(repo_name="omniweb", repo_root=tmp_path)
+
+    flagged_validators = {g.validator for g in gaps}
+    # mypy-type-check and pydantic-patterns apply_to_repos list does not include omniweb.
+    assert "mypy-type-check" not in flagged_validators
+    assert "pydantic-patterns" not in flagged_validators
+
+
+def test_scan_rejects_unknown_repo(tmp_path: Path) -> None:
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    with pytest.raises(ValueError, match="unknown repo"):
+        consumer.scan_repo(repo_name="not-a-real-repo", repo_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Blocking exit behavior
+# ---------------------------------------------------------------------------
+
+
+def test_report_exit_code_zero_on_clean_repo(tmp_path: Path, spec_data: dict) -> None:
+    """When every required validator for the target repo is present with
+    required pre-commit + CI wiring and no warning-mode wrapper, scan_repo
+    must return an empty list."""
+    # Build a repo that satisfies every validator listed as applies-to omnibase_core.
+    pre_commit_ids = [
+        "validate-local-paths",
+        "validate-spdx-headers",
+        "no-hardcoded-topics",
+        "check-stub-implementations",
+        "check-enum-governance",
+        "validate-naming-conventions",
+        "check-self-gating-workflows",
+        "bandit",
+        "mypy-type-check",
+        "ruff-format",
+        "check-ai-slop",
+        "validate-pydantic-patterns",
+        "onex-single-class-per-file",
+        "detect-secrets",
+        "no-untracked-todos",
+        "validate-no-transport-imports",
+    ]
+    _write_precommit(tmp_path, pre_commit_ids)
+
+    # Flatten into a single CI workflow that exposes a step per validator.
+    _write_workflow(tmp_path, "ci.yml", pre_commit_ids)
+
+    consumer = ValidatorRequirementsConsumer.from_spec_path(SPEC_PATH)
+    gaps = consumer.scan_repo(repo_name="omnibase_core", repo_root=tmp_path)
+
+    # Nothing else applies to omnibase_core in the current spec, so zero gaps expected.
+    assert gaps == [], f"expected clean repo to produce zero gaps, got: {gaps}"
+
+
+def test_scan_gap_model_is_frozen() -> None:
+    """ModelValidatorRequirementGap must be a frozen Pydantic model (per repo pydantic
+    conventions) — gaps are facts about a point-in-time scan and must not be
+    mutated post-construction."""
+    gap = ModelValidatorRequirementGap(
+        repo="omnibase_compat",
+        validator="detect-secrets",
+        kind=EnumValidatorRequirementGapKind.MISSING_PRE_COMMIT,
+        detail="missing hook id",
+    )
+    with pytest.raises(ValueError):
+        gap.detail = "mutated"  # type: ignore[misc]

--- a/tests/validation/test_validator_requirements_consumer.py
+++ b/tests/validation/test_validator_requirements_consumer.py
@@ -125,6 +125,70 @@ def test_consumer_rejects_malformed_spec(tmp_path: Path) -> None:
         ValidatorRequirementsConsumer.from_spec_path(bad)
 
 
+def test_consumer_normalizes_entry_validation_to_value_error(tmp_path: Path) -> None:
+    """A malformed validator entry must surface as ``ValueError`` at the loader
+    boundary (documented contract) rather than leaking Pydantic's
+    ``ValidationError`` to callers."""
+    bad = tmp_path / "bad_entry.yaml"
+    # pre_commit must be 'required'|'optional' (EnumValidatorRequirementScope);
+    # 'warn' is a scope typo that used to be accepted when the field was a bare str.
+    bad.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": {"major": 1, "minor": 1, "patch": 0},
+                "required_validators": {
+                    "bogus-validator": {
+                        "description": "x",
+                        "central_source": "x",
+                        "pre_commit": "warn",
+                        "ci_workflow": "required",
+                        "required_check_on_main": None,
+                        "silent_skip_allowed": False,
+                        "excludes": {"allowed": [], "forbidden": []},
+                        "applies_to_repos": "all",
+                    }
+                },
+                "metadata": {},
+                "known_repos": [],
+            }
+        )
+    )
+    with pytest.raises(
+        ValueError, match=r"spec.required_validators\['bogus-validator'\] is malformed"
+    ):
+        ValidatorRequirementsConsumer.from_spec_path(bad)
+
+
+def test_consumer_rejects_unknown_entry_field(tmp_path: Path) -> None:
+    """Unknown fields on a validator entry must fail loud (extra='forbid') so
+    schema drift surfaces at load time rather than silently being ignored."""
+    bad = tmp_path / "extra_field.yaml"
+    bad.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": {"major": 1, "minor": 1, "patch": 0},
+                "required_validators": {
+                    "drifty-validator": {
+                        "description": "x",
+                        "central_source": "x",
+                        "pre_commit": "required",
+                        "ci_workflow": "required",
+                        "required_check_on_main": None,
+                        "silent_skip_allowed": False,
+                        "excludes": {"allowed": [], "forbidden": []},
+                        "applies_to_repos": "all",
+                        "unexpected_drift_field": "oops",
+                    }
+                },
+                "metadata": {},
+                "known_repos": [],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="drifty-validator"):
+        ValidatorRequirementsConsumer.from_spec_path(bad)
+
+
 # ---------------------------------------------------------------------------
 # Per-repo compliance scanning
 # ---------------------------------------------------------------------------

--- a/tests/validation/test_validator_requirements_spec.py
+++ b/tests/validation/test_validator_requirements_spec.py
@@ -40,6 +40,11 @@ REQUIRED_VALIDATOR_FIELDS = {
     "silent_skip_allowed",
     "excludes",
     "applies_to_repos",
+    # OMN-9115: matcher fields used by the enforcement consumer so
+    # .pre-commit-config.yaml / .github/workflows/*.yml scans are driven by
+    # the spec rather than hardcoded in the consumer.
+    "pre_commit_hook_ids",
+    "ci_workflow_keywords",
 }
 
 VALID_SCOPE_VALUES = {"required", "optional"}

--- a/tests/validation/test_validator_requirements_spec.py
+++ b/tests/validation/test_validator_requirements_spec.py
@@ -29,7 +29,12 @@ SPEC_PATH = (
 # Minimum number of validators the DoD requires. The ticket asks for >= 10.
 MIN_VALIDATORS = 10
 
-REQUIRED_TOP_LEVEL_KEYS = {"schema_version", "required_validators", "metadata"}
+REQUIRED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "required_validators",
+    "metadata",
+    "known_repos",
+}
 
 REQUIRED_VALIDATOR_FIELDS = {
     "description",


### PR DESCRIPTION
[skip-receipt-gate: OMN-9115 consumer PR predates receipt producer wiring]

[skip-receipt-gate: OMN-9115 is the validator requirements CONSUMER; a ModelDodReceipt for this PR requires the OMN-9051 receipt-producer side which just landed in main — receipts can be produced on the NEXT PR, not retroactively on this one]

[skip-deploy-gate: deploy-agent inactive per OMN-8841]

## Summary

OMN-9051 merged `architecture-handshakes/validator-requirements.yaml` as the single source of truth for which validators every repo must wire on pre-commit + CI. The dogfood audit (`docs/tracking/2026-04-17-dogfood-audit.md`) found **zero** Python or workflow consumers — 4 doc-file references only. The compliance-gate design shipped by OMN-9051 was paper.

This PR ships the enforcement consumer so the spec is actually read and fails CI on any regression.

## What's new

- `EnumValidatorRequirementGapKind` — `MISSING_PRE_COMMIT` | `MISSING_CI_WORKFLOW` | `SILENT_SKIP_WRAPPER`
- `ModelValidatorRequirementGap` — frozen pydantic model carrying per-gap facts
- `ModelValidatorRequirementEntry` — typed view over a spec entry so drift surfaces as pydantic errors
- `ValidatorRequirementsConsumer` — reads the spec, scans a target repo's `.pre-commit-config.yaml` + `.github/workflows/*.yml`, emits gaps per `applies_to_repos`
- CLI (`uv run python -m omnibase_core.validation.validator_requirements_consumer --repo … --repo-root … [--baseline …]`) with **ratchet baseline** mode mirroring the established `validate-dict-any-usage` pattern

## Spec changes

- Added `pre_commit_hook_ids: list[str]` + `ci_workflow_keywords: list[str]` matcher fields to every validator so matching is declarative, not hardcoded
- `schema_version` bumped `1.0.0 → 1.1.0`
- `test_validator_requirements_spec.REQUIRED_VALIDATOR_FIELDS` updated to expect the two new fields

## Enforcement wiring (this repo; OMN-9049 propagates to other 10 repos)

- New pre-commit hook `validate-validator-requirements` (pre-commit stage)
- New step in `.github/workflows/check-handshake.yml` invoking the consumer
- Initial `validator-requirements-baseline.yaml` captures the 14 real gaps in `omnibase_core` today — baseline entries close as OMN-9048 sub-tickets land

## TDD (10 new tests)

1. Spec load + malformed-spec error + missing-spec error
2. Missing pre-commit → `MISSING_PRE_COMMIT`
3. Missing CI workflow → `MISSING_CI_WORKFLOW`
4. `|| true` wrapper → `SILENT_SKIP_WRAPPER` (per `feedback_no_informational_gates`)
5. `applies_to_repos` scoping respected (`omniweb` not held to Python validators)
6. Unknown repo name fails loudly
7. Clean repo → zero gaps
8. Gap model is frozen (mutation raises)

All 21 tests green (10 new + 11 existing spec-shape).

## Baseline ratchet design

Any NEW gap not in baseline → CI red.
Any baseline entry NOT reproduced by the scan → CI red (stale baseline).
Zero wiggle room, no advisory modes — satisfies `feedback_no_informational_gates` while allowing incremental rollout.

## Cross-cite

- OMN-9051 — shipped the spec file
- OMN-9048 — parent validator-standardization epic
- OMN-9049 — universal handshake coverage (this workflow block is the template)
- OMN-9113 — ValidatorBannedComposeVars re-wiring (one of the spec's enumerated validators)

## Test plan

- [x] `uv run pytest tests/validation/` (106/106 green)
- [x] `uv run mypy --strict` on new files
- [x] `pre-commit run --files` + `pre-commit run --hook-stage pre-push --files` all green
- [x] Consumer CLI runs against omnibase_core, reports 14 gaps without baseline, exit 0 with baseline
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced validator-requirements scanning across repos (pre-commit + CI evidence), with silent-skip detection, matching by hook IDs and workflow keywords, CLI supports baseline-aware validation.

* **Chores**
  * Added a ratcheting baseline for accepted validator gaps.
  * Validation now runs in pre-commit and CI; CI job timeout increased to 10 minutes.
  * Lint/pre-commit config updated to accommodate the new consumer.

* **Tests**
  * Added tests for spec parsing, repo scanning, gap detection, and baseline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->