### PR TITLE
feat(validation): add ValidatorHardcodedTopics — reject hardcoded topic strings [OMN-9152]

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -54,3 +54,16 @@
   pass_filenames: true
   require_serial: true
   stages: [pre-commit]
+
+- id: check-hardcoded-topics-v2
+  name: Hardcoded ONEX Topic Strings (contract-driven)
+  description: >
+    Reject hardcoded onex.(cmd|evt|dlq).* topic strings and *_TOPIC env-var assignments outside approved
+    constant files. Contract-driven with per-rule enable/disable and line-level suppression markers. Suppression:
+    # onex-topic-sot, # onex-topic-test-fixture, # onex-topic-doc-example, # onex-topic-allow: <reason>
+  language: python
+  entry: python -m omnibase_core.validation.validator_hardcoded_topics
+  types_or: [python, yaml, shell, dockerfile]
+  pass_filenames: true
+  require_serial: true
+  stages: [pre-commit]

--- a/src/omnibase_core/validation/__init__.py
+++ b/src/omnibase_core/validation/__init__.py
@@ -138,6 +138,7 @@ from .validator_contract_pipeline import (
     ContractValidationPipeline,
     ModelExpandedContractResult,
 )
+from .validator_hardcoded_topics import ValidatorHardcodedTopics
 from .validator_local_paths import (
     ModelLocalPathViolation,
     ValidatorLocalPaths,
@@ -495,6 +496,8 @@ __all__ = [
     "ModelLocalPathViolation",
     # Banned compose vars validator — compose↔contract topic drift (OMN-9062)
     "ValidatorBannedComposeVars",
+    # Hardcoded topics validator — reject topic string literals (OMN-9152)
+    "ValidatorHardcodedTopics",
     # Naming Convention validator (OMN-1291)
     "ValidatorNamingConvention",
     "RULE_FILE_NAMING",

--- a/src/omnibase_core/validation/contracts/hardcoded_topics.validation.yaml
+++ b/src/omnibase_core/validation/contracts/hardcoded_topics.validation.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+contract_kind: validation_subcontract
+validation:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  validator_id: hardcoded_topics
+  validator_name: Hardcoded Topics Validator
+  validator_description: |
+    Rejects hardcoded ONEX topic string literals and *_TOPIC env-var
+    assignments outside approved source-of-truth files.
+
+    Detects:
+    - Quoted strings matching onex.(cmd|evt|dlq).*.vN
+    - Assignments to INPUT_TOPIC / OUTPUT_TOPIC / *_TOPIC env vars
+
+    Approved files (topic registries, contract YAML, enum modules) are
+    exempt.  Lines can be suppressed with: # onex-topic-sot,
+    # onex-topic-test-fixture, # onex-topic-doc-example,
+    # onex-topic-allow: <reason>
+
+  target_patterns:
+    - "**/*.py"
+    - "**/*.yaml"
+    - "**/*.yml"
+    - "**/*.sh"
+    - "**/*.env*"
+    - "**/Dockerfile*"
+    - "**/docker-compose*.yml"
+
+  exclude_patterns:
+    - "**/tests/**"
+    - "**/test_*.py"
+    - "**/*_test.py"
+    - "**/tests/**"
+    - "**/__pycache__/**"
+    - "**/.git/**"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+    - "**/venv/**"
+    - "**/archived/**"
+
+  rules:
+    - rule_id: hardcoded_topic_literal
+      description: >-
+        Rejects quoted onex.(cmd|evt|dlq).* topic strings outside approved constant files.  Use TopicBase
+        / contract.yaml instead.
+      severity: error
+      enabled: true
+
+    - rule_id: hardcoded_topic_env_var
+      description: >-
+        Rejects *_TOPIC env-var assignments that bypass contract-driven topic catalog.  Derive topics
+        from contract subscriptions.
+      severity: error
+      enabled: true
+
+  suppression_comments:
+    - "# onex-topic-sot"
+    - "# onex-topic-test-fixture"
+    - "# onex-topic-doc-example"
+    - "# onex-topic-allow:"
+
+  fail_on_error: true
+  fail_on_warning: false
+  max_violations: 0
+  severity_default: error
+  parallel_execution: true

--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -59,7 +59,7 @@ from omnibase_core.validation.validator_base import ValidatorBase
 _ONEX_TOPIC_LITERAL = re.compile(r"""["']onex\.(cmd|evt|dlq)\.[^"'\s]+["']""")
 
 _TOPIC_ENV_VAR = re.compile(
-    r"""^(?:export\s+|ENV\s+)?[A-Z][A-Z0-9_]*_TOPIC\b[A-Z0-9_]*\s*[:=]""",
+    r"""^\s*(?:export\s+|ENV\s+)?[A-Z][A-Z0-9_]*_TOPIC\b[A-Z0-9_]*\s*[:=]""",
 )
 
 _LINE_SUPPRESSION_MARKERS: frozenset[str] = frozenset(

--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -56,11 +56,10 @@ from omnibase_core.models.contracts.subcontracts.model_validator_subcontract imp
 )
 from omnibase_core.validation.validator_base import ValidatorBase
 
-_ONEX_TOPIC_LITERAL = re.compile(r"""["']onex\.(cmd|evt|dlq)\.[a-z0-9._-]+\.v\d+["']""")
+_ONEX_TOPIC_LITERAL = re.compile(r"""["']onex\.(cmd|evt|dlq)\.[^"'\s]+["']""")
 
 _TOPIC_ENV_VAR = re.compile(
-    r"""^[A-Z_]*(?:INPUT|OUTPUT|_)_?TOPIC\b[A-Z_]*\s*[:=]""",
-    re.MULTILINE,
+    r"""^(?:export\s+|ENV\s+)?[A-Z][A-Z0-9_]*_TOPIC\b[A-Z0-9_]*\s*[:=]""",
 )
 
 _LINE_SUPPRESSION_MARKERS: frozenset[str] = frozenset(
@@ -149,31 +148,27 @@ class ValidatorHardcodedTopics(ValidatorBase):
                     )
                 )
 
-        stripped = text.lstrip()
-        if stripped and not stripped.startswith(("#", "---", "contract_kind:")):
-            for match in _TOPIC_ENV_VAR.finditer(text):
-                matched_line = text[: match.start()].count("\n") + 1
-                if matched_line > len(lines):
-                    continue
-                line_text = lines[matched_line - 1]
-                if self._line_is_suppressed(line_text):
-                    continue
-                enabled, severity = self._get_rule_config(_RULE_TOPIC_ENV_VAR, contract)
-                if not enabled:
-                    continue
-                issues.append(
-                    ModelValidationIssue(
-                        severity=severity,
-                        message=(
-                            f"hardcoded topic env-var assignment: {match.group().strip()!r}"
-                            " -- derive from contract subscriptions"
-                        ),
-                        code=_RULE_TOPIC_ENV_VAR,
-                        file_path=path,
-                        line_number=matched_line,
-                        rule_name=_RULE_TOPIC_ENV_VAR,
-                    )
+            if line.lstrip().startswith(("#", "//")):
+                continue
+            env_match = _TOPIC_ENV_VAR.match(line)
+            if env_match is None:
+                continue
+            enabled, severity = self._get_rule_config(_RULE_TOPIC_ENV_VAR, contract)
+            if not enabled:
+                continue
+            issues.append(
+                ModelValidationIssue(
+                    severity=severity,
+                    message=(
+                        f"hardcoded topic env-var assignment: {env_match.group().strip()!r}"
+                        " -- derive from contract subscriptions"
+                    ),
+                    code=_RULE_TOPIC_ENV_VAR,
+                    file_path=path,
+                    line_number=lineno,
+                    rule_name=_RULE_TOPIC_ENV_VAR,
                 )
+            )
 
         return tuple(issues)
 

--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorHardcodedTopics -- reject hardcoded ONEX topic string literals.
+
+Detects two classes of violations:
+
+1. **Topic literals** -- quoted strings matching ``onex.(cmd|evt|dlq).*``
+2. **Env-var topics** -- assignments to ``*_TOPIC`` environment variables
+
+Approved source-of-truth files (topic registries, contract YAML, topic enum
+modules) are exempt.  Individual lines can be suppressed with marker comments.
+
+Usage Examples:
+    Programmatic usage::
+
+        from pathlib import Path
+        from omnibase_core.validation import ValidatorHardcodedTopics
+
+        validator = ValidatorHardcodedTopics()
+        result = validator.validate(Path("src/"))
+        if not result.is_valid:
+            for issue in result.issues:
+                print(f"{issue.file_path}:{issue.line_number}: {issue.message}")
+
+    CLI usage::
+
+        python -m omnibase_core.validation.validator_hardcoded_topics src/
+
+    Pre-commit hook::
+
+        check-hardcoded-topics-v2  [files...]
+
+Suppression:
+    Add one of these markers anywhere on a line to suppress::
+
+        # onex-topic-sot          -- source-of-truth declaration
+        # onex-topic-test-fixture -- test fixture data
+        # onex-topic-doc-example  -- documentation example
+        # onex-topic-allow: <reason>  -- explicit override
+
+Schema Version:
+    v1.0.0 - Initial version (OMN-9152)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import ClassVar
+
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.validation.validator_base import ValidatorBase
+
+_ONEX_TOPIC_LITERAL = re.compile(r"""["']onex\.(cmd|evt|dlq)\.[a-z0-9._-]+\.v\d+["']""")
+
+_TOPIC_ENV_VAR = re.compile(
+    r"""^[A-Z_]*(?:INPUT|OUTPUT|_)_?TOPIC\b[A-Z_]*\s*[:=]""",
+    re.MULTILINE,
+)
+
+_LINE_SUPPRESSION_MARKERS: frozenset[str] = frozenset(
+    {
+        "onex-topic-sot",
+        "onex-topic-test-fixture",
+        "onex-topic-doc-example",
+        "onex-topic-allow:",
+    }
+)
+
+_APPROVED_BASENAMES: frozenset[str] = frozenset(
+    {
+        "topics.py",
+        "topics.ts",
+        "topics.yaml",
+        "topic_constants.py",
+        "constants_topic_taxonomy.py",
+        "platform_topic_suffixes.py",
+        "topic_naming_baseline.txt",
+        "governance_emitter.py",
+        "contract_topic_extractor.py",
+        "check_topic_drift.py",
+    }
+)
+
+_APPROVED_SUFFIXES: frozenset[str] = frozenset(
+    {
+        "/contract.yaml",
+        "/handler_contract.yaml",
+    }
+)
+
+_RULE_TOPIC_LITERAL = "hardcoded_topic_literal"
+_RULE_TOPIC_ENV_VAR = "hardcoded_topic_env_var"
+
+
+class ValidatorHardcodedTopics(ValidatorBase):
+    """Reject hardcoded ONEX topic strings outside approved constant files.
+
+    Detects ``onex.(cmd|evt|dlq).*`` quoted literals and ``*_TOPIC``
+    environment-variable assignments.  Contract YAML files, topic enum
+    modules, and lines with suppression markers are exempt.
+    """
+
+    validator_id: ClassVar[str] = "hardcoded_topics"
+
+    def _validate_file(
+        self,
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        issues: list[ModelValidationIssue] = []
+
+        if self._is_approved_file(path):
+            return tuple(issues)
+
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return tuple(issues)
+
+        lines = text.splitlines()
+        for lineno, line in enumerate(lines, start=1):
+            if self._line_is_suppressed(line):
+                continue
+
+            for match in _ONEX_TOPIC_LITERAL.finditer(line):
+                enabled, severity = self._get_rule_config(_RULE_TOPIC_LITERAL, contract)
+                if not enabled:
+                    continue
+                issues.append(
+                    ModelValidationIssue(
+                        severity=severity,
+                        message=(
+                            f"hardcoded topic string {match.group()!r}"
+                            " -- use a constant from the canonical topic registry"
+                        ),
+                        code=_RULE_TOPIC_LITERAL,
+                        file_path=path,
+                        line_number=lineno,
+                        column_number=match.start() + 1,
+                        rule_name=_RULE_TOPIC_LITERAL,
+                    )
+                )
+
+        stripped = text.lstrip()
+        if stripped and not stripped.startswith(("#", "---", "contract_kind:")):
+            for match in _TOPIC_ENV_VAR.finditer(text):
+                matched_line = text[: match.start()].count("\n") + 1
+                if matched_line > len(lines):
+                    continue
+                line_text = lines[matched_line - 1]
+                if self._line_is_suppressed(line_text):
+                    continue
+                enabled, severity = self._get_rule_config(_RULE_TOPIC_ENV_VAR, contract)
+                if not enabled:
+                    continue
+                issues.append(
+                    ModelValidationIssue(
+                        severity=severity,
+                        message=(
+                            f"hardcoded topic env-var assignment: {match.group().strip()!r}"
+                            " -- derive from contract subscriptions"
+                        ),
+                        code=_RULE_TOPIC_ENV_VAR,
+                        file_path=path,
+                        line_number=matched_line,
+                        rule_name=_RULE_TOPIC_ENV_VAR,
+                    )
+                )
+
+        return tuple(issues)
+
+    @staticmethod
+    def _is_approved_file(path: Path) -> bool:
+        name = path.name
+        if name in _APPROVED_BASENAMES:
+            return True
+        posix = path.as_posix()
+        for suffix in _APPROVED_SUFFIXES:
+            if posix.endswith(suffix):
+                return True
+        return False
+
+    @staticmethod
+    def _line_is_suppressed(line: str) -> bool:
+        stripped = line.lstrip()
+        if stripped.startswith(("#", "//")):
+            for marker in _LINE_SUPPRESSION_MARKERS:
+                if marker in stripped:
+                    return True
+        for marker in _LINE_SUPPRESSION_MARKERS:
+            if marker in line:
+                return True
+        return False
+
+
+if __name__ == "__main__":
+    sys.exit(ValidatorHardcodedTopics.main())

--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -78,12 +78,14 @@ _APPROVED_BASENAMES: frozenset[str] = frozenset(
         "topics.ts",
         "topics.yaml",
         "topic_constants.py",
+        "constants_event_types.py",
         "constants_topic_taxonomy.py",
         "platform_topic_suffixes.py",
         "topic_naming_baseline.txt",
         "governance_emitter.py",
         "contract_topic_extractor.py",
         "check_topic_drift.py",
+        "validator_topic_suffix.py",
     }
 )
 

--- a/tests/unit/validation/test_validator_hardcoded_topics.py
+++ b/tests/unit/validation/test_validator_hardcoded_topics.py
@@ -393,3 +393,56 @@ class TestEdgeCases:
         result = v.validate_file(p)
         env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
         assert len(env_issues) == 0
+
+    def test_detects_unversioned_literal(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """TOPIC = "onex.evt.billing.charge_succeeded"\n""",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        literal_issues = [i for i in result.issues if i.code == _RULE_TOPIC_LITERAL]
+        assert len(literal_issues) == 1
+
+    def test_detects_export_topic_env_var(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            export INPUT_TOPIC=onex.cmd.user.created.v1
+            """,
+            name="deploy.sh",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 1
+
+    def test_detects_dockerfile_env_topic(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            ENV INPUT_TOPIC=onex.cmd.user.created.v1
+            """,
+            name="Dockerfile",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 1
+
+    def test_comment_header_does_not_gate_env_var_detection(
+        self, tmp_path: Path
+    ) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            # Module header line one
+            # Module header line two
+            INPUT_TOPIC = "onex.evt.test.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 1
+        assert env_issues[0].line_number == 3

--- a/tests/unit/validation/test_validator_hardcoded_topics.py
+++ b/tests/unit/validation/test_validator_hardcoded_topics.py
@@ -430,6 +430,23 @@ class TestEdgeCases:
         env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
         assert len(env_issues) == 1
 
+    def test_detects_indented_env_var_assignment(self, tmp_path: Path) -> None:
+        # Lines nested inside functions, conditionals, or YAML blocks are
+        # common. The regex must not require start-of-line with zero
+        # indentation.
+        p = _write(
+            tmp_path,
+            """\
+            def configure():
+                INPUT_TOPIC = "onex.evt.test.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 1
+        assert env_issues[0].line_number == 2
+
     def test_comment_header_does_not_gate_env_var_detection(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/validation/test_validator_hardcoded_topics.py
+++ b/tests/unit/validation/test_validator_hardcoded_topics.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ValidatorHardcodedTopics (OMN-9152)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_severity import EnumSeverity
+from omnibase_core.models.contracts.subcontracts.model_validator_rule import (
+    ModelValidatorRule,
+)
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.validation.validator_hardcoded_topics import (
+    _RULE_TOPIC_ENV_VAR,
+    _RULE_TOPIC_LITERAL,
+    ValidatorHardcodedTopics,
+)
+
+
+def _make_contract(
+    *,
+    rules: list[ModelValidatorRule] | None = None,
+    suppression_comments: list[str] | None = None,
+) -> ModelValidatorSubcontract:
+    default_rules = [
+        ModelValidatorRule(
+            rule_id=_RULE_TOPIC_LITERAL,
+            description="test",
+            severity=EnumSeverity.ERROR,
+            enabled=True,
+        ),
+        ModelValidatorRule(
+            rule_id=_RULE_TOPIC_ENV_VAR,
+            description="test",
+            severity=EnumSeverity.ERROR,
+            enabled=True,
+        ),
+    ]
+    return ModelValidatorSubcontract(
+        version=ModelSemVer(major=1, minor=0, patch=0),
+        validator_id="hardcoded_topics",
+        validator_name="Test",
+        validator_description="Test",
+        target_patterns=["**/*.py", "**/*.yaml"],
+        exclude_patterns=[],
+        suppression_comments=suppression_comments
+        or [
+            "# onex-topic-sot",
+            "# onex-topic-test-fixture",
+            "# onex-topic-doc-example",
+            "# onex-topic-allow:",
+        ],
+        fail_on_error=True,
+        fail_on_warning=False,
+        severity_default=EnumSeverity.ERROR,
+        rules=rules if rules is not None else default_rules,
+    )
+
+
+def _write(tmp_path: Path, content: str, name: str = "test.py") -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+@pytest.mark.unit
+class TestValidatorHardcodedTopicsInit:
+    def test_validator_id(self) -> None:
+        assert ValidatorHardcodedTopics.validator_id == "hardcoded_topics"
+
+    def test_init_with_contract(self, tmp_path: Path) -> None:
+        contract = _make_contract()
+        v = ValidatorHardcodedTopics(contract=contract)
+        assert v.contract.validator_id == "hardcoded_topics"
+
+
+@pytest.mark.unit
+class TestTopicLiteralDetection:
+    def test_detects_evt_topic(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """TOPIC = "onex.evt.platform.node-introspection.v1"\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert not result.is_valid
+        assert any(i.code == _RULE_TOPIC_LITERAL for i in result.issues)
+
+    def test_detects_cmd_topic(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """TOPIC = "onex.cmd.runtime.start-session.v1"\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert not result.is_valid
+
+    def test_detects_dlq_topic(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """TOPIC = "onex.dlq.platform.dlq-message.v1"\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert not result.is_valid
+
+    def test_clean_file_no_violations(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """TOPIC = "something-else"\nprint("hello")\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_reports_file_and_line(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            x = 1
+            TOPIC = "onex.evt.test.event.v1"
+            y = 2
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert len(result.issues) == 1
+        issue = result.issues[0]
+        assert issue.line_number == 2
+        assert issue.file_path == p
+
+    def test_multiple_violations_in_one_file(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            B = "onex.cmd.test.b.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert len(result.issues) == 2
+
+
+@pytest.mark.unit
+class TestEnvVarDetection:
+    def test_detects_input_topic_assignment(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            import os
+            ONEX_INPUT_TOPIC = "onex.evt.test.input.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) >= 1
+
+    def test_detects_output_topic_assignment(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            OUTPUT_TOPIC = "something"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) >= 1
+
+
+@pytest.mark.unit
+class TestApprovedFiles:
+    def test_topics_py_exempt(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            B = "onex.cmd.test.b.v1"
+            """,
+            name="topics.py",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_contract_yaml_exempt(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            subscriptions:
+              - topic: "onex.evt.test.a.v1"
+            """,
+            name="contract.yaml",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_topic_constants_py_exempt(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            MY_TOPIC: str = "onex.evt.test.a.v1"
+            """,
+            name="topic_constants.py",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+
+@pytest.mark.unit
+class TestSuppression:
+    def test_onex_topic_sot_suppresses(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"  # onex-topic-sot
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_onex_topic_test_fixture_suppresses(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"  # onex-topic-test-fixture
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_onex_topic_allow_suppresses(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"  # onex-topic-allow: legacy adapter
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_unsuppressed_line_still_fails(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            B = "onex.evt.test.b.v1"  # onex-topic-sot
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert not result.is_valid
+        assert len(result.issues) == 1
+        assert result.issues[0].line_number == 1
+
+
+@pytest.mark.unit
+class TestRuleConfiguration:
+    def test_disabled_rule_skipped(self, tmp_path: Path) -> None:
+        rules = [
+            ModelValidatorRule(
+                rule_id=_RULE_TOPIC_LITERAL,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=False,
+            ),
+            ModelValidatorRule(
+                rule_id=_RULE_TOPIC_ENV_VAR,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+        ]
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract(rules=rules))
+        result = v.validate_file(p)
+        literal_issues = [i for i in result.issues if i.code == _RULE_TOPIC_LITERAL]
+        assert len(literal_issues) == 0
+
+    def test_severity_override(self, tmp_path: Path) -> None:
+        rules = [
+            ModelValidatorRule(
+                rule_id=_RULE_TOPIC_LITERAL,
+                description="test",
+                severity=EnumSeverity.WARNING,
+                enabled=True,
+            ),
+        ]
+        p = _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract(rules=rules))
+        result = v.validate_file(p)
+        assert len(result.issues) == 1
+        assert result.issues[0].severity == EnumSeverity.WARNING
+
+    def test_yaml_file_with_topic_in_contract_field_exempt(
+        self, tmp_path: Path
+    ) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            contract_kind: validation_subcontract
+            validation:
+              subscriptions:
+                - topic: "onex.evt.test.a.v1"
+            """,
+            name="some_contract.yaml",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 0
+
+
+@pytest.mark.unit
+class TestDirectoryValidation:
+    def test_validates_directory(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            """\
+            A = "onex.evt.test.a.v1"
+            """,
+            name="bad.py",
+        )
+        _write(
+            tmp_path,
+            """\
+            B = "clean"
+            """,
+            name="good.py",
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate(tmp_path)
+        assert not result.is_valid
+        assert len(result.issues) == 1
+
+
+@pytest.mark.unit
+class TestEdgeCases:
+    def test_empty_file(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, "")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_unreadable_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("A = 1\n")
+        p.chmod(0o000)
+        try:
+            v = ValidatorHardcodedTopics(contract=_make_contract())
+            result = v.validate_file(p)
+            assert result.is_valid
+        finally:
+            p.chmod(0o644)
+
+    def test_single_quote_topic(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """TOPIC = 'onex.evt.test.event.v1'\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert not result.is_valid
+
+    def test_partial_match_not_flagged(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """x = "not-a-onex-topic"\n""")
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        assert result.is_valid
+
+    def test_docstring_topic_not_flagged_by_env_rule(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            '''\
+            """
+            Set ONEX_INPUT_TOPIC = "onex.evt.test.v1" to configure.
+            """
+            ''',
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 0


### PR DESCRIPTION
## Summary

- Implements `ValidatorHardcodedTopics` — a contract-driven validator that detects hardcoded `onex.(cmd|evt|dlq).*` topic string literals and `*_TOPIC` env-var assignments
- Follows the ValidatorBase pattern with YAML-driven contract, per-rule enable/disable, severity overrides, and inline suppression
- Includes pre-commit hook `check-hardcoded-topics-v2` for consumer repos
- 26 unit tests covering detection, approved file exemptions, suppression markers, rule configuration, edge cases

## Scope (OMN-9152)

- **New file:** `src/omnibase_core/validation/validator_hardcoded_topics.py`
- **New contract:** `src/omnibase_core/validation/contracts/hardcoded_topics.validation.yaml`
- **New tests:** `tests/unit/validation/test_validator_hardcoded_topics.py`
- **Modified:** `src/omnibase_core/validation/__init__.py` (registration)
- **Modified:** `.pre-commit-hooks.yaml` (exported hook)

## Detection rules

| Rule | What it catches |
|------|----------------|
| `hardcoded_topic_literal` | Quoted `onex.(cmd|evt|dlq).*` strings |
| `hardcoded_topic_env_var` | `*_TOPIC` assignment patterns |

## Approved files (exempt)

- `topics.py`, `topics.ts`, `topic_constants.py`, `contract.yaml`, etc.
- Files with names matching known SoT patterns

## Suppression markers

- `# onex-topic-sot` — source-of-truth declaration
- `# onex-topic-test-fixture` — test fixture
- `# onex-topic-doc-example` — documentation
- `# onex-topic-allow: <reason>` — explicit override

## Note

This supersedes the simpler `no-hardcoded-topics` hook from `onex_change_control` with a richer contract-driven version. The old hook can be retired once all repos adopt `check-hardcoded-topics-v2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New pre-commit check enforcing contract-driven topic management across Python, YAML, Shell, and Dockerfiles
  * Detects hardcoded topic string literals and environment-variable topic assignments that bypass the centralized topic catalog
  * Supports per-line suppression markers and a whitelist of approved source files

* **Tests**
  * Added comprehensive tests covering detection, suppression, allowlist exemptions, and various file syntaxes and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->