### PR TITLE
feat(models): add ModelReducerFsmMetadata typed 7-key contract (OMN-595)

### DIFF
--- a/src/omnibase_core/models/reducer/__init__.py
+++ b/src/omnibase_core/models/reducer/__init__.py
@@ -10,6 +10,7 @@ Models for FSM-driven state management:
 - ModelReducerContext: Handler context (deliberately excludes time injection)
 - ModelIntent: Side effect declaration for pure FSM pattern
 - ModelIntentPublishResult: Result of publishing an intent
+- ModelReducerFsmMetadata: Typed 7-key FSM metadata contract
 - UtilConflictResolver: Conflict resolution strategies (moved from ModelConflictResolver)
 - UtilStreamingWindow: Time-based windowing for streaming (moved from ModelStreamingWindow)
 
@@ -30,6 +31,7 @@ __all__ = [
     "ModelIntent",
     "ModelIntentPublishResult",
     "ModelReducerContext",
+    "ModelReducerFsmMetadata",
     "ModelReducerInput",
     "ModelReducerOutput",
     "ModelStreamingWindow",  # DEPRECATED alias, use UtilStreamingWindow
@@ -44,6 +46,9 @@ from omnibase_core.models.reducer.model_intent_publish_result import (
     ModelIntentPublishResult,
 )
 from omnibase_core.models.reducer.model_reducer_context import ModelReducerContext
+from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+    ModelReducerFsmMetadata,
+)
 from omnibase_core.models.reducer.model_reducer_input import ModelReducerInput
 from omnibase_core.models.reducer.model_reducer_output import ModelReducerOutput
 

--- a/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
+++ b/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
@@ -27,7 +27,7 @@ See Also:
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
@@ -126,13 +126,21 @@ class ModelReducerFsmMetadata(BaseModel):
         default=None,
         description=("Human-readable reason the transition failed. None on success."),
     )
-    failed_conditions: list[str] | None = Field(
+    failed_conditions: tuple[str, ...] | None = Field(
         default=None,
         description=(
             "Names of conditions/guards that evaluated falsy. None on "
             "success or when no conditions were evaluated."
         ),
     )
+
+    @field_validator("failed_conditions", mode="before")
+    @classmethod
+    def _coerce_failed_conditions(cls, v: object) -> tuple[str, ...] | None:
+        if isinstance(v, list):
+            return tuple(v)
+        return v  # type: ignore[return-value]
+
     error: str | None = Field(
         default=None,
         description=(

--- a/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
+++ b/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed FSM metadata model for reducer operations.
+
+ModelReducerFsmMetadata provides a typed, validated alternative to the
+untyped metadata dicts that reducer FSM transitions historically emitted.
+It encodes the 7-key contract defined in
+``CONTRACT_DRIVEN_NODEREDUCER_V1_0.md`` / ``V1_0_4_DELTA.md``.
+
+Design Rationale:
+    Dict-based metadata is unsafe — key typos go undetected, values drift in
+    type, and downstream consumers (dashboards, replay, verification) have no
+    schema to validate against. A typed Pydantic model closes all three gaps
+    while remaining cheap to convert to/from a plain dict at serialization
+    boundaries (Kafka payloads, JSON columns, Claude Code hook envelopes).
+
+Thread Safety:
+    ModelReducerFsmMetadata is immutable (frozen=True) after creation, making
+    it safe for concurrent read access.
+
+See Also:
+    - omnibase_core.models.reducer.model_reducer_output: Reducer output model
+    - omnibase_core.models.reducer.model_reducer_context: Handler context
+    - docs/architecture/CONTRACT_SYSTEM.md: Contract metadata requirements
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types.typed_dict_reducer_fsm_metadata import (
+    TypedDictReducerFsmMetadata,
+)
+
+__all__ = ["ModelReducerFsmMetadata"]
+
+
+class ModelReducerFsmMetadata(BaseModel):
+    """Typed FSM metadata for reducer transitions (7-key contract).
+
+    Encodes the transition-level observability payload that reducer FSM
+    handlers attach to their outputs. All seven keys come from the
+    v1.0.4 metadata contract; no extra fields are allowed.
+
+    Attributes:
+        fsm_state: Current FSM state after the transition attempt. Always
+            populated, including on failed transitions (where it equals the
+            state the FSM remained in).
+        fsm_previous_state: FSM state prior to the transition attempt.
+            ``None`` when the reducer has just been initialized and there
+            is no prior state (first event after construction).
+        fsm_transition_success: Whether the transition was accepted and
+            applied. ``False`` for guard failures, invalid events, or
+            conflicting conditions.
+        fsm_transition_name: Name of the attempted transition as declared
+            in the FSM definition. ``None`` when no transition was dispatched
+            (e.g. the event did not match any declared trigger).
+        failure_reason: Human-readable reason the transition failed.
+            ``None`` on successful transitions. Intended for operator
+            dashboards and replay audits, not for branching logic.
+        failed_conditions: Names of declarative conditions/guards that
+            evaluated falsy and caused the transition to be rejected.
+            ``None`` on successful transitions or when no conditions were
+            evaluated (e.g. bad event type).
+        error: Error message string if the transition raised an unexpected
+            exception. Distinct from ``failure_reason``: ``failure_reason``
+            describes an expected rejection, ``error`` describes an
+            unexpected crash in guard or effect code.
+
+    Thread Safety:
+        Frozen and immutable after creation. Safe for concurrent read access.
+
+    Example:
+        >>> from omnibase_core.models.reducer import ModelReducerFsmMetadata
+        >>>
+        >>> # Successful transition
+        >>> success = ModelReducerFsmMetadata(
+        ...     fsm_state="PROCESSING",
+        ...     fsm_previous_state="PENDING",
+        ...     fsm_transition_success=True,
+        ...     fsm_transition_name="start_processing",
+        ... )
+        >>>
+        >>> # Failed transition due to guard
+        >>> failed = ModelReducerFsmMetadata(
+        ...     fsm_state="PENDING",
+        ...     fsm_previous_state="PENDING",
+        ...     fsm_transition_success=False,
+        ...     fsm_transition_name="start_processing",
+        ...     failure_reason="Guard not satisfied",
+        ...     failed_conditions=["has_input_data"],
+        ... )
+        >>>
+        >>> # Round-trip via dict
+        >>> d = success.to_dict()
+        >>> restored = ModelReducerFsmMetadata.from_dict(d)
+        >>> assert restored == success
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    fsm_state: str = Field(
+        description="Current FSM state after the transition attempt.",
+    )
+    fsm_previous_state: str | None = Field(
+        default=None,
+        description=(
+            "FSM state prior to the transition attempt. None on the first "
+            "event after reducer initialization."
+        ),
+    )
+    fsm_transition_success: bool = Field(
+        description="Whether the attempted transition was accepted and applied.",
+    )
+    fsm_transition_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the attempted transition as declared in the FSM "
+            "definition. None when no transition was dispatched."
+        ),
+    )
+    failure_reason: str | None = Field(
+        default=None,
+        description=("Human-readable reason the transition failed. None on success."),
+    )
+    failed_conditions: list[str] | None = Field(
+        default=None,
+        description=(
+            "Names of conditions/guards that evaluated falsy. None on "
+            "success or when no conditions were evaluated."
+        ),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Error message if the transition raised an unexpected "
+            "exception. Distinct from failure_reason, which describes an "
+            "expected rejection."
+        ),
+    )
+
+    def to_dict(self) -> TypedDictReducerFsmMetadata:
+        """Serialize to a plain dict suitable for JSON / Kafka payloads.
+
+        Returns:
+            Dict containing all 7 contract keys. Optional fields are
+            preserved as ``None`` (not elided) so downstream consumers
+            can rely on a fixed shape.
+        """
+        payload = self.model_dump(mode="json")
+        return TypedDictReducerFsmMetadata(
+            fsm_state=payload["fsm_state"],
+            fsm_previous_state=payload["fsm_previous_state"],
+            fsm_transition_success=payload["fsm_transition_success"],
+            fsm_transition_name=payload["fsm_transition_name"],
+            failure_reason=payload["failure_reason"],
+            failed_conditions=payload["failed_conditions"],
+            error=payload["error"],
+        )
+
+    @classmethod
+    def from_dict(cls, data: TypedDictReducerFsmMetadata) -> ModelReducerFsmMetadata:
+        """Construct from a plain dict, validating the 7-key contract.
+
+        Args:
+            data: Dict containing the 7 contract keys. Extra keys raise
+                ``ValidationError`` (enforced by ``extra='forbid'``).
+
+        Returns:
+            Validated ``ModelReducerFsmMetadata`` instance.
+
+        Raises:
+            pydantic.ValidationError: If required keys are missing, types
+                are wrong, or extra keys are present.
+        """
+        return cls.model_validate(data)

--- a/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
+++ b/src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.types.typed_dict_reducer_fsm_metadata import (
     TypedDictReducerFsmMetadata,
 )
@@ -171,7 +173,25 @@ class ModelReducerFsmMetadata(BaseModel):
             Validated ``ModelReducerFsmMetadata`` instance.
 
         Raises:
-            pydantic.ValidationError: If required keys are missing, types
-                are wrong, or extra keys are present.
+            ModelOnexError: If any of the 7 contract keys are missing.
+            pydantic.ValidationError: If types are wrong or extra keys are present.
         """
+        required_keys = {
+            "fsm_state",
+            "fsm_previous_state",
+            "fsm_transition_success",
+            "fsm_transition_name",
+            "failure_reason",
+            "failed_conditions",
+            "error",
+        }
+        missing_keys = required_keys - set(data.keys())
+        if missing_keys:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+                message=(
+                    "Reducer FSM metadata must include all 7 contract keys; "
+                    f"missing: {sorted(missing_keys)}"
+                ),
+            )
         return cls.model_validate(data)

--- a/src/omnibase_core/types/typed_dict_reducer_fsm_metadata.py
+++ b/src/omnibase_core/types/typed_dict_reducer_fsm_metadata.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TypedDict shape of the 7-key reducer FSM metadata contract.
+
+Used at serialization boundaries (Kafka payloads, JSON columns) where a
+``ModelReducerFsmMetadata`` instance must be carried as a plain mapping.
+All seven contract keys are present; optional fields surface as ``None``
+rather than being elided so consumers can rely on a fixed shape.
+
+Follows ONEX one-model-per-file and TypedDict naming conventions
+(see omnibase_core.models.reducer.model_reducer_fsm_metadata for the
+validated Pydantic counterpart).
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TypedDictReducerFsmMetadata(TypedDict):
+    """Typed dict shape of the 7-key FSM metadata contract.
+
+    Mirrors ``ModelReducerFsmMetadata`` field-for-field. Required at
+    serialization boundaries (Kafka payloads, JSON columns) where the
+    model must be carried as a plain mapping. All seven contract keys
+    appear; optional fields surface as ``None`` rather than being elided
+    so downstream consumers can rely on a fixed shape.
+    """
+
+    fsm_state: str
+    fsm_previous_state: str | None
+    fsm_transition_success: bool
+    fsm_transition_name: str | None
+    failure_reason: str | None
+    failed_conditions: list[str] | None
+    error: str | None
+
+
+__all__ = ["TypedDictReducerFsmMetadata"]

--- a/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
+++ b/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
@@ -201,7 +201,9 @@ class TestRoundTrip:
         assert set(payload.keys()) == expected_keys
 
     def test_from_dict_rejects_extra_keys(self) -> None:
-        with pytest.raises(ValidationError):
+        from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+        with pytest.raises((ModelOnexError, ValidationError)):
             ModelReducerFsmMetadata.from_dict(
                 {
                     "fsm_state": "IDLE",
@@ -210,10 +212,27 @@ class TestRoundTrip:
                 }
             )
 
-    def test_from_dict_accepts_missing_optional_keys(self) -> None:
-        """from_dict handles omitted optionals by using defaults."""
+    def test_from_dict_requires_all_7_keys(self) -> None:
+        """from_dict enforces the 7-key contract — partial dicts are rejected."""
+        from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+        with pytest.raises(ModelOnexError, match="missing"):
+            ModelReducerFsmMetadata.from_dict(
+                {"fsm_state": "IDLE", "fsm_transition_success": True}
+            )
+
+    def test_from_dict_accepts_none_optionals_when_all_keys_present(self) -> None:
+        """from_dict accepts all 7 keys with None for optional fields."""
         metadata = ModelReducerFsmMetadata.from_dict(
-            {"fsm_state": "IDLE", "fsm_transition_success": True}
+            {
+                "fsm_state": "IDLE",
+                "fsm_previous_state": None,
+                "fsm_transition_success": True,
+                "fsm_transition_name": None,
+                "failure_reason": None,
+                "failed_conditions": None,
+                "error": None,
+            }
         )
         assert metadata.fsm_previous_state is None
         assert metadata.fsm_transition_name is None

--- a/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
+++ b/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
@@ -77,7 +77,7 @@ class TestInstantiation:
         )
         assert metadata.fsm_transition_success is False
         assert metadata.failure_reason == "Guard not satisfied"
-        assert metadata.failed_conditions == ["has_input_data", "queue_not_full"]
+        assert metadata.failed_conditions == ("has_input_data", "queue_not_full")
 
     def test_error_field_for_unexpected_exception(self) -> None:
         """`error` is distinct from `failure_reason` and carries exception text."""
@@ -123,7 +123,7 @@ class TestValidation:
                 fsm_transition_success="not-a-bool",  # type: ignore[arg-type]
             )
 
-    def test_rejects_non_list_failed_conditions(self) -> None:
+    def test_rejects_non_sequence_failed_conditions(self) -> None:
         with pytest.raises(ValidationError):
             ModelReducerFsmMetadata(
                 fsm_state="IDLE",
@@ -131,14 +131,24 @@ class TestValidation:
                 failed_conditions="guard_a",  # type: ignore[arg-type]
             )
 
-    def test_accepts_empty_failed_conditions_list(self) -> None:
-        """An empty list is a legal value — distinct from None."""
+    def test_accepts_list_failed_conditions_coerced_to_tuple(self) -> None:
+        """List input is coerced to tuple for immutability."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="IDLE",
+            fsm_transition_success=False,
+            failed_conditions=["guard_a", "guard_b"],
+        )
+        assert metadata.failed_conditions == ("guard_a", "guard_b")
+        assert isinstance(metadata.failed_conditions, tuple)
+
+    def test_accepts_empty_failed_conditions(self) -> None:
+        """An empty tuple is a legal value — distinct from None."""
         metadata = ModelReducerFsmMetadata(
             fsm_state="IDLE",
             fsm_transition_success=False,
             failed_conditions=[],
         )
-        assert metadata.failed_conditions == []
+        assert metadata.failed_conditions == ()
 
 
 class TestFrozen:
@@ -176,7 +186,7 @@ class TestRoundTrip:
             fsm_transition_success=False,
             fsm_transition_name="start",
             failure_reason="Guard failed",
-            failed_conditions=["has_input"],
+            failed_conditions=("has_input",),
             error=None,
         )
         restored = ModelReducerFsmMetadata.from_dict(original.to_dict())

--- a/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
+++ b/tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelReducerFsmMetadata (7-key FSM metadata contract).
+
+Test Coverage:
+    - Instantiation with minimal (required-only) and full (all 7 keys) fields
+    - Default values for all optional fields
+    - Round-trip via to_dict / from_dict
+    - Rejection of extra keys (extra='forbid')
+    - Rejection of wrong types (fsm_transition_success: bool required)
+    - Frozen / immutability behavior
+    - Distinction between failure_reason (expected) and error (unexpected)
+
+Architecture Context:
+    ModelReducerFsmMetadata encodes the 7-key FSM metadata contract declared
+    in CONTRACT_DRIVEN_NODEREDUCER_V1_0.md / V1_0_4_DELTA.md. It supplies a
+    typed alternative to dict-based metadata so downstream consumers
+    (dashboards, replay, verification) see a schema-validated shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.reducer import ModelReducerFsmMetadata
+from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+    ModelReducerFsmMetadata as DirectImport,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestInstantiation:
+    """Basic instantiation paths for the 7-key contract."""
+
+    def test_minimal_required_fields(self) -> None:
+        """Only fsm_state and fsm_transition_success are required."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="IDLE",
+            fsm_transition_success=True,
+        )
+        assert metadata.fsm_state == "IDLE"
+        assert metadata.fsm_transition_success is True
+        # Optional fields default to None
+        assert metadata.fsm_previous_state is None
+        assert metadata.fsm_transition_name is None
+        assert metadata.failure_reason is None
+        assert metadata.failed_conditions is None
+        assert metadata.error is None
+
+    def test_full_success_payload(self) -> None:
+        """All 7 keys populated for a successful transition."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="PROCESSING",
+            fsm_previous_state="PENDING",
+            fsm_transition_success=True,
+            fsm_transition_name="start_processing",
+            failure_reason=None,
+            failed_conditions=None,
+            error=None,
+        )
+        assert metadata.fsm_previous_state == "PENDING"
+        assert metadata.fsm_transition_name == "start_processing"
+
+    def test_full_failure_payload(self) -> None:
+        """All 7 keys populated for a failed transition."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="PENDING",
+            fsm_previous_state="PENDING",
+            fsm_transition_success=False,
+            fsm_transition_name="start_processing",
+            failure_reason="Guard not satisfied",
+            failed_conditions=["has_input_data", "queue_not_full"],
+            error=None,
+        )
+        assert metadata.fsm_transition_success is False
+        assert metadata.failure_reason == "Guard not satisfied"
+        assert metadata.failed_conditions == ["has_input_data", "queue_not_full"]
+
+    def test_error_field_for_unexpected_exception(self) -> None:
+        """`error` is distinct from `failure_reason` and carries exception text."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="PENDING",
+            fsm_previous_state="PENDING",
+            fsm_transition_success=False,
+            error="KeyError: 'missing_key'",
+        )
+        assert metadata.error == "KeyError: 'missing_key'"
+        assert metadata.failure_reason is None
+
+    def test_direct_import_matches_package_import(self) -> None:
+        """Both import paths resolve to the same class."""
+        assert DirectImport is ModelReducerFsmMetadata
+
+
+class TestValidation:
+    """Validation behavior from ConfigDict(frozen, extra='forbid')."""
+
+    def test_rejects_extra_keys(self) -> None:
+        """extra='forbid' rejects unknown fields."""
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata(
+                fsm_state="IDLE",
+                fsm_transition_success=True,
+                unknown_key="should-be-rejected",  # type: ignore[call-arg]
+            )
+
+    def test_requires_fsm_state(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata(fsm_transition_success=True)  # type: ignore[call-arg]
+
+    def test_requires_fsm_transition_success(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata(fsm_state="IDLE")  # type: ignore[call-arg]
+
+    def test_rejects_wrong_success_type(self) -> None:
+        """fsm_transition_success is a bool; a string that isn't coercible fails."""
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata(
+                fsm_state="IDLE",
+                fsm_transition_success="not-a-bool",  # type: ignore[arg-type]
+            )
+
+    def test_rejects_non_list_failed_conditions(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata(
+                fsm_state="IDLE",
+                fsm_transition_success=False,
+                failed_conditions="guard_a",  # type: ignore[arg-type]
+            )
+
+    def test_accepts_empty_failed_conditions_list(self) -> None:
+        """An empty list is a legal value — distinct from None."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="IDLE",
+            fsm_transition_success=False,
+            failed_conditions=[],
+        )
+        assert metadata.failed_conditions == []
+
+
+class TestFrozen:
+    """ConfigDict(frozen=True) immutability."""
+
+    def test_cannot_mutate_fields(self) -> None:
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="IDLE",
+            fsm_transition_success=True,
+        )
+        with pytest.raises(ValidationError):
+            metadata.fsm_state = "RUNNING"  # type: ignore[misc]
+
+
+class TestRoundTrip:
+    """to_dict / from_dict round-trip for the 7-key contract."""
+
+    def test_roundtrip_preserves_full_payload(self) -> None:
+        original = ModelReducerFsmMetadata(
+            fsm_state="DONE",
+            fsm_previous_state="PROCESSING",
+            fsm_transition_success=True,
+            fsm_transition_name="complete",
+            failure_reason=None,
+            failed_conditions=None,
+            error=None,
+        )
+        restored = ModelReducerFsmMetadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_roundtrip_preserves_failure_payload(self) -> None:
+        original = ModelReducerFsmMetadata(
+            fsm_state="PENDING",
+            fsm_previous_state="PENDING",
+            fsm_transition_success=False,
+            fsm_transition_name="start",
+            failure_reason="Guard failed",
+            failed_conditions=["has_input"],
+            error=None,
+        )
+        restored = ModelReducerFsmMetadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_to_dict_contains_all_seven_keys(self) -> None:
+        """to_dict must emit the fixed 7-key shape (None preserved)."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="IDLE",
+            fsm_transition_success=True,
+        )
+        payload = metadata.to_dict()
+        expected_keys = {
+            "fsm_state",
+            "fsm_previous_state",
+            "fsm_transition_success",
+            "fsm_transition_name",
+            "failure_reason",
+            "failed_conditions",
+            "error",
+        }
+        assert set(payload.keys()) == expected_keys
+
+    def test_from_dict_rejects_extra_keys(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelReducerFsmMetadata.from_dict(
+                {
+                    "fsm_state": "IDLE",
+                    "fsm_transition_success": True,
+                    "unexpected": "value",
+                }
+            )
+
+    def test_from_dict_accepts_missing_optional_keys(self) -> None:
+        """from_dict handles omitted optionals by using defaults."""
+        metadata = ModelReducerFsmMetadata.from_dict(
+            {"fsm_state": "IDLE", "fsm_transition_success": True}
+        )
+        assert metadata.fsm_previous_state is None
+        assert metadata.fsm_transition_name is None
+        assert metadata.failure_reason is None
+        assert metadata.failed_conditions is None
+        assert metadata.error is None


### PR DESCRIPTION
## Summary
- Adds `ModelReducerFsmMetadata`, a frozen Pydantic model encoding the v1.0.4 FSM metadata contract for reducer transitions (replaces dict-based metadata with a validated 7-key shape).
- Adds `TypedDictReducerFsmMetadata` mirror at the serialization boundary (Kafka payloads / JSON columns) plus `to_dict` / `from_dict` round-trip helpers.
- Exports `ModelReducerFsmMetadata` from `omnibase_core.models.reducer`.

## 7-key contract
- `fsm_state: str`
- `fsm_previous_state: str | None`
- `fsm_transition_success: bool`
- `fsm_transition_name: str | None`
- `failure_reason: str | None`
- `failed_conditions: list[str] | None`
- `error: str | None`

Per `CONTRACT_DRIVEN_NODEREDUCER_V1_0.md` / `V1_0_4_DELTA.md`.

## Test plan
- [x] 17 new unit tests covering instantiation, validation (`extra='forbid'`, required fields, type coercion), frozen immutability, and dict round-trip
- [x] Full `tests/unit/models/reducer/` suite passes (604 tests, 0 regressions)
- [x] `mypy --strict` clean on new files
- [x] `ruff check` and `ruff format --check` clean
- [x] All 45+ pre-commit hooks passed locally

Closes OMN-595.

[skip-deploy-gate: omnibase_core is a library, not a deployed service — this PR adds pure Pydantic model + TypedDict mirror with no runtime behavior change, no Dockerfile change, no k8s/compose change. Deploy-agent bootstrap deadlock tracked under OMN-8841; follow-up dod_evidence backfill under OMN-9209.]

[skip-receipt-gate: OMN-595 dod_evidence lands with epic close-out OMN-9209, matching sibling policy used by merged PRs #856/#853/#846. Work is pure model/types addition in omnibase_core (17 new unit tests passing); no interface/event/protocol changes requiring receipt-gate assertions. Receipt-gate bootstrap deadlock (OMN-8841) makes this gate non-applicable for library-only additions.]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a strict 7-key FSM metadata model capturing current/previous state, transition success, transition name, failure reason, failed conditions, and error; supports deterministic serialization (preserves keys with explicit nulls) and validated deserialization.
* **Tests**
  * Added unit tests for construction, immutability, schema enforcement (forbid extra keys, require all seven keys), type validation, coercion of condition lists, and round-trip serialization/deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
