### PR TITLE
fix(ci/receipt-gate): strip onex_change_control prefix + force editable install [OMN-9190]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -11,12 +11,12 @@
 # pattern for precedent). Required status-check name: `receipt-gate / verify`.
 #
 # Inputs:
-#   contracts-dir:  path to ticket contract YAMLs (default:
-#                   onex_change_control/contracts — assumes the repo has a
-#                   submodule/pip-installed copy of onex_change_control OR the
-#                   workflow checks out that repo into a sibling directory)
-#   receipts-dir:   path to ModelDodReceipt YAMLs (default:
-#                   onex_change_control/drift/dod_receipts)
+#   contracts-dir:  path to ticket contract YAMLs, relative to the
+#                   onex_change_control checkout (default: contracts). The
+#                   Run Receipt-Gate step always prepends `.onex_change_control/`
+#                   since this workflow checks that repo out at that path.
+#   receipts-dir:   path to ModelDodReceipt YAMLs, relative to the
+#                   onex_change_control checkout (default: drift/dod_receipts).
 #
 # Secrets:
 #   (none — receipts + contracts are in-repo files, no API calls required)

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -27,15 +27,15 @@ on:
   workflow_call:
     inputs:
       contracts-dir:
-        description: Path to the contracts directory on disk.
+        description: Path to the contracts directory on disk, relative to the onex_change_control checkout.
         type: string
         required: false
-        default: onex_change_control/contracts
+        default: contracts
       receipts-dir:
-        description: Path to the dod_receipts directory on disk.
+        description: Path to the dod_receipts directory on disk, relative to the onex_change_control checkout.
         type: string
         required: false
-        default: onex_change_control/drift/dod_receipts
+        default: drift/dod_receipts
 
 permissions:
   contents: read
@@ -101,12 +101,17 @@ jobs:
         # Never fall back to PyPI — the published package has a broken transitive
         # dep (git+https omnibase-compat URL) that fails in CI.
         run: |
+          # --refresh forces uv to rebuild from the editable source even when a
+          # same-version wheel is cached locally or resolvable from PyPI. Without
+          # it, uv can resolve ./path against PyPI when pyproject.toml `version`
+          # matches a published release (e.g. feature lands on main without a
+          # version bump — see OMN-9192).
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
-            uv pip install --system -e .
+            uv pip install --system --refresh -e .
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
-            uv pip install --system -e ./omnibase_compat -e ./omnibase_core
+            uv pip install --system --refresh -e ./omnibase_compat -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
-            uv pip install --system -e ./.receipt-gate-deps/omnibase_compat -e ./.receipt-gate-deps/omnibase_core
+            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_compat -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"
             exit 1


### PR DESCRIPTION
## Summary

Ticket: **[OMN-9190](https://linear.app/omninode/issue/OMN-9190)** (blocks 5 in-flight PRs)

Two stacked bugs in `.github/workflows/receipt-gate.yml`. Both surfaced when 5 PRs across omnibase_core and omnibase_infra hit the gate simultaneously this morning.

### Target + approach (per OMN-6925)
- **Target:** `omnibase_core/.github/workflows/receipt-gate.yml` — single file.
- **Approach:** two independent minimal edits. No functional change beyond unblocking the gate's intended happy path.

### Bug A — doubled contracts/receipts path
The Run Receipt-Gate step always prepends `.onex_change_control/` to the input paths:
```yaml
--contracts-dir ".onex_change_control/${{ inputs.contracts-dir }}"
--receipts-dir ".onex_change_control/${{ inputs.receipts-dir }}"
```
But the defaults also carried `onex_change_control/`, yielding `.onex_change_control/onex_change_control/contracts/…` — non-existent.

**Fix:** strip the redundant segment from both defaults.

### Bug B — uv pip install landing PyPI wheel instead of editable source
In CI the log showed:
```
+ omnibase-compat==0.3.1 (from file:///.../omnibase_compat)
+ omnibase-core==0.39.0                                     ← PyPI, not from file:///
```
PyPI `omnibase-core==0.39.0` was published 2026-04-06. `receipt_gate_cli.py` landed on main 2026-04-18 (commit `ee3ad934`). Because source `pyproject.toml` version was never bumped past 0.39.0, uv preferred the indexed wheel. Result: `ModuleNotFoundError: omnibase_core.validation.receipt_gate_cli` on every caller-repo run.

**Fix:** `--refresh` on all three branches of the Install step forces uv to rebuild from the editable source regardless of index cache.

Underlying "bump source version when new code lands" issue tracked as [OMN-9192](https://linear.app/omninode/issue/OMN-9192).

### Related
- [OMN-9191](https://linear.app/omninode/issue/OMN-9191): Receipts infra has never produced a real receipt — the gate has only ever passed via override. Documents why every currently-blocked PR is using `[skip-receipt-gate:]` rather than real contracts.

## Currently blocking
- `omnibase_core#842` (OMN-9150)
- `omnibase_infra#1336` (OMN-8732)
- `omnibase_infra#1337` (OMN-8731)
- `omnibase_infra#1341` (OMN-9125)
- `omnibase_infra#1342` (OMN-9126)

## Test plan
- [x] Local uv repro confirmed source tree installs `receipt_gate_cli` correctly when not shadowed by PyPI.
- [ ] GitHub Actions CI on this PR (self-hosting: receipt-gate runs against this branch's workflow).
- [ ] Re-run one blocked PR (#1342 — smallest surface) after merge and confirm the `+ omnibase-core==0.39.0 (from file:///...)` install marker appears, NOT `(5.1MiB)` PyPI download.

[skip-receipt-gate: OMN-9190 — workflow fix for the gate itself; bootstrapping]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow input defaults and descriptions to use shorter, relative directory paths for contracts and receipts.
  * Modified dependency installation to add a refresh option, forcing fresh source rebuilds instead of relying on cached/resolved artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->