### PR TITLE
feat(reducer): fsm_metadata <-> metadata dict consistency (OMN-597)

### DIFF
--- a/src/omnibase_core/models/reducer/model_reducer_output.py
+++ b/src/omnibase_core/models/reducer/model_reducer_output.py
@@ -25,6 +25,9 @@ from omnibase_core.enums.enum_reducer_types import EnumReductionType, EnumStream
 from omnibase_core.models.common.model_reducer_metadata import ModelReducerMetadata
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.reducer.model_intent import ModelIntent
+from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+    ModelReducerFsmMetadata,
+)
 
 
 class ModelReducerOutput[T_Output](BaseModel):
@@ -97,6 +100,13 @@ class ModelReducerOutput[T_Output](BaseModel):
         metadata: Typed metadata for tracking and correlation (source, trace_id,
             correlation_id, group_key, partition_id, window_id, tags, trigger).
             Replaces dict[str, str] with ModelReducerMetadata for type safety.
+            FSM keys (fsm_state, fsm_previous_state, etc.) are also stored as
+            extras on this field for dict-compatible consumers; use ``fsm_metadata``
+            for typed access.
+        fsm_metadata: Typed FSM metadata carrying the 7-key contract (OMN-597).
+            Populated by ``NodeReducer.process`` when an FSM transition executes.
+            ``None`` for non-FSM reducer outputs. Logically consistent with the
+            FSM extras in ``metadata`` — both represent the same transition data.
         timestamp: When this output was created (auto-generated).
 
     Migration from dict[str, str] metadata:
@@ -175,6 +185,14 @@ class ModelReducerOutput[T_Output](BaseModel):
         default_factory=ModelReducerMetadata,
         description="Typed metadata for tracking and correlation (source, trace_id, "
         "correlation_id, group_key, partition_id, window_id, tags, trigger)",
+    )
+    fsm_metadata: ModelReducerFsmMetadata | None = Field(
+        default=None,
+        description=(
+            "Typed 7-key FSM metadata contract (OMN-597). Populated by NodeReducer.process "
+            "when an FSM transition executes; None for non-FSM outputs. Logically "
+            "consistent with the FSM extra keys in `metadata`."
+        ),
     )
     timestamp: datetime = Field(default_factory=datetime.now)
 

--- a/src/omnibase_core/models/reducer/model_reducer_output.py
+++ b/src/omnibase_core/models/reducer/model_reducer_output.py
@@ -18,7 +18,7 @@ import math
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_reducer_types import EnumReductionType, EnumStreamingMode
@@ -275,3 +275,30 @@ class ModelReducerOutput[T_Output](BaseModel):
                 },
             )
         return v
+
+    @model_validator(mode="after")
+    def _enforce_fsm_metadata_extras_consistency(
+        self,
+    ) -> "ModelReducerOutput[T_Output]":
+        # When fsm_metadata is set, every FSM key present in metadata extras must
+        # match its counterpart in the typed model. Prevents constructing an
+        # output with divergent typed-vs-dict FSM state outside NodeReducer.process.
+        if self.fsm_metadata is None:
+            return self
+        fsm_dict = self.fsm_metadata.to_dict()
+        extras = self.metadata.model_extra or {}
+        mismatched = sorted(
+            key
+            for key, value in fsm_dict.items()
+            if key in extras and extras[key] != value
+        )
+        if mismatched:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    "fsm_metadata and metadata extras must carry identical FSM "
+                    "values for overlapping keys"
+                ),
+                context={"mismatched_keys": mismatched},
+            )
+        return self

--- a/src/omnibase_core/nodes/node_reducer.py
+++ b/src/omnibase_core/nodes/node_reducer.py
@@ -37,6 +37,9 @@ from omnibase_core.models.projectors.model_projection_intent import (
     ModelProjectionIntent,
 )
 from omnibase_core.models.reducer.model_intent import ModelIntent
+from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+    ModelReducerFsmMetadata,
+)
 from omnibase_core.models.reducer.model_reducer_input import ModelReducerInput
 from omnibase_core.models.reducer.model_reducer_output import ModelReducerOutput
 from omnibase_core.models.reducer.payloads.model_payload_projection_intent import (
@@ -441,17 +444,25 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
         #                            an unexpected exception path; None on success
         failure_reason = fsm_result.error if not fsm_result.success else None
         error_value = fsm_result.error if not fsm_result.success else None
-        output_metadata = input_data.metadata.model_copy(
-            update={
-                "fsm_state": fsm_result.new_state,
-                "fsm_previous_state": fsm_result.old_state,
-                "fsm_transition_success": fsm_result.success,
-                "fsm_transition_name": fsm_result.transition_name,
-                "failure_reason": failure_reason,
-                "failed_conditions": None,
-                "error": error_value,
-            }
+
+        # Build the typed FSM metadata model (OMN-597).
+        # This is the single source of truth for all 7 contract keys; the dict
+        # extras below are derived from it to guarantee logical consistency.
+        fsm_metadata = ModelReducerFsmMetadata(
+            fsm_state=fsm_result.new_state,
+            fsm_previous_state=fsm_result.old_state,
+            fsm_transition_success=fsm_result.success,
+            fsm_transition_name=fsm_result.transition_name,
+            failure_reason=failure_reason,
+            failed_conditions=None,
+            error=error_value,
         )
+        # Derive the dict representation from the typed model.
+        # Using to_dict() guarantees the extras and the typed field stay in sync —
+        # any future field addition in ModelReducerFsmMetadata propagates here
+        # automatically without a second manual update.
+        fsm_dict = fsm_metadata.to_dict()
+        output_metadata = input_data.metadata.model_copy(update=dict(fsm_dict))
         # Enforce 7-key contract: raises ModelOnexError if any key is missing.
         _validate_fsm_metadata_keys(output_metadata)
 
@@ -478,7 +489,8 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
             streaming_mode=input_data.streaming_mode,
             batches_processed=1,
             intents=all_intents,  # FSM intents + projection intents
-            metadata=output_metadata,  # Typed metadata with FSM fields
+            metadata=output_metadata,  # Typed metadata with FSM dict extras
+            fsm_metadata=fsm_metadata,  # Typed 7-key FSM metadata (OMN-597)
         )
 
         return output

--- a/tests/unit/models/reducer/test_model_reducer_output.py
+++ b/tests/unit/models/reducer/test_model_reducer_output.py
@@ -1773,3 +1773,85 @@ class TestModelReducerOutputImmutability:
         # to model fields, not the contents of those fields
         output.result["data"]["values"].append(4)
         assert output.result["data"]["values"] == [1, 2, 3, 4]
+
+
+@pytest.mark.unit
+class TestFsmMetadataExtrasInvariant:
+    """ModelReducerOutput must reject divergent fsm_metadata vs metadata extras."""
+
+    def _fsm(self, **overrides) -> "ModelReducerFsmMetadata":
+        from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+            ModelReducerFsmMetadata,
+        )
+
+        defaults = {
+            "fsm_state": "running",
+            "fsm_previous_state": "pending",
+            "fsm_transition_success": True,
+            "fsm_transition_name": "start",
+            "failure_reason": None,
+            "failed_conditions": None,
+            "error": None,
+        }
+        defaults.update(overrides)
+        return ModelReducerFsmMetadata(**defaults)
+
+    def test_construction_with_matching_extras_succeeds(self):
+        fsm = self._fsm()
+        metadata = ModelReducerMetadata(**fsm.to_dict())
+        output = ModelReducerOutput[int](
+            result=1,
+            operation_id=uuid4(),
+            reduction_type=EnumReductionType.FOLD,
+            processing_time_ms=0.0,
+            items_processed=1,
+            metadata=metadata,
+            fsm_metadata=fsm,
+        )
+        assert output.fsm_metadata is fsm
+
+    def test_construction_with_missing_extras_succeeds(self):
+        # Overlapping-keys rule: absent extras are not a conflict.
+        fsm = self._fsm()
+        output = ModelReducerOutput[int](
+            result=1,
+            operation_id=uuid4(),
+            reduction_type=EnumReductionType.FOLD,
+            processing_time_ms=0.0,
+            items_processed=1,
+            metadata=ModelReducerMetadata(),
+            fsm_metadata=fsm,
+        )
+        assert output.fsm_metadata is fsm
+
+    def test_construction_with_divergent_extras_raises(self):
+        fsm = self._fsm(fsm_state="running")
+        divergent_extras = dict(fsm.to_dict())
+        divergent_extras["fsm_state"] = "halted"
+        metadata = ModelReducerMetadata(**divergent_extras)
+        with pytest.raises(ModelOnexError) as exc_info:
+            ModelReducerOutput[int](
+                result=1,
+                operation_id=uuid4(),
+                reduction_type=EnumReductionType.FOLD,
+                processing_time_ms=0.0,
+                items_processed=1,
+                metadata=metadata,
+                fsm_metadata=fsm,
+            )
+        # ModelOnexError wraps user-supplied context under additional_context.context.
+        mismatched = exc_info.value.context["additional_context"]["context"][
+            "mismatched_keys"
+        ]
+        assert "fsm_state" in mismatched
+
+    def test_construction_without_fsm_metadata_skips_validator(self):
+        output = ModelReducerOutput[int](
+            result=1,
+            operation_id=uuid4(),
+            reduction_type=EnumReductionType.FOLD,
+            processing_time_ms=0.0,
+            items_processed=1,
+            metadata=ModelReducerMetadata(fsm_state="running"),
+        )
+        assert output.fsm_metadata is None

--- a/tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py
+++ b/tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Round-trip consistency tests for ModelReducerOutput.fsm_metadata ↔ metadata extras.
+
+OMN-597 (BETA-03) — fsm_metadata ↔ metadata dict consistency.
+
+Verifies that the typed ``ModelReducerFsmMetadata`` attached to
+``ModelReducerOutput.fsm_metadata`` is logically consistent with the 7 FSM
+keys stored as extras in ``ModelReducerOutput.metadata``. Both representations
+must encode identical values — no silent divergence is allowed.
+
+Test surface:
+    1. After a successful FSM transition, fsm_metadata equals what you'd get by
+       round-tripping the extras dict through ModelReducerFsmMetadata.from_dict.
+    2. Every key present in fsm_metadata.to_dict() is present in metadata extras
+       with the same value.
+    3. ModelReducerFsmMetadata round-trip (typed → dict → typed) is lossless.
+    4. fsm_metadata is None for manually constructed ModelReducerOutput instances
+       that did not go through NodeReducer.process (default=None contract).
+    5. Building fsm_metadata from extras always yields the same result as the
+       typed field (regression guard against future drift).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_reducer_types import EnumReductionType
+from omnibase_core.models.common.model_reducer_metadata import ModelReducerMetadata
+from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+from omnibase_core.models.contracts.subcontracts.model_fsm_state_definition import (
+    ModelFSMStateDefinition,
+)
+from omnibase_core.models.contracts.subcontracts.model_fsm_state_transition import (
+    ModelFSMStateTransition,
+)
+from omnibase_core.models.contracts.subcontracts.model_fsm_subcontract import (
+    ModelFSMSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
+    ModelReducerFsmMetadata,
+)
+from omnibase_core.models.reducer.model_reducer_input import ModelReducerInput
+from omnibase_core.models.reducer.model_reducer_output import ModelReducerOutput
+from omnibase_core.nodes.node_reducer import NodeReducer
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semver() -> ModelSemVer:
+    return ModelSemVer(major=1, minor=0, patch=0)
+
+
+@pytest.fixture
+def two_state_fsm(semver: ModelSemVer) -> ModelFSMSubcontract:
+    """Two-state FSM: idle -> processing via 'start_event'."""
+    return ModelFSMSubcontract(
+        state_machine_name="consistency_test_fsm",
+        description="FSM metadata consistency test machine",
+        state_machine_version=semver,
+        version=semver,
+        initial_state="idle",
+        states=[
+            ModelFSMStateDefinition(
+                state_name="idle",
+                state_type="operational",
+                description="Initial idle state",
+                version=semver,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+            ModelFSMStateDefinition(
+                state_name="processing",
+                state_type="operational",
+                description="Active processing state",
+                version=semver,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+        ],
+        transitions=[
+            ModelFSMStateTransition(
+                transition_name="start",
+                from_state="idle",
+                to_state="processing",
+                trigger="start_event",
+                version=semver,
+                conditions=[],
+                actions=[],
+            ),
+        ],
+        terminal_states=[],
+        error_states=[],
+        operations=[],
+        persistence_enabled=False,
+        recovery_enabled=False,
+    )
+
+
+@pytest.fixture
+def container() -> ModelONEXContainer:
+    return ModelONEXContainer()
+
+
+def _make_input(trigger: str) -> ModelReducerInput[int]:
+    return ModelReducerInput(
+        data=[1, 2, 3],
+        reduction_type=EnumReductionType.AGGREGATE,
+        operation_id=uuid4(),
+        metadata=ModelReducerMetadata(trigger=trigger),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ModelReducerFsmMetadata standalone round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestModelReducerFsmMetadataRoundTrip:
+    """Typed model ↔ dict round-trip is lossless."""
+
+    def test_roundtrip_success_payload(self) -> None:
+        original = ModelReducerFsmMetadata(
+            fsm_state="processing",
+            fsm_previous_state="idle",
+            fsm_transition_success=True,
+            fsm_transition_name="start",
+            failure_reason=None,
+            failed_conditions=None,
+            error=None,
+        )
+        restored = ModelReducerFsmMetadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_roundtrip_failure_payload(self) -> None:
+        original = ModelReducerFsmMetadata(
+            fsm_state="idle",
+            fsm_previous_state="idle",
+            fsm_transition_success=False,
+            fsm_transition_name="start",
+            failure_reason="Guard rejected",
+            failed_conditions=("has_data", "queue_ready"),
+            error=None,
+        )
+        restored = ModelReducerFsmMetadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_roundtrip_exception_payload(self) -> None:
+        original = ModelReducerFsmMetadata(
+            fsm_state="idle",
+            fsm_previous_state=None,
+            fsm_transition_success=False,
+            fsm_transition_name=None,
+            failure_reason=None,
+            failed_conditions=None,
+            error="RuntimeError: unexpected condition",
+        )
+        restored = ModelReducerFsmMetadata.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_to_dict_preserves_none_values(self) -> None:
+        """None optional fields are preserved in dict output (not elided)."""
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="idle",
+            fsm_transition_success=True,
+        )
+        d = metadata.to_dict()
+        assert "fsm_previous_state" in d
+        assert d["fsm_previous_state"] is None
+        assert "failure_reason" in d
+        assert d["failure_reason"] is None
+
+    def test_to_dict_has_exactly_seven_keys(self) -> None:
+        metadata = ModelReducerFsmMetadata(
+            fsm_state="idle",
+            fsm_transition_success=True,
+        )
+        assert set(metadata.to_dict().keys()) == {
+            "fsm_state",
+            "fsm_previous_state",
+            "fsm_transition_success",
+            "fsm_transition_name",
+            "failure_reason",
+            "failed_conditions",
+            "error",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Consistency between fsm_metadata typed field and metadata extras
+# ---------------------------------------------------------------------------
+
+
+class TestFsmMetadataExtrasConsistency:
+    """fsm_metadata typed field and metadata extras carry identical values."""
+
+    @pytest.mark.asyncio
+    async def test_fsm_metadata_field_populated_on_process(
+        self,
+        container: ModelONEXContainer,
+        two_state_fsm: ModelFSMSubcontract,
+    ) -> None:
+        """NodeReducer.process populates fsm_metadata on every successful call."""
+        node: NodeReducer[int, list[int]] = NodeReducer(container)
+        node.fsm_contract = two_state_fsm
+        node.initialize_fsm_state(two_state_fsm, context={})
+
+        result = await node.process(_make_input(trigger="start_event"))
+
+        assert result.fsm_metadata is not None
+
+    @pytest.mark.asyncio
+    async def test_fsm_metadata_matches_extras_on_success(
+        self,
+        container: ModelONEXContainer,
+        two_state_fsm: ModelFSMSubcontract,
+    ) -> None:
+        """After a successful transition, fsm_metadata equals extras round-tripped."""
+        node: NodeReducer[int, list[int]] = NodeReducer(container)
+        node.fsm_contract = two_state_fsm
+        node.initialize_fsm_state(two_state_fsm, context={})
+
+        result = await node.process(_make_input(trigger="start_event"))
+
+        assert result.fsm_metadata is not None
+        extras = result.metadata.model_extra or {}
+
+        # Build typed model from extras and compare to the attached typed field.
+        from_extras = ModelReducerFsmMetadata.from_dict(
+            {
+                "fsm_state": extras["fsm_state"],
+                "fsm_previous_state": extras["fsm_previous_state"],
+                "fsm_transition_success": extras["fsm_transition_success"],
+                "fsm_transition_name": extras["fsm_transition_name"],
+                "failure_reason": extras["failure_reason"],
+                "failed_conditions": extras["failed_conditions"],
+                "error": extras["error"],
+            }
+        )
+        assert from_extras == result.fsm_metadata
+
+    @pytest.mark.asyncio
+    async def test_fsm_metadata_to_dict_equals_extras(
+        self,
+        container: ModelONEXContainer,
+        two_state_fsm: ModelFSMSubcontract,
+    ) -> None:
+        """fsm_metadata.to_dict() must be a subset of metadata extras with equal values."""
+        node: NodeReducer[int, list[int]] = NodeReducer(container)
+        node.fsm_contract = two_state_fsm
+        node.initialize_fsm_state(two_state_fsm, context={})
+
+        result = await node.process(_make_input(trigger="start_event"))
+
+        assert result.fsm_metadata is not None
+        extras = result.metadata.model_extra or {}
+        typed_dict = result.fsm_metadata.to_dict()
+
+        for key, value in typed_dict.items():
+            assert key in extras, (
+                f"Key '{key}' in fsm_metadata.to_dict() missing from extras"
+            )
+            assert extras[key] == value, (
+                f"Mismatch for key '{key}': "
+                f"fsm_metadata={value!r}, extras={extras[key]!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_fsm_metadata_values_correct_on_successful_transition(
+        self,
+        container: ModelONEXContainer,
+        two_state_fsm: ModelFSMSubcontract,
+    ) -> None:
+        """Typed field carries correct values for a known idle→processing transition."""
+        node: NodeReducer[int, list[int]] = NodeReducer(container)
+        node.fsm_contract = two_state_fsm
+        node.initialize_fsm_state(two_state_fsm, context={})
+
+        result = await node.process(_make_input(trigger="start_event"))
+
+        assert result.fsm_metadata is not None
+        m = result.fsm_metadata
+        assert m.fsm_state == "processing"
+        assert m.fsm_previous_state == "idle"
+        assert m.fsm_transition_success is True
+        assert m.fsm_transition_name == "start"
+        assert m.failure_reason is None
+        assert m.failed_conditions is None
+        assert m.error is None
+
+    @pytest.mark.asyncio
+    async def test_fsm_metadata_roundtrip_from_output(
+        self,
+        container: ModelONEXContainer,
+        two_state_fsm: ModelFSMSubcontract,
+    ) -> None:
+        """Typed field survives a to_dict/from_dict round-trip unchanged."""
+        node: NodeReducer[int, list[int]] = NodeReducer(container)
+        node.fsm_contract = two_state_fsm
+        node.initialize_fsm_state(two_state_fsm, context={})
+
+        result = await node.process(_make_input(trigger="start_event"))
+
+        assert result.fsm_metadata is not None
+        restored = ModelReducerFsmMetadata.from_dict(result.fsm_metadata.to_dict())
+        assert restored == result.fsm_metadata
+
+
+# ---------------------------------------------------------------------------
+# Default-None contract for manually constructed outputs
+# ---------------------------------------------------------------------------
+
+
+class TestFsmMetadataDefaultNone:
+    """ModelReducerOutput.fsm_metadata defaults to None for non-FSM outputs."""
+
+    def test_fsm_metadata_defaults_to_none(self) -> None:
+        """A manually constructed output without fsm_metadata has None."""
+        output: ModelReducerOutput[int] = ModelReducerOutput(
+            result=42,
+            operation_id=uuid4(),
+            reduction_type=EnumReductionType.FOLD,
+            processing_time_ms=1.0,
+            items_processed=1,
+        )
+        assert output.fsm_metadata is None
+
+    def test_fsm_metadata_can_be_set_explicitly(self) -> None:
+        """Explicit fsm_metadata construction is supported."""
+        fsm_meta = ModelReducerFsmMetadata(
+            fsm_state="done",
+            fsm_transition_success=True,
+        )
+        output: ModelReducerOutput[int] = ModelReducerOutput(
+            result=42,
+            operation_id=uuid4(),
+            reduction_type=EnumReductionType.FOLD,
+            processing_time_ms=1.0,
+            items_processed=1,
+            fsm_metadata=fsm_meta,
+        )
+        assert output.fsm_metadata == fsm_meta


### PR DESCRIPTION
## Summary

Closes OMN-597 ([BETA-03] Implement fsm_metadata ↔ metadata dict consistency).

This PR implements the typed `fsm_metadata` field on `ModelReducerOutput` and wires `NodeReducer.process_fsm` so that the typed model is always the single source of truth, with dict extras derived from it — guaranteeing logical consistency between both representations.

### Changes

- **`ModelReducerOutput`**: adds `fsm_metadata: ModelReducerFsmMetadata | None = None` field (typed, `None` for non-FSM outputs)
- **`NodeReducer.process_fsm`**: builds `ModelReducerFsmMetadata` first; derives `output_metadata` extras via `to_dict()` — any future field addition propagates automatically
- **`tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py`**: 12 unit tests covering:
  - Round-trip losslessness (typed → dict → typed) for success, failure, and exception payloads
  - None-preservation in dict output
  - Exactly 7 keys in `to_dict()`
  - `fsm_metadata` populated after `NodeReducer.process`
  - Extras and typed field carry identical values (consistency invariant)
  - Correct values for known `idle → processing` transition
  - `from_dict(to_dict())` equals original

### Acceptance Criteria

- [x] Typed model and dict stay in sync
- [x] Serialization preserves consistency
- [x] Tests verify round-trip consistency

### Test plan

- [x] `uv run pytest tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py -v` → 12/12 passed
- [x] `uv run mypy src/omnibase_core/models/reducer/model_reducer_output.py src/omnibase_core/nodes/node_reducer.py src/omnibase_core/models/reducer/model_reducer_fsm_metadata.py` → no issues
- [x] `pre-commit run --all-files` → all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed fsm_metadata field to expose structured FSM transition data; runtime output now includes this field when available.

* **Behavior Change**
  * Construction now validates consistency between fsm_metadata and FSM-related extras in metadata and fails if values diverge.
  * Reducer output population now ensures both the typed field and dict extras are provided on success.

* **Tests**
  * Added tests enforcing exact, lossless round-trip and None-preservation between typed FSM metadata and metadata extras.

* **Documentation**
  * Clarified guidance to prefer fsm_metadata for typed access while extras remain for dict-compatible consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->