### PR TITLE
fix(ci/receipt-gate): force --reinstall-package to prefer editable checkout [OMN-9191]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -101,17 +101,24 @@ jobs:
         # Never fall back to PyPI — the published package has a broken transitive
         # dep (git+https omnibase-compat URL) that fails in CI.
         run: |
-          # --refresh forces uv to rebuild from the editable source even when a
-          # same-version wheel is cached locally or resolvable from PyPI. Without
-          # it, uv can resolve ./path against PyPI when pyproject.toml `version`
-          # matches a published release (e.g. feature lands on main without a
-          # version bump — see OMN-9192).
+          # --refresh + --reinstall-package force uv to rebuild the editable source
+          # and reinstall these specific packages regardless of whether a
+          # same-version wheel is cached locally or resolvable from PyPI.
+          # Without --reinstall-package, uv can resolve ./path against PyPI when
+          # pyproject.toml `version` matches a published release (e.g. feature
+          # lands on main without a version bump — see OMN-9191/OMN-9192
+          # diagnosis: docs/diagnosis-omn-9198-verify-gate-receipt-cli.md).
+          # Transitive deps still resolve normally from PyPI.
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
-            uv pip install --system --refresh -e .
+            uv pip install --system --refresh --reinstall-package omnibase-core -e .
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./omnibase_compat -e ./omnibase_core
+            uv pip install --system --refresh \
+              --reinstall-package omnibase-compat --reinstall-package omnibase-core \
+              -e ./omnibase_compat -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_compat -e ./.receipt-gate-deps/omnibase_core
+            uv pip install --system --refresh \
+              --reinstall-package omnibase-compat --reinstall-package omnibase-core \
+              -e ./.receipt-gate-deps/omnibase_compat -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"
             exit 1


### PR DESCRIPTION
[skip-receipt-gate: receipt-gate self-bootstrap — this PR IS the fix for the receipt_gate_cli import failure that was blocking OMN-9198/OMN-9191/OMN-9192. Prose references cite prior-fix tickets (OMN-9051/9190/9192/9198) that do not need their own contracts here; the install-side fix is self-verified by the `Install omnibase_core` step output showing `omnibase-core==0.39.0 (from file:///...)`. Follow-up ticket OMN-9209 will author proper contracts for new work tickets within 7 days per override-SLA.]

## Summary

Durable fix for the `Receipt Gate / verify` required check failing with `No module named omnibase_core.validation.receipt_gate_cli` on PRs that touch runtime paths (e.g. omnibase_infra PR #1344).

## Root Cause

Diagnosed in [`docs/diagnosis-omn-9198-verify-gate-receipt-cli.md`](https://github.com/OmniNode-ai/omni_home/blob/main/docs/diagnosis-omn-9198-verify-gate-receipt-cli.md):

The receipt-gate reusable workflow's `uv pip install --system --refresh -e <path>` commands were still resolving `omnibase-core==0.39.0` from PyPI instead of the editable checkout the workflow just set up. This happened because when `main` ships features without a version bump, uv's resolver sees two candidates for `omnibase-core==0.39.0` — the editable path and the stale PyPI wheel — and may pick the wheel.

`--refresh` only rebuilds already-selected editable sources; it doesn't force the resolver to pick the local path when version strings match.

PyPI `omnibase-core==0.39.0` was uploaded 2026-04-06, before `receipt_gate_cli.py` was added to the source tree. Every PR reaching into post-0.39.0 code hit ModuleNotFoundError.

## Fix

Add `--reinstall-package omnibase-core` (and `omnibase-compat` where applicable) to all three `uv pip install` branches in `.github/workflows/receipt-gate.yml`. This forces uv to reinstall those specific packages from the editable source unconditionally, overriding any cache hit or PyPI resolution.

Transitive deps (pydantic, pyyaml, etc.) still resolve normally from PyPI.

This is the durable Option B fix from the diagnosis — locks the receipt-gate's omnibase_core source to the cloned checkout regardless of version-string drift between main and the last published wheel.

## Test plan

- [x] Workflow YAML syntax valid (pre-commit `check-yaml` passed)
- [ ] `Receipt Gate / verify` check passes on this PR (self-verifies the fix — this PR itself runs the updated workflow)
- [ ] Downstream: rerun `Receipt Gate / verify` on omnibase_infra#1344 after this merges to confirm it unblocks the consumer side

## References

- Diagnosis: `docs/diagnosis-omn-9198-verify-gate-receipt-cli.md` (in omni_home)
- Tickets: OMN-9191 (this fix), OMN-9192 (same regression surface), OMN-9198 (downstream blocked by this), OMN-9051 + OMN-9190 (prior partial fixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to ensure packages are freshly rebuilt during dependency installation, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->