### PR TITLE
fix(ci): single-pass editable install for receipt-gate [OMN-9198]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -118,16 +118,14 @@ jobs:
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
             uv pip install --system --refresh \
               --reinstall-package omnibase-compat \
-              -e ./omnibase_compat
-            uv pip install --system --refresh --no-index \
               --reinstall-package omnibase-core \
+              -e ./omnibase_compat \
               -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
             uv pip install --system --refresh \
               --reinstall-package omnibase-compat \
-              -e ./.receipt-gate-deps/omnibase_compat
-            uv pip install --system --refresh --no-index \
               --reinstall-package omnibase-core \
+              -e ./.receipt-gate-deps/omnibase_compat \
               -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"


### PR DESCRIPTION
Superseded by #851 (same single-pass editable install fix, merged 2026-04-19T13:43Z).

Closing as duplicate.