### PR TITLE
fix(ci): uninstall-then-install editable for receipt-gate [OMN-9198]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -117,13 +117,27 @@ jobs:
           # first, so omnibase_core's constraint on compat is already satisfied
           # by editable when pass 2 runs, avoiding --no-index entirely).
           uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
+
+          # Resolve compat install path independently from core — sibling
+          # ./omnibase_compat may exist even when the workspace is the
+          # omnibase_core repo itself, and mixed layouts are common.
+          if [ -f "./omnibase_compat/pyproject.toml" ]; then
+            compat_path="./omnibase_compat"
+          elif [ -f "./.receipt-gate-deps/omnibase_compat/pyproject.toml" ]; then
+            compat_path="./.receipt-gate-deps/omnibase_compat"
+          else
+            compat_path=""
+          fi
+
+          if [ -n "$compat_path" ]; then
+            uv pip install --system --refresh -e "$compat_path"
+          fi
+
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
             uv pip install --system --refresh -e .
-          elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./omnibase_compat
+          elif [ -f "./omnibase_core/pyproject.toml" ]; then
             uv pip install --system --refresh -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_compat
             uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -101,33 +101,30 @@ jobs:
         # Never fall back to PyPI — the published package has a broken transitive
         # dep (git+https omnibase-compat URL) that fails in CI.
         run: |
-          # --refresh + --reinstall-package force uv to rebuild the editable source
-          # and reinstall these specific packages regardless of whether a
-          # same-version wheel is cached locally or resolvable from PyPI.
+          # OMN-9198 history:
+          #   - PR #850 two-pass with --no-index on pass 2 failed: uv couldn't
+          #     satisfy the caller's `omnibase-core>=X` constraint against the
+          #     editable path with index disabled.
+          #   - PR #851 single-pass with `--reinstall-package -e ./path` still
+          #     pulled the PyPI wheel: the editable source and published wheel
+          #     share version 0.39.0, and uv's preference order
+          #     (cached → index → path) wins even under --refresh.
           #
-          # Single-pass install: install both omnibase_compat AND omnibase_core
-          # editable in one resolver pass so uv can see both `-e <path>`
-          # registrations simultaneously. This avoids the --no-index failure
-          # observed in OMN-9198 where pass 2 could not resolve a self-dep
-          # constraint against its own editable install.
-          #
-          # --reinstall-package omnibase-core + --refresh ensures the local
-          # editable source is preferred over any cached PyPI wheel, satisfying
-          # the original OMN-9198 concern without breaking resolution.
+          # Fix: explicit uninstall-then-install-editable. Clearing the cached
+          # wheel eliminates uv's preferred target, forcing it to build from
+          # the editable path. Split installs let each editable resolve its own
+          # transitive deps against PyPI cleanly (pass 1 installs omnibase_compat
+          # first, so omnibase_core's constraint on compat is already satisfied
+          # by editable when pass 2 runs, avoiding --no-index entirely).
+          uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
-            uv pip install --system --refresh --reinstall-package omnibase-core -e .
+            uv pip install --system --refresh -e .
           elif [ -d "./omnibase_core" ] && [ -f "./omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh \
-              --reinstall-package omnibase-compat \
-              --reinstall-package omnibase-core \
-              -e ./omnibase_compat \
-              -e ./omnibase_core
+            uv pip install --system --refresh -e ./omnibase_compat
+            uv pip install --system --refresh -e ./omnibase_core
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh \
-              --reinstall-package omnibase-compat \
-              --reinstall-package omnibase-core \
-              -e ./.receipt-gate-deps/omnibase_compat \
-              -e ./.receipt-gate-deps/omnibase_core
+            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_compat
+            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_core
           else
             echo "::error::omnibase_core not installable — no source checkout available"
             exit 1


### PR DESCRIPTION
[skip-receipt-gate: bootstrap — modifying receipt-gate workflow itself]
[skip-deploy-gate: CI-workflow-only change; no runtime paths touched.]

## Summary

Third iteration of the OMN-9198 receipt-gate install fix. PR #850 (two-pass `--no-index`) failed on version-constraint resolution; PR #851 (single-pass `-e <path>` + `--reinstall-package`) merged but still pulled PyPI wheel.

## Smoking gun evidence from PR #851's real-world run

omnibase_infra #1348 CI run 24630544192 (after #851 merged to omnibase_core main) logged:
```
Downloading omnibase-core (5.1MiB)
+ omnibase-core==0.39.0
```
followed by step-9 failure:
```
ImportError: cannot import name 'receipt_gate_cli' from 'omnibase_core.validation' (/opt/hostedtoolcache/.../site-packages/omnibase_core/validation/__init__.py)
omnibase_core at: /opt/hostedtoolcache/.../site-packages/omnibase_core
```

The `-e ./.receipt-gate-deps/omnibase_core` was silently ignored. `omnibase_core` installed from PyPI into site-packages, not the editable source path.

## Root cause

Editable source and published wheel both claim `version = "0.39.0"`. uv's preference under `--refresh --reinstall-package` is **cache → index → path**. With matching versions, the index wins. The wheel was published before `receipt_gate_cli.py` was added, so the installed package is missing that module — step 9 catches this.

## Fix

Explicit `uv pip uninstall` first. With no cached wheel and no prior install present, uv has only the editable path as a target.

```bash
uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_compat
uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_core
```

Split installs: compat first resolves its own transitive deps against PyPI, then core's constraint on compat is satisfied by the editable install when the second `uv pip install` runs. No `--no-index` needed.

## Acceptance

The existing step-9 `python -c "from omnibase_core.validation import receipt_gate_cli"` check is the acceptance gate — fails loudly iff editable source ≠ installed source.

## Blast radius

Currently stuck on `verify / verify` red:
- omnibase_infra #1348 (OMN-9202)
- omnibase_infra #1349 (OMN-7369)
- Any new caller-repo PR

Will unblock all on merge.

## Test plan

- [x] YAML parses
- [ ] This PR's own receipt-gate run passes (self-bootstrapping — the updated workflow is in the queue branch)
- [ ] After merge: empty-commit retrigger on #1348 and #1349; confirm `verify / verify` turns green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow installation process to improve dependency resolution reliability by switching to a safer two-stage install and clearer handling of different checkout layouts to avoid cached artifacts and ensure correct editable installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->