### PR TITLE
fix(ci): --no-index alongside --no-deps for downstream callers [OMN-9198]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -159,6 +159,7 @@ jobs:
           # Without hatchling pre-installed, uv cannot build the editable source.
           uv pip install --system \
             'hatchling' \
+            'editables' \
             'pydantic>=2.12.5,<3.0.0' \
             'pyyaml>=6.0.2,<7.0.0' \
             'dependency-injector>=4.48.3,<5.0.0' \

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -163,10 +163,23 @@ jobs:
             'blake3>=1.0.8,<2.0.0' \
             'ruamel-yaml>=0.18.0'
 
-          # --no-deps forces uv to skip candidate selection for omnibase-core.
-          # Install the editable path exactly, without resolving its declared
-          # deps (already present from the seed step above).
-          uv pip install --system --no-deps \
+          # OMN-9198 follow-up: PR #863 (--no-deps alone) worked in omnibase_core's
+          # OWN PRs (core_path=".") but FAILED in downstream callers where
+          # core_path=".receipt-gate-deps/omnibase_core". Evidence from
+          # omnibase_infra PR #1351 run 24656453993: with --no-deps + -e <subpath>,
+          # uv's resolver STILL considered the PyPI index and chose it over the
+          # editable (log: `Resolved 1 package in 134ms / Downloading omnibase-core
+          # (5.1MiB) / + omnibase-core==0.39.0` — no `(from file://...)` suffix).
+          #
+          # Root cause refinement: `.` (self-project) gets special treatment from
+          # uv's resolver and always wins. Any other -e path is just one candidate
+          # competing with the index, and at matching versions uv picks index.
+          #
+          # Fix: add --no-index alongside --no-deps. With --no-deps there are no
+          # transitive deps to resolve (already seeded above), so --no-index won't
+          # break PR #850's problem of unsatisfiable version constraints — it just
+          # removes the index candidate that was winning over the -e path.
+          uv pip install --system --no-deps --no-index \
             --reinstall-package omnibase-core \
             -e "$core_path"
 

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -149,9 +149,16 @@ jobs:
             exit 1
           fi
 
-          # Seed omnibase_core's transitive deps from PyPI before the --no-deps
-          # editable install below. Keep in sync with omnibase_core/pyproject.toml.
+          # Seed omnibase_core's transitive deps from PyPI before the --no-deps +
+          # --no-index editable install below. Keep in sync with
+          # omnibase_core/pyproject.toml [dependencies].
+          #
+          # Also includes `hatchling` (build backend from [build-system.requires])
+          # because the editable install below uses --no-index, which disables
+          # PyPI lookups for EVERYTHING including build-system requirements.
+          # Without hatchling pre-installed, uv cannot build the editable source.
           uv pip install --system \
+            'hatchling' \
             'pydantic>=2.12.5,<3.0.0' \
             'pyyaml>=6.0.2,<7.0.0' \
             'dependency-injector>=4.48.3,<5.0.0' \
@@ -179,7 +186,10 @@ jobs:
           # transitive deps to resolve (already seeded above), so --no-index won't
           # break PR #850's problem of unsatisfiable version constraints — it just
           # removes the index candidate that was winning over the -e path.
-          uv pip install --system --no-deps --no-index \
+          # --no-build-isolation: use hatchling from the env (seeded above) rather
+          # than letting uv spin up an isolated build env that would also need
+          # PyPI (which --no-index disables).
+          uv pip install --system --no-deps --no-index --no-build-isolation \
             --reinstall-package omnibase-core \
             -e "$core_path"
 


### PR DESCRIPTION
[skip-receipt-gate: bootstrap — modifying receipt-gate workflow itself]
[skip-deploy-gate: CI-workflow-only change; no runtime paths touched.]

## Summary

Follow-up to #863. The `--no-deps` fix worked in omnibase_core's OWN PRs (where `core_path="."`) but FAILED in downstream callers like omnibase_infra where `core_path=".receipt-gate-deps/omnibase_core"`.

## Refined root cause

uv's resolver treats `.` (self-project) specially — it always wins candidate-selection. Any OTHER `-e <path>` is just one candidate competing with the index, and at matching versions uv picks index.

## Evidence

**Downstream caller failure** (omnibase_infra PR #1351 retrigger, CI run 24656453993, job 72091068084, 2026-04-20T08:30Z):

```
Resolved 1 package in 134ms
Downloading omnibase-core (5.1MiB)    <-- chose PyPI over -e path
+ omnibase-core==0.39.0                <-- no `(from file://...)` suffix
ImportError: cannot import name 'receipt_gate_cli' from 'omnibase_core.validation'
```

**Self-project success** (PR #863's own verify run, job 72080049292, same omnibase_core repo, `core_path="."`):

```
Resolved 1 package in 1ms
Building omnibase-core @ file:///home/runner/work/omnibase_core/omnibase_core
+ omnibase-core==0.39.0 (from file:///...)
```

The `(from file:///...)` suffix is the smoking gun: present when editable won, absent when index won.

## Fix

Add `--no-index` alongside `--no-deps` on the core install. With `--no-deps` there is no transitive resolution, so `--no-index` can't regress PR #850's problem of unsatisfiable version constraints — it simply removes the index candidate that was winning over `-e`.

## Why this wasn't caught in PR #863

PR #863's own verify/verify ran in `omnibase_core` repo where `core_path="."` — the self-project special case. Self-validation was a false positive. The test that would have caught this is a cross-repo integration check — running the gate against a caller repo checkout.

## Blast radius

Unblocks receipt-gate for ALL downstream caller repos (omnibase_infra, onex_change_control, etc.). The self-project path already works via #863.

## Test plan

- [x] YAML parses
- [x] Local install logic traced end-to-end
- [ ] `verify / verify` on this PR passes (self-project path; should continue to work)
- [ ] After merge: retrigger omnibase_infra#1351 with empty commit — expected: install log shows `Building omnibase-core @ file:///...` and `+ omnibase-core==0.39.0 (from file:///...)`, then the importability check passes, then Receipt Gate evaluates the PR normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build workflow to ensure reproducible, consistent package installation during runs.
  * Seeded the build environment with required tooling and adjusted installation behavior so editable installs use the local source and avoid consulting remote package indexes or creating isolated build environments, reducing unexpected remote builds and deployment variance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->