### PR TITLE
fix(OMN-9592): remove mergeMethod from enqueuePullRequest mutation

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -113,7 +113,7 @@ jobs:
           if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
             echo "could not resolve PR id"; exit 0
           fi
-          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId,mergeMethod:SQUASH}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
+          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
             echo "enqueued: $output"
           else
             # Tolerate only known benign states.


### PR DESCRIPTION
## Summary

- GitHub removed `mergeMethod` from `EnqueuePullRequestInput` in their GraphQL schema
- The `Force enqueue to merge queue` step in `auto-merge.yml` was passing `mergeMethod:SQUASH`, causing `argumentNotAccepted` on every run
- This caused the `Enable Auto-Merge` workflow to fail, leaving PR 891 (and any future PR) unable to re-arm after queue ejection
- Fix: drop `mergeMethod` from the `enqueuePullRequest` mutation — the queue ruleset controls merge method, not the enqueue call

## Root cause

`omnibase_core#891` was ejected twice. Investigation showed all 70+ CI checks passed; only the `Enable Auto-Merge` workflow run was `FAILED`. Log line:

```
enqueue failed: {"errors":[{"path":["mutation","enqueuePullRequest","input","mergeMethod"],...,"message":"InputObject 'EnqueuePullRequestInput' doesn't accept argument 'mergeMethod'"}]}
```

PR 891 was manually enqueued via GraphQL (without `mergeMethod`) and is currently at queue position 1.

## Ticket

OMN-9592

[skip-receipt-gate: CI infrastructure fix — workflow schema correction, no dod_evidence required]

## Test plan

- [ ] Merge this PR — subsequent PRs should show `Enable Auto-Merge` passing (green) with `Force enqueue` succeeding
- [ ] Verify queue state after next PR open with `gh api graphql -f query='{repository(owner:"OmniNode-ai",name:"omnibase_core"){mergeQueue{entries(first:5){nodes{position pullRequest{number}}}}}}'`