### PR TITLE
feat(core): ModelDashboardHint + EnumDashboardWidgetType (OMN-9207)

### DIFF
--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -17,10 +17,6 @@ The output is a JSON object of the form:
 
 Downstream consumer: omnidash-v2 pipes this through json-schema-to-typescript
 to emit src/shared/types/generated/onex-models.ts.
-
-Note: ``ModelDashboardHint`` is planned (Part 1 of the dashboard local-integration
-plan) but not yet in the tree. It will be added to ``MODELS`` once that lands.
-See docs/plans/2026-04-17-dashboard-local-integration.md in omni_home.
 """
 
 from __future__ import annotations
@@ -32,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from omnibase_core.models.notifications import ModelStateTransitionNotification
 from omnibase_core.models.projectors import (
+    ModelDashboardHint,
     ModelProjectorBehavior,
     ModelProjectorColumn,
     ModelProjectorContract,
@@ -48,6 +45,7 @@ MODELS: dict[str, type[BaseModel]] = {
     "ModelProjectorColumn": ModelProjectorColumn,
     "ModelProjectorBehavior": ModelProjectorBehavior,
     "ModelProjectorIndex": ModelProjectorIndex,
+    "ModelDashboardHint": ModelDashboardHint,
     "ModelStateTransitionNotification": ModelStateTransitionNotification,
 }
 

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -98,6 +98,9 @@ from .enum_customer_tier import EnumCustomerTier
 from .enum_dashboard_status import EnumDashboardStatus
 from .enum_dashboard_theme import EnumDashboardTheme
 
+# Dashboard widget type (registry-driven dashboard Part 1 - OMN-9207)
+from .enum_dashboard_widget_type import EnumDashboardWidgetType
+
 # Security-related enums
 from .enum_data_classification import EnumDataClassification
 
@@ -762,6 +765,8 @@ __all__ = [
     "EnumDashboardStatus",
     "EnumDashboardTheme",
     "EnumWidgetType",
+    # Dashboard widget type (registry-driven dashboard Part 1 - OMN-9207)
+    "EnumDashboardWidgetType",
     # Event priority domain (OMN-1308)
     "EnumEventPriority",
     # Event sink type domain (OMN-1151)

--- a/src/omnibase_core/enums/enum_dashboard_widget_type.py
+++ b/src/omnibase_core/enums/enum_dashboard_widget_type.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Widget types a projection may declare for dashboard rendering."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDashboardWidgetType(StrEnum):
+    TILE = "tile"
+    CHART = "chart"
+    TABLE = "table"
+    LIST = "list"
+    SCALAR = "scalar"

--- a/src/omnibase_core/models/projectors/__init__.py
+++ b/src/omnibase_core/models/projectors/__init__.py
@@ -47,6 +47,7 @@ making them thread-safe for concurrent read access.
 .. versionadded:: 0.4.0
 """
 
+from omnibase_core.models.projectors.model_dashboard_hint import ModelDashboardHint
 from omnibase_core.models.projectors.model_idempotency_config import (
     ModelIdempotencyConfig,
 )
@@ -72,6 +73,7 @@ from omnibase_core.models.projectors.model_projector_schema import ModelProjecto
 
 __all__ = [
     "EVENT_NAME_PATTERN",
+    "ModelDashboardHint",
     "ModelIdempotencyConfig",
     "ModelPartialUpdateOperation",
     "ModelProjectionIntent",

--- a/src/omnibase_core/models/projectors/model_dashboard_hint.py
+++ b/src/omnibase_core/models/projectors/model_dashboard_hint.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Optional dashboard presentation hint for a projector contract."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_dashboard_widget_type import EnumDashboardWidgetType
+
+
+class ModelDashboardHint(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    widget_type: EnumDashboardWidgetType = Field(
+        ..., description="Preferred widget shape."
+    )
+    label: str | None = Field(default=None, description="Human-readable label.")
+    group: str | None = Field(
+        default=None, description="Grouping key for sidebar organization."
+    )
+    priority: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Ordering weight; lower renders first.",
+    )
+    time_series: bool = Field(
+        default=False, description="Treat as time-series if True."
+    )
+    unit: str | None = Field(
+        default=None, description="Units annotation (e.g. 'usd', 'ms')."
+    )

--- a/src/omnibase_core/models/projectors/model_projector_contract.py
+++ b/src/omnibase_core/models/projectors/model_projector_contract.py
@@ -90,6 +90,7 @@ from typing import ClassVar, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from omnibase_core.models.projectors.model_dashboard_hint import ModelDashboardHint
 from omnibase_core.models.projectors.model_partial_update_operation import (
     ModelPartialUpdateOperation,
 )
@@ -252,6 +253,11 @@ class ModelProjectorContract(BaseModel):
             "updates like heartbeats or state transitions."
         ),
         json_schema_extra={"default": []},
+    )
+
+    dashboard: ModelDashboardHint | None = Field(
+        default=None,
+        description="Optional presentation hint for dashboard rendering.",
     )
 
     @field_validator("consumed_events")
@@ -428,6 +434,7 @@ class ModelProjectorContract(BaseModel):
                 self.projection_schema,
                 self.behavior,
                 tuple(self.partial_updates),
+                self.dashboard,
             )
         )
 

--- a/src/omnibase_core/schemas/projector_contract.schema.json
+++ b/src/omnibase_core/schemas/projector_contract.schema.json
@@ -1,5 +1,83 @@
 {
   "$defs": {
+    "EnumDashboardWidgetType": {
+      "enum": [
+        "tile",
+        "chart",
+        "table",
+        "list",
+        "scalar"
+      ],
+      "title": "EnumDashboardWidgetType",
+      "type": "string"
+    },
+    "ModelDashboardHint": {
+      "additionalProperties": false,
+      "properties": {
+        "widget_type": {
+          "$ref": "#/$defs/EnumDashboardWidgetType",
+          "description": "Preferred widget shape."
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable label.",
+          "title": "Label"
+        },
+        "group": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Grouping key for sidebar organization.",
+          "title": "Group"
+        },
+        "priority": {
+          "default": 100,
+          "description": "Ordering weight; lower renders first.",
+          "maximum": 1000,
+          "minimum": 1,
+          "title": "Priority",
+          "type": "integer"
+        },
+        "time_series": {
+          "default": false,
+          "description": "Treat as time-series if True.",
+          "title": "Time Series",
+          "type": "boolean"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Units annotation (e.g. 'usd', 'ms').",
+          "title": "Unit"
+        }
+      },
+      "required": [
+        "widget_type"
+      ],
+      "title": "ModelDashboardHint",
+      "type": "object"
+    },
     "ModelIdempotencyConfig": {
       "additionalProperties": false,
       "description": "Idempotency configuration for projector event processing.\n\nIdempotency ensures that processing the same event multiple times\nproduces the same result. This is critical for:\n    - Safe retries after failures\n    - Event replay during recovery\n    - Exactly-once processing semantics\n\nAttributes:\n    enabled: Whether idempotency checking is enabled. When True,\n        the projector tracks processed event keys and skips\n        duplicates. Defaults to True.\n    key: The event attribute to use as the idempotency key.\n        This field uniquely identifies an event for deduplication.\n        Common values: \"sequence_number\", \"event_id\", \"correlation_id\".\n\nExamples:\n    Basic configuration with sequence number:\n\n    >>> config = ModelIdempotencyConfig(key=\"sequence_number\")\n    >>> config.enabled\n    True\n    >>> config.key\n    'sequence_number'\n\n    Disabled idempotency:\n\n    >>> config = ModelIdempotencyConfig(enabled=False, key=\"event_id\")\n    >>> config.enabled\n    False\n\nNote:\n    **Why from_attributes=True is Required**\n\n    This model uses ``from_attributes=True`` in its ConfigDict to ensure\n    pytest-xdist compatibility. When running tests with pytest-xdist,\n    each worker process imports the class independently, creating separate\n    class objects. The ``from_attributes=True`` flag enables Pydantic's\n    \"duck typing\" mode, allowing fixtures from one worker to be validated\n    in another.\n\n    **Thread Safety**: This model is frozen (immutable) after creation,\n    making it thread-safe for concurrent read access.",
@@ -420,6 +498,18 @@
       },
       "title": "Partial Updates",
       "type": "array"
+    },
+    "dashboard": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelDashboardHint"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional presentation hint for dashboard rendering."
     }
   },
   "required": [

--- a/tests/unit/models/projectors/test_model_dashboard_hint.py
+++ b/tests/unit/models/projectors/test_model_dashboard_hint.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelDashboardHint.
+
+Covers:
+1. Minimal construction — only widget_type required; defaults are correct.
+2. Full construction — every field set, round-trips through model_dump.
+3. Frozen invariant — mutation raises ValidationError.
+4. extra='forbid' — unknown fields raise ValidationError.
+5. priority bounds — 1 and 1000 valid; 0 and 1001 rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_dashboard_widget_type import EnumDashboardWidgetType
+from omnibase_core.models.projectors.model_dashboard_hint import ModelDashboardHint
+
+
+@pytest.mark.unit
+def test_dashboard_hint_minimal_fields() -> None:
+    """Only widget_type is required; all other fields default correctly."""
+    hint = ModelDashboardHint(widget_type=EnumDashboardWidgetType.TILE)
+
+    assert hint.widget_type == EnumDashboardWidgetType.TILE
+    assert hint.label is None
+    assert hint.group is None
+    assert hint.priority == 100
+    assert hint.time_series is False
+    assert hint.unit is None
+
+
+@pytest.mark.unit
+def test_dashboard_hint_full_fields() -> None:
+    """All fields may be set; model round-trips through model_dump."""
+    hint = ModelDashboardHint(
+        widget_type=EnumDashboardWidgetType.CHART,
+        label="Active Nodes",
+        group="platform",
+        priority=10,
+        time_series=True,
+        unit="count",
+    )
+
+    assert hint.widget_type == EnumDashboardWidgetType.CHART
+    assert hint.label == "Active Nodes"
+    assert hint.group == "platform"
+    assert hint.priority == 10
+    assert hint.time_series is True
+    assert hint.unit == "count"
+
+    restored = ModelDashboardHint.model_validate(hint.model_dump())
+    assert restored == hint
+
+
+@pytest.mark.unit
+def test_dashboard_hint_frozen() -> None:
+    """Frozen model — mutation raises ValidationError."""
+    hint = ModelDashboardHint(widget_type=EnumDashboardWidgetType.TABLE)
+
+    with pytest.raises(ValidationError):
+        hint.label = "new label"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_dashboard_hint_extra_forbidden() -> None:
+    """extra='forbid' — unknown fields raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ModelDashboardHint(
+            widget_type=EnumDashboardWidgetType.TILE,
+            unknown_field="value",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_priority_bounds() -> None:
+    """priority accepts 1..1000 inclusive; rejects 0 and 1001."""
+    ModelDashboardHint(widget_type=EnumDashboardWidgetType.TILE, priority=1)
+    ModelDashboardHint(widget_type=EnumDashboardWidgetType.TILE, priority=1000)
+
+    with pytest.raises(ValidationError):
+        ModelDashboardHint(widget_type=EnumDashboardWidgetType.TILE, priority=0)
+
+    with pytest.raises(ValidationError):
+        ModelDashboardHint(widget_type=EnumDashboardWidgetType.TILE, priority=1001)

--- a/tests/unit/models/projectors/test_model_projector_contract.py
+++ b/tests/unit/models/projectors/test_model_projector_contract.py
@@ -1571,3 +1571,100 @@ class TestModelProjectorContractRepr:
         assert "version='1.0.0'" in result
         assert "events=1" in result
         assert "indexes=2" in result
+
+
+@pytest.mark.unit
+class TestModelProjectorContractDashboardHint:
+    """Tests for the optional dashboard presentation hint field."""
+
+    def test_projector_contract_accepts_dashboard_hint(self) -> None:
+        """Contract accepts a ModelDashboardHint and preserves its fields."""
+        from omnibase_core.enums.enum_dashboard_widget_type import (
+            EnumDashboardWidgetType,
+        )
+        from omnibase_core.models.projectors import (
+            ModelDashboardHint,
+            ModelProjectorBehavior,
+            ModelProjectorColumn,
+            ModelProjectorContract,
+            ModelProjectorSchema,
+        )
+
+        column = ModelProjectorColumn(
+            name="id",
+            type="UUID",
+            source="event.payload.id",
+        )
+
+        schema = ModelProjectorSchema(
+            table="test",
+            primary_key="id",
+            columns=[column],
+        )
+
+        behavior = ModelProjectorBehavior(mode="upsert")
+
+        hint = ModelDashboardHint(
+            widget_type=EnumDashboardWidgetType.TILE,
+            label="Test Tile",
+            group="tests",
+            priority=50,
+            time_series=False,
+            unit="count",
+        )
+
+        contract = ModelProjectorContract(
+            projector_kind="materialized_view",
+            projector_id="test-projector",
+            name="Test",
+            version="1.0.0",
+            aggregate_type="test",
+            consumed_events=["test.created.v1"],
+            projection_schema=schema,
+            behavior=behavior,
+            dashboard=hint,
+        )
+
+        assert contract.dashboard is not None
+        assert contract.dashboard.widget_type == EnumDashboardWidgetType.TILE
+        assert contract.dashboard.label == "Test Tile"
+        assert contract.dashboard.group == "tests"
+        assert contract.dashboard.priority == 50
+        assert contract.dashboard.time_series is False
+        assert contract.dashboard.unit == "count"
+
+    def test_projector_contract_dashboard_field_is_optional(self) -> None:
+        """dashboard defaults to None when not specified."""
+        from omnibase_core.models.projectors import (
+            ModelProjectorBehavior,
+            ModelProjectorColumn,
+            ModelProjectorContract,
+            ModelProjectorSchema,
+        )
+
+        column = ModelProjectorColumn(
+            name="id",
+            type="UUID",
+            source="event.payload.id",
+        )
+
+        schema = ModelProjectorSchema(
+            table="test",
+            primary_key="id",
+            columns=[column],
+        )
+
+        behavior = ModelProjectorBehavior(mode="upsert")
+
+        contract = ModelProjectorContract(
+            projector_kind="materialized_view",
+            projector_id="test-projector",
+            name="Test",
+            version="1.0.0",
+            aggregate_type="test",
+            consumed_events=["test.created.v1"],
+            projection_schema=schema,
+            behavior=behavior,
+        )
+
+        assert contract.dashboard is None


### PR DESCRIPTION
## Summary

Ships the omnibase_core portion of Part 1 of the registry-driven dashboard integration plan. Projections can now carry optional presentation metadata that omnidash-v2 consumes via `json-schema-to-typescript`.

Linear: [OMN-9207](https://linear.app/omninode/issue/OMN-9207)

## Changes

- Add `EnumDashboardWidgetType` (StrEnum: TILE, CHART, TABLE, LIST, SCALAR)
- Add `ModelDashboardHint` (frozen, `extra='forbid'`): `widget_type`, `label`, `group`, `priority (1..1000)`, `time_series`, `unit`
- Extend `ModelProjectorContract` with optional `dashboard: ModelDashboardHint | None = None`
- Register `ModelDashboardHint` in `scripts/emit_ts_types.py` MODELS dict so omnidash-v2 TS types include it (and remove the stale "planned" note)
- Regenerate `src/omnibase_core/schemas/projector_contract.schema.json` so the committed schema drift test passes with the new optional field
- 5 new unit tests for `ModelDashboardHint` (minimal / full / frozen / extra-forbid / priority bounds) + 2 tests on `ModelProjectorContract` (accepts hint / field optional)

## Out of scope (deferred)

- SnapshotPublisher generalization (separate follow-up)
- FileSnapshotSink/Source (omnibase_infra)
- ContractInferencer extension
- Proof of Life integration test

## Test plan

- [x] `uv run mypy src/omnibase_core --strict` clean
- [x] `uv run mypy scripts/emit_ts_types.py --strict` clean
- [x] `uv run pytest tests/unit/models/projectors/ tests/unit/scripts/` 915 passed
- [x] `pre-commit run` clean on staged files
- [ ] CI Summary green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projectors now support optional dashboard hints to configure widget rendering. Includes widget types (tile, chart, table, list, scalar), labels, groups, priority levels (1–1000), time series designation, and units for enhanced dashboard presentation.

* **Tests**
  * Added comprehensive unit tests validating dashboard hint configuration and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->