### PR TITLE
feat(OMN-9611): add EnumHookBit + hook_enabled() helper

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -287,6 +287,26 @@ allowed_files:
     added: "2026-04-17"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/cli/cli_pack.py"
+    reason: >-
+      onex pack CLI must parse heterogeneous third-party metadata.yaml + contract.yaml files from arbitrary
+      node directories before any Pydantic model applies. contract.yaml schemas vary by node type (ModelContractCompute,
+      ModelContractEffect, ModelContractReducer, ModelContractOrchestrator), so raw YAML parsing is required
+      to route to the correct model. metadata.yaml is a thin descriptor consumed before any registry lookup.
+      Both sites validate required keys explicitly (mapping check, name/version presence) before use.
+      Parallels cli_install.py pattern (OMN-7537).
+    added: "2026-04-24"
+    review: "2026-06-13"
+
+  - file: "src/omnibase_core/cli/cli_config.py"
+    reason: >-
+      onex config get reads ~/.onex/config.yaml as free-form user configuration. No fixed Pydantic schema
+      exists for this file — the config is a thin key-value YAML with optional sections (kafka, logging,
+      aws). Raw yaml.safe_load() is required to support dotted-key access (e.g. kafka.bootstrap_servers)
+      before any Pydantic model applies. Parallels cli_refresh_credentials.py pattern (OMN-9011).
+    added: "2026-04-24"
+    review: "2026-06-13"
+
 # Specific filenames that are allowed (matched by basename)
 # Allows the same utility to be used across different module paths (e.g., copied utilities)
 allowed_filenames:

--- a/src/omnibase_core/cli/cli_bootstrap.py
+++ b/src/omnibase_core/cli/cli_bootstrap.py
@@ -16,7 +16,7 @@ def _config_path() -> Path:
 
 
 @click.group("bootstrap")
-def bootstrap() -> None:
+def bootstrap() -> None:  # stub-ok
     """Bootstrap commands for ONEX standalone configuration."""
 
 

--- a/src/omnibase_core/cli/cli_config.py
+++ b/src/omnibase_core/cli/cli_config.py
@@ -35,7 +35,7 @@ def _config_path() -> Path:
 
 
 @click.group("config")
-def config_group() -> None:
+def config_group() -> None:  # stub-ok
     """Manage ONEX configuration."""
 
 

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -209,6 +209,9 @@ from .enum_health_detail_type import EnumHealthDetailType
 from .enum_health_status import EnumHealthStatus
 from .enum_health_status_value import EnumHealthStatusValue
 
+# Hook bitmask gating (OMN-9611)
+from .enum_hook_bit import EnumHookBit, hook_enabled
+
 # Hub and coordination enums
 from .enum_hub_capability import EnumHubCapability
 
@@ -663,6 +666,9 @@ __all__ = [
     "EnumHandlerTypeCategory",
     # Hash algorithm domain (handler packaging OMN-1119)
     "EnumHashAlgorithm",
+    # Hook bitmask gating (OMN-9611)
+    "EnumHookBit",
+    "hook_enabled",
     # Version and contract domain
     "EnumVersionStatus",
     "EnumContractCompliance",

--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -113,7 +113,7 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
     """
     if mask is not None:
         if mask < 0:
-            return True  # fail-open: negative masks silently disable bits
+            return True  # fallback-ok: reject negative explicit mask, preserve hook continuity
         return bool(mask & int(bit))
     raw = os.environ.get("ONEX_HOOKS_MASK")
     if raw is None:
@@ -125,5 +125,5 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
     ):  # fallback-ok: fail-open on malformed mask favors hook continuity
         return True
     if parsed < 0:
-        return True  # fail-open: reject negative masks from env
+        return True  # fallback-ok: reject negative env mask, preserve hook continuity
     return bool(parsed & int(bit))

--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -114,8 +114,8 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
         else:
             try:
                 mask = int(raw, 0)
-            except ValueError:
-                # Fail-open favors hook continuity over honoring broken user config.
-                # A CLI warning on write is a follow-up (OMN-9614).
+            except (
+                ValueError
+            ):  # fallback-ok: fail-open on malformed mask favors hook continuity
                 mask = _DEFAULT_MASK
     return bool(mask & bit)

--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -13,6 +13,8 @@ broken user config. A CLI warning on write is a follow-up (OMN-9614).
 
 from __future__ import annotations
 
+import functools
+import operator
 import os
 from enum import IntEnum, unique
 
@@ -89,10 +91,11 @@ class EnumHookBit(IntEnum):
     SESSION_START_ONEX_CLI_PIN_CHECK = 1 << 56
 
 
-# Default mask is derived dynamically from the enum width so adding the 65th
-# member does NOT silently truncate the default to 64 bits. The generator
-# (Task 3) emits the equivalent literal into hook_bits.sh at generation time.
-_DEFAULT_MASK: int = (1 << len(EnumHookBit)) - 1
+# Default mask ORs all actual member values — correct even after tombstones are
+# added (which lower len() but leave high bit positions in active members).
+# (1 << len()) - 1 would silently disable the highest bits once any member is
+# tombstoned. The generator (Task 3) emits the equivalent literal into hook_bits.sh.
+_DEFAULT_MASK: int = functools.reduce(operator.or_, (int(m) for m in EnumHookBit))
 
 
 def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
@@ -102,7 +105,7 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
         bit: The hook bit to test.
         mask: Explicit mask. If None, reads `ONEX_HOOKS_MASK` from env,
               accepts hex (`0x...`), binary (`0b...`), or decimal literal.
-              Malformed or missing => default mask (all-on, width-matched to enum).
+              Malformed or missing => default mask (all-on).
     """
     if mask is None:
         raw = os.environ.get("ONEX_HOOKS_MASK")
@@ -115,4 +118,4 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
                 # Fail-open favors hook continuity over honoring broken user config.
                 # A CLI warning on write is a follow-up (OMN-9614).
                 mask = _DEFAULT_MASK
-    return bool(mask & int(bit))
+    return bool(mask & bit)

--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -105,17 +105,25 @@ def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
         bit: The hook bit to test.
         mask: Explicit mask. If None, reads `ONEX_HOOKS_MASK` from env,
               accepts hex (`0x...`), binary (`0b...`), or decimal literal.
-              Malformed or missing => default mask (all-on).
+              Malformed, missing, or negative => default mask (all-on).
+
+    Negative masks are rejected (fail-open) because Python's arbitrary-precision
+    integers allow e.g. ``-2 & (1<<0) == 0``, which would silently disable
+    specific hooks and violate the fail-open contract.
     """
-    if mask is None:
-        raw = os.environ.get("ONEX_HOOKS_MASK")
-        if raw is None:
-            mask = _DEFAULT_MASK
-        else:
-            try:
-                mask = int(raw, 0)
-            except (
-                ValueError
-            ):  # fallback-ok: fail-open on malformed mask favors hook continuity
-                mask = _DEFAULT_MASK
-    return bool(mask & bit)
+    if mask is not None:
+        if mask < 0:
+            return True  # fail-open: negative masks silently disable bits
+        return bool(mask & int(bit))
+    raw = os.environ.get("ONEX_HOOKS_MASK")
+    if raw is None:
+        return bool(_DEFAULT_MASK & int(bit))
+    try:
+        parsed = int(raw, 0)
+    except (
+        ValueError
+    ):  # fallback-ok: fail-open on malformed mask favors hook continuity
+        return True
+    if parsed < 0:
+        return True  # fail-open: reject negative masks from env
+    return bool(parsed & int(bit))

--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""EnumHookBit and hook_enabled() — bitmask gating for omniclaude hooks.
+
+Source of truth for which hook wrappers are active. Each member is a single-bit
+power of two. Bit positions are APPEND-ONLY forever — never reorder or reuse.
+
+Runtime mask: env var `ONEX_HOOKS_MASK` (defaults to all-on when unset or malformed).
+
+Fail-open on malformed mask is deliberate: favors hook continuity over honoring
+broken user config. A CLI warning on write is a follow-up (OMN-9614).
+"""
+
+from __future__ import annotations
+
+import os
+from enum import IntEnum, unique
+
+__all__ = ["EnumHookBit", "_DEFAULT_MASK", "hook_enabled"]
+
+
+@unique
+class EnumHookBit(IntEnum):
+    """Bit positions for omniclaude hook wrappers.
+
+    APPEND-ONLY. Never reorder. Never reuse a removed value.
+    Ordinals match the Task 1 (OMN-9610) governance freeze ordering.
+    """
+
+    # --- top-level hooks (plugins/onex/hooks/) ---
+    CI_REMINDER = 1 << 0
+    RUFF_FIX = 1 << 1
+    CONVENTION_INJECTOR = 1 << 2
+
+    # --- scripts/ GATE wrappers ---
+    EPIC_POSTACTION_GATE = 1 << 3
+    EPIC_PREFLIGHT_GATE = 1 << 4
+    FILE_PATH_CONVENTION_INJECT = 1 << 5
+    HOOK_DISPATCH_CLAIM_POSTTOOL = 1 << 6
+    HOOK_DISPATCH_CLAIM_PRETOOL = 1 << 7
+    HOOK_IDLE_NOTIFICATION_RATELIMIT = 1 << 8
+    HOOK_VERIFIER_ROLE_GUARD = 1 << 9
+    PERMISSION_DENIED_LOGGER = 1 << 10
+    POST_SKILL_DELEGATION_ENFORCER = 1 << 11
+    POST_TOOL_DELEGATION_COUNTER = 1 << 12
+    POST_TOOL_USE_QUALITY = 1 << 13
+    TEST_REMINDER = 1 << 14
+    POST_TOOL_AGENT_RESULT_VERIFIER = 1 << 15
+    AUTO_CHECKPOINT = 1 << 16
+    AUTO_HOSTILE_REVIEW = 1 << 17
+    CHANGESET_GUARD_POST = 1 << 18
+    POST_TOOL_COMMIT_VERIFY = 1 << 19
+    POST_TOOL_CRON_ACTION_GUARD = 1 << 20
+    ENV_SYNC = 1 << 21
+    POST_TOOL_KAFKA_POISON_MESSAGE_GUARD = 1 << 22
+    POST_TOOL_OUTPUT_SUPPRESSOR = 1 << 23
+    POST_TOOL_RETURN_PATH_AUDITOR = 1 << 24
+    POST_TOOL_STATE_VERIFY = 1 << 25
+    POST_TOOL_SUBAGENT_TOOL_LOG = 1 << 26
+    TEAM_OBSERVABILITY = 1 << 27
+    POST_TOOL_TSC_CHECK = 1 << 28
+    PRE_COMPACT = 1 << 29
+    PRE_TOOL_USE_QUALITY = 1 << 30
+    PRE_TOOL_AGENT_DISPATCH_GATE = 1 << 31
+    PRE_TOOL_AGENT_TOOL_GATE = 1 << 32
+    PRE_TOOL_AUTHORIZATION_SHIM = 1 << 33
+    BASH_GUARD = 1 << 34
+    BRANCH_PROTECTION_GUARD = 1 << 35
+    CHANGESET_GUARD_PRE = 1 << 36
+    CONTEXT_SCOPE_AUDITOR = 1 << 37
+    DISPATCH_GUARD = 1 << 38
+    DISPATCH_GUARD_TICKET_EVIDENCE = 1 << 39
+    DISPATCH_MODE_GUARDRAIL = 1 << 40
+    DOD_COMPLETION_GUARD = 1 << 41
+    HOSTILE_REVIEW_GATE = 1 << 42
+    LINEAR_DONE_VERIFY = 1 << 43
+    MODEL_ROUTER = 1 << 44
+    OVERSEER_FOREGROUND_BLOCK = 1 << 45
+    PIPELINE_GATE = 1 << 46
+    PLAN_EXISTENCE_GATE = 1 << 47
+    POLY_ENFORCER = 1 << 48
+    PREPUSH_VALIDATOR = 1 << 49
+    SCOPE_GATE = 1 << 50
+    SWEEP_PREFLIGHT = 1 << 51
+    TDD_DISPATCH_GATE = 1 << 52
+    TEAM_LEAD_GUARD = 1 << 53
+    WORKFLOW_GUARD = 1 << 54
+    SESSION_START = 1 << 55
+    SESSION_START_ONEX_CLI_PIN_CHECK = 1 << 56
+
+
+# Default mask is derived dynamically from the enum width so adding the 65th
+# member does NOT silently truncate the default to 64 bits. The generator
+# (Task 3) emits the equivalent literal into hook_bits.sh at generation time.
+_DEFAULT_MASK: int = (1 << len(EnumHookBit)) - 1
+
+
+def hook_enabled(bit: EnumHookBit, mask: int | None = None) -> bool:
+    """Return True if the given bit is set in the effective mask.
+
+    Args:
+        bit: The hook bit to test.
+        mask: Explicit mask. If None, reads `ONEX_HOOKS_MASK` from env,
+              accepts hex (`0x...`), binary (`0b...`), or decimal literal.
+              Malformed or missing => default mask (all-on, width-matched to enum).
+    """
+    if mask is None:
+        raw = os.environ.get("ONEX_HOOKS_MASK")
+        if raw is None:
+            mask = _DEFAULT_MASK
+        else:
+            try:
+                mask = int(raw, 0)
+            except ValueError:
+                # Fail-open favors hook continuity over honoring broken user config.
+                # A CLI warning on write is a follow-up (OMN-9614).
+                mask = _DEFAULT_MASK
+    return bool(mask & int(bit))

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -40,11 +40,11 @@ class TestEnumHookBit:
     def test_member_count_matches_inventory(self) -> None:
         assert len(list(EnumHookBit)) == _N_GATE
 
-    def test_default_mask_width_matches_enum(self) -> None:
+    def test_default_mask_covers_all_members(self) -> None:
         from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK
 
-        expected = (1 << len(EnumHookBit)) - 1
-        assert expected == _DEFAULT_MASK
+        for m in EnumHookBit:
+            assert _DEFAULT_MASK & m, f"{m.name} not covered by _DEFAULT_MASK"
 
     def test_default_mask_is_not_hardcoded_0xffffffff(self) -> None:
         from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -92,3 +92,26 @@ class TestHookEnabled:
         monkeypatch.setenv("ONEX_HOOKS_MASK", "not-a-number")
         for m in EnumHookBit:
             assert hook_enabled(m) is True
+
+    def test_explicit_negative_mask_minus_one_is_fail_open(self) -> None:
+        for m in EnumHookBit:
+            assert hook_enabled(m, mask=-1) is True, (
+                f"{m.name}: mask=-1 should fail-open (True), not silently disable"
+            )
+
+    def test_explicit_negative_mask_minus_two_is_fail_open(self) -> None:
+        # -2 in Python two's complement: bit 0 is clear, so CI_REMINDER would
+        # return False if negative masks were evaluated as-is.
+        for m in EnumHookBit:
+            assert hook_enabled(m, mask=-2) is True, (
+                f"{m.name}: mask=-2 must fail-open, not clear bit 0"
+            )
+
+    def test_env_negative_mask_is_fail_open(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_HOOKS_MASK", "-2")
+        for m in EnumHookBit:
+            assert hook_enabled(m) is True, (
+                f"{m.name}: ONEX_HOOKS_MASK=-2 must fail-open"
+            )

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import enum
 
-import pytest  # noqa: TC002
+import pytest
 
 from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
+
+pytestmark = pytest.mark.unit
 
 # Frozen GATE count from Task 1 inventory. Update only when the inventory doc changes.
 _N_GATE = 57

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for EnumHookBit and hook_enabled()."""
+
+from __future__ import annotations
+
+import enum
+
+import pytest  # noqa: TC002
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
+
+# Frozen GATE count from Task 1 inventory. Update only when the inventory doc changes.
+_N_GATE = 57
+
+
+class TestEnumHookBit:
+    def test_is_int_enum(self) -> None:
+        assert issubclass(EnumHookBit, enum.IntEnum)
+
+    def test_ci_reminder_is_power_of_two(self) -> None:
+        assert EnumHookBit.CI_REMINDER > 0
+        v = int(EnumHookBit.CI_REMINDER)
+        assert v & (v - 1) == 0, "CI_REMINDER must be a single-bit power of two"
+
+    def test_every_member_is_power_of_two(self) -> None:
+        for m in EnumHookBit:
+            v = int(m)
+            assert v > 0
+            assert v & (v - 1) == 0, f"{m.name}={v} is not a single-bit value"
+
+    def test_no_duplicate_bits(self) -> None:
+        values = [int(m) for m in EnumHookBit]
+        assert len(values) == len(set(values))
+
+    def test_bits_fit_in_64(self) -> None:
+        for m in EnumHookBit:
+            assert int(m) < (1 << 64)
+
+    def test_member_count_matches_inventory(self) -> None:
+        assert len(list(EnumHookBit)) == _N_GATE
+
+    def test_default_mask_width_matches_enum(self) -> None:
+        from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK
+
+        expected = (1 << len(EnumHookBit)) - 1
+        assert expected == _DEFAULT_MASK
+
+    def test_default_mask_is_not_hardcoded_0xffffffff(self) -> None:
+        from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK
+
+        assert _DEFAULT_MASK != 0xFFFFFFFF
+
+
+class TestHookEnabled:
+    def test_default_mask_all_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ONEX_HOOKS_MASK", raising=False)
+        for m in EnumHookBit:
+            assert hook_enabled(m) is True
+
+    def test_explicit_mask_disables_one_bit(self) -> None:
+        ci = int(EnumHookBit.CI_REMINDER)
+        all_on = (1 << len(EnumHookBit)) - 1
+        mask = all_on & ~ci
+        assert hook_enabled(EnumHookBit.CI_REMINDER, mask=mask) is False
+        other = next(m for m in EnumHookBit if m is not EnumHookBit.CI_REMINDER)
+        assert hook_enabled(other, mask=mask) is True
+
+    def test_env_mask_hex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ci = int(EnumHookBit.CI_REMINDER)
+        all_on = (1 << len(EnumHookBit)) - 1
+        monkeypatch.setenv("ONEX_HOOKS_MASK", hex(all_on & ~ci))
+        assert hook_enabled(EnumHookBit.CI_REMINDER) is False
+
+    def test_env_mask_decimal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ci = int(EnumHookBit.CI_REMINDER)
+        all_on = (1 << len(EnumHookBit)) - 1
+        monkeypatch.setenv("ONEX_HOOKS_MASK", str(all_on & ~ci))
+        assert hook_enabled(EnumHookBit.CI_REMINDER) is False
+
+    def test_env_mask_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ci = int(EnumHookBit.CI_REMINDER)
+        all_on = (1 << len(EnumHookBit)) - 1
+        monkeypatch.setenv("ONEX_HOOKS_MASK", bin(all_on & ~ci))
+        assert hook_enabled(EnumHookBit.CI_REMINDER) is False
+
+    def test_malformed_mask_defaults_to_all_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_HOOKS_MASK", "not-a-number")
+        for m in EnumHookBit:
+            assert hook_enabled(m) is True


### PR DESCRIPTION
## Summary

Implements Task 2 of the hook-bitmask plan (OMN-9609): `EnumHookBit(IntEnum)` + `hook_enabled()` helper in `omnibase_core`.

- **`EnumHookBit`** — 57 GATE members, one per omniclaude hook wrapper (seeded from `plugins/onex/hooks/scripts/` + top-level hooks; LIBRARY/INFRA scripts excluded). Each member is a unique single-bit power of two. Append-only per bit governance rules.
- **`hook_enabled(bit, mask=None)`** — reads `ONEX_HOOKS_MASK` env var; accepts `0x...` hex, `0b...` binary, or decimal; fails-open on malformed values (hook continuity bias, CLI warning is OMN-9614 follow-up).
- **`_DEFAULT_MASK`** — computed dynamically as `(1 << len(EnumHookBit)) - 1`, not hardcoded `0xFFFFFFFF`.
- Both exported from `omnibase_core.enums.__init__`.

## Test plan

- [x] TDD: test file written first, confirmed failing with `ModuleNotFoundError`
- [x] 17 tests covering: `IntEnum` subtype, power-of-two invariant, no duplicates, 64-bit headroom, inventory count guard, default-mask width match, not-hardcoded assertion, all `hook_enabled()` paths (default, explicit mask, hex/decimal/binary env, malformed env, negative explicit, negative env)
- [x] `uv run mypy src/omnibase_core/enums/enum_hook_bit.py --strict` — clean
- [x] `uv run ruff check` — clean
- [x] All pre-commit hooks passed (50+ checks)

Unblocks: OMN-9613 (generator reads this enum), OMN-9614 (CLI), OMN-9615 (drift check).
Plan: `docs/plans/2026-04-24-hook-bitmask-enum.md` Task 2.

[skip-receipt-gate: OMN-9611 is the ticket; dod_evidence is the 17 passing tests + mypy clean above]

[skip-deploy-gate: OMN-9611 is an enum-only module (EnumHookBit + hook_enabled helper) with no runtime deploy path — no service, no container, no migration. The 17 unit tests cover all semantics including negative-mask rejection. No OCC receipt applies to a pure Python enum definition.]