### PR TITLE
chore: remove polymorphic-agent references from models and tests [OMN-9504]

### DIFF
--- a/src/omnibase_core/models/audit/model_task_dispatch.py
+++ b/src/omnibase_core/models/audit/model_task_dispatch.py
@@ -51,7 +51,7 @@ class ModelTaskDispatch(BaseModel):
         ...,
         min_length=1,
         max_length=256,
-        description="Type of agent dispatched (e.g., 'onex:polymorphic-agent')",
+        description="Type of agent dispatched (e.g., 'onex:general-purpose')",
     )
 
     tool_scope: list[str] = Field(

--- a/tests/unit/models/audit/test_model_task_dispatch.py
+++ b/tests/unit/models/audit/test_model_task_dispatch.py
@@ -19,10 +19,10 @@ class TestModelTaskDispatch:
 
     def test_minimal_construction(self) -> None:
         dispatch = ModelTaskDispatch(
-            agent_type="onex:polymorphic-agent",
+            agent_type="onex:general-purpose",
         )
         assert isinstance(dispatch.task_id, UUID)
-        assert dispatch.agent_type == "onex:polymorphic-agent"
+        assert dispatch.agent_type == "onex:general-purpose"
         assert dispatch.parent_task_id is None
         assert dispatch.tool_scope == []
         assert dispatch.context_budget_tokens is None
@@ -40,7 +40,7 @@ class TestModelTaskDispatch:
         dispatch = ModelTaskDispatch(
             task_id=task_uuid,
             parent_task_id=parent_uuid,
-            agent_type="onex:polymorphic-agent",
+            agent_type="onex:general-purpose",
             tool_scope=["Bash", "Read", "Write"],
             context_budget_tokens=50000,
             session_id=session_uuid,
@@ -59,7 +59,7 @@ class TestModelTaskDispatch:
 
     def test_frozen_immutability(self) -> None:
         dispatch = ModelTaskDispatch(
-            agent_type="onex:polymorphic-agent",
+            agent_type="onex:general-purpose",
         )
         with pytest.raises(ValidationError):
             dispatch.agent_type = "changed"  # type: ignore[misc]
@@ -67,7 +67,7 @@ class TestModelTaskDispatch:
     def test_context_budget_minimum(self) -> None:
         with pytest.raises(ValidationError):
             ModelTaskDispatch(
-                agent_type="onex:polymorphic-agent",
+                agent_type="onex:general-purpose",
                 context_budget_tokens=0,
             )
 
@@ -80,7 +80,7 @@ class TestModelTaskTree:
         self,
         task_id: UUID | None = None,
         parent_task_id: UUID | None = None,
-        agent_type: str = "onex:polymorphic-agent",
+        agent_type: str = "onex:general-purpose",
     ) -> ModelTaskDispatch:
         return ModelTaskDispatch(
             task_id=task_id or uuid4(),


### PR DESCRIPTION
## Summary
- Replace `polymorphic-agent` with `general-purpose` in model docstrings, test fixtures, and field descriptions
- Part of the broader polymorphic-agent scrub epic (OMN-9504)

## Testing
- All pre-commit hooks pass (ruff, mypy, pyright)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal default values and associated test fixtures to maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->