### PR TITLE
fix(ci): --no-binary omnibase-core for editable-source build [OMN-9198]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -116,11 +116,20 @@ jobs:
           # transitive deps against PyPI cleanly (pass 1 installs omnibase_compat
           # first, so omnibase_core's constraint on compat is already satisfied
           # by editable when pass 2 runs, avoiding --no-index entirely).
+          # Belt-and-suspenders editable install for omnibase-core:
+          #   - uninstall clears any prior install (wheel or editable) from site-packages
+          #   - --reinstall-package + --refresh-package force fresh build of the named
+          #     package regardless of caches
+          #   - --no-binary omnibase-core forbids using a pre-built wheel, so uv must
+          #     build from the -e source path (PR #854 fix was not enough on its own:
+          #     uv still preferred the PyPI wheel for omnibase-core even after the
+          #     uninstall, because the resolver picked the cached index entry ahead
+          #     of the editable path target)
+          #
+          # omnibase-compat does not hit this problem — it works with plain -e — so
+          # it keeps the simpler install shape.
           uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
 
-          # Resolve compat install path independently from core — sibling
-          # ./omnibase_compat may exist even when the workspace is the
-          # omnibase_core repo itself, and mixed layouts are common.
           if [ -f "./omnibase_compat/pyproject.toml" ]; then
             compat_path="./omnibase_compat"
           elif [ -f "./.receipt-gate-deps/omnibase_compat/pyproject.toml" ]; then
@@ -134,15 +143,21 @@ jobs:
           fi
 
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
-            uv pip install --system --refresh -e .
+            core_path="."
           elif [ -f "./omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./omnibase_core
+            core_path="./omnibase_core"
           elif [ -f "./.receipt-gate-deps/omnibase_core/pyproject.toml" ]; then
-            uv pip install --system --refresh -e ./.receipt-gate-deps/omnibase_core
+            core_path="./.receipt-gate-deps/omnibase_core"
           else
             echo "::error::omnibase_core not installable — no source checkout available"
             exit 1
           fi
+
+          uv pip install --system \
+            --reinstall-package omnibase-core \
+            --refresh-package omnibase-core \
+            --no-binary omnibase-core \
+            -e "$core_path"
 
       - name: Verify receipt_gate_cli importable
         # Fail-fast check: the preceding install step claims success, but if uv


### PR DESCRIPTION
[skip-receipt-gate: bootstrap — modifying receipt-gate workflow itself]
[skip-deploy-gate: CI-workflow-only change; no runtime paths touched.]

## Summary

Fourth iteration of the OMN-9198 receipt-gate install fix. PR #854 (uninstall + `-e <path>`) merged but CI on omnibase_infra #1348 afterwards still showed `Downloading omnibase-core (5.1MiB)` — uv's resolver prefers the cached PyPI index entry ahead of the editable path target for `omnibase-core`, even after an explicit uninstall.

Note: `omnibase-compat` does **not** hit this problem. The same run shows `Building omnibase-compat @ file://...` — editable install worked. Only `omnibase-core` has the substitution bug. I do not fully understand why, which is why this fix is scoped narrowly to core.

## Fix

Add `--no-binary omnibase-core` — forbids uv from using a pre-built wheel for this specific package. Combined with `-e <path>`, uv must build from source, and `-e` means "from the editable path I gave you". Keeps `--reinstall-package` and `--refresh-package` to bust all package-level caches.

## Test plan

- [x] YAML parses
- [ ] CI on this PR's own receipt-gate run shows `Building omnibase-core @ file://...` in the install step log
- [ ] After merge: empty-commit retrigger on omnibase_infra #1348 and #1349; confirm `verify / verify` turns green
- [ ] Confirm `receipt_gate_cli` importable check passes on downstream caller

## History

- PR #850 — two-pass with `--no-index`: failed on version-constraint resolution (`omnibase-core>=X`).
- PR #851 — single-pass with `--reinstall-package -e <path>`: merged; failed on cascade (PyPI wheel substitution).
- PR #854 — `uv pip uninstall` + `-e <path>`: merged; still failed on cascade (same substitution).
- **This PR (#?)** — `--no-binary omnibase-core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to improve consistency and reliability of dependency installation and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->