### PR TITLE
ci(deps): cascade omnibase_core releases to onex_change_control [OMN-9425]

### DIFF
--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -8,9 +8,13 @@
 # to pick up the new version.
 #
 # Downstream mapping:
-#   omnibase_core  -> omnibase_infra, omniintelligence, omnimemory, omniclaude
+#   omnibase_core  -> omnibase_infra, omniintelligence, omnimemory, omniclaude, onex_change_control
 #   omnibase_spi   -> omnibase_infra, omniintelligence, omnimemory, omniclaude
 #   omnibase_infra -> omniintelligence, omnimemory, omniclaude
+#
+# Note (OMN-9425): onex_change_control depends on omnibase-core only (not spi/infra);
+# see onex_change_control/pyproject.toml. If ccc later adds spi or infra deps,
+# extend the corresponding cases below.
 #
 # This workflow is reusable so that omnibase_core and omnibase_spi can also call
 # it from their own release workflows.
@@ -72,7 +76,7 @@ jobs:
 
           case "$PACKAGE" in
             omnibase_core)
-              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude"]'
+              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude", "onex_change_control"]'
               ;;
             omnibase_spi)
               REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude"]'

--- a/tests/scripts/test_dependency_cascade_matrix.py
+++ b/tests/scripts/test_dependency_cascade_matrix.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for .github/workflows/dependency-cascade.yml downstream matrix.
+
+OMN-9425: the cascade workflow opens dependency-bump PRs in downstream repos
+when a foundation package (omnibase_core / omnibase_spi / omnibase_infra) is
+released. The downstream set is hardcoded in a shell ``case`` statement inside
+the workflow and has silently drifted from the actual consumer list in the past
+(ccc was missing even though onex_change_control depends on omnibase-core).
+
+This test parses the workflow YAML, extracts the ``case`` block, and asserts
+that each foundation package's downstream list contains every repo that
+actually consumes it — guarding against future omissions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "dependency-cascade.yml"
+
+
+def _extract_case_mapping() -> dict[str, list[str]]:
+    """Parse the ``case "$PACKAGE" in ... esac`` block in the workflow.
+
+    Returns a dict mapping each foundation package name to its list of
+    downstream repos, exactly as the workflow will emit them at runtime.
+    """
+    content = WORKFLOW_PATH.read_text()
+    case_re = re.compile(
+        r"(?P<pkg>[a-z_]+)\)\s*\n\s*REPOS=\'(?P<repos>\[[^\]]*\])\'",
+        re.MULTILINE,
+    )
+    mapping: dict[str, list[str]] = {}
+    for match in case_re.finditer(content):
+        pkg = match.group("pkg")
+        repos = json.loads(match.group("repos"))
+        mapping[pkg] = repos
+    return mapping
+
+
+@pytest.mark.unit
+def test_workflow_yaml_parses() -> None:
+    """The workflow file must be valid YAML."""
+    with WORKFLOW_PATH.open() as fh:
+        doc = yaml.safe_load(fh)
+    assert doc["name"] == "Dependency Cascade"
+
+
+@pytest.mark.unit
+def test_omnibase_core_cascades_to_onex_change_control() -> None:
+    """OMN-9425: ccc's uv.lock must be auto-bumped on omnibase_core release.
+
+    onex_change_control depends on omnibase-core (see ccc/pyproject.toml).
+    Without this entry, ccc PRs block on stale lockfiles when new core
+    modules ship, as happened with ccc#301 pre-OMN-9425.
+    """
+    mapping = _extract_case_mapping()
+    assert "omnibase_core" in mapping, (
+        "omnibase_core case missing from dependency-cascade.yml"
+    )
+    assert "onex_change_control" in mapping["omnibase_core"], (
+        "onex_change_control must be in the omnibase_core downstream matrix; "
+        "without it, ccc's uv.lock won't auto-bump on core releases "
+        "(see OMN-9425 and the ccc#301 regression)."
+    )
+
+
+@pytest.mark.unit
+def test_all_foundation_packages_have_downstream_lists() -> None:
+    """Each foundation package in the docstring must have a case branch."""
+    mapping = _extract_case_mapping()
+    expected = {"omnibase_core", "omnibase_spi", "omnibase_infra"}
+    assert expected.issubset(mapping.keys()), (
+        f"Missing case branches for: {expected - mapping.keys()}"
+    )
+
+
+@pytest.mark.unit
+def test_downstream_lists_are_non_empty_and_unique() -> None:
+    """Sanity: every case emits at least one repo and no duplicates."""
+    mapping = _extract_case_mapping()
+    for pkg, repos in mapping.items():
+        assert repos, f"{pkg}: downstream list is empty"
+        assert len(repos) == len(set(repos)), (
+            f"{pkg}: downstream list has duplicates: {repos}"
+        )
+
+
+@pytest.mark.unit
+def test_omnibase_spi_and_infra_exclude_ccc() -> None:
+    """ccc does not hard-depend on spi or infra; keep them out.
+
+    Guard against over-eager additions. If ccc's pyproject.toml ever gains a
+    spi or infra dependency, update the workflow case AND this test together.
+    """
+    mapping = _extract_case_mapping()
+    assert "onex_change_control" not in mapping.get("omnibase_spi", []), (
+        "ccc does not depend on omnibase-spi; see onex_change_control/pyproject.toml"
+    )
+    assert "onex_change_control" not in mapping.get("omnibase_infra", []), (
+        "ccc does not depend on omnibase-infra; see onex_change_control/pyproject.toml"
+    )


### PR DESCRIPTION
## Summary

- Add `onex_change_control` to the `omnibase_core` downstream matrix in `.github/workflows/dependency-cascade.yml`, closing the gap that caused ccc#301 and 7 bot PRs to block on a stale uv.lock when 0.40.0 shipped new modules.
- ccc depends only on `omnibase-core` (see `onex_change_control/pyproject.toml`), so the spi and infra cases are intentionally unchanged.
- New test `tests/scripts/test_dependency_cascade_matrix.py` parses the workflow YAML and locks in the mapping so future omissions fail CI instead of silently drifting.

Linear: [OMN-9425](https://linear.app/omninode/issue/OMN-9425)

## Why not `dependents.yaml`?

The ticket suggested making the matrix configurable. Propagation *targets* already live in `.github/propagation-targets.yaml` (OMN-9344), which includes ccc. The cascade workflow's shell `case` is a different mechanism, and generalizing it is out of scope for this fix — the test now guards the current shape so the next round of refactoring can replace the `case` statement without losing coverage.

## Test plan

- [x] `uv run pytest tests/scripts/test_dependency_cascade_matrix.py -v` (5/5 pass)
- [x] Pre-commit hooks clean on commit and push
- [ ] CI green on PR
- [ ] On next omnibase_core release, a bump PR appears in onex_change_control

## Notes

- PAT permissions for `OmniNode-ai/onex_change_control` are already in place (propagate-config.sh has been opening PRs there since OMN-9344), so no secret/permission changes needed.