### PR TITLE
fix(ci): propagator bot dedup — open-PR check + ticket ref in title [OMN-9344]

### DIFF
--- a/.github/workflows/propagate-config.yml
+++ b/.github/workflows/propagate-config.yml
@@ -20,6 +20,18 @@
 name: Propagate config across downstream repos
 
 on:
+  push:
+    paths:
+      - .github/workflows/propagate-config.yml
+      - .github/propagation-targets.yaml
+      - scripts/propagate-config.sh
+      - tests/scripts/test_propagate_config.py
+  pull_request:
+    paths:
+      - .github/workflows/propagate-config.yml
+      - .github/propagation-targets.yaml
+      - scripts/propagate-config.sh
+      - tests/scripts/test_propagate_config.py
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/propagate-config.yml
+++ b/.github/workflows/propagate-config.yml
@@ -20,18 +20,6 @@
 name: Propagate config across downstream repos
 
 on:
-  push:
-    paths:
-      - .github/workflows/propagate-config.yml
-      - .github/propagation-targets.yaml
-      - scripts/propagate-config.sh
-      - tests/scripts/test_propagate_config.py
-  pull_request:
-    paths:
-      - .github/workflows/propagate-config.yml
-      - .github/propagation-targets.yaml
-      - scripts/propagate-config.sh
-      - tests/scripts/test_propagate_config.py
   release:
     types: [published]
   workflow_dispatch:

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -61,6 +61,15 @@ if match is None:
     sys.exit(3)
 
 supported_ops = {"append_hook_entry"}
+supported_merge_methods = {"queue_default", "squash", "merge", "rebase"}
+merge_method = match.get("merge_method", "queue_default")
+if merge_method not in supported_merge_methods:
+    sys.stderr.write(
+        f"ERROR: unsupported merge_method '{merge_method}' "
+        f"(supported: {sorted(supported_merge_methods)})\n"
+    )
+    sys.exit(5)
+
 for target in match.get("targets") or []:
     op = target.get("operation")
     if op not in supported_ops:
@@ -69,7 +78,7 @@ for target in match.get("targets") or []:
 
 print(json.dumps({
     "auto_merge": bool(match.get("auto_merge", False)),
-    "merge_method": match.get("merge_method", "queue_default"),
+    "merge_method": merge_method,
     "targets": match.get("targets") or [],
 }))
 PY
@@ -122,6 +131,9 @@ EOF
   trap "rm -rf $TMPDIR" EXIT
   pushd "$TMPDIR" >/dev/null
 
+  # gh repo clone uses GITHUB_TOKEN for the initial clone, but subsequent
+  # git push requires git credentials configured separately.
+  gh auth setup-git
   gh repo clone "$REPO" downstream -- --depth=5
   cd downstream
 

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -110,7 +110,9 @@ EOF
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "DRY_RUN: gh pr create --repo ${REPO} --head ${BRANCH} --base main --title \"${TITLE}\""
     if [[ "$AUTO_MERGE" == "True" || "$AUTO_MERGE" == "true" ]]; then
-      echo "DRY_RUN: gh pr merge --repo ${REPO} --auto --${MERGE_METHOD/queue_default/squash} <pr-number>"
+      # Per OMN-8838: always arm auto-merge via GraphQL enablePullRequestAutoMerge
+      # (never `gh pr merge --auto` — it silently picks the wrong method).
+      echo "DRY_RUN: gh api graphql enablePullRequestAutoMerge(mergeMethod: SQUASH) --auto ${REPO}#<pr>"
     fi
     continue
   fi
@@ -156,14 +158,20 @@ SNIPPET
 
   if [[ "$AUTO_MERGE" == "True" || "$AUTO_MERGE" == "true" ]]; then
     PR_NUMBER="$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')"
-    # queue_default == merge queue arms auto-merge without choosing a method;
-    # fall back to --squash for repos that predate merge queues.
-    if [[ "$MERGE_METHOD" == "queue_default" ]]; then
-      gh pr merge "$PR_NUMBER" --repo "$REPO" --auto || \
-        gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
-    else
-      gh pr merge "$PR_NUMBER" --repo "$REPO" --auto "--${MERGE_METHOD}"
-    fi
+    # Per OMN-8838 + memory reference_github_merge_queue_api: always arm
+    # auto-merge via GraphQL enablePullRequestAutoMerge with explicit
+    # mergeMethod. `gh pr merge --auto` silently picks the wrong method on
+    # merge-queue-enabled repos.
+    case "$MERGE_METHOD" in
+      queue_default|squash) GRAPHQL_METHOD="SQUASH" ;;
+      merge) GRAPHQL_METHOD="MERGE" ;;
+      rebase) GRAPHQL_METHOD="REBASE" ;;
+      *) echo "ERROR: unknown merge_method '$MERGE_METHOD'" >&2; exit 5 ;;
+    esac
+    PR_ID="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.node_id')"
+    gh api graphql \
+      -f query='mutation($id:ID!,$m:PullRequestMergeMethod!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:$m}){pullRequest{number}}}' \
+      -f id="$PR_ID" -f m="$GRAPHQL_METHOD"
   fi
 
   popd >/dev/null

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -102,7 +102,7 @@ for i in $(seq 0 $((TARGET_COUNT - 1))); do
   FILE_PATH="$(python3 -c 'import json,sys;i=int(sys.argv[2]);print(json.loads(sys.argv[1])["targets"][i]["path"])' "$PROPAGATION_JSON" "$i")"
   HOOK_ID="$(python3 -c 'import json,sys;i=int(sys.argv[2]);print(json.loads(sys.argv[1])["targets"][i]["hook_id"])' "$PROPAGATION_JSON" "$i")"
 
-  TITLE="chore(ci): propagate ${PROPAGATION_NAME} to ${FILE_PATH} [bot]"
+  TITLE="chore(ci): propagate ${PROPAGATION_NAME} to ${FILE_PATH} [bot] [OMN-9344]"
   BODY=$(cat <<EOF
 Automated config propagation emitted by \`omnibase_core/propagate-config.yml\`.
 
@@ -117,6 +117,7 @@ EOF
 )
 
   if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY_RUN: gh pr list --repo ${REPO} --state open --search \"propagate ${PROPAGATION_NAME}\" (dedup check)"
     echo "DRY_RUN: gh pr create --repo ${REPO} --head ${BRANCH} --base main --title \"${TITLE}\""
     if [[ "$AUTO_MERGE" == "True" || "$AUTO_MERGE" == "true" ]]; then
       # Per OMN-8838: always arm auto-merge via GraphQL enablePullRequestAutoMerge
@@ -136,6 +137,20 @@ EOF
   gh auth setup-git
   gh repo clone "$REPO" downstream -- --depth=5
   cd downstream
+
+  # Dedup: skip if an open bot PR for this propagation already exists. Each
+  # workflow_dispatch gets a unique manual-<run_id> tag, so without this check
+  # every re-run opens a fresh PR even though the previous one is still open.
+  EXISTING_PR="$(gh pr list --repo "$REPO" --state open \
+    --search "propagate ${PROPAGATION_NAME}" --json number,headRefName \
+    --jq "[.[] | select(.headRefName | startswith(\"bot/propagate-${PROPAGATION_NAME}-\"))] | first | .number" 2>/dev/null || true)"
+  if [[ -n "$EXISTING_PR" && "$EXISTING_PR" != "null" ]]; then
+    echo "SKIP: ${REPO} already has open PR #${EXISTING_PR} for propagation ${PROPAGATION_NAME}"
+    popd >/dev/null
+    rm -rf "$TMPDIR"
+    trap - EXIT
+    continue
+  fi
 
   if [[ ! -f "$FILE_PATH" ]]; then
     echo "ERROR: ${REPO} is missing ${FILE_PATH} — skipping to avoid creating invalid config" >&2
@@ -171,7 +186,7 @@ SNIPPET
   git config user.email "bot@omninode.ai"
   git checkout -b "$BRANCH"
   git add "$FILE_PATH"
-  git commit -m "chore(ci): propagate ${PROPAGATION_NAME} [bot] [OMN-9344]"
+  git commit -m "chore(ci): propagate ${PROPAGATION_NAME} [bot]"
   git push -u origin "$BRANCH" --force-with-lease
 
   PR_URL="$(gh pr create --repo "$REPO" --head "$BRANCH" --base main \

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -125,6 +125,14 @@ EOF
   gh repo clone "$REPO" downstream -- --depth=5
   cd downstream
 
+  if [[ ! -f "$FILE_PATH" ]]; then
+    echo "ERROR: ${REPO} is missing ${FILE_PATH} — skipping to avoid creating invalid config" >&2
+    popd >/dev/null
+    rm -rf "$TMPDIR"
+    trap - EXIT
+    continue
+  fi
+
   if grep -q "id:\s*${HOOK_ID}" "$FILE_PATH" 2>/dev/null; then
     echo "SKIP: ${REPO} already contains hook ${HOOK_ID} in ${FILE_PATH}"
     popd >/dev/null

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -61,15 +61,6 @@ if match is None:
     sys.exit(3)
 
 supported_ops = {"append_hook_entry"}
-supported_merge_methods = {"queue_default", "squash", "merge", "rebase"}
-merge_method = match.get("merge_method", "queue_default")
-if merge_method not in supported_merge_methods:
-    sys.stderr.write(
-        f"ERROR: unsupported merge_method '{merge_method}' "
-        f"(supported: {sorted(supported_merge_methods)})\n"
-    )
-    sys.exit(5)
-
 for target in match.get("targets") or []:
     op = target.get("operation")
     if op not in supported_ops:
@@ -78,7 +69,7 @@ for target in match.get("targets") or []:
 
 print(json.dumps({
     "auto_merge": bool(match.get("auto_merge", False)),
-    "merge_method": merge_method,
+    "merge_method": match.get("merge_method", "queue_default"),
     "targets": match.get("targets") or [],
 }))
 PY
@@ -119,9 +110,7 @@ EOF
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "DRY_RUN: gh pr create --repo ${REPO} --head ${BRANCH} --base main --title \"${TITLE}\""
     if [[ "$AUTO_MERGE" == "True" || "$AUTO_MERGE" == "true" ]]; then
-      # Per OMN-8838: always arm auto-merge via GraphQL enablePullRequestAutoMerge
-      # (never `gh pr merge --auto` — it silently picks the wrong method).
-      echo "DRY_RUN: gh api graphql enablePullRequestAutoMerge(mergeMethod: SQUASH) --auto ${REPO}#<pr>"
+      echo "DRY_RUN: gh pr merge --repo ${REPO} --auto --${MERGE_METHOD/queue_default/squash} <pr-number>"
     fi
     continue
   fi
@@ -131,25 +120,12 @@ EOF
   trap "rm -rf $TMPDIR" EXIT
   pushd "$TMPDIR" >/dev/null
 
-  # gh repo clone uses GITHUB_TOKEN for the initial clone, but subsequent
-  # git push requires git credentials configured separately.
-  gh auth setup-git
   gh repo clone "$REPO" downstream -- --depth=5
   cd downstream
-
-  if [[ ! -f "$FILE_PATH" ]]; then
-    echo "ERROR: ${REPO} is missing ${FILE_PATH} — skipping to avoid creating invalid config" >&2
-    popd >/dev/null
-    rm -rf "$TMPDIR"
-    trap - EXIT
-    continue
-  fi
 
   if grep -q "id:\s*${HOOK_ID}" "$FILE_PATH" 2>/dev/null; then
     echo "SKIP: ${REPO} already contains hook ${HOOK_ID} in ${FILE_PATH}"
     popd >/dev/null
-    rm -rf "$TMPDIR"
-    trap - EXIT
     continue
   fi
 
@@ -180,20 +156,14 @@ SNIPPET
 
   if [[ "$AUTO_MERGE" == "True" || "$AUTO_MERGE" == "true" ]]; then
     PR_NUMBER="$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')"
-    # Per OMN-8838 + memory reference_github_merge_queue_api: always arm
-    # auto-merge via GraphQL enablePullRequestAutoMerge with explicit
-    # mergeMethod. `gh pr merge --auto` silently picks the wrong method on
-    # merge-queue-enabled repos.
-    case "$MERGE_METHOD" in
-      queue_default|squash) GRAPHQL_METHOD="SQUASH" ;;
-      merge) GRAPHQL_METHOD="MERGE" ;;
-      rebase) GRAPHQL_METHOD="REBASE" ;;
-      *) echo "ERROR: unknown merge_method '$MERGE_METHOD'" >&2; exit 5 ;;
-    esac
-    PR_ID="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.node_id')"
-    gh api graphql \
-      -f query='mutation($id:ID!,$m:PullRequestMergeMethod!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:$m}){pullRequest{number}}}' \
-      -f id="$PR_ID" -f m="$GRAPHQL_METHOD"
+    # queue_default == merge queue arms auto-merge without choosing a method;
+    # fall back to --squash for repos that predate merge queues.
+    if [[ "$MERGE_METHOD" == "queue_default" ]]; then
+      gh pr merge "$PR_NUMBER" --repo "$REPO" --auto || \
+        gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+    else
+      gh pr merge "$PR_NUMBER" --repo "$REPO" --auto "--${MERGE_METHOD}"
+    fi
   fi
 
   popd >/dev/null

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -148,6 +148,8 @@ EOF
   if grep -q "id:\s*${HOOK_ID}" "$FILE_PATH" 2>/dev/null; then
     echo "SKIP: ${REPO} already contains hook ${HOOK_ID} in ${FILE_PATH}"
     popd >/dev/null
+    rm -rf "$TMPDIR"
+    trap - EXIT
     continue
   fi
 

--- a/scripts/propagate-config.sh
+++ b/scripts/propagate-config.sh
@@ -128,6 +128,20 @@ EOF
   fi
 
   # Live path (executed inside GitHub Actions runner with gh + git configured).
+
+  # Dedup: refuse to create a second PR if one is already open for this branch.
+  # Uses exit-status check instead of || true to surface auth/API failures.
+  if ! EXISTING_PR="$(gh pr list --repo "$REPO" --state open \
+    --search "propagate ${PROPAGATION_NAME}" --json number,headRefName \
+    --jq "[.[] | select(.headRefName | startswith(\"bot/propagate-${PROPAGATION_NAME}-\"))] | first | .number" 2>/dev/null)"; then
+    echo "ERROR: dedup check failed for ${REPO}; refusing to proceed blindly" >&2
+    continue
+  fi
+  if [[ -n "$EXISTING_PR" && "$EXISTING_PR" != "null" ]]; then
+    echo "SKIP: ${REPO} already has open PR #${EXISTING_PR} for branch ${BRANCH}"
+    continue
+  fi
+
   TMPDIR="$(mktemp -d)"
   trap "rm -rf $TMPDIR" EXIT
   pushd "$TMPDIR" >/dev/null

--- a/tests/scripts/test_propagate_config.py
+++ b/tests/scripts/test_propagate_config.py
@@ -125,6 +125,27 @@ def test_unknown_propagation_name_exits_nonzero(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_unsupported_merge_method_rejected(tmp_path: Path) -> None:
+    targets = _write_targets(
+        tmp_path,
+        """
+        propagations:
+          - name: normalization-symmetry-hook
+            targets:
+              - repo: OmniNode-ai/omnibase_infra
+                path: .pre-commit-config.yaml
+                operation: append_hook_entry
+                hook_id: normalization-symmetry
+            auto_merge: true
+            merge_method: invalid_method
+        """,
+    )
+    result = _run(targets)
+    assert result.returncode != 0
+    assert "unsupported merge_method" in (result.stderr + result.stdout).lower()
+
+
+@pytest.mark.unit
 def test_unsupported_operation_rejected(tmp_path: Path) -> None:
     targets = _write_targets(
         tmp_path,

--- a/tests/scripts/test_propagate_config.py
+++ b/tests/scripts/test_propagate_config.py
@@ -49,6 +49,56 @@ def _run(
 
 
 @pytest.mark.unit
+def test_pr_title_includes_ticket_ref(tmp_path: Path) -> None:
+    targets = _write_targets(
+        tmp_path,
+        """
+        propagations:
+          - name: normalization-symmetry-hook
+            targets:
+              - repo: OmniNode-ai/omnibase_infra
+                path: .pre-commit-config.yaml
+                operation: append_hook_entry
+                hook_id: normalization-symmetry
+            auto_merge: false
+            merge_method: queue_default
+        """,
+    )
+    result = _run(targets)
+    assert result.returncode == 0, result.stderr
+    create_lines = [
+        line for line in result.stdout.splitlines() if "gh pr create" in line
+    ]
+    assert len(create_lines) == 1
+    assert "OMN-9344" in create_lines[0], (
+        f"PR title missing OMN-9344 ticket ref: {create_lines[0]}"
+    )
+
+
+@pytest.mark.unit
+def test_dry_run_emits_dedup_check(tmp_path: Path) -> None:
+    targets = _write_targets(
+        tmp_path,
+        """
+        propagations:
+          - name: normalization-symmetry-hook
+            targets:
+              - repo: OmniNode-ai/omnibase_infra
+                path: .pre-commit-config.yaml
+                operation: append_hook_entry
+                hook_id: normalization-symmetry
+            auto_merge: false
+            merge_method: queue_default
+        """,
+    )
+    result = _run(targets)
+    assert result.returncode == 0, result.stderr
+    assert "dedup check" in result.stdout, (
+        f"Expected dedup check in dry-run output: {result.stdout}"
+    )
+
+
+@pytest.mark.unit
 def test_dry_run_emits_one_pr_per_target(tmp_path: Path) -> None:
     targets = _write_targets(
         tmp_path,

--- a/tests/scripts/test_propagate_config.py
+++ b/tests/scripts/test_propagate_config.py
@@ -102,8 +102,10 @@ def test_dry_run_arms_auto_merge_per_pr(tmp_path: Path) -> None:
     )
     result = _run(targets)
     assert result.returncode == 0, result.stderr
-    assert "DRY_RUN: gh pr merge" in result.stdout, result.stdout
-    assert "--auto" in result.stdout
+    # Per OMN-8838: auto-merge is armed via GraphQL enablePullRequestAutoMerge,
+    # never `gh pr merge --auto` (which silently picks the wrong method).
+    assert "enablePullRequestAutoMerge" in result.stdout, result.stdout
+    assert "SQUASH" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/scripts/test_propagate_config.py
+++ b/tests/scripts/test_propagate_config.py
@@ -102,10 +102,8 @@ def test_dry_run_arms_auto_merge_per_pr(tmp_path: Path) -> None:
     )
     result = _run(targets)
     assert result.returncode == 0, result.stderr
-    # Per OMN-8838: auto-merge is armed via GraphQL enablePullRequestAutoMerge,
-    # never `gh pr merge --auto` (which silently picks the wrong method).
-    assert "enablePullRequestAutoMerge" in result.stdout, result.stdout
-    assert "SQUASH" in result.stdout
+    assert "DRY_RUN: gh pr merge" in result.stdout, result.stdout
+    assert "--auto" in result.stdout
 
 
 @pytest.mark.unit
@@ -122,27 +120,6 @@ def test_unknown_propagation_name_exits_nonzero(tmp_path: Path) -> None:
     )
     result = _run(targets, propagation_name="normalization-symmetry-hook")
     assert result.returncode != 0
-
-
-@pytest.mark.unit
-def test_unsupported_merge_method_rejected(tmp_path: Path) -> None:
-    targets = _write_targets(
-        tmp_path,
-        """
-        propagations:
-          - name: normalization-symmetry-hook
-            targets:
-              - repo: OmniNode-ai/omnibase_infra
-                path: .pre-commit-config.yaml
-                operation: append_hook_entry
-                hook_id: normalization-symmetry
-            auto_merge: true
-            merge_method: invalid_method
-        """,
-    )
-    result = _run(targets)
-    assert result.returncode != 0
-    assert "unsupported merge_method" in (result.stderr + result.stdout).lower()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Root cause**: each `workflow_dispatch` generated a unique `manual-<run_id>` tag, producing `BRANCH=bot/propagate-<name>-<run_id>`. Since the idempotency check only compared hook presence in main (not open PRs), every re-run created a fresh branch and PR, generating 14 duplicates across omnibase_compat and omnimemory.
- **Fix 1 (dedup)**: added open-PR check per target repo before cloning — skips if any open bot PR already exists with the same propagation name prefix.
- **Fix 2 (pr-title-check)**: added `[OMN-9344]` to the bot-generated PR title; was failing the `pr-title / check-title` gate.
- **Fix 3 (contract-compliance-check)**: removed `[OMN-9344]` from the git commit message. The compliance check was extracting the ticket ID from commits and failing because `contracts/OMN-9344.yaml` doesn't exist in each downstream repo.
- **Cleanup**: closed 7 duplicate PRs in omnibase_compat (#68–#74, kept #75) and 7 in omnimemory (#270–#276, kept #277).

## Test plan

- [ ] `uv run pytest tests/scripts/test_propagate_config.py -v -m unit` — 7 tests pass
- [ ] `test_pr_title_includes_ticket_ref` asserts `[OMN-9344]` present in generated title
- [ ] `test_dry_run_emits_dedup_check` asserts dedup check is emitted in dry-run output
- [ ] Pre-commit hooks pass locally
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagation PR titles now include tracking tokens while commit messages omit them.
  * Live deduplication prevents creating duplicate propagation PRs when one already exists; dry-run shows planned dedup checks.

* **Tests**
  * Added unit tests verifying PR title tracking token inclusion and dry-run deduplication output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->