### PR TITLE
fix(container): get_service_sync safe in async context [OMN-9200]

### DIFF
--- a/src/omnibase_core/container/container_service_registry.py
+++ b/src/omnibase_core/container/container_service_registry.py
@@ -18,6 +18,7 @@ from omnibase_core.enums import (
     EnumOperationStatus,
     EnumServiceLifecycle,
 )
+from omnibase_core.errors.error_service_resolution import ServiceResolutionError
 from omnibase_core.logging.logging_structured import (
     emit_log_event_sync as emit_log_event,
 )
@@ -562,7 +563,11 @@ class ServiceRegistry:
                 interface.__name__ if hasattr(interface, "__name__") else str(interface)
             )
 
-            # Find registrations for interface
+            # Find registrations for interface. ServiceResolutionError is a
+            # narrow subclass of ModelOnexError specifically signaling
+            # "service-not-registered"; HandlerResolver catches it at Step 3 to
+            # fall through to event_bus/zero-arg rather than failing the whole
+            # auto-wiring pass. See services.ServiceHandlerResolver.
             if interface_name not in self._interface_map:
                 available_interfaces = sorted(self._interface_map.keys())
                 msg = (
@@ -570,7 +575,7 @@ class ServiceRegistry:
                     f"Available interfaces: {', '.join(available_interfaces) if available_interfaces else 'none'}. "
                     f"Register a service using register_service() or register_instance() before attempting resolution."
                 )
-                raise ModelOnexError(
+                raise ServiceResolutionError(
                     message=msg,
                     error_code=EnumCoreErrorCode.REGISTRY_RESOLUTION_FAILED,
                 )
@@ -582,7 +587,7 @@ class ServiceRegistry:
                     f"The interface was previously registered but all registrations have been removed. "
                     f"Re-register a service implementation for this interface."
                 )
-                raise ModelOnexError(
+                raise ServiceResolutionError(
                     message=msg,
                     error_code=EnumCoreErrorCode.REGISTRY_RESOLUTION_FAILED,
                 )

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -542,6 +542,24 @@ class ModelONEXContainer:
                 RuntimeError,
                 ValueError,
             ) as registry_error:
+                # Preserve narrow ServiceResolutionError so HandlerResolver Step 3
+                # can distinguish "service not registered — fall through to
+                # event_bus/zero-arg" from "real wiring failure". Wrapping
+                # everything in DEPENDENCY_UNAVAILABLE broke all auto-wiring.
+                from omnibase_core.errors.error_service_resolution import (
+                    ServiceResolutionError,
+                )
+
+                if isinstance(registry_error, ServiceResolutionError):
+                    emit_log_event(
+                        LogLevel.DEBUG,
+                        f"ServiceRegistry miss (documented): {protocol_name}",
+                        {
+                            "error": str(registry_error),
+                            "correlation_id": str(final_correlation_id),
+                        },
+                    )
+                    raise
                 # Fail fast - ServiceRegistry is the only resolution mechanism when enabled
                 emit_log_event(
                     LogLevel.ERROR,
@@ -1106,8 +1124,14 @@ def get_model_onex_container_sync() -> ModelONEXContainer:
     (via contextvars). If no container exists, it creates a new one
     and sets it in the context.
 
-    Note: This creates a new event loop for each call when no container
-    is available. Prefer using get_model_onex_container() in async code.
+    Worker-thread fallback (OMN-9200): when called from inside a running
+    event loop (e.g. handler ``__init__`` during async auto-wiring), the
+    underlying ``create_model_onex_container()`` coroutine is dispatched
+    to a short-lived worker thread via ``_run_coro_sync()``. The calling
+    thread blocks on ``Thread.join()`` until it completes. When no loop
+    is running, the coroutine runs in-process via ``asyncio.run()`` as
+    before. Prefer ``get_model_onex_container()`` (async) in async code
+    to avoid the thread-offload overhead.
 
     Returns:
         ModelONEXContainer: The container instance for the current context

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -37,7 +37,8 @@ See Also:
 
 # NOTE(OMN-1302): I001 (import order) disabled - Dual-Import Pattern for DI container (see OMN-1261).
 
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+from collections.abc import Coroutine
 
 from omnibase_core.decorators.decorator_allow_dict_any import allow_dict_any
 from omnibase_core.decorators.decorator_error_handling import standard_error_handling
@@ -133,6 +134,35 @@ from omnibase_core.protocols.compute import ProtocolToolCache
 #    model_onex_container -> container_service_registry -> models/container/__init__ -> model_onex_container
 
 T = TypeVar("T")
+
+
+def _run_coro_sync(coro: "Coroutine[Any, Any, T]") -> T:
+    """Run a coroutine to completion from sync code, safe inside a running loop.
+
+    ``asyncio.run()`` raises ``RuntimeError`` when called from inside a running
+    event loop. That happens during async auto-wiring, when handler ``__init__``
+    methods (which are inherently sync — Python doesn't allow ``async __init__``)
+    call ``container.get_service_sync(...)`` while the wiring coroutine is being
+    awaited.
+
+    When no loop is running, this falls through to ``asyncio.run()`` — the
+    cheap path. When a loop IS running, the coroutine is dispatched to a
+    short-lived thread with its own event loop, and the calling thread blocks
+    on ``Thread.join()`` until it completes. This is O(thread-spawn) but
+    correct; callers should prefer ``get_service_async()`` when they can.
+    """
+    import concurrent.futures
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — cheap path
+        return asyncio.run(coro)
+
+    # Running loop detected — dispatch to a worker thread with its own loop.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coro).result()
+
 
 # === CORE CONTAINER DEFINITION ===
 
@@ -552,6 +582,12 @@ class ModelONEXContainer:
         """
         Synchronous service resolution with optional performance monitoring.
 
+        Works from both sync and async contexts: when called from inside a
+        running event loop (e.g. handler __init__ during async auto-wiring),
+        the coroutine runs in a short-lived thread with its own event loop
+        to avoid ``RuntimeError: asyncio.run() cannot be called from a
+        running event loop``.
+
         Args:
             protocol_type: Protocol interface to resolve
             service_name: Optional service name
@@ -561,7 +597,7 @@ class ModelONEXContainer:
         """
         if not self.enable_performance_cache or not self.performance_monitor:
             # Standard resolution without performance monitoring
-            return asyncio.run(self.get_service_async(protocol_type, service_name))
+            return _run_coro_sync(self.get_service_async(protocol_type, service_name))
 
         # Enhanced resolution with performance monitoring
         correlation_id = f"svc_{int(time.time() * 1000)}_{service_name or 'default'}"
@@ -583,7 +619,7 @@ class ModelONEXContainer:
                     )
 
             # Perform actual service resolution
-            service_instance = asyncio.run(
+            service_instance = _run_coro_sync(
                 self.get_service_async(protocol_type, service_name)
             )
 
@@ -1082,9 +1118,9 @@ def get_model_onex_container_sync() -> ModelONEXContainer:
         return container
 
     # No container exists - create one
-    # asyncio.run creates a new context, so the container set inside
-    # won't propagate back. We need to capture and set it here.
-    container = asyncio.run(create_model_onex_container())
+    # _run_coro_sync works whether or not an event loop is already running,
+    # so this path is safe from both sync and async callers.
+    container = _run_coro_sync(create_model_onex_container())
 
     # Set in context for future access
     set_current_container(container)

--- a/tests/unit/models/container/test_get_service_sync_from_async.py
+++ b/tests/unit/models/container/test_get_service_sync_from_async.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit test: get_service_sync() must not crash when called from an async context.
+
+Handler __init__ methods are inherently sync (Python has no ``async __init__``)
+but run during async auto-wiring. They call ``container.get_service_sync(...)``
+for DI resolution. Prior to this fix the container used ``asyncio.run()``
+internally, which raises ``RuntimeError: asyncio.run() cannot be called from
+a running event loop`` in that scenario, breaking all auto-wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from omnibase_core.models.container.model_onex_container import (
+    create_model_onex_container,
+)
+
+
+@pytest.mark.unit
+def test_get_service_sync_from_running_event_loop() -> None:
+    """Calling get_service_sync from inside asyncio.run() must not raise."""
+
+    async def _scenario() -> None:
+        container = await create_model_onex_container()
+        # This call happens SYNCHRONOUSLY inside a running event loop —
+        # the same conditions handler __init__ runs under during auto-wiring.
+        # Requesting an unregistered protocol is fine; we only care that the
+        # asyncio.run() inside get_service_sync doesn't raise.
+        try:
+            container.get_service_sync(type("UnregisteredProtocol", (), {}))
+        except RuntimeError as exc:
+            if "asyncio.run() cannot be called from a running event loop" in str(exc):
+                pytest.fail(
+                    "get_service_sync raised the forbidden asyncio.run() "
+                    "RuntimeError when called from within a running event loop; "
+                    "it must dispatch the coroutine to a worker thread instead."
+                )
+            # Any other RuntimeError (e.g. service-not-found) is allowed —
+            # we only guard against the async-context regression.
+        except Exception:  # noqa: BLE001
+            # Unrelated resolution failures (service not found etc.) are fine;
+            # this test asserts ONLY the async-context invariant.
+            pass
+
+    asyncio.run(_scenario())


### PR DESCRIPTION
## Problem
Handler __init__ methods are inherently sync (Python has no async __init__) but are constructed during async auto-wiring. They call container.get_service_sync() for DI resolution during their own init. That method internally called asyncio.run(), which raises "asyncio.run() cannot be called from a running event loop" because the wiring coroutine is actively being awaited.

Production evidence: runtime container on .201 has been crash-looping for 24+ hours. Exit shows:

    Auto-wiring failed for 98 contract(s):
      node_artifact_change_detector_effect: handler=HandlerPRWebhookIngestion:
        RuntimeError: asyncio.run() cannot be called from a running event loop
      ... 97 more identical failures

## Fix
_run_coro_sync() helper: detect running loop via asyncio.get_running_loop(). No loop → fall through to asyncio.run() (cheap path). Loop present → dispatch coroutine to a one-off thread with its own event loop, block on result. get_service_sync() and get_or_create_container_sync() now use this helper.

## Why this wasn't caught
**Zero unit tests** for get_service_sync called from within a running event loop. The async-context scenario exists in every handler __init__ that runs during auto-wiring — the most critical path in runtime startup — and was untested.

## Test
tests/unit/models/container/test_get_service_sync_from_async.py — single unit test that runs get_service_sync inside asyncio.run() and asserts no RuntimeError about the running event loop. Passes with fix, fails without.

[skip-deploy-gate: omnibase_core is a library, not a deployed service]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous service retrieval now works reliably when called from within an active async event loop; improved fallback behavior for service resolution errors so unresolved services are signaled without obscuring the original cause.
* **Tests**
  * Added tests ensuring synchronous service retrieval behaves correctly inside running async contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Ticket:** OMN-9200 — get_service_sync async-context crash blocking auto-wiring.

`[skip-receipt-gate: OMN-9200 dod_evidence lands with epic close-out OMN-9209]`
