### PR TITLE
chore(test): exempt omnibase-compat from SDK boundary guard per CLAUDE.md §7 layering [OMN-9241-prep]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,9 @@ The following are **unstable** (may change without notice):
 
 **CI enforcement**: `test_no_internal_deps.py` prevents internal OmniNode packages
 from appearing in hard dependencies (`sdk-boundary-check` CI job).
+`omnibase-compat` is the single exemption — per `omni_home/CLAUDE.md` §7
+(`compat -> core -> spi -> infra`), compat is the shared substrate every
+OmniNode repo is allowed to hard-depend on.
 
 ---
 

--- a/tests/unit/test_no_internal_deps.py
+++ b/tests/unit/test_no_internal_deps.py
@@ -7,7 +7,7 @@ Internal packages belong in [project.optional-dependencies] so that
 omnibase-core can be installed as a standalone SDK.
 
 Exception -- ``omnibase-compat``: per ``omni_home/CLAUDE.md`` section 7 (repo
-layering ``compat -> core -> spi -> infra``), ``omnibase_compat`` is the
+layering ``compat -> core -> spi -> infra``), ``omnibase-compat`` is the
 designated shared substrate every OmniNode repo is allowed to hard-depend on.
 It is the ONLY OmniNode package ``omnibase_core`` may list in
 ``[project.dependencies]``. All other OmniNode packages (spi, infra,

--- a/tests/unit/test_no_internal_deps.py
+++ b/tests/unit/test_no_internal_deps.py
@@ -5,6 +5,15 @@
 
 Internal packages belong in [project.optional-dependencies] so that
 omnibase-core can be installed as a standalone SDK.
+
+Exception -- ``omnibase-compat``: per ``omni_home/CLAUDE.md`` section 7 (repo
+layering ``compat -> core -> spi -> infra``), ``omnibase_compat`` is the
+designated shared substrate every OmniNode repo is allowed to hard-depend on.
+It is the ONLY OmniNode package ``omnibase_core`` may list in
+``[project.dependencies]``. All other OmniNode packages (spi, infra,
+intelligence, memory, claude, change-control, onex-change-control,
+omninode-infra) must remain in optional-dependencies so core stays
+installable as a standalone SDK.
 """
 
 import tomllib
@@ -19,7 +28,6 @@ OMNINODE_PACKAGES = {
     "omninode-memory",
     "omninode-claude",
     "onex-change-control",
-    "omnibase-compat",
     "omninode-infra",
 }
 


### PR DESCRIPTION
## Summary

The SDK boundary guard (`tests/unit/test_no_internal_deps.py::test_no_internal_repo_hard_dependencies`) forbids any OmniNode-internal repo from appearing as a hard dependency in `omnibase_core/pyproject.toml`. That blanket forbid is wrong for `omnibase-compat`.

Per `omni_home/CLAUDE.md` §7 (repo layering `compat → core → spi → infra`), `omnibase_compat` is the designated shared substrate every OmniNode repo is allowed to hard-depend on. It is the ONLY OmniNode package `omnibase_core` may list in `[project.dependencies]`. All other OmniNode packages (spi, infra, intelligence, memory, claude, change-control, omninode-infra) must remain in `optional-dependencies` so core stays installable as a standalone SDK.

## Why now

PR #860 (OMN-9241) consolidates the `_run_coro_sync` helper from #853 into the canonical `omnibase_compat.concurrency.run_coro_sync`. That swap requires a hard dep on `omnibase-compat`, which the current guard rejects. This PR is the prerequisite that lands the architectural exemption first; #860 then proceeds without modification.

## Changes

- Drop `omnibase-compat` from `OMNINODE_PACKAGES` in `tests/unit/test_no_internal_deps.py`.
- Document the exemption in the test module docstring (cites `omni_home/CLAUDE.md` §7).
- Mirror the exemption note in this repo's `CLAUDE.md` "External SDK Surface" section.

## Pre-push verification

- `uv run pytest tests/unit/test_no_internal_deps.py -v` — 2/2 passed
- `uv run ruff format src/ tests/` — clean
- `uv run ruff check src/ tests/` — clean
- `uv run mypy --strict tests/unit/test_no_internal_deps.py` — clean
- `pre-commit run` — all hooks passed

## Test plan

- [ ] CI green
- [ ] After merge, PR #860 (OMN-9241) `sdk-boundary-check` job passes

## Related

- Linear: OMN-9241 (parent ticket)
- Unblocks: #860
- Architectural reference: `omni_home/CLAUDE.md` §7 ("Repo layering")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation specifying a CI dependency exemption for a shared compatibility package.
* **Tests**
  * Updated unit test expectations to reflect the documented exemption in layering rules.
* **Chores**
  * Adjusted CI enforcement configuration to permit the documented exemption.

Note: These are infrastructure/documentation changes with no user-visible impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->