### PR TITLE
feat(omnibase_core): add ModelTicketWorkflowState + util_ticket_workflow_persistence [OMN-9142]

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -65,6 +65,16 @@ allowed_files:
     added: "2026-04-17"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/utils/util_ticket_workflow_persistence.py"
+    reason: >-
+      Persistence helper for ModelTicketWorkflowState YAML embedded inside Linear ticket descriptions
+      (Markdown-fenced yaml blocks). extract_workflow_state must degrade gracefully to None on malformed
+      input (arbitrary Markdown content) rather than raising, so direct yaml.safe_load + Pydantic model_validate
+      is used. Routing through util_safe_yaml_loader would require a lazy import to avoid a circular dependency
+      through omnibase_core.mixins. (OMN-9142)
+    added: "2026-04-18"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/utils/util_safe_yaml_loader.py"
     reason: >-
       Foundational utility layer that bridges raw YAML parsing and Pydantic validation - provides safe

--- a/src/omnibase_core/enums/ticket/__init__.py
+++ b/src/omnibase_core/enums/ticket/__init__.py
@@ -36,6 +36,9 @@ from omnibase_core.enums.ticket.enum_ticket_types import (
     Status,
     VerificationKind,
 )
+from omnibase_core.enums.ticket.enum_ticket_workflow_phase import (
+    EnumTicketWorkflowPhase,
+)
 
 __all__ = [
     "EnumTicketPhase",
@@ -59,4 +62,5 @@ __all__ = [
     "DefinitionLocation",
     "EnumInterfaceSurface",
     "InterfaceSurface",
+    "EnumTicketWorkflowPhase",
 ]

--- a/src/omnibase_core/enums/ticket/enum_ticket_workflow_phase.py
+++ b/src/omnibase_core/enums/ticket/enum_ticket_workflow_phase.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumTicketWorkflowPhase — phase strings persisted in ticket-work workflow state.
+
+Distinct from ``EnumTicketPhase`` (which drives the contract-action mapping in
+``enum_ticket_types``): workflow-phase values are the *wire format* written into
+Linear ticket descriptions by the ticket-work handler, so string values must
+match the historical on-disk format exactly.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTicketWorkflowPhase(StrEnum):
+    """Phases of the ticket-work handler FSM.
+
+    Values are the exact strings persisted to Linear ticket YAML contracts —
+    changing them breaks resume-on-existing-ticket paths.
+    """
+
+    INTAKE = "intake"
+    RESEARCH = "research"
+    QUESTIONS = "questions"
+    SPEC = "spec"
+    IMPLEMENT = "implement"
+    REVIEW = "review"
+    DONE = "done"
+
+
+__all__ = ["EnumTicketWorkflowPhase"]

--- a/src/omnibase_core/models/ticket/__init__.py
+++ b/src/omnibase_core/models/ticket/__init__.py
@@ -75,9 +75,21 @@ from omnibase_core.models.ticket.model_ticket_contract import (
     ModelTicketContract,
     TicketContract,
 )
+from omnibase_core.models.ticket.model_ticket_workflow_state import (
+    ModelTicketWorkflowState,
+)
 from omnibase_core.models.ticket.model_verification_step import (
     ModelVerificationStep,
     VerificationStep,
+)
+from omnibase_core.models.ticket.model_workflow_context import ModelWorkflowContext
+from omnibase_core.models.ticket.model_workflow_gate import ModelWorkflowGate
+from omnibase_core.models.ticket.model_workflow_question import ModelWorkflowQuestion
+from omnibase_core.models.ticket.model_workflow_requirement import (
+    ModelWorkflowRequirement,
+)
+from omnibase_core.models.ticket.model_workflow_verification import (
+    ModelWorkflowVerification,
 )
 
 __all__ = [
@@ -126,4 +138,12 @@ __all__ = [
     "ModelTCBConstraint",
     "ModelTCBAssumption",
     "ModelTCBProvenance",
+    # Workflow state (distinct from ModelTicketContract) — FSM state embedded
+    # in Linear ticket descriptions by the ticket-work handler.
+    "ModelTicketWorkflowState",
+    "ModelWorkflowContext",
+    "ModelWorkflowGate",
+    "ModelWorkflowQuestion",
+    "ModelWorkflowRequirement",
+    "ModelWorkflowVerification",
 ]

--- a/src/omnibase_core/models/ticket/model_ticket_workflow_state.py
+++ b/src/omnibase_core/models/ticket/model_ticket_workflow_state.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelTicketWorkflowState — mutable FSM state for the ticket-work handler.
+
+Distinct from ``ModelTicketContract`` (the canonical Linear ticket contract that
+carries dod_evidence, golden_path, etc.). ``ModelTicketWorkflowState`` tracks the
+handler's in-flight workflow: the phase it is in, the clarifying questions it has
+posed, the requirements/verification/gates it has declared, and the commits/PR it
+has produced. It is serialized to YAML and embedded in the Linear ticket
+description so the handler can resume across sessions.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.ticket.enum_ticket_workflow_phase import (
+    EnumTicketWorkflowPhase,
+)
+from omnibase_core.models.ticket.model_workflow_context import ModelWorkflowContext
+from omnibase_core.models.ticket.model_workflow_gate import ModelWorkflowGate
+from omnibase_core.models.ticket.model_workflow_question import ModelWorkflowQuestion
+from omnibase_core.models.ticket.model_workflow_requirement import (
+    ModelWorkflowRequirement,
+)
+from omnibase_core.models.ticket.model_workflow_verification import (
+    ModelWorkflowVerification,
+)
+
+
+class ModelTicketWorkflowState(BaseModel):
+    """Mutable FSM state for the ticket-work handler, persisted to Linear.
+
+    Serialized into the ``## Contract`` YAML block of the Linear ticket
+    description so the handler can resume a ticket across sessions.
+
+    Phase values are strings (via ``EnumTicketWorkflowPhase``) rather than the
+    canonical ``EnumTicketPhase`` because the wire format pre-dates the
+    canonical contract model and would break resume on existing tickets if
+    changed — ``IMPLEMENTATION`` vs ``IMPLEMENT`` in particular. The two
+    enums are intentionally distinct.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ticket_id: str = Field(default="")
+    title: str = Field(default="")
+    repo: str = Field(default="")
+    branch: str | None = Field(default=None)
+
+    phase: EnumTicketWorkflowPhase = Field(default=EnumTicketWorkflowPhase.INTAKE)
+    created_at: str = Field(default="")
+    updated_at: str = Field(default="")
+
+    context: ModelWorkflowContext = Field(default_factory=ModelWorkflowContext)
+
+    questions: list[ModelWorkflowQuestion] = Field(default_factory=list)
+
+    requirements: list[ModelWorkflowRequirement] = Field(default_factory=list)
+    verification: list[ModelWorkflowVerification] = Field(default_factory=list)
+    gates: list[ModelWorkflowGate] = Field(default_factory=list)
+
+    commits: list[str] = Field(default_factory=list)
+    pr_url: str | None = Field(default=None)
+    hardening_tickets: list[str] = Field(default_factory=list)
+
+    def is_questions_complete(self) -> bool:
+        """All required questions have non-empty answers."""
+        return all(q.answer and q.answer.strip() for q in self.questions if q.required)
+
+    def is_spec_complete(self) -> bool:
+        """At least one requirement, and every requirement has acceptance criteria."""
+        if not self.requirements:
+            return False
+        return all(len(r.acceptance) > 0 for r in self.requirements)
+
+    def is_verification_complete(self) -> bool:
+        """All blocking verification passed or skipped."""
+        return all(
+            v.status in ("passed", "skipped") for v in self.verification if v.blocking
+        )
+
+    def is_gates_complete(self) -> bool:
+        """All required gates approved."""
+        return all(g.status == "approved" for g in self.gates if g.required)
+
+    def is_done(self) -> bool:
+        """Workflow reached DONE and all completion checks pass."""
+        return (
+            self.phase == EnumTicketWorkflowPhase.DONE
+            and self.is_questions_complete()
+            and self.is_spec_complete()
+            and self.is_verification_complete()
+            and self.is_gates_complete()
+        )
+
+
+__all__ = ["ModelTicketWorkflowState"]

--- a/src/omnibase_core/models/ticket/model_workflow_context.py
+++ b/src/omnibase_core/models/ticket/model_workflow_context.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkflowContext — research context embedded in ModelTicketWorkflowState."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelWorkflowContext(BaseModel):
+    """Research context populated during the RESEARCH phase of ticket-work."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    relevant_files: list[str] = Field(default_factory=list)
+    patterns_found: list[str] = Field(default_factory=list)
+    notes: str = Field(default="")
+
+
+__all__ = ["ModelWorkflowContext"]

--- a/src/omnibase_core/models/ticket/model_workflow_gate.py
+++ b/src/omnibase_core/models/ticket/model_workflow_gate.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkflowGate — human or policy gate in the ticket-work state."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelWorkflowGate(BaseModel):
+    """A human or policy gate declared during the SPEC phase."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default="")
+    title: str = Field(default="")
+    kind: str = Field(default="human_approval")
+    required: bool = Field(default=True)
+    status: str = Field(default="pending")
+    notes: str | None = Field(default=None)
+    resolved_at: str | None = Field(default=None)
+
+
+__all__ = ["ModelWorkflowGate"]

--- a/src/omnibase_core/models/ticket/model_workflow_gate.py
+++ b/src/omnibase_core/models/ticket/model_workflow_gate.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.enums.ticket.enum_ticket_types import (
+    EnumGateKind,
+    EnumTicketStepStatus,
+)
+
 
 class ModelWorkflowGate(BaseModel):
     """A human or policy gate declared during the SPEC phase."""
@@ -15,9 +20,9 @@ class ModelWorkflowGate(BaseModel):
 
     id: str = Field(default="")
     title: str = Field(default="")
-    kind: str = Field(default="human_approval")
+    kind: EnumGateKind = Field(default=EnumGateKind.HUMAN_APPROVAL)
     required: bool = Field(default=True)
-    status: str = Field(default="pending")
+    status: EnumTicketStepStatus = Field(default=EnumTicketStepStatus.PENDING)
     notes: str | None = Field(default=None)
     resolved_at: str | None = Field(default=None)
 

--- a/src/omnibase_core/models/ticket/model_workflow_question.py
+++ b/src/omnibase_core/models/ticket/model_workflow_question.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkflowQuestion — clarifying question raised during the QUESTIONS phase."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelWorkflowQuestion(BaseModel):
+    """A clarifying question raised during the QUESTIONS phase of ticket-work."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default="")
+    text: str = Field(default="")
+    category: str = Field(default="architecture")
+    required: bool = Field(default=True)
+    answer: str | None = Field(default=None)
+    answered_at: str | None = Field(default=None)
+
+
+__all__ = ["ModelWorkflowQuestion"]

--- a/src/omnibase_core/models/ticket/model_workflow_requirement.py
+++ b/src/omnibase_core/models/ticket/model_workflow_requirement.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkflowRequirement — implementation requirement recorded during SPEC."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelWorkflowRequirement(BaseModel):
+    """A single implementation requirement recorded during the SPEC phase."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default="")
+    statement: str = Field(default="")
+    rationale: str = Field(default="")
+    acceptance: list[str] = Field(default_factory=list)
+
+
+__all__ = ["ModelWorkflowRequirement"]

--- a/src/omnibase_core/models/ticket/model_workflow_verification.py
+++ b/src/omnibase_core/models/ticket/model_workflow_verification.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkflowVerification — verification step in the ticket-work state."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelWorkflowVerification(BaseModel):
+    """A verification step declared during SPEC and executed during REVIEW."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default="")
+    title: str = Field(default="")
+    kind: str = Field(default="unit_tests")
+    command: str = Field(default="")
+    expected: str = Field(default="exit 0")
+    blocking: bool = Field(default=True)
+    status: str = Field(default="pending")
+    evidence: str | None = Field(default=None)
+    executed_at: str | None = Field(default=None)
+
+
+__all__ = ["ModelWorkflowVerification"]

--- a/src/omnibase_core/utils/util_ticket_workflow_persistence.py
+++ b/src/omnibase_core/utils/util_ticket_workflow_persistence.py
@@ -21,6 +21,8 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.ticket.model_ticket_workflow_state import (
     ModelTicketWorkflowState,
 )
@@ -87,14 +89,46 @@ def update_description_with_workflow_state(
     return description.rstrip() + contract_block
 
 
+def _validate_ticket_id(ticket_id: str) -> None:
+    """Reject ticket ids that would escape the tickets root on disk.
+
+    A valid id is a single, relative path segment containing no separators.
+    Anything else could redirect writes outside ``$ONEX_STATE_DIR/tickets``.
+    """
+    ticket_path = Path(ticket_id)
+    if (
+        not ticket_id
+        or ticket_path.is_absolute()
+        or len(ticket_path.parts) != 1
+        or ticket_path.parts[0] in {".", ".."}
+        or "/" in ticket_id
+        or "\\" in ticket_id
+    ):
+        raise ModelOnexError(
+            "ticket_id must be a single relative path segment",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+
+
 def _tickets_dir() -> Path:
     """Resolve the on-disk tickets directory.
 
     Honors ``ONEX_STATE_DIR`` when set; otherwise falls back to
-    ``~/.onex_state``. Never reads or writes ``~/.claude/``.
+    ``~/.onex_state``. Any value that resolves into ``~/.claude`` is rejected
+    so agent-session writes can never land there (CLAUDE.md rule).
     """
     base = os.environ.get("ONEX_STATE_DIR")
-    root = Path(base) if base else Path.home() / ".onex_state"
+    root = (
+        Path(base).expanduser().resolve(strict=False)
+        if base
+        else (Path.home() / ".onex_state").resolve(strict=False)
+    )
+    claude_root = (Path.home() / ".claude").resolve(strict=False)
+    if root == claude_root or claude_root in root.parents:
+        raise ModelOnexError(
+            "ONEX_STATE_DIR must not point to ~/.claude",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
     return root / "tickets"
 
 
@@ -105,6 +139,7 @@ def persist_workflow_state_locally(
 
     Writes atomically via a ``.tmp`` sibling followed by ``os.replace``.
     """
+    _validate_ticket_id(ticket_id)
     target_dir = _tickets_dir() / ticket_id
     target_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/omnibase_core/utils/util_ticket_workflow_persistence.py
+++ b/src/omnibase_core/utils/util_ticket_workflow_persistence.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persistence helpers for ``ModelTicketWorkflowState``.
+
+Provides extraction, in-description updates, and on-disk persistence for the
+workflow state YAML embedded in Linear ticket descriptions.
+
+``persist_workflow_state_locally`` writes to ``$ONEX_STATE_DIR/tickets/``.
+``~/.claude/tickets/`` is never written to by any path in this module (CLAUDE.md
+agent-session write rule — see OMN-9142).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.ticket.model_ticket_workflow_state import (
+    ModelTicketWorkflowState,
+)
+
+_CONTRACT_MARKER = "## Contract"
+_YAML_FENCE_RE = re.compile(r"```(?:yaml|YAML)?\s*\n(.*?)\n\s*```", re.DOTALL)
+
+
+def workflow_state_to_yaml(state: ModelTicketWorkflowState) -> str:
+    """Serialize a workflow state to YAML for embedding in a ticket description."""
+    data = state.model_dump(mode="json", exclude_none=False)
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+
+def extract_workflow_state(description: str) -> ModelTicketWorkflowState | None:
+    """Extract and parse the workflow-state YAML from a Linear description.
+
+    Looks for the last ``## Contract`` section with a fenced yaml block.
+    Returns ``None`` if the marker is missing, the fence is missing, the YAML
+    is malformed, or validation against ``ModelTicketWorkflowState`` fails.
+    """
+    if _CONTRACT_MARKER not in description:
+        return None
+
+    idx = description.rfind(_CONTRACT_MARKER)
+    contract_section = description[idx:]
+
+    match = _YAML_FENCE_RE.search(contract_section)
+    if not match:
+        return None
+
+    # Parse then validate: the YAML fence may contain arbitrary Markdown
+    # content on disk, so bad input must degrade to ``None`` rather than
+    # raising. ``yaml.safe_load`` (no Python-object tags) is sufficient here
+    # because the only consumers are Pydantic-validated below.
+    try:
+        raw: Any = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    try:
+        return ModelTicketWorkflowState.model_validate(raw)
+    except ValidationError:
+        return None
+
+
+def update_description_with_workflow_state(
+    description: str, state: ModelTicketWorkflowState
+) -> str:
+    """Insert or replace the ``## Contract`` YAML block in a ticket description."""
+    contract_yaml = workflow_state_to_yaml(state)
+    contract_block = f"\n---\n{_CONTRACT_MARKER}\n\n```yaml\n{contract_yaml}```\n"
+
+    if _CONTRACT_MARKER in description:
+        idx = description.rfind(_CONTRACT_MARKER)
+        delimiter_match = re.search(r"\n---\n\s*$", description[:idx])
+        if delimiter_match:
+            return description[: delimiter_match.start()] + contract_block
+        return description[:idx] + contract_block
+
+    return description.rstrip() + contract_block
+
+
+def _tickets_dir() -> Path:
+    """Resolve the on-disk tickets directory.
+
+    Honors ``ONEX_STATE_DIR`` when set; otherwise falls back to
+    ``~/.onex_state``. Never reads or writes ``~/.claude/``.
+    """
+    base = os.environ.get("ONEX_STATE_DIR")
+    root = Path(base) if base else Path.home() / ".onex_state"
+    return root / "tickets"
+
+
+def persist_workflow_state_locally(
+    ticket_id: str, state: ModelTicketWorkflowState
+) -> None:
+    """Persist a workflow state to ``$ONEX_STATE_DIR/tickets/<ticket_id>/contract.yaml``.
+
+    Writes atomically via a ``.tmp`` sibling followed by ``os.replace``.
+    """
+    target_dir = _tickets_dir() / ticket_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    contract_path = target_dir / "contract.yaml"
+    tmp_path = contract_path.with_suffix(".yaml.tmp")
+    tmp_path.write_text(workflow_state_to_yaml(state))
+    tmp_path.replace(contract_path)
+
+
+__all__ = [
+    "extract_workflow_state",
+    "persist_workflow_state_locally",
+    "update_description_with_workflow_state",
+    "workflow_state_to_yaml",
+]

--- a/tests/unit/models/ticket/test_model_ticket_workflow_state.py
+++ b/tests/unit/models/ticket/test_model_ticket_workflow_state.py
@@ -202,3 +202,34 @@ class TestIsDone:
             ],
         )
         assert state.is_done() is True
+
+
+@pytest.mark.unit
+class TestGateFieldStrongTyping:
+    """Gate ``kind`` / ``status`` must reject values outside their enums."""
+
+    def test_invalid_kind_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelWorkflowGate(id="g1", kind="not_a_kind")  # type: ignore[arg-type]
+
+    def test_invalid_status_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelWorkflowGate(id="g1", status="banana")  # type: ignore[arg-type]
+
+    def test_valid_enum_values_accepted(self) -> None:
+        from omnibase_core.enums.ticket.enum_ticket_types import (
+            EnumGateKind,
+            EnumTicketStepStatus,
+        )
+
+        gate = ModelWorkflowGate(
+            id="g1",
+            kind=EnumGateKind.POLICY_CHECK,
+            status=EnumTicketStepStatus.APPROVED,
+        )
+        assert gate.kind == EnumGateKind.POLICY_CHECK
+        assert gate.status == EnumTicketStepStatus.APPROVED

--- a/tests/unit/models/ticket/test_model_ticket_workflow_state.py
+++ b/tests/unit/models/ticket/test_model_ticket_workflow_state.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``ModelTicketWorkflowState`` and its sub-models (OMN-9142)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.ticket.enum_ticket_workflow_phase import (
+    EnumTicketWorkflowPhase,
+)
+from omnibase_core.models.ticket.model_ticket_workflow_state import (
+    ModelTicketWorkflowState,
+    ModelWorkflowContext,
+    ModelWorkflowGate,
+    ModelWorkflowQuestion,
+    ModelWorkflowRequirement,
+    ModelWorkflowVerification,
+)
+
+
+@pytest.mark.unit
+class TestEnumTicketWorkflowPhase:
+    """Wire-format values must match the historical handler strings."""
+
+    def test_string_values_are_the_persisted_wire_format(self) -> None:
+        assert EnumTicketWorkflowPhase.INTAKE.value == "intake"
+        assert EnumTicketWorkflowPhase.RESEARCH.value == "research"
+        assert EnumTicketWorkflowPhase.QUESTIONS.value == "questions"
+        assert EnumTicketWorkflowPhase.SPEC.value == "spec"
+        assert EnumTicketWorkflowPhase.IMPLEMENT.value == "implement"
+        assert EnumTicketWorkflowPhase.REVIEW.value == "review"
+        assert EnumTicketWorkflowPhase.DONE.value == "done"
+
+    def test_is_distinct_from_canonical_implementation_value(self) -> None:
+        # Canonical EnumTicketPhase uses "implementation"; workflow uses "implement".
+        # Keeping them distinct is why this enum exists.
+        assert EnumTicketWorkflowPhase.IMPLEMENT.value != "implementation"
+
+
+@pytest.mark.unit
+class TestModelTicketWorkflowStateConstruction:
+    def test_defaults_are_sane(self) -> None:
+        state = ModelTicketWorkflowState()
+        assert state.ticket_id == ""
+        assert state.phase == EnumTicketWorkflowPhase.INTAKE
+        assert state.context == ModelWorkflowContext()
+        assert state.questions == []
+        assert state.requirements == []
+        assert state.verification == []
+        assert state.gates == []
+        assert state.commits == []
+        assert state.pr_url is None
+        assert state.hardening_tickets == []
+
+    def test_accepts_phase_as_string(self) -> None:
+        state = ModelTicketWorkflowState(phase="review")
+        assert state.phase == EnumTicketWorkflowPhase.REVIEW
+
+    def test_extra_fields_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelTicketWorkflowState(ticket_id="OMN-1", not_a_field=True)  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestIsQuestionsComplete:
+    def test_empty_questions_is_complete(self) -> None:
+        assert ModelTicketWorkflowState().is_questions_complete() is True
+
+    def test_unanswered_required_question_is_incomplete(self) -> None:
+        state = ModelTicketWorkflowState(
+            questions=[ModelWorkflowQuestion(id="q1", required=True, answer=None)]
+        )
+        assert state.is_questions_complete() is False
+
+    def test_unanswered_optional_question_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            questions=[ModelWorkflowQuestion(id="q1", required=False, answer=None)]
+        )
+        assert state.is_questions_complete() is True
+
+    def test_answered_required_question_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            questions=[ModelWorkflowQuestion(id="q1", required=True, answer="yes")]
+        )
+        assert state.is_questions_complete() is True
+
+    def test_whitespace_only_answer_is_incomplete(self) -> None:
+        state = ModelTicketWorkflowState(
+            questions=[ModelWorkflowQuestion(id="q1", required=True, answer="   ")]
+        )
+        assert state.is_questions_complete() is False
+
+
+@pytest.mark.unit
+class TestIsSpecComplete:
+    def test_empty_requirements_is_incomplete(self) -> None:
+        assert ModelTicketWorkflowState().is_spec_complete() is False
+
+    def test_requirement_without_acceptance_is_incomplete(self) -> None:
+        state = ModelTicketWorkflowState(
+            requirements=[ModelWorkflowRequirement(id="r1", statement="Do X")]
+        )
+        assert state.is_spec_complete() is False
+
+    def test_requirement_with_acceptance_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            requirements=[
+                ModelWorkflowRequirement(
+                    id="r1", statement="Do X", acceptance=["X is done"]
+                )
+            ]
+        )
+        assert state.is_spec_complete() is True
+
+
+@pytest.mark.unit
+class TestIsVerificationComplete:
+    def test_empty_verification_is_complete(self) -> None:
+        assert ModelTicketWorkflowState().is_verification_complete() is True
+
+    def test_pending_blocking_step_is_incomplete(self) -> None:
+        state = ModelTicketWorkflowState(
+            verification=[
+                ModelWorkflowVerification(id="v1", blocking=True, status="pending")
+            ]
+        )
+        assert state.is_verification_complete() is False
+
+    def test_pending_non_blocking_step_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            verification=[
+                ModelWorkflowVerification(id="v1", blocking=False, status="pending")
+            ]
+        )
+        assert state.is_verification_complete() is True
+
+    def test_passed_blocking_step_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            verification=[
+                ModelWorkflowVerification(id="v1", blocking=True, status="passed")
+            ]
+        )
+        assert state.is_verification_complete() is True
+
+    def test_skipped_blocking_step_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            verification=[
+                ModelWorkflowVerification(id="v1", blocking=True, status="skipped")
+            ]
+        )
+        assert state.is_verification_complete() is True
+
+
+@pytest.mark.unit
+class TestIsGatesComplete:
+    def test_empty_gates_is_complete(self) -> None:
+        assert ModelTicketWorkflowState().is_gates_complete() is True
+
+    def test_pending_required_gate_is_incomplete(self) -> None:
+        state = ModelTicketWorkflowState(
+            gates=[ModelWorkflowGate(id="g1", required=True, status="pending")]
+        )
+        assert state.is_gates_complete() is False
+
+    def test_approved_required_gate_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            gates=[ModelWorkflowGate(id="g1", required=True, status="approved")]
+        )
+        assert state.is_gates_complete() is True
+
+    def test_pending_optional_gate_is_complete(self) -> None:
+        state = ModelTicketWorkflowState(
+            gates=[ModelWorkflowGate(id="g1", required=False, status="pending")]
+        )
+        assert state.is_gates_complete() is True
+
+
+@pytest.mark.unit
+class TestIsDone:
+    def test_not_in_done_phase_is_not_done(self) -> None:
+        state = ModelTicketWorkflowState(
+            phase=EnumTicketWorkflowPhase.REVIEW,
+            requirements=[
+                ModelWorkflowRequirement(id="r1", statement="X", acceptance=["ok"])
+            ],
+        )
+        assert state.is_done() is False
+
+    def test_done_phase_without_spec_is_not_done(self) -> None:
+        state = ModelTicketWorkflowState(phase=EnumTicketWorkflowPhase.DONE)
+        assert state.is_done() is False
+
+    def test_done_phase_with_all_complete_is_done(self) -> None:
+        state = ModelTicketWorkflowState(
+            phase=EnumTicketWorkflowPhase.DONE,
+            requirements=[
+                ModelWorkflowRequirement(id="r1", statement="X", acceptance=["ok"])
+            ],
+        )
+        assert state.is_done() is True

--- a/tests/unit/utils/test_util_ticket_workflow_persistence.py
+++ b/tests/unit/utils/test_util_ticket_workflow_persistence.py
@@ -13,6 +13,7 @@ import yaml
 from omnibase_core.enums.ticket.enum_ticket_workflow_phase import (
     EnumTicketWorkflowPhase,
 )
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.ticket.model_ticket_workflow_state import (
     ModelTicketWorkflowState,
     ModelWorkflowQuestion,
@@ -210,3 +211,52 @@ class TestPersistWorkflowStateLocally:
         contract_path = tmp_path / "tickets" / "OMN-1234" / "contract.yaml"
         parsed = yaml.safe_load(contract_path.read_text())
         assert parsed["phase"] == "done"
+
+
+@pytest.mark.unit
+class TestTicketIdValidation:
+    """``ticket_id`` must be a single relative path segment (path-traversal guard)."""
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "",
+            "..",
+            ".",
+            "../escape",
+            "/etc/passwd",
+            "nested/OMN-1",
+            "back\\slash",
+        ],
+    )
+    def test_rejects_unsafe_ticket_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_id: str
+    ) -> None:
+        monkeypatch.setenv("ONEX_STATE_DIR", str(tmp_path))
+        with pytest.raises(ModelOnexError, match="ticket_id must be a single"):
+            persist_workflow_state_locally(bad_id, _sample_state())
+
+
+@pytest.mark.unit
+class TestClaudeRootRejection:
+    """``_tickets_dir`` must reject any config that resolves under ``~/.claude``."""
+
+    def test_rejects_direct_claude_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.setenv("ONEX_STATE_DIR", str(fake_home / ".claude"))
+        with pytest.raises(ModelOnexError, match=r"must not point to ~/\.claude"):
+            persist_workflow_state_locally("OMN-1234", _sample_state())
+
+    def test_rejects_claude_subdir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.setenv("ONEX_STATE_DIR", str(fake_home / ".claude" / "nested"))
+        with pytest.raises(ModelOnexError, match=r"must not point to ~/\.claude"):
+            persist_workflow_state_locally("OMN-1234", _sample_state())

--- a/tests/unit/utils/test_util_ticket_workflow_persistence.py
+++ b/tests/unit/utils/test_util_ticket_workflow_persistence.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``util_ticket_workflow_persistence`` (OMN-9142)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.ticket.enum_ticket_workflow_phase import (
+    EnumTicketWorkflowPhase,
+)
+from omnibase_core.models.ticket.model_ticket_workflow_state import (
+    ModelTicketWorkflowState,
+    ModelWorkflowQuestion,
+)
+from omnibase_core.utils.util_ticket_workflow_persistence import (
+    extract_workflow_state,
+    persist_workflow_state_locally,
+    update_description_with_workflow_state,
+    workflow_state_to_yaml,
+)
+
+
+def _sample_state(phase: str = "spec") -> ModelTicketWorkflowState:
+    return ModelTicketWorkflowState(
+        ticket_id="OMN-1234",
+        title="Test ticket",
+        repo="omnimarket",
+        phase=phase,  # type: ignore[arg-type]
+        created_at="2026-04-18T00:00:00Z",
+        updated_at="2026-04-18T00:00:00Z",
+    )
+
+
+@pytest.mark.unit
+class TestWorkflowStateToYaml:
+    def test_roundtrip_via_yaml(self) -> None:
+        state = _sample_state()
+        dumped = workflow_state_to_yaml(state)
+        parsed = yaml.safe_load(dumped)
+        assert parsed["ticket_id"] == "OMN-1234"
+        assert parsed["phase"] == "spec"
+
+    def test_phase_serializes_as_string(self) -> None:
+        state = _sample_state(phase="implement")
+        dumped = workflow_state_to_yaml(state)
+        assert "phase: implement" in dumped
+
+
+@pytest.mark.unit
+class TestExtractWorkflowState:
+    def test_returns_none_when_marker_missing(self) -> None:
+        assert extract_workflow_state("Regular description.") is None
+
+    def test_returns_none_when_fence_missing(self) -> None:
+        desc = "Some text.\n\n## Contract\n\nNo yaml fence here."
+        assert extract_workflow_state(desc) is None
+
+    def test_returns_none_when_yaml_invalid(self) -> None:
+        desc = "## Contract\n\n```yaml\n: : not valid : :\n```\n"
+        assert extract_workflow_state(desc) is None
+
+    def test_returns_none_when_yaml_is_scalar(self) -> None:
+        desc = "## Contract\n\n```yaml\njust a string\n```\n"
+        assert extract_workflow_state(desc) is None
+
+    def test_returns_none_on_validation_failure(self) -> None:
+        desc = "## Contract\n\n```yaml\nticket_id: 123\nphase: not_a_phase\n```\n"
+        assert extract_workflow_state(desc) is None
+
+    def test_parses_valid_embedded_state(self) -> None:
+        state = _sample_state()
+        desc = update_description_with_workflow_state("Original.", state)
+        parsed = extract_workflow_state(desc)
+        assert parsed is not None
+        assert parsed.ticket_id == "OMN-1234"
+        assert parsed.phase == EnumTicketWorkflowPhase.SPEC
+
+    def test_uses_last_contract_marker(self) -> None:
+        # Two ## Contract blocks — extractor takes the last (current) one.
+        first = _sample_state(phase="intake")
+        second = _sample_state(phase="review")
+        desc = update_description_with_workflow_state("Start.", first)
+        desc = (
+            desc
+            + "\n\n## Contract\n\n```yaml\n"
+            + workflow_state_to_yaml(second)
+            + "```\n"
+        )
+        parsed = extract_workflow_state(desc)
+        assert parsed is not None
+        assert parsed.phase == EnumTicketWorkflowPhase.REVIEW
+
+
+@pytest.mark.unit
+class TestUpdateDescriptionWithWorkflowState:
+    def test_appends_when_no_existing_contract(self) -> None:
+        state = _sample_state()
+        result = update_description_with_workflow_state("Plain body.", state)
+        assert "Plain body." in result
+        assert "## Contract" in result
+        assert "```yaml" in result
+        assert "ticket_id: OMN-1234" in result
+
+    def test_replaces_when_contract_exists(self) -> None:
+        state_a = _sample_state(phase="intake")
+        desc = update_description_with_workflow_state("Body.", state_a)
+        state_b = state_a.model_copy(update={"title": "Updated title"})
+        desc2 = update_description_with_workflow_state(desc, state_b)
+        assert desc2.count("## Contract") == 1
+        assert "Updated title" in desc2
+
+    def test_preserves_pre_existing_body(self) -> None:
+        state = _sample_state()
+        desc = update_description_with_workflow_state(
+            "Body line 1\nBody line 2\n", state
+        )
+        assert "Body line 1" in desc
+        assert "Body line 2" in desc
+
+    def test_handles_required_question_shape(self) -> None:
+        state = _sample_state()
+        state = state.model_copy(
+            update={
+                "questions": [
+                    ModelWorkflowQuestion(
+                        id="q1", text="Which path?", required=True, answer=None
+                    )
+                ]
+            }
+        )
+        desc = update_description_with_workflow_state("Body.", state)
+        parsed = extract_workflow_state(desc)
+        assert parsed is not None
+        assert parsed.is_questions_complete() is False
+
+
+@pytest.mark.unit
+class TestPersistWorkflowStateLocally:
+    def test_honors_onex_state_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_STATE_DIR", str(tmp_path))
+        state = _sample_state()
+        persist_workflow_state_locally("OMN-1234", state)
+        contract_path = tmp_path / "tickets" / "OMN-1234" / "contract.yaml"
+        assert contract_path.exists()
+        parsed = yaml.safe_load(contract_path.read_text())
+        assert parsed["ticket_id"] == "OMN-1234"
+
+    def test_falls_back_to_home_onex_state_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ONEX_STATE_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        state = _sample_state()
+        persist_workflow_state_locally("OMN-1234", state)
+        contract_path = (
+            tmp_path / ".onex_state" / "tickets" / "OMN-1234" / "contract.yaml"
+        )
+        assert contract_path.exists()
+
+    def test_never_writes_to_tilde_claude(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fake a home containing a .claude/tickets/ tree; persist must not
+        # touch it under any env-var configuration.
+        fake_home = tmp_path / "home"
+        claude_dir = fake_home / ".claude" / "tickets"
+        claude_dir.mkdir(parents=True)
+        sentinel = claude_dir / "sentinel.txt"
+        sentinel.write_text("untouched")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.setenv("ONEX_STATE_DIR", str(tmp_path / "custom_state"))
+
+        persist_workflow_state_locally("OMN-1234", _sample_state())
+
+        # Sentinel preserved.
+        assert sentinel.read_text() == "untouched"
+        # Nothing written under ~/.claude/tickets for this ticket.
+        assert not (claude_dir / "OMN-1234").exists()
+        # Write landed under ONEX_STATE_DIR.
+        assert (
+            tmp_path / "custom_state" / "tickets" / "OMN-1234" / "contract.yaml"
+        ).exists()
+
+    def test_is_atomic_via_tmp_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_STATE_DIR", str(tmp_path))
+        state = _sample_state()
+        persist_workflow_state_locally("OMN-1234", state)
+        target_dir = tmp_path / "tickets" / "OMN-1234"
+        # No leftover .tmp sibling after successful write.
+        assert not any(p.suffix == ".tmp" for p in target_dir.iterdir())
+
+    def test_overwrites_existing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_STATE_DIR", str(tmp_path))
+        state_a = _sample_state(phase="intake")
+        persist_workflow_state_locally("OMN-1234", state_a)
+        state_b = state_a.model_copy(update={"phase": EnumTicketWorkflowPhase.DONE})
+        persist_workflow_state_locally("OMN-1234", state_b)
+        contract_path = tmp_path / "tickets" / "OMN-1234" / "contract.yaml"
+        parsed = yaml.safe_load(contract_path.read_text())
+        assert parsed["phase"] == "done"


### PR DESCRIPTION
[skip-deploy-gate: pure omnibase_core model + util additions; no runtime handler changes, no service restart required. Deploy agent (OMN-8841) is separately inactive and unrelated to this PRs scope.]
[skip-receipt-gate: OMN-9142 contract lands in onex_change_control#287 (in merge queue, blocked only on CI). OMN-8841 citation is contextual (deploy agent inactivity reference, not a DoD dependency). Per CLAUDE.md standing orders, receipt-gate skip permitted for bootstrap; OMN-9209 tracks 7-day SLA to backfill.]


## Summary

Adds the ticket-work handler's FSM state model + persistence helpers to `omnibase_core` so they live at the right layer. Per repo layering (`compat → core → spi → infra`), models owned by application-layer nodes like `omnimarket` are a violation — siblings aren't guaranteed installed.

New surfaces:
- `EnumTicketWorkflowPhase` — wire-format phase strings (`intake`/`research`/`questions`/`spec`/`implement`/`review`/`done`). Distinct from canonical `EnumTicketPhase` (whose `IMPLEMENTATION` value would break resume on existing ticket YAML).
- `ModelTicketWorkflowState` — mutable FSM state record (`ConfigDict(extra="forbid")`). Sub-models `ModelWorkflow{Context,Question,Requirement,Verification,Gate}` each in their own file per the single-class-per-file rule.
- `util_ticket_workflow_persistence` — four helpers: `workflow_state_to_yaml`, `extract_workflow_state`, `update_description_with_workflow_state`, `persist_workflow_state_locally`.
- `persist_workflow_state_locally` writes to `$ONEX_STATE_DIR/tickets/` (fallback `~/.onex_state/tickets/`); never `~/.claude/tickets/` (CLAUDE.md agent-session write rule).

Paired with an omnimarket follow-up PR that deletes the legacy `ModelTicketContract` duplicate in `node_ticket_work/models/` and migrates `handler_ticket_work.py` + its tests to these new surfaces.

## Linear

[OMN-9142](https://linear.app/omninode/issue/OMN-9142) — Remove legacy ModelTicketContract duplicate in omnimarket

## Notes for reviewers

- `util_ticket_workflow_persistence.py` is added to `.yaml-validation-allowlist.yaml` (semi-annual review 2026-06-13). Justification: `extract_workflow_state` has to degrade to `None` on malformed input (arbitrary Markdown content in Linear descriptions), so direct `yaml.safe_load` + Pydantic `model_validate` is appropriate; routing through `util_safe_yaml_loader.load_yaml_content_as_model` would require a lazy import to avoid a circular dependency via `omnibase_core.mixins`.
- `EnumTicketWorkflowPhase` is intentionally disjoint from `EnumTicketPhase` — the on-disk wire format (`implement`) would break on existing Linear tickets if unified with canonical (`implementation`). Explicit test guards this invariant.

## Test plan

- [x] `uv run pytest tests/unit/models/ticket/test_model_ticket_workflow_state.py tests/unit/utils/test_util_ticket_workflow_persistence.py -v` — 43/43 green
- [x] `uv run pytest tests/unit/validation/test_yaml_allowlist.py` — 10/10 green (allowlist entry integrity)
- [x] `uv run mypy --strict src/omnibase_core/enums/ticket/enum_ticket_workflow_phase.py src/omnibase_core/models/ticket/model_ticket_workflow_state.py src/omnibase_core/utils/util_ticket_workflow_persistence.py` — clean
- [x] `uv run ruff check` — clean on new files
- [x] `pre-commit run --files <changed files>` — all hooks pass
- [ ] `uv run pytest tests/ -v` (full suite, CI) — sequential isolated runs clean; parallel `-n auto` locally surfaced pre-existing flakes in `test_spi_protocol_implementations.py` / `test_model_cli_command_registry.py` / `test_validator_reserved_enum.py` that also reproduce on `main` with different failure sets each run. Not related to this change.
- [ ] Explicit assertion that no write path touches `~/.claude/tickets/` (test `test_never_writes_to_tilde_claude`) — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ticket workflow state management with defined phases (intake → done), tracking for context, questions, requirements, verifications, and approval gates
  * Local persistence of workflow state and helpers to embed/extract YAML contract blocks
  * Completion validation helpers for workflow progress

* **Tests**
  * Added comprehensive unit tests covering models, serialization, extraction, update behavior, persistence, and edge cases

* **Chores**
  * Allowed YAML parsing for workflow persistence under the YAML-validation allowlist
<!-- end of auto-generated comment: release notes by coderabbit.ai -->