### PR TITLE
fix(runtime): persist handler_result for compute-mode + fallback-ok marker [OMN-9467]

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -998,6 +998,8 @@ class RuntimeLocal:
             handle_method, method_name, handler_instance, initial_payload
         )
 
+        if result_obj is not None:
+            self._handler_result = result_obj
         self._result = self._classify_result(result_obj)
         logger.info(
             "RuntimeLocal: compute handler returned, result=%s", self._result.value
@@ -1217,6 +1219,8 @@ class RuntimeLocal:
                     )
                     data["handler_result"] = serialized
             except (TypeError, ValueError, OverflowError):
+                # fallback-ok: persist a best-effort representation when the
+                # handler result cannot be fully serialized to JSON.
                 data["handler_result"] = repr(self._handler_result)
         result_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         logger.info("RuntimeLocal: wrote state to %s", result_path)

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -185,6 +185,8 @@ class RuntimeLocal:
         self._events_received: dict[str, int] = {}
         self._last_error: str | None = None
         self._handlers_wired: list[str] = []
+        self._terminal_payload: dict[str, Any] | None = None
+        self._handler_result: Any = None
 
     # ONEX_EXCLUDE: dict_str_any — event bus payload
     def _on_terminal_event(self, payload: dict[str, Any]) -> None:
@@ -196,6 +198,7 @@ class RuntimeLocal:
 
         status = payload.get("status", "success")
         logger.info("RuntimeLocal: terminal event received (status=%s)", status)
+        self._terminal_payload = payload
         if status == "failure":
             self._result = EnumWorkflowResult.FAILED
         else:
@@ -422,6 +425,7 @@ class RuntimeLocal:
         # failure), preserve that result rather than overwriting with a classification
         # of None.
         if result_obj is not None:
+            self._handler_result = result_obj
             self._result = self._classify_result(result_obj)
             await self._publish_synthesized_terminal(bus, terminal_topic)
             logger.info("RuntimeLocal: handler returned, result=%s", self._result.value)
@@ -1194,11 +1198,26 @@ class RuntimeLocal:
         """Serialize workflow result to ``state_root/workflow_result.json``."""
         self.state_root.mkdir(parents=True, exist_ok=True)
         result_path = self.state_root / "workflow_result.json"
-        data = {
+        data: dict[str, Any] = {
             "result": self._result.value,
             "exit_code": self.exit_code,
             "workflow": str(self.workflow_path),
         }
+        if self._terminal_payload is not None:
+            data["terminal_payload"] = self._terminal_payload
+        if self._handler_result is not None:
+            try:
+                if hasattr(self._handler_result, "model_dump"):
+                    data["handler_result"] = self._handler_result.model_dump(
+                        mode="json"
+                    )
+                else:
+                    serialized = json.loads(
+                        json.dumps(self._handler_result, default=repr)
+                    )
+                    data["handler_result"] = serialized
+            except (TypeError, ValueError, OverflowError):
+                data["handler_result"] = repr(self._handler_result)
         result_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         logger.info("RuntimeLocal: wrote state to %s", result_path)
 

--- a/tests/unit/runtime/test_runtime_local_execution.py
+++ b/tests/unit/runtime/test_runtime_local_execution.py
@@ -550,6 +550,69 @@ def test_compute_mode_writes_state(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_compute_mode_persists_handler_result(tmp_path: Path) -> None:
+    """Compute mode sets _handler_result and writes handler_result to workflow_result.json.
+
+    Regression: _run_compute() previously classified result_obj but never assigned
+    self._handler_result, so workflow_result.json omitted 'handler_result' for the
+    main CLI path (onex node <name> --input <file>). OMN-9467.
+    """
+    import sys
+    import types
+
+    from pydantic import BaseModel
+
+    class _HandlerOutput(BaseModel):
+        status: str
+        data: str
+
+    class _ResultHandler:
+        def handle(self, _input: Any = None) -> _HandlerOutput:
+            return _HandlerOutput(status="success", data="compute-result")
+
+    mod = types.ModuleType("_test_compute_handler_result_mod")
+    mod._ResultHandler = _ResultHandler  # type: ignore[attr-defined]
+    sys.modules["_test_compute_handler_result_mod"] = mod
+
+    try:
+        yaml_text = (
+            "name: test_handler_result\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: compute\n"
+            "description: handler_result persistence test\n"
+            "handler_routing:\n"
+            "  default_handler: _test_compute_handler_result_mod:_ResultHandler\n"
+        )
+        workflow = tmp_path / "handler_result.yaml"
+        workflow.write_text(yaml_text)
+        state_dir = tmp_path / "state"
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=state_dir,
+            timeout=5,
+        )
+        result = runtime.run()
+        assert result == EnumWorkflowResult.COMPLETED
+
+        # _handler_result must be set on the runtime instance
+        assert runtime._handler_result is not None
+        assert isinstance(runtime._handler_result, _HandlerOutput)
+        assert runtime._handler_result.data == "compute-result"
+
+        # workflow_result.json must include handler_result
+        result_file = state_dir / "workflow_result.json"
+        assert result_file.exists()
+        data = json.loads(result_file.read_text())
+        assert "handler_result" in data, (
+            "handler_result missing from workflow_result.json"
+        )
+        assert data["handler_result"]["status"] == "success"
+        assert data["handler_result"]["data"] == "compute-result"
+    finally:
+        sys.modules.pop("_test_compute_handler_result_mod", None)
+
+
+@pytest.mark.unit
 def test_no_terminal_event_no_default_handler_fails(tmp_path: Path) -> None:
     """Contract with neither terminal_event nor default_handler fails."""
     yaml_text = (


### PR DESCRIPTION
## Summary
- `_run_compute()` now sets `self._handler_result = result_obj` when result is non-None, matching the existing single-handler path. Previously compute-mode classified `result_obj` but discarded it — `workflow_result.json` omitted `handler_result` for the main CLI flow (`onex node <name> --input <file>`).
- The `except (TypeError, ValueError, OverflowError)` serialization fallback in `_write_state()` now carries the required `# fallback-ok:` marker per Error Handling conventions in CLAUDE.md.
- Added `test_compute_mode_persists_handler_result` covering both invariants.

## Context
OpenCode skill wrappers (`omniopencode`) call `onex node <name> --input <file>` and need the handler's actual output (merged/blocked PRs, review findings, etc.) not just a success/fail status. Previously RuntimeLocal discarded all handler output after reducing it to a 4-value enum.

Ticket: OMN-9467

[skip-deploy-gate: runtime_local.py change is logic-only — no Docker, no kernel wiring, no container restart required. Adds field assignment + comment. No deploy needed.]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow state management to capture and persist terminal and handler execution outputs for improved debugging and execution history tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->