### PR TITLE
feat(core): resolver models + outcome enum [OMN-9196]

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -178,6 +178,9 @@ from .enum_handler_command_type import EnumHandlerCommandType
 # Handler execution phase enums (OMN-1108)
 from .enum_handler_execution_phase import EnumHandlerExecutionPhase
 
+# Handler resolution outcome enum (HandlerResolver Phase 1 — OMN-9195/OMN-9196)
+from .enum_handler_resolution_outcome import EnumHandlerResolutionOutcome
+
 # Handler role enums (OMN-1086)
 from .enum_handler_role import EnumHandlerRole
 
@@ -644,6 +647,8 @@ __all__ = [
     "EnumHandlerCommandType",
     # Handler execution phase domain (OMN-1108)
     "EnumHandlerExecutionPhase",
+    # Handler resolution outcome domain (HandlerResolver Phase 1 — OMN-9195/OMN-9196)
+    "EnumHandlerResolutionOutcome",
     # Handler routing strategy domain (OMN-1295)
     "EnumHandlerRoutingStrategy",
     # Handler role domain (OMN-1086)

--- a/src/omnibase_core/enums/enum_handler_resolution_outcome.py
+++ b/src/omnibase_core/enums/enum_handler_resolution_outcome.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumHandlerResolutionOutcome - terminal outcomes of HandlerResolver.resolve().
+
+Represents the six terminal branches of the `HandlerResolver` precedence chain
+introduced by OMN-9195 (HandlerResolver Architecture Phase 1).
+
+Five values correspond to successful resolution paths (including the
+deliberate LOCAL_OWNERSHIP_SKIP non-error path, where the handler's parent
+node is not hosted in this runtime). The sixth value (`UNRESOLVABLE`) is a
+reserved terminal label; the resolver does NOT return it — it raises
+`TypeError` when the precedence chain is exhausted so that OMN-8735's
+fail-fast invariant is preserved.
+
+Justification for introducing this enum rather than reusing
+`EnumCoreErrorCode`: the outcomes are successful branches of a decision
+chain, not error codes. Five of six values are success states. See
+`docs/plans/2026-04-18-handler-resolver-architecture.md` §"Known Types
+Inventory".
+"""
+
+from enum import StrEnum
+
+
+class EnumHandlerResolutionOutcome(StrEnum):
+    """Terminal outcome labels for the HandlerResolver precedence chain.
+
+    Values are lowercase-snake for wire-stable serialization in wiring reports.
+    """
+
+    RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP = "resolved_via_local_ownership_skip"
+    RESOLVED_VIA_NODE_REGISTRY = "resolved_via_node_registry"
+    RESOLVED_VIA_CONTAINER = "resolved_via_container"
+    RESOLVED_VIA_EVENT_BUS = "resolved_via_event_bus"
+    RESOLVED_VIA_ZERO_ARG = "resolved_via_zero_arg"
+    UNRESOLVABLE = "unresolvable"

--- a/src/omnibase_core/errors/container_wiring_error.py
+++ b/src/omnibase_core/errors/container_wiring_error.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContainerWiringError — base class for DI-container-wiring failures.
+
+Hierarchy:
+    ModelOnexError                          (omnibase_core.models.errors)
+        └── ContainerWiringError            (this module)
+                └── ServiceResolutionError  (error_service_resolution.py)
+
+Reserved namespace for future container-wiring-specific errors (registration
+conflicts, configuration issues, etc.). Callers should typically catch a more
+specific subclass (currently only `ServiceResolutionError`).
+
+Design note: kept intentionally minimal — no error-code enum plumbing or
+extra metadata fields. Sole purpose is to give the resolver a narrow
+inheritance target for `except` clauses without swallowing unrelated
+container-internal bugs. See
+`docs/plans/2026-04-18-handler-resolver-architecture.md` §"Task 3 Step 3a".
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+
+class ContainerWiringError(ModelOnexError):
+    """Generic DI-container-wiring failure — base class for narrower errors."""
+
+
+__all__ = ["ContainerWiringError"]

--- a/src/omnibase_core/errors/error_service_resolution.py
+++ b/src/omnibase_core/errors/error_service_resolution.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ServiceResolutionError — the requested service is not registered.
+
+This is the narrow "soft miss" that `HandlerResolver` (in
+`omnibase_core.services.service_handler_resolver`) catches and treats as a
+fallthrough signal to later precedence steps (event_bus / zero-arg). Any
+other container exception (KeyError, AttributeError, RuntimeError, or an
+unrelated `ContainerWiringError` subclass) propagates untouched so
+container-internal bugs are never silenced.
+
+Hierarchy:
+    ModelOnexError                          (omnibase_core.models.errors)
+        └── ContainerWiringError            (container_wiring_error.py)
+                └── ServiceResolutionError  (this module)
+
+Kept intentionally minimal — no error-code enum plumbing or extra metadata
+fields. Sole purpose is narrow `except` targeting for the resolver
+fallthrough. Additional fields require a plan revision, not a drive-by
+append. See `docs/plans/2026-04-18-handler-resolver-architecture.md`
+§"Task 3 Step 3a".
+"""
+
+from __future__ import annotations
+
+from omnibase_core.errors.container_wiring_error import ContainerWiringError
+
+
+class ServiceResolutionError(ContainerWiringError):
+    """The requested service is not registered in the DI container."""
+
+
+__all__ = ["ServiceResolutionError"]

--- a/src/omnibase_core/models/__init__.py
+++ b/src/omnibase_core/models/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "projection",
     "providers",
     "registration",
+    "resolver",  # HandlerResolver input/output models (OMN-9195/OMN-9196)
     "results",
     "routing",  # Tiered resolution routing models (OMN-2890)
     "skill",  # Skill execution result models (OMN-3867)

--- a/src/omnibase_core/models/resolver/__init__.py
+++ b/src/omnibase_core/models/resolver/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolver models module.
+
+Frozen Pydantic models supporting the HandlerResolver precedence chain
+introduced by OMN-9195 (HandlerResolver Architecture Phase 1). See
+`docs/plans/2026-04-18-handler-resolver-architecture.md` for the full spec.
+"""
+
+from omnibase_core.models.resolver.model_handler_resolution import (
+    ModelHandlerResolution,
+)
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+
+__all__ = [
+    "ModelHandlerResolution",
+    "ModelHandlerResolverContext",
+]

--- a/src/omnibase_core/models/resolver/model_handler_resolution.py
+++ b/src/omnibase_core/models/resolver/model_handler_resolution.py
@@ -33,7 +33,9 @@ Layering (permanent, see §"Layering Invariants" in the plan):
     available in a future phase, tighten here first.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.enum_handler_resolution_outcome import (
     EnumHandlerResolutionOutcome,
@@ -78,6 +80,53 @@ class ModelHandlerResolution(BaseModel):
             "on successful resolution."
         ),
     )
+
+    @model_validator(mode="after")
+    def _enforce_outcome_invariants(self) -> Self:
+        """Enforce outcome-dependent invariants per module docstring contract.
+
+        SKIP outcome:
+            - handler_instance MUST be None
+            - skipped_handler and skipped_reason MUST be non-empty
+
+        All other outcomes:
+            - handler_instance MUST NOT be None
+            - skipped_handler and skipped_reason MUST be empty strings
+
+        Comparison uses `==` (value equality), not `is` (identity), per the
+        Pydantic/enum convention. See OMN-9196.
+        """
+        is_skip = (
+            self.outcome
+            == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+        )
+        if is_skip:
+            if self.handler_instance is not None:
+                raise ValueError(
+                    "SKIP outcome requires handler_instance=None; "
+                    f"got {type(self.handler_instance).__name__}"
+                )
+            if not self.skipped_handler:
+                raise ValueError("SKIP outcome requires non-empty skipped_handler")
+            if not self.skipped_reason:
+                raise ValueError("SKIP outcome requires non-empty skipped_reason")
+        else:
+            if self.handler_instance is None:
+                raise ValueError(
+                    f"Non-skip outcome {self.outcome.name} requires "
+                    "handler_instance to be non-None"
+                )
+            if self.skipped_handler:
+                raise ValueError(
+                    f"Non-skip outcome {self.outcome.name} requires "
+                    "skipped_handler to be empty"
+                )
+            if self.skipped_reason:
+                raise ValueError(
+                    f"Non-skip outcome {self.outcome.name} requires "
+                    "skipped_reason to be empty"
+                )
+        return self
 
 
 __all__ = ["ModelHandlerResolution"]

--- a/src/omnibase_core/models/resolver/model_handler_resolution.py
+++ b/src/omnibase_core/models/resolver/model_handler_resolution.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelHandlerResolution - return value from HandlerResolver.resolve().
+
+Frozen Pydantic model encoding the terminal decision of the resolver's
+precedence chain for one handler. See
+`docs/plans/2026-04-18-handler-resolver-architecture.md` §"Skip Semantics".
+
+Return contract:
+    - On successful construction via any precedence path (node registry,
+      container, event-bus injection, zero-arg), `outcome` is the matching
+      `EnumHandlerResolutionOutcome` value and `handler_instance` is the
+      constructed handler instance.
+    - On deliberate ownership skip, `outcome` is
+      `RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP`, `handler_instance` is None,
+      `skipped_handler` carries the handler-name identifier, and
+      `skipped_reason` carries the human-readable reason text.
+    - `UNRESOLVABLE` is NOT returned — the resolver raises `TypeError`
+      when the precedence chain is exhausted (OMN-8735 fail-fast
+      invariant). See §"Skip Semantics" for the skip-vs-failure contract.
+
+Justification for introducing this model rather than reusing existing
+core/spi types: no comparable decision-result model exists in either repo.
+`EnumHandlerResolutionOutcome` alone cannot carry the instance or the skip
+metadata.
+
+Layering (permanent, see §"Layering Invariants" in the plan):
+    `handler_instance` is typed `object | None`. Narrowing is blocked by
+    the compat -> core -> spi -> infra layering rule; the concrete handler
+    protocol lives in `omnibase_spi` (`ProtocolHandleable`) and cannot be
+    referenced from `omnibase_core`. If a core-safe narrowing becomes
+    available in a future phase, tighten here first.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+
+
+class ModelHandlerResolution(BaseModel):
+    """Terminal decision record returned by `HandlerResolver.resolve()`."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+        arbitrary_types_allowed=True,
+    )
+
+    outcome: EnumHandlerResolutionOutcome = Field(
+        ...,
+        description="Which precedence branch resolved this handler (or skip).",
+    )
+    handler_instance: object | None = Field(
+        default=None,
+        description=(
+            "Constructed handler instance. None iff outcome is "
+            "RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP. Typed object | None "
+            "per layering invariants."
+        ),
+    )
+    # Preserve the handler name on SKIP so wiring reports can cite which
+    # handler was skipped without re-deriving from context.
+    skipped_handler: str = Field(
+        default="",
+        description=(
+            "Handler-name identifier preserved on SKIP. Empty string on "
+            "successful resolution."
+        ),
+    )
+    skipped_reason: str = Field(
+        default="",
+        description=(
+            "Human-readable reason text for a SKIP outcome. Empty string "
+            "on successful resolution."
+        ),
+    )
+
+
+__all__ = ["ModelHandlerResolution"]

--- a/src/omnibase_core/models/resolver/model_handler_resolver_context.py
+++ b/src/omnibase_core/models/resolver/model_handler_resolver_context.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelHandlerResolverContext - input to HandlerResolver.resolve().
+
+Frozen Pydantic model carrying the construction-time inputs required for a
+single handler resolution decision. Populated at auto-wiring time (manifest
+load) and passed to the resolver without mutation.
+
+Justification for introducing this model rather than reusing `PreparedWiring`:
+`PreparedWiring` represents the *output* of wiring (post-resolution:
+callback, category, routes). `ModelHandlerResolverContext` is the *input*.
+Different phase, different data. See the plan §"Known Types Inventory" at
+`docs/plans/2026-04-18-handler-resolver-architecture.md`.
+
+Layering (permanent, see §"Layering Invariants" in the plan):
+    `ownership_query`, `container`, `event_bus`, and the SPI-owned
+    resolver-produced `handler_instance` are typed `object | None`. The
+    repository layering rule forbids `omnibase_core` from importing
+    `omnibase_spi`. Runtime `isinstance(ownership_query,
+    ProtocolHandlerOwnershipQuery)` checks are performed at the infra
+    boundary in `handler_wiring.py`, not here. Do NOT narrow these fields
+    without first lifting the layering constraint at the plan level.
+
+Scope (by partner ruling):
+    This model carries only the inputs required for construction-time
+    resolution. Logging, metrics, feature flags, runtime identity, backend
+    registries, and post-resolution report state are explicitly out of
+    scope. Additions require a plan revision, not a one-line field append.
+
+Explicit dependencies split into TWO fields intentionally:
+    - `explicit_dependency_shape` — declarative names only, populated by
+      `discover_contracts()`. Safe to carry in a frozen manifest; never
+      constructs anything.
+    - `materialized_explicit_dependencies` — runtime-filled per-handler
+      dep map produced by `create_registry(...)` at wiring time.
+    Discovery touches only the former; the resolver consumes only the
+    latter for construction.
+"""
+
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelHandlerResolverContext(BaseModel):
+    """Input to `HandlerResolver.resolve()` — frozen, extra-forbidden."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+        arbitrary_types_allowed=True,
+    )
+
+    handler_cls: type = Field(
+        ...,
+        description="Handler class (already imported) to resolve to an instance.",
+    )
+    handler_module: str = Field(
+        ...,
+        min_length=1,
+        description="Fully-qualified module path of the handler class.",
+    )
+    handler_name: str = Field(
+        ...,
+        min_length=1,
+        description="Handler class name, used in wiring-report identifiers.",
+    )
+    contract_name: str = Field(
+        ...,
+        min_length=1,
+        description="Discovered contract name owning this handler declaration.",
+    )
+    node_name: str = Field(
+        ...,
+        min_length=1,
+        description="Node name whose registry declares this handler.",
+    )
+    # Declarative: dependency names per handler, populated by discovery.
+    explicit_dependency_shape: Mapping[str, tuple[str, ...]] | None = Field(
+        default=None,
+        description=(
+            "Declarative per-handler dependency names. Safe to carry in a "
+            "frozen manifest; never constructs anything. Populated by "
+            "discover_contracts() (Task 6)."
+        ),
+    )
+    # Runtime: materialized per-handler dep maps, filled by create_registry.
+    materialized_explicit_dependencies: Mapping[str, Mapping[str, object]] | None = (
+        Field(
+            default=None,
+            description=(
+                "Runtime-filled per-handler dependency map produced by "
+                "create_registry(...) at wiring time. Consumed by the "
+                "resolver for Step 2 construction."
+            ),
+        )
+    )
+    event_bus: object | None = Field(
+        default=None,
+        description=(
+            "Event-bus candidate. Typed object | None per layering "
+            "invariants; narrowed at the infra boundary, not here."
+        ),
+    )
+    container: object | None = Field(
+        default=None,
+        description=(
+            "DI container candidate. Typed object | None per layering "
+            "invariants; narrowed at the infra boundary."
+        ),
+    )
+    # ownership_query: typed as object | None. See the plan's
+    # "Layering Invariants" section — the SPI protocol lives in omnibase_spi
+    # and cannot be referenced from omnibase_core without violating the
+    # compat -> core -> spi -> infra dependency direction.
+    ownership_query: object | None = Field(
+        default=None,
+        description=(
+            "Local-ownership query answering 'is this handler's parent "
+            "node hosted in this runtime?'. Typed object | None "
+            "permanently per layering invariants."
+        ),
+    )
+
+
+__all__ = ["ModelHandlerResolverContext"]

--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""HandlerResolver — ordered-precedence handler resolution.
+
+Precedence (first match wins):
+    1. Local ownership skip — node not hosted here -> skip cleanly
+    2. Node registry        — materialized explicit dep map from create_registry
+    3. Container DI         — container.get_service(handler_cls)
+    4. Event-bus injection  — __init__(self, event_bus) single param
+    5. Zero-arg             — handler_cls()
+    6. TypeError            — unresolvable (never returns UNRESOLVABLE)
+
+Layering (permanent):
+    `omnibase_core` MUST NOT import `omnibase_spi`. The resolver therefore
+    duck-types `context.ownership_query.is_owned_here(...)` rather than
+    referencing `ProtocolHandlerOwnershipQuery`. Runtime conformance is
+    enforced one layer up, at the infra boundary in `handler_wiring.py`
+    (Task 5), before the context is constructed. See the plan's
+    §"Layering Invariants" for rationale.
+
+Narrow exception handling (Step 3a):
+    Only `ServiceResolutionError` (service-not-registered) is treated as a
+    container miss and falls through to later precedence steps. Any other
+    exception from `container.get_service(...)` — `KeyError`, `AttributeError`,
+    `RuntimeError`, etc. — propagates untouched so container-internal bugs
+    are never masked as graceful fallback.
+
+Forward-compat namespace (not yet implemented — see
+docs/plans/research/2026-04-18-marketplace-dynamic-loading-plans.md:192-199
+and memory reference_hot_reload_is_planned.md):
+    * hot-reload / late handler registration after boot
+    * onex.backends pluggable backend resolution
+These will extend `resolve` or add sibling methods in a future phase once
+runtime identity and backend contracts are modeled. No stub methods are
+reserved here — adding speculative API surface before the contract is
+known is a commitment cost that future work would have to rename or delete.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
+from omnibase_core.models.resolver.model_handler_resolution import (
+    ModelHandlerResolution,
+)
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONCRETE_PARAM_KINDS = (
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.KEYWORD_ONLY,
+)
+
+
+class HandlerResolver:
+    """Ordered-precedence resolver for handler instantiation.
+
+    Pure in its context argument — holds no internal state. Multiple
+    concurrent `resolve()` calls on the same instance are safe.
+    """
+
+    def resolve(self, context: ModelHandlerResolverContext) -> ModelHandlerResolution:
+        """Apply the six-step precedence chain; return a resolution record.
+
+        Raises:
+            TypeError: When no precedence path can construct the handler.
+                       The error message names the handler and its required
+                       constructor parameters to aid debugging.
+            ServiceResolutionError: Never — this is caught internally as a
+                soft miss and falls through to later steps.
+            Exception: Any non-ServiceResolutionError raised by the container
+                propagates untouched (container-internal bug, not a miss).
+        """
+        # Step 1 - local ownership skip (deliberate non-error skip).
+        # Duck-typed per layering invariants: core cannot import the spi
+        # Protocol. `handler_wiring.py` validates conformance before calling.
+        if context.ownership_query is not None and hasattr(
+            context.ownership_query, "is_owned_here"
+        ):
+            is_owned = context.ownership_query.is_owned_here(context.node_name)
+            if not is_owned:
+                logger.info(
+                    "HandlerResolver: skipping %s.%s — node %r not hosted here",
+                    context.handler_module,
+                    context.handler_name,
+                    context.node_name,
+                )
+                return ModelHandlerResolution(
+                    outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+                    handler_instance=None,
+                    skipped_handler=context.handler_name,
+                    skipped_reason=(f"node {context.node_name!r} is not hosted here"),
+                )
+
+        # Step 2 - explicit materialized dependency map from node registry.
+        mat = context.materialized_explicit_dependencies
+        deps_for_this_handler = (
+            mat.get(context.handler_name) if mat is not None else None
+        )
+        if deps_for_this_handler is not None:
+            try:
+                instance = context.handler_cls(**dict(deps_for_this_handler))
+            except TypeError as exc:
+                # TypeError is the idiomatic Python signal for a constructor-arg
+                # mismatch and matches the handler_cls(**deps) failure mode
+                # callers must catch. Wrapping as OnexError would obscure the
+                # signature-mismatch diagnostic. Plan §"Task 3 Step 6" (OMN-9199).
+                # error-ok: HandlerResolver constructor-arg mismatch surface.
+                raise TypeError(
+                    f"Handler {context.handler_module}.{context.handler_name} "
+                    f"could not be constructed from materialized explicit "
+                    f"dependencies: {exc}"
+                ) from exc
+            _log_overlap_if_any(context, chose="node_registry")
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+                handler_instance=instance,
+            )
+
+        # Step 3 - container DI (narrow: only service-not-registered falls through).
+        if context.container is not None:
+            get_service = getattr(context.container, "get_service", None)
+            if get_service is not None:
+                try:
+                    instance = get_service(context.handler_cls)
+                except ServiceResolutionError:
+                    # Documented miss — fall through to steps 4/5/6.
+                    logger.debug(
+                        "HandlerResolver: container miss "
+                        "(ServiceResolutionError) for %s.%s — trying "
+                        "event_bus/zero-arg",
+                        context.handler_module,
+                        context.handler_name,
+                    )
+                else:
+                    _log_overlap_if_any(context, chose="container")
+                    return ModelHandlerResolution(
+                        outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
+                        handler_instance=instance,
+                    )
+
+        # Compute concrete required params once for steps 4/5/6.
+        sig = inspect.signature(context.handler_cls)
+        non_self_required_params = {
+            k: v
+            for k, v in sig.parameters.items()
+            if k != "self"
+            and v.kind in _CONCRETE_PARAM_KINDS
+            and v.default is inspect.Parameter.empty
+        }
+
+        # Step 4 - event_bus injection.
+        if context.event_bus is not None and set(non_self_required_params) == {
+            "event_bus"
+        }:
+            instance = context.handler_cls(event_bus=context.event_bus)
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+                handler_instance=instance,
+            )
+
+        # Step 5 - zero-arg.
+        if not non_self_required_params:
+            instance = context.handler_cls()
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG,
+                handler_instance=instance,
+            )
+
+        # Step 6 - unresolvable: HARD FAILURE (not a skip).
+        dep_names = list(non_self_required_params)
+        # TypeError is the idiomatic signal to handler_wiring.py that no
+        # precedence path satisfied the handler's constructor requirements.
+        # OnexError would add serialization overhead without improving the
+        # caller's recovery surface; this is always a wiring bug, never a
+        # recoverable runtime state. Plan §"Task 3 Step 6" (OMN-9199).
+        # error-ok: HandlerResolver fail-fast per OMN-8735 invariant.
+        raise TypeError(
+            f"Handler {context.handler_module}.{context.handler_name} "
+            f"requires constructor parameters {dep_names!r} but no "
+            f"ownership_query, node registry explicit deps, container, or "
+            f"event_bus could satisfy them."
+        )
+
+
+def _log_overlap_if_any(context: ModelHandlerResolverContext, *, chose: str) -> None:
+    """Surface architecture smell: multiple precedence paths would have resolved.
+
+    Logs at DEBUG only. Never raises. See plan §"Conflict Semantics".
+    """
+    shadowed: list[str] = []
+    mat = context.materialized_explicit_dependencies
+    if chose != "node_registry" and mat is not None and context.handler_name in mat:
+        shadowed.append("node_registry")
+    if chose != "container" and context.container is not None:
+        # We don't re-probe the container here to avoid side effects; a
+        # conservative "container present" signal is enough to warrant
+        # investigation.
+        shadowed.append("container(present)")
+    if shadowed:
+        logger.debug(
+            "HandlerResolver: resolved %s.%s via %s; shadowed paths: %s",
+            context.handler_module,
+            context.handler_name,
+            chose,
+            ",".join(shadowed),
+        )
+
+
+__all__ = ["HandlerResolver"]

--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -60,7 +60,7 @@ _CONCRETE_PARAM_KINDS = (
 )
 
 
-class HandlerResolver:
+class ServiceHandlerResolver:
     """Ordered-precedence resolver for handler instantiation.
 
     Pure in its context argument — holds no internal state. Multiple
@@ -215,4 +215,4 @@ def _log_overlap_if_any(context: ModelHandlerResolverContext, *, chose: str) -> 
         )
 
 
-__all__ = ["HandlerResolver"]
+__all__ = ["ServiceHandlerResolver"]

--- a/src/omnibase_core/services/service_local_handler_ownership_query.py
+++ b/src/omnibase_core/services/service_local_handler_ownership_query.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Ownership query — does THIS runtime host the node owning this handler?
+
+Phase 1 semantics: "hosted here" is resolved against the set of locally
+discovered contracts — i.e. the frozen `node_name` set produced by
+`discover_contracts()` at manifest boot. No SQL call is made.
+
+Why no projection read:
+    The ``registration_projections`` table (omnibase_infra/docker/migrations/
+    forward/001_registration_projection.sql:51-108) carries entity_id +
+    node_type + state but no ``runtime_id`` column. Cluster-level ownership
+    therefore cannot be answered from the projection today; "hosted here"
+    operationally means "did the local manifest see this contract at boot."
+
+Forward-compat:
+    A future ``ServiceClusterHandlerOwnershipQuery`` — implementing the same
+    ``ProtocolHandlerOwnershipQuery`` shape over a runtime-aware projection —
+    is deliberately left as follow-on work once runtime identity is modeled
+    explicitly. See plan §"Forward-Compat Seams".
+
+Layering:
+    This module is intentionally free of ``omnibase_spi`` imports. The Round 3
+    layering ruling forbids core→spi. The protocol-conformance check
+    (isinstance against ``ProtocolHandlerOwnershipQuery``) is performed at the
+    infra boundary (see ``omnibase_infra/runtime/auto_wiring/handler_wiring.py``
+    in Task 5), NOT here. Callers in core rely on the duck-typed
+    ``is_owned_here(node_name: str) -> bool`` shape.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ServiceLocalHandlerOwnershipQuery(BaseModel):
+    """Answer Phase 1 ownership via local set-membership.
+
+    Construction is frozen — the ``local_node_names`` set passed at init time
+    is immutable for the lifetime of the service. Callers pre-compute this set
+    from ``ModelAutoWiringManifest`` at boot.
+
+    Attributes:
+        local_node_names: Frozen set of ``node_name`` strings the local runtime
+            discovered via ``discover_contracts()`` at boot. Membership in
+            this set IS the Phase 1 ownership answer.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    local_node_names: frozenset[str] = Field(
+        ...,
+        description=(
+            "Frozen set of node_name strings discovered locally at boot. "
+            "Membership in this set is the Phase 1 definition of 'hosted here'."
+        ),
+    )
+
+    def is_owned_here(self, node_name: str) -> bool:
+        """Return True iff ``node_name`` is in the locally discovered set.
+
+        Pure in-memory set-membership. No I/O, no SQL, no projection reads.
+        Deterministic and idempotent — safe to call from hot paths.
+
+        Args:
+            node_name: The node name to check for local ownership.
+
+        Returns:
+            True if the local manifest saw this contract at boot, else False.
+        """
+        return node_name in self.local_node_names

--- a/tests/unit/enums/test_enum_handler_resolution_outcome.py
+++ b/tests/unit/enums/test_enum_handler_resolution_outcome.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumHandlerResolutionOutcome (OMN-9195/OMN-9196).
+
+Verifies the enum contract for the HandlerResolver precedence chain:
+exactly six terminal outcomes with lowercase-snake wire-stable values.
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum, StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+
+
+@pytest.mark.unit
+class TestEnumHandlerResolutionOutcomeMembership:
+    """Membership + inheritance contract."""
+
+    def test_enum_inherits_from_str_enum(self) -> None:
+        """Enum is a StrEnum (str + Enum)."""
+        assert issubclass(EnumHandlerResolutionOutcome, StrEnum)
+        assert issubclass(EnumHandlerResolutionOutcome, str)
+        assert issubclass(EnumHandlerResolutionOutcome, Enum)
+
+    def test_enum_has_six_members(self) -> None:
+        """Plan §Task 1 Step 1: exactly six members with fixed names."""
+        assert {m.name for m in EnumHandlerResolutionOutcome} == {
+            "RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP",
+            "RESOLVED_VIA_NODE_REGISTRY",
+            "RESOLVED_VIA_CONTAINER",
+            "RESOLVED_VIA_EVENT_BUS",
+            "RESOLVED_VIA_ZERO_ARG",
+            "UNRESOLVABLE",
+        }
+        assert len(list(EnumHandlerResolutionOutcome)) == 6
+
+
+@pytest.mark.unit
+class TestEnumHandlerResolutionOutcomeValues:
+    """Wire-stable lowercase-snake serialization contract."""
+
+    def test_enum_values_are_lowercase_snake(self) -> None:
+        """Plan §Task 1 Step 1: explicit test asserting value format."""
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP.value
+            == "resolved_via_local_ownership_skip"
+        )
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY.value
+            == "resolved_via_node_registry"
+        )
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER.value
+            == "resolved_via_container"
+        )
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS.value
+            == "resolved_via_event_bus"
+        )
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG.value
+            == "resolved_via_zero_arg"
+        )
+        assert EnumHandlerResolutionOutcome.UNRESOLVABLE.value == "unresolvable"
+
+    def test_values_are_all_strings(self) -> None:
+        for member in EnumHandlerResolutionOutcome:
+            assert isinstance(member.value, str)
+            assert member.value == member.value.lower()
+            assert " " not in member.value
+
+    def test_values_are_unique(self) -> None:
+        """No aliasing — five success branches + UNRESOLVABLE are distinct."""
+        values = [m.value for m in EnumHandlerResolutionOutcome]
+        assert len(values) == len(set(values))
+
+
+@pytest.mark.unit
+class TestEnumHandlerResolutionOutcomeRoundTrip:
+    """Round-trip from value string reconstructs the correct member."""
+
+    def test_from_string_round_trip(self) -> None:
+        for member in EnumHandlerResolutionOutcome:
+            reconstructed = EnumHandlerResolutionOutcome(member.value)
+            assert reconstructed is member
+
+    def test_json_round_trip(self) -> None:
+        for member in EnumHandlerResolutionOutcome:
+            serialized = json.dumps(member.value)
+            deserialized = json.loads(serialized)
+            assert EnumHandlerResolutionOutcome(deserialized) is member
+
+    def test_invalid_value_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            EnumHandlerResolutionOutcome("not_a_real_outcome")
+
+
+@pytest.mark.unit
+class TestEnumHandlerResolutionOutcomeExportedFromPackage:
+    """Re-export hygiene: enum is importable from `omnibase_core.enums`."""
+
+    def test_reexport_from_enums_package(self) -> None:
+        from omnibase_core.enums import (
+            EnumHandlerResolutionOutcome as ReexportedEnum,
+        )
+
+        assert ReexportedEnum is EnumHandlerResolutionOutcome
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/models/resolver/__init__.py
+++ b/tests/unit/models/resolver/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/resolver/test_model_handler_resolution.py
+++ b/tests/unit/models/resolver/test_model_handler_resolution.py
@@ -31,37 +31,57 @@ class TestModelHandlerResolutionFrozen:
     def test_resolution_is_frozen(self) -> None:
         res = ModelHandlerResolution(
             outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            handler_instance=object(),
         )
         with pytest.raises(ValidationError):
-            res.skipped_reason = "Mutated"  # type: ignore[misc]
+            res.skipped_reason = "Mutated"  # type: ignore[misc]  # NOTE(OMN-9196): intentional assignment to frozen field verifies immutability enforcement
 
     def test_resolution_rejects_extra_fields(self) -> None:
         with pytest.raises(ValidationError):
             ModelHandlerResolution(
                 outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
-                unknown_field="x",  # type: ignore[call-arg]
+                handler_instance=object(),
+                unknown_field="x",  # type: ignore[call-arg]  # NOTE(OMN-9196): intentional unknown kwarg verifies extra='forbid' rejection
             )
 
 
 @pytest.mark.unit
 class TestModelHandlerResolutionDefaults:
-    """Default-value contract for optional fields."""
+    """Default-value contract for optional fields on SKIP outcome.
 
-    def test_handler_instance_defaults_none(self) -> None:
+    Note: the cross-field validator rejects non-skip outcomes without a
+    handler_instance, and rejects skip outcomes without skip metadata. These
+    tests therefore use the SKIP outcome (which permits default=None for
+    handler_instance) and verify the default semantics of skipped_*
+    via the minimal valid SKIP construction.
+    """
+
+    def test_handler_instance_defaults_none_on_skip(self) -> None:
         res = ModelHandlerResolution(
-            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+            skipped_handler="HandlerFoo",
+            skipped_reason="not hosted",
         )
         assert res.handler_instance is None
 
-    def test_skipped_handler_defaults_empty_string(self) -> None:
+    def test_non_skip_requires_handler_instance(self) -> None:
+        """Cross-field invariant: non-skip outcomes must carry an instance."""
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            )
+
+    def test_skipped_handler_empty_on_successful_resolution(self) -> None:
         res = ModelHandlerResolution(
             outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            handler_instance=object(),
         )
         assert res.skipped_handler == ""
 
-    def test_skipped_reason_defaults_empty_string(self) -> None:
+    def test_skipped_reason_empty_on_successful_resolution(self) -> None:
         res = ModelHandlerResolution(
             outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            handler_instance=object(),
         )
         assert res.skipped_reason == ""
 
@@ -72,7 +92,7 @@ class TestModelHandlerResolutionRequiredFields:
 
     def test_missing_outcome_raises(self) -> None:
         with pytest.raises(ValidationError):
-            ModelHandlerResolution()  # type: ignore[call-arg]
+            ModelHandlerResolution()  # type: ignore[call-arg]  # NOTE(OMN-9196): intentional missing required arg verifies outcome is mandatory
 
 
 @pytest.mark.unit
@@ -83,7 +103,16 @@ class TestModelHandlerResolutionOutcomeAcceptsAllEnumValues:
     def test_accepts_every_outcome_member(
         self, outcome: EnumHandlerResolutionOutcome
     ) -> None:
-        res = ModelHandlerResolution(outcome=outcome)
+        # Cross-field invariant: SKIP requires skip metadata; non-SKIP requires
+        # handler_instance. Supply both so each enum value constructs successfully.
+        if outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP:
+            res = ModelHandlerResolution(
+                outcome=outcome,
+                skipped_handler="HandlerFoo",
+                skipped_reason="not hosted here",
+            )
+        else:
+            res = ModelHandlerResolution(outcome=outcome, handler_instance=object())
         assert res.outcome is outcome
 
 
@@ -112,6 +141,61 @@ class TestModelHandlerResolutionSkipMode:
             handler_instance=sentinel_instance,
         )
         assert res.handler_instance is sentinel_instance
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionOutcomeInvariants:
+    """Cross-field validator: outcome dictates handler_instance + skip metadata.
+
+    Per module docstring contract:
+        - SKIP outcome: handler_instance MUST be None; skipped_* MUST be non-empty
+        - Non-SKIP outcome: handler_instance MUST NOT be None; skipped_* MUST be empty
+    """
+
+    def test_skip_outcome_rejects_non_none_handler_instance(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+                handler_instance=object(),
+                skipped_handler="HandlerFoo",
+                skipped_reason="not hosted",
+            )
+
+    def test_skip_outcome_rejects_empty_skipped_handler(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+                skipped_reason="not hosted",
+            )
+
+    def test_skip_outcome_rejects_empty_skipped_reason(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+                skipped_handler="HandlerFoo",
+            )
+
+    def test_non_skip_outcome_rejects_none_handler_instance(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            )
+
+    def test_non_skip_outcome_rejects_populated_skipped_handler(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+                handler_instance=object(),
+                skipped_handler="HandlerFoo",
+            )
+
+    def test_non_skip_outcome_rejects_populated_skipped_reason(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+                handler_instance=object(),
+                skipped_reason="not hosted",
+            )
 
 
 @pytest.mark.unit

--- a/tests/unit/models/resolver/test_model_handler_resolution.py
+++ b/tests/unit/models/resolver/test_model_handler_resolution.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelHandlerResolution (OMN-9195/OMN-9196).
+
+Verifies:
+- frozen + extra="forbid" config
+- outcome is the only required field
+- handler_instance defaults to None, skipped_handler/skipped_reason default ""
+- all six EnumHandlerResolutionOutcome values are accepted
+- skip-mode construction preserves handler name + reason text
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.models.resolver.model_handler_resolution import (
+    ModelHandlerResolution,
+)
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionFrozen:
+    """Frozen + extra='forbid' config."""
+
+    def test_resolution_is_frozen(self) -> None:
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+        )
+        with pytest.raises(ValidationError):
+            res.skipped_reason = "Mutated"  # type: ignore[misc]
+
+    def test_resolution_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionDefaults:
+    """Default-value contract for optional fields."""
+
+    def test_handler_instance_defaults_none(self) -> None:
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+        )
+        assert res.handler_instance is None
+
+    def test_skipped_handler_defaults_empty_string(self) -> None:
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+        )
+        assert res.skipped_handler == ""
+
+    def test_skipped_reason_defaults_empty_string(self) -> None:
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+        )
+        assert res.skipped_reason == ""
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionRequiredFields:
+    """`outcome` is the only required field."""
+
+    def test_missing_outcome_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelHandlerResolution()  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionOutcomeAcceptsAllEnumValues:
+    """Construction accepts every enum member (resolver may return any)."""
+
+    @pytest.mark.parametrize("outcome", list(EnumHandlerResolutionOutcome))
+    def test_accepts_every_outcome_member(
+        self, outcome: EnumHandlerResolutionOutcome
+    ) -> None:
+        res = ModelHandlerResolution(outcome=outcome)
+        assert res.outcome is outcome
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionSkipMode:
+    """Skip path carries handler identifier + reason text."""
+
+    def test_skip_preserves_handler_and_reason(self) -> None:
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+            skipped_handler="HandlerFoo",
+            skipped_reason="node_foo not hosted in this runtime",
+        )
+        assert (
+            res.outcome
+            == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+        )
+        assert res.skipped_handler == "HandlerFoo"
+        assert res.skipped_reason == "node_foo not hosted in this runtime"
+        assert res.handler_instance is None
+
+    def test_resolved_mode_carries_handler_instance(self) -> None:
+        sentinel_instance = object()
+        res = ModelHandlerResolution(
+            outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+            handler_instance=sentinel_instance,
+        )
+        assert res.handler_instance is sentinel_instance
+
+
+@pytest.mark.unit
+class TestModelHandlerResolutionExportedFromPackage:
+    """Re-export hygiene: model importable from `omnibase_core.models.resolver`."""
+
+    def test_reexport_from_resolver_package(self) -> None:
+        from omnibase_core.models.resolver import (
+            ModelHandlerResolution as ReexportedRes,
+        )
+
+        assert ReexportedRes is ModelHandlerResolution
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/models/resolver/test_model_handler_resolver_context.py
+++ b/tests/unit/models/resolver/test_model_handler_resolver_context.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelHandlerResolverContext (OMN-9195/OMN-9196).
+
+Verifies:
+- frozen + extra="forbid" config (plan Step 4/5)
+- required-field signature (handler_cls/module/name/contract/node)
+- 5 optional fields default to None (plan Acceptance)
+- two explicit-dependency fields modeled separately (plan Step 5)
+- layering invariant: `object | None` fields accept arbitrary non-protocol sentinels
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+
+
+class _HandlerClassFixture:
+    """Dummy handler-like class used as `handler_cls` in tests."""
+
+
+def _make_minimal_context(**overrides: object) -> ModelHandlerResolverContext:
+    """Helper building a minimal valid context with only the required fields."""
+    base: dict[str, object] = {
+        "handler_cls": _HandlerClassFixture,
+        "handler_module": "pkg.mod",
+        "handler_name": "HandlerFoo",
+        "contract_name": "node_foo",
+        "node_name": "node_foo",
+    }
+    base.update(overrides)
+    return ModelHandlerResolverContext(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextFrozen:
+    """Frozen/immutable-assignment contract."""
+
+    def test_context_is_frozen(self) -> None:
+        """Plan Step 4: mutation must raise ValidationError."""
+        ctx = _make_minimal_context()
+        with pytest.raises(ValidationError):
+            ctx.handler_name = "Mutated"  # type: ignore[misc]
+
+    def test_context_rejects_extra_fields(self) -> None:
+        """Plan Step 4: extra='forbid' rejects unknown kwargs."""
+        with pytest.raises(ValidationError):
+            ModelHandlerResolverContext(
+                handler_cls=_HandlerClassFixture,
+                handler_module="pkg.mod",
+                handler_name="HandlerFoo",
+                contract_name="node_foo",
+                node_name="node_foo",
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextOptionalFields:
+    """All 5 SPI/runtime-bound fields default to None (acceptance criterion)."""
+
+    def test_context_optional_fields_default_none(self) -> None:
+        """Plan Acceptance: test asserts 5 fields default to None."""
+        ctx = _make_minimal_context()
+        assert ctx.explicit_dependency_shape is None
+        assert ctx.materialized_explicit_dependencies is None
+        assert ctx.event_bus is None
+        assert ctx.container is None
+        assert ctx.ownership_query is None
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextRequiredFields:
+    """Required-field signature fails closed when any core field is missing."""
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "handler_cls",
+            "handler_module",
+            "handler_name",
+            "contract_name",
+            "node_name",
+        ],
+    )
+    def test_missing_required_field_raises(self, missing_field: str) -> None:
+        kwargs: dict[str, object] = {
+            "handler_cls": _HandlerClassFixture,
+            "handler_module": "pkg.mod",
+            "handler_name": "HandlerFoo",
+            "contract_name": "node_foo",
+            "node_name": "node_foo",
+        }
+        kwargs.pop(missing_field)
+        with pytest.raises(ValidationError):
+            ModelHandlerResolverContext(**kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "empty_field",
+        [
+            "handler_module",
+            "handler_name",
+            "contract_name",
+            "node_name",
+        ],
+    )
+    def test_empty_string_fields_rejected(self, empty_field: str) -> None:
+        """min_length=1 on string fields — empty string must fail."""
+        with pytest.raises(ValidationError):
+            _make_minimal_context(**{empty_field: ""})
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextExplicitDependencySplit:
+    """Two explicit-dependency fields exist and have distinct types."""
+
+    def test_shape_and_materialized_are_separate_fields(self) -> None:
+        """Plan Step 5: declarative names-only vs runtime-materialized map."""
+        field_names = set(ModelHandlerResolverContext.model_fields.keys())
+        assert "explicit_dependency_shape" in field_names
+        assert "materialized_explicit_dependencies" in field_names
+        # Ensure we have NOT collapsed them into a single legacy field.
+        assert "explicit_dependencies" not in field_names
+
+    def test_can_supply_shape_without_materialized(self) -> None:
+        """Discovery phase: shape populated, materialized is None."""
+        ctx = _make_minimal_context(
+            explicit_dependency_shape={"HandlerFoo": ("dep_a", "dep_b")},
+        )
+        assert ctx.explicit_dependency_shape == {"HandlerFoo": ("dep_a", "dep_b")}
+        assert ctx.materialized_explicit_dependencies is None
+
+    def test_can_supply_materialized_without_shape(self) -> None:
+        """Runtime: materialized populated, shape may be None."""
+        sentinel_dep = object()
+        ctx = _make_minimal_context(
+            materialized_explicit_dependencies={
+                "HandlerFoo": {"dep_a": sentinel_dep},
+            },
+        )
+        assert ctx.materialized_explicit_dependencies is not None
+        assert (
+            ctx.materialized_explicit_dependencies["HandlerFoo"]["dep_a"]
+            is sentinel_dep
+        )
+        assert ctx.explicit_dependency_shape is None
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextLayeringInvariant:
+    """Layering invariant: object|None fields accept non-protocol objects.
+
+    Verifies that construction does NOT narrow to any SPI protocol — any
+    Python object is accepted at the core layer; protocol conformance is
+    enforced at the infra boundary (plan §Layering Invariants).
+    """
+
+    def test_accepts_arbitrary_objects_for_spi_fields(self) -> None:
+        bus_sentinel = object()
+        container_sentinel = object()
+        ownership_sentinel = object()
+        ctx = _make_minimal_context(
+            event_bus=bus_sentinel,
+            container=container_sentinel,
+            ownership_query=ownership_sentinel,
+        )
+        assert ctx.event_bus is bus_sentinel
+        assert ctx.container is container_sentinel
+        assert ctx.ownership_query is ownership_sentinel
+
+
+@pytest.mark.unit
+class TestModelHandlerResolverContextExportedFromPackage:
+    """Re-export hygiene: model importable from `omnibase_core.models.resolver`."""
+
+    def test_reexport_from_resolver_package(self) -> None:
+        from omnibase_core.models.resolver import (
+            ModelHandlerResolverContext as ReexportedCtx,
+        )
+
+        assert ReexportedCtx is ModelHandlerResolverContext
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/models/resolver/test_model_handler_resolver_context.py
+++ b/tests/unit/models/resolver/test_model_handler_resolver_context.py
@@ -35,7 +35,7 @@ def _make_minimal_context(**overrides: object) -> ModelHandlerResolverContext:
         "node_name": "node_foo",
     }
     base.update(overrides)
-    return ModelHandlerResolverContext(**base)  # type: ignore[arg-type]
+    return ModelHandlerResolverContext(**base)  # type: ignore[arg-type]  # NOTE(OMN-9196): dict[str, object] splat into Pydantic model with typed fields; mypy cannot narrow kwargs from a generic mapping
 
 
 @pytest.mark.unit
@@ -46,7 +46,7 @@ class TestModelHandlerResolverContextFrozen:
         """Plan Step 4: mutation must raise ValidationError."""
         ctx = _make_minimal_context()
         with pytest.raises(ValidationError):
-            ctx.handler_name = "Mutated"  # type: ignore[misc]
+            ctx.handler_name = "Mutated"  # type: ignore[misc]  # NOTE(OMN-9196): intentional assignment to frozen field verifies immutability enforcement
 
     def test_context_rejects_extra_fields(self) -> None:
         """Plan Step 4: extra='forbid' rejects unknown kwargs."""
@@ -57,7 +57,7 @@ class TestModelHandlerResolverContextFrozen:
                 handler_name="HandlerFoo",
                 contract_name="node_foo",
                 node_name="node_foo",
-                unknown_field="x",  # type: ignore[call-arg]
+                unknown_field="x",  # type: ignore[call-arg]  # NOTE(OMN-9196): intentional unknown kwarg verifies extra='forbid' rejection
             )
 
 
@@ -99,7 +99,7 @@ class TestModelHandlerResolverContextRequiredFields:
         }
         kwargs.pop(missing_field)
         with pytest.raises(ValidationError):
-            ModelHandlerResolverContext(**kwargs)  # type: ignore[arg-type]
+            ModelHandlerResolverContext(**kwargs)  # type: ignore[arg-type]  # NOTE(OMN-9196): dict[str, object] splat into Pydantic model with typed fields; mypy cannot narrow kwargs from a generic mapping
 
     @pytest.mark.parametrize(
         "empty_field",

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for HandlerResolver (OMN-9199 Task 3).
+"""Unit tests for ServiceHandlerResolver (OMN-9199 Task 3).
 
 Each test exercises one precedence branch in isolation plus the negative
 cases described in the plan:
@@ -34,7 +34,7 @@ from omnibase_core.errors.error_service_resolution import ServiceResolutionError
 from omnibase_core.models.resolver.model_handler_resolver_context import (
     ModelHandlerResolverContext,
 )
-from omnibase_core.services.service_handler_resolver import HandlerResolver
+from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
 
 
 class _HandlerNoDeps:
@@ -72,7 +72,7 @@ def test_step_1_local_ownership_skip_when_not_owned_here() -> None:
         ownership_query=ownership,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert (
         result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
@@ -97,7 +97,7 @@ def test_step_1_local_ownership_owned_here_falls_through() -> None:
         ownership_query=ownership,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -121,7 +121,7 @@ def test_step_1_duck_typed_ownership_query_without_method_ignored() -> None:
     )
 
     # Should skip Step 1 and fall through to Step 5 (zero-arg).
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
 
 
@@ -143,7 +143,7 @@ def test_step_2_explicit_dep_map_wins_over_container() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
     assert isinstance(result.handler_instance, _HandlerWithDeps)
@@ -164,7 +164,7 @@ def test_step_3_container_used_when_no_explicit_deps() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER
     assert result.handler_instance is expected
@@ -185,7 +185,7 @@ def test_step_3_container_miss_falls_through_to_zero_arg() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -206,7 +206,7 @@ def test_step_3_container_internal_bug_propagates() -> None:
     )
 
     with pytest.raises(KeyError):
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
 
 @pytest.mark.unit
@@ -226,7 +226,7 @@ def test_step_3_container_without_get_service_skipped() -> None:
     )
 
     # Should not raise AttributeError; falls through to zero-arg.
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
 
 
@@ -242,7 +242,7 @@ def test_step_4_event_bus_injection() -> None:
         event_bus=event_bus,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
     assert isinstance(result.handler_instance, _HandlerEventBusOnly)
@@ -259,7 +259,7 @@ def test_step_5_zero_arg_construction() -> None:
         node_name="node_foo",
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -278,7 +278,7 @@ def test_step_6_type_error_when_unresolvable() -> None:
     )
 
     with pytest.raises(TypeError) as exc:
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     msg = str(exc.value)
     assert "_HandlerWithDeps" in msg
@@ -301,7 +301,7 @@ def test_explicit_dep_type_error_surfaces_missing_key() -> None:
     )
 
     with pytest.raises(TypeError) as exc:
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     assert "reducer" in str(exc.value)
 
@@ -331,7 +331,7 @@ def test_conflict_overlap_logs_debug(
         logging.DEBUG,
         logger="omnibase_core.services.service_handler_resolver",
     ):
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     assert any(
         "shadowed" in rec.message.lower() or "overlap" in rec.message.lower()
@@ -352,7 +352,7 @@ def test_resolver_is_pure_in_context() -> None:
         contract_name="node_foo",
         node_name="node_foo",
     )
-    resolver = HandlerResolver()
+    resolver = ServiceHandlerResolver()
 
     first = resolver.resolve(ctx)
     second = resolver.resolve(ctx)
@@ -385,7 +385,7 @@ def test_skip_precedes_node_registry() -> None:
         },
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert (
         result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for HandlerResolver (OMN-9199 Task 3).
+
+Each test exercises one precedence branch in isolation plus the negative
+cases described in the plan:
+
+    Step 1 - ownership skip
+    Step 2 - explicit deps win over container
+    Step 3 - container hit
+    Step 3 - container miss (ServiceResolutionError) -> fallthrough
+    Step 3 - container internal bug propagates (non-miss)
+    Step 4 - event_bus injection
+    Step 5 - zero-arg
+    Step 6 - unresolvable raises TypeError
+    Step 2 - incomplete explicit deps surface missing key in TypeError
+    Conflict overlap logs at DEBUG
+    Ownership query without is_owned_here attr is ignored (duck-typed)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+from omnibase_core.services.service_handler_resolver import HandlerResolver
+
+
+class _HandlerNoDeps:
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerEventBusOnly:
+    def __init__(self, event_bus: object) -> None:
+        self.event_bus = event_bus
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerWithDeps:
+    def __init__(self, projection_reader: object, reducer: object) -> None:
+        self.projection_reader = projection_reader
+        self.reducer = reducer
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+@pytest.mark.unit
+def test_step_1_local_ownership_skip_when_not_owned_here() -> None:
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = False
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert (
+        result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+    )
+    assert result.handler_instance is None
+    assert result.skipped_handler == "H"
+    assert "not hosted here" in result.skipped_reason
+    ownership.is_owned_here.assert_called_once_with("node_foo")
+
+
+@pytest.mark.unit
+def test_step_1_local_ownership_owned_here_falls_through() -> None:
+    """If ownership_query says owned, resolver proceeds to later steps."""
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = True
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_1_duck_typed_ownership_query_without_method_ignored() -> None:
+    """An ownership_query without is_owned_here is ignored (duck-typed)."""
+
+    class _NotAnOwnershipQuery:
+        # No `is_owned_here` attr at all.
+        pass
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=_NotAnOwnershipQuery(),
+    )
+
+    # Should skip Step 1 and fall through to Step 5 (zero-arg).
+    result = HandlerResolver().resolve(ctx)
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+
+
+@pytest.mark.unit
+def test_step_2_explicit_dep_map_wins_over_container() -> None:
+    proj = object()
+    reducer = object()
+    container = MagicMock()
+    container.get_service.return_value = _HandlerWithDeps(proj, reducer)
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
+    assert isinstance(result.handler_instance, _HandlerWithDeps)
+    container.get_service.assert_not_called()
+
+
+@pytest.mark.unit
+def test_step_3_container_used_when_no_explicit_deps() -> None:
+    expected = _HandlerNoDeps()
+    container = MagicMock()
+    container.get_service.return_value = expected
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER
+    assert result.handler_instance is expected
+    container.get_service.assert_called_once_with(_HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_3_container_miss_falls_through_to_zero_arg() -> None:
+    """Container raises ServiceResolutionError; resolver falls through to Step 5."""
+    container = MagicMock()
+    container.get_service.side_effect = ServiceResolutionError("not registered")
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_3_container_internal_bug_propagates() -> None:
+    """Non-miss exception from container (e.g. KeyError) must NOT be swallowed."""
+    container = MagicMock()
+    container.get_service.side_effect = KeyError("container corruption")
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    with pytest.raises(KeyError):
+        HandlerResolver().resolve(ctx)
+
+
+@pytest.mark.unit
+def test_step_3_container_without_get_service_skipped() -> None:
+    """Container present but missing get_service attr — safely skipped."""
+
+    class _NoGetServiceContainer:
+        pass
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=_NoGetServiceContainer(),
+    )
+
+    # Should not raise AttributeError; falls through to zero-arg.
+    result = HandlerResolver().resolve(ctx)
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+
+
+@pytest.mark.unit
+def test_step_4_event_bus_injection() -> None:
+    event_bus = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerEventBusOnly,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        event_bus=event_bus,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
+    assert isinstance(result.handler_instance, _HandlerEventBusOnly)
+    assert result.handler_instance.event_bus is event_bus
+
+
+@pytest.mark.unit
+def test_step_5_zero_arg_construction() -> None:
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_6_type_error_when_unresolvable() -> None:
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        # In production handler_name == class name; the TypeError message
+        # surfaces handler_module.handler_name so the operator can find it.
+        handler_name="_HandlerWithDeps",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+
+    with pytest.raises(TypeError) as exc:
+        HandlerResolver().resolve(ctx)
+
+    msg = str(exc.value)
+    assert "_HandlerWithDeps" in msg
+    assert "projection_reader" in msg
+    assert "reducer" in msg
+
+
+@pytest.mark.unit
+def test_explicit_dep_type_error_surfaces_missing_key() -> None:
+    """Explicit materialized map incomplete -> resolver raises TypeError naming missing key."""
+    proj = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        # `reducer` missing intentionally.
+        materialized_explicit_dependencies={"H": {"projection_reader": proj}},
+    )
+
+    with pytest.raises(TypeError) as exc:
+        HandlerResolver().resolve(ctx)
+
+    assert "reducer" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_conflict_overlap_logs_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Step 2 resolves but container also present -> DEBUG log names shadowed path."""
+    proj = object()
+    reducer = object()
+    container = MagicMock()
+    container.get_service.return_value = _HandlerWithDeps(proj, reducer)
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+        container=container,
+    )
+
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="omnibase_core.services.service_handler_resolver",
+    ):
+        HandlerResolver().resolve(ctx)
+
+    assert any(
+        "shadowed" in rec.message.lower() or "overlap" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_resolver_is_pure_in_context() -> None:
+    """Repeated resolve() calls with the same context yield the same outcome.
+
+    Demonstrates the service holds no state that leaks across calls.
+    """
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+    resolver = HandlerResolver()
+
+    first = resolver.resolve(ctx)
+    second = resolver.resolve(ctx)
+
+    assert (
+        first.outcome
+        == second.outcome
+        == (EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG)
+    )
+    # Different instances (each resolve() constructs a fresh handler).
+    assert first.handler_instance is not second.handler_instance
+
+
+@pytest.mark.unit
+def test_skip_precedes_node_registry() -> None:
+    """Ownership skip beats node_registry when not-owned-here."""
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = False
+    proj: Any = object()
+    reducer: Any = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert (
+        result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+    )
+    assert result.handler_instance is None

--- a/tests/unit/services/test_service_local_handler_ownership_query.py
+++ b/tests/unit/services/test_service_local_handler_ownership_query.py
@@ -87,7 +87,7 @@ def test_local_node_names_is_immutable_post_construction() -> None:
     """Pydantic frozen config forbids reassigning fields after construction."""
     svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
     with pytest.raises(ValidationError):
-        svc.local_node_names = frozenset({"b"})  # type: ignore[misc]
+        svc.local_node_names = frozenset({"b"})  # type: ignore[misc]  # NOTE(OMN-9200): intentional assignment to frozen field verifies immutability enforcement
 
 
 @pytest.mark.unit
@@ -96,4 +96,4 @@ def test_frozenset_field_rejects_mutation_attempts() -> None:
     svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
     # frozenset has no .add() — AttributeError, not silent success
     with pytest.raises(AttributeError):
-        svc.local_node_names.add("b")  # type: ignore[attr-defined]
+        svc.local_node_names.add("b")  # type: ignore[attr-defined]  # NOTE(OMN-9200): intentional call to non-existent mutator verifies frozenset has no .add()

--- a/tests/unit/services/test_service_local_handler_ownership_query.py
+++ b/tests/unit/services/test_service_local_handler_ownership_query.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ServiceLocalHandlerOwnershipQuery.
+
+Covers the Phase 1 local-ownership semantics: "hosted here" == "node_name is in
+the frozen set of locally discovered contracts." No SQL, no projection reads.
+
+Layering note (OMN-9200 plan §Layering Invariants):
+    omnibase_core MUST NOT import omnibase_spi. The protocol-conformance check
+    (isinstance against ProtocolHandlerOwnershipQuery) lives under
+    omnibase_infra/tests/unit/runtime/ — here we verify the duck-typed shape
+    only.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.services.service_local_handler_ownership_query import (
+    ServiceLocalHandlerOwnershipQuery,
+)
+
+
+@pytest.mark.unit
+def test_returns_true_for_locally_discovered_node() -> None:
+    svc = ServiceLocalHandlerOwnershipQuery(
+        local_node_names=frozenset({"node_foo", "node_bar"})
+    )
+    assert svc.is_owned_here("node_foo") is True
+
+
+@pytest.mark.unit
+def test_returns_false_for_unknown_node() -> None:
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"node_foo"}))
+    assert svc.is_owned_here("node_other") is False
+
+
+@pytest.mark.unit
+def test_empty_local_set_rejects_everything() -> None:
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset())
+    assert svc.is_owned_here("node_foo") is False
+    assert svc.is_owned_here("") is False
+
+
+@pytest.mark.unit
+def test_is_owned_here_is_deterministic_and_pure() -> None:
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
+    assert svc.is_owned_here("a") is True
+    assert svc.is_owned_here("a") is True  # idempotent
+    assert svc.is_owned_here("b") is False
+    assert svc.is_owned_here("b") is False  # idempotent
+
+
+@pytest.mark.unit
+def test_is_owned_here_has_duck_typed_protocol_shape() -> None:
+    """Structural shape only — core tests cannot import omnibase_spi.
+
+    The concrete protocol-conformance assertion (isinstance against
+    ProtocolHandlerOwnershipQuery) lives in
+    omnibase_infra/tests/unit/runtime/test_handler_wiring_resolver_integration.py
+    where spi is importable. Here we only verify the method exists and returns
+    bool, matching the duck-typed contract the resolver depends on.
+    """
+    import inspect
+
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
+    assert hasattr(svc, "is_owned_here")
+    assert callable(svc.is_owned_here)
+    assert isinstance(svc.is_owned_here("a"), bool)
+
+    # Signature: is_owned_here(self, node_name: str) -> bool
+    # Note: the implementation uses `from __future__ import annotations`, so
+    # inspect.signature surfaces annotations as strings. Resolve eagerly with
+    # eval_str=True to compare against the real types.
+    sig = inspect.signature(svc.is_owned_here, eval_str=True)
+    params = list(sig.parameters.values())
+    assert len(params) == 1
+    assert params[0].name == "node_name"
+    assert params[0].annotation is str
+    assert sig.return_annotation is bool
+
+
+@pytest.mark.unit
+def test_local_node_names_is_immutable_post_construction() -> None:
+    """Pydantic frozen config forbids reassigning fields after construction."""
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
+    with pytest.raises(ValidationError):
+        svc.local_node_names = frozenset({"b"})  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_frozenset_field_rejects_mutation_attempts() -> None:
+    """The stored frozenset itself has no mutation API — sanity check."""
+    svc = ServiceLocalHandlerOwnershipQuery(local_node_names=frozenset({"a"}))
+    # frozenset has no .add() — AttributeError, not silent success
+    with pytest.raises(AttributeError):
+        svc.local_node_names.add("b")  # type: ignore[attr-defined]


### PR DESCRIPTION
[skip-receipt-gate: HandlerResolver epic OMN-9195 decomposition (Tasks 1/3/4 combined: OMN-9196/OMN-9199/OMN-9200) — contracts for these sub-tickets have not yet been authored in onex_change_control. Work is pure model/enum + service additions in omnibase_core (41 new unit tests passing); no interface/event/protocol changes requiring receipt-gate assertions. Follow-up ticket OMN-9209 will backfill contracts within 7 days per override-SLA.]

[skip-deploy-gate: Tasks 1/3/4 add pure model/enum + service implementations in `omnibase_core`. No runtime behavior change — these files are imported but not yet wired at boot (Task 5 OMN-9201 is the boot-path cutover PR). Deploy-agent is tracked under OMN-8841; receipt-gate override under OMN-9209.]

## Summary
Task 1 of HandlerResolver Architecture Phase 1 — epic **OMN-9195**. Introduces the three foundation types the resolver precedence chain will consume:

- `EnumHandlerResolutionOutcome` — StrEnum with six terminal labels
- `ModelHandlerResolverContext` — frozen Pydantic input to `HandlerResolver.resolve()`
- `ModelHandlerResolution` — frozen Pydantic return value from `resolve()`

Plan: `docs/plans/2026-04-18-handler-resolver-architecture.md` §Task 1 (starts at L202, 1780-line plan, Round 4 tightening applied, APPROVED FOR TICKETIZATION).

## Layering compliance
Partner invariant: `compat → core → spi → infra`. `omnibase_core` must NOT import `omnibase_spi`.
`grep -r "from omnibase_spi" src/omnibase_core/enums/enum_handler_resolution_outcome.py src/omnibase_core/models/resolver/` → **zero matches**.

SPI-owned runtime contracts (`ownership_query`, `container`, `event_bus`, `handler_instance`) are typed `object | None` **permanently**. Protocol conformance is enforced at the infra boundary in Task 5's `handler_wiring.py` cutover, not here. See plan §Layering Invariants (L33).

## Test plan
- [x] 41 new unit tests pass: `uv run pytest tests/unit/enums/test_enum_handler_resolution_outcome.py tests/unit/models/resolver/ -v`
- [x] `ruff format` + `ruff check --fix` clean
- [x] `mypy --strict` on new files: 0 issues
- [x] All 28 pre-commit hooks pass (including ONEX enum governance, protocol checks, Kafka-in-core prevention)
- [ ] CI green on PR
- [ ] Auto-merge armed (merge queue)

## Coverage highlights
- Frozen + extra-forbid enforcement
- Required-field fail-closed (5 parameterized tests)
- `min_length=1` enforcement on string fields
- Declarative-vs-materialized dependency split (explicit assertion that `explicit_dependencies` was NOT collapsed)
- Layering invariant: `object | None` fields accept arbitrary non-protocol sentinels at core layer
- Re-export hygiene from `omnibase_core.enums` and `omnibase_core.models.resolver`

## Epic linkage
Refs OMN-9195 (epic). Unblocks Wave 1: OMN-9199 (Task 3 HandlerResolver service) and OMN-9200 (Task 4 ownership query).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stable enum for handler resolution outcomes.
  * Added immutable, validated models for resolver context and resolution results.
  * Added a local ownership query service to check node ownership.
  * Added a handler resolver service implementing a six-step resolution precedence.
  * Added container/container-service wiring error types for clearer error handling.

* **Tests**
  * Added unit tests covering the enum, resolver models, ownership query, and handler resolver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->