### PR TITLE
fix(ci): build wheel + --find-links for receipt-gate on downstream callers [OMN-9283]

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -171,28 +171,38 @@ jobs:
             'blake3>=1.0.8,<2.0.0' \
             'ruamel-yaml>=0.18.0'
 
-          # OMN-9198 follow-up: PR #863 (--no-deps alone) worked in omnibase_core's
-          # OWN PRs (core_path=".") but FAILED in downstream callers where
-          # core_path=".receipt-gate-deps/omnibase_core". Evidence from
-          # omnibase_infra PR #1351 run 24656453993: with --no-deps + -e <subpath>,
-          # uv's resolver STILL considered the PyPI index and chose it over the
-          # editable (log: `Resolved 1 package in 134ms / Downloading omnibase-core
-          # (5.1MiB) / + omnibase-core==0.39.0` — no `(from file://...)` suffix).
+          # OMN-9283: PR #864 (--no-index + --no-deps + -e <subpath>) worked for
+          # omnibase_core's OWN PRs (core_path=".") but FAILED in downstream callers
+          # where core_path="./.receipt-gate-deps/omnibase_core". Evidence from
+          # omnibase_infra PR #1351 run 24661986639 job 72110050548:
+          #   × No solution found when resolving dependencies:
+          #   ╰─▶ Because omnibase-core was not found in the provided package
+          #       locations and you require omnibase-core>=0.39.0, we can conclude
+          #       that your requirements are unsatisfiable.
           #
-          # Root cause refinement: `.` (self-project) gets special treatment from
-          # uv's resolver and always wins. Any other -e path is just one candidate
-          # competing with the index, and at matching versions uv picks index.
+          # Root cause: uv auto-discovers the cwd's pyproject.toml (the caller
+          # repo, e.g. omnibase_infra) and treats its "omnibase-core>=0.39.0"
+          # declaration as a top-level resolver requirement. A nested -e <subpath>
+          # outside the cwd-project root is registered as a candidate offer but
+          # is not matched against the cwd-project's own constraint. With
+          # --no-index, there is no other source, so uv fails with "no solution".
+          # Self-project ("." as editable) works because the editable IS the cwd
+          # project — uv collapses them into one node.
           #
-          # Fix: add --no-index alongside --no-deps. With --no-deps there are no
-          # transitive deps to resolve (already seeded above), so --no-index won't
-          # break PR #850's problem of unsatisfiable version constraints — it just
-          # removes the index candidate that was winning over the -e path.
-          # --no-build-isolation: use hatchling from the env (seeded above) rather
-          # than letting uv spin up an isolated build env that would also need
-          # PyPI (which --no-index disables).
-          uv pip install --system --no-deps --no-index --no-build-isolation \
+          # Fix (Option B from diagnosis-receipt-gate-v4-subpath-editable.md):
+          # build a wheel from source, install from a local --find-links. The
+          # resolver operates on a named package from a wheel location, which
+          # unambiguously satisfies the cwd-project's version constraint.
+          # Not editable, but receipt-gate imports the module once and exits —
+          # editability was never a functional requirement, only a means to use
+          # source instead of PyPI.
+          mkdir -p /tmp/receipt-gate-wheels
+          (cd "$core_path" && uv build --wheel --out-dir /tmp/receipt-gate-wheels)
+
+          uv pip install --system --no-deps --no-index \
+            --find-links /tmp/receipt-gate-wheels \
             --reinstall-package omnibase-core \
-            -e "$core_path"
+            omnibase-core
 
       - name: Verify receipt_gate_cli importable
         # Fail-fast check: the preceding install step claims success, but if uv

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Structural tests for .github/workflows/receipt-gate.yml install logic.
+
+Guards against regressions in the OMN-9198 / OMN-9283 remediation:
+- The workflow must never fall back to PyPI for `omnibase-core` (the published
+  wheel has a broken transitive `git+https` dep on `omnibase-compat`).
+- The workflow must use the build-a-wheel + `--find-links` pattern so the same
+  install command works for both self-project (core_path=".") and downstream
+  callers (core_path="./.receipt-gate-deps/omnibase_core"). Editable/`-e` +
+  `--no-index` fails on subpath callers because uv auto-discovers the cwd's
+  pyproject constraint separately from the -e candidate registration.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "receipt-gate.yml"
+)
+
+
+def _install_step_script() -> str:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"]["verify"]["steps"]
+    for step in steps:
+        if step.get("name") == "Install omnibase_core":
+            script: str = step["run"]
+            return script
+    raise AssertionError("Install omnibase_core step not found in receipt-gate.yml")
+
+
+def test_install_step_builds_wheel_from_source() -> None:
+    """Core install must build a wheel, not install from PyPI."""
+    script = _install_step_script()
+    assert "uv build --wheel" in script, (
+        "receipt-gate must build omnibase-core from source via `uv build --wheel` "
+        "(OMN-9283 — editable -e <subpath> is not matched against caller-pyproject "
+        "constraint under --no-index)"
+    )
+
+
+def test_install_step_uses_find_links() -> None:
+    """Install must resolve omnibase-core from the local wheel dir."""
+    script = _install_step_script()
+    assert "--find-links" in script, (
+        "receipt-gate install must use --find-links pointing at the locally-built "
+        "wheel directory so uv's resolver has a source that satisfies the caller's "
+        "`omnibase-core>=X` constraint without hitting PyPI"
+    )
+
+
+def test_install_step_uses_no_index_for_core() -> None:
+    """Final core install must disable the PyPI index — the whole point of OMN-9198."""
+    script = _install_step_script()
+    # Join shell line-continuations before matching (the install command is
+    # wrapped across multiple lines with trailing backslashes).
+    joined = re.sub(r"\\\n\s*", " ", script)
+    pattern = re.compile(r"uv pip install\b[^\n]*--no-index[^\n]*omnibase-core")
+    assert pattern.search(joined), (
+        "the final `uv pip install ... omnibase-core` must include --no-index "
+        "so uv cannot fall back to the broken PyPI wheel"
+    )
+
+
+def test_install_step_has_no_bare_pypi_core_install() -> None:
+    """Regression guard: no `uv pip install` of bare `omnibase-core` without --no-index."""
+    script = _install_step_script()
+    # Join shell line-continuations so multi-line `uv pip install ... \\\n  flag` reads as one logical command.
+    joined = re.sub(r"\\\n\s*", " ", script)
+    for line in joined.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uv pip install"):
+            continue
+        if "omnibase-core" not in stripped:
+            continue
+        if "--no-index" in stripped:
+            continue
+        pytest.fail(
+            f"bare `uv pip install omnibase-core` without --no-index found: {stripped!r}. "
+            f"This would pull the broken PyPI wheel (OMN-9198)."
+        )
+
+
+def test_install_step_seeds_transitive_deps_from_pypi() -> None:
+    """Transitive deps (pydantic, etc.) must still be resolvable — seeded before --no-index step."""
+    script = _install_step_script()
+    assert "pydantic>=" in script, (
+        "transitive deps must be pre-seeded from PyPI before the --no-index core install; "
+        "otherwise --no-deps + --no-index leaves runtime imports broken"
+    )
+
+
+def test_install_step_locates_core_path_for_both_self_and_subpath() -> None:
+    """Core-path detection must handle self-project, sibling checkout, and receipt-gate-deps subpath."""
+    script = _install_step_script()
+    assert 'core_path="."' in script, "must detect self-project case"
+    assert 'core_path="./.receipt-gate-deps/omnibase_core"' in script, (
+        "must detect downstream-caller subpath case (was broken in #864)"
+    )
+
+
+def test_workflow_checks_out_omnibase_core_when_missing() -> None:
+    """The subpath case requires a `Check out omnibase_core` step for downstream callers."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"]["verify"]["steps"]
+    names = [s.get("name", "") for s in steps]
+    assert any("Check out omnibase_core" in n for n in names), (
+        "receipt-gate must check out omnibase_core source for downstream callers "
+        "that don't already have it in-tree"
+    )


### PR DESCRIPTION
[skip-receipt-gate: bootstrap — modifying receipt-gate workflow itself]
[skip-deploy-gate: CI-workflow-only change; no runtime paths touched.]

## Summary

5th iteration on OMN-9198. PR #864 (--no-index + --no-deps + `-e <subpath>` + seeded hatchling) made receipt-gate green on omnibase_core's own PRs where `core_path="."`, but verify/verify continues to fail on **every downstream caller** (omnibase_infra, onex_change_control, etc.) where `core_path="./.receipt-gate-deps/omnibase_core"`.

Diagnosis is written (5 attempts catalogued, 4 options compared):
`omni_home/docs/diagnosis-receipt-gate-v4-subpath-editable.md`

Linear: https://linear.app/omninode/issue/OMN-9283

## Ground-truth failure

omnibase_infra PR #1351, run 24661986639, job 72110050548, 2026-04-20T10:39:40Z:

```
uv pip install --system --no-deps --no-index --no-build-isolation \
  --reinstall-package omnibase-core \
  -e ./.receipt-gate-deps/omnibase_core

  × No solution found when resolving dependencies:
  ╰─▶ Because omnibase-core was not found in the provided package locations
      and you require omnibase-core>=0.39.0, we can conclude that your
      requirements are unsatisfiable.
      hint: Packages were unavailable because index lookups were disabled
      and no additional package locations were provided
```

## Refined root cause

`uv pip install` is not a pure pip shim. When the cwd contains a `pyproject.toml`, uv auto-discovers that project and treats its declared dependencies as top-level requirements during resolution — independently of the `-e <path>` argument. `omnibase_infra/pyproject.toml` declares `"omnibase-core>=0.39.0"`; uv reads that and tries to satisfy it.

`-e ./<subpath>` registers a candidate offer for the package `omnibase-core`, but in uv's internal graph the caller-pyproject's `omnibase-core>=0.39.0` requirement and the editable offer are **not matched** when the editable's pyproject lives outside the cwd-project root. With `--no-index` the index candidate is gone, the editable is orphaned, and the top-level requirement has no location → "no solution".

Self-project (`core_path="."`) works because the editable IS the cwd project — uv collapses the two into one resolver node.

## Fix — Option B (build wheel + --find-links)

```bash
mkdir -p /tmp/receipt-gate-wheels
(cd "$core_path" && uv build --wheel --out-dir /tmp/receipt-gate-wheels)

uv pip install --system --no-deps --no-index \
  --find-links /tmp/receipt-gate-wheels \
  --reinstall-package omnibase-core \
  omnibase-core
```

- Conventional pattern — `uv build` + `--find-links` is documented, used in other OmniNode CI (`omnibase_infra/scripts/build-runtime.sh`).
- `--find-links` is a first-class package-location source that uv resolves against declared requirements — unambiguously satisfies the caller's `omnibase-core>=0.39.0`.
- Failure mode (if any) would be a *build* failure with a clear error, not a silent resolver misbehavior.
- Not editable, but receipt-gate imports the module once and exits — editability was never a functional requirement.

Chosen over:
- **Option A (cd /tmp)** — one-line but relies on unstated uv project-discovery semantics; doubles down on #863's self-validate-only mistake.
- **Option C (PYTHONPATH)** — diverges from install-as-package; breaks `importlib.metadata`.
- **Option D (real pip)** — mixes toolchains.

## Test plan

- [x] `uv run pytest tests/unit/validation/test_receipt_gate_workflow_shape.py -v` — 7/7 pass
- [x] `uv run pytest tests/unit/validation/ -n 4` — 3600 pass, 4 skipped
- [x] `uv run mypy tests/unit/validation/test_receipt_gate_workflow_shape.py --strict` — clean
- [x] `uv run ruff check` + `ruff format` — clean
- [x] Full pre-commit hook suite — all pass (SPDX, AI-slop, etc.)
- [ ] `verify / verify` on this PR passes (self-project path — should continue to work)
- [ ] **Downstream verification (hard gate):** after merge, empty commit on omnibase_infra#1351 retriggers verify/verify; expected install log contains `Building omnibase-core @ file://...` or `Installed 1 package: omnibase-core==0.39.0` (NOT `Downloading omnibase-core` from PyPI); CI run URL + UTC timestamp reported as empirical proof

## Acceptance criteria (closes #863's verification gap)

Do NOT treat this PR as done on self-validation alone. A green `verify / verify` on omnibase_infra#1351 (downstream caller, `core_path="./.receipt-gate-deps/omnibase_core"`) is the acceptance.

## Two-strike commitment

Two Option-B fix attempts authorized under this diagnosis. If both fail, STOP, write v5 diagnosis — failure mode would be outside uv resolver semantics (runner cache pollution, hatchling regression, `--find-links` fallthrough).

## Regression guards

New `tests/unit/validation/test_receipt_gate_workflow_shape.py` asserts:
- Install step uses `uv build --wheel`
- Install step uses `--find-links`
- Final `uv pip install omnibase-core` includes `--no-index`
- No bare `uv pip install omnibase-core` without `--no-index` anywhere in the script
- Transitive deps (pydantic, etc.) are pre-seeded from PyPI
- Core-path detection handles both self-project and `.receipt-gate-deps` subpath
- Workflow checks out omnibase_core source when missing

Related: #849, #850, #851, #854, #855, #863, #864
Linear: OMN-9283 (blocked-by: OMN-9198)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow to build and install dependencies from a local wheel instead of editable mode.
  * Added comprehensive validation tests to ensure workflow configuration compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->