### PR TITLE
fix(OMN-9547): arm auto-merge explicitly as SQUASH to prevent silent queue drop

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -88,7 +88,7 @@ jobs:
           set -euo pipefail
           # "already enqueued" race is benign — treat as success.
           # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi
@@ -113,7 +113,7 @@ jobs:
           if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
             echo "could not resolve PR id"; exit 0
           fi
-          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
+          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId,mergeMethod:SQUASH}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
             echo "enqueued: $output"
           else
             # Tolerate only known benign states.


### PR DESCRIPTION
## Summary

Fix the `Enable Auto-Merge` workflow to arm with explicit `--squash`, preventing the silent queue-drop failure mode tracked in [OMN-9547](https://linear.app/omninode/issue/OMN-9547).

## Root Cause (empirically confirmed 2026-04-23)

When `gh pr merge --auto` is invoked without `--squash`/`--merge`/`--rebase`, the `enablePullRequestAutoMerge` GraphQL mutation falls back to the **repository default** merge method. Even after the repo-settings fix forced `allow_merge_commit: false, allow_squash_merge: true, allow_rebase_merge: false`, PRs were still being armed as `MERGE` by this workflow. Observed today: a sibling PR armed as `MERGE` (`merge_method: "merge"` in REST auto_merge), which silently drops the PR from the SQUASH-only merge queue (the queue ruleset rejects the mismatched method without error and the PR sits armed-but-dropped).

## Fix

Pass `--squash` explicitly to `gh pr merge --auto`. The repo guard was inverted in a parallel sweep to allow SQUASH (only MERGE/REBASE are now blocked), so this flag is both required and permitted.

## Evidence

- Empirical: a sibling PR observed armed as MERGE at 20:39Z today via the github-actions bot.
- Memory reference: the merge-queue-method-mismatch failure mode was confirmed on merge-queue repos.

## Test plan

- [ ] Workflow parses cleanly (syntax check via GitHub actions runner on PR open)
- [ ] After merge: next PR opened on this repo arms with `mergeMethod: SQUASH` (verify via `gh api repos/<owner>/<repo>/pulls/<N> --jq .auto_merge.merge_method` returns `squash`)
- [ ] Next PR enters the merge queue (not dropped silently)

## DoD evidence

Tracked by OMN-9547. Contract + PASS receipts live in `onex_change_control/contracts/OMN-9547.yaml` and `onex_change_control/drift/dod_receipts/OMN-9547/dod-001..dod-004/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified automated pull request merging workflow to enforce squash-based merge strategy. This consolidates multiple commits from a pull request into a single, unified commit during merges. The change results in a cleaner repository history, improved commit traceability, and simplified development timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->