### PR TITLE
fix(OMN-9592): make node entry point discovery lazy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -251,13 +251,14 @@ repos:
       # Exclusions:
       # - typed_dict_demo.py: sample_id and ticket_id are external corpus identifiers, not internal UUIDs (OMN-1396)
       # - doctor_check_base.py: check_id is a semantic identifier ("kafka", "postgres"), not a version string
+      # - contracts/OMN-*.yaml: ticket-contract schema is owned by onex_change_control and currently requires string schema_version
       - id: validate-string-versions
         name: ONEX String Version Anti-Pattern Detection
         entry: uv run python scripts/validation/validate-string-versions.py
         language: system
         pass_filenames: true
         files: ^.*\.(py|yaml|yml)$
-        exclude: ^(tests/fixtures/validation/|archived/|archive/|src/omnibase_core/protocols/|src/omnibase_core/validation/validator_|src/omnibase_core/validation/visitor_|src/omnibase_core/models/contracts/subcontracts/model_validator_|src/omnibase_core/types/typed_dict_demo\.py|examples/contracts/handlers/|src/omnibase_core/models/ticket/model_ticket_context_bundle\.py$|src/omnibase_core/models/epic/model_epic_state\.py$|src/omnibase_core/doctor/doctor_check_base\.py$)
+        exclude: ^(tests/fixtures/validation/|archived/|archive/|contracts/OMN-[0-9]+\.yaml$|src/omnibase_core/protocols/|src/omnibase_core/validation/validator_|src/omnibase_core/validation/visitor_|src/omnibase_core/models/contracts/subcontracts/model_validator_|src/omnibase_core/types/typed_dict_demo\.py|examples/contracts/handlers/|src/omnibase_core/models/ticket/model_ticket_context_bundle\.py$|src/omnibase_core/models/epic/model_epic_state\.py$|src/omnibase_core/doctor/doctor_check_base\.py$)
         stages: [pre-commit]
 
       - id: validate-archived-imports

--- a/contracts/OMN-9592.yaml
+++ b/contracts/OMN-9592.yaml
@@ -1,0 +1,55 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9592
+summary: "Implement ONCP install isolation or lazy node entry-point loading for metadata-scoped dependencies"
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "public_api"
+evidence_requirements:
+  - kind: "ci"
+    description: "omnibase_core PR checks pass, including deploy-gate"
+    command: "gh pr checks <pr-number> --repo OmniNode-ai/omnibase_core --watch"
+  - kind: "manual"
+    description: "Focused entry-point discovery and ONCP install tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/discovery/test_discovery_external_nodes.py tests/unit/cli/test_cli_node.py
+      tests/unit/cli/test_cli_install.py -q"
+  - kind: "manual"
+    description: "Post-deploy runtime smoke proves metadata discovery does not import node modules"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_core.discovery.discovery_external_nodes
+      import discover_external_nodes; nodes = discover_external_nodes(); assert isinstance(nodes, dict)\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused unit tests cover lazy discovery, packaged contract lookup, and ONCP install
+      validation"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/discovery/test_discovery_external_nodes.py
+          tests/unit/cli/test_cli_node.py tests/unit/cli/test_cli_install.py -q"
+  - id: "dod-002"
+    description: "Touched Python surfaces pass lint, format, and type checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run ruff check src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py
+          src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py
+          tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py
+          && PYTHONPATH=src uv run ruff format --check src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py
+          src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py
+          tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py
+          && PYTHONPATH=src uv run mypy src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py
+          src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py
+          tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py"
+  - id: "dod-003"
+    description: "Post-deploy runtime smoke confirms discovery remains metadata-only in the runtime image"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_core.discovery.discovery_external_nodes
+          import discover_external_nodes; nodes = discover_external_nodes(); assert isinstance(nodes,
+          dict)\""

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -352,9 +352,7 @@ def discover(ctx: click.Context, strict: bool) -> None:
     for name, node in sorted(nodes.items()):
         click.echo(f"  {name} ({node.package_name} {node.package_version})")
         if verbose:
-            click.echo(
-                f"    Class: {node.node_class.__module__}.{node.node_class.__name__}"
-            )
+            click.echo(f"    Entry point: {node.entry_point_value}")
 
 
 @cli.command()

--- a/src/omnibase_core/cli/cli_install.py
+++ b/src/omnibase_core/cli/cli_install.py
@@ -11,6 +11,7 @@ Supports two installation modes:
 from __future__ import annotations
 
 import importlib.metadata
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -63,54 +64,68 @@ def _rollback_install(pkg: str) -> None:
 
 
 def _validate_contract(contract_path: Path) -> dict[str, object]:
-    """Validate a contract.yaml file and return its contents.
+    """Validate a contract.yaml file with the Pydantic contract model.
 
     Raises:
-        click.ClickException: If the contract is missing required fields.
+        click.ClickException: If the contract is malformed or invalid.
     """
-    # NOTE(OMN-7537): contract.yaml is an external contract file with varying
-    # schemas across node types. yaml.safe_load is the correct approach for
-    # reading untrusted third-party contract files.
-    import yaml
+    from pydantic import ValidationError
 
     try:
-        with open(contract_path) as f:
-            raw = yaml.safe_load(f)
+        from omnibase_core.contracts.contract_loader import load_contract
+        from omnibase_core.models.contracts.model_yaml_contract import (
+            ModelYamlContract,
+        )
+
+        contract = load_contract(contract_path)
+        ModelYamlContract.model_validate(contract)
     except Exception as e:
+        if isinstance(e, click.ClickException):
+            raise
         msg = f"contract.yaml at {contract_path} is not valid: {e}"
+        if isinstance(e, ValidationError):
+            msg = f"contract.yaml at {contract_path} failed model validation: {e}"
         raise click.ClickException(msg) from e
 
-    if not isinstance(raw, dict):
-        msg = f"contract.yaml at {contract_path} is not a valid YAML mapping"
-        raise click.ClickException(msg)
-
-    contract: dict[str, object] = raw
-
     # name is always required
-    if "name" not in contract:
+    raw_name = contract.get("name")
+    if not isinstance(raw_name, str) or not raw_name.strip():
         msg = "contract.yaml missing required field: name"
         raise click.ClickException(msg)
 
-    # version may be 'version', 'contract_version', or 'node_version'
-    has_version = (
-        "contract_version" in contract
-        or "node_version" in contract
-        or "version" in contract
-    )
-    if not has_version:
-        msg = "contract.yaml missing version field"
+    if "contract_version" not in contract:
+        msg = "contract.yaml missing required field: contract_version"
         raise click.ClickException(msg)
 
-    # Validate topic format for any declared topics
-    for topic_key in ("publish_topics", "subscribe_topics"):
-        topics = contract.get(topic_key, [])
-        if isinstance(topics, list):
-            for topic in topics:
-                if isinstance(topic, str) and not topic.startswith("onex."):
-                    msg = f"Invalid topic format in {topic_key}: {topic} (must start with 'onex.')"
-                    raise click.ClickException(msg)
-
     return contract
+
+
+def _entry_point_module(value: str) -> str:
+    """Return the importable module portion of an entry-point value."""
+    return value.split(":", 1)[0].strip()
+
+
+def _resolve_entry_point_contract_path(entry_point_value: str) -> Path:
+    """Resolve a packaged contract path without importing the node module."""
+    module_path = _entry_point_module(entry_point_value)
+    spec = importlib.util.find_spec(module_path)
+    if spec is None:
+        raise click.ClickException(
+            f"Cannot resolve module {module_path} from installed metadata"
+        )
+    if spec.submodule_search_locations:
+        module_dir = Path(next(iter(spec.submodule_search_locations))).resolve()
+    elif spec.origin is not None:
+        module_dir = Path(spec.origin).resolve().parent
+    else:
+        raise click.ClickException(
+            f"Module {module_path} has no import origin for contract resolution"
+        )
+
+    contract_path = module_dir / "contract.yaml"
+    if not contract_path.exists():
+        raise click.ClickException(f"Missing contract.yaml in {module_path}")
+    return contract_path
 
 
 def _install_oncp(
@@ -328,22 +343,11 @@ def cli_install(
     validated_contracts: list[dict[str, object]] = []
     for ep in matching:
         try:
-            module = importlib.import_module(ep.module)
-        except ImportError as e:
+            contract_path = _resolve_entry_point_contract_path(ep.value)
+        except click.ClickException:
             if not dry_run:
                 _rollback_install(package_path)
-            raise click.ClickException(f"Cannot import module {ep.module}: {e}") from e
-
-        if module.__file__ is None:
-            if not dry_run:
-                _rollback_install(package_path)
-            raise click.ClickException(f"Module {ep.module} has no __file__ attribute")
-
-        contract_path = Path(module.__file__).parent / "contract.yaml"
-        if not contract_path.exists():
-            if not dry_run:
-                _rollback_install(package_path)
-            raise click.ClickException(f"Missing contract.yaml in {ep.module}")
+            raise
 
         try:
             contract = _validate_contract(contract_path)

--- a/src/omnibase_core/cli/cli_node.py
+++ b/src/omnibase_core/cli/cli_node.py
@@ -14,7 +14,7 @@ See ``docs/plans/2026-04-16-prove-core-runtime-standalone.md`` § Task 3.
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import logging
 import sys
 from importlib.metadata import entry_points
@@ -51,20 +51,23 @@ def _resolve_packaged_contract(node_name: str) -> Path:
             f"Duplicate entry-point name '{node_name}' registered by: {sources}. "
             "Disambiguate by uninstalling the conflicting package."
         )
-    module_path = matches[0].value
-    try:
-        mod = importlib.import_module(module_path)
-    except ImportError as exc:
+    module_path = _entry_point_module(matches[0].value)
+    spec = importlib.util.find_spec(module_path)
+    if spec is None:
         raise click.ClickException(
-            f"Failed to import node module '{module_path}': {exc}"
-        ) from exc
+            f"Failed to resolve node module '{module_path}' from installed metadata."
+        )
 
-    if mod.__file__ is None:
+    if spec.submodule_search_locations:
+        module_dir = Path(next(iter(spec.submodule_search_locations))).resolve()
+    elif spec.origin is not None:
+        module_dir = Path(spec.origin).resolve().parent
+    else:
         raise click.ClickException(
-            f"Node '{node_name}' module '{module_path}' has no __file__; "
+            f"Node '{node_name}' module '{module_path}' has no origin; "
             "cannot locate packaged contract.yaml under current packaging convention."
         )
-    module_dir = Path(mod.__file__).resolve().parent
+
     contract = module_dir / "contract.yaml"
     if not contract.exists():
         raise click.ClickException(
@@ -73,6 +76,11 @@ def _resolve_packaged_contract(node_name: str) -> Path:
             "Use --contract to point at the actual contract location."
         )
     return contract
+
+
+def _entry_point_module(value: str) -> str:
+    """Return the importable module portion of an entry-point value."""
+    return value.split(":", 1)[0].strip()
 
 
 @click.command("node")

--- a/src/omnibase_core/discovery/discovery_external_nodes.py
+++ b/src/omnibase_core/discovery/discovery_external_nodes.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from importlib.metadata import entry_points
+from importlib.metadata import EntryPoint, entry_points
 
 from omnibase_core.errors.error_node_discovery import NodeDiscoveryError
 
@@ -19,16 +19,24 @@ class DiscoveredNode:
     """Metadata for a discovered external node."""
 
     name: str
-    node_class: type
     package_name: str
     package_version: str
+    entry_point_value: str
+    node_class: type | None = None
 
 
-def discover_external_nodes(*, strict: bool = False) -> dict[str, DiscoveredNode]:
+def discover_external_nodes(
+    *,
+    strict: bool = False,
+    load_classes: bool = False,
+) -> dict[str, DiscoveredNode]:
     """Discover ONEX nodes registered via entry points.
 
     Args:
         strict: If True, raise on duplicate entry-point names.
+        load_classes: If True, import and validate each node class. Defaults to
+            False so metadata discovery does not require every node's optional
+            runtime dependencies to be installed.
 
     Returns:
         Dictionary mapping entry-point names to DiscoveredNode metadata.
@@ -51,31 +59,18 @@ def discover_external_nodes(*, strict: bool = False) -> dict[str, DiscoveredNode
             logger.warning(msg)
             continue
 
-        try:
-            loaded = ep.load()
-        except Exception:  # noqa: BLE001  # catch-all-ok: entry point loading can fail in many ways
-            logger.warning(
-                "Failed to load entry point '%s' from '%s'",
-                ep.name,
-                dist_name,
-                exc_info=True,
-            )
-            continue
-
-        if not _is_valid_node_class(loaded):
-            logger.warning(
-                "Entry point '%s' from '%s' is not a valid node class (got %s)",
-                ep.name,
-                dist_name,
-                type(loaded).__name__,
-            )
-            continue
+        loaded: type | None = None
+        if load_classes:
+            loaded = _load_entry_point_class(ep, dist_name)
+            if loaded is None:
+                continue
 
         discovered[ep.name] = DiscoveredNode(
             name=ep.name,
-            node_class=loaded,
             package_name=dist_name,
             package_version=dist_version,
+            entry_point_value=ep.value,
+            node_class=loaded,
         )
         logger.info(
             "Discovered external node: %s from %s %s",
@@ -84,6 +79,30 @@ def discover_external_nodes(*, strict: bool = False) -> dict[str, DiscoveredNode
             dist_version,
         )
     return discovered
+
+
+def _load_entry_point_class(ep: EntryPoint, dist_name: str) -> type | None:
+    """Load and validate an entry-point class only when a caller needs code."""
+    try:
+        loaded = ep.load()
+    except Exception:  # noqa: BLE001  # catch-all-ok: entry point loading can fail in many ways
+        logger.warning(
+            "Failed to load entry point '%s' from '%s'",
+            ep.name,
+            dist_name,
+            exc_info=True,
+        )
+        return None
+
+    if not _is_valid_node_class(loaded):
+        logger.warning(
+            "Entry point '%s' from '%s' is not a valid node class (got %s)",
+            ep.name,
+            dist_name,
+            type(loaded).__name__,
+        )
+        return None
+    return loaded
 
 
 def _is_valid_node_class(obj: object) -> bool:

--- a/tests/unit/cli/test_cli_install.py
+++ b/tests/unit/cli/test_cli_install.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import io
 import tarfile
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,7 +14,10 @@ import click
 import pytest
 import yaml
 
-from omnibase_core.cli.cli_install import _install_oncp
+from omnibase_core.cli.cli_install import (
+    _install_oncp,
+    _resolve_entry_point_contract_path,
+)
 
 
 def _make_oncp(
@@ -28,7 +32,11 @@ def _make_oncp(
     archive = tmp_path / archive_name
 
     if contract is None:
-        contract = {"name": "test_node", "version": "1.0.0"}
+        contract = {
+            "name": "test_node",
+            "contract_version": {"major": 1, "minor": 0, "patch": 0},
+            "node_type": "COMPUTE_GENERIC",
+        }
 
     with tarfile.open(archive, "w:gz") as tar:
 
@@ -60,6 +68,32 @@ class TestInstallOncpMetadataValidation:
                 click.ClickException, match="'name' must be a non-empty"
             ):
                 _install_oncp(archive, dry_run=True, upgrade=False, verbose=False)
+
+
+@pytest.mark.unit
+class TestInstallEntrypointContractResolution:
+    """Entry-point contract lookup must not import node code."""
+
+    def test_resolves_contract_from_module_spec(self, tmp_path: Path) -> None:
+        node_dir = tmp_path / "node_pkg"
+        node_dir.mkdir()
+        contract = node_dir / "contract.yaml"
+        contract.write_text(
+            "name: node\ncontract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: COMPUTE_GENERIC\n",
+            encoding="utf-8",
+        )
+        spec = ModuleSpec("node_pkg", loader=None, is_package=True)
+        spec.submodule_search_locations = [str(node_dir)]
+
+        with patch(
+            "omnibase_core.cli.cli_install.importlib.util.find_spec",
+            return_value=spec,
+        ) as find_spec:
+            resolved = _resolve_entry_point_contract_path("node_pkg:Node")
+
+        assert resolved == contract
+        find_spec.assert_called_once_with("node_pkg")
 
     def test_missing_version_raises(self, tmp_path: Path) -> None:
         archive = _make_oncp(tmp_path, metadata={"name": "test_node"})
@@ -159,7 +193,13 @@ class TestInstallOncpPathTraversal:
             )
             _add(
                 "contract.yaml",
-                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+                yaml.safe_dump(
+                    {
+                        "name": "node",
+                        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+                        "node_type": "COMPUTE_GENERIC",
+                    }
+                ).encode(),
             )
             traversal = tarfile.TarInfo(name="../escape.txt")
             traversal.size = 3
@@ -196,7 +236,13 @@ class TestInstallOncpPathTraversal:
             )
             _add(
                 "contract.yaml",
-                yaml.safe_dump({"name": "node", "version": "1.0.0"}).encode(),
+                yaml.safe_dump(
+                    {
+                        "name": "node",
+                        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+                        "node_type": "COMPUTE_GENERIC",
+                    }
+                ).encode(),
             )
             absolute = tarfile.TarInfo(name="/tmp/absolute-escape.txt")
             absolute.size = 3
@@ -226,7 +272,10 @@ class TestInstallOncpAtomicity:
         archive = _make_oncp(
             tmp_path,
             metadata={"name": "node", "version": "1.0.0"},
-            contract={"version": "1.0.0"},
+            contract={
+                "contract_version": {"major": 1, "minor": 0, "patch": 0},
+                "node_type": "COMPUTE_GENERIC",
+            },
         )
         with patch(
             "omnibase_core.cli.cli_install._get_registry_dir",
@@ -246,7 +295,10 @@ class TestInstallOncpAtomicity:
         bad_archive = _make_oncp(
             tmp_path,
             metadata={"name": "node", "version": "2.0.0"},
-            contract={"version": "2.0.0"},
+            contract={
+                "contract_version": {"major": 2, "minor": 0, "patch": 0},
+                "node_type": "COMPUTE_GENERIC",
+            },
         )
 
         with patch(

--- a/tests/unit/cli/test_cli_node.py
+++ b/tests/unit/cli/test_cli_node.py
@@ -13,6 +13,7 @@ Covers the 5 CLI migration branches:
 
 from __future__ import annotations
 
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import patch
 
@@ -95,13 +96,13 @@ def test_missing_packaged_contract_reports_convention_violation(tmp_path: Path) 
     fake_pkg = tmp_path / "fake_pkg"
     fake_pkg.mkdir()
     (fake_pkg / "__init__.py").write_text("", encoding="utf-8")
+    spec = ModuleSpec("fake_pkg", loader=None, is_package=True)
+    spec.submodule_search_locations = [str(fake_pkg)]
 
     class _FakeEP:
         name = "node_has_no_contract"
         value = "fake_pkg"
         dist = "local-fake"
-
-    fake_module = type("FakeMod", (), {"__file__": str(fake_pkg / "__init__.py")})
 
     with (
         patch(
@@ -109,13 +110,48 @@ def test_missing_packaged_contract_reports_convention_violation(tmp_path: Path) 
             return_value=[_FakeEP()],
         ),
         patch(
-            "omnibase_core.cli.cli_node.importlib.import_module",
-            return_value=fake_module,
+            "omnibase_core.cli.cli_node.importlib.util.find_spec",
+            return_value=spec,
         ),
     ):
         with pytest.raises(Exception) as exc_info:
             _resolve_packaged_contract("node_has_no_contract")
     assert "packaging convention" in str(exc_info.value)
+
+
+def test_packaged_contract_resolution_does_not_import_node_module(
+    tmp_path: Path,
+) -> None:
+    """Contract lookup uses module specs so optional deps are not imported."""
+    fake_pkg = tmp_path / "fake_pkg"
+    fake_pkg.mkdir()
+    (fake_pkg / "contract.yaml").write_text(
+        "name: fake\ncontract_version: {major: 1, minor: 0, patch: 0}\n"
+        "node_type: COMPUTE_GENERIC\n",
+        encoding="utf-8",
+    )
+    spec = ModuleSpec("fake_pkg", loader=None, is_package=True)
+    spec.submodule_search_locations = [str(fake_pkg)]
+
+    class _FakeEP:
+        name = "node_has_contract"
+        value = "fake_pkg:Node"
+        dist = "local-fake"
+
+    with (
+        patch(
+            "omnibase_core.cli.cli_node.entry_points",
+            return_value=[_FakeEP()],
+        ),
+        patch(
+            "omnibase_core.cli.cli_node.importlib.util.find_spec",
+            return_value=spec,
+        ) as find_spec,
+    ):
+        contract = _resolve_packaged_contract("node_has_contract")
+
+    assert contract == fake_pkg / "contract.yaml"
+    find_spec.assert_called_once_with("fake_pkg")
 
 
 def test_input_file_not_found_surfaces_cli_error(tmp_path: Path) -> None:

--- a/tests/unit/discovery/test_discovery_external_nodes.py
+++ b/tests/unit/discovery/test_discovery_external_nodes.py
@@ -27,6 +27,7 @@ def _make_entry_point(
     """Create a mock entry point with the given properties."""
     ep = MagicMock()
     ep.name = name
+    ep.value = f"{dist_name.replace('-', '_')}.{name}"
     ep.dist = MagicMock()
     ep.dist.name = dist_name
     ep.dist.version = dist_version
@@ -56,7 +57,7 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("my_node", load_return=node_cls)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert "my_node" in result
         node = result["my_node"]
@@ -65,6 +66,20 @@ class TestDiscoverExternalNodes:
         assert node.node_class is node_cls
         assert node.package_name == "my-plugin"
         assert node.package_version == "1.0.0"
+        assert node.entry_point_value == "my_plugin.my_node"
+
+    @pytest.mark.unit
+    def test_discover_does_not_import_entry_points_by_default(self) -> None:
+        ep = _make_entry_point(
+            "node_with_optional_deps", load_raises=ImportError("missing dependency")
+        )
+
+        with patch(_EP_MODULE, return_value=[ep]):
+            result = discover_external_nodes()
+
+        assert "node_with_optional_deps" in result
+        assert result["node_with_optional_deps"].node_class is None
+        ep.load.assert_not_called()
 
     @pytest.mark.unit
     def test_discover_skips_failing_entry_point(self) -> None:
@@ -73,7 +88,7 @@ class TestDiscoverExternalNodes:
         )
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert result == {}
 
@@ -89,7 +104,7 @@ class TestDiscoverExternalNodes:
         )
 
         with patch(_EP_MODULE, return_value=[ep_a, ep_b]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         # Should keep first registered
         assert len(result) == 1
@@ -109,7 +124,7 @@ class TestDiscoverExternalNodes:
 
         with patch(_EP_MODULE, return_value=[ep_a, ep_b]):
             with pytest.raises(NodeDiscoveryError, match="Duplicate entry-point name"):
-                discover_external_nodes(strict=True)
+                discover_external_nodes(strict=True, load_classes=True)
 
     @pytest.mark.unit
     def test_discover_rejects_non_class_entry_point(self) -> None:
@@ -117,7 +132,7 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("func_node", load_return=lambda: None)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert result == {}
 
@@ -128,7 +143,7 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("contract_node", load_return=node_cls)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert "contract_node" in result
 
@@ -139,7 +154,7 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("typed_node", load_return=node_cls)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert "typed_node" in result
 
@@ -150,7 +165,7 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("handler_node", load_return=node_cls)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert "handler_node" in result
         assert result["handler_node"].node_class is node_cls
@@ -162,6 +177,6 @@ class TestDiscoverExternalNodes:
         ep = _make_entry_point("plain_node", load_return=node_cls)
 
         with patch(_EP_MODULE, return_value=[ep]):
-            result = discover_external_nodes()
+            result = discover_external_nodes(load_classes=True)
 
         assert result == {}


### PR DESCRIPTION
## Summary

- Make `onex.nodes` discovery metadata-first by default so optional node dependencies are not imported during discovery.
- Resolve packaged `contract.yaml` paths from entry-point module specs instead of importing node modules in `onex node` and `onex install`.
- Validate ONCP `contract.yaml` through the existing Pydantic YAML contract model and reject loose legacy version fallbacks.
- Add OMN-9592 contract evidence and keep ticket-contract schema validation authoritative for `contracts/OMN-*.yaml`.

## Validation

- `PYTHONPATH=src uv run pytest tests/unit/discovery/test_discovery_external_nodes.py tests/unit/cli/test_cli_node.py tests/unit/cli/test_cli_install.py -q`
- `PYTHONPATH=src uv run ruff check src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py`
- `PYTHONPATH=src uv run ruff format --check src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py`
- `PYTHONPATH=src uv run mypy src/omnibase_core/cli/cli_install.py src/omnibase_core/cli/cli_node.py src/omnibase_core/cli/cli_commands.py src/omnibase_core/discovery/discovery_external_nodes.py tests/unit/cli/test_cli_install.py tests/unit/cli/test_cli_node.py tests/unit/discovery/test_discovery_external_nodes.py`
- `PYTHONPATH=src uv run validate-yaml contracts/OMN-9592.yaml`
- `PYTHONPATH=src uv run python scripts/validation/validate_pr_deploy_required.py --changed-files "$(git diff --name-only origin/main...HEAD)" --pr-body "OMN-9592" --contracts-dir contracts`

## Notes

- Local shell environment prepends the canonical clone to `PYTHONPATH`; validation commands explicitly set `PYTHONPATH=src` so tests import this worktree.
- No deploy-gate bypass token is used.

Closes OMN-9592.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI `discover` command's verbose output now displays configured entry point values rather than implementation details.

* **Improvements**
  * Refactored contract validation to enhance reliability and provide more descriptive error messages.
  * Improved node discovery with optional loading support and enhanced error handling.

* **Chores**
  * Updated pre-commit validation rules for contract files.
  * Added new contract specification file for system enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->