### PR TITLE
feat(validation): producer/consumer normalization symmetry checker [OMN-9333]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,19 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Producer/Consumer Normalization Symmetry (OMN-9333)
+      # BLOCKING — would have caught OMN-9215 whitespace-strip asymmetry at commit time.
+      # Scans all .py under src/ for TopicBase producer (.send/.produce/.publish/.emit)
+      # vs consumer (.subscribe/.lookup/handler_for) call sites and flags any topic with
+      # divergent .strip() chains between sides. Std-lib only; no warn-only mode.
+      - id: normalization-symmetry
+        name: ONEX Producer/Consumer Normalization Symmetry (OMN-9333)
+        entry: uv run python -m omnibase_core.validation.checker_normalization_symmetry src
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
   # ONEX Framework Validation (from shared templates)
   - repo: local
     hooks:
@@ -470,7 +483,8 @@ repos:
         # - model_epic_state.py: Tightly coupled epic state model family (ModelEpicTicketStatus, ModelEpicWave, ModelEpicState) (OMN-4405)
         # - validate_markdown_links.py: CLI script with tightly coupled data classes (LinkInfo, BrokenLink, ValidationResult, MarkdownLinkConfig) (OMN-5084)
         # - runtime_local.py: Private _ResolvedRoutingEntry co-located with RuntimeLocal (internal dataclass)
-        exclude: ^(tests/|archived/|archive/|scripts/validation/|src/omnibase_core/utils/util_singleton_holders\.py$|src/omnibase_core/models/core/model_action_config_value\.py$|src/omnibase_core/models/configuration/model_node_config_value\.py$|src/omnibase_core/mixins/mixin_event_bus\.py$|src/omnibase_core/mixins/mixin_health_check\.py$|src/omnibase_core/validation/checker_enum_governance\.py$|src/omnibase_core/types/typed_dict_demo\.py$|src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph\.py$|src/omnibase_core/models/validation/model_rule_configs\.py$|src/omnibase_core/protocols/|src/omnibase_core/models/contracts/model_cli_contribution\.py$|src/omnibase_core/navigation/model_contract_graph\.py$|src/omnibase_core/models/nodes/contract_resolve/model_contract_resolve_input\.py$|src/omnibase_core/models/nodes/contract_resolve/model_contract_resolve_output\.py$|src/omnibase_core/navigation/model_backward_chaining\.py$|src/omnibase_core/models/events/model_github_pr_status_event\.py$|src/omnibase_core/models/validation/model_validation_report\.py$|src/omnibase_core/services/service_contract_validator\.py$|src/omnibase_core/validation/validator_local_paths\.py$|src/omnibase_core/navigation/model_graph_boundary\.py$|src/omnibase_core/services/service_protocol_auditor\.py$|src/omnibase_core/contracts/contract_loader\.py$|src/omnibase_core/navigation/model_action_set\.py$|src/omnibase_core/models/ticket/model_ticket_context_bundle\.py$|src/omnibase_core/validation/scripts/validate_string_versions\.py$|src/omnibase_core/validation/scripts/timeout_utils\.py$|src/omnibase_core/models/epic/model_epic_state\.py$|src/omnibase_core/scripts/validate_markdown_links\.py$|src/omnibase_core/runtime/runtime_local\.py$)
+        # - checker_normalization_symmetry.py: Tightly coupled AST visitor + small result dataclasses (TopicUse, SymmetryIssue) — same pattern as checker_enum_governance.py (OMN-9333)
+        exclude: ^(tests/|archived/|archive/|scripts/validation/|src/omnibase_core/utils/util_singleton_holders\.py$|src/omnibase_core/models/core/model_action_config_value\.py$|src/omnibase_core/models/configuration/model_node_config_value\.py$|src/omnibase_core/mixins/mixin_event_bus\.py$|src/omnibase_core/mixins/mixin_health_check\.py$|src/omnibase_core/validation/checker_enum_governance\.py$|src/omnibase_core/validation/checker_normalization_symmetry\.py$|src/omnibase_core/types/typed_dict_demo\.py$|src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph\.py$|src/omnibase_core/models/validation/model_rule_configs\.py$|src/omnibase_core/protocols/|src/omnibase_core/models/contracts/model_cli_contribution\.py$|src/omnibase_core/navigation/model_contract_graph\.py$|src/omnibase_core/models/nodes/contract_resolve/model_contract_resolve_input\.py$|src/omnibase_core/models/nodes/contract_resolve/model_contract_resolve_output\.py$|src/omnibase_core/navigation/model_backward_chaining\.py$|src/omnibase_core/models/events/model_github_pr_status_event\.py$|src/omnibase_core/models/validation/model_validation_report\.py$|src/omnibase_core/services/service_contract_validator\.py$|src/omnibase_core/validation/validator_local_paths\.py$|src/omnibase_core/navigation/model_graph_boundary\.py$|src/omnibase_core/services/service_protocol_auditor\.py$|src/omnibase_core/contracts/contract_loader\.py$|src/omnibase_core/navigation/model_action_set\.py$|src/omnibase_core/models/ticket/model_ticket_context_bundle\.py$|src/omnibase_core/validation/scripts/validate_string_versions\.py$|src/omnibase_core/validation/scripts/timeout_utils\.py$|src/omnibase_core/models/epic/model_epic_state\.py$|src/omnibase_core/scripts/validate_markdown_links\.py$|src/omnibase_core/runtime/runtime_local\.py$)
         stages: [pre-commit]
 
       - id: validate-enum-model-imports

--- a/src/omnibase_core/validation/checker_normalization_symmetry.py
+++ b/src/omnibase_core/validation/checker_normalization_symmetry.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Checker for producer/consumer topic-normalization symmetry (OMN-9333).
+
+Detects the OMN-9215 class of bug: a producer emits ``TopicBase.X.strip()``
+while a consumer subscribes to the raw ``TopicBase.X`` (or vice versa). Unit
+tests on each side pass independently, but the dispatcher key drift only
+surfaces at runtime.
+
+Scope (minimum viable — Option A):
+    * ``.strip()`` asymmetry on ``TopicBase.X`` arguments to producer/consumer
+      call patterns.
+
+Producer patterns (anything matches = producer use):
+    * ``<any>.send(topic_expr, ...)``
+    * ``<any>.produce(topic_expr, ...)``
+    * ``<any>.publish(topic_expr, ...)``
+    * ``<any>.emit(topic_expr, ...)``
+
+Consumer patterns (anything matches = consumer use):
+    * ``<any>.subscribe([topic_expr, ...])``
+    * ``<any>.subscribe(topic_expr, ...)``
+    * ``<any>.lookup(topic_expr, ...)``
+    * ``handler_for(topic_expr)`` decorator / call
+
+Follow-ups filed:
+    * OMN-9339 Pydantic schema field-set symmetry
+    * OMN-9340 casefold/lower/upper symmetry
+    * OMN-9341 contract-YAML-driven topic discovery
+
+IMPORT ORDER CONSTRAINTS (Critical — Do Not Break):
+    * Standard library only — this module runs as a pre-commit hook without
+      project dependencies installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+_PRODUCER_METHODS: frozenset[str] = frozenset({"send", "produce", "publish", "emit"})
+_CONSUMER_METHODS: frozenset[str] = frozenset({"subscribe", "lookup"})
+_CONSUMER_FREE_FUNCTIONS: frozenset[str] = frozenset({"handler_for"})
+_TOPIC_BASE_NAME = "TopicBase"
+
+Role = Literal["producer", "consumer"]
+
+
+@dataclass(frozen=True)
+class TopicUse:
+    """A single producer- or consumer-side use of a TopicBase member."""
+
+    file_path: str
+    line_number: int
+    role: Role
+    topic_name: str
+    normalizations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SymmetryIssue:
+    """Normalization asymmetry found between producer and consumer sites."""
+
+    topic_name: str
+    producer_file: str
+    producer_line: int
+    producer_normalizations: tuple[str, ...]
+    consumer_file: str
+    consumer_line: int
+    consumer_normalizations: tuple[str, ...]
+
+    @property
+    def message(self) -> str:
+        prod = ", ".join(self.producer_normalizations) or "(none)"
+        cons = ", ".join(self.consumer_normalizations) or "(none)"
+        return (
+            f"Normalization asymmetry on TopicBase.{self.topic_name}: "
+            f"producer applies [{prod}] at {self.producer_file}:"
+            f"{self.producer_line}, consumer applies [{cons}] at "
+            f"{self.consumer_file}:{self.consumer_line}. "
+            "Normalization must match on both sides."
+        )
+
+
+class NormalizationSymmetryChecker(ast.NodeVisitor):
+    """ast.NodeVisitor that records TopicBase producer/consumer uses.
+
+    For each call-site that takes a ``TopicBase.X`` expression as its topic
+    argument, records the role (producer vs consumer) and the chain of
+    ``.strip()`` / similar normalization methods applied to the topic before
+    the call.
+
+    Also tracks single-line local-name bindings of the form
+    ``topic = TopicBase.X.strip()`` and resolves them at call sites where
+    the first argument is a bare Name. This handles the common OMN-9215
+    producer pattern of extracting the topic expression to a local before
+    ``.send(topic, payload)``.
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self.topic_uses: list[TopicUse] = []
+        self._name_bindings: dict[str, tuple[str, tuple[str, ...]]] = {}
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            topic_name, normalizations = self._extract_topic_use(node.value)
+            if topic_name is not None:
+                self._name_bindings[node.targets[0].id] = (topic_name, normalizations)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        self._record_call(node)
+        self.generic_visit(node)
+
+    def _record_call(self, node: ast.Call) -> None:
+        role = self._classify_call(node)
+        if role is None:
+            return
+
+        for arg in self._topic_arg_candidates(node):
+            topic_name, normalizations = self._extract_topic_use(arg)
+            if topic_name is None and isinstance(arg, ast.Name):
+                bound = self._name_bindings.get(arg.id)
+                if bound is not None:
+                    topic_name, normalizations = bound
+            if topic_name is None:
+                continue
+            self.topic_uses.append(
+                TopicUse(
+                    file_path=self.file_path,
+                    line_number=node.lineno,
+                    role=role,
+                    topic_name=topic_name,
+                    normalizations=normalizations,
+                )
+            )
+
+    @staticmethod
+    def _classify_call(node: ast.Call) -> Role | None:
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            attr = func.attr
+            if attr in _PRODUCER_METHODS:
+                return "producer"
+            if attr in _CONSUMER_METHODS:
+                return "consumer"
+        elif isinstance(func, ast.Name):
+            if func.id in _CONSUMER_FREE_FUNCTIONS:
+                return "consumer"
+        return None
+
+    @staticmethod
+    def _topic_arg_candidates(node: ast.Call) -> Iterable[ast.expr]:
+        """Yield argument expressions that could be a topic reference.
+
+        Producer convention: first positional arg is the topic.
+        Consumer ``.subscribe([...])`` convention: first positional arg may be
+        a list/tuple of topics. Both shapes are normalized here.
+        """
+        if not node.args:
+            return
+        first = node.args[0]
+        if isinstance(first, (ast.List, ast.Tuple)):
+            yield from first.elts
+        else:
+            yield first
+
+    @staticmethod
+    def _extract_topic_use(expr: ast.expr) -> tuple[str | None, tuple[str, ...]]:
+        """Return (topic_member_name, normalizations) or (None, ()) if not a topic ref.
+
+        Walks outward from a TopicBase.X attribute access through any chained
+        no-arg method calls (``.strip()``, etc.) to collect the normalization
+        chain applied before the topic is passed as an argument.
+        """
+        normalizations: list[str] = []
+        current = expr
+        while (
+            isinstance(current, ast.Call) and not current.args and not current.keywords
+        ):
+            inner_func = current.func
+            if not isinstance(inner_func, ast.Attribute):
+                return None, ()
+            normalizations.append(inner_func.attr)
+            current = inner_func.value
+
+        if isinstance(current, ast.Attribute) and isinstance(current.value, ast.Name):
+            if current.value.id == _TOPIC_BASE_NAME:
+                return current.attr, tuple(reversed(normalizations))
+
+        return None, ()
+
+
+def scan_source_tree(root: Path) -> list[SymmetryIssue]:
+    """Scan *root* recursively and return normalization-asymmetry findings.
+
+    Collects every producer/consumer TopicBase use across all Python files
+    under *root*, then groups by topic member name. If a topic has at least
+    one producer AND one consumer site whose normalization chains differ, a
+    ``SymmetryIssue`` is emitted pairing the first divergent sites.
+    """
+    all_uses: list[TopicUse] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        checker = NormalizationSymmetryChecker(str(path))
+        checker.visit(tree)
+        all_uses.extend(checker.topic_uses)
+
+    by_topic: dict[str, list[TopicUse]] = {}
+    for use in all_uses:
+        by_topic.setdefault(use.topic_name, []).append(use)
+
+    issues: list[SymmetryIssue] = []
+    for topic_name, uses in by_topic.items():
+        producers = [u for u in uses if u.role == "producer"]
+        consumers = [u for u in uses if u.role == "consumer"]
+        if not producers or not consumers:
+            continue
+
+        producer_chains = {u.normalizations for u in producers}
+        consumer_chains = {u.normalizations for u in consumers}
+
+        if producer_chains == consumer_chains:
+            continue
+
+        producer = producers[0]
+        consumer = consumers[0]
+        issues.append(
+            SymmetryIssue(
+                topic_name=topic_name,
+                producer_file=producer.file_path,
+                producer_line=producer.line_number,
+                producer_normalizations=producer.normalizations,
+                consumer_file=consumer.file_path,
+                consumer_line=consumer.line_number,
+                consumer_normalizations=consumer.normalizations,
+            )
+        )
+
+    return issues
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="checker-normalization-symmetry",
+        description=(
+            "Verify producer/consumer topic-normalization symmetry for the ONEX "
+            "event bus. Fails on OMN-9215-class asymmetries (e.g. producer "
+            "strips whitespace, consumer does not)."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["src"],
+        help="Directories to scan recursively for .py files (default: src)",
+    )
+    args = parser.parse_args(argv)
+
+    all_issues: list[SymmetryIssue] = []
+    for path_str in args.paths:
+        root = Path(path_str)
+        if not root.exists():
+            continue
+        all_issues.extend(scan_source_tree(root))
+
+    if not all_issues:
+        return 0
+
+    for issue in all_issues:
+        sys.stderr.write(issue.message + "\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validation/test_checker_normalization_symmetry.py
+++ b/tests/unit/validation/test_checker_normalization_symmetry.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for checker_normalization_symmetry.
+
+Detects producer/consumer topic-normalization asymmetry — specifically the
+OMN-9215 class where a producer emits ``.send(TopicBase.X.strip(), ...)`` while
+the consumer does ``.subscribe([TopicBase.X])`` unchanged, leading to dispatcher
+key drift.
+
+Minimum viable scope (OMN-9333):
+    * `.strip()` asymmetry on TopicBase.X arguments to send/subscribe/handler_for.
+    * Follow-ups filed: OMN-9339 (Pydantic), OMN-9340 (casefold), OMN-9341 (contract YAML).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validation.checker_normalization_symmetry import (
+    NormalizationSymmetryChecker,
+    scan_source_tree,
+)
+
+pytestmark = pytest.mark.unit
+
+
+RED_PRODUCER_SOURCE = '''
+"""Producer that strips whitespace off the topic before emit — OMN-9215 pattern."""
+from omnibase_core.topics import TopicBase
+
+
+class _Producer:
+    def emit(self) -> None:
+        topic = TopicBase.SESSION_STARTED.strip()
+        self._bus.send(topic, {"foo": "bar"})
+'''
+
+RED_CONSUMER_SOURCE = '''
+"""Consumer that subscribes to the raw TopicBase value — no strip."""
+from omnibase_core.topics import TopicBase
+
+
+class _Consumer:
+    def register(self) -> None:
+        self._bus.subscribe([TopicBase.SESSION_STARTED])
+'''
+
+
+GREEN_SYMMETRIC_STRIP_SOURCE = '''
+"""Both sides strip — symmetric, validator should pass."""
+from omnibase_core.topics import TopicBase
+
+
+class _Producer:
+    def emit(self) -> None:
+        topic = TopicBase.SESSION_STARTED.strip()
+        self._bus.send(topic, {})
+
+
+class _Consumer:
+    def register(self) -> None:
+        self._bus.subscribe([TopicBase.SESSION_STARTED.strip()])
+'''
+
+
+GREEN_SYMMETRIC_RAW_SOURCE = '''
+"""Neither side strips — symmetric, validator should pass."""
+from omnibase_core.topics import TopicBase
+
+
+class _Producer:
+    def emit(self) -> None:
+        self._bus.send(TopicBase.SESSION_STARTED, {})
+
+
+class _Consumer:
+    def register(self) -> None:
+        self._bus.subscribe([TopicBase.SESSION_STARTED])
+'''
+
+
+def _write_fixture(tmp_path: Path, name: str, source: str) -> Path:
+    path = tmp_path / name
+    path.write_text(source)
+    return path
+
+
+class TestNormalizationSymmetryChecker:
+    def test_flags_omn9215_whitespace_asymmetry(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "producer.py", RED_PRODUCER_SOURCE)
+        _write_fixture(tmp_path, "consumer.py", RED_CONSUMER_SOURCE)
+
+        issues = scan_source_tree(tmp_path)
+
+        assert len(issues) == 1, f"expected one asymmetry finding, got: {issues}"
+        issue = issues[0]
+        assert "SESSION_STARTED" in issue.message
+        assert "strip" in issue.message.lower()
+        assert "producer" in issue.message.lower()
+        assert "consumer" in issue.message.lower()
+
+    def test_passes_when_both_sides_strip(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "symmetric_strip.py", GREEN_SYMMETRIC_STRIP_SOURCE)
+
+        issues = scan_source_tree(tmp_path)
+
+        assert issues == [], f"unexpected findings on symmetric-strip fixture: {issues}"
+
+    def test_passes_when_neither_side_strips(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "symmetric_raw.py", GREEN_SYMMETRIC_RAW_SOURCE)
+
+        issues = scan_source_tree(tmp_path)
+
+        assert issues == [], f"unexpected findings on symmetric-raw fixture: {issues}"
+
+    def test_passes_when_no_topicbase_refs(self, tmp_path: Path) -> None:
+        _write_fixture(
+            tmp_path,
+            "unrelated.py",
+            "def f() -> int:\n    return 42\n",
+        )
+
+        issues = scan_source_tree(tmp_path)
+
+        assert issues == []
+
+    def test_ignores_producer_only_files(self, tmp_path: Path) -> None:
+        """Producer emits with strip but no consumer anywhere — no asymmetry to flag."""
+        _write_fixture(tmp_path, "producer_only.py", RED_PRODUCER_SOURCE)
+
+        issues = scan_source_tree(tmp_path)
+
+        assert issues == []
+
+    def test_checker_visitor_records_topic_uses(self) -> None:
+        """The ast.NodeVisitor records producer and consumer topic uses per file."""
+        import ast
+
+        tree = ast.parse(RED_PRODUCER_SOURCE)
+        checker = NormalizationSymmetryChecker("producer.py")
+        checker.visit(tree)
+
+        assert len(checker.topic_uses) == 1
+        use = checker.topic_uses[0]
+        assert use.role == "producer"
+        assert use.topic_name == "SESSION_STARTED"
+        assert use.normalizations == ("strip",)


### PR DESCRIPTION
## Summary

Stacked on PR #867 ([OMN-9335](https://linear.app/omninode/issue/OMN-9335) — adds canonical `omnibase_core.topics`). Must land after #867. Update base to `main` after #867 merges.

Adds an AST-based pre-commit checker that would have caught the exact [OMN-9215](https://linear.app/omninode/issue/OMN-9215) whitespace-strip asymmetry at commit time.

## What it detects

For every `TopicBase.X` value, walks all `.py` files under `src/` and finds:

- **Producer sites** — `.send / .produce / .publish / .emit(topic_expr, ...)` calls.
- **Consumer sites** — `.subscribe / .lookup(topic_expr, ...)` calls and `handler_for(topic_expr)` calls/decorators.

Records the chain of no-arg method calls (`.strip()`, etc.) applied to the topic expression before the call. Also resolves single-line `topic = TopicBase.X.strip()` local bindings when the call site is `.send(topic, ...)`. If producer normalization chains differ from consumer normalization chains for the same topic, the checker fails with both file/line sites and the observed diff.

## Scope (minimum viable — Option A approved)

Catches `.strip()` asymmetry only. Explicitly out of scope (filed as follow-ups):
- [OMN-9339](https://linear.app/omninode/issue/OMN-9339) — Pydantic schema field-set symmetry.
- [OMN-9340](https://linear.app/omninode/issue/OMN-9340) — casefold/lower/upper symmetry.
- [OMN-9341](https://linear.app/omninode/issue/OMN-9341) — contract-YAML-driven topic discovery.

Principle: \"Three similar lines better than premature abstraction\" — ship what catches the next OMN-9215-class regression immediately; layer in broader dimensions as separate tickets with their own fixtures.

## BLOCKING mode

Per memory `feedback_no_informational_gates` — no `--advisory`, no warn-only. Wired as a BLOCKING `pre-commit` stage hook in this PR; `required status check on main across 11 repos` lands in the bot-propagation PR that follows the release.

## Test plan

- [x] Red fixture (OMN-9215 asymmetric strip, producer/consumer in separate files) → checker flags with producer+consumer sites and \"strip\" in the message.
- [x] Green fixture: both sides strip → passes.
- [x] Green fixture: neither side strips → passes.
- [x] Ignores files with no `TopicBase` references.
- [x] Ignores producer-only files (no consumer anywhere to be asymmetric with).
- [x] `NormalizationSymmetryChecker(ast.NodeVisitor)` direct unit test: records `('producer', 'SESSION_STARTED', ('strip',))` for the RED fixture.
- [x] `uv run pytest tests/unit/validation/test_checker_normalization_symmetry.py` — 6/6 pass, 1.39s.
- [x] `uv run mypy --strict` clean on the checker module.
- [x] `uv run ruff format` + `ruff check` clean.
- [x] `pre-commit run` on all staged files — every ONEX gate passes, including the new `normalization-symmetry` hook itself (which runs against `src/` and finds no asymmetries in current code — expected).
- [ ] CI green on this PR.

## Design notes

- **Std-lib only.** Runs as a pre-commit hook without `uv sync` of the project; the checker imports only `argparse`, `ast`, `sys`, `dataclasses`, `pathlib`, `collections.abc`, `typing`.
- **AST-based, not regex.** Mirrors `checker_generic_pattern.py` / `checker_enum_governance.py` conventions.
- **Contract-driven** (via the TopicBase enum in the canonical `omnibase_core.topics` module introduced in #867). The enum IS the wire-format truth — checker attributes are grounded in it.
- **Follows established single-class-per-file exemption pattern** — added alongside `checker_enum_governance.py` in the exclusion list (tightly-coupled AST visitor + small result dataclasses).

## Linked

- Ticket: [OMN-9333](https://linear.app/omninode/issue/OMN-9333) (Urgent)
- Related class-of-bug: [OMN-9215](https://linear.app/omninode/issue/OMN-9215), [OMN-9285](https://linear.app/omninode/issue/OMN-9285), [OMN-9283](https://linear.app/omninode/issue/OMN-9283)
- Depends on: PR #867 ([OMN-9335](https://linear.app/omninode/issue/OMN-9335))
- Follow-ups: [OMN-9339](https://linear.app/omninode/issue/OMN-9339), [OMN-9340](https://linear.app/omninode/issue/OMN-9340), [OMN-9341](https://linear.app/omninode/issue/OMN-9341)