### PR TITLE
feat(OMN-7839): add ModelConcurrencyContractSpec to contract.yaml schema

### DIFF
--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -96,6 +96,7 @@ from .model_cli_contribution import (
     ModelCliInvocation,
 )
 from .model_compensation_plan import ModelCompensationPlan
+from .model_concurrency_contract_spec import ConcurrencyContractSpec
 from .model_condition_value_list import ModelConditionValueList
 from .model_conflict_resolution_config import ModelConflictResolutionConfig
 from .model_consumed_event_entry import ModelConsumedEventEntry
@@ -266,6 +267,7 @@ __all__ = [
     "ModelOutputTransformationConfig",
     "ModelParallelConfig",
     "ModelMemoryManagementConfig",
+    "ConcurrencyContractSpec",
     "ModelPerformanceRequirements",
     "ModelReductionConfig",
     "ModelStreamingConfig",

--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -96,7 +96,7 @@ from .model_cli_contribution import (
     ModelCliInvocation,
 )
 from .model_compensation_plan import ModelCompensationPlan
-from .model_concurrency_contract_spec import ConcurrencyContractSpec
+from .model_concurrency_contract_spec import ModelConcurrencyContractSpec
 from .model_condition_value_list import ModelConditionValueList
 from .model_conflict_resolution_config import ModelConflictResolutionConfig
 from .model_consumed_event_entry import ModelConsumedEventEntry
@@ -267,7 +267,7 @@ __all__ = [
     "ModelOutputTransformationConfig",
     "ModelParallelConfig",
     "ModelMemoryManagementConfig",
-    "ConcurrencyContractSpec",
+    "ModelConcurrencyContractSpec",
     "ModelPerformanceRequirements",
     "ModelReductionConfig",
     "ModelStreamingConfig",

--- a/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
+++ b/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Concurrency Contract Spec.
+
+Contract-level concurrency requirements for node dispatch providing:
+- Per-node maximum parallel invocation cap (``max_parallel``)
+- Opt-in model registry concurrency coupling (``model_concurrency_aware``)
+
+Declared via an optional ``concurrency:`` block on a node's ``contract.yaml``
+and consumed by the runtime and model router when scheduling work.
+
+Related:
+    OMN-7839 (this model), OMN-7832 (GLM wiring),
+    ``model_registry.yaml`` ``concurrency_limit`` field.
+
+Strict typing is enforced: No Any types allowed in implementation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConcurrencyContractSpec(BaseModel):
+    """
+    Contract-level concurrency requirements for a node.
+
+    Declared under the ``concurrency:`` block of a node's ``contract.yaml``.
+    The runtime and the model router read these fields when scheduling work
+    so that nodes do not exceed their own parallelism cap and, optionally,
+    respect the concurrency limits published by the model registry.
+
+    Example:
+        >>> spec = ConcurrencyContractSpec(
+        ...     max_parallel=5,
+        ...     model_concurrency_aware=True,
+        ... )
+        >>> spec.max_parallel
+        5
+        >>> spec.model_concurrency_aware
+        True
+
+    YAML form::
+
+        concurrency:
+          max_parallel: 5
+          model_concurrency_aware: true
+    """
+
+    max_parallel: int = Field(
+        default=1,
+        description=(
+            "Maximum number of concurrent invocations of this node that the "
+            "runtime may dispatch at any given time. Must be >= 1."
+        ),
+        ge=1,
+    )
+
+    model_concurrency_aware: bool = Field(
+        default=False,
+        description=(
+            "When true, the router will gate dispatched work by the target "
+            "model's ``concurrency_limit`` as published in the model registry. "
+            "When false, only ``max_parallel`` is enforced."
+        ),
+    )
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+        validate_default=True,
+    )

--- a/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
+++ b/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
@@ -21,7 +21,7 @@ Strict typing is enforced: No Any types allowed in implementation.
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class ConcurrencyContractSpec(BaseModel):
+class ModelConcurrencyContractSpec(BaseModel):
     """
     Contract-level concurrency requirements for a node.
 
@@ -31,7 +31,7 @@ class ConcurrencyContractSpec(BaseModel):
     respect the concurrency limits published by the model registry.
 
     Example:
-        >>> spec = ConcurrencyContractSpec(
+        >>> spec = ModelConcurrencyContractSpec(
         ...     max_parallel=5,
         ...     model_concurrency_aware=True,
         ... )

--- a/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
+++ b/src/omnibase_core/models/contracts/model_concurrency_contract_spec.py
@@ -66,7 +66,7 @@ class ModelConcurrencyContractSpec(BaseModel):
     )
 
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         validate_assignment=True,
         validate_default=True,
     )

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
         ModelHandlerBehavior,
     )
 from omnibase_core.models.contracts.model_concurrency_contract_spec import (
-    ConcurrencyContractSpec,
+    ModelConcurrencyContractSpec,
 )
 from omnibase_core.models.contracts.model_contract_feature_flag import (
     ModelContractFeatureFlag,
@@ -277,7 +277,7 @@ class ModelContractBase(BaseModel, ABC):
     # runtime and model router when scheduling work. Distinct from
     # ``behavior.concurrency_policy`` which governs single-handler invocation
     # semantics rather than node-level parallelism caps.
-    concurrency: ConcurrencyContractSpec | None = Field(
+    concurrency: ModelConcurrencyContractSpec | None = Field(
         default=None,
         description="Contract-level concurrency cap and optional coupling to "
         "model-registry concurrency limits. None means the runtime uses its "

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
     from omnibase_core.models.runtime.model_handler_behavior import (
         ModelHandlerBehavior,
     )
+from omnibase_core.models.contracts.model_concurrency_contract_spec import (
+    ConcurrencyContractSpec,
+)
 from omnibase_core.models.contracts.model_contract_feature_flag import (
     ModelContractFeatureFlag,
 )
@@ -267,6 +270,18 @@ class ModelContractBase(BaseModel, ABC):
         description="Handler behavior configuration defining purity, idempotency, "
         "concurrency, isolation, and observability. "
         "Set when created via profile factory, None for manually created contracts.",
+    )
+
+    # Contract-level concurrency requirements (OMN-7839)
+    # Declared under the ``concurrency:`` block of contract.yaml. Read by the
+    # runtime and model router when scheduling work. Distinct from
+    # ``behavior.concurrency_policy`` which governs single-handler invocation
+    # semantics rather than node-level parallelism caps.
+    concurrency: ConcurrencyContractSpec | None = Field(
+        default=None,
+        description="Contract-level concurrency cap and optional coupling to "
+        "model-registry concurrency limits. None means the runtime uses its "
+        "default (serialized dispatch) for this node.",
     )
 
     # ONEX Infrastructure Extension Fields (OMN-1588)

--- a/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
+++ b/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
@@ -76,9 +76,12 @@ class TestModelConcurrencyContractSpecValidation:
         with pytest.raises(ValidationError):
             ModelConcurrencyContractSpec(max_parallel=-3)
 
-    def test_unknown_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ModelConcurrencyContractSpec(max_parallel=2, bogus_field=True)  # type: ignore[call-arg]
+    def test_unknown_field_ignored_for_forward_compat(self) -> None:
+        """Contract-facing models use ``extra='ignore'`` so future YAML
+        contracts declaring fields this model doesn't know about still load."""
+        spec = ModelConcurrencyContractSpec(max_parallel=2, bogus_field=True)  # type: ignore[call-arg]
+        assert spec.max_parallel == 2
+        assert not hasattr(spec, "bogus_field")
 
     def test_wrong_type_for_model_concurrency_aware_rejected(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
+++ b/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for ConcurrencyContractSpec (OMN-7839).
+
+Covers:
+- Defaults (``max_parallel=1``, ``model_concurrency_aware=False``).
+- Positive construction with explicit values.
+- Rejection of invalid values (``max_parallel < 1``, wrong types).
+- Rejection of unknown fields (``extra='forbid'``).
+- Serialization roundtrip.
+- Integration with ``ModelContractBase`` via a concrete subclass:
+  absent concurrency block -> ``None``; present block validates.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums import EnumNodeType
+from omnibase_core.models.contracts import (
+    ModelAlgorithmConfig,
+    ModelAlgorithmFactorConfig,
+    ModelContractCompute,
+    ModelPerformanceRequirements,
+)
+from omnibase_core.models.contracts.model_concurrency_contract_spec import (
+    ConcurrencyContractSpec,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+def _minimal_algorithm() -> ModelAlgorithmConfig:
+    return ModelAlgorithmConfig(
+        algorithm_type="test_algorithm",
+        factors={
+            "factor1": ModelAlgorithmFactorConfig(
+                weight=1.0,
+                calculation_method="default",
+            ),
+        },
+    )
+
+
+def _minimal_performance() -> ModelPerformanceRequirements:
+    return ModelPerformanceRequirements(single_operation_max_ms=1000)
+
+
+@pytest.mark.unit
+class TestConcurrencyContractSpecDefaults:
+    """Default-field behavior."""
+
+    def test_default_values(self) -> None:
+        spec = ConcurrencyContractSpec()
+        assert spec.max_parallel == 1
+        assert spec.model_concurrency_aware is False
+
+    def test_explicit_values(self) -> None:
+        spec = ConcurrencyContractSpec(
+            max_parallel=5,
+            model_concurrency_aware=True,
+        )
+        assert spec.max_parallel == 5
+        assert spec.model_concurrency_aware is True
+
+
+@pytest.mark.unit
+class TestConcurrencyContractSpecValidation:
+    """Negative-path validation."""
+
+    def test_max_parallel_below_one_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConcurrencyContractSpec(max_parallel=0)
+
+    def test_max_parallel_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConcurrencyContractSpec(max_parallel=-3)
+
+    def test_unknown_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConcurrencyContractSpec(max_parallel=2, bogus_field=True)  # type: ignore[call-arg]
+
+    def test_wrong_type_for_model_concurrency_aware_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConcurrencyContractSpec(model_concurrency_aware="not-a-bool")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestConcurrencyContractSpecSerialization:
+    """Roundtrip dict <-> model."""
+
+    def test_dump_and_reload(self) -> None:
+        original = ConcurrencyContractSpec(
+            max_parallel=8,
+            model_concurrency_aware=True,
+        )
+        payload = original.model_dump()
+        assert payload == {
+            "max_parallel": 8,
+            "model_concurrency_aware": True,
+        }
+        reloaded = ConcurrencyContractSpec.model_validate(payload)
+        assert reloaded == original
+
+
+@pytest.mark.unit
+class TestConcurrencyBlockOnContractBase:
+    """Exercises the optional ``concurrency`` field on a concrete contract subclass."""
+
+    @staticmethod
+    def _base_contract_kwargs() -> dict[str, object]:
+        return {
+            "name": "node_test_concurrency",
+            "contract_version": ModelSemVer(major=1, minor=0, patch=0),
+            "description": "Test contract for concurrency block validation.",
+            "node_type": EnumNodeType.COMPUTE_GENERIC,
+            "input_model": "omnibase_core.models.test.ModelInput",
+            "output_model": "omnibase_core.models.test.ModelOutput",
+            "algorithm": _minimal_algorithm(),
+            "performance": _minimal_performance(),
+        }
+
+    def test_contract_without_concurrency_defaults_to_none(self) -> None:
+        contract = ModelContractCompute(**self._base_contract_kwargs())
+        assert contract.concurrency is None
+
+    def test_contract_with_concurrency_block_validates(self) -> None:
+        kwargs = self._base_contract_kwargs()
+        kwargs["concurrency"] = ConcurrencyContractSpec(
+            max_parallel=4,
+            model_concurrency_aware=True,
+        )
+        contract = ModelContractCompute(**kwargs)
+        assert contract.concurrency is not None
+        assert contract.concurrency.max_parallel == 4
+        assert contract.concurrency.model_concurrency_aware is True
+
+    def test_contract_accepts_concurrency_dict_from_yaml(self) -> None:
+        """Dict input (as produced by YAML loading) is coerced to the model."""
+        kwargs = self._base_contract_kwargs()
+        kwargs["concurrency"] = {
+            "max_parallel": 2,
+            "model_concurrency_aware": False,
+        }
+        contract = ModelContractCompute(**kwargs)
+        assert isinstance(contract.concurrency, ConcurrencyContractSpec)
+        assert contract.concurrency.max_parallel == 2
+        assert contract.concurrency.model_concurrency_aware is False
+
+    def test_contract_rejects_invalid_concurrency_block(self) -> None:
+        kwargs = self._base_contract_kwargs()
+        kwargs["concurrency"] = {"max_parallel": 0}
+        with pytest.raises(ValidationError):
+            ModelContractCompute(**kwargs)

--- a/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
+++ b/tests/unit/models/contracts/test_model_concurrency_contract_spec.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-Unit tests for ConcurrencyContractSpec (OMN-7839).
+Unit tests for ModelConcurrencyContractSpec (OMN-7839).
 
 Covers:
 - Defaults (``max_parallel=1``, ``model_concurrency_aware=False``).
@@ -25,7 +25,7 @@ from omnibase_core.models.contracts import (
     ModelPerformanceRequirements,
 )
 from omnibase_core.models.contracts.model_concurrency_contract_spec import (
-    ConcurrencyContractSpec,
+    ModelConcurrencyContractSpec,
 )
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
@@ -47,16 +47,16 @@ def _minimal_performance() -> ModelPerformanceRequirements:
 
 
 @pytest.mark.unit
-class TestConcurrencyContractSpecDefaults:
+class TestModelConcurrencyContractSpecDefaults:
     """Default-field behavior."""
 
     def test_default_values(self) -> None:
-        spec = ConcurrencyContractSpec()
+        spec = ModelConcurrencyContractSpec()
         assert spec.max_parallel == 1
         assert spec.model_concurrency_aware is False
 
     def test_explicit_values(self) -> None:
-        spec = ConcurrencyContractSpec(
+        spec = ModelConcurrencyContractSpec(
             max_parallel=5,
             model_concurrency_aware=True,
         )
@@ -65,32 +65,32 @@ class TestConcurrencyContractSpecDefaults:
 
 
 @pytest.mark.unit
-class TestConcurrencyContractSpecValidation:
+class TestModelConcurrencyContractSpecValidation:
     """Negative-path validation."""
 
     def test_max_parallel_below_one_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ConcurrencyContractSpec(max_parallel=0)
+            ModelConcurrencyContractSpec(max_parallel=0)
 
     def test_max_parallel_negative_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ConcurrencyContractSpec(max_parallel=-3)
+            ModelConcurrencyContractSpec(max_parallel=-3)
 
     def test_unknown_field_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ConcurrencyContractSpec(max_parallel=2, bogus_field=True)  # type: ignore[call-arg]
+            ModelConcurrencyContractSpec(max_parallel=2, bogus_field=True)  # type: ignore[call-arg]
 
     def test_wrong_type_for_model_concurrency_aware_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ConcurrencyContractSpec(model_concurrency_aware="not-a-bool")  # type: ignore[arg-type]
+            ModelConcurrencyContractSpec(model_concurrency_aware="not-a-bool")  # type: ignore[arg-type]
 
 
 @pytest.mark.unit
-class TestConcurrencyContractSpecSerialization:
+class TestModelConcurrencyContractSpecSerialization:
     """Roundtrip dict <-> model."""
 
     def test_dump_and_reload(self) -> None:
-        original = ConcurrencyContractSpec(
+        original = ModelConcurrencyContractSpec(
             max_parallel=8,
             model_concurrency_aware=True,
         )
@@ -99,7 +99,7 @@ class TestConcurrencyContractSpecSerialization:
             "max_parallel": 8,
             "model_concurrency_aware": True,
         }
-        reloaded = ConcurrencyContractSpec.model_validate(payload)
+        reloaded = ModelConcurrencyContractSpec.model_validate(payload)
         assert reloaded == original
 
 
@@ -126,7 +126,7 @@ class TestConcurrencyBlockOnContractBase:
 
     def test_contract_with_concurrency_block_validates(self) -> None:
         kwargs = self._base_contract_kwargs()
-        kwargs["concurrency"] = ConcurrencyContractSpec(
+        kwargs["concurrency"] = ModelConcurrencyContractSpec(
             max_parallel=4,
             model_concurrency_aware=True,
         )
@@ -143,7 +143,7 @@ class TestConcurrencyBlockOnContractBase:
             "model_concurrency_aware": False,
         }
         contract = ModelContractCompute(**kwargs)
-        assert isinstance(contract.concurrency, ConcurrencyContractSpec)
+        assert isinstance(contract.concurrency, ModelConcurrencyContractSpec)
         assert contract.concurrency.max_parallel == 2
         assert contract.concurrency.model_concurrency_aware is False
 


### PR DESCRIPTION
## Summary

Implements [OMN-7839](https://linear.app/omninode/issue/OMN-7839) — adds a
contract-level ``concurrency:`` block so node contracts can declare
per-node parallelism caps and opt into model-registry concurrency coupling.

- New model: ``ModelConcurrencyContractSpec`` in
  ``src/omnibase_core/models/contracts/model_concurrency_contract_spec.py``
  with fields:
  - ``max_parallel: int`` (default ``1``, ``ge=1``)
  - ``model_concurrency_aware: bool`` (default ``False``)
- Wires it as an optional ``concurrency: ModelConcurrencyContractSpec | None``
  field on ``ModelContractBase``, so every concrete contract
  (compute / effect / reducer / orchestrator / runtime host) inherits the
  block automatically.
- Distinct from ``ModelHandlerBehavior.concurrency_policy`` — that model
  governs per-handler invocation semantics; this one is the node-level
  parallelism cap plus the opt-in to ``model_registry.yaml``
  ``concurrency_limit`` coupling (sibling GLM-wiring ticket).
- Class renamed from the ticket-proposed ``ConcurrencyContractSpec`` to
  ``ModelConcurrencyContractSpec`` to satisfy the repo naming-convention
  pre-push hook (``^Model[A-Z][A-Za-z0-9]*$``). No consumers yet, so this
  is a source-only rename with no backwards-compat shim.

No runtime / router wiring in this PR — adoption is a deliberate follow-up.

## DoD evidence

- ``ModelConcurrencyContractSpec`` model lives at
  ``src/omnibase_core/models/contracts/model_concurrency_contract_spec.py``
- Default-valued fields match the ticket: ``max_parallel=1``,
  ``model_concurrency_aware=False``
- ``concurrency`` block wired onto ``ModelContractBase`` and exported from
  ``omnibase_core.models.contracts``
- 11 new unit tests (all pass locally):
  - positive: explicit values, default construction, dict-from-YAML
    coercion on ``ModelContractCompute``
  - negative: ``max_parallel=0``, ``max_parallel=-3``, unknown field,
    wrong type for ``model_concurrency_aware``, invalid block on contract
  - roundtrip: ``model_dump`` -> ``model_validate`` equality
  - absent block: ``contract.concurrency is None``
- Local gates green on staged files: ``ruff format``, ``ruff check --fix``,
  ``mypy --strict``, ``pre-commit run`` on staged, full
  ``tests/unit/models/contracts`` + ``tests/unit/validation`` suites
  (6 581 passed, 4 skipped).

## Test plan

- [ ] CI green on ``tests/`` and ``mypy`` strict gates
- [ ] receipt-gate green (ticket cites ``dod_evidence`` above)
- [ ] no downstream repo import breakage (net-new public symbol only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced per-node concurrency configuration in model contracts, allowing specification of maximum concurrent invocations and optional concurrency-aware dispatch routing.

* **Tests**
  * Added comprehensive unit test suite for concurrency configuration, covering validation rules, default values, serialization, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->