### PR TITLE
fix(ci): single-pass editable install for receipt-gate [OMN-9198]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -105,29 +105,28 @@ jobs:
           # and reinstall these specific packages regardless of whether a
           # same-version wheel is cached locally or resolvable from PyPI.
           #
-          # Two-pass install (OMN-9198, see docs/diagnosis-omn-9198-receipt-gate-still-pulls-pypi.md):
-          #   Pass 1: install omnibase_compat editable (with PyPI available
-          #           so pydantic/etc. resolve). uv may still resolve
-          #           omnibase-core transitively from PyPI into the cache.
-          #   Pass 2: install omnibase_core editable with --no-index, forcing
-          #           uv to use the local source checkout even when a cached
-          #           PyPI wheel exists. All transitive deps are already
-          #           satisfied by pass 1, so --no-index doesn't break.
+          # Single-pass install: install both omnibase_compat AND omnibase_core
+          # editable in one resolver pass so uv can see both `-e <path>`
+          # registrations simultaneously. This avoids the --no-index failure
+          # observed in OMN-9198 where pass 2 could not resolve a self-dep
+          # constraint against its own editable install.
+          #
+          # --reinstall-package omnibase-core + --refresh ensures the local
+          # editable source is preferred over any cached PyPI wheel, satisfying
+          # the original OMN-9198 concern without breaking resolution.
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
             uv pip install --system --refresh --reinstall-package omnibase-core -e .
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
             uv pip install --system --refresh \
               --reinstall-package omnibase-compat \
-              -e ./omnibase_compat
-            uv pip install --system --refresh --no-index \
               --reinstall-package omnibase-core \
+              -e ./omnibase_compat \
               -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
             uv pip install --system --refresh \
               --reinstall-package omnibase-compat \
-              -e ./.receipt-gate-deps/omnibase_compat
-            uv pip install --system --refresh --no-index \
               --reinstall-package omnibase-core \
+              -e ./.receipt-gate-deps/omnibase_compat \
               -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"


### PR DESCRIPTION
[skip-deploy-gate: CI-workflow-only change; no runtime paths touched.]
[skip-receipt-gate: circular — this PR fixes receipt-gate itself. Meta-gate cannot enforce its own fix.]

## Summary

Fixes the persistent `verify / verify` failure across every downstream caller repo that uses receipt-gate (omnibase_infra, onex_change_control, omnimarket). Install step was failing at:

```
Because omnibase-core was not found in the provided package locations
and you require omnibase-core>=0.39.0, we can conclude that your
requirements are unsatisfiable.
hint: Packages were unavailable because index lookups were disabled
```

## Root cause

The OMN-9198 two-pass install uses `--no-index` on pass 2 to force uv to prefer the `-e ./path` editable source over any cached PyPI wheel. But uv treats the caller's `omnibase-core>=0.39.0` version constraint as a **separate resolver input** from the `-e <path>` target — with `--no-index`, uv cannot reconcile the two, and install fails.

## Fix

Collapse to a **single resolver pass** with both editable targets passed simultaneously:

```
uv pip install --system --refresh \
  --reinstall-package omnibase-compat \
  --reinstall-package omnibase-core \
  -e ./omnibase_compat \
  -e ./omnibase_core
```

`--reinstall-package` + `--refresh` still ensure the local editable source is used (not a cached PyPI wheel), satisfying the original OMN-9198 concern without breaking resolution.

## Blast radius

Every downstream caller repo currently has `verify / verify` red, blocking merge-queue advancement under `ALLGREEN`. Currently blocking:
- omnibase_infra #1348 (OMN-9202)
- omnibase_infra #1349 (OMN-7369)
- omnimarket PRs (same workflow)
- onex_change_control PRs (same workflow)

## Test plan

- [x] Workflow YAML parses cleanly
- [ ] CI green on this PR (will verify post-push)
- [ ] Downstream caller PRs turn green once this lands on main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow dependency installation process to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->