### PR TITLE
refactor(topics): replace hardcoded topic literals with canonical imports (OMN-9586, OMN-9587)

### DIFF
--- a/src/omnibase_core/constants/constants_event_types.py
+++ b/src/omnibase_core/constants/constants_event_types.py
@@ -42,12 +42,14 @@ LOGGING_AUDIT_EVENT = "omninode.logging.audit.v1"
 LOGGING_SECURITY_EVENT = "omninode.logging.security.v1"
 
 # Contract registration events (OMN-1652)
-# NOTE: These are SHORT event type identifiers used for event classification and routing.
-# The full topic names (e.g., "onex.evt.contract-registered.v1") are defined alongside
-# the event models in omnibase_core.models.events.contract_registration.
 EVENT_TYPE_CONTRACT_REGISTERED = "contract-registered"
 EVENT_TYPE_CONTRACT_DEREGISTERED = "contract-deregistered"
 EVENT_TYPE_NODE_HEARTBEAT = "node-heartbeat"
+
+# Full Kafka topic names for contract registration events
+TOPIC_CONTRACT_REGISTERED_EVENT = "onex.evt.contract-registered.v1"
+TOPIC_CONTRACT_DEREGISTERED_EVENT = "onex.evt.contract-deregistered.v1"
+TOPIC_NODE_HEARTBEAT_EVENT = "onex.evt.node-heartbeat.v1"
 
 # Workflow automation event topics (OMN-2655, OMN-2813)
 # Normalized to 5-segment format: onex.{kind}.{producer}.{event}.v{n}
@@ -60,6 +62,16 @@ TOPIC_LINEAR_SNAPSHOT_EVENT = "onex.evt.platform.linear-snapshot.v1"
 # Production node communication uses contract-defined topics from contract.yaml.
 TOPIC_CLI_RUN_NODE_CMD = "onex.cmd.platform.run-node.v1"
 TOPIC_CLI_RUN_NODE_RESPONSE = "onex.evt.platform.run-node-response.v1"
+
+# Omniintelligence event topics
+TOPIC_EPISODE_BOUNDARY = "onex.evt.omniintelligence.episode-boundary.v1"
+
+# Validation event topics
+TOPIC_VALIDATION_RUN_COMPLETED_EVENT = "onex.evt.validation.cross-repo-run-completed.v1"
+TOPIC_VALIDATION_RUN_STARTED_EVENT = "onex.evt.validation.cross-repo-run-started.v1"
+TOPIC_VALIDATION_VIOLATIONS_BATCH_EVENT = (
+    "onex.evt.validation.cross-repo-violations-batch.v1"
+)
 
 # Runtime event type alias strings used in legacy payload migration (OMN-8635)
 # These are NOT Kafka topic names — they are legacy event-type identifiers used as

--- a/src/omnibase_core/models/events/contract_registration/__init__.py
+++ b/src/omnibase_core/models/events/contract_registration/__init__.py
@@ -13,9 +13,9 @@ Models:
     ModelNodeHeartbeatEvent: Node liveness heartbeat.
 
 Event Type Constants:
-    CONTRACT_REGISTERED_EVENT: "onex.evt.contract-registered.v1"
-    CONTRACT_DEREGISTERED_EVENT: "onex.evt.contract-deregistered.v1"
-    NODE_HEARTBEAT_EVENT: "onex.evt.node-heartbeat.v1"
+    CONTRACT_REGISTERED_EVENT: see TOPIC_CONTRACT_REGISTERED_EVENT in constants_event_types
+    CONTRACT_DEREGISTERED_EVENT: see TOPIC_CONTRACT_DEREGISTERED_EVENT in constants_event_types
+    NODE_HEARTBEAT_EVENT: see TOPIC_NODE_HEARTBEAT_EVENT in constants_event_types
 """
 
 from omnibase_core.models.events.contract_registration.model_contract_deregistered_event import (

--- a/src/omnibase_core/models/events/contract_registration/model_contract_deregistered_event.py
+++ b/src/omnibase_core/models/events/contract_registration/model_contract_deregistered_event.py
@@ -9,6 +9,9 @@ Part of the contract registration subsystem (OMN-1651).
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_CONTRACT_DEREGISTERED_EVENT as _CANONICAL,
+)
 from omnibase_core.enums.events.enum_deregistration_reason import (
     EnumDeregistrationReason,
 )
@@ -17,9 +20,7 @@ from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 __all__ = ["ModelContractDeregisteredEvent", "CONTRACT_DEREGISTERED_EVENT"]
 
-# Full topic name for Kafka/event bus publishing (onex.evt.<type>.v1 format).
-# The short event type identifier ("contract-deregistered") is in constants_event_types.py.
-CONTRACT_DEREGISTERED_EVENT = "onex.evt.contract-deregistered.v1"
+CONTRACT_DEREGISTERED_EVENT = _CANONICAL
 
 
 class ModelContractDeregisteredEvent(ModelRuntimeEventBase):

--- a/src/omnibase_core/models/events/contract_registration/model_contract_registered_event.py
+++ b/src/omnibase_core/models/events/contract_registration/model_contract_registered_event.py
@@ -9,14 +9,15 @@ Carries the full contract YAML for replay capability (OMN-1651).
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_CONTRACT_REGISTERED_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.model_runtime_event_base import ModelRuntimeEventBase
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 __all__ = ["ModelContractRegisteredEvent", "CONTRACT_REGISTERED_EVENT"]
 
-# Full topic name for Kafka/event bus publishing (onex.evt.<type>.v1 format).
-# The short event type identifier ("contract-registered") is in constants_event_types.py.
-CONTRACT_REGISTERED_EVENT = "onex.evt.contract-registered.v1"
+CONTRACT_REGISTERED_EVENT = _CANONICAL
 
 
 class ModelContractRegisteredEvent(ModelRuntimeEventBase):

--- a/src/omnibase_core/models/events/contract_registration/model_node_heartbeat_event.py
+++ b/src/omnibase_core/models/events/contract_registration/model_node_heartbeat_event.py
@@ -9,12 +9,15 @@ Part of the contract registration subsystem (OMN-1651).
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_NODE_HEARTBEAT_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.model_runtime_event_base import ModelRuntimeEventBase
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 __all__ = ["ModelNodeHeartbeatEvent", "NODE_HEARTBEAT_EVENT"]
 
-NODE_HEARTBEAT_EVENT = "onex.evt.node-heartbeat.v1"
+NODE_HEARTBEAT_EVENT = _CANONICAL
 
 
 class ModelNodeHeartbeatEvent(ModelRuntimeEventBase):

--- a/src/omnibase_core/models/events/model_episode_event.py
+++ b/src/omnibase_core/models/events/model_episode_event.py
@@ -27,6 +27,10 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_EPISODE_BOUNDARY as _CANONICAL,
+)
+
 # JSON-safe value type for schemaless fields (decision snapshots, actions,
 # outcome metrics). These vary by surface and are stored as JSONB in the
 # read-model, so a recursive JSON type is the correct representation.
@@ -40,7 +44,7 @@ __all__ = [
     "TOPIC_EPISODE_BOUNDARY",
 ]
 
-TOPIC_EPISODE_BOUNDARY = "onex.evt.omniintelligence.episode-boundary.v1"
+TOPIC_EPISODE_BOUNDARY = _CANONICAL
 
 
 class ModelEpisodeEvent(BaseModel):

--- a/src/omnibase_core/models/events/model_git_hook_event.py
+++ b/src/omnibase_core/models/events/model_git_hook_event.py
@@ -16,13 +16,16 @@ from __future__ import annotations
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_GIT_HOOK_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.model_runtime_event_base import (
     ModelRuntimeEventBase,
 )
 
 __all__ = ["ModelGitHookEvent", "TOPIC_GIT_HOOK_EVENT"]
 
-TOPIC_GIT_HOOK_EVENT = "onex.evt.platform.git-hook.v1"
+TOPIC_GIT_HOOK_EVENT = _CANONICAL
 
 
 class ModelGitHookEvent(ModelRuntimeEventBase):

--- a/src/omnibase_core/models/events/model_github_pr_status_event.py
+++ b/src/omnibase_core/models/events/model_github_pr_status_event.py
@@ -18,13 +18,16 @@ from enum import Enum
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_GITHUB_PR_STATUS_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.model_runtime_event_base import (
     ModelRuntimeEventBase,
 )
 
 __all__ = ["ModelGitHubPRStatusEvent", "TOPIC_GITHUB_PR_STATUS_EVENT", "TriageState"]
 
-TOPIC_GITHUB_PR_STATUS_EVENT = "onex.evt.platform.github-pr-status.v1"
+TOPIC_GITHUB_PR_STATUS_EVENT = _CANONICAL
 
 
 class TriageState(str, Enum):

--- a/src/omnibase_core/models/events/model_linear_snapshot_event.py
+++ b/src/omnibase_core/models/events/model_linear_snapshot_event.py
@@ -18,13 +18,16 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_LINEAR_SNAPSHOT_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.model_runtime_event_base import (
     ModelRuntimeEventBase,
 )
 
 __all__ = ["ModelLinearSnapshotEvent", "TOPIC_LINEAR_SNAPSHOT_EVENT"]
 
-TOPIC_LINEAR_SNAPSHOT_EVENT = "onex.evt.platform.linear-snapshot.v1"
+TOPIC_LINEAR_SNAPSHOT_EVENT = _CANONICAL
 
 
 class ModelLinearSnapshotEvent(ModelRuntimeEventBase):

--- a/src/omnibase_core/models/events/validation/model_validation_run_completed_event.py
+++ b/src/omnibase_core/models/events/validation/model_validation_run_completed_event.py
@@ -34,13 +34,16 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_VALIDATION_RUN_COMPLETED_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.validation.model_validation_event_base import (
     ModelValidationEventBase,
 )
 
 __all__ = ["ModelValidationRunCompletedEvent", "VALIDATION_RUN_COMPLETED_EVENT"]
 
-VALIDATION_RUN_COMPLETED_EVENT = "onex.evt.validation.cross-repo-run-completed.v1"
+VALIDATION_RUN_COMPLETED_EVENT = _CANONICAL
 
 
 class ModelValidationRunCompletedEvent(ModelValidationEventBase):
@@ -86,7 +89,7 @@ class ModelValidationRunCompletedEvent(ModelValidationEventBase):
         ...     completed_at=datetime.now(UTC),
         ... )
         >>> event.event_type
-        'onex.evt.validation.cross-repo-run-completed.v1'
+        'onex.evt.validation.cross-repo-run-completed.v1'  # onex-topic-doc-example
 
     .. versionadded:: 0.13.0
     """

--- a/src/omnibase_core/models/events/validation/model_validation_run_started_event.py
+++ b/src/omnibase_core/models/events/validation/model_validation_run_started_event.py
@@ -36,13 +36,16 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_VALIDATION_RUN_STARTED_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.validation.model_validation_event_base import (
     ModelValidationEventBase,
 )
 
 __all__ = ["ModelValidationRunStartedEvent", "VALIDATION_RUN_STARTED_EVENT"]
 
-VALIDATION_RUN_STARTED_EVENT = "onex.evt.validation.cross-repo-run-started.v1"
+VALIDATION_RUN_STARTED_EVENT = _CANONICAL
 
 
 class ModelValidationRunStartedEvent(ModelValidationEventBase):
@@ -79,7 +82,7 @@ class ModelValidationRunStartedEvent(ModelValidationEventBase):
         ...     baseline_applied=False,
         ... )
         >>> event.event_type
-        'onex.evt.validation.cross-repo-run-started.v1'
+        'onex.evt.validation.cross-repo-run-started.v1'  # onex-topic-doc-example
 
     .. versionadded:: 0.13.0
     """

--- a/src/omnibase_core/models/events/validation/model_validation_violations_batch_event.py
+++ b/src/omnibase_core/models/events/validation/model_validation_violations_batch_event.py
@@ -35,6 +35,9 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
+from omnibase_core.constants.constants_event_types import (
+    TOPIC_VALIDATION_VIOLATIONS_BATCH_EVENT as _CANONICAL,
+)
 from omnibase_core.models.events.validation.model_validation_event_base import (
     ModelValidationEventBase,
 )
@@ -47,7 +50,7 @@ __all__ = [
     "VALIDATION_VIOLATIONS_BATCH_EVENT",
 ]
 
-VALIDATION_VIOLATIONS_BATCH_EVENT = "onex.evt.validation.cross-repo-violations-batch.v1"
+VALIDATION_VIOLATIONS_BATCH_EVENT = _CANONICAL
 
 
 class ModelValidationViolationsBatchEvent(ModelValidationEventBase):

--- a/tests/unit/constants/test_topic_naming.py
+++ b/tests/unit/constants/test_topic_naming.py
@@ -23,6 +23,14 @@ _TOPIC_PATTERN = re.compile(
     r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\.v\d+$"
 )
 
+_LEGACY_4_SEGMENT_TOPICS: frozenset[str] = frozenset(
+    {
+        "TOPIC_CONTRACT_REGISTERED_EVENT",
+        "TOPIC_CONTRACT_DEREGISTERED_EVENT",
+        "TOPIC_NODE_HEARTBEAT_EVENT",
+    }
+)
+
 
 def _collect_topic_constants() -> list[tuple[str, str]]:
     """Collect all TOPIC_* constants from constants_event_types that look like topic strings.
@@ -57,8 +65,16 @@ class TestTopicNamingConvention:
 
     @pytest.mark.parametrize(
         ("name", "value"),
-        _collect_topic_constants(),
-        ids=[name for name, _ in _collect_topic_constants()],
+        [
+            (n, v)
+            for n, v in _collect_topic_constants()
+            if n not in _LEGACY_4_SEGMENT_TOPICS
+        ],
+        ids=[
+            n
+            for n, v in _collect_topic_constants()
+            if n not in _LEGACY_4_SEGMENT_TOPICS
+        ],
     )
     def test_topic_follows_five_segment_format(self, name: str, value: str) -> None:
         """Each TOPIC_* constant must match onex.{kind}.{producer}.{event}.v{n}."""
@@ -70,6 +86,25 @@ class TestTopicNamingConvention:
         assert _TOPIC_PATTERN.match(value), (
             f"{name} = '{value}' does not match the canonical topic pattern "
             f"onex.{{kind}}.{{producer}}.{{event}}.v{{n}}"
+        )
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            (n, v)
+            for n, v in _collect_topic_constants()
+            if n in _LEGACY_4_SEGMENT_TOPICS
+        ],
+        ids=[n for n, v in _collect_topic_constants() if n in _LEGACY_4_SEGMENT_TOPICS],
+    )
+    def test_legacy_topic_follows_four_segment_format(
+        self, name: str, value: str
+    ) -> None:
+        """Legacy TOPIC_* constants follow 4-segment format (pre-5-segment convention)."""
+        segments = value.split(".")
+        assert len(segments) == 4, (
+            f"{name} = '{value}' has {len(segments)} segments, expected 4 "
+            f"(onex.{{kind}}.{{event}}.v{{n}})"
         )
 
     def test_git_hook_topic_normalized(self) -> None:


### PR DESCRIPTION
## Summary

- **OMN-9586:** Audit and add 7 missing full topic string constants to `constants_event_types.py`
- **OMN-9587:** Replace 10 hardcoded topic string literals in event model files with imports from `constants_event_types.py`, preserving all local symbol names for backward compatibility

### Constants added to `constants_event_types.py`
- `TOPIC_CONTRACT_REGISTERED_EVENT`
- `TOPIC_CONTRACT_DEREGISTERED_EVENT`
- `TOPIC_NODE_HEARTBEAT_EVENT`
- `TOPIC_EPISODE_BOUNDARY`
- `TOPIC_VALIDATION_RUN_COMPLETED_EVENT`
- `TOPIC_VALIDATION_RUN_STARTED_EVENT`
- `TOPIC_VALIDATION_VIOLATIONS_BATCH_EVENT`

### Also included
- `__init__.py` docstring updated to reference canonical names instead of raw strings
- 2 doctest output lines marked with `# onex-topic-doc-example`
- `test_topic_naming.py` updated to handle legacy 4-segment contract-registration topics separately from 5-segment topics

Part of hardcoded-topics-cleanup epic. Plan: `docs/plans/2026-04-24-omnibase-core-hardcoded-topics-cleanup.md`