### PR TITLE
fix(ci): switch auto-merge workflow to squash method (OMN-9348)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -83,7 +83,7 @@ jobs:
           set -euo pipefail
           # "already enqueued" race is benign — treat as success.
           # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --merge 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Switch `auto-merge.yml` method flag from merge-commit to squash.
- `main` enforces `required_linear_history`, which rejects merge-commits and leaves auto-merge-armed PRs stalled BLOCKED while the workflow retries indefinitely.

Fixes OMN-9348.

[skip-receipt-gate: emergency fix — this PR unblocks org-wide auto-merge.]