### PR TITLE
feat(OMN-9622): add EnumAgentProtocol to omnibase_core

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -12,6 +12,9 @@ organized by functional domains for better maintainability.
 from .audit.enum_audit_enforcement_level import EnumAuditEnforcementLevel
 from .enum_action_status import EnumActionStatus
 
+# Agent protocol enum (OMN-9622 — A2A wire protocol classification)
+from .enum_agent_protocol import EnumAgentProtocol
+
 # Architecture and system enums
 from .enum_architecture import EnumArchitecture
 
@@ -846,6 +849,8 @@ __all__ = [
     "EnumProofKind",
     # Proof type domain (capability attestation verification - OMN-2892)
     "EnumProofType",
+    # Agent protocol domain (A2A wire protocol classification - OMN-9622)
+    "EnumAgentProtocol",
     # NOTE: Removed from __all__ due to missing module files or circular imports:
     # - "EnumRegistryType" (module doesn't exist)
     # - "ModelServiceModeEnum" (replaced with correct "EnumServiceMode")

--- a/src/omnibase_core/enums/enum_agent_protocol.py
+++ b/src/omnibase_core/enums/enum_agent_protocol.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Enum for agent-level protocol classification.
+
+Meaningful only when EnumInvocationKind == AGENT. Classifies the wire protocol
+used to communicate with the remote agent peer (e.g., A2A). This is a higher-
+level concept layered on transport — do NOT conflate with EnumInfraTransportType,
+which tags infrastructure-level transport failures.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumAgentProtocol(StrValueHelper, str, Enum):
+    """Agent-level protocol used to invoke a remote agent.
+
+    Applicable only when the invocation kind is AGENT. Each value names a
+    distinct agent-interoperability protocol with its own lifecycle semantics.
+    """
+
+    A2A = "A2A"
+
+
+__all__ = ["EnumAgentProtocol"]

--- a/tests/unit/enums/test_enum_agent_protocol.py
+++ b/tests/unit/enums/test_enum_agent_protocol.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumAgentProtocol."""
+
+import json
+
+import pytest
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+
+
+@pytest.mark.unit
+class TestEnumAgentProtocol:
+    """Test basic enum structure and values."""
+
+    def test_a2a_value(self) -> None:
+        assert EnumAgentProtocol.A2A.value == "A2A"
+
+    def test_str_returns_value(self) -> None:
+        assert str(EnumAgentProtocol.A2A) == "A2A"
+
+    def test_enum_is_unique(self) -> None:
+        values = [m.value for m in EnumAgentProtocol]
+        assert len(values) == len(set(values))
+
+    def test_enum_is_string_subclass(self) -> None:
+        assert isinstance(EnumAgentProtocol.A2A, str)
+
+    def test_enum_equality_with_string(self) -> None:
+        assert EnumAgentProtocol.A2A == "A2A"
+
+    def test_enum_membership(self) -> None:
+        assert EnumAgentProtocol.A2A in EnumAgentProtocol
+
+    def test_enum_from_value(self) -> None:
+        assert EnumAgentProtocol("A2A") is EnumAgentProtocol.A2A
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EnumAgentProtocol("UNKNOWN")
+
+
+@pytest.mark.unit
+class TestEnumAgentProtocolSerialization:
+    """Test serialization compatibility."""
+
+    def test_json_serialization_via_value(self) -> None:
+        data = {"protocol": EnumAgentProtocol.A2A.value}
+        assert json.dumps(data) == '{"protocol": "A2A"}'
+
+    def test_yaml_round_trip(self) -> None:
+        data = {"agent_protocol": EnumAgentProtocol.A2A.value}
+        loaded = yaml.safe_load(yaml.dump(data))
+        assert loaded["agent_protocol"] == "A2A"
+        assert EnumAgentProtocol(loaded["agent_protocol"]) is EnumAgentProtocol.A2A
+
+    def test_pydantic_field_assignment(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol
+
+        m = M(protocol=EnumAgentProtocol.A2A)
+        assert m.protocol is EnumAgentProtocol.A2A
+
+    def test_pydantic_string_coercion(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol
+
+        m = M(protocol="A2A")
+        assert m.protocol is EnumAgentProtocol.A2A
+
+    def test_pydantic_invalid_raises(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol
+
+        with pytest.raises(ValidationError):
+            M(protocol="INVALID")
+
+    def test_pydantic_model_dump(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol
+
+        m = M(protocol=EnumAgentProtocol.A2A)
+        assert m.model_dump() == {"protocol": "A2A"}
+
+    def test_pydantic_model_dump_json(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol
+
+        m = M(protocol=EnumAgentProtocol.A2A)
+        assert m.model_dump_json() == '{"protocol":"A2A"}'
+
+
+@pytest.mark.unit
+class TestEnumAgentProtocolOptionalField:
+    """Test use as an Optional field — primary consumer pattern."""
+
+    def test_optional_field_none(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol | None = None
+
+        m = M()
+        assert m.protocol is None
+
+    def test_optional_field_set(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol | None = None
+
+        m = M(protocol=EnumAgentProtocol.A2A)
+        assert m.protocol is EnumAgentProtocol.A2A
+
+    def test_optional_field_dump_none(self) -> None:
+        class M(BaseModel):
+            protocol: EnumAgentProtocol | None = None
+
+        assert M().model_dump() == {"protocol": None}

--- a/tests/unit/enums/test_enum_agent_protocol.py
+++ b/tests/unit/enums/test_enum_agent_protocol.py
@@ -33,7 +33,7 @@ class TestEnumAgentProtocol:
         assert EnumAgentProtocol.A2A == "A2A"
 
     def test_enum_membership(self) -> None:
-        assert EnumAgentProtocol.A2A in EnumAgentProtocol
+        assert EnumAgentProtocol.A2A in list(EnumAgentProtocol)
 
     def test_enum_from_value(self) -> None:
         assert EnumAgentProtocol("A2A") is EnumAgentProtocol.A2A


### PR DESCRIPTION
## Summary

- Adds `EnumAgentProtocol` enum (`A2A` as first member) to `omnibase_core/enums/`
- Follows the same `StrValueHelper, str, Enum` + `@unique` + `SCREAMING_SNAKE` pattern as `EnumAgentCapability`
- Meaningful only when `EnumInvocationKind == AGENT`; classifies the wire protocol for remote agent communication — deliberately separate from `EnumInfraTransportType` (infrastructure-layer error context)
- Companion test file with 18 unit tests covering values, string coercion, Pydantic integration, optional-field usage, and YAML round-trip
- Part of the A2A Delegation Bridge epic (Wave 0)

## Ticket

Closes OMN-9622.

## DoD Evidence

dod_evidence:
  - type: code_change
    description: Added enum_agent_protocol.py with A2A member and 18 unit tests
  - type: test_pass
    description: 18/18 unit tests pass (uv run pytest tests/unit/enums/test_enum_agent_protocol.py -v)
  - type: type_check
    description: mypy --strict clean on enum_agent_protocol.py (0 issues)
  - type: lint
    description: ruff format + ruff check clean on both new files
  - type: pre_commit
    description: pre-commit run --all-files passes all hooks

## Test Plan

- [x] uv run pytest tests/unit/enums/test_enum_agent_protocol.py -v -- 18 passed
- [x] uv run mypy src/omnibase_core/enums/enum_agent_protocol.py --strict -- clean
- [x] uv run ruff format and ruff check -- clean
- [x] uv run pre-commit run --all-files -- all hooks pass

[skip-deploy-gate: pure enum model addition -- no runtime handler, Dockerfile, or infra path touched]