### PR TITLE
feat(contracts): add behavior_proven DoD evidence receipt [OMN-9278]

### DIFF
--- a/src/omnibase_core/enums/ticket/enum_behavior_proven_assertion.py
+++ b/src/omnibase_core/enums/ticket/enum_behavior_proven_assertion.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumBehaviorProvenAssertion — outcome of a live-state behavior probe."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumBehaviorProvenAssertion(StrEnum):
+    """Outcome of a behavior_proven DoD evidence probe.
+
+    Used by `ModelBehaviorProvenReceipt` to declare whether the recorded
+    command+query combination observed the expected live state. Absence
+    of a receipt is treated identically to FAILED by downstream gates
+    (OMN-9279 DoD guard, OMN-9281 CI gate).
+    """
+
+    PASSED = "passed"
+    FAILED = "failed"
+
+
+__all__ = ["EnumBehaviorProvenAssertion"]

--- a/src/omnibase_core/models/contracts/ticket/model_behavior_proven_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_behavior_proven_receipt.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelBehaviorProvenReceipt — proof artifact for behavior_proven DoD evidence.
+
+Parent epic: OMN-9277. Sibling: OMN-9279 (DoD guard), OMN-9280 (scaffold
+skill), OMN-9281 (pre-merge CI gate).
+
+A behavior_proven receipt asserts that a ticket's handler / pipeline /
+consumer / effect work was exercised against live external state, not
+merely unit-tested. Tickets labelled handler/pipeline/consumer/effect
+cannot close Done without a passing receipt (see OMN-9279).
+
+The receipt is a discriminated sibling of :class:`ModelDodReceipt`; both
+are recognised by the receipt-gate. `behavior_proven` is registered as a
+first-class ``check_type`` via :const:`BEHAVIOR_PROVEN_CHECK_TYPE` so
+existing :class:`ModelDodEvidenceItem` YAML contracts accept it without
+schema migration.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.ticket.enum_behavior_proven_assertion import (
+    EnumBehaviorProvenAssertion,
+)
+
+BEHAVIOR_PROVEN_CHECK_TYPE = "behavior_proven"
+
+_TICKET_ID_RE = re.compile(r"^OMN-\d+$")
+
+
+class ModelBehaviorProvenReceipt(BaseModel):
+    """Receipt proving a behavior_proven DoD check ran against live state.
+
+    Frozen. Every field except ``observed_state`` is required — a receipt
+    that doesn't record what was run, what was queried, and what was
+    observed is worthless as proof. Treated identically to absence by
+    the DoD guard (OMN-9279) and the CI gate (OMN-9281).
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    ticket_id: str = Field(
+        ..., description="Linear ticket this receipt proves (e.g., OMN-9214)"
+    )
+    # string-id-ok: evidence item IDs are human-readable slugs from contract YAML
+    evidence_item_id: str = Field(
+        ...,
+        min_length=1,
+        description="dod_evidence[].id this receipt covers",
+    )
+    command_run: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The exact command executed to exercise the behavior "
+            "(e.g., 'kcat -P -b ... -t onex.cmd.merge_sweep.v1')."
+        ),
+    )
+    query: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Live-state query used to observe the effect "
+            "(e.g., 'rpk topic consume onex.evt.merge_sweep.completed.v1')."
+        ),
+    )
+    assertion: EnumBehaviorProvenAssertion = Field(
+        ...,
+        description="passed or failed — absence is treated identically to failed",
+    )
+    observed_at: datetime = Field(
+        ..., description="UTC timestamp when the live state was observed"
+    )
+    observed_state: str | None = Field(
+        default=None,
+        description=(
+            "Truncated observed state (stdout, query body, rendered snapshot). "
+            "Large payloads should be stored in a sibling file and referenced "
+            "here by path. None is allowed when the probe produced no output."
+        ),
+    )
+
+    @field_validator("ticket_id")
+    @classmethod
+    def _validate_ticket_id(cls, v: str) -> str:
+        if not _TICKET_ID_RE.match(v):
+            raise ValueError(f"ticket_id must match OMN-\\d+, got: {v!r}")
+        return v
+
+    @field_validator("observed_at")
+    @classmethod
+    def _validate_tz_aware(cls, v: Any) -> datetime:
+        if not isinstance(v, datetime):
+            raise ValueError(f"observed_at must be datetime, got {type(v).__name__}")
+        if v.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware (UTC)")
+        return v.astimezone(UTC)
+
+
+__all__ = [
+    "BEHAVIOR_PROVEN_CHECK_TYPE",
+    "ModelBehaviorProvenReceipt",
+]

--- a/src/omnibase_core/models/contracts/ticket/model_behavior_proven_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_behavior_proven_receipt.py
@@ -24,7 +24,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from omnibase_core.enums.ticket.enum_behavior_proven_assertion import (
     EnumBehaviorProvenAssertion,
@@ -96,6 +96,20 @@ class ModelBehaviorProvenReceipt(BaseModel):
     def _validate_ticket_id(cls, v: str) -> str:
         if not _TICKET_ID_RE.match(v):
             raise ValueError(f"ticket_id must match OMN-\\d+, got: {v!r}")
+        return v
+
+    @field_validator("evidence_item_id", "command_run", "query")
+    @classmethod
+    def _reject_blank_required_strings(cls, v: str, info: ValidationInfo) -> str:
+        if not v.strip():
+            raise ValueError(f"{info.field_name} must not be blank")
+        return v
+
+    @field_validator("observed_state")
+    @classmethod
+    def _reject_blank_observed_state(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("observed_state must not be blank when provided")
         return v
 
     @field_validator("observed_at")

--- a/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
+++ b/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
@@ -109,6 +109,31 @@ class TestModelBehaviorProvenReceiptValidators:
         with pytest.raises(ValidationError):
             ModelBehaviorProvenReceipt(**fields)
 
+    @pytest.mark.parametrize(
+        "field_name",
+        ["evidence_item_id", "command_run", "query"],
+    )
+    @pytest.mark.parametrize("blank", ["   ", "\t", "\n", " \t\n "])
+    def test_whitespace_only_required_field_rejected(
+        self, field_name: str, blank: str
+    ) -> None:
+        fields = _base_fields()
+        fields[field_name] = blank
+        with pytest.raises(ValidationError, match=field_name):
+            ModelBehaviorProvenReceipt(**fields)
+
+    def test_whitespace_only_observed_state_rejected(self) -> None:
+        fields = _base_fields()
+        fields["observed_state"] = "   "
+        with pytest.raises(ValidationError, match="observed_state"):
+            ModelBehaviorProvenReceipt(**fields)
+
+    def test_none_observed_state_still_accepted(self) -> None:
+        fields = _base_fields()
+        fields["observed_state"] = None
+        receipt = ModelBehaviorProvenReceipt(**fields)
+        assert receipt.observed_state is None
+
 
 @pytest.mark.unit
 class TestBehaviorProvenEvidenceItemIntegration:

--- a/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
+++ b/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelBehaviorProvenReceipt (OMN-9278).
+
+behavior_proven is a first-class dod_evidence type proving that a ticket's
+handler / pipeline / consumer / effect work was exercised against live
+external state, not merely unit-tested. Every receipt records the command
+that ran, the query used to inspect live state, the pass/fail assertion,
+and the observation timestamp.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.ticket.enum_behavior_proven_assertion import (
+    EnumBehaviorProvenAssertion,
+)
+from omnibase_core.models.contracts.ticket.model_behavior_proven_receipt import (
+    BEHAVIOR_PROVEN_CHECK_TYPE,
+    ModelBehaviorProvenReceipt,
+)
+from omnibase_core.models.contracts.ticket.model_dod_evidence_check import (
+    ModelDodEvidenceCheck,
+)
+from omnibase_core.models.contracts.ticket.model_dod_evidence_item import (
+    ModelDodEvidenceItem,
+)
+
+
+def _base_fields() -> dict:
+    return {
+        "ticket_id": "OMN-9214",
+        "evidence_item_id": "dod-behavior-001",
+        "command_run": "kcat -P -b 192.168.86.201:19092 -t onex.cmd.merge_sweep.v1",
+        "query": "rpk topic consume onex.evt.merge_sweep.completed.v1 --num 1",
+        "assertion": EnumBehaviorProvenAssertion.PASSED,
+        "observed_at": datetime.now(tz=UTC),
+    }
+
+
+@pytest.mark.unit
+class TestModelBehaviorProvenReceiptConstruction:
+    def test_minimum_valid_receipt_constructs(self) -> None:
+        receipt = ModelBehaviorProvenReceipt(**_base_fields())
+        assert receipt.ticket_id == "OMN-9214"
+        assert receipt.assertion is EnumBehaviorProvenAssertion.PASSED
+        assert receipt.observed_state is None
+
+    def test_full_receipt_with_observed_state(self) -> None:
+        fields = _base_fields()
+        fields["observed_state"] = '{"offset": 42, "value": "merged"}'
+        receipt = ModelBehaviorProvenReceipt(**fields)
+        assert receipt.observed_state == '{"offset": 42, "value": "merged"}'
+
+    def test_receipt_is_frozen(self) -> None:
+        receipt = ModelBehaviorProvenReceipt(**_base_fields())
+        with pytest.raises(ValidationError):
+            receipt.assertion = EnumBehaviorProvenAssertion.FAILED  # type: ignore[misc]
+
+    def test_receipt_rejects_extra_fields(self) -> None:
+        fields = _base_fields()
+        fields["rogue"] = "nope"
+        with pytest.raises(ValidationError):
+            ModelBehaviorProvenReceipt(**fields)
+
+
+@pytest.mark.unit
+class TestModelBehaviorProvenReceiptValidators:
+    @pytest.mark.parametrize(
+        "bad_id",
+        ["OMN-", "omn-1", "1", "OMN-abc", "OMN1", "", "PROJ-1"],
+    )
+    def test_invalid_ticket_id_rejected(self, bad_id: str) -> None:
+        fields = _base_fields()
+        fields["ticket_id"] = bad_id
+        with pytest.raises(ValidationError, match="ticket_id"):
+            ModelBehaviorProvenReceipt(**fields)
+
+    def test_naive_observed_at_rejected(self) -> None:
+        fields = _base_fields()
+        fields["observed_at"] = datetime(2026, 4, 20, 12, 0, 0)  # no tzinfo
+        with pytest.raises(ValidationError, match="timezone-aware"):
+            ModelBehaviorProvenReceipt(**fields)
+
+    def test_non_utc_observed_at_converted_to_utc(self) -> None:
+        from datetime import timedelta, timezone
+
+        eastern = timezone(timedelta(hours=-5))
+        fields = _base_fields()
+        fields["observed_at"] = datetime(2026, 4, 20, 12, 0, 0, tzinfo=eastern)
+        receipt = ModelBehaviorProvenReceipt(**fields)
+        assert receipt.observed_at.tzinfo is UTC
+        assert receipt.observed_at.hour == 17
+
+    def test_empty_command_run_rejected(self) -> None:
+        fields = _base_fields()
+        fields["command_run"] = ""
+        with pytest.raises(ValidationError):
+            ModelBehaviorProvenReceipt(**fields)
+
+    def test_empty_query_rejected(self) -> None:
+        fields = _base_fields()
+        fields["query"] = ""
+        with pytest.raises(ValidationError):
+            ModelBehaviorProvenReceipt(**fields)
+
+
+@pytest.mark.unit
+class TestBehaviorProvenEvidenceItemIntegration:
+    """behavior_proven receipts must be recognizable as check entries on
+    ModelDodEvidenceItem so the existing receipt-gate stays backwards-compatible.
+    """
+
+    def test_evidence_item_accepts_behavior_proven_check_type(self) -> None:
+        item = ModelDodEvidenceItem(
+            id="dod-behavior-001",
+            description="merge_sweep emits onex.cmd and PR enters queue",
+            checks=[
+                ModelDodEvidenceCheck(
+                    check_type=BEHAVIOR_PROVEN_CHECK_TYPE,
+                    check_value="kcat -P ... then rpk topic consume ...",
+                ),
+            ],
+        )
+        assert item.checks[0].check_type == "behavior_proven"
+        assert BEHAVIOR_PROVEN_CHECK_TYPE == "behavior_proven"
+
+    def test_existing_check_types_still_valid(self) -> None:
+        """Migration path: rendered_output / runtime_boot items remain valid."""
+        item = ModelDodEvidenceItem(
+            id="dod-render-001",
+            description="dashboard renders",
+            checks=[
+                ModelDodEvidenceCheck(
+                    check_type="rendered_output",
+                    check_value="playwright test tests/dashboard/nodes.spec.ts",
+                ),
+            ],
+        )
+        assert item.checks[0].check_type == "rendered_output"
+
+
+@pytest.mark.unit
+class TestBehaviorProvenAssertionEnum:
+    def test_enum_values_are_stable_strings(self) -> None:
+        assert EnumBehaviorProvenAssertion.PASSED.value == "passed"
+        assert EnumBehaviorProvenAssertion.FAILED.value == "failed"
+
+    def test_enum_rejects_unknown_value(self) -> None:
+        with pytest.raises(ValueError):
+            EnumBehaviorProvenAssertion("maybe")


### PR DESCRIPTION
## Summary
- Wave 1 of epic OMN-9277. Sub-ticket: OMN-9278.
- Adds ModelBehaviorProvenReceipt + EnumBehaviorProvenAssertion + BEHAVIOR_PROVEN_CHECK_TYPE constant to omnibase_core.
- Receipt proves that a ticket's handler / pipeline / consumer / effect work was exercised against live external state, not merely unit-tested.

## Design notes
- Registered as a first-class check_type on existing ModelDodEvidenceItem via the BEHAVIOR_PROVEN_CHECK_TYPE constant — no schema migration, backwards-compatible with rendered_output / runtime_boot / integration_test check types already in use.
- Enum lives in omnibase_core/enums/ticket/enum_behavior_proven_assertion.py (per single-class-per-file rule). Model lives in omnibase_core/models/contracts/ticket/model_behavior_proven_receipt.py.
- Receipt is frozen, extra="forbid". Required fields: ticket_id (OMN-\d+ regex), evidence_item_id, command_run, query, assertion (passed|failed), observed_at (tz-aware, coerced to UTC). Optional observed_state for truncated stdout / query body / rendered snapshot.
- Absence of a receipt is treated identically to FAILED by downstream gates — no silent pass.

## Test plan
- 19 new unit tests (construction, frozen, extra-field rejection, ticket_id regex, UTC coercion, naive-datetime rejection, empty-field rejection, enum round-trip, migration-path compat with existing rendered_output check type).
- uv run pytest tests/unit/models/contracts/ -v — 2897 passed, zero regressions.
- uv run mypy on the new model --strict — clean.
- Pre-commit — all hooks pass after enum split.

[skip-deploy-gate: pydantic model + enum only; no runtime service path, no container entrypoint, no Kafka topic, no DB migration. The model is a contract schema consumed by downstream tooling which will ship their own deploy evidence. No behavior change to any running runtime until those downstream tickets land.]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added behavior assertion tracking system with PASSED and FAILED outcome states.
  * Introduced receipt model for capturing behavior proof evidence with comprehensive validation, automatic UTC timestamp normalization, and enforcement of required fields.

* **Tests**
  * Added comprehensive unit test suite for behavior assertion receipts covering construction, immutability, field validation, and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->