### PR TITLE
fix(validation): broaden approved basenames for topic SoT files (OMN-9151)

### DIFF
--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -77,6 +77,7 @@ _APPROVED_BASENAMES: frozenset[str] = frozenset(
         "topics.ts",
         "topics.yaml",
         "topic_constants.py",
+        "constants.py",
         "constants_event_types.py",
         "constants_topic_taxonomy.py",
         "platform_topic_suffixes.py",
@@ -85,6 +86,10 @@ _APPROVED_BASENAMES: frozenset[str] = frozenset(
         "contract_topic_extractor.py",
         "check_topic_drift.py",
         "validator_topic_suffix.py",
+        "topic_allowlist.yaml",
+        "topic_registry.yaml",
+        "service_topic_registry.py",
+        "validation_exemptions.yaml",
     }
 )
 


### PR DESCRIPTION
## Summary

Add 5 common topic SoT file patterns to the validator's approved basenames list so they don't need per-line suppression markers:

- `constants.py` — per-package topic constants (e.g., omniintelligence/constants.py)
- `topic_allowlist.yaml` — topic allowlist registries (e.g., omniclaude)
- `topic_registry.yaml` — topic registry files
- `service_topic_registry.py` — runtime topic registries (e.g., omnibase_infra)
- `validation_exemptions.yaml` — validation exemption catalogs

These files legitimately contain topic string literals as declarations.

Parent epic: OMN-9151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validator logic to exempt additional configuration and registry files from hardcoded topic scanning, improving code quality processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->