### PR TITLE
chore(release): bump version to 0.40.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.39.0"
+version = "0.40.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.39.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
[skip-receipt-gate: version-bump chore — no new code, releasing modules already merged via OMN-9335 (PR #867)]

## Summary

- Bumps \`pyproject.toml\` version from \`0.39.0\` → \`0.40.0\`
- Updates \`uv.lock\` to reflect new version

## Why

Commit \`9a353982\` (PR #867, merged 2026-04-20, OMN-9335) added two new modules to main **after** the \`v0.39.0\` tag was cut (2026-04-06):
- \`omnibase_core.validation.checker_normalization_symmetry\`
- \`omnibase_core.topics\` (TopicBase + build_topic helpers)

Without a new release, \`ccc#301\` and 7 downstream bot PRs remain blocked because those modules are not available on PyPI.

## Release mechanism

On merge, the \`Auto-Tag on Merge\` workflow detects the \`release\` label, reads \`pyproject.toml\`, creates tag \`v0.40.0\`, and pushes it. The tag push triggers the \`Release\` workflow which builds and publishes to PyPI, then fires \`dependency-cascade\` to open lockfile-bump PRs in downstream repos.

## Test plan
- [ ] CI green on this PR
- [ ] Auto-tag creates \`v0.40.0\` on merge
- [ ] Release workflow publishes \`omnibase-core==0.40.0\` to PyPI
- [ ] \`ccc-uv-bump-fixer\` unblocks after PyPI confirms publish