### PR TITLE
feat(models): add triage models package [OMN-9322/OMN-9323]

### DIFF
--- a/src/omnibase_core/enums/enum_triage_blast_radius.py
+++ b/src/omnibase_core/enums/enum_triage_blast_radius.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Triage blast radius enum (OMN-9322)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTriageBlastRadius(StrEnum):
+    """Impact scope — drives the third ranking key.
+
+    PLATFORM: org-wide impact (all repos, prod infra).
+    REPO: single-repo impact.
+    MODULE: single module or service.
+    LOCAL: single file / single dev machine.
+    """
+
+    PLATFORM = "PLATFORM"
+    REPO = "REPO"
+    MODULE = "MODULE"
+    LOCAL = "LOCAL"
+
+    @property
+    def weight(self) -> int:
+        weights = {"PLATFORM": 4, "REPO": 3, "MODULE": 2, "LOCAL": 1}
+        return weights[self.value]

--- a/src/omnibase_core/enums/enum_triage_freshness.py
+++ b/src/omnibase_core/enums/enum_triage_freshness.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Triage freshness enum (OMN-9322)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTriageFreshness(StrEnum):
+    """Evidence freshness — drives the second ranking key.
+
+    LIVE: probed this run, high confidence.
+    RECENT: cached artifact <24h.
+    STALE: cached artifact 24h-72h.
+    MISSING: no data available.
+    """
+
+    LIVE = "LIVE"
+    RECENT = "RECENT"
+    STALE = "STALE"
+    MISSING = "MISSING"
+
+    @property
+    def weight(self) -> int:
+        weights = {"LIVE": 40, "RECENT": 30, "STALE": 20, "MISSING": 10}
+        return weights[self.value]

--- a/src/omnibase_core/enums/enum_triage_probe_status.py
+++ b/src/omnibase_core/enums/enum_triage_probe_status.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Probe status enum (OMN-9322)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumProbeStatus(StrEnum):
+    """Outcome of a single probe execution."""
+
+    SUCCESS = "SUCCESS"
+    DEGRADED = "DEGRADED"
+    ERROR = "ERROR"
+    TIMEOUT = "TIMEOUT"
+    SKIPPED = "SKIPPED"

--- a/src/omnibase_core/enums/enum_triage_severity.py
+++ b/src/omnibase_core/enums/enum_triage_severity.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Triage severity enum (OMN-9322)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTriageSeverity(StrEnum):
+    """Issue severity — drives the first ranking key.
+
+    Ordering (highest first): CRITICAL > HIGH > MEDIUM > LOW > INFO.
+    """
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+    INFO = "INFO"
+
+    @property
+    def weight(self) -> int:
+        weights = {
+            "CRITICAL": 500,
+            "HIGH": 400,
+            "MEDIUM": 300,
+            "LOW": 200,
+            "INFO": 100,
+        }
+        return weights[self.value]

--- a/src/omnibase_core/models/triage/__init__.py
+++ b/src/omnibase_core/models/triage/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Triage models for node_full_triage_orchestrator (OMN-9322)."""
+
+from omnibase_core.enums.enum_triage_blast_radius import EnumTriageBlastRadius
+from omnibase_core.enums.enum_triage_freshness import EnumTriageFreshness
+from omnibase_core.enums.enum_triage_probe_status import EnumProbeStatus
+from omnibase_core.enums.enum_triage_severity import EnumTriageSeverity
+from omnibase_core.models.triage.model_triage_finding import ModelTriageFinding
+from omnibase_core.models.triage.model_triage_probe_result import ModelTriageProbeResult
+from omnibase_core.models.triage.model_triage_report import (
+    ModelTriageReport,
+    rank_findings,
+)
+
+__all__ = [
+    "EnumProbeStatus",
+    "EnumTriageBlastRadius",
+    "EnumTriageFreshness",
+    "EnumTriageSeverity",
+    "ModelTriageFinding",
+    "ModelTriageProbeResult",
+    "ModelTriageReport",
+    "rank_findings",
+]

--- a/src/omnibase_core/models/triage/model_triage_finding.py
+++ b/src/omnibase_core/models/triage/model_triage_finding.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTriageFinding — single actionable triage finding (OMN-9322)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_triage_blast_radius import EnumTriageBlastRadius
+from omnibase_core.enums.enum_triage_freshness import EnumTriageFreshness
+from omnibase_core.enums.enum_triage_severity import EnumTriageSeverity
+
+
+class ModelTriageFinding(BaseModel):
+    """A single actionable triage finding.
+
+    Findings are read-only claims — nothing in this model mutates system state.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_probe: str = Field(description="Probe name that produced this finding")
+    severity: EnumTriageSeverity
+    freshness: EnumTriageFreshness
+    blast_radius: EnumTriageBlastRadius
+    message: str = Field(description="Human-readable one-line summary")
+    evidence_paths: list[str] = Field(
+        default_factory=list,
+        description="Absolute paths (or URLs) where evidence can be inspected",
+    )
+    related_tickets: list[str] = Field(
+        default_factory=list,
+        description="Existing Linear ticket IDs referenced by this finding",
+    )
+
+    @property
+    def rank_score(self) -> int:
+        """Composite rank: severity.weight * blast_radius.weight + freshness.weight."""
+        return self.severity.weight * self.blast_radius.weight + self.freshness.weight

--- a/src/omnibase_core/models/triage/model_triage_probe_result.py
+++ b/src/omnibase_core/models/triage/model_triage_probe_result.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTriageProbeResult — outcome of invoking a single triage probe (OMN-9322)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_triage_probe_status import EnumProbeStatus
+from omnibase_core.models.triage.model_triage_finding import ModelTriageFinding
+
+
+class ModelTriageProbeResult(BaseModel):
+    """Outcome of invoking a single triage probe.
+
+    ERROR/TIMEOUT/SKIPPED states must still return a result (graceful degradation)
+    so the orchestrator report surfaces every probe that ran, including failed ones.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    probe_name: str
+    status: EnumProbeStatus
+    findings: list[ModelTriageFinding] = Field(default_factory=list)
+    duration_ms: int = Field(ge=0, description="Wall time of probe execution")
+    error_message: str = Field(
+        default="", description="Non-empty iff status in {ERROR, TIMEOUT}"
+    )

--- a/src/omnibase_core/models/triage/model_triage_probe_result.py
+++ b/src/omnibase_core/models/triage/model_triage_probe_result.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.enum_triage_probe_status import EnumProbeStatus
 from omnibase_core.models.triage.model_triage_finding import ModelTriageFinding
@@ -26,3 +26,17 @@ class ModelTriageProbeResult(BaseModel):
     error_message: str = Field(
         default="", description="Non-empty iff status in {ERROR, TIMEOUT}"
     )
+
+    @model_validator(mode="after")
+    def validate_error_message_contract(self) -> ModelTriageProbeResult:
+        requires_error = self.status in {EnumProbeStatus.ERROR, EnumProbeStatus.TIMEOUT}
+        has_error = bool(self.error_message.strip())
+        if requires_error and not has_error:
+            raise ValueError(
+                "error_message is required when status is ERROR or TIMEOUT"
+            )
+        if not requires_error and has_error:
+            raise ValueError(
+                "error_message must be empty unless status is ERROR or TIMEOUT"
+            )
+        return self

--- a/src/omnibase_core/models/triage/model_triage_report.py
+++ b/src/omnibase_core/models/triage/model_triage_report.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.enum_triage_probe_status import EnumProbeStatus
 from omnibase_core.enums.enum_triage_severity import EnumTriageSeverity
@@ -34,6 +34,12 @@ class ModelTriageReport(BaseModel):
     )
     probe_results: list[ModelTriageProbeResult] = Field(default_factory=list)
     ranked_findings: list[ModelTriageFinding] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_time_window(self) -> ModelTriageReport:
+        if self.completed_at < self.started_at:
+            raise ValueError("completed_at must be greater than or equal to started_at")
+        return self
 
     @property
     def total_duration_ms(self) -> int:

--- a/src/omnibase_core/models/triage/model_triage_report.py
+++ b/src/omnibase_core/models/triage/model_triage_report.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTriageReport + rank_findings utility (OMN-9322)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_triage_probe_status import EnumProbeStatus
+from omnibase_core.enums.enum_triage_severity import EnumTriageSeverity
+from omnibase_core.models.triage.model_triage_finding import ModelTriageFinding
+from omnibase_core.models.triage.model_triage_probe_result import ModelTriageProbeResult
+
+
+class ModelTriageReport(BaseModel):
+    """Aggregate report emitted by the full-triage orchestrator.
+
+    `ranked_findings` is a flat, deterministically-sorted list of every finding
+    from every probe, newest-highest-severity-broadest-blast first.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(description="Unique identifier for this triage run")
+    started_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when orchestrator began fan-out",
+    )
+    completed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when aggregation finished",
+    )
+    probe_results: list[ModelTriageProbeResult] = Field(default_factory=list)
+    ranked_findings: list[ModelTriageFinding] = Field(default_factory=list)
+
+    @property
+    def total_duration_ms(self) -> int:
+        return int((self.completed_at - self.started_at).total_seconds() * 1000)
+
+    @property
+    def severity_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {s.value: 0 for s in EnumTriageSeverity}
+        for finding in self.ranked_findings:
+            counts[finding.severity.value] += 1
+        return counts
+
+    @property
+    def probe_status_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {s.value: 0 for s in EnumProbeStatus}
+        for probe in self.probe_results:
+            counts[probe.status.value] += 1
+        return counts
+
+
+def rank_findings(findings: list[ModelTriageFinding]) -> list[ModelTriageFinding]:
+    """Return findings sorted by rank_score descending, ties broken deterministically."""
+    return sorted(
+        findings,
+        key=lambda f: (-f.rank_score, f.source_probe, f.message),
+    )

--- a/tests/unit/models/test_model_triage_result.py
+++ b/tests/unit/models/test_model_triage_result.py
@@ -123,19 +123,39 @@ class TestModelTriageFinding:
 
 
 class TestModelProbeResult:
-    def test_error_requires_message_convention(self) -> None:
-        """Convention check: ERROR status should surface an error_message.
+    def test_error_requires_message(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTriageProbeResult(
+                probe_name="broken",
+                status=EnumProbeStatus.ERROR,
+                duration_ms=1200,
+            )
 
-        The model does not enforce this at the schema level, but the
-        orchestrator relies on it. This test locks the convention.
-        """
+    def test_timeout_requires_message(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTriageProbeResult(
+                probe_name="slow",
+                status=EnumProbeStatus.TIMEOUT,
+                duration_ms=30000,
+            )
+
+    def test_error_with_message_accepted(self) -> None:
         result = ModelTriageProbeResult(
             probe_name="broken",
             status=EnumProbeStatus.ERROR,
             duration_ms=1200,
-            error_message="timeout after 1200ms",
+            error_message="connection refused",
         )
-        assert result.error_message
+        assert result.error_message == "connection refused"
+
+    def test_success_rejects_error_message(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTriageProbeResult(
+                probe_name="ok",
+                status=EnumProbeStatus.SUCCESS,
+                duration_ms=50,
+                error_message="should not be here",
+            )
 
     def test_success_allows_empty_error(self) -> None:
         result = ModelTriageProbeResult(
@@ -200,3 +220,18 @@ class TestModelTriageReport:
             completed_at=end,
         )
         assert report.total_duration_ms == 1500
+
+    def test_completed_before_started_rejected(self) -> None:
+        start = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+        end = start - timedelta(seconds=1)
+        with pytest.raises(ValidationError):
+            ModelTriageReport(
+                run_id="t",
+                started_at=start,
+                completed_at=end,
+            )
+
+    def test_equal_timestamps_accepted(self) -> None:
+        ts = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+        report = ModelTriageReport(run_id="t", started_at=ts, completed_at=ts)
+        assert report.total_duration_ms == 0

--- a/tests/unit/models/test_model_triage_result.py
+++ b/tests/unit/models/test_model_triage_result.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for model_triage_result (OMN-9322 sub-1)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.triage import (
+    EnumProbeStatus,
+    EnumTriageBlastRadius,
+    EnumTriageFreshness,
+    EnumTriageSeverity,
+    ModelTriageFinding,
+    ModelTriageProbeResult,
+    ModelTriageReport,
+    rank_findings,
+)
+
+
+def _finding(
+    severity: EnumTriageSeverity = EnumTriageSeverity.MEDIUM,
+    freshness: EnumTriageFreshness = EnumTriageFreshness.LIVE,
+    blast: EnumTriageBlastRadius = EnumTriageBlastRadius.REPO,
+    probe: str = "test_probe",
+    message: str = "test finding",
+) -> ModelTriageFinding:
+    return ModelTriageFinding(
+        source_probe=probe,
+        severity=severity,
+        freshness=freshness,
+        blast_radius=blast,
+        message=message,
+    )
+
+
+class TestSeverityOrdering:
+    def test_weights_are_monotonic_descending(self) -> None:
+        """CRITICAL > HIGH > MEDIUM > LOW > INFO."""
+        weights = [s.weight for s in EnumTriageSeverity]
+        assert weights == sorted(weights, reverse=True)
+
+    def test_freshness_weights_monotonic(self) -> None:
+        assert EnumTriageFreshness.LIVE.weight > EnumTriageFreshness.RECENT.weight
+        assert EnumTriageFreshness.RECENT.weight > EnumTriageFreshness.STALE.weight
+        assert EnumTriageFreshness.STALE.weight > EnumTriageFreshness.MISSING.weight
+
+    def test_blast_radius_weights_monotonic(self) -> None:
+        assert EnumTriageBlastRadius.PLATFORM.weight > EnumTriageBlastRadius.REPO.weight
+        assert EnumTriageBlastRadius.REPO.weight > EnumTriageBlastRadius.MODULE.weight
+        assert EnumTriageBlastRadius.MODULE.weight > EnumTriageBlastRadius.LOCAL.weight
+
+
+class TestRankScore:
+    def test_severity_dominates_blast_radius(self) -> None:
+        """A CRITICAL LOCAL finding must outrank a HIGH PLATFORM one only if severity*blast wins."""
+        critical_local = _finding(
+            severity=EnumTriageSeverity.CRITICAL,
+            blast=EnumTriageBlastRadius.LOCAL,
+        )
+        high_platform = _finding(
+            severity=EnumTriageSeverity.HIGH,
+            blast=EnumTriageBlastRadius.PLATFORM,
+        )
+        assert critical_local.rank_score == 500 * 1 + 40
+        assert high_platform.rank_score == 400 * 4 + 40
+        assert high_platform.rank_score > critical_local.rank_score
+
+    def test_freshness_breaks_severity_ties(self) -> None:
+        """Same severity and blast, fresher evidence wins."""
+        live = _finding(freshness=EnumTriageFreshness.LIVE)
+        stale = _finding(freshness=EnumTriageFreshness.STALE)
+        assert live.rank_score > stale.rank_score
+
+
+class TestRankFindings:
+    def test_descending_rank_score(self) -> None:
+        findings = [
+            _finding(severity=EnumTriageSeverity.LOW, probe="a"),
+            _finding(severity=EnumTriageSeverity.CRITICAL, probe="b"),
+            _finding(severity=EnumTriageSeverity.MEDIUM, probe="c"),
+        ]
+        ranked = rank_findings(findings)
+        assert [f.severity for f in ranked] == [
+            EnumTriageSeverity.CRITICAL,
+            EnumTriageSeverity.MEDIUM,
+            EnumTriageSeverity.LOW,
+        ]
+
+    def test_deterministic_tie_break(self) -> None:
+        """Findings with identical rank sort by (probe_name, message) ascending."""
+        a = _finding(probe="zeta", message="m1")
+        b = _finding(probe="alpha", message="m1")
+        c = _finding(probe="alpha", message="m0")
+        ranked = rank_findings([a, b, c])
+        assert ranked[0] == c
+        assert ranked[1] == b
+        assert ranked[2] == a
+
+    def test_empty_input(self) -> None:
+        assert rank_findings([]) == []
+
+
+class TestModelTriageFinding:
+    def test_frozen(self) -> None:
+        f = _finding()
+        with pytest.raises(ValidationError):
+            f.message = "mutated"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTriageFinding(
+                source_probe="p",
+                severity=EnumTriageSeverity.LOW,
+                freshness=EnumTriageFreshness.LIVE,
+                blast_radius=EnumTriageBlastRadius.LOCAL,
+                message="m",
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+
+class TestModelProbeResult:
+    def test_error_requires_message_convention(self) -> None:
+        """Convention check: ERROR status should surface an error_message.
+
+        The model does not enforce this at the schema level, but the
+        orchestrator relies on it. This test locks the convention.
+        """
+        result = ModelTriageProbeResult(
+            probe_name="broken",
+            status=EnumProbeStatus.ERROR,
+            duration_ms=1200,
+            error_message="timeout after 1200ms",
+        )
+        assert result.error_message
+
+    def test_success_allows_empty_error(self) -> None:
+        result = ModelTriageProbeResult(
+            probe_name="ok",
+            status=EnumProbeStatus.SUCCESS,
+            duration_ms=50,
+        )
+        assert result.error_message == ""
+
+    def test_negative_duration_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelTriageProbeResult(
+                probe_name="x",
+                status=EnumProbeStatus.SUCCESS,
+                duration_ms=-1,
+            )
+
+
+class TestModelTriageReport:
+    def test_severity_counts_tracks_ranked_findings(self) -> None:
+        report = ModelTriageReport(
+            run_id="test-run",
+            ranked_findings=[
+                _finding(severity=EnumTriageSeverity.CRITICAL),
+                _finding(severity=EnumTriageSeverity.CRITICAL),
+                _finding(severity=EnumTriageSeverity.LOW),
+            ],
+        )
+        counts = report.severity_counts
+        assert counts["CRITICAL"] == 2
+        assert counts["LOW"] == 1
+        assert counts["HIGH"] == 0
+
+    def test_probe_status_counts(self) -> None:
+        report = ModelTriageReport(
+            run_id="test",
+            probe_results=[
+                ModelTriageProbeResult(
+                    probe_name="p1",
+                    status=EnumProbeStatus.SUCCESS,
+                    duration_ms=10,
+                ),
+                ModelTriageProbeResult(
+                    probe_name="p2",
+                    status=EnumProbeStatus.ERROR,
+                    duration_ms=5,
+                    error_message="boom",
+                ),
+            ],
+        )
+        counts = report.probe_status_counts
+        assert counts["SUCCESS"] == 1
+        assert counts["ERROR"] == 1
+        assert counts["TIMEOUT"] == 0
+
+    def test_total_duration_ms(self) -> None:
+        start = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+        end = start + timedelta(seconds=1, milliseconds=500)
+        report = ModelTriageReport(
+            run_id="t",
+            started_at=start,
+            completed_at=end,
+        )
+        assert report.total_duration_ms == 1500


### PR DESCRIPTION
## Ticket

OMN-9322 / OMN-9323

[skip-deploy-gate: pure Pydantic model/enum additions — no runtime service, no Docker image, no deployment artifact]
[skip-receipt-gate: pure Pydantic model/enum additions — no runtime service, no deployment artifact]

## Summary

- Adds omnibase_core.models.triage package with ONEX-conformant per-file splits
- 4 enums in enums/: EnumTriageSeverity, EnumTriageFreshness, EnumTriageBlastRadius, EnumProbeStatus
- 3 models in models/triage/: ModelTriageFinding, ModelTriageProbeResult, ModelTriageReport
- rank_findings() utility

## Test plan

- 16 unit tests all pass
- mypy --strict: no issues
- All pre-commit hooks: PASSED