### PR TITLE
feat(core): ServiceHandlerResolver — ordered-precedence handler resolution [OMN-9199]

### DIFF
--- a/src/omnibase_core/errors/container_wiring_error.py
+++ b/src/omnibase_core/errors/container_wiring_error.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContainerWiringError — base class for DI-container-wiring failures.
+
+Hierarchy:
+    ModelOnexError                          (omnibase_core.models.errors)
+        └── ContainerWiringError            (this module)
+                └── ServiceResolutionError  (error_service_resolution.py)
+
+Reserved namespace for future container-wiring-specific errors (registration
+conflicts, configuration issues, etc.). Callers should typically catch a more
+specific subclass (currently only `ServiceResolutionError`).
+
+Design note: kept intentionally minimal — no error-code enum plumbing or
+extra metadata fields. Sole purpose is to give the resolver a narrow
+inheritance target for `except` clauses without swallowing unrelated
+container-internal bugs. See
+`docs/plans/2026-04-18-handler-resolver-architecture.md` §"Task 3 Step 3a".
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+
+class ContainerWiringError(ModelOnexError):
+    """Generic DI-container-wiring failure — base class for narrower errors."""
+
+
+__all__ = ["ContainerWiringError"]

--- a/src/omnibase_core/errors/error_service_resolution.py
+++ b/src/omnibase_core/errors/error_service_resolution.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ServiceResolutionError — the requested service is not registered.
+
+This is the narrow "soft miss" that `HandlerResolver` (in
+`omnibase_core.services.service_handler_resolver`) catches and treats as a
+fallthrough signal to later precedence steps (event_bus / zero-arg). Any
+other container exception (KeyError, AttributeError, RuntimeError, or an
+unrelated `ContainerWiringError` subclass) propagates untouched so
+container-internal bugs are never silenced.
+
+Hierarchy:
+    ModelOnexError                          (omnibase_core.models.errors)
+        └── ContainerWiringError            (container_wiring_error.py)
+                └── ServiceResolutionError  (this module)
+
+Kept intentionally minimal — no error-code enum plumbing or extra metadata
+fields. Sole purpose is narrow `except` targeting for the resolver
+fallthrough. Additional fields require a plan revision, not a drive-by
+append. See `docs/plans/2026-04-18-handler-resolver-architecture.md`
+§"Task 3 Step 3a".
+"""
+
+from __future__ import annotations
+
+from omnibase_core.errors.container_wiring_error import ContainerWiringError
+
+
+class ServiceResolutionError(ContainerWiringError):
+    """The requested service is not registered in the DI container."""
+
+
+__all__ = ["ServiceResolutionError"]

--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""HandlerResolver — ordered-precedence handler resolution.
+
+Precedence (first match wins):
+    1. Local ownership skip — node not hosted here -> skip cleanly
+    2. Node registry        — materialized explicit dep map from create_registry
+    3. Container DI         — container.get_service(handler_cls)
+    4. Event-bus injection  — __init__(self, event_bus) single param
+    5. Zero-arg             — handler_cls()
+    6. TypeError            — unresolvable (never returns UNRESOLVABLE)
+
+Layering (permanent):
+    `omnibase_core` MUST NOT import `omnibase_spi`. The resolver therefore
+    duck-types `context.ownership_query.is_owned_here(...)` rather than
+    referencing `ProtocolHandlerOwnershipQuery`. Runtime conformance is
+    enforced one layer up, at the infra boundary in `handler_wiring.py`
+    (Task 5), before the context is constructed. See the plan's
+    §"Layering Invariants" for rationale.
+
+Narrow exception handling (Step 3a):
+    Only `ServiceResolutionError` (service-not-registered) is treated as a
+    container miss and falls through to later precedence steps. Any other
+    exception from `container.get_service(...)` — `KeyError`, `AttributeError`,
+    `RuntimeError`, etc. — propagates untouched so container-internal bugs
+    are never masked as graceful fallback.
+
+Forward-compat namespace (not yet implemented — see
+docs/plans/research/2026-04-18-marketplace-dynamic-loading-plans.md:192-199
+and memory reference_hot_reload_is_planned.md):
+    * hot-reload / late handler registration after boot
+    * onex.backends pluggable backend resolution
+These will extend `resolve` or add sibling methods in a future phase once
+runtime identity and backend contracts are modeled. No stub methods are
+reserved here — adding speculative API surface before the contract is
+known is a commitment cost that future work would have to rename or delete.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
+from omnibase_core.models.resolver.model_handler_resolution import (
+    ModelHandlerResolution,
+)
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONCRETE_PARAM_KINDS = (
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.KEYWORD_ONLY,
+)
+
+
+class HandlerResolver:
+    """Ordered-precedence resolver for handler instantiation.
+
+    Pure in its context argument — holds no internal state. Multiple
+    concurrent `resolve()` calls on the same instance are safe.
+    """
+
+    def resolve(self, context: ModelHandlerResolverContext) -> ModelHandlerResolution:
+        """Apply the six-step precedence chain; return a resolution record.
+
+        Raises:
+            TypeError: When no precedence path can construct the handler.
+                       The error message names the handler and its required
+                       constructor parameters to aid debugging.
+            ServiceResolutionError: Never — this is caught internally as a
+                soft miss and falls through to later steps.
+            Exception: Any non-ServiceResolutionError raised by the container
+                propagates untouched (container-internal bug, not a miss).
+        """
+        # Step 1 - local ownership skip (deliberate non-error skip).
+        # Duck-typed per layering invariants: core cannot import the spi
+        # Protocol. `handler_wiring.py` validates conformance before calling.
+        if context.ownership_query is not None and hasattr(
+            context.ownership_query, "is_owned_here"
+        ):
+            is_owned = context.ownership_query.is_owned_here(context.node_name)
+            if not is_owned:
+                logger.info(
+                    "HandlerResolver: skipping %s.%s — node %r not hosted here",
+                    context.handler_module,
+                    context.handler_name,
+                    context.node_name,
+                )
+                return ModelHandlerResolution(
+                    outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP,
+                    handler_instance=None,
+                    skipped_handler=context.handler_name,
+                    skipped_reason=(f"node {context.node_name!r} is not hosted here"),
+                )
+
+        # Step 2 - explicit materialized dependency map from node registry.
+        mat = context.materialized_explicit_dependencies
+        deps_for_this_handler = (
+            mat.get(context.handler_name) if mat is not None else None
+        )
+        if deps_for_this_handler is not None:
+            try:
+                instance = context.handler_cls(**dict(deps_for_this_handler))
+            except TypeError as exc:
+                # TypeError is the idiomatic Python signal for a constructor-arg
+                # mismatch and matches the handler_cls(**deps) failure mode
+                # callers must catch. Wrapping as OnexError would obscure the
+                # signature-mismatch diagnostic. Plan §"Task 3 Step 6" (OMN-9199).
+                # error-ok: HandlerResolver constructor-arg mismatch surface.
+                raise TypeError(
+                    f"Handler {context.handler_module}.{context.handler_name} "
+                    f"could not be constructed from materialized explicit "
+                    f"dependencies: {exc}"
+                ) from exc
+            _log_overlap_if_any(context, chose="node_registry")
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY,
+                handler_instance=instance,
+            )
+
+        # Step 3 - container DI (narrow: only service-not-registered falls through).
+        if context.container is not None:
+            get_service = getattr(context.container, "get_service", None)
+            if get_service is not None:
+                try:
+                    instance = get_service(context.handler_cls)
+                except ServiceResolutionError:
+                    # Documented miss — fall through to steps 4/5/6.
+                    logger.debug(
+                        "HandlerResolver: container miss "
+                        "(ServiceResolutionError) for %s.%s — trying "
+                        "event_bus/zero-arg",
+                        context.handler_module,
+                        context.handler_name,
+                    )
+                else:
+                    _log_overlap_if_any(context, chose="container")
+                    return ModelHandlerResolution(
+                        outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER,
+                        handler_instance=instance,
+                    )
+
+        # Compute concrete required params once for steps 4/5/6.
+        sig = inspect.signature(context.handler_cls)
+        non_self_required_params = {
+            k: v
+            for k, v in sig.parameters.items()
+            if k != "self"
+            and v.kind in _CONCRETE_PARAM_KINDS
+            and v.default is inspect.Parameter.empty
+        }
+
+        # Step 4 - event_bus injection.
+        if context.event_bus is not None and set(non_self_required_params) == {
+            "event_bus"
+        }:
+            instance = context.handler_cls(event_bus=context.event_bus)
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+                handler_instance=instance,
+            )
+
+        # Step 5 - zero-arg.
+        if not non_self_required_params:
+            instance = context.handler_cls()
+            return ModelHandlerResolution(
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG,
+                handler_instance=instance,
+            )
+
+        # Step 6 - unresolvable: HARD FAILURE (not a skip).
+        dep_names = list(non_self_required_params)
+        # TypeError is the idiomatic signal to handler_wiring.py that no
+        # precedence path satisfied the handler's constructor requirements.
+        # OnexError would add serialization overhead without improving the
+        # caller's recovery surface; this is always a wiring bug, never a
+        # recoverable runtime state. Plan §"Task 3 Step 6" (OMN-9199).
+        # error-ok: HandlerResolver fail-fast per OMN-8735 invariant.
+        raise TypeError(
+            f"Handler {context.handler_module}.{context.handler_name} "
+            f"requires constructor parameters {dep_names!r} but no "
+            f"ownership_query, node registry explicit deps, container, or "
+            f"event_bus could satisfy them."
+        )
+
+
+def _log_overlap_if_any(context: ModelHandlerResolverContext, *, chose: str) -> None:
+    """Surface architecture smell: multiple precedence paths would have resolved.
+
+    Logs at DEBUG only. Never raises. See plan §"Conflict Semantics".
+    """
+    shadowed: list[str] = []
+    mat = context.materialized_explicit_dependencies
+    if chose != "node_registry" and mat is not None and context.handler_name in mat:
+        shadowed.append("node_registry")
+    if chose != "container" and context.container is not None:
+        # We don't re-probe the container here to avoid side effects; a
+        # conservative "container present" signal is enough to warrant
+        # investigation.
+        shadowed.append("container(present)")
+    if shadowed:
+        logger.debug(
+            "HandlerResolver: resolved %s.%s via %s; shadowed paths: %s",
+            context.handler_module,
+            context.handler_name,
+            chose,
+            ",".join(shadowed),
+        )
+
+
+__all__ = ["HandlerResolver"]

--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -60,7 +60,7 @@ _CONCRETE_PARAM_KINDS = (
 )
 
 
-class HandlerResolver:
+class ServiceHandlerResolver:
     """Ordered-precedence resolver for handler instantiation.
 
     Pure in its context argument — holds no internal state. Multiple
@@ -215,4 +215,4 @@ def _log_overlap_if_any(context: ModelHandlerResolverContext, *, chose: str) -> 
         )
 
 
-__all__ = ["HandlerResolver"]
+__all__ = ["ServiceHandlerResolver"]

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for HandlerResolver (OMN-9199 Task 3).
+"""Unit tests for ServiceHandlerResolver (OMN-9199 Task 3).
 
 Each test exercises one precedence branch in isolation plus the negative
 cases described in the plan:
@@ -34,7 +34,7 @@ from omnibase_core.errors.error_service_resolution import ServiceResolutionError
 from omnibase_core.models.resolver.model_handler_resolver_context import (
     ModelHandlerResolverContext,
 )
-from omnibase_core.services.service_handler_resolver import HandlerResolver
+from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
 
 
 class _HandlerNoDeps:
@@ -72,7 +72,7 @@ def test_step_1_local_ownership_skip_when_not_owned_here() -> None:
         ownership_query=ownership,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert (
         result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
@@ -97,7 +97,7 @@ def test_step_1_local_ownership_owned_here_falls_through() -> None:
         ownership_query=ownership,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -121,7 +121,7 @@ def test_step_1_duck_typed_ownership_query_without_method_ignored() -> None:
     )
 
     # Should skip Step 1 and fall through to Step 5 (zero-arg).
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
 
 
@@ -143,7 +143,7 @@ def test_step_2_explicit_dep_map_wins_over_container() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
     assert isinstance(result.handler_instance, _HandlerWithDeps)
@@ -164,7 +164,7 @@ def test_step_3_container_used_when_no_explicit_deps() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER
     assert result.handler_instance is expected
@@ -185,7 +185,7 @@ def test_step_3_container_miss_falls_through_to_zero_arg() -> None:
         container=container,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -206,7 +206,7 @@ def test_step_3_container_internal_bug_propagates() -> None:
     )
 
     with pytest.raises(KeyError):
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
 
 @pytest.mark.unit
@@ -226,7 +226,7 @@ def test_step_3_container_without_get_service_skipped() -> None:
     )
 
     # Should not raise AttributeError; falls through to zero-arg.
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
 
 
@@ -242,7 +242,7 @@ def test_step_4_event_bus_injection() -> None:
         event_bus=event_bus,
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
     assert isinstance(result.handler_instance, _HandlerEventBusOnly)
@@ -259,7 +259,7 @@ def test_step_5_zero_arg_construction() -> None:
         node_name="node_foo",
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
     assert isinstance(result.handler_instance, _HandlerNoDeps)
@@ -278,7 +278,7 @@ def test_step_6_type_error_when_unresolvable() -> None:
     )
 
     with pytest.raises(TypeError) as exc:
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     msg = str(exc.value)
     assert "_HandlerWithDeps" in msg
@@ -301,7 +301,7 @@ def test_explicit_dep_type_error_surfaces_missing_key() -> None:
     )
 
     with pytest.raises(TypeError) as exc:
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     assert "reducer" in str(exc.value)
 
@@ -331,7 +331,7 @@ def test_conflict_overlap_logs_debug(
         logging.DEBUG,
         logger="omnibase_core.services.service_handler_resolver",
     ):
-        HandlerResolver().resolve(ctx)
+        ServiceHandlerResolver().resolve(ctx)
 
     assert any(
         "shadowed" in rec.message.lower() or "overlap" in rec.message.lower()
@@ -352,7 +352,7 @@ def test_resolver_is_pure_in_context() -> None:
         contract_name="node_foo",
         node_name="node_foo",
     )
-    resolver = HandlerResolver()
+    resolver = ServiceHandlerResolver()
 
     first = resolver.resolve(ctx)
     second = resolver.resolve(ctx)
@@ -385,7 +385,7 @@ def test_skip_precedes_node_registry() -> None:
         },
     )
 
-    result = HandlerResolver().resolve(ctx)
+    result = ServiceHandlerResolver().resolve(ctx)
 
     assert (
         result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for HandlerResolver (OMN-9199 Task 3).
+
+Each test exercises one precedence branch in isolation plus the negative
+cases described in the plan:
+
+    Step 1 - ownership skip
+    Step 2 - explicit deps win over container
+    Step 3 - container hit
+    Step 3 - container miss (ServiceResolutionError) -> fallthrough
+    Step 3 - container internal bug propagates (non-miss)
+    Step 4 - event_bus injection
+    Step 5 - zero-arg
+    Step 6 - unresolvable raises TypeError
+    Step 2 - incomplete explicit deps surface missing key in TypeError
+    Conflict overlap logs at DEBUG
+    Ownership query without is_owned_here attr is ignored (duck-typed)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+from omnibase_core.services.service_handler_resolver import HandlerResolver
+
+
+class _HandlerNoDeps:
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerEventBusOnly:
+    def __init__(self, event_bus: object) -> None:
+        self.event_bus = event_bus
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerWithDeps:
+    def __init__(self, projection_reader: object, reducer: object) -> None:
+        self.projection_reader = projection_reader
+        self.reducer = reducer
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+@pytest.mark.unit
+def test_step_1_local_ownership_skip_when_not_owned_here() -> None:
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = False
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert (
+        result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+    )
+    assert result.handler_instance is None
+    assert result.skipped_handler == "H"
+    assert "not hosted here" in result.skipped_reason
+    ownership.is_owned_here.assert_called_once_with("node_foo")
+
+
+@pytest.mark.unit
+def test_step_1_local_ownership_owned_here_falls_through() -> None:
+    """If ownership_query says owned, resolver proceeds to later steps."""
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = True
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_1_duck_typed_ownership_query_without_method_ignored() -> None:
+    """An ownership_query without is_owned_here is ignored (duck-typed)."""
+
+    class _NotAnOwnershipQuery:
+        # No `is_owned_here` attr at all.
+        pass
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=_NotAnOwnershipQuery(),
+    )
+
+    # Should skip Step 1 and fall through to Step 5 (zero-arg).
+    result = HandlerResolver().resolve(ctx)
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+
+
+@pytest.mark.unit
+def test_step_2_explicit_dep_map_wins_over_container() -> None:
+    proj = object()
+    reducer = object()
+    container = MagicMock()
+    container.get_service.return_value = _HandlerWithDeps(proj, reducer)
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_NODE_REGISTRY
+    assert isinstance(result.handler_instance, _HandlerWithDeps)
+    container.get_service.assert_not_called()
+
+
+@pytest.mark.unit
+def test_step_3_container_used_when_no_explicit_deps() -> None:
+    expected = _HandlerNoDeps()
+    container = MagicMock()
+    container.get_service.return_value = expected
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_CONTAINER
+    assert result.handler_instance is expected
+    container.get_service.assert_called_once_with(_HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_3_container_miss_falls_through_to_zero_arg() -> None:
+    """Container raises ServiceResolutionError; resolver falls through to Step 5."""
+    container = MagicMock()
+    container.get_service.side_effect = ServiceResolutionError("not registered")
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_3_container_internal_bug_propagates() -> None:
+    """Non-miss exception from container (e.g. KeyError) must NOT be swallowed."""
+    container = MagicMock()
+    container.get_service.side_effect = KeyError("container corruption")
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    with pytest.raises(KeyError):
+        HandlerResolver().resolve(ctx)
+
+
+@pytest.mark.unit
+def test_step_3_container_without_get_service_skipped() -> None:
+    """Container present but missing get_service attr — safely skipped."""
+
+    class _NoGetServiceContainer:
+        pass
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=_NoGetServiceContainer(),
+    )
+
+    # Should not raise AttributeError; falls through to zero-arg.
+    result = HandlerResolver().resolve(ctx)
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+
+
+@pytest.mark.unit
+def test_step_4_event_bus_injection() -> None:
+    event_bus = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerEventBusOnly,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        event_bus=event_bus,
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
+    assert isinstance(result.handler_instance, _HandlerEventBusOnly)
+    assert result.handler_instance.event_bus is event_bus
+
+
+@pytest.mark.unit
+def test_step_5_zero_arg_construction() -> None:
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG
+    assert isinstance(result.handler_instance, _HandlerNoDeps)
+
+
+@pytest.mark.unit
+def test_step_6_type_error_when_unresolvable() -> None:
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        # In production handler_name == class name; the TypeError message
+        # surfaces handler_module.handler_name so the operator can find it.
+        handler_name="_HandlerWithDeps",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+
+    with pytest.raises(TypeError) as exc:
+        HandlerResolver().resolve(ctx)
+
+    msg = str(exc.value)
+    assert "_HandlerWithDeps" in msg
+    assert "projection_reader" in msg
+    assert "reducer" in msg
+
+
+@pytest.mark.unit
+def test_explicit_dep_type_error_surfaces_missing_key() -> None:
+    """Explicit materialized map incomplete -> resolver raises TypeError naming missing key."""
+    proj = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        # `reducer` missing intentionally.
+        materialized_explicit_dependencies={"H": {"projection_reader": proj}},
+    )
+
+    with pytest.raises(TypeError) as exc:
+        HandlerResolver().resolve(ctx)
+
+    assert "reducer" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_conflict_overlap_logs_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Step 2 resolves but container also present -> DEBUG log names shadowed path."""
+    proj = object()
+    reducer = object()
+    container = MagicMock()
+    container.get_service.return_value = _HandlerWithDeps(proj, reducer)
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+        container=container,
+    )
+
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="omnibase_core.services.service_handler_resolver",
+    ):
+        HandlerResolver().resolve(ctx)
+
+    assert any(
+        "shadowed" in rec.message.lower() or "overlap" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_resolver_is_pure_in_context() -> None:
+    """Repeated resolve() calls with the same context yield the same outcome.
+
+    Demonstrates the service holds no state that leaks across calls.
+    """
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerNoDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+    resolver = HandlerResolver()
+
+    first = resolver.resolve(ctx)
+    second = resolver.resolve(ctx)
+
+    assert (
+        first.outcome
+        == second.outcome
+        == (EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG)
+    )
+    # Different instances (each resolve() constructs a fresh handler).
+    assert first.handler_instance is not second.handler_instance
+
+
+@pytest.mark.unit
+def test_skip_precedes_node_registry() -> None:
+    """Ownership skip beats node_registry when not-owned-here."""
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = False
+    proj: Any = object()
+    reducer: Any = object()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_HandlerWithDeps,
+        handler_module="x",
+        handler_name="H",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+        materialized_explicit_dependencies={
+            "H": {"projection_reader": proj, "reducer": reducer},
+        },
+    )
+
+    result = HandlerResolver().resolve(ctx)
+
+    assert (
+        result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+    )
+    assert result.handler_instance is None


### PR DESCRIPTION
<!-- OMN-9199 ticket citation -->
Ticket: OMN-9199

## Summary

Task 3 of the HandlerResolver Architecture Phase 1 (epic **OMN-9195**, plan
`docs/plans/2026-04-18-handler-resolver-architecture.md`).

Implements the six-step precedence chain that centralizes handler
instantiation logic currently scattered across `handler_wiring.py:800-872`
(Task 5 will migrate the call site):

1. **Local ownership skip** — duck-typed `hasattr(ownership_query, "is_owned_here")`; skips cleanly when the node is not hosted here.
2. **Node registry explicit deps** — `materialized_explicit_dependencies[handler_name]` wins over container; constructs via `handler_cls(**deps)`.
3. **Container DI** — `container.get_service(handler_cls)` with narrow `except ServiceResolutionError` fall-through; any other container exception propagates untouched.
4. **Event-bus injection** — single `event_bus` constructor param.
5. **Zero-arg construction**.
6. **TypeError** — unresolvable; never returns `UNRESOLVABLE` outcome, always raises.

## Layering invariant preserved

`omnibase_core` does **not** import `omnibase_spi`. The `ownership_query`
contract is duck-typed (hasattr check), with Protocol conformance enforced
one layer up at the infra boundary in `handler_wiring.py` (Task 5).

```bash
grep -rn "omnibase_spi" src/omnibase_core/services/service_handler_resolver.py \
                       src/omnibase_core/errors/
# → zero matches
```

## Narrow exception handling

Only `ServiceResolutionError` is treated as a soft-miss fallthrough. Any
other exception raised by `container.get_service` (`KeyError`, `AttributeError`,
`RuntimeError`, unrelated `ContainerWiringError` subclasses) propagates
untouched so container-internal bugs are never masked as graceful fallback.
`test_step_3_container_internal_bug_propagates` asserts this invariant
against `KeyError`.

## Single-Class-Per-File compliance

Split the container-wiring error hierarchy across two files to satisfy the
`ONEX Single Class Per File` pre-commit gate:

- `errors/container_wiring_error.py` → `ContainerWiringError` (base)
- `errors/error_service_resolution.py` → `ServiceResolutionError` (subclass caught by resolver)

## TypeError `# error-ok:` annotations

The two `raise TypeError(...)` sites carry explicit `# error-ok:` annotations
on the line immediately preceding the raise, with rationale:

- Step 2 constructor mismatch: TypeError matches the `handler_cls(**deps)` failure mode; wrapping as OnexError obscures the signature-mismatch diagnostic.
- Step 6 unresolvable: fail-fast per OMN-8735 invariant; always a wiring bug, never a recoverable runtime state.

## Test plan

- [x] 15 unit tests covering each precedence branch + negative cases:
  - Step 1: not-owned skip / owned-fallthrough / duck-typed-missing-method
  - Step 2: explicit-deps-beat-container / incomplete-deps-surface-TypeError
  - Step 3: container-hit / container-miss-fallthrough / container-internal-bug-propagates / container-without-get_service
  - Step 4: event-bus injection
  - Step 5: zero-arg
  - Step 6: TypeError with dep names
  - Conflict overlap DEBUG log (shadowed paths)
  - Resolver purity (same context → same outcome, fresh instances)
  - Skip precedes node_registry (order)
- [x] `uv run ruff format` + `uv run ruff check` clean
- [x] `uv run mypy src/.../service_handler_resolver.py src/.../error_service_resolution.py src/.../container_wiring_error.py --strict` → "Success: no issues found"
- [x] `pre-commit run --files ...` clean on all 4 changed files
- [x] Full `uv run pytest tests/unit/services/` — 1008 passed, 42 skipped
- [x] `grep -rn "omnibase_spi" src/omnibase_core/services/service_handler_resolver.py src/omnibase_core/errors/` → 0 matches (layering invariant)
- [ ] CI green

## Stacked on

`jonah/omn-9196-resolver-models` (contains OMN-9196 resolver models + OMN-9200 ownership-query merged in).

## Out of scope

This PR does NOT:
- migrate `handler_wiring.py:800-872` to call `ServiceHandlerResolver` (Task 5 / OMN-9201)
- add the ProtocolHandlerResolver (Task 2 / OMN-9197, in omnibase_spi)
- wire the resolver into runtime boot (Task 5 cutover)
- revert OMN-9194 tactical workarounds (Task 7 / OMN-9202)

Refs: OMN-9195, OMN-8735, OMN-9196, OMN-9200