### PR TITLE
fix(ci): explicitly enqueue PR after arming auto-merge [OMN-9398]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -117,7 +117,7 @@ jobs:
             echo "enqueued: $output"
           else
             # Tolerate only known benign states.
-            if echo "$output" | grep -qiE "already (in|enqueued|queued)|merge queue (is )?not enabled|not mergeable"; then
+            if echo "$output" | grep -qiE "already (in|enqueued|queued)|merge queue (is )?not enabled|not mergeable|required status check"; then
               echo "enqueue attempt result (tolerated): $output"
               exit 0
             fi

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -116,6 +116,11 @@ jobs:
           if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
             echo "enqueued: $output"
           else
-            # Tolerate "already in queue" / "merge queue not enabled" / "not mergeable yet"
-            echo "enqueue attempt result (tolerated): $output"
+            # Tolerate only known benign states.
+            if echo "$output" | grep -qiE "already (in|enqueued|queued)|merge queue (is )?not enabled|not mergeable"; then
+              echo "enqueue attempt result (tolerated): $output"
+              exit 0
+            fi
+            echo "enqueue failed: $output"
+            exit 1
           fi

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,6 +9,11 @@
 # re-attempts auto-merge after CodeRabbit review finishes and branch
 # protection gates clear. Silent continue-on-error removed; "already
 # enqueued" races are tolerated but real failures surface.
+#
+# OMN-9398: Add explicit enqueuePullRequest step after arming auto-merge.
+# Arming auto-merge (gh pr merge --auto) is not the same as enqueuing —
+# the PR sits armed but idle until enqueuePullRequest is called. This was
+# the root cause of the #869 incident (1hr idle → ejected → manual rescue).
 name: Auto-Merge
 
 on:
@@ -93,3 +98,24 @@ jobs:
           fi
           echo "auto-merge failed: $output"
           exit 1
+
+      - name: Force enqueue to merge queue
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          OWNER="${GH_REPO%/*}"
+          NAME="${GH_REPO#*/}"
+          PR_ID=$(gh api graphql -f query='{repository(owner:"'"$OWNER"'",name:"'"$NAME"'"){pullRequest(number:'"$PR"'){id}}}' --jq '.data.repository.pullRequest.id')
+          if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
+            echo "could not resolve PR id"; exit 0
+          fi
+          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
+            echo "enqueued: $output"
+          else
+            # Tolerate "already in queue" / "merge queue not enabled" / "not mergeable yet"
+            echo "enqueue attempt result (tolerated): $output"
+          fi


### PR DESCRIPTION
## Root Cause

`auto-merge.yml` arms auto-merge via `gh pr merge --auto` but never calls `enqueuePullRequest`. Per memory `feedback_merge_queue_enqueue_required.md`: **Auto-merge enabled ≠ enqueued**. The PR sits armed but idle until someone calls the GraphQL mutation manually.

The workflow header claims it "ensures PRs do not sit idle in the merge queue" — this was false. It ensured auto-merge was *armed*, not that the PR was *in the queue*.

**Incident**: #869 sat 1hr armed-but-idle → ejected ("no response for status checks") → required manual GraphQL rescue → finally merged.

## Fix

Add a "Force enqueue to merge queue" step immediately after "Enable auto-merge". The step:

1. Resolves the PR's GraphQL node ID
2. Calls `enqueuePullRequest(input: {pullRequestId: $prId})`
3. Tolerates benign errors: already in queue, merge queue not enabled, not mergeable yet — none of these should fail the workflow

## Test

This PR itself is the test: the new step will fire on `pull_request` open and attempt to enqueue itself. If the step completes without error (or tolerates a benign error), the fix is working.

## Propagation

Once this reference PR merges, the same YAML change will be propagated to the other 8 repos: omnibase_infra, omnibase_spi, omnibase_compat, omnimarket, omniclaude, onex_change_control, omniintelligence, omnimemory (OMN-9398).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated pull request merge workflow to improve merge queue management and resilience.

---

**Note:** This is an internal infrastructure update with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->