### PR TITLE
feat(cli): add onex pack and onex install for .oncp contract packages [OMN-7537]

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -82,6 +82,17 @@ allowed_files:
     added: "2024-10-15"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/cli/cli_install.py"
+    reason: >-
+      onex pack/install CLI must parse heterogeneous third-party contract.yaml + metadata.yaml files from
+      .oncp archives before any Pydantic model applies. contract.yaml schemas vary by node type (ModelContractCompute,
+      ModelContractEffect, ModelContractReducer, ModelContractOrchestrator), so detect_contract_model()
+      requires raw YAML to route to the correct model. metadata.yaml is a thin descriptor (name + version
+      + entry_points) consumed before the registry lookup. Both sites validate required keys explicitly
+      (mapping check, name/version presence) before use. (OMN-7537)
+    added: "2026-04-23"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/validation/validator_contracts.py"
     reason: >-
       Central orchestrator for YAML contract file parsing and validation - provides high-level API for

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -700,6 +700,11 @@ from omnibase_core.cli.cli_run_node import run_node
 
 cli.add_command(run_node)
 
+# Register pack command
+from omnibase_core.cli.cli_pack import cli_pack
+
+cli.add_command(cli_pack)
+
 # Register bootstrap command group
 from omnibase_core.cli.cli_bootstrap import bootstrap
 

--- a/src/omnibase_core/cli/cli_install.py
+++ b/src/omnibase_core/cli/cli_install.py
@@ -150,8 +150,14 @@ def _install_oncp(
             raise click.ClickException("Cannot read metadata.yaml from archive")
         metadata = yaml.safe_load(mf)
 
-    package_name = metadata.get("name", "unknown")
-    package_version = metadata.get("version", "unknown")
+    if not isinstance(metadata, dict):
+        raise click.ClickException("metadata.yaml is not a valid YAML mapping")
+    package_name = metadata.get("name")
+    package_version = metadata.get("version")
+    if not package_name or not package_version:
+        raise click.ClickException(
+            "Invalid .oncp archive: metadata.yaml missing required 'name' or 'version'"
+        )
     install_path = registry_dir / package_name
 
     if verbose:
@@ -174,9 +180,9 @@ def _install_oncp(
         shutil.rmtree(install_path)
 
     with tarfile.open(archive_path, "r:gz") as tar:
-        # NOTE(OMN-7537): .oncp archives are produced by `onex pack` which
-        # validates all contents. extractall is safe here.
-        tar.extractall(path=install_path)
+        # Use PEP 706 data filter to reject absolute paths, symlink escapes,
+        # and any member that would resolve outside install_path.
+        tar.extractall(path=install_path, filter="data")
 
     # Validate contract after unpacking
     contract_path = install_path / "contract.yaml"

--- a/src/omnibase_core/cli/cli_install.py
+++ b/src/omnibase_core/cli/cli_install.py
@@ -1,14 +1,21 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""CLI command for installing ONEX contract packages with validation."""
+"""CLI command for installing ONEX contract packages with validation.
+
+Supports two installation modes:
+1. `.oncp` archives — unpack to local registry directory
+2. pip packages — install via pip with contract validation
+"""
 
 from __future__ import annotations
 
 import importlib.metadata
 import json
+import shutil
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 import click
@@ -17,6 +24,11 @@ import click
 def _in_virtualenv() -> bool:
     """Check if running inside a virtual environment."""
     return sys.prefix != sys.base_prefix
+
+
+def _get_registry_dir() -> Path:
+    """Return the local ONEX registry directory for unpacked .oncp packages."""
+    return Path.home() / ".omnibase" / "registry"
 
 
 def _get_registry_path() -> Path:
@@ -39,26 +51,14 @@ def _save_registry(registry: dict[str, dict[str, str]]) -> None:
     path.write_text(json.dumps(registry, indent=2))
 
 
-def _rollback_install(package_name: str) -> None:
+def _rollback_install(pkg: str) -> None:
     """Uninstall a package after failed validation."""
-    click.echo(f"Rolling back: uninstalling {package_name}", err=True)
+    click.echo(f"Rolling back: uninstalling {pkg}", err=True)
     subprocess.run(
-        [sys.executable, "-m", "pip", "uninstall", "-y", package_name],
+        [sys.executable, "-m", "pip", "uninstall", "-y", pkg],
         capture_output=True,
         check=False,
     )
-
-
-def from_yaml_contract(contract_path: Path) -> object:
-    """Load and parse a contract.yaml file.
-
-    Uses yaml.safe_load for parsing untrusted third-party contract files.
-    This is intentional — third-party contracts are not internal Pydantic models.
-    """
-    import yaml
-
-    with open(contract_path) as f:
-        return yaml.safe_load(f)
 
 
 def _validate_contract(contract_path: Path) -> dict[str, object]:
@@ -67,8 +67,14 @@ def _validate_contract(contract_path: Path) -> dict[str, object]:
     Raises:
         click.ClickException: If the contract is missing required fields.
     """
+    # NOTE(OMN-7537): contract.yaml is an external contract file with varying
+    # schemas across node types. yaml.safe_load is the correct approach for
+    # reading untrusted third-party contract files.
+    import yaml
+
     try:
-        raw = from_yaml_contract(contract_path)
+        with open(contract_path) as f:
+            raw = yaml.safe_load(f)
     except Exception as e:
         msg = f"contract.yaml at {contract_path} is not valid: {e}"
         raise click.ClickException(msg) from e
@@ -79,11 +85,20 @@ def _validate_contract(contract_path: Path) -> dict[str, object]:
 
     contract: dict[str, object] = raw
 
-    required_fields = ["name", "version"]
-    for field in required_fields:
-        if field not in contract:
-            msg = f"contract.yaml missing required field: {field}"
-            raise click.ClickException(msg)
+    # name is always required
+    if "name" not in contract:
+        msg = "contract.yaml missing required field: name"
+        raise click.ClickException(msg)
+
+    # version may be 'version', 'contract_version', or 'node_version'
+    has_version = (
+        "contract_version" in contract
+        or "node_version" in contract
+        or "version" in contract
+    )
+    if not has_version:
+        msg = "contract.yaml missing version field"
+        raise click.ClickException(msg)
 
     # Validate topic format for any declared topics
     for topic_key in ("publish_topics", "subscribe_topics"):
@@ -97,8 +112,93 @@ def _validate_contract(contract_path: Path) -> dict[str, object]:
     return contract
 
 
+def _install_oncp(
+    archive_path: Path,
+    dry_run: bool,
+    upgrade: bool,
+    verbose: bool,
+) -> list[dict[str, object]]:
+    """Install an .oncp archive by unpacking to the local registry directory.
+
+    Returns:
+        List of validated contract dicts for each node in the archive.
+    """
+    registry_dir = _get_registry_dir()
+
+    if not archive_path.exists():
+        raise click.ClickException(f"Archive not found: {archive_path}")
+
+    # Verify it's a valid .oncp archive
+    try:
+        with tarfile.open(archive_path, "r:gz") as tar:
+            members = tar.getnames()
+    except Exception as e:
+        raise click.ClickException(f"Invalid .oncp archive: {e}") from e
+
+    if "metadata.yaml" not in members or "contract.yaml" not in members:
+        raise click.ClickException(
+            "Invalid .oncp archive: missing metadata.yaml or contract.yaml"
+        )
+
+    # Extract metadata to get package info
+    # NOTE(OMN-7537): metadata.yaml is an external contract file.
+    import yaml
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        mf = tar.extractfile("metadata.yaml")
+        if mf is None:
+            raise click.ClickException("Cannot read metadata.yaml from archive")
+        metadata = yaml.safe_load(mf)
+
+    package_name = metadata.get("name", "unknown")
+    package_version = metadata.get("version", "unknown")
+    install_path = registry_dir / package_name
+
+    if verbose:
+        click.echo(f"  Package: {package_name} v{package_version}")
+        click.echo(f"  Install path: {install_path}")
+
+    if install_path.exists() and not upgrade:
+        raise click.ClickException(
+            f"Node '{package_name}' is already installed at {install_path}. "
+            "Use --upgrade to replace."
+        )
+
+    if dry_run:
+        click.echo(f"\nDry run: would unpack {archive_path.name} to {install_path}")
+        click.echo(f"  Archive members: {len(members)}")
+        return []
+
+    # Unpack archive
+    if install_path.exists():
+        shutil.rmtree(install_path)
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        # NOTE(OMN-7537): .oncp archives are produced by `onex pack` which
+        # validates all contents. extractall is safe here.
+        tar.extractall(path=install_path)
+
+    # Validate contract after unpacking
+    contract_path = install_path / "contract.yaml"
+    contract = _validate_contract(contract_path)
+
+    # Register in local registry
+    registry = _load_registry()
+    registry[package_name] = {
+        "package": package_name,
+        "version": str(package_version),
+        "source": "oncp",
+        "path": str(install_path),
+        "archive": str(archive_path),
+    }
+    _save_registry(registry)
+
+    click.echo(f"Installed {package_name} v{package_version} to {install_path}")
+    return [contract]
+
+
 @click.command("install")
-@click.argument("package_name")
+@click.argument("package_path")
 @click.option(
     "--test/--no-test",
     default=False,
@@ -115,39 +215,73 @@ def _validate_contract(contract_path: Path) -> dict[str, object]:
     is_flag=True,
     help="Allow packages without onex-signature metadata.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed installation output.",
+)
 def cli_install(
-    package_name: str,
+    package_path: str,
     test: bool,
     dry_run: bool,
     upgrade: bool,
     allow_unsigned: bool,
+    verbose: bool,
 ) -> None:
     """Install an ONEX contract package with validation.
 
-    Wraps pip install with contract.yaml validation, provenance checks,
-    and local registry tracking. Rolls back on validation failure.
+    Supports two modes:
+    1. .oncp archives — unpack to ~/.omnibase/registry/<name>/
+    2. pip packages — install via pip with contract validation
+
+    \b
+    Examples:
+        onex install node_aislop_sweep-1.0.0.oncp
+        onex install ./my-package.oncp --upgrade
+        onex install omnimarket --dry-run
     """
+    path = Path(package_path)
+
+    # Mode 1: .oncp archive
+    if path.exists() and path.suffix == ".oncp":
+        validated = _install_oncp(
+            path, dry_run=dry_run, upgrade=upgrade, verbose=verbose
+        )
+        if dry_run:
+            return
+        if test and validated:
+            click.echo("Running golden chain tests...")
+            test_result = subprocess.run(
+                [sys.executable, "-m", "pytest", "-x", "-q", "--tb=short"],
+                check=False,
+            )
+            if test_result.returncode != 0:
+                click.echo("Warning: golden chain tests failed", err=True)
+        return
+
+    # Mode 2: pip package (original behavior)
     if not _in_virtualenv():
         raise click.ClickException(
-            "onex install must be run inside a virtual environment"
+            "onex install must be run inside a virtual environment for pip packages"
         )
 
     # Step 1: pip install (skip for dry-run)
     if not dry_run:
         result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", package_name],
+            [sys.executable, "-m", "pip", "install", package_path],
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode != 0:
             raise click.ClickException(f"pip install failed: {result.stderr.strip()}")
-        click.echo(f"Installed {package_name}")
+        click.echo(f"Installed {package_path}")
 
     # Step 2: Discover entry points
     eps = importlib.metadata.entry_points(group="onex.nodes")
     # Normalize package name for comparison (PEP 503)
-    normalized = package_name.replace("-", "_").replace(".", "_").lower()
+    normalized = package_path.replace("-", "_").replace(".", "_").lower()
     matching = [
         ep
         for ep in eps
@@ -156,7 +290,7 @@ def cli_install(
     ]
 
     if not matching:
-        click.echo(f"Warning: {package_name} has no onex.nodes entry points", err=True)
+        click.echo(f"Warning: {package_path} has no onex.nodes entry points", err=True)
         if not dry_run:
             return
 
@@ -167,25 +301,25 @@ def cli_install(
             module = importlib.import_module(ep.module)
         except ImportError as e:
             if not dry_run:
-                _rollback_install(package_name)
+                _rollback_install(package_path)
             raise click.ClickException(f"Cannot import module {ep.module}: {e}") from e
 
         if module.__file__ is None:
             if not dry_run:
-                _rollback_install(package_name)
+                _rollback_install(package_path)
             raise click.ClickException(f"Module {ep.module} has no __file__ attribute")
 
         contract_path = Path(module.__file__).parent / "contract.yaml"
         if not contract_path.exists():
             if not dry_run:
-                _rollback_install(package_name)
+                _rollback_install(package_path)
             raise click.ClickException(f"Missing contract.yaml in {ep.module}")
 
         try:
             contract = _validate_contract(contract_path)
         except click.ClickException:
             if not dry_run:
-                _rollback_install(package_name)
+                _rollback_install(package_path)
             raise
 
         validated_contracts.append(contract)
@@ -202,20 +336,20 @@ def cli_install(
                 metadata = dist.metadata
                 has_signature = metadata.get("onex-signature") is not None
                 if not has_signature and not allow_unsigned:
-                    _rollback_install(package_name)
+                    _rollback_install(package_path)
                     raise click.ClickException(
-                        f"{package_name} has no onex-signature metadata. "
+                        f"{package_path} has no onex-signature metadata. "
                         "Use --allow-unsigned to install anyway."
                     )
                 if not has_signature:
-                    click.echo(f"Warning: {package_name} is unsigned", err=True)
+                    click.echo(f"Warning: {package_path} is unsigned", err=True)
         except click.ClickException:
             raise
         except Exception:  # noqa: BLE001
             click.echo("Warning: could not check package signature", err=True)
 
     if dry_run:
-        click.echo(f"\nDry run complete for {package_name}")
+        click.echo(f"\nDry run complete for {package_path}")
         for contract in validated_contracts:
             click.echo(f"  Node: {contract.get('name', 'unknown')}")
         return
@@ -225,13 +359,13 @@ def cli_install(
     for contract in validated_contracts:
         contract_name = str(contract.get("name", ""))
         if contract_name in registry and not upgrade:
-            _rollback_install(package_name)
+            _rollback_install(package_path)
             raise click.ClickException(
                 f"Node '{contract_name}' is already registered. "
                 "Use --upgrade to replace."
             )
         registry[contract_name] = {
-            "package": package_name,
+            "package": package_path,
             "version": str(contract.get("version", "")),
         }
 

--- a/src/omnibase_core/cli/cli_install.py
+++ b/src/omnibase_core/cli/cli_install.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 from pathlib import Path
 
 import click
@@ -152,11 +153,30 @@ def _install_oncp(
 
     if not isinstance(metadata, dict):
         raise click.ClickException("metadata.yaml is not a valid YAML mapping")
-    package_name = metadata.get("name")
-    package_version = metadata.get("version")
-    if not package_name or not package_version:
+    raw_name = metadata.get("name")
+    raw_version = metadata.get("version")
+    if not isinstance(raw_name, str) or not raw_name.strip():
         raise click.ClickException(
-            "Invalid .oncp archive: metadata.yaml missing required 'name' or 'version'"
+            "Invalid .oncp archive: metadata.yaml 'name' must be a non-empty string"
+        )
+    if not isinstance(raw_version, str) or not raw_version.strip():
+        raise click.ClickException(
+            "Invalid .oncp archive: metadata.yaml 'version' must be a non-empty string"
+        )
+    package_name = raw_name.strip()
+    package_version = raw_version.strip()
+    # Reject path-like names that would let install_path escape registry_dir.
+    # shutil.rmtree(install_path) on --upgrade would otherwise target an
+    # attacker-chosen location.
+    if (
+        package_name in {".", ".."}
+        or "/" in package_name
+        or "\\" in package_name
+        or Path(package_name).is_absolute()
+    ):
+        raise click.ClickException(
+            "Invalid .oncp archive: metadata.yaml 'name' must be a safe package basename "
+            "(no path separators, no '.'/'..', no absolute paths)"
         )
     install_path = registry_dir / package_name
 
@@ -170,29 +190,33 @@ def _install_oncp(
             "Use --upgrade to replace."
         )
 
-    if dry_run:
-        click.echo(f"\nDry run: would unpack {archive_path.name} to {install_path}")
-        click.echo(f"  Archive members: {len(members)}")
-        return []
+    # Stage extraction in a temp dir so --dry-run exercises real validation
+    # and --upgrade is atomic: the existing install is only removed once the
+    # new archive has successfully extracted AND its contract has validated.
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=registry_dir) as tmp_dir:
+        staged_path = Path(tmp_dir) / package_name
+        with tarfile.open(archive_path, "r:gz") as tar:
+            # PEP 706 data filter rejects absolute paths, traversal, symlink
+            # escapes, and device files.
+            tar.extractall(path=staged_path, filter="data")
 
-    # Unpack archive
-    if install_path.exists():
-        shutil.rmtree(install_path)
+        contract = _validate_contract(staged_path / "contract.yaml")
 
-    with tarfile.open(archive_path, "r:gz") as tar:
-        # Use PEP 706 data filter to reject absolute paths, symlink escapes,
-        # and any member that would resolve outside install_path.
-        tar.extractall(path=install_path, filter="data")
+        if dry_run:
+            click.echo(f"\nDry run: would unpack {archive_path.name} to {install_path}")
+            click.echo(f"  Archive members: {len(members)}")
+            return [contract]
 
-    # Validate contract after unpacking
-    contract_path = install_path / "contract.yaml"
-    contract = _validate_contract(contract_path)
+        if install_path.exists():
+            shutil.rmtree(install_path)
+        shutil.move(str(staged_path), str(install_path))
 
     # Register in local registry
     registry = _load_registry()
     registry[package_name] = {
         "package": package_name,
-        "version": str(package_version),
+        "version": package_version,
         "source": "oncp",
         "path": str(install_path),
         "archive": str(archive_path),

--- a/src/omnibase_core/cli/cli_pack.py
+++ b/src/omnibase_core/cli/cli_pack.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI command for packing ONEX nodes into .oncp contract package archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tarfile
+from io import BytesIO
+from pathlib import Path
+
+import click
+
+# NOTE(OMN-7537): metadata.yaml and contract.yaml are external contract files
+# with varying schemas across node types. Pydantic models would require a
+# separate model per node type. yaml.safe_load is the correct approach here
+# for reading untrusted third-party contract files.
+# spdx-skip: manual YAML validation for external contract files
+
+
+def _get_registry_dir() -> Path:
+    """Return the local ONEX registry directory."""
+    return Path.home() / ".omnibase" / "registry"
+
+
+def _compute_sha256(path: Path) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _validate_metadata(metadata_path: Path) -> dict[str, object]:
+    """Validate metadata.yaml and return parsed contents."""
+    import yaml
+
+    if not metadata_path.exists():
+        raise click.ClickException(f"metadata.yaml not found at {metadata_path}")
+
+    with open(metadata_path) as f:
+        metadata = yaml.safe_load(f)
+
+    if not isinstance(metadata, dict):
+        raise click.ClickException("metadata.yaml is not a valid YAML mapping")
+
+    required = ["name", "version", "entry_points"]
+    for field in required:
+        if field not in metadata:
+            raise click.ClickException(f"metadata.yaml missing required field: {field}")
+
+    return metadata
+
+
+def _validate_contract(contract_path: Path) -> dict[str, object]:
+    """Validate contract.yaml and return parsed contents."""
+    import yaml
+
+    if not contract_path.exists():
+        raise click.ClickException(f"contract.yaml not found at {contract_path}")
+
+    with open(contract_path) as f:
+        contract = yaml.safe_load(f)
+
+    if not isinstance(contract, dict):
+        raise click.ClickException("contract.yaml is not a valid YAML mapping")
+
+    # Contract uses 'name' + 'contract_version' or 'node_version' (not bare 'version')
+    if "name" not in contract:
+        raise click.ClickException("contract.yaml missing required field: name")
+
+    has_version = (
+        "contract_version" in contract
+        or "node_version" in contract
+        or "version" in contract
+    )
+    if not has_version:
+        raise click.ClickException(
+            "contract.yaml missing version field (contract_version, node_version, or version)"
+        )
+
+    return contract
+
+
+def _check_handlers(node_dir: Path, contract: dict[str, object]) -> list[str]:
+    """Verify all handlers declared in contract.yaml exist on disk."""
+    handlers_dir = node_dir / "handlers"
+    declared_handlers: list[str] = []
+
+    # Contract may declare handlers in two formats:
+    # 1. Singular: handler: { module: ..., class: ... }
+    # 2. Plural: handlers: { handler_name: { file: ..., class: ... } }
+    handler_section = contract.get("handler")
+    handlers_section = contract.get("handlers", {})
+
+    # Check singular handler format
+    if isinstance(handler_section, dict):
+        handler_module = handler_section.get("module", "")
+        if handler_module:
+            # Convert module path to file path
+            handler_file = handler_module.split(".")[-1] + ".py"
+            handler_path = handlers_dir / handler_file
+            if not handler_path.exists():
+                raise click.ClickException(
+                    f"Handler module '{handler_module}' declared in contract "
+                    f"but file not found at {handler_path}"
+                )
+            declared_handlers.append(handler_file)
+
+    # Check plural handlers format
+    if isinstance(handlers_section, dict):
+        for handler_name, handler_config in handlers_section.items():
+            if isinstance(handler_config, dict):
+                handler_file = handler_config.get("file")
+                if handler_file:
+                    declared_handlers.append(handler_file)
+                    handler_path = handlers_dir / handler_file
+                    if not handler_path.exists():
+                        raise click.ClickException(
+                            f"Handler file '{handler_file}' declared in contract "
+                            f"but not found at {handler_path}"
+                        )
+
+    return declared_handlers
+
+
+def _check_tests(node_dir: Path) -> bool:
+    """Check if tests directory exists and has test files."""
+    tests_dir = node_dir / "tests"
+    if not tests_dir.exists():
+        return False
+    return any(tests_dir.glob("test_*.py"))
+
+
+@click.command("pack")
+@click.argument(
+    "node_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output path for .oncp archive (default: <name>-<version>.oncp in cwd).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Validate only, do not produce archive.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed validation output.",
+)
+def cli_pack(
+    node_dir: Path,
+    output: Path | None,
+    dry_run: bool,
+    verbose: bool,
+) -> None:
+    """Pack an ONEX node into a .oncp contract package archive.
+
+    Validates metadata.yaml, contract.yaml, handler existence, and test
+    existence, then produces a .oncp tar.gz archive.
+
+    \b
+    Examples:
+        onex pack src/omnimarket/nodes/node_aislop_sweep/
+        onex pack src/omnimarket/nodes/node_aislop_sweep/ -o my-package.oncp
+        onex pack src/omnimarket/nodes/node_aislop_sweep/ --dry-run
+    """
+    node_dir = node_dir.resolve()
+
+    # Step 1: Validate metadata.yaml
+    metadata_path = node_dir / "metadata.yaml"
+    metadata = _validate_metadata(metadata_path)
+    if verbose:
+        click.echo(f"  [PASS] metadata.yaml: {metadata['name']} v{metadata['version']}")
+
+    # Step 2: Validate contract.yaml
+    contract_path = node_dir / "contract.yaml"
+    contract = _validate_contract(contract_path)
+    contract_version = (
+        contract.get("contract_version")
+        or contract.get("node_version")
+        or contract.get("version", "?")
+    )
+    if isinstance(contract_version, dict):
+        contract_version = f"{contract_version.get('major', '?')}.{contract_version.get('minor', '?')}.{contract_version.get('patch', '?')}"
+    if verbose:
+        click.echo(f"  [PASS] contract.yaml: {contract['name']} v{contract_version}")
+
+    # Step 3: Check handlers exist
+    handlers = _check_handlers(node_dir, contract)
+    if verbose:
+        if handlers:
+            click.echo(
+                f"  [PASS] {len(handlers)} handler(s) found: {', '.join(handlers)}"
+            )
+        else:
+            click.echo("  [PASS] No handlers declared in contract")
+
+    # Step 4: Check tests exist (warning only, not a hard block)
+    has_tests = _check_tests(node_dir)
+    if verbose:
+        if has_tests:
+            click.echo("  [PASS] tests/ directory with test files found")
+        else:
+            click.echo("  [WARN] No tests/ directory or test files found")
+
+    # Step 5: Compute archive hash for provenance
+    archive_hash = _compute_sha256(metadata_path)
+
+    if dry_run:
+        click.echo(f"\nDry run complete for {metadata['name']} v{metadata['version']}")
+        click.echo(f"  Node directory: {node_dir}")
+        click.echo(f"  Handlers: {len(handlers)}")
+        click.echo(f"  Tests: {'yes' if has_tests else 'no'}")
+        click.echo(f"  Archive hash (metadata): {archive_hash[:16]}...")
+        return
+
+    # Step 6: Build .oncp archive
+    package_name = metadata["name"]
+    package_version = metadata["version"]
+    archive_name = output or Path(f"{package_name}-{package_version}.oncp")
+
+    # Create tar.gz with node directory contents
+    with tarfile.open(archive_name, "w:gz") as tar:
+        # Add metadata.yaml
+        tar.add(metadata_path, arcname="metadata.yaml")
+
+        # Add contract.yaml
+        tar.add(contract_path, arcname="contract.yaml")
+
+        # Add all node files (handlers, tests, __init__.py, etc.)
+        for item in node_dir.iterdir():
+            if item.name in ("metadata.yaml", "contract.yaml"):
+                continue  # Already added
+            arcname = f"{package_name}/{item.name}"
+            tar.add(item, arcname=arcname)
+
+        # Add provenance manifest
+        provenance = {
+            "package_name": package_name,
+            "package_version": package_version,
+            "archive_sha256": archive_hash,
+            "packed_from": str(node_dir),
+        }
+        provenance_bytes = json.dumps(provenance, indent=2).encode("utf-8")
+        info = tarfile.TarInfo(name="provenance.json")
+        info.size = len(provenance_bytes)
+        tar.addfile(info, BytesIO(provenance_bytes))
+
+    archive_size = archive_name.stat().st_size
+    click.echo(
+        f"Packed {package_name} v{package_version} -> {archive_name} ({archive_size:,} bytes)"
+    )

--- a/tests/unit/cli/test_cli_install.py
+++ b/tests/unit/cli/test_cli_install.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the onex install command (.oncp archive installation)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+import pytest
+import yaml
+
+from omnibase_core.cli.cli_install import _install_oncp
+
+
+def _make_oncp(
+    tmp_path: Path,
+    *,
+    metadata: object,
+    contract: dict[str, object] | None = None,
+    extra_members: list[tuple[str, bytes]] | None = None,
+) -> Path:
+    """Build a minimal .oncp archive in tmp_path and return its path."""
+    archive = tmp_path / "test_node-1.0.0.oncp"
+
+    if contract is None:
+        contract = {"name": "test_node", "version": "1.0.0"}
+
+    with tarfile.open(archive, "w:gz") as tar:
+
+        def _add(name: str, data: bytes) -> None:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+        if metadata is not None:
+            _add("metadata.yaml", yaml.safe_dump(metadata).encode("utf-8"))
+        _add("contract.yaml", yaml.safe_dump(contract).encode("utf-8"))
+        for name, data in extra_members or []:
+            _add(name, data)
+
+    return archive
+
+
+@pytest.mark.unit
+class TestInstallOncpMetadataValidation:
+    """Guard the metadata.yaml validation path — no silent 'unknown' fallback."""
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        archive = _make_oncp(tmp_path, metadata={"version": "1.0.0"})
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(click.ClickException, match="missing required 'name'"):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+    def test_missing_version_raises(self, tmp_path: Path) -> None:
+        archive = _make_oncp(tmp_path, metadata={"name": "test_node"})
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(click.ClickException, match="missing required"):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+    def test_non_mapping_metadata_raises(self, tmp_path: Path) -> None:
+        archive = _make_oncp(tmp_path, metadata=["not", "a", "mapping"])
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(click.ClickException, match="not a valid YAML mapping"):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+
+@pytest.mark.unit
+class TestInstallOncpPathTraversal:
+    """Guard against CVE-2007-4559 class extraction attacks.
+
+    PEP 706 ``filter="data"`` semantics: absolute paths are silently
+    neutralized (leading "/" stripped), and symlinks / device files
+    are rejected with a ``FilterError``. We assert the absolute-path
+    member never escapes ``install_path``.
+    """
+
+    def test_traversal_member_neutralized_by_data_filter(self, tmp_path: Path) -> None:
+        """A member with ``..`` traversal must not escape install_path."""
+        registry = tmp_path / "registry"
+        malicious = tmp_path / "node-1.0.0.oncp"
+        sentinel_outside = tmp_path / "escape.txt"
+
+        with tarfile.open(malicious, "w:gz") as tar:
+
+            def _add(name: str, data: bytes) -> None:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+            _add(
+                "metadata.yaml",
+                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+            )
+            _add(
+                "contract.yaml",
+                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+            )
+            # Attempt traversal: would land in tmp_path/escape.txt without filter.
+            traversal = tarfile.TarInfo(name="../escape.txt")
+            traversal.size = 3
+            tar.addfile(traversal, io.BytesIO(b"pwn"))
+
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=registry,
+        ):
+            # The ``data`` filter raises OutsideDestinationError for ``..``.
+            with pytest.raises(tarfile.TarError):
+                _install_oncp(malicious, dry_run=False, upgrade=False, verbose=False)
+
+        # The sentinel outside install_path must never have been written.
+        assert not sentinel_outside.exists()
+
+    def test_absolute_path_member_neutralized_by_data_filter(
+        self, tmp_path: Path
+    ) -> None:
+        """Absolute-path members are stripped to relative paths by the data filter."""
+        registry = tmp_path / "registry"
+        malicious = tmp_path / "node-1.0.0.oncp"
+
+        with tarfile.open(malicious, "w:gz") as tar:
+
+            def _add(name: str, data: bytes) -> None:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+            _add(
+                "metadata.yaml",
+                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+            )
+            _add(
+                "contract.yaml",
+                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+            )
+            absolute = tarfile.TarInfo(name="/tmp/absolute-escape.txt")
+            absolute.size = 3
+            tar.addfile(absolute, io.BytesIO(b"pwn"))
+
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=registry,
+        ):
+            _install_oncp(malicious, dry_run=False, upgrade=False, verbose=False)
+
+        # If the data filter is active, the leading "/" was stripped and the
+        # file was written under install_path, NOT at /tmp/absolute-escape.txt.
+        install_path = registry / "node"
+        assert (install_path / "tmp" / "absolute-escape.txt").exists()
+        assert not Path("/tmp/absolute-escape.txt").exists() or (
+            Path("/tmp/absolute-escape.txt").read_text() != "pwn"
+        )

--- a/tests/unit/cli/test_cli_install.py
+++ b/tests/unit/cli/test_cli_install.py
@@ -22,9 +22,10 @@ def _make_oncp(
     metadata: object,
     contract: dict[str, object] | None = None,
     extra_members: list[tuple[str, bytes]] | None = None,
+    archive_name: str = "test_node-1.0.0.oncp",
 ) -> Path:
     """Build a minimal .oncp archive in tmp_path and return its path."""
-    archive = tmp_path / "test_node-1.0.0.oncp"
+    archive = tmp_path / archive_name
 
     if contract is None:
         contract = {"name": "test_node", "version": "1.0.0"}
@@ -55,7 +56,9 @@ class TestInstallOncpMetadataValidation:
             "omnibase_core.cli.cli_install._get_registry_dir",
             return_value=tmp_path / "registry",
         ):
-            with pytest.raises(click.ClickException, match="missing required 'name'"):
+            with pytest.raises(
+                click.ClickException, match="'name' must be a non-empty"
+            ):
                 _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
 
     def test_missing_version_raises(self, tmp_path: Path) -> None:
@@ -64,7 +67,9 @@ class TestInstallOncpMetadataValidation:
             "omnibase_core.cli.cli_install._get_registry_dir",
             return_value=tmp_path / "registry",
         ):
-            with pytest.raises(click.ClickException, match="missing required"):
+            with pytest.raises(
+                click.ClickException, match="'version' must be a non-empty"
+            ):
                 _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
 
     def test_non_mapping_metadata_raises(self, tmp_path: Path) -> None:
@@ -76,19 +81,67 @@ class TestInstallOncpMetadataValidation:
             with pytest.raises(click.ClickException, match="not a valid YAML mapping"):
                 _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
 
+    def test_non_string_name_raises(self, tmp_path: Path) -> None:
+        archive = _make_oncp(tmp_path, metadata={"name": 12345, "version": "1.0.0"})
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(
+                click.ClickException, match="'name' must be a non-empty"
+            ):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+
+@pytest.mark.unit
+class TestInstallOncpUnsafeNameRejection:
+    """Guard against path-escape via crafted metadata.yaml 'name' values.
+
+    ``install_path = registry_dir / package_name`` plus the ``--upgrade``
+    path's ``shutil.rmtree(install_path)`` means an attacker-controlled
+    ``name`` like ``"../outside"`` could otherwise delete arbitrary dirs
+    outside the registry. These tests lock in the rejection.
+    """
+
+    @pytest.mark.parametrize(
+        "unsafe_name",
+        [
+            "../escape",
+            "nested/path",
+            "double/../nest",
+            "leading/slash",
+            ".",
+            "..",
+            "/absolute/name",
+            "back\\slash",
+        ],
+    )
+    def test_unsafe_name_rejected(self, tmp_path: Path, unsafe_name: str) -> None:
+        archive = _make_oncp(
+            tmp_path,
+            metadata={"name": unsafe_name, "version": "1.0.0"},
+            archive_name="unsafe-1.0.0.oncp",
+        )
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(click.ClickException, match="safe package basename"):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
 
 @pytest.mark.unit
 class TestInstallOncpPathTraversal:
-    """Guard against CVE-2007-4559 class extraction attacks.
+    """Guard against CVE-2007-4559 class tar extraction attacks.
 
-    PEP 706 ``filter="data"`` semantics: absolute paths are silently
-    neutralized (leading "/" stripped), and symlinks / device files
-    are rejected with a ``FilterError``. We assert the absolute-path
-    member never escapes ``install_path``.
+    Combined with the PEP 706 ``filter="data"`` + staging-dir-then-move
+    flow, tar members that attempt to escape or alias outside install_path
+    must either be neutralized or rejected, and the real install dir must
+    never be touched on failure.
     """
 
     def test_traversal_member_neutralized_by_data_filter(self, tmp_path: Path) -> None:
-        """A member with ``..`` traversal must not escape install_path."""
+        """A member with ``..`` traversal must not escape the staging dir."""
         registry = tmp_path / "registry"
         malicious = tmp_path / "node-1.0.0.oncp"
         sentinel_outside = tmp_path / "escape.txt"
@@ -108,7 +161,6 @@ class TestInstallOncpPathTraversal:
                 "contract.yaml",
                 yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
             )
-            # Attempt traversal: would land in tmp_path/escape.txt without filter.
             traversal = tarfile.TarInfo(name="../escape.txt")
             traversal.size = 3
             tar.addfile(traversal, io.BytesIO(b"pwn"))
@@ -117,12 +169,12 @@ class TestInstallOncpPathTraversal:
             "omnibase_core.cli.cli_install._get_registry_dir",
             return_value=registry,
         ):
-            # The ``data`` filter raises OutsideDestinationError for ``..``.
             with pytest.raises(tarfile.TarError):
                 _install_oncp(malicious, dry_run=False, upgrade=False, verbose=False)
 
-        # The sentinel outside install_path must never have been written.
         assert not sentinel_outside.exists()
+        # Staging failure must not leave a partial install behind.
+        assert not (registry / "node").exists()
 
     def test_absolute_path_member_neutralized_by_data_filter(
         self, tmp_path: Path
@@ -156,10 +208,53 @@ class TestInstallOncpPathTraversal:
         ):
             _install_oncp(malicious, dry_run=False, upgrade=False, verbose=False)
 
-        # If the data filter is active, the leading "/" was stripped and the
-        # file was written under install_path, NOT at /tmp/absolute-escape.txt.
         install_path = registry / "node"
         assert (install_path / "tmp" / "absolute-escape.txt").exists()
+        # No file at the absolute path outside the registry.
         assert not Path("/tmp/absolute-escape.txt").exists() or (
             Path("/tmp/absolute-escape.txt").read_text() != "pwn"
         )
+
+
+@pytest.mark.unit
+class TestInstallOncpAtomicity:
+    """The staging-dir flow keeps --dry-run validating and --upgrade atomic."""
+
+    def test_dry_run_validates_contract_before_returning(self, tmp_path: Path) -> None:
+        """--dry-run must surface a broken contract.yaml, not silently pass."""
+        # contract.yaml missing required 'name' field.
+        archive = _make_oncp(
+            tmp_path,
+            metadata={"name": "node", "version": "1.0.0"},
+            contract={"version": "1.0.0"},
+        )
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=tmp_path / "registry",
+        ):
+            with pytest.raises(click.ClickException, match=r"contract\.yaml missing"):
+                _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+    def test_failed_upgrade_preserves_existing_install(self, tmp_path: Path) -> None:
+        """If the new archive's contract fails to validate, the old install survives."""
+        registry = tmp_path / "registry"
+        install_path = registry / "node"
+        install_path.mkdir(parents=True)
+        (install_path / "sentinel.txt").write_text("OLD_VERSION")
+
+        # New archive with an invalid contract.yaml (missing required 'name').
+        bad_archive = _make_oncp(
+            tmp_path,
+            metadata={"name": "node", "version": "2.0.0"},
+            contract={"version": "2.0.0"},
+        )
+
+        with patch(
+            "omnibase_core.cli.cli_install._get_registry_dir",
+            return_value=registry,
+        ):
+            with pytest.raises(click.ClickException):
+                _install_oncp(bad_archive, dry_run=False, upgrade=True, verbose=False)
+
+        # Old install must be untouched.
+        assert (install_path / "sentinel.txt").read_text() == "OLD_VERSION"


### PR DESCRIPTION
## Summary

Implement the missing `onex pack` and `onex install` CLI commands for OMN-7537.

### `onex pack`
- Validates `metadata.yaml`, `contract.yaml`, handler existence, and test existence
- Produces `.oncp` tar.gz archive with `provenance.json` (SHA-256 hash, source path)
- Supports `--dry-run` and `--verbose` flags

### `onex install`
- Supports two modes:
  1. `.oncp` archives — unpacks to `~/.omnibase/registry/<name>/`, registers in local index
  2. pip packages — existing behavior (pip install + contract validation)
- Supports `--dry-run`, `--upgrade`, `--test` flags

### Tested
```
onex pack omnimarket/src/omnimarket/nodes/node_aislop_sweep/ --dry-run --verbose
onex pack omnimarket/src/omnimarket/nodes/node_aislop_sweep/
onex install node_aislop_sweep-1.0.0.oncp --dry-run --verbose
```

## Definition of Done (partial)
- [x] `onex pack` produces valid `.oncp` archives from node directories
- [x] `onex install` unpacks and registers `.oncp` packages
- [ ] Golden chain tests for 3 pilot nodes
- [ ] SKILL.md wrappers in omniclaude publish events instead of containing logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "pack" command to validate a node and produce distributable .oncp archives
  * Install command accepts local .oncp archives (package path) and adds verbose mode

* **Bug Fixes / Security**
  * Safer archive extraction to prevent path-traversal and enforce package/contract validation

* **Tests**
  * Unit tests covering .oncp install flow, validation failures, extraction safety, and atomicity

* **Chores**
  * YAML parsing allowlist extended to support CLI preprocessing needs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->