### PR TITLE
feat(OMN-9623): add EnumModelRoutingBackend + EnumAgentTaskLifecycleType

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Common imports:
 
 ```python
 from omnibase_core.nodes import NodeCompute
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core import ModelOnexError
 ```
 
 Core is a Python 3.12+ package. Package metadata, optional dependency groups,
@@ -142,7 +142,11 @@ surfaces. Dated plans and migration notes are historical or execution context
 unless a stable architecture, reference, runbook, or migration page explicitly
 promotes them.
 
-Current topic naming truth lives in Core topic validators and standards docs.
+Known active context:
+
+- The hardcoded-topic cleanup plan in the umbrella `omni_home` docs is an
+  execution plan, not the current architecture source of truth.
+- Current topic naming truth lives in Core topic validators and standards docs.
 
 ## License
 

--- a/contracts/OMN-9623.yaml
+++ b/contracts/OMN-9623.yaml
@@ -1,0 +1,46 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9623
+summary: "Add EnumModelRoutingBackend + EnumAgentTaskLifecycleType for A2A delegation bridge"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "ci"
+    description: "omnibase_core PR checks pass including deploy-gate"
+    command: "gh pr checks 900 --repo OmniNode-ai/omnibase_core --watch"
+  - kind: "manual"
+    description: "Unit tests for both new enums pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/enums/test_enum_model_routing_backend.py tests/unit/enums/test_enum_agent_task_lifecycle_type.py
+      -v"
+  - kind: "manual"
+    description: "mypy --strict passes on both new enum files"
+    command: "PYTHONPATH=src uv run mypy src/omnibase_core/enums/enum_model_routing_backend.py src/omnibase_core/enums/enum_agent_task_lifecycle_type.py
+      --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "21 unit tests across both new enum files pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/enums/test_enum_model_routing_backend.py
+          tests/unit/enums/test_enum_agent_task_lifecycle_type.py -v"
+  - id: "dod-002"
+    description: "mypy --strict clean on both new enum files"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run mypy src/omnibase_core/enums/enum_model_routing_backend.py
+          src/omnibase_core/enums/enum_agent_task_lifecycle_type.py --strict"
+  - id: "dod-003"
+    description: "Post-deploy runtime smoke: both enums are importable in the runtime container"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_core.enums.enum_model_routing_backend
+          import EnumModelRoutingBackend; from omnibase_core.enums.enum_agent_task_lifecycle_type import
+          EnumAgentTaskLifecycleType; assert EnumModelRoutingBackend.BIFROST and EnumAgentTaskLifecycleType.COMPLETED\""

--- a/src/omnibase_core/enums/enum_agent_task_lifecycle_type.py
+++ b/src/omnibase_core/enums/enum_agent_task_lifecycle_type.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumAgentTaskLifecycleType: remote-agent task lifecycle event types (OMN-9623).
+
+Distinct from EnumDelegationState which models the orchestrator FSM transitions
+(RECEIVED, ROUTED, etc.). This enum classifies the lifecycle events emitted by
+a remote agent peer, translated from the A2A protocol by HandlerA2ATask.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumAgentTaskLifecycleType(StrValueHelper, str, Enum):
+    """Lifecycle event types emitted by a remote agent task.
+
+    Classifies the observable state transitions of a remote agent task
+    as received from the peer (e.g. via the A2A protocol) and translated
+    into typed Kafka events by the bridge effect node.
+
+    Values:
+        SUBMITTED: Task has been submitted to the remote agent.
+        ACCEPTED: Remote agent has accepted the task.
+        PROGRESS: Remote agent is actively working on the task.
+        ARTIFACT: Remote agent has produced an intermediate artifact.
+        COMPLETED: Remote agent has completed the task successfully.
+        FAILED: Remote agent reported an unrecoverable failure.
+        TIMED_OUT: Task exceeded its allowed execution window.
+        CANCELED: Task was canceled before completion.
+    """
+
+    SUBMITTED = "SUBMITTED"
+    ACCEPTED = "ACCEPTED"
+    PROGRESS = "PROGRESS"
+    ARTIFACT = "ARTIFACT"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    TIMED_OUT = "TIMED_OUT"
+    CANCELED = "CANCELED"
+
+
+__all__ = ["EnumAgentTaskLifecycleType"]

--- a/src/omnibase_core/enums/enum_model_routing_backend.py
+++ b/src/omnibase_core/enums/enum_model_routing_backend.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumModelRoutingBackend: model-routing substrate selector (OMN-9623).
+
+Only meaningful when EnumInvocationKind == MODEL. Part 2 (Bifrost integration
+under node_llm_inference_effect) consumes this; Part 1 defines it so the
+reducer's command envelope is typed end-to-end from day one.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumModelRoutingBackend(StrValueHelper, str, Enum):
+    """Enumeration of model-routing backends.
+
+    Classifies the internal routing substrate used when dispatching a
+    MODEL invocation. Only meaningful when invocation_kind == MODEL.
+
+    Values:
+        BIFROST: Internal Bifrost routing layer (Part 2 integration).
+        DIRECT: Direct endpoint call with no routing middleware.
+        OPENAI_COMPAT: OpenAI-compatible endpoint passthrough.
+    """
+
+    BIFROST = "BIFROST"
+    DIRECT = "DIRECT"
+    OPENAI_COMPAT = "OPENAI_COMPAT"
+
+
+__all__ = ["EnumModelRoutingBackend"]

--- a/tests/unit/enums/test_enum_agent_task_lifecycle_type.py
+++ b/tests/unit/enums/test_enum_agent_task_lifecycle_type.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumAgentTaskLifecycleType (OMN-9623)."""
+
+import json
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+
+
+@pytest.mark.unit
+class TestEnumAgentTaskLifecycleType:
+    """Test cases for EnumAgentTaskLifecycleType enum."""
+
+    def test_enum_values(self) -> None:
+        """Test that enum has expected SCREAMING_SNAKE string values."""
+        assert EnumAgentTaskLifecycleType.SUBMITTED.value == "SUBMITTED"
+        assert EnumAgentTaskLifecycleType.ACCEPTED.value == "ACCEPTED"
+        assert EnumAgentTaskLifecycleType.PROGRESS.value == "PROGRESS"
+        assert EnumAgentTaskLifecycleType.ARTIFACT.value == "ARTIFACT"
+        assert EnumAgentTaskLifecycleType.COMPLETED.value == "COMPLETED"
+        assert EnumAgentTaskLifecycleType.FAILED.value == "FAILED"
+        assert EnumAgentTaskLifecycleType.TIMED_OUT.value == "TIMED_OUT"
+        assert EnumAgentTaskLifecycleType.CANCELED.value == "CANCELED"
+
+    def test_enum_inheritance(self) -> None:
+        """Test that enum inherits from str and Enum."""
+        assert issubclass(EnumAgentTaskLifecycleType, str)
+        assert issubclass(EnumAgentTaskLifecycleType, Enum)
+
+    def test_enum_string_behavior(self) -> None:
+        """Test that enum values behave as strings."""
+        lifecycle = EnumAgentTaskLifecycleType.COMPLETED
+        assert isinstance(lifecycle, str)
+        assert str(lifecycle) == "COMPLETED"
+
+    def test_enum_iteration(self) -> None:
+        """Test that enum can be iterated and has exactly 8 members."""
+        values = list(EnumAgentTaskLifecycleType)
+        assert len(values) == 8
+
+    def test_enum_all_values(self) -> None:
+        """Test that all expected values are present and no extras."""
+        expected = {
+            "SUBMITTED",
+            "ACCEPTED",
+            "PROGRESS",
+            "ARTIFACT",
+            "COMPLETED",
+            "FAILED",
+            "TIMED_OUT",
+            "CANCELED",
+        }
+        actual = {member.value for member in EnumAgentTaskLifecycleType}
+        assert actual == expected
+
+    def test_enum_membership(self) -> None:
+        """Test enum membership via string values."""
+        values = {m.value for m in EnumAgentTaskLifecycleType}
+        assert "SUBMITTED" in values
+        assert "COMPLETED" in values
+        assert "TIMED_OUT" in values
+        assert "invalid_lifecycle" not in values
+
+    def test_enum_unique(self) -> None:
+        """Test that all enum values are unique (enforced by @unique)."""
+        values = [m.value for m in EnumAgentTaskLifecycleType]
+        assert len(values) == len(set(values))
+
+    def test_enum_serialization(self) -> None:
+        """Test that enum values serialize to their string representations."""
+        lifecycle = EnumAgentTaskLifecycleType.TIMED_OUT
+        assert json.dumps(lifecycle) == '"TIMED_OUT"'
+
+    def test_enum_deserialization(self) -> None:
+        """Test that enum members can be constructed from their string values."""
+        assert (
+            EnumAgentTaskLifecycleType("SUBMITTED")
+            == EnumAgentTaskLifecycleType.SUBMITTED
+        )
+        assert (
+            EnumAgentTaskLifecycleType("CANCELED")
+            == EnumAgentTaskLifecycleType.CANCELED
+        )
+
+    def test_enum_invalid_value_raises(self) -> None:
+        """Test that constructing from an invalid value raises ValueError."""
+        with pytest.raises(ValueError):
+            EnumAgentTaskLifecycleType("invalid")
+
+    def test_terminal_states_present(self) -> None:
+        """Test that both terminal states (COMPLETED, FAILED) are present."""
+        terminal = {
+            EnumAgentTaskLifecycleType.COMPLETED,
+            EnumAgentTaskLifecycleType.FAILED,
+            EnumAgentTaskLifecycleType.TIMED_OUT,
+            EnumAgentTaskLifecycleType.CANCELED,
+        }
+        all_values = set(EnumAgentTaskLifecycleType)
+        assert terminal.issubset(all_values)

--- a/tests/unit/enums/test_enum_model_routing_backend.py
+++ b/tests/unit/enums/test_enum_model_routing_backend.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumModelRoutingBackend (OMN-9623)."""
+
+import json
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_model_routing_backend import EnumModelRoutingBackend
+
+
+@pytest.mark.unit
+class TestEnumModelRoutingBackend:
+    """Test cases for EnumModelRoutingBackend enum."""
+
+    def test_enum_values(self) -> None:
+        """Test that enum has expected SCREAMING_SNAKE string values."""
+        assert EnumModelRoutingBackend.BIFROST.value == "BIFROST"
+        assert EnumModelRoutingBackend.DIRECT.value == "DIRECT"
+        assert EnumModelRoutingBackend.OPENAI_COMPAT.value == "OPENAI_COMPAT"
+
+    def test_enum_inheritance(self) -> None:
+        """Test that enum inherits from str and Enum."""
+        assert issubclass(EnumModelRoutingBackend, str)
+        assert issubclass(EnumModelRoutingBackend, Enum)
+
+    def test_enum_string_behavior(self) -> None:
+        """Test that enum values behave as strings."""
+        backend = EnumModelRoutingBackend.BIFROST
+        assert isinstance(backend, str)
+        assert str(backend) == "BIFROST"
+
+    def test_enum_iteration(self) -> None:
+        """Test that enum can be iterated and has exactly 3 members."""
+        values = list(EnumModelRoutingBackend)
+        assert len(values) == 3
+
+    def test_enum_all_values(self) -> None:
+        """Test that all expected values are present and no extras."""
+        expected = {"BIFROST", "DIRECT", "OPENAI_COMPAT"}
+        actual = {member.value for member in EnumModelRoutingBackend}
+        assert actual == expected
+
+    def test_enum_membership(self) -> None:
+        """Test enum membership via string values."""
+        values = {m.value for m in EnumModelRoutingBackend}
+        assert "BIFROST" in values
+        assert "DIRECT" in values
+        assert "OPENAI_COMPAT" in values
+        assert "invalid_backend" not in values
+
+    def test_enum_unique(self) -> None:
+        """Test that all enum values are unique (enforced by @unique)."""
+        values = [m.value for m in EnumModelRoutingBackend]
+        assert len(values) == len(set(values))
+
+    def test_enum_serialization(self) -> None:
+        """Test that enum values serialize to their string representations."""
+        backend = EnumModelRoutingBackend.OPENAI_COMPAT
+        assert json.dumps(backend) == '"OPENAI_COMPAT"'
+
+    def test_enum_deserialization(self) -> None:
+        """Test that enum members can be constructed from their string values."""
+        assert EnumModelRoutingBackend("BIFROST") == EnumModelRoutingBackend.BIFROST
+        assert EnumModelRoutingBackend("DIRECT") == EnumModelRoutingBackend.DIRECT
+
+    def test_enum_invalid_value_raises(self) -> None:
+        """Test that constructing from an invalid value raises ValueError."""
+        with pytest.raises(ValueError):
+            EnumModelRoutingBackend("invalid")


### PR DESCRIPTION
## Summary

- Adds `EnumModelRoutingBackend` (`BIFROST`, `DIRECT`, `OPENAI_COMPAT`) — classifies model-routing backends; only meaningful when `invocation_kind == MODEL`. Part 2 (Bifrost integration) consumes this; Part 1 defines it so the reducer command envelope is typed end-to-end from day one.
- Adds `EnumAgentTaskLifecycleType` (`SUBMITTED`, `ACCEPTED`, `PROGRESS`, `ARTIFACT`, `COMPLETED`, `FAILED`, `TIMED_OUT`, `CANCELED`) — classifies remote agent task lifecycle events emitted by a peer (e.g. A2A). Distinct from `EnumDelegationState` which models the orchestrator FSM transitions.
- Each enum gets its own file + test file (21 tests total), all SCREAMING_SNAKE values, `StrValueHelper, str, Enum`, `@unique`, mypy --strict clean.
- Fixes three pre-existing pre-commit failures on main: YAML allowlist entries for `cli_pack.py` + `cli_config.py`, and `# stub-ok` annotations on Click group entry points in `cli_config.py` + `cli_bootstrap.py`.

## Ticket

OMN-9623 — Epic: A2A Delegation Bridge Part 1, Wave 0

## dod_evidence

- `enum_model_routing_backend.py` + `enum_agent_task_lifecycle_type.py` created in `omnibase_core/src/omnibase_core/enums/`
- 21 unit tests, all passing (`pytest tests/unit/enums/test_enum_model_routing_backend.py tests/unit/enums/test_enum_agent_task_lifecycle_type.py -v`)
- `mypy src/omnibase_core/enums/enum_model_routing_backend.py src/omnibase_core/enums/enum_agent_task_lifecycle_type.py --strict` → `Success: no issues found in 2 source files`
- `pre-commit run --all-files` → all hooks passed (including fixing 3 pre-existing failures)
- Branch: `jonah/omn-9623-enum-routing-lifecycle`

## Test plan

- [x] CI passes green (unit + type-check jobs)
- [x] `pytest tests/unit/enums/test_enum_model_routing_backend.py tests/unit/enums/test_enum_agent_task_lifecycle_type.py` — 21 passed
- [x] `mypy --strict` on both new files — 0 errors
- [x] Pre-commit all hooks pass