### PR TITLE
feat(OMN-8765): AST-based deterministic-skill routing CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,9 +414,14 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Run AST-based skill routing validator (OMN-8765)
         run: |
-          python3 scripts/validate_deterministic_skill_routing.py \
+          python scripts/validate_deterministic_skill_routing.py \
             --skills-root _external/omniclaude/plugins/onex/skills
 
       - name: Skill routing summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
   #   - node-purity-check: Declarative node purity guarantees
   #   - mypy-validation-scripts: Type check validation scripts
   #   - core-infra-boundary: Transport/I/O import validation (ADR-005)
+  #   - check-deterministic-skills: AST-based SkillRoutingError enforcement (OMN-8765)
   #   - enum-governance: Enum architectural standards validation (OMN-1313)
   #   - detect-secrets: Baseline security scan (detect-secrets)
   #
@@ -382,6 +383,56 @@ jobs:
           echo "- No gRPC or WebSocket libraries" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "See: docs/decisions/ADR-005-core-infra-dependency-boundary.md" >> $GITHUB_STEP_SUMMARY
+
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Deterministic Skill Routing Gate (OMN-8765) — enforces that every Tier 1
+  # deterministic skill in omniclaude routes through `onex run-node` / `onex
+  # node` (or a Kafka publish) and surfaces `SkillRoutingError`. Blocking gate.
+  check-deterministic-skills:
+    name: Deterministic Skill Routing
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v6
+
+      - name: Checkout omniclaude (skill source)
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omniclaude
+          path: _external/omniclaude
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run AST-based skill routing validator (OMN-8765)
+        run: |
+          python3 scripts/validate_deterministic_skill_routing.py \
+            --skills-root _external/omniclaude/plugins/onex/skills
+
+      - name: Skill routing summary
+        if: always()
+        run: |
+          echo "## Deterministic Skill Routing (OMN-8765)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "AST-based CI lint gate — verifies every Tier 1 deterministic" >> $GITHUB_STEP_SUMMARY
+          echo "skill:" >> $GITHUB_STEP_SUMMARY
+          echo "- declares a node dispatch (\`onex run-node\` / \`onex node\` /" >> $GITHUB_STEP_SUMMARY
+          echo "  Kafka publish to \`onex.cmd.*\`)" >> $GITHUB_STEP_SUMMARY
+          echo "- imports zero LLM SDKs (anthropic/openai/google.generativeai)" >> $GITHUB_STEP_SUMMARY
+          echo "- does not wrap dispatch in subprocess orchestration" >> $GITHUB_STEP_SUMMARY
+          echo "- does not call \`client.messages.create\` / completion APIs" >> $GITHUB_STEP_SUMMARY
+          echo "- does not contain conditional prose fallback branches" >> $GITHUB_STEP_SUMMARY
+          echo "- references \`SkillRoutingError\` with \`do not produce prose\`" >> $GITHUB_STEP_SUMMARY
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Quick documentation check (not blocking test-parallel)
@@ -736,7 +787,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance]
     if: always()
 
     steps:
@@ -750,6 +801,7 @@ jobs:
           exports="${{ needs.exports-validation.result }}"
           mypy_scripts="${{ needs.mypy-validation-scripts.result }}"
           core_infra="${{ needs.core-infra-boundary.result }}"
+          det_skills="${{ needs.check-deterministic-skills.result }}"
           docs="${{ needs.docs-validation.result }}"
           purity="${{ needs.node-purity-check.result }}"
           enum_gov="${{ needs.enum-governance.result }}"
@@ -764,6 +816,7 @@ jobs:
           echo "| Exports Validation | $exports |" >> $GITHUB_STEP_SUMMARY
           echo "| Mypy Validation Scripts | $mypy_scripts |" >> $GITHUB_STEP_SUMMARY
           echo "| Core-Infra Boundary | $core_infra |" >> $GITHUB_STEP_SUMMARY
+          echo "| Deterministic Skill Routing | $det_skills |" >> $GITHUB_STEP_SUMMARY
           echo "| Documentation Validation | $docs |" >> $GITHUB_STEP_SUMMARY
           echo "| Node Purity Check | $purity |" >> $GITHUB_STEP_SUMMARY
           echo "| Enum Governance | $enum_gov |" >> $GITHUB_STEP_SUMMARY
@@ -777,6 +830,7 @@ jobs:
              [[ "$exports" == "success" ]] && \
              [[ "$mypy_scripts" == "success" ]] && \
              [[ "$core_infra" == "success" ]] && \
+             [[ "$det_skills" == "success" ]] && \
              [[ "$docs" == "success" ]] && \
              [[ "$enum_gov" == "success" ]] && \
              [[ "$secrets" == "success" ]] && \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -610,6 +610,20 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # ONEX Deterministic Skill Routing (OMN-8765)
+      # AST-based CI gate enforcing that every Tier 1 deterministic skill in
+      # omniclaude routes through `onex run-node` / `onex node` (or a Kafka
+      # publish) and surfaces `SkillRoutingError` on routing failure. Skips
+      # when the omniclaude sibling clone is absent (e.g., contributors who
+      # have not cloned the full omni_home registry).
+      - id: validate-deterministic-skill-routing
+        name: ONEX Deterministic Skill Routing (OMN-8765)
+        entry: bash scripts/pre_commit_validate_deterministic_skills.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       # ONEX Kafka/Listener API Prevention (OMN-1747, OMN-1745)
       # Prevents reintroduction of Kafka and listener management APIs removed from core.
       # omnibase_core must be transport-agnostic - use EventBusSubcontractWiring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,7 @@ ignore = [
 "src/omnibase_core/scripts/validate_markdown_links.py" = ["T201"]
 "scripts/pin_bump.py" = ["T201"]  # CLI output for publish-downstream-pin-bump workflow [OMN-9050]
 "scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation
+"scripts/validate_deterministic_skill_routing.py" = ["T201"]  # CLI output for CI gate report
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]
 

--- a/scripts/pre_commit_validate_deterministic_skills.sh
+++ b/scripts/pre_commit_validate_deterministic_skills.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Pre-commit wrapper around scripts/validate_deterministic_skill_routing.py
+# (OMN-8765). The deterministic-skill routing gate lives in this repo but
+# scans SKILL.md files that are owned by ``omniclaude``. In CI the
+# check-deterministic-skills job clones omniclaude into ``_external/``; for
+# local pre-commit runs we look for the sibling clone at
+# ``../omniclaude/plugins/onex/skills`` (standard omni_home layout). When the
+# sibling is absent the hook succeeds silently so contributors who have not
+# cloned the full omni_home registry are not blocked.
+
+set -euo pipefail
+
+SKILL_ROOT=""
+if [ -n "${DETERMINISTIC_SKILL_ROOT:-}" ]; then
+  SKILL_ROOT="${DETERMINISTIC_SKILL_ROOT}"
+elif [ -d "../omniclaude/plugins/onex/skills" ]; then
+  SKILL_ROOT="../omniclaude/plugins/onex/skills"
+elif [ -n "${OMNI_HOME:-}" ] && [ -d "${OMNI_HOME}/omniclaude/plugins/onex/skills" ]; then
+  SKILL_ROOT="${OMNI_HOME}/omniclaude/plugins/onex/skills"
+fi
+
+if [ -z "${SKILL_ROOT}" ]; then
+  echo "Skipping OMN-8765 deterministic-skill gate (omniclaude sibling not found)"
+  exit 0
+fi
+
+exec uv run python scripts/validate_deterministic_skill_routing.py \
+  --skills-root "${SKILL_ROOT}"

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -109,18 +109,6 @@ BANNED_LLM_ATTR_CALLS: frozenset[tuple[str, str]] = frozenset(
     }
 )
 
-SUBPROCESS_ORCHESTRATION_CALLS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("subprocess", "run"),
-        ("subprocess", "Popen"),
-        ("subprocess", "call"),
-        ("subprocess", "check_call"),
-        ("subprocess", "check_output"),
-        ("os", "system"),
-        ("os", "popen"),
-    }
-)
-
 SUBPROCESS_BANNED_NAMES: frozenset[str] = frozenset(
     {"run", "Popen", "call", "check_call", "check_output"}
 )
@@ -303,7 +291,25 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
                     )
         if node.module is not None:
             banned = _banned_module_root(node.module)
-            if banned is not None:
+            # Also catch ``from google import generativeai`` where the module
+            # root is ``google`` but the name completes a banned SDK path.
+            banned_alias: str | None = None
+            if banned is None:
+                banned_alias = next(
+                    (
+                        alias.name
+                        for alias in node.names
+                        if _banned_module_root(f"{node.module}.{alias.name}")
+                        is not None
+                    ),
+                    None,
+                )
+            if banned is not None or banned_alias is not None:
+                import_repr = (
+                    f"from {node.module} import {banned_alias}"
+                    if banned_alias is not None
+                    else f"from {node.module} import ..."
+                )
                 self.violations.append(
                     RoutingViolation(
                         skill_name=self.skill_name,
@@ -311,7 +317,7 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
                         check=CHECK_LLM_IMPORT,
                         line_number=self._abs_line(node.lineno),
                         message=(
-                            f"LLM SDK import 'from {node.module} import ...' is not "
+                            f"LLM SDK import '{import_repr}' is not "
                             "allowed in a deterministic skill shim."
                         ),
                     )
@@ -507,8 +513,12 @@ def _line_is_dispatch(tokens: tuple[str, ...], raw: str) -> bool:
     if not head_tokens:
         return False
 
-    if head_tokens[0] == "onex" and len(head_tokens) >= 3:
-        subcmd = head_tokens[1]
+    # Accept both ``onex run-node X`` and ``uv run onex run-node X``.
+    onex_tokens = head_tokens
+    if len(head_tokens) >= 2 and head_tokens[0] == "uv" and head_tokens[1] == "run":
+        onex_tokens = head_tokens[2:]
+    if onex_tokens and onex_tokens[0] == "onex" and len(onex_tokens) >= 3:
+        subcmd = onex_tokens[1]
         if subcmd in {"run", "run-node", "node"}:
             return True
 

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -42,9 +42,6 @@ Additionally, the markdown body must still reference ``SkillRoutingError``
 with the ``do not produce prose`` directive (inherited from OMN-8749) so that
 the markdown contract matches the AST contract.
 
-Skills without a backing node (S17 scope) are excluded via
-``MISSING_NODE_SKILLS``.
-
 Exit codes:
     0  All Tier 1 deterministic skills pass
     1  One or more violations found (blocking), or invalid invocation
@@ -56,11 +53,14 @@ from __future__ import annotations
 
 import argparse
 import ast
+import logging
 import re
 import shlex
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Skill classification (mirrors OMN-8749)
@@ -86,17 +86,6 @@ TIER1_DETERMINISTIC_SKILLS: frozenset[str] = frozenset(
         "session",
         "start_environment",
         "verify_plugin",
-    }
-)
-
-MISSING_NODE_SKILLS: frozenset[str] = frozenset(
-    {
-        "bus_audit",
-        "dod_sweep",
-        "env_parity",
-        "gap",
-        "integration_sweep",
-        "pr_watch",
     }
 )
 
@@ -131,6 +120,12 @@ SUBPROCESS_ORCHESTRATION_CALLS: frozenset[tuple[str, str]] = frozenset(
         ("os", "popen"),
     }
 )
+
+SUBPROCESS_BANNED_NAMES: frozenset[str] = frozenset(
+    {"run", "Popen", "call", "check_call", "check_output"}
+)
+
+OS_BANNED_NAMES: frozenset[str] = frozenset({"system", "popen"})
 
 # ---------------------------------------------------------------------------
 # Violation codes
@@ -255,6 +250,15 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
         self.skill_path = skill_path
         self.block = block
         self.violations: list[RoutingViolation] = []
+        # Track aliases so ``import subprocess as sp`` and ``from subprocess
+        # import run`` still trip the subprocess-orchestration check. Always
+        # include the module names themselves to preserve the default binding.
+        self._subprocess_aliases: set[str] = {"subprocess"}
+        self._os_aliases: set[str] = {"os"}
+        # Names imported directly from subprocess/os (``from subprocess import run``)
+        # map local-name -> canonical (module, attr) so bare ``run(...)`` calls
+        # are recognised as subprocess orchestration.
+        self._direct_orch_calls: dict[str, tuple[str, str]] = {}
 
     def _abs_line(self, node_lineno: int) -> int:
         # +1 because the fence itself sits on block.start_line, body starts next line.
@@ -262,6 +266,10 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
+            if alias.name == "subprocess":
+                self._subprocess_aliases.add(alias.asname or alias.name)
+            elif alias.name == "os":
+                self._os_aliases.add(alias.asname or alias.name)
             banned = _banned_module_root(alias.name)
             if banned is not None:
                 self.violations.append(
@@ -279,6 +287,20 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in SUBPROCESS_BANNED_NAMES:
+                    self._direct_orch_calls[alias.asname or alias.name] = (
+                        "subprocess",
+                        alias.name,
+                    )
+        elif node.module == "os":
+            for alias in node.names:
+                if alias.name in OS_BANNED_NAMES:
+                    self._direct_orch_calls[alias.asname or alias.name] = (
+                        "os",
+                        alias.name,
+                    )
         if node.module is not None:
             banned = _banned_module_root(node.module)
             if banned is not None:
@@ -302,8 +324,12 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
             owner = func.value.id
             attr = func.attr
-            pair = (owner, attr)
-            if pair in SUBPROCESS_ORCHESTRATION_CALLS:
+            in_subprocess = (
+                owner in self._subprocess_aliases and attr in SUBPROCESS_BANNED_NAMES
+            )
+            in_os = owner in self._os_aliases and attr in OS_BANNED_NAMES
+            if in_subprocess or in_os:
+                canonical_module = "subprocess" if in_subprocess else "os"
                 self.violations.append(
                     RoutingViolation(
                         skill_name=self.skill_name,
@@ -311,11 +337,25 @@ class PythonBlockAnalyzer(ast.NodeVisitor):
                         check=CHECK_SUBPROCESS_ORCH,
                         line_number=self._abs_line(node.lineno),
                         message=(
-                            f"Subprocess orchestration call '{owner}.{attr}(...)' "
+                            f"Subprocess orchestration call '{canonical_module}.{attr}(...)' "
                             "is not allowed around the dispatch."
                         ),
                     )
                 )
+        elif isinstance(func, ast.Name) and func.id in self._direct_orch_calls:
+            canonical_module, canonical_attr = self._direct_orch_calls[func.id]
+            self.violations.append(
+                RoutingViolation(
+                    skill_name=self.skill_name,
+                    skill_path=self.skill_path,
+                    check=CHECK_SUBPROCESS_ORCH,
+                    line_number=self._abs_line(node.lineno),
+                    message=(
+                        f"Subprocess orchestration call '{canonical_module}.{canonical_attr}(...)' "
+                        "is not allowed around the dispatch."
+                    ),
+                )
+            )
         # Detect chained attribute calls like client.messages.create(...).
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
             inner = func.value
@@ -344,18 +384,15 @@ def check_python_block(
     try:
         tree = ast.parse(block.source)
     except SyntaxError as exc:
-        # Many skills embed pseudocode; we log but don't block on parse errors.
-        return [
-            RoutingViolation(
-                skill_name=skill_name,
-                skill_path=skill_path,
-                check=CHECK_PARSE_ERROR,
-                line_number=block.start_line,
-                message=(
-                    f"Skipping unparseable python block (line {exc.lineno}): {exc.msg}"
-                ),
-            )
-        ]
+        # Many skills embed pseudocode; log and skip without emitting a
+        # blocking violation so ``main()`` does not fail on narrative blocks.
+        logger.info(
+            "Skipping unparseable python block in %s (line %s): %s",
+            skill_path,
+            exc.lineno,
+            exc.msg,
+        )
+        return []
     analyzer = PythonBlockAnalyzer(skill_name, skill_path, block)
     analyzer.visit(tree)
     return analyzer.violations
@@ -618,9 +655,12 @@ def _branch_tests_failure(raw: str) -> bool:
 # ---------------------------------------------------------------------------
 
 # Inline-code dispatch: `onex run-node X` or `onex node X` or
-# `uv run onex node X` — captured from a markdown backtick span.
+# `uv run onex node X` — captured from a markdown backtick span. The target
+# must be a real node identifier (alnum / underscore / dot / hyphen), not a
+# placeholder like ``<node_name>`` which would let the boilerplate routing
+# sentence satisfy the contract without naming any node.
 _INLINE_DISPATCH_RE = re.compile(
-    r"`(?:uv\s+run\s+)?onex\s+(?:run-node|node|run)\s+\S+`"
+    r"`(?:uv\s+run\s+)?onex\s+(?:run-node|node|run)\s+[A-Za-z0-9_][A-Za-z0-9_.\-]*`"
 )
 
 # Publish declaration: "Publish to `onex.cmd.foo.bar.v1`" or
@@ -628,7 +668,8 @@ _INLINE_DISPATCH_RE = re.compile(
 # (publish / dispatch / emit / send) followed by an onex.cmd.* topic within
 # the same line, tolerating backticks and angle brackets around the topic.
 _PUBLISH_DECLARATION_RE = re.compile(
-    r"(?:publish|dispatch(?:es)?|emit|sends?)\b[^\n`]{0,80}"
+    r"(?:publish(?:es|ed)?|dispatch(?:es|ed)?|emit(?:s|ted)?|sends?)\b"
+    r"[^\n`]{0,80}"
     r"`?(onex\.cmd\.[A-Za-z0-9_\-]+(?:\.[A-Za-z0-9_\-]+)+)`?",
     re.IGNORECASE,
 )

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -731,7 +731,20 @@ def scan_skill(skill_path: Path) -> list[RoutingViolation]:
 
     # Whole-document dispatch evidence: a code-fenced command, an inline-code
     # dispatch reference, or a prose "Publish to onex.cmd.*" declaration.
+    # Also check prompt.md in the same directory — some skills (e.g. session)
+    # keep the canonical dispatch command there to satisfy per-skill audit gates
+    # that count onex-run occurrences across all files in the skill directory.
     document_dispatches = total_shell_dispatches + _count_document_dispatches(content)
+    if document_dispatches == 0:
+        prompt_md = skill_path.parent / "prompt.md"
+        if prompt_md.exists():
+            prompt_content = prompt_md.read_text(encoding="utf-8")
+            prompt_blocks = extract_code_blocks(prompt_content)
+            for block in prompt_blocks:
+                if block.language in SHELL_LANGUAGES:
+                    count, _ = check_shell_block(skill_name, skill_path, block)
+                    document_dispatches += count
+            document_dispatches += _count_document_dispatches(prompt_content)
     if document_dispatches == 0:
         violations.append(
             RoutingViolation(
@@ -742,8 +755,8 @@ def scan_skill(skill_path: Path) -> list[RoutingViolation]:
                 message=(
                     "Deterministic skill must declare at least one node "
                     "dispatch (`onex run-node` / `onex node` in a shell block "
-                    "or inline code, OR a Kafka publish to an `onex.cmd.*` "
-                    "topic). None found."
+                    "or inline code in SKILL.md or prompt.md, OR a Kafka "
+                    "publish to an `onex.cmd.*` topic). None found."
                 ),
             )
         )

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -464,6 +464,21 @@ def _tokenize_shell(block: CodeBlock) -> list[ShellLine]:
                 tokens=tokens,
             )
         )
+    if buffer:
+        assert buffer_start is not None
+        logical = " ".join(segment.strip() for segment in buffer).strip()
+        if logical and not logical.startswith("#"):
+            try:
+                tokens = tuple(shlex.split(logical, comments=True, posix=True))
+            except ValueError:
+                tokens = (logical,)
+            result.append(
+                ShellLine(
+                    abs_line=block.start_line + buffer_start,
+                    raw=logical,
+                    tokens=tokens,
+                )
+            )
     return result
 
 
@@ -519,7 +534,9 @@ def _line_is_dispatch(tokens: tuple[str, ...], raw: str) -> bool:
         onex_tokens = head_tokens[2:]
     if onex_tokens and onex_tokens[0] == "onex" and len(onex_tokens) >= 3:
         subcmd = onex_tokens[1]
-        if subcmd in {"run", "run-node", "node"}:
+        target = onex_tokens[2]
+        invalid_target = target.startswith("-") or "<" in target or ">" in target
+        if subcmd in {"run", "run-node", "node"} and not invalid_target:
             return True
 
     # Kafka publish with onex.cmd.* topic anywhere in the command.
@@ -539,7 +556,8 @@ def _is_wrapped_dispatch(raw: str) -> bool:
     We detect the wrapper pattern when one of the "-c" wrappers contains the
     onex command string literally.
     """
-    if "onex run" not in raw and "onex node" not in raw:
+    lowered = raw.lower()
+    if "onex" not in lowered:
         return False
     wrapper_prefixes = (
         "python -c",
@@ -548,8 +566,9 @@ def _is_wrapped_dispatch(raw: str) -> bool:
         "sh -c",
         "zsh -c",
     )
-    lowered = raw.lower()
-    return any(prefix in lowered for prefix in wrapper_prefixes)
+    if not any(prefix in lowered for prefix in wrapper_prefixes):
+        return False
+    return re.search(r"\bonex\b[^A-Za-z0-9]+(?:run-node|run|node)\b", lowered) is not None
 
 
 def _is_prose_fallback(line: ShellLine) -> bool:
@@ -562,7 +581,14 @@ def _is_prose_fallback(line: ShellLine) -> bool:
     We require a prose verb at the head of the command (after env assignments),
     and the raw line must contain a word hinting at fallback / degrade / prose.
     """
-    head = line.tokens[0] if line.tokens else ""
+    idx = 0
+    while idx < len(line.tokens) and "=" in line.tokens[idx] and not line.tokens[idx].startswith("-"):
+        name = line.tokens[idx].split("=", 1)[0]
+        if name and name.replace("_", "").isalnum() and name[0].isalpha():
+            idx += 1
+            continue
+        break
+    head = line.tokens[idx] if idx < len(line.tokens) else ""
     if head not in _PROSE_FALLBACK_VERBS:
         return False
     hint_re = re.compile(

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -1,0 +1,899 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""AST-based CI lint gate: deterministic-skill routing enforcement (OMN-8765).
+
+Enforces the W3 Hard Gate from OMN-8737: every Tier 1 deterministic skill
+must route through ``onex run-node`` / ``onex node`` (or the equivalent Kafka
+command dispatch) and surface ``SkillRoutingError`` on routing failure. Skills
+must not contain inline LLM SDK usage or subprocess orchestration wrappers
+that would let an agent produce prose instead of dispatching.
+
+The predecessor in ``omniclaude`` (OMN-8749) enforces the same contract with
+regex heuristics over the full markdown. This gate is stricter: it parses
+each fenced ```python``` block with ``ast`` and each fenced shell block
+(``bash`` / ``sh`` / ``shell`` / ``zsh``) as tokens, and applies structural
+checks rather than line-count thresholds:
+
+  1. Zero LLM SDK imports in any Python block (``anthropic``, ``openai``,
+     ``google.generativeai``).
+  2. At least one node-dispatch declaration (``onex run-node`` / ``onex
+     run`` / ``onex node`` in a bash/sh/shell block or inline-code, OR a
+     Kafka publish to an ``onex.cmd.*`` topic). CLI usage banners and
+     comments are skipped.
+  3. No subprocess orchestration wrappers around the dispatch
+     (``subprocess.run``/``subprocess.Popen``/``os.system``) in Python blocks,
+     and no shell ``python -c`` / ``bash -c`` wrapping the dispatch line.
+  4. No ``client.messages.create`` / ``client.completions.create`` (Anthropic /
+     OpenAI message APIs) anywhere in the Python blocks.
+  5. No hidden conditional prose fallback path after a routing failure — e.g.,
+     a shell conditional that responds/writes/describes when the dispatch
+     exits non-zero. Detected structurally by walking the token stream after
+     the dispatch site.
+
+Per amendment A4 on OMN-8765, dispatch *presence* is asserted via structural
+token-matching rather than a line-count threshold; the "exactly one" phrasing
+in the original amendment is interpreted as "at least one, unambiguous"
+because Kafka-publish dispatches are declared in payload schemas rather than
+as imperative shell commands.
+
+Additionally, the markdown body must still reference ``SkillRoutingError``
+with the ``do not produce prose`` directive (inherited from OMN-8749) so that
+the markdown contract matches the AST contract.
+
+Skills without a backing node (S17 scope) are excluded via
+``MISSING_NODE_SKILLS``.
+
+Exit codes:
+    0  All Tier 1 deterministic skills pass
+    1  One or more violations found (blocking), or invalid invocation
+
+Linear: OMN-8765 (S18). Parent: OMN-8737.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Skill classification (mirrors OMN-8749)
+# ---------------------------------------------------------------------------
+
+TIER1_DETERMINISTIC_SKILLS: frozenset[str] = frozenset(
+    {
+        "autopilot",
+        "aislop_sweep",
+        "build_loop",
+        "ci_watch",
+        "compliance_sweep",
+        "contract_sweep",
+        "dashboard_sweep",
+        "data_flow_sweep",
+        "golden_chain_sweep",
+        "merge_sweep",
+        "pipeline_fill",
+        "platform_readiness",
+        "redeploy",
+        "release",
+        "runtime_sweep",
+        "session",
+        "start_environment",
+        "verify_plugin",
+    }
+)
+
+MISSING_NODE_SKILLS: frozenset[str] = frozenset(
+    {
+        "bus_audit",
+        "dod_sweep",
+        "env_parity",
+        "gap",
+        "integration_sweep",
+        "pr_watch",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Banned LLM SDK imports
+# ---------------------------------------------------------------------------
+
+BANNED_LLM_MODULES: frozenset[str] = frozenset(
+    {
+        "anthropic",
+        "openai",
+        "google.generativeai",
+    }
+)
+
+BANNED_LLM_ATTR_CALLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("messages", "create"),
+        ("completions", "create"),
+        ("chat", "completions"),
+    }
+)
+
+SUBPROCESS_ORCHESTRATION_CALLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("subprocess", "run"),
+        ("subprocess", "Popen"),
+        ("subprocess", "call"),
+        ("subprocess", "check_call"),
+        ("subprocess", "check_output"),
+        ("os", "system"),
+        ("os", "popen"),
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Violation codes
+# ---------------------------------------------------------------------------
+
+CHECK_MISSING_SKILL_MD = "MISSING_SKILL_MD"
+CHECK_LLM_IMPORT = "LLM_SDK_IMPORT"
+CHECK_LLM_API_CALL = "LLM_API_CALL"
+CHECK_SUBPROCESS_ORCH = "SUBPROCESS_ORCHESTRATION"
+CHECK_DISPATCH_COUNT = "DISPATCH_COUNT"
+CHECK_SHELL_WRAPPER = "SHELL_WRAPPER_AROUND_DISPATCH"
+CHECK_PROSE_FALLBACK = "PROSE_FALLBACK_BRANCH"
+CHECK_MISSING_ROUTING_ERROR = "MISSING_SKILL_ROUTING_ERROR"
+CHECK_PARSE_ERROR = "CODE_BLOCK_PARSE_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Code block extraction
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CodeBlock:
+    """A fenced code block extracted from a SKILL.md file."""
+
+    language: str
+    start_line: int  # 1-indexed line number of the opening fence
+    source: str
+
+
+_FENCE_RE = re.compile(r"^([`~]{3,})\s*([A-Za-z0-9_+-]*)\s*$")
+
+
+def extract_code_blocks(markdown: str) -> list[CodeBlock]:
+    """Extract all fenced code blocks from a markdown document.
+
+    Handles both backtick (```) and tilde (~~~) fences. The opening and closing
+    fence must use the same character and length.
+    """
+    blocks: list[CodeBlock] = []
+    lines = markdown.splitlines()
+    i = 0
+    while i < len(lines):
+        match = _FENCE_RE.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+        fence = match.group(1)
+        language = match.group(2).lower()
+        start_line = i + 1  # 1-indexed
+        body: list[str] = []
+        j = i + 1
+        while j < len(lines):
+            closing = _FENCE_RE.match(lines[j])
+            if closing is not None and closing.group(1) == fence:
+                break
+            body.append(lines[j])
+            j += 1
+        blocks.append(
+            CodeBlock(
+                language=language,
+                start_line=start_line,
+                source="\n".join(body),
+            )
+        )
+        # Skip past the closing fence (or EOF)
+        i = j + 1
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Violations
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutingViolation:
+    skill_name: str
+    skill_path: Path
+    check: str
+    line_number: int  # 0 when the violation is skill-level rather than block-level
+    message: str
+
+    def format_line(self) -> str:
+        loc = f"{self.skill_path}"
+        if self.line_number > 0:
+            loc = f"{loc}:{self.line_number}"
+        return f"{loc}: [{self.check}] {self.message}"
+
+
+@dataclass
+class ScanResult:
+    skills_scanned: int = 0
+    skills_with_violations: int = 0
+    total_violations: int = 0
+    violations: list[RoutingViolation] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Python AST checks
+# ---------------------------------------------------------------------------
+
+
+def _banned_module_root(module: str) -> str | None:
+    """Return the banned prefix if ``module`` matches a banned LLM SDK."""
+    for banned in BANNED_LLM_MODULES:
+        if module == banned or module.startswith(banned + "."):
+            return banned
+    return None
+
+
+class PythonBlockAnalyzer(ast.NodeVisitor):
+    """AST visitor that records deterministic-skill violations in a Python block."""
+
+    def __init__(
+        self,
+        skill_name: str,
+        skill_path: Path,
+        block: CodeBlock,
+    ) -> None:
+        self.skill_name = skill_name
+        self.skill_path = skill_path
+        self.block = block
+        self.violations: list[RoutingViolation] = []
+
+    def _abs_line(self, node_lineno: int) -> int:
+        # +1 because the fence itself sits on block.start_line, body starts next line.
+        return self.block.start_line + node_lineno
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            banned = _banned_module_root(alias.name)
+            if banned is not None:
+                self.violations.append(
+                    RoutingViolation(
+                        skill_name=self.skill_name,
+                        skill_path=self.skill_path,
+                        check=CHECK_LLM_IMPORT,
+                        line_number=self._abs_line(node.lineno),
+                        message=(
+                            f"LLM SDK import '{alias.name}' is not allowed in a "
+                            "deterministic skill shim."
+                        ),
+                    )
+                )
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module is not None:
+            banned = _banned_module_root(node.module)
+            if banned is not None:
+                self.violations.append(
+                    RoutingViolation(
+                        skill_name=self.skill_name,
+                        skill_path=self.skill_path,
+                        check=CHECK_LLM_IMPORT,
+                        line_number=self._abs_line(node.lineno),
+                        message=(
+                            f"LLM SDK import 'from {node.module} import ...' is not "
+                            "allowed in a deterministic skill shim."
+                        ),
+                    )
+                )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Detect subprocess orchestration and LLM API invocations.
+        func = node.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            owner = func.value.id
+            attr = func.attr
+            pair = (owner, attr)
+            if pair in SUBPROCESS_ORCHESTRATION_CALLS:
+                self.violations.append(
+                    RoutingViolation(
+                        skill_name=self.skill_name,
+                        skill_path=self.skill_path,
+                        check=CHECK_SUBPROCESS_ORCH,
+                        line_number=self._abs_line(node.lineno),
+                        message=(
+                            f"Subprocess orchestration call '{owner}.{attr}(...)' "
+                            "is not allowed around the dispatch."
+                        ),
+                    )
+                )
+        # Detect chained attribute calls like client.messages.create(...).
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Attribute):
+            inner = func.value
+            pair = (inner.attr, func.attr)
+            if pair in BANNED_LLM_ATTR_CALLS:
+                self.violations.append(
+                    RoutingViolation(
+                        skill_name=self.skill_name,
+                        skill_path=self.skill_path,
+                        check=CHECK_LLM_API_CALL,
+                        line_number=self._abs_line(node.lineno),
+                        message=(
+                            f"Banned LLM API call '...{inner.attr}.{func.attr}(...)' "
+                            "found in deterministic skill shim."
+                        ),
+                    )
+                )
+        self.generic_visit(node)
+
+
+def check_python_block(
+    skill_name: str,
+    skill_path: Path,
+    block: CodeBlock,
+) -> list[RoutingViolation]:
+    try:
+        tree = ast.parse(block.source)
+    except SyntaxError as exc:
+        # Many skills embed pseudocode; we log but don't block on parse errors.
+        return [
+            RoutingViolation(
+                skill_name=skill_name,
+                skill_path=skill_path,
+                check=CHECK_PARSE_ERROR,
+                line_number=block.start_line,
+                message=(
+                    f"Skipping unparseable python block (line {exc.lineno}): {exc.msg}"
+                ),
+            )
+        ]
+    analyzer = PythonBlockAnalyzer(skill_name, skill_path, block)
+    analyzer.visit(tree)
+    return analyzer.violations
+
+
+# ---------------------------------------------------------------------------
+# Shell block checks
+# ---------------------------------------------------------------------------
+
+SHELL_LANGUAGES: frozenset[str] = frozenset({"bash", "sh", "shell", "zsh"})
+
+_ONEX_CMD_TOPIC_RE = re.compile(r"onex\.cmd\.[A-Za-z0-9_\-]+(?:\.[A-Za-z0-9_\-]+)+")
+_PROSE_FALLBACK_VERBS: frozenset[str] = frozenset(
+    {"echo", "printf", "cat", "write", "describe", "respond"}
+)
+
+
+@dataclass
+class ShellLine:
+    abs_line: int
+    raw: str
+    tokens: tuple[str, ...]
+
+
+def _tokenize_shell(block: CodeBlock) -> list[ShellLine]:
+    """Tokenize shell lines with best-effort shlex parsing.
+
+    Logical lines continued with a trailing ``\\`` are joined before
+    tokenization so multi-line ``onex run-node ... \\`` invocations are
+    counted as a single dispatch. Lines that fail shlex (unbalanced quotes,
+    heredoc markers, etc.) are kept as single raw tokens so downstream
+    matchers can still run regex checks.
+    """
+    result: list[ShellLine] = []
+    buffer: list[str] = []
+    buffer_start: int | None = None
+    for rel_line, raw in enumerate(block.source.splitlines(), start=1):
+        if raw.rstrip().endswith("\\"):
+            if buffer_start is None:
+                buffer_start = rel_line
+            buffer.append(raw.rstrip()[:-1])
+            continue
+        if buffer:
+            buffer.append(raw)
+            logical = " ".join(segment.strip() for segment in buffer).strip()
+            start_rel = buffer_start if buffer_start is not None else rel_line
+            buffer = []
+            buffer_start = None
+        else:
+            logical = raw.strip()
+            start_rel = rel_line
+
+        if not logical or logical.startswith("#"):
+            continue
+        try:
+            tokens = tuple(shlex.split(logical, comments=True, posix=True))
+        except ValueError:
+            tokens = (logical,)
+        result.append(
+            ShellLine(
+                abs_line=block.start_line + start_rel,
+                raw=logical,
+                tokens=tokens,
+            )
+        )
+    return result
+
+
+def _is_cli_banner_line(raw: str) -> bool:
+    """Skip usage banners / documentation examples that mention ``onex run``.
+
+    Banner examples we want to allow — they are not dispatch calls:
+      - ``Usage: onex run-node <node>``
+      - ``Run via: onex run-node session_orchestrator``
+      - ``# Example: onex node merge_sweep``
+    The heuristic: if the line begins with a non-command prose token (``usage``,
+    ``example``, ``run via``, ``see``, etc.) *before* the onex invocation, it is
+    documentation, not executable dispatch. A command line dispatching ``onex
+    run-node`` starts with ``onex`` (or with an env-prefix like ``ENV=...``).
+    """
+    lowered = raw.lower().lstrip()
+    for banner in ("usage:", "example:", "example:", "run via:", "see ", "see:"):
+        if lowered.startswith(banner):
+            return True
+    return False
+
+
+def _line_is_dispatch(tokens: tuple[str, ...], raw: str) -> bool:
+    """Return True if the tokenized shell line is a node-dispatch invocation.
+
+    Three accepted forms:
+      - ``onex run-node <node>`` / ``onex run <node>`` / ``onex node <node>``
+      - ``rpk topic produce onex.cmd.<service>.<...>`` (Kafka publish wrapper)
+      - any other top-level command whose args include an ``onex.cmd.*`` topic
+        (generalised publish, covering ``kcat``/``kafka-console-producer``/…)
+    """
+    if not tokens:
+        return False
+    if _is_cli_banner_line(raw):
+        return False
+
+    # Strip env-var assignments (e.g., ``FOO=bar onex run-node x``).
+    idx = 0
+    while idx < len(tokens) and "=" in tokens[idx] and not tokens[idx].startswith("-"):
+        head = tokens[idx].split("=", 1)[0]
+        if head and head.replace("_", "").isalnum() and head[0].isalpha():
+            idx += 1
+            continue
+        break
+    head_tokens = tokens[idx:]
+
+    if not head_tokens:
+        return False
+
+    if head_tokens[0] == "onex" and len(head_tokens) >= 3:
+        subcmd = head_tokens[1]
+        if subcmd in {"run", "run-node", "node"}:
+            return True
+
+    # Kafka publish with onex.cmd.* topic anywhere in the command.
+    for tok in head_tokens:
+        if _ONEX_CMD_TOPIC_RE.search(tok):
+            return True
+
+    return False
+
+
+def _is_wrapped_dispatch(raw: str) -> bool:
+    """Detect subprocess wrappers around ``onex run-node`` dispatches.
+
+    Examples that should trip this:
+      - ``python -c "import subprocess; subprocess.run(['onex', 'run-node', ...])"``
+      - ``bash -c 'onex run-node ...'``
+    We detect the wrapper pattern when one of the "-c" wrappers contains the
+    onex command string literally.
+    """
+    if "onex run" not in raw and "onex node" not in raw:
+        return False
+    wrapper_prefixes = (
+        "python -c",
+        "python3 -c",
+        "bash -c",
+        "sh -c",
+        "zsh -c",
+    )
+    lowered = raw.lower()
+    return any(prefix in lowered for prefix in wrapper_prefixes)
+
+
+def _is_prose_fallback(line: ShellLine) -> bool:
+    """Detect a prose-writing fallback line inside an ``if ... fi`` block.
+
+    Trips on:
+      - ``echo "...fallback prose..."``
+      - ``printf "..."``
+      - ``cat <<EOF ... EOF``
+    We require a prose verb at the head of the command (after env assignments),
+    and the raw line must contain a word hinting at fallback / degrade / prose.
+    """
+    head = line.tokens[0] if line.tokens else ""
+    if head not in _PROSE_FALLBACK_VERBS:
+        return False
+    hint_re = re.compile(
+        r"(?:fallback|degrade|unavailable|if\s+.*?(?:fails?|unavailable)|"
+        r"claude|prose|advisory)",
+        re.IGNORECASE,
+    )
+    return hint_re.search(line.raw) is not None
+
+
+def check_shell_block(
+    skill_name: str,
+    skill_path: Path,
+    block: CodeBlock,
+) -> tuple[int, list[RoutingViolation]]:
+    """Return (dispatch_count, violations) for a shell block.
+
+    ``dispatch_count`` is summed across all shell blocks by the skill-level
+    aggregator before the ``exactly one dispatch`` rule is enforced.
+    """
+    violations: list[RoutingViolation] = []
+    dispatch_count = 0
+    lines = _tokenize_shell(block)
+
+    # Track whether we are inside a failure branch (``if ... fi`` block after a
+    # dispatch line) so we can flag prose fallback writes.
+    in_failure_branch = False
+    branch_depth = 0
+    saw_dispatch_before_branch = False
+
+    for line in lines:
+        raw = line.raw
+
+        # Flag shell wrappers around the dispatch.
+        if _is_wrapped_dispatch(raw):
+            violations.append(
+                RoutingViolation(
+                    skill_name=skill_name,
+                    skill_path=skill_path,
+                    check=CHECK_SHELL_WRAPPER,
+                    line_number=line.abs_line,
+                    message=(
+                        "Dispatch must be invoked directly; subprocess wrappers "
+                        "(python -c, bash -c, ...) around `onex run-node` are "
+                        "forbidden."
+                    ),
+                )
+            )
+
+        if _line_is_dispatch(line.tokens, raw):
+            dispatch_count += 1
+            saw_dispatch_before_branch = True
+            continue
+
+        # Track failure-branch depth.
+        if line.tokens and line.tokens[0] == "if":
+            branch_depth += 1
+            if saw_dispatch_before_branch and _branch_tests_failure(raw):
+                in_failure_branch = True
+            continue
+        if line.tokens and line.tokens[0] == "fi":
+            if branch_depth > 0:
+                branch_depth -= 1
+            if branch_depth == 0:
+                in_failure_branch = False
+            continue
+
+        if in_failure_branch and _is_prose_fallback(line):
+            violations.append(
+                RoutingViolation(
+                    skill_name=skill_name,
+                    skill_path=skill_path,
+                    check=CHECK_PROSE_FALLBACK,
+                    line_number=line.abs_line,
+                    message=(
+                        "Conditional prose fallback after routing failure is "
+                        "forbidden; surface SkillRoutingError instead."
+                    ),
+                )
+            )
+
+    return dispatch_count, violations
+
+
+def _branch_tests_failure(raw: str) -> bool:
+    """Heuristic: does an ``if`` line test for a non-zero exit (routing failure)?"""
+    failure_patterns = (
+        "$? -ne 0",
+        "$? != 0",
+        '"$?" -ne 0',
+        '"$?" != 0',
+        "! onex ",
+        "|| ",
+    )
+    return any(pattern in raw for pattern in failure_patterns)
+
+
+# ---------------------------------------------------------------------------
+# Document-scope dispatch scanner
+# ---------------------------------------------------------------------------
+
+# Inline-code dispatch: `onex run-node X` or `onex node X` or
+# `uv run onex node X` — captured from a markdown backtick span.
+_INLINE_DISPATCH_RE = re.compile(
+    r"`(?:uv\s+run\s+)?onex\s+(?:run-node|node|run)\s+\S+`"
+)
+
+# Publish declaration: "Publish to `onex.cmd.foo.bar.v1`" or
+# "Dispatch: Kafka publish to `onex.cmd.foo.bar.v1`". We match the verb
+# (publish / dispatch / emit / send) followed by an onex.cmd.* topic within
+# the same line, tolerating backticks and angle brackets around the topic.
+_PUBLISH_DECLARATION_RE = re.compile(
+    r"(?:publish|dispatch(?:es)?|emit|sends?)\b[^\n`]{0,80}"
+    r"`?(onex\.cmd\.[A-Za-z0-9_\-]+(?:\.[A-Za-z0-9_\-]+)+)`?",
+    re.IGNORECASE,
+)
+
+
+def _count_document_dispatches(content: str) -> int:
+    """Count dispatch declarations expressed outside of shell code blocks.
+
+    Returns the count of inline-code dispatches (``\\`onex run-node X\\```)
+    plus prose publish declarations (``Publish to \\`onex.cmd.*\\```).
+    Both forms satisfy the routing contract when paired with the
+    SkillRoutingError directive.
+    """
+    inline = len(_INLINE_DISPATCH_RE.findall(content))
+    prose = len(_PUBLISH_DECLARATION_RE.findall(content))
+    return inline + prose
+
+
+# ---------------------------------------------------------------------------
+# Skill-level scan
+# ---------------------------------------------------------------------------
+
+_ROUTING_ERROR_RE = re.compile(r"SkillRoutingError")
+_NO_PROSE_RE = re.compile(r"do not produce prose", re.IGNORECASE)
+
+
+def scan_skill(skill_path: Path) -> list[RoutingViolation]:
+    skill_name = skill_path.parent.name
+    content = skill_path.read_text(encoding="utf-8")
+    violations: list[RoutingViolation] = []
+
+    blocks = extract_code_blocks(content)
+
+    # Python-block checks
+    for block in blocks:
+        if block.language == "python":
+            violations.extend(check_python_block(skill_name, skill_path, block))
+
+    # Shell-block checks (flag prose fallbacks + subprocess wrappers). The
+    # dispatch-presence check runs at whole-document scope below because valid
+    # dispatch declarations also appear in inline code and prose bullet lists
+    # for Kafka-publish skills.
+    total_shell_dispatches = 0
+    for block in blocks:
+        if block.language in SHELL_LANGUAGES:
+            count, block_violations = check_shell_block(skill_name, skill_path, block)
+            total_shell_dispatches += count
+            violations.extend(block_violations)
+
+    # Whole-document dispatch evidence: a code-fenced command, an inline-code
+    # dispatch reference, or a prose "Publish to onex.cmd.*" declaration.
+    document_dispatches = total_shell_dispatches + _count_document_dispatches(content)
+    if document_dispatches == 0:
+        violations.append(
+            RoutingViolation(
+                skill_name=skill_name,
+                skill_path=skill_path,
+                check=CHECK_DISPATCH_COUNT,
+                line_number=0,
+                message=(
+                    "Deterministic skill must declare at least one node "
+                    "dispatch (`onex run-node` / `onex node` in a shell block "
+                    "or inline code, OR a Kafka publish to an `onex.cmd.*` "
+                    "topic). None found."
+                ),
+            )
+        )
+
+    # Markdown-level SkillRoutingError contract (mirrors OMN-8749)
+    if _ROUTING_ERROR_RE.search(content) is None:
+        violations.append(
+            RoutingViolation(
+                skill_name=skill_name,
+                skill_path=skill_path,
+                check=CHECK_MISSING_ROUTING_ERROR,
+                line_number=0,
+                message=(
+                    "SKILL.md must reference `SkillRoutingError` and instruct "
+                    "agents to surface it directly (`do not produce prose`)."
+                ),
+            )
+        )
+    elif _NO_PROSE_RE.search(content) is None:
+        violations.append(
+            RoutingViolation(
+                skill_name=skill_name,
+                skill_path=skill_path,
+                check=CHECK_MISSING_ROUTING_ERROR,
+                line_number=0,
+                message=(
+                    "SKILL.md references `SkillRoutingError` but is missing the "
+                    "`do not produce prose` directive."
+                ),
+            )
+        )
+
+    return violations
+
+
+def scan_skills_root(skills_root: Path) -> ScanResult:
+    result = ScanResult()
+    for skill_name in sorted(TIER1_DETERMINISTIC_SKILLS):
+        skill_file = skills_root / skill_name / "SKILL.md"
+        result.skills_scanned += 1
+        if not skill_file.exists():
+            violation = RoutingViolation(
+                skill_name=skill_name,
+                skill_path=skill_file,
+                check=CHECK_MISSING_SKILL_MD,
+                line_number=0,
+                message=(
+                    f"SKILL.md not found for Tier 1 deterministic skill '{skill_name}'."
+                ),
+            )
+            result.violations.append(violation)
+            result.skills_with_violations += 1
+            result.total_violations += 1
+            continue
+        skill_violations = scan_skill(skill_file)
+        if skill_violations:
+            result.skills_with_violations += 1
+            result.total_violations += len(skill_violations)
+            result.violations.extend(skill_violations)
+    return result
+
+
+def scan_single_skill(skills_root: Path, skill_name: str) -> ScanResult:
+    result = ScanResult(skills_scanned=1)
+    skill_file = skills_root / skill_name / "SKILL.md"
+    if not skill_file.exists():
+        violation = RoutingViolation(
+            skill_name=skill_name,
+            skill_path=skill_file,
+            check=CHECK_MISSING_SKILL_MD,
+            line_number=0,
+            message=f"SKILL.md not found for skill '{skill_name}'.",
+        )
+        result.violations.append(violation)
+        result.skills_with_violations = 1
+        result.total_violations = 1
+        return result
+    violations = scan_skill(skill_file)
+    if violations:
+        result.skills_with_violations = 1
+        result.total_violations = len(violations)
+        result.violations.extend(violations)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_result(result: ScanResult, *, report_mode: bool) -> None:
+    if not result.violations:
+        print(
+            f"validate_deterministic_skill_routing: OK — "
+            f"{result.skills_scanned} Tier 1 skill(s) scanned, 0 violations."
+        )
+        return
+
+    label = "Report" if report_mode else "FAILED"
+    print(
+        f"\nvalidate_deterministic_skill_routing: {label} — "
+        f"{result.total_violations} violation(s) in "
+        f"{result.skills_with_violations} skill(s)\n"
+    )
+    for violation in result.violations:
+        print(f"  {violation.format_line()}")
+
+    if not report_mode:
+        print(
+            "\nEach Tier 1 deterministic skill must:\n"
+            "  1. Import zero LLM SDKs (anthropic, openai, google.generativeai)\n"
+            "  2. Declare at least one node dispatch (`onex run-node` / `onex node`\n"
+            "     in a shell block or inline code, OR a Kafka publish to an\n"
+            "     `onex.cmd.*` topic)\n"
+            "  3. Not wrap dispatch in subprocess.run / bash -c / python -c\n"
+            "  4. Not invoke LLM completion APIs (client.messages.create, ...)\n"
+            "  5. Not contain conditional prose fallback branches\n"
+            "  6. Reference `SkillRoutingError` with `do not produce prose`\n"
+        )
+
+
+def _default_skills_root() -> Path:
+    """Resolve the default skills root by walking up to find an omniclaude sibling.
+
+    Search order (first existing wins):
+      1. ``$DETERMINISTIC_SKILL_ROOT`` env var
+      2. ``plugins/onex/skills`` relative to cwd
+      3. ``<repo_root>/../omniclaude/plugins/onex/skills``
+      4. ``$OMNI_HOME/omniclaude/plugins/onex/skills``
+    """
+    import os
+
+    env = os.environ.get("DETERMINISTIC_SKILL_ROOT")
+    if env:
+        return Path(env)
+    candidates: list[Path] = [Path.cwd() / "plugins" / "onex" / "skills"]
+    script_path = Path(__file__).resolve()
+    # scripts/ -> repo root -> parent
+    candidates.append(
+        script_path.parent.parent.parent / "omniclaude" / "plugins" / "onex" / "skills"
+    )
+    omni_home = os.environ.get("OMNI_HOME")
+    if omni_home:
+        candidates.append(
+            Path(omni_home) / "omniclaude" / "plugins" / "onex" / "skills"
+        )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "AST-based CI lint gate enforcing SkillRoutingError routing "
+            "across all Tier 1 deterministic skills (OMN-8765)."
+        ),
+    )
+    parser.add_argument(
+        "--skills-root",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the deterministic skills directory "
+            "(default: auto-discovered from omniclaude sibling or "
+            "$DETERMINISTIC_SKILL_ROOT)."
+        ),
+    )
+    parser.add_argument(
+        "--skill",
+        metavar="SKILL_NAME",
+        help="Scan only a single named skill (useful for local iteration).",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Print violations but exit 0 (non-blocking mode for rollout).",
+    )
+    args = parser.parse_args(argv)
+
+    skills_root: Path = args.skills_root or _default_skills_root()
+    if not skills_root.exists():
+        print(
+            f"ERROR: deterministic skills root not found: {skills_root}\n"
+            "       Pass --skills-root <path> or set $DETERMINISTIC_SKILL_ROOT.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.skill is not None:
+        result = scan_single_skill(skills_root, args.skill)
+    else:
+        result = scan_skills_root(skills_root)
+
+    _print_result(result, report_mode=args.report)
+
+    if args.report:
+        return 0
+    return 1 if result.total_violations > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -495,7 +495,7 @@ def _is_cli_banner_line(raw: str) -> bool:
     run-node`` starts with ``onex`` (or with an env-prefix like ``ENV=...``).
     """
     lowered = raw.lower().lstrip()
-    for banner in ("usage:", "example:", "example:", "run via:", "see ", "see:"):
+    for banner in ("usage:", "example:", "run via:", "see ", "see:"):
         if lowered.startswith(banner):
             return True
     return False

--- a/tests/unit/scripts/test_validate_deterministic_skill_routing.py
+++ b/tests/unit/scripts/test_validate_deterministic_skill_routing.py
@@ -25,6 +25,8 @@ from types import ModuleType
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[3]
     / "scripts"
@@ -457,3 +459,112 @@ def test_main_single_skill_flag(validator_mod: ModuleType, tmp_path: Path) -> No
         ["--skills-root", str(tmp_path), "--skill", clean_name]
     )
     assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit review hardening (OMN-8765, post-merge follow-ups)
+# ---------------------------------------------------------------------------
+
+
+def test_flags_subprocess_orch_via_aliased_import(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """`import subprocess as sp; sp.run(...)` must still trip the check."""
+    body = (
+        "---\ndescription: aliased subprocess\n---\n\n"
+        "```bash\nonex run-node node_x\n```\n\n"
+        "```python\n"
+        "import subprocess as sp\n"
+        "sp.run(['onex', 'run-node', 'x'])\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "alias_sub", body)
+    assert validator_mod.CHECK_SUBPROCESS_ORCH in _violation_codes(violations)
+
+
+def test_flags_subprocess_orch_via_from_import(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """`from subprocess import run; run(...)` must still trip the check."""
+    body = (
+        "---\ndescription: from-import subprocess\n---\n\n"
+        "```bash\nonex run-node node_x\n```\n\n"
+        "```python\n"
+        "from subprocess import run\n"
+        "run(['onex', 'run-node', 'x'])\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "from_sub", body)
+    assert validator_mod.CHECK_SUBPROCESS_ORCH in _violation_codes(violations)
+
+
+def test_flags_os_system_via_from_import(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """`from os import system; system(...)` must trip the subprocess-orch check."""
+    body = (
+        "---\ndescription: from-import os.system\n---\n\n"
+        "```bash\nonex run-node node_x\n```\n\n"
+        "```python\n"
+        "from os import system\n"
+        "system('onex run-node x')\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "from_os", body)
+    assert validator_mod.CHECK_SUBPROCESS_ORCH in _violation_codes(violations)
+
+
+def test_unparseable_python_block_is_not_blocking(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """Pseudocode in a python fence must log and skip, not emit a violation."""
+    body = (
+        "---\ndescription: pseudocode\n---\n\n"
+        "```bash\nonex run-node node_x\n```\n\n"
+        "```python\n"
+        "# pseudocode, not parseable:\n"
+        "if thing => other: do the stuff\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "pseudocode", body)
+    codes = _violation_codes(violations)
+    assert validator_mod.CHECK_PARSE_ERROR not in codes
+    assert violations == [], (
+        "An unparseable python block should be skipped silently, not treated "
+        f"as a violation; got {violations}"
+    )
+
+
+def test_placeholder_inline_dispatch_does_not_satisfy_contract(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """Boilerplate ``onex node <node_name>`` placeholder must NOT satisfy dispatch."""
+    # Deliberately strip real dispatch fences; only the routing-contract
+    # placeholder sentence references ``onex node <node_name>``.
+    body = (
+        "---\ndescription: placeholder only\n---\n\n"
+        "# placeholder_only\n\n"
+        "Plain prose with no real dispatch.\n\n"
+        "## Routing Contract\n\n"
+        "Dispatch must use `onex node <node_name>`. Non-zero exit emits a "
+        "`SkillRoutingError` JSON envelope — surface it directly, do not "
+        "produce prose.\n"
+    )
+    violations = _scan(validator_mod, tmp_path, "placeholder_only", body)
+    assert validator_mod.CHECK_DISPATCH_COUNT in _violation_codes(violations)
+
+
+def test_real_inline_dispatch_satisfies_contract(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    """A concrete inline-code dispatch with a real node identifier still counts."""
+    body = (
+        "---\ndescription: inline concrete dispatch\n---\n\n"
+        "Invoke via `onex run-node node_merge_sweep_compute` for the sweep.\n\n"
+        + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "inline_real", body)
+    assert violations == [], (
+        "An inline-code dispatch pointing to a real node should satisfy the "
+        f"dispatch requirement; got {violations}"
+    )

--- a/tests/unit/scripts/test_validate_deterministic_skill_routing.py
+++ b/tests/unit/scripts/test_validate_deterministic_skill_routing.py
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``scripts/validate_deterministic_skill_routing.py`` (OMN-8765).
+
+Covers the positive path (a clean skill passes) and the negative paths for
+each structural violation category emitted by the CI lint gate:
+
+- LLM SDK import in an embedded python block (``anthropic`` / ``openai``)
+- ``client.messages.create`` banned LLM API call
+- Subprocess orchestration call (``subprocess.run``) in a python block
+- Shell wrapper around the dispatch (``bash -c 'onex run-node …'``)
+- Conditional prose-fallback branch after a routing failure
+- Missing dispatch declaration entirely
+- Missing ``SkillRoutingError`` / ``do not produce prose`` directives
+
+Linear ticket: OMN-8765. Parent: OMN-8737.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "validate_deterministic_skill_routing.py"
+)
+
+
+@pytest.fixture(scope="module")
+def validator_mod() -> ModuleType:
+    """Load the validator script as an importable module.
+
+    The script defines ``@dataclass(frozen=True)`` classes which call
+    ``sys.modules.get(cls.__module__).__dict__`` during class creation. We
+    must register the module in ``sys.modules`` before executing it, or that
+    lookup returns ``None`` and the dataclass machinery crashes.
+    """
+    import sys
+
+    module_name = "validate_deterministic_skill_routing_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: fixture SKILL.md content
+# ---------------------------------------------------------------------------
+
+
+_SKILL_ROUTING_CONTRACT = (
+    "## Routing Contract\n\n"
+    "Dispatch must use `onex node <node_name>`. Non-zero exit emits a "
+    "`SkillRoutingError` JSON envelope — surface it directly, do not produce "
+    "prose.\n"
+)
+
+
+def _clean_skill_md() -> str:
+    return (
+        "---\n"
+        "description: test skill\n"
+        "---\n"
+        "\n"
+        "# example\n\n"
+        "```bash\n"
+        "onex run-node node_example --arg value\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_kafka_publish() -> str:
+    return (
+        "---\n"
+        "description: kafka publish skill\n"
+        "---\n"
+        "\n"
+        "# kafka_example\n\n"
+        "This skill publishes to `onex.cmd.omnimarket.example-start.v1` and "
+        "polls for the result.\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_llm_import() -> str:
+    return (
+        "---\n"
+        "description: bad skill (llm import)\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_bad\n"
+        "```\n\n"
+        "```python\n"
+        "import anthropic  # should be flagged\n"
+        "client = anthropic.Anthropic()\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_openai_from_import() -> str:
+    return (
+        "---\n"
+        "description: openai from-import\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_bad\n"
+        "```\n\n"
+        "```python\n"
+        "from openai import OpenAI\n"
+        "client = OpenAI()\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_banned_llm_call() -> str:
+    return (
+        "---\n"
+        "description: banned llm call\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_bad\n"
+        "```\n\n"
+        "```python\n"
+        "response = client.messages.create(model='claude', messages=[])\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_subprocess_orch() -> str:
+    return (
+        "---\n"
+        "description: subprocess orch\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_bad\n"
+        "```\n\n"
+        "```python\n"
+        "import subprocess\n"
+        "subprocess.run(['onex', 'run-node', 'x'])\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_shell_wrapper() -> str:
+    return (
+        "---\n"
+        "description: shell wrapper\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "bash -c 'onex run-node node_bad'\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_with_prose_fallback() -> str:
+    return (
+        "---\n"
+        "description: prose fallback\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_bad\n"
+        "if [[ $? -ne 0 ]]; then\n"
+        '  echo "fallback prose when routing fails"\n'
+        "fi\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+
+
+def _skill_without_dispatch() -> str:
+    # Deliberately avoids the shared routing-contract block because that
+    # boilerplate contains an inline-code dispatch token for documentation
+    # purposes. This fixture proves the gate trips when no dispatch declaration
+    # exists anywhere in the skill.
+    return (
+        "---\n"
+        "description: no dispatch\n"
+        "---\n"
+        "\n"
+        "# no_dispatch\n\n"
+        "Some prose with no dispatch invocation whatsoever.\n\n"
+        "On failure, a SkillRoutingError is emitted; do not produce prose.\n"
+    )
+
+
+def _skill_missing_routing_error() -> str:
+    return (
+        "---\n"
+        "description: no routing error\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_x\n"
+        "```\n\n"
+        "No SkillRoutingError directive here.\n"
+    )
+
+
+def _skill_missing_no_prose_directive() -> str:
+    return (
+        "---\n"
+        "description: routing error present, missing the directive\n"
+        "---\n"
+        "\n"
+        "```bash\n"
+        "onex run-node node_x\n"
+        "```\n\n"
+        "On failure: surface `SkillRoutingError` as the envelope.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(tmp_path: Path, name: str, body: str) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(body, encoding="utf-8")
+    return skill_file
+
+
+def _scan(
+    validator_mod: ModuleType, tmp_path: Path, name: str, body: str
+) -> list[object]:
+    _write_skill(tmp_path, name, body)
+    # Use scan_skill which returns a plain list of violations; operates on a
+    # single file without requiring the enforced-skills allowlist.
+    return list(validator_mod.scan_skill(tmp_path / name / "SKILL.md"))
+
+
+def _violation_codes(violations: list[object]) -> set[str]:
+    return {v.check for v in violations}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Positive cases
+# ---------------------------------------------------------------------------
+
+
+def test_clean_skill_passes(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(validator_mod, tmp_path, "clean", _clean_skill_md())
+    assert violations == [], f"clean skill should have no violations, got {violations}"
+
+
+def test_kafka_publish_skill_passes(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "kafka_example", _skill_with_kafka_publish()
+    )
+    assert violations == [], (
+        "A skill whose dispatch is a Kafka publish declared in prose should "
+        f"pass; got {violations}"
+    )
+
+
+def test_line_continuation_dispatch_counts(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    body = (
+        "---\n"
+        "description: line-continuation dispatch\n"
+        "---\n"
+        "```bash\n"
+        "onex run-node node_x \\\n"
+        "  --arg1 foo \\\n"
+        "  --arg2 bar\n"
+        "```\n\n" + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "multiline", body)
+    assert violations == [], (
+        f"multi-line dispatch should count as a single dispatch; got {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — Python block structural checks
+# ---------------------------------------------------------------------------
+
+
+def test_flags_anthropic_import(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_anthropic", _skill_with_llm_import()
+    )
+    codes = _violation_codes(violations)
+    assert validator_mod.CHECK_LLM_IMPORT in codes
+
+
+def test_flags_openai_from_import(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_openai", _skill_with_openai_from_import()
+    )
+    assert validator_mod.CHECK_LLM_IMPORT in _violation_codes(violations)
+
+
+def test_flags_google_generativeai_import(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    body = (
+        "---\ndescription: google gen ai\n---\n\n"
+        "```bash\nonex run-node node_x\n```\n\n"
+        "```python\nimport google.generativeai as genai\n```\n\n"
+        + _SKILL_ROUTING_CONTRACT
+    )
+    violations = _scan(validator_mod, tmp_path, "bad_google", body)
+    assert validator_mod.CHECK_LLM_IMPORT in _violation_codes(violations)
+
+
+def test_flags_banned_llm_api_call(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_llm_call", _skill_with_banned_llm_call()
+    )
+    assert validator_mod.CHECK_LLM_API_CALL in _violation_codes(violations)
+
+
+def test_flags_subprocess_orchestration(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_subprocess", _skill_with_subprocess_orch()
+    )
+    assert validator_mod.CHECK_SUBPROCESS_ORCH in _violation_codes(violations)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — shell-block structural checks
+# ---------------------------------------------------------------------------
+
+
+def test_flags_shell_wrapper_around_dispatch(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_wrapper", _skill_with_shell_wrapper()
+    )
+    assert validator_mod.CHECK_SHELL_WRAPPER in _violation_codes(violations)
+
+
+def test_flags_prose_fallback_branch(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "bad_fallback", _skill_with_prose_fallback()
+    )
+    assert validator_mod.CHECK_PROSE_FALLBACK in _violation_codes(violations)
+
+
+def test_flags_missing_dispatch(validator_mod: ModuleType, tmp_path: Path) -> None:
+    violations = _scan(
+        validator_mod, tmp_path, "no_dispatch", _skill_without_dispatch()
+    )
+    assert validator_mod.CHECK_DISPATCH_COUNT in _violation_codes(violations)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — markdown contract
+# ---------------------------------------------------------------------------
+
+
+def test_flags_missing_skill_routing_error(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    violations = _scan(
+        validator_mod,
+        tmp_path,
+        "missing_routing_err",
+        _skill_missing_routing_error(),
+    )
+    assert validator_mod.CHECK_MISSING_ROUTING_ERROR in _violation_codes(violations)
+
+
+def test_flags_missing_no_prose_directive(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    violations = _scan(
+        validator_mod,
+        tmp_path,
+        "missing_no_prose",
+        _skill_missing_no_prose_directive(),
+    )
+    assert validator_mod.CHECK_MISSING_ROUTING_ERROR in _violation_codes(violations)
+
+
+# ---------------------------------------------------------------------------
+# Skill-root scan & CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def test_scan_skills_root_mixed(validator_mod: ModuleType, tmp_path: Path) -> None:
+    # Install one clean Tier 1 skill and one violating Tier 1 skill at a fake root.
+    tier1_names = iter(sorted(validator_mod.TIER1_DETERMINISTIC_SKILLS))
+    clean_name = next(tier1_names)
+    dirty_name = next(tier1_names)
+
+    _write_skill(tmp_path, clean_name, _clean_skill_md())
+    _write_skill(tmp_path, dirty_name, _skill_with_llm_import())
+
+    result = validator_mod.scan_skills_root(tmp_path)
+    # scan_skills_root walks the full allowlist; missing ones produce violations.
+    assert result.skills_scanned == len(validator_mod.TIER1_DETERMINISTIC_SKILLS)
+    # The clean skill must contribute zero violations; dirty must contribute ≥1.
+    codes_by_skill: dict[str, set[str]] = {}
+    for v in result.violations:
+        codes_by_skill.setdefault(v.skill_name, set()).add(v.check)
+    assert clean_name not in codes_by_skill
+    assert validator_mod.CHECK_LLM_IMPORT in codes_by_skill[dirty_name]
+
+
+def test_main_exit_code_on_clean_tmp_root(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    # Install all Tier 1 skills with clean content so main() exits 0.
+    for name in validator_mod.TIER1_DETERMINISTIC_SKILLS:
+        _write_skill(tmp_path, name, _clean_skill_md())
+    exit_code = validator_mod.main(["--skills-root", str(tmp_path)])
+    assert exit_code == 0
+
+
+def test_main_exit_code_on_dirty_tmp_root(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    for name in validator_mod.TIER1_DETERMINISTIC_SKILLS:
+        _write_skill(tmp_path, name, _skill_with_llm_import())
+    exit_code = validator_mod.main(["--skills-root", str(tmp_path)])
+    assert exit_code == 1
+
+
+def test_main_report_mode_always_exits_zero(
+    validator_mod: ModuleType, tmp_path: Path
+) -> None:
+    for name in validator_mod.TIER1_DETERMINISTIC_SKILLS:
+        _write_skill(tmp_path, name, _skill_with_llm_import())
+    exit_code = validator_mod.main(["--skills-root", str(tmp_path), "--report"])
+    assert exit_code == 0
+
+
+def test_main_single_skill_flag(validator_mod: ModuleType, tmp_path: Path) -> None:
+    clean_name = sorted(validator_mod.TIER1_DETERMINISTIC_SKILLS)[0]
+    _write_skill(tmp_path, clean_name, _clean_skill_md())
+    exit_code = validator_mod.main(
+        ["--skills-root", str(tmp_path), "--skill", clean_name]
+    )
+    assert exit_code == 0


### PR DESCRIPTION
## Summary

Adds the W3 hard-gate CI lint check from [OMN-8765](https://linear.app/omninode/issue/OMN-8765) (parent epic: `OMN‑8737`). New job `check-deterministic-skills` blocks merge if any Tier 1 deterministic skill in `omniclaude` violates the SkillRoutingError routing contract, using **AST analysis** (python blocks) and **structural token-matching** (shell blocks) instead of the line-count heuristics the `OMN‑8749` predecessor used.

## What the validator enforces per Tier 1 skill

- Zero LLM SDK imports (`anthropic`, `openai`, `google.generativeai`)
- No banned LLM API calls (`client.messages.create`, `client.completions.create`, `...chat.completions`)
- No subprocess orchestration in python blocks (`subprocess.run`, `subprocess.Popen`, `os.system`, …)
- No `python -c` / `bash -c` / `sh -c` wrappers around the dispatch
- No conditional prose-fallback branches after a routing failure
- At least one node-dispatch declaration (`onex run-node` / `onex node` in a shell block or inline-code, OR a Kafka publish to an `onex.cmd.*` topic). Multi-line backslash continuations are merged before tokenizing.
- SKILL.md references `SkillRoutingError` with `do not produce prose`

See the module docstring for the full amendment-A4 mapping. The ticket's "exactly one dispatch" phrasing is interpreted as "at least one, unambiguous" because Kafka-publish skills declare dispatch as a payload schema, not an imperative shell command.

## Files

- `scripts/validate_deterministic_skill_routing.py` — AST validator (mypy --strict clean, ~900 lines)
- `scripts/pre_commit_validate_deterministic_skills.sh` — pre-commit wrapper that skips silently when the omniclaude sibling is absent
- `tests/unit/scripts/test_validate_deterministic_skill_routing.py` — 18 unit tests (clean skill passes + every negative path)
- `.github/workflows/ci.yml` — new blocking Phase 1 job `check-deterministic-skills`; added to `quality-gate` aggregator's evaluation
- `.pre-commit-config.yaml` — `validate-deterministic-skill-routing` hook

## Verification

- `uv run pytest tests/unit/scripts/ -q` → **623 passed** (18 new)
- `uv run mypy --strict scripts/validate_deterministic_skill_routing.py` → clean
- `uv run mypy --strict tests/unit/scripts/test_validate_deterministic_skill_routing.py` → clean
- `uv run ruff format` / `ruff check src/ tests/` → clean
- `pre-commit run` on all changed files → all hooks green, including the new OMN-8765 hook
- `python scripts/validate_deterministic_skill_routing.py --skills-root /…/omniclaude/plugins/onex/skills` → `OK — 18 Tier 1 skill(s) scanned, 0 violations`

All 18 current Tier 1 deterministic skills in omniclaude pass the new gate, so merging this PR activates the blocking gate cleanly.

## DoD Evidence (from OMN-8765)

- [x] CI check `check-deterministic-skills` blocks merge if any deterministic shim lacks dispatch / contains LLM SDK import / contains subprocess orchestration / contains conditional prose fallback
- [x] Gate is AST-based (not grep/line-count)
- [x] Gate passing on all current Tier 1 shims

## Test plan

- [ ] CI `check-deterministic-skills` job turns green on this PR
- [ ] `quality-gate` aggregator passes with the new gate included
- [ ] Future PR that intentionally adds `import anthropic` to a Tier 1 SKILL.md fails the gate (regression coverage from unit test suite)

🔗 Linear: [OMN-8765](https://linear.app/omninode/issue/OMN-8765)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI "Deterministic Skill Routing" validation job and made the overall quality gate require its success.
  * Integrated a pre-commit hook to run the deterministic routing validator locally (skips enforcement if skills repo is missing).

* **New Features**
  * Added a CLI validator that scans skill docs for routing dispatches, banned SDK/subprocess patterns, and required error/directive markers; emits pass/fail/report outputs.

* **Tests**
  * Added comprehensive unit tests covering scanner rules, CLI flags, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->