### PR TITLE
fix(ci/receipt-gate): match package name line, not any grep hit [OMN-9051]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -101,7 +101,7 @@ jobs:
         # Never fall back to PyPI — the published package has a broken transitive
         # dep (git+https omnibase-compat URL) that fails in CI.
         run: |
-          if [ -f "./pyproject.toml" ] && grep -q "omnibase.core\|omnibase_core" ./pyproject.toml 2>/dev/null; then
+          if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
             uv pip install --system -e .
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
             uv pip install --system -e ./omnibase_compat -e ./omnibase_core


### PR DESCRIPTION
Tighter regex for the in-tree detection branch. Prior grep matched any pyproject.toml that listed omnibase-core as a dep (e.g. omnibase_infra), triggering the wrong install path and hitting the broken PyPI transitive omnibase-compat dep. Now matches only the package-name declaration line.

Unblocks verify/verify on ~6 stuck PRs across omnibase_infra/omniclaude/omnimarket.

[skip-receipt-gate: OMN-9051 bootstrap substrate fix — self-gating]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation detection logic in the build workflow to use more precise pattern matching for identifying the core package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->