### PR TITLE
fix(validation): suppress doc/example topic strings + fix env-var regex (OMN-9589, OMN-9588, OMN-9591)

### DIFF
--- a/src/omnibase_core/enums/enum_execution_shape.py
+++ b/src/omnibase_core/enums/enum_execution_shape.py
@@ -109,7 +109,7 @@ class EnumMessageCategory(StrValueHelper, str, Enum):
 
         The matching is segment-based to prevent false positives. For example:
         - "onex.user.events" matches EVENT (segment "events" exists)
-        - "onex.evt.platform.node-introspection.v1" matches EVENT (segment "evt")
+        - "onex.evt.platform.node-introspection.v1" matches EVENT (segment "evt")  # onex-topic-doc-example
         - "dev.eventsource.data.v1" does NOT match ("eventsource" != "events")
 
         Note:
@@ -128,7 +128,7 @@ class EnumMessageCategory(StrValueHelper, str, Enum):
         Example:
             >>> EnumMessageCategory.from_topic("user.events")
             <EnumMessageCategory.EVENT: 'event'>
-            >>> EnumMessageCategory.from_topic("onex.evt.platform.node-introspection.v1")
+            >>> EnumMessageCategory.from_topic("onex.evt.platform.node-introspection.v1")  # onex-topic-doc-example
             <EnumMessageCategory.EVENT: 'event'>
             >>> EnumMessageCategory.from_topic("dev.user.events.v1")
             <EnumMessageCategory.EVENT: 'event'>

--- a/src/omnibase_core/models/validation/model_topic_suffix_parts.py
+++ b/src/omnibase_core/models/validation/model_topic_suffix_parts.py
@@ -25,7 +25,7 @@ Example:
     ...     producer="omnimemory",
     ...     event_name="intent-stored",
     ...     version=1,
-    ...     raw_suffix="onex.evt.omnimemory.intent-stored.v1",
+    ...     raw_suffix="onex.evt.omnimemory.intent-stored.v1",  # onex-topic-doc-example
     ... )
     >>> parts.kind
     'evt'
@@ -86,7 +86,7 @@ class ModelTopicSuffixParts(BaseModel):
         ...     producer="user-service",
         ...     event_name="account-created",
         ...     version=1,
-        ...     raw_suffix="onex.evt.user-service.account-created.v1",
+        ...     raw_suffix="onex.evt.user-service.account-created.v1",  # onex-topic-doc-example
         ... )
         >>> parts.producer
         'user-service'

--- a/src/omnibase_core/models/validation/model_topic_validation_result.py
+++ b/src/omnibase_core/models/validation/model_topic_validation_result.py
@@ -20,7 +20,7 @@ Example:
     >>> # Valid result
     >>> result = ModelTopicValidationResult(
     ...     is_valid=True,
-    ...     suffix="onex.evt.omnimemory.intent-stored.v1",
+    ...     suffix="onex.evt.omnimemory.intent-stored.v1",  # onex-topic-doc-example
     ...     error=None,
     ...     parsed=some_parsed_parts,
     ... )
@@ -70,7 +70,7 @@ class ModelTopicValidationResult(BaseModel):
         >>> # Successful validation
         >>> result = ModelTopicValidationResult(
         ...     is_valid=True,
-        ...     suffix="onex.evt.user-service.account-created.v1",
+        ...     suffix="onex.evt.user-service.account-created.v1",  # onex-topic-doc-example
         ...     error=None,
         ...     parsed=parsed_parts,
         ... )

--- a/src/omnibase_core/schemas/cli_contribution.v1.example.yaml
+++ b/src/omnibase_core/schemas/cli_contribution.v1.example.yaml
@@ -45,7 +45,7 @@ commands:
     output_schema_ref: "com.omninode.omnimemory.query.output.v1"
     invocation:
       invocation_type: "kafka_event"
-      topic: "onex.cmd.omnimemory.query.v1"
+      topic: "onex.cmd.omnimemory.query.v1"  # onex-topic-doc-example
     permissions:
       - "memory:read"
     risk: "low"
@@ -66,7 +66,7 @@ commands:
     output_schema_ref: "com.omninode.omnimemory.ingest.output.v1"
     invocation:
       invocation_type: "kafka_event"
-      topic: "onex.cmd.omnimemory.ingest.v1"
+      topic: "onex.cmd.omnimemory.ingest.v1"  # onex-topic-doc-example
     permissions:
       - "memory:write"
     risk: "medium"
@@ -84,7 +84,7 @@ commands:
     output_schema_ref: "com.omninode.omnimemory.purge.output.v1"
     invocation:
       invocation_type: "kafka_event"
-      topic: "onex.cmd.omnimemory.purge.v1"
+      topic: "onex.cmd.omnimemory.purge.v1"  # onex-topic-doc-example
     permissions:
       - "memory:admin"
     risk: "critical"

--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -59,7 +59,7 @@ from omnibase_core.validation.validator_base import ValidatorBase
 _ONEX_TOPIC_LITERAL = re.compile(r"""["']onex\.(cmd|evt|dlq)\.[^"'\s]+["']""")
 
 _TOPIC_ENV_VAR = re.compile(
-    r"""^\s*(?:export\s+|ENV\s+)?[A-Z][A-Z0-9_]*_TOPIC\b[A-Z0-9_]*\s*[:=]""",
+    r"""^\s*(?:export\s+|ENV\s+)?[A-Z][A-Z0-9_]*_TOPIC\b[A-Z0-9_]*\s*=(?!=)""",
 )
 
 _LINE_SUPPRESSION_MARKERS: frozenset[str] = frozenset(

--- a/tests/unit/validation/test_validator_hardcoded_topics.py
+++ b/tests/unit/validation/test_validator_hardcoded_topics.py
@@ -463,3 +463,19 @@ class TestEdgeCases:
         env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
         assert len(env_issues) == 1
         assert env_issues[0].line_number == 3
+
+    def test_class_attribute_with_type_annotation_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        p = _write(
+            tmp_path,
+            """\
+            class MyPublisher:
+                INTENT_TOPIC: str = TOPIC_EVENT_PUBLISH_INTENT
+                OUTPUT_TOPIC: ClassVar[str] = SOME_TOPIC
+            """,
+        )
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        result = v.validate_file(p)
+        env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
+        assert len(env_issues) == 0


### PR DESCRIPTION
## Summary

- **OMN-9589:** Add `# onex-topic-doc-example` suppression markers to 5 docstring/doctest topic strings in 3 files
- **OMN-9588:** Add `# onex-topic-doc-example` markers to 3 topic strings in example contribution YAML
- **OMN-9591:** Tighten `_TOPIC_ENV_VAR` regex to only match `=` (not `:`), fixing false positives on Python class attributes like `INTENT_TOPIC: str = ...`

Parent epic: OMN-9151. Plan: `docs/plans/2026-04-24-omnibase-core-hardcoded-topics-cleanup.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying inline comments to code examples in docstrings and configuration files
* **Bug Fixes**
  * Improved validation accuracy for hardcoded topic detection to avoid false positives with typed class attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->