### PR TITLE
feat(scripts): emit_ts_types.py for dashboard TS type generation [OMN-9150]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ ignore = [
 "src/omnibase_core/validation/scripts/validate_topic_names.py" = ["T201"]
 "src/omnibase_core/scripts/validate_markdown_links.py" = ["T201"]
 "scripts/pin_bump.py" = ["T201"]  # CLI output for publish-downstream-pin-bump workflow [OMN-9050]
+"scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]
 

--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Emit combined JSON Schema for Pydantic models consumed by omnidash-v2.
+
+Usage:
+    uv run python scripts/emit_ts_types.py <output_json_path>
+
+The output is a JSON object of the form:
+    {
+        "$id": "https://omninode.ai/schemas/omnidash-v2.json",
+        "$defs": {
+            "ModelProjectorContract": { ... Pydantic JSON schema ... },
+            "ModelProjectorSchema": { ... },
+            ...
+        }
+    }
+
+Downstream consumer: omnidash-v2 pipes this through json-schema-to-typescript
+to emit src/shared/types/generated/onex-models.ts.
+
+Note: ``ModelDashboardHint`` is planned (Part 1 of the dashboard local-integration
+plan) but not yet in the tree. It will be added to ``MODELS`` once that lands.
+See docs/plans/2026-04-17-dashboard-local-integration.md in omni_home.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from omnibase_core.models.notifications import ModelStateTransitionNotification
+from omnibase_core.models.projectors import (
+    ModelProjectorBehavior,
+    ModelProjectorColumn,
+    ModelProjectorContract,
+    ModelProjectorIndex,
+    ModelProjectorSchema,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+MODELS: dict[str, type[BaseModel]] = {
+    "ModelProjectorContract": ModelProjectorContract,
+    "ModelProjectorSchema": ModelProjectorSchema,
+    "ModelProjectorColumn": ModelProjectorColumn,
+    "ModelProjectorBehavior": ModelProjectorBehavior,
+    "ModelProjectorIndex": ModelProjectorIndex,
+    "ModelStateTransitionNotification": ModelStateTransitionNotification,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: emit_ts_types.py <output_json_path>", file=sys.stderr)
+        return 1
+    output = Path(sys.argv[1])
+    combined = {
+        "$id": "https://omninode.ai/schemas/omnidash-v2.json",
+        "$defs": {name: model.model_json_schema() for name, model in MODELS.items()},
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(combined, indent=2))
+    print(f"wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_emit_ts_types.py
+++ b/tests/unit/scripts/test_emit_ts_types.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for scripts/emit_ts_types.py.
+
+Verifies:
+1. ``main()`` writes a file at the requested path and returns 0 on success.
+2. Output is valid JSON with the expected top-level shape.
+3. ``$defs`` contains a key for every model in the ``MODELS`` dict.
+4. Each entry is a Pydantic-generated object schema.
+5. ``main()`` returns a non-zero exit code when argv is malformed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+
+from emit_ts_types import MODELS, main  # type: ignore[import-not-found]
+
+
+@pytest.fixture(autouse=True)
+def _restore_argv() -> Any:
+    saved = list(sys.argv)
+    try:
+        yield
+    finally:
+        sys.argv = saved
+
+
+def test_main_writes_combined_schema(tmp_path: Path) -> None:
+    target = tmp_path / "onex-models.json"
+    sys.argv = ["emit_ts_types.py", str(target)]
+
+    rc = main()
+
+    assert rc == 0
+    assert target.exists(), "output file was not written"
+
+    payload = json.loads(target.read_text())
+
+    assert payload["$id"] == "https://omninode.ai/schemas/omnidash-v2.json"
+    assert "$defs" in payload
+    defs = payload["$defs"]
+    assert isinstance(defs, dict)
+
+    for name in MODELS:
+        assert name in defs, f"missing $defs entry for {name}"
+        entry = defs[name]
+        assert isinstance(entry, dict), f"{name} entry is not a dict"
+        # Pydantic-generated object schemas declare "type": "object" at the top
+        # level (or route through "$ref" / "allOf"/"anyOf" for composed models).
+        has_object_shape = (
+            entry.get("type") == "object"
+            or "$ref" in entry
+            or "allOf" in entry
+            or "anyOf" in entry
+            or "oneOf" in entry
+        )
+        assert has_object_shape, (
+            f"{name} schema does not look like an object schema: {entry!r}"
+        )
+
+
+def test_main_creates_parent_directories(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir" / "onex-models.json"
+    sys.argv = ["emit_ts_types.py", str(target)]
+
+    rc = main()
+
+    assert rc == 0
+    assert target.exists()
+
+
+def test_main_usage_error_on_missing_argument(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sys.argv = ["emit_ts_types.py"]
+
+    rc = main()
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "usage:" in err
+
+
+def test_main_usage_error_on_extra_arguments(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    sys.argv = ["emit_ts_types.py", str(tmp_path / "a.json"), "extra"]
+
+    rc = main()
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "usage:" in err


### PR DESCRIPTION
## Summary

Ticket: **[OMN-9150](https://linear.app/omninode/issue/OMN-9150)**

Adds `scripts/emit_ts_types.py`, a small CLI that emits combined JSON Schema for a fixed list of Pydantic models consumed by omnidash-v2. Output shape:

```json
{
  "$id": "https://omninode.ai/schemas/omnidash-v2.json",
  "$defs": {
    "ModelProjectorContract": { ... },
    "ModelProjectorSchema": { ... },
    ...
  }
}
```

Downstream, omnidash-v2 pipes this through `json-schema-to-typescript` to generate `src/shared/types/generated/onex-models.ts`. This unblocks the local-integration workstream in that repo.

## Models currently exported

- `ModelProjectorContract`
- `ModelProjectorSchema`
- `ModelProjectorColumn`
- `ModelProjectorBehavior`
- `ModelProjectorIndex`
- `ModelStateTransitionNotification`

### Deferred: `ModelDashboardHint`

The dashboard Part 1 plan adds `ModelDashboardHint`, `EnumDashboardWidgetType`, and a `ModelProjectorContract.dashboard` field. Those are not yet in the tree on `main`, so `ModelDashboardHint` is intentionally **omitted from `MODELS`** in this PR.

Once Part 1 lands, `MODELS` gets one additional entry:

```python
from omnibase_core.models.projectors import ModelDashboardHint  # once Part 1 lands

MODELS["ModelDashboardHint"] = ModelDashboardHint
```

No other coupling to Part 1.

## Other changes

- Appends one line to `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` to allow `T201` in `scripts/emit_ts_types.py` for the script's user-facing `wrote <path>` status print. Mirrors the pattern used by `scripts/pin_bump.py`.

## Test plan

- [x] `uv run ruff format scripts/emit_ts_types.py tests/unit/scripts/test_emit_ts_types.py`
- [x] `uv run ruff check scripts/emit_ts_types.py tests/unit/scripts/test_emit_ts_types.py`
- [x] `uv run mypy scripts/emit_ts_types.py --strict`
- [x] `uv run pytest tests/unit/scripts/test_emit_ts_types.py -v` (4/4 passing)
- [x] `pre-commit run --files scripts/emit_ts_types.py tests/unit/scripts/test_emit_ts_types.py pyproject.toml`
- [ ] GitHub Actions CI

Unit tests cover: successful write + JSON validity + `$defs` shape per model, parent-directory creation, and usage errors on zero/extra args.