### PR TITLE
OMN-9261: guard HandlerBusAdapter against dict/None/unsupported handler returns

### DIFF
--- a/src/omnibase_core/runtime/runtime_local_adapter.py
+++ b/src/omnibase_core/runtime/runtime_local_adapter.py
@@ -13,6 +13,8 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from pydantic import BaseModel
+
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
@@ -107,8 +109,6 @@ class HandlerBusAdapter:
         if not self.output_topic:
             return
         try:
-            from pydantic import BaseModel
-
             if isinstance(result, BaseModel):
                 output_bytes = result.model_dump_json().encode("utf-8")
             elif isinstance(result, dict):

--- a/src/omnibase_core/runtime/runtime_local_adapter.py
+++ b/src/omnibase_core/runtime/runtime_local_adapter.py
@@ -13,6 +13,9 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,21 +102,38 @@ class HandlerBusAdapter:
         )
 
         # 3. Publish output
-        if result is not None and self.output_topic:
-            try:
+        if result is None:
+            return
+        if not self.output_topic:
+            return
+        try:
+            from pydantic import BaseModel
+
+            if isinstance(result, BaseModel):
                 output_bytes = result.model_dump_json().encode("utf-8")
-                await self.bus.publish(self.output_topic, None, output_bytes)
-                logger.info(
-                    "HandlerBusAdapter: published to %s (correlation_id=%s)",
-                    self.output_topic,
-                    correlation_id,
+            elif isinstance(result, dict):
+                output_bytes = json.dumps(result).encode("utf-8")
+            else:
+                raise ModelOnexError(
+                    message=(
+                        f"HandlerBusAdapter: handler {self.handler.__class__.__name__!r}"
+                        f" returned unsupported type {type(result).__name__!r};"
+                        " expected BaseModel, dict, or None"
+                    ),
+                    error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
                 )
-            except Exception:
-                logger.exception(
-                    "HandlerBusAdapter: publish failed for %s -> %s (correlation_id=%s)",
-                    self.handler_name,
-                    self.output_topic,
-                    correlation_id,
-                )
-                if self.on_error:
-                    self.on_error()
+            await self.bus.publish(self.output_topic, None, output_bytes)
+            logger.info(
+                "HandlerBusAdapter: published to %s (correlation_id=%s)",
+                self.output_topic,
+                correlation_id,
+            )
+        except Exception:
+            logger.exception(
+                "HandlerBusAdapter: publish failed for %s -> %s (correlation_id=%s)",
+                self.handler_name,
+                self.output_topic,
+                correlation_id,
+            )
+            if self.on_error:
+                self.on_error()

--- a/tests/unit/runtime/test_runtime_local_execution.py
+++ b/tests/unit/runtime/test_runtime_local_execution.py
@@ -1040,7 +1040,7 @@ async def test_adapter_none_return_no_publish() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_adapter_unsupported_return_type_raises_on_error() -> None:
-    """Handler returning int/str → on_error fires with TypeError message."""
+    """Handler returning unsupported type → ModelOnexError raised, on_error fires, nothing published."""
 
     class IntHandler:
         async def handle(self, **kwargs: Any) -> int:

--- a/tests/unit/runtime/test_runtime_local_execution.py
+++ b/tests/unit/runtime/test_runtime_local_execution.py
@@ -985,6 +985,91 @@ def test_compute_mode_with_top_level_handler_spec(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_dict_return_publishes_json() -> None:
+    """Reducer returning dict → bus receives valid JSON envelope."""
+
+    class DictHandler:
+        async def handle(self, **kwargs: Any) -> dict[str, Any]:
+            return {"correlation_id": kwargs.get("correlation_id"), "status": "ok"}
+
+    bus = MockBus()
+    adapter = HandlerBusAdapter(
+        handler=DictHandler(),
+        handler_name="test-dict",
+        input_model_cls=MockInput,
+        output_topic="out.dict",
+        bus=bus,
+    )
+
+    msg = MockMessage(value=_input_bytes(correlation_id="cid-dict"))
+    await adapter.on_message(msg)
+
+    assert len(bus.published) == 1
+    topic, _key, value = bus.published[0]
+    assert topic == "out.dict"
+    data = json.loads(value)
+    assert data["correlation_id"] == "cid-dict"
+    assert data["status"] == "ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_none_return_no_publish() -> None:
+    """Handler returning None → no message published."""
+
+    class NoneHandler:
+        async def handle(self, **kwargs: Any) -> None:
+            return None
+
+    bus = MockBus()
+    adapter = HandlerBusAdapter(
+        handler=NoneHandler(),
+        handler_name="test-none",
+        input_model_cls=MockInput,
+        output_topic="out.none",
+        bus=bus,
+    )
+
+    msg = MockMessage(value=_input_bytes(correlation_id="cid-none"))
+    await adapter.on_message(msg)
+
+    assert len(bus.published) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_unsupported_return_type_raises_on_error() -> None:
+    """Handler returning int/str → on_error fires with TypeError message."""
+
+    class IntHandler:
+        async def handle(self, **kwargs: Any) -> int:
+            return 42
+
+    bus = MockBus()
+    error_called = False
+
+    def _on_error() -> None:
+        nonlocal error_called
+        error_called = True
+
+    adapter = HandlerBusAdapter(
+        handler=IntHandler(),
+        handler_name="test-int",
+        input_model_cls=MockInput,
+        output_topic="out.int",
+        bus=bus,
+        on_error=_on_error,
+    )
+
+    msg = MockMessage(value=_input_bytes(correlation_id="cid-int"))
+    await adapter.on_message(msg)
+
+    assert error_called
+    assert len(bus.published) == 0
+
+
+@pytest.mark.unit
 def test_compute_mode_fallback_run_full_cycle(tmp_path: Path) -> None:
     """Compute node without terminal_event + no handle() falls back to run_full_cycle (OMN-7788)."""
     import sys


### PR DESCRIPTION
## Summary

- `HandlerBusAdapter.on_message` called `result.model_dump_json()` unconditionally, crashing when reducers return a plain `dict` (OMN-8950 convention)
- Fix dispatches on return type: `BaseModel` → `.model_dump_json()`, `dict` → `json.dumps()`, `None` → no publish (early return), unsupported type → `ModelOnexError(HANDLER_EXECUTION_ERROR)`
- Three new unit tests cover the three new branches

## Test plan

- [x] `test_adapter_dict_return_publishes_json` — reducer returning `dict` publishes valid JSON
- [x] `test_adapter_none_return_no_publish` — handler returning `None` skips publish
- [x] `test_adapter_unsupported_return_type_raises_on_error` — unsupported type triggers `on_error`
- [x] 372 runtime unit tests pass, mypy --strict clean, pre-commit all pass

[skip-deploy-gate: Pure bus adapter serialization fix — no deploy artifact, Dockerfile, or k8s changes. deploy-gate fires because runtime_local_adapter.py is in a runtime path but this fix does not require a redeploy.]

[skip-receipt-gate: Pure logic fix in runtime_local_adapter.py — no schema migrations, no new event types, no Kafka topic changes. Receipt gate bootstrap deadlock (OMN-8841) makes this gate non-applicable.]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced message output publishing with improved control flow and edge case handling
  * Strengthened error handling with better error reporting callbacks
  * Improved data serialization support for various output types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->