### PR TITLE
fix(OMN-9685): narrow deploy-gate scope and remove skip-token bypass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ ignore = [
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/receipt_gate_cli.py" = ["T201"]
 "scripts/validation/validate_pr_receipts.py" = ["T201"]
+"scripts/validation/validate_pr_deploy_required.py" = ["T201"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]
 "src/omnibase_core/validation/validator_local_paths.py" = ["T201"]
 "src/omnibase_core/validation/validator_patterns.py" = ["T201"]

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -57,6 +57,7 @@ RUNTIME_PATH_PATTERNS = [
     "src/omnimarket/services/**/*.py",
     # Cross-repo node handlers and runtime paths (OMN-9685: narrowed from catch-all)
     # Use both flat and nested forms since ** requires at least one path segment
+    "src/*/nodes/*.py",
     "src/*/nodes/**/*.py",
     "src/*/runtime/*.py",
     "src/*/runtime/**/*.py",

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -67,8 +67,9 @@ RUNTIME_PATH_PATTERNS = [
     "src/*/services/**/*.py",
     "src/*/cli/*.py",
     "src/*/cli/**/*.py",
-    # Contract files trigger deploy (behavior change)
-    "**/contract.yaml",
+    # Contract files trigger deploy (behavior change) — scoped to src/ to avoid
+    # matching test fixtures and example directories.
+    "src/**/contract.yaml",
 ]
 
 # Deploy evidence: a dod_evidence check whose check_value contains one of these.

--- a/scripts/validation/validate_pr_deploy_required.py
+++ b/scripts/validation/validate_pr_deploy_required.py
@@ -15,7 +15,7 @@ Usage (CI):
         --contracts-dir contracts/
 
 Exit codes:
-    0  - Gate passed (no runtime change, override token, or deploy evidence found)
+    0  - Gate passed (no runtime change, or deploy evidence found)
     1  - Gate failed (runtime change detected but no deploy evidence)
 """
 
@@ -26,7 +26,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Pattern
+from re import Pattern
 
 import yaml
 
@@ -40,6 +40,7 @@ RUNTIME_PATH_PATTERNS = [
     "docker/docker-compose*.yml",
     "docker/docker-compose*.yaml",
     "docker/**/*.Dockerfile",
+    "Dockerfile*",
     # Node handlers + contracts (omnibase_infra)
     "src/omnibase_infra/nodes/*/handlers/*.py",
     "src/omnibase_infra/nodes/*/handlers/*/*.py",
@@ -49,18 +50,29 @@ RUNTIME_PATH_PATTERNS = [
     "src/omnibase_infra/runtime/**/*.py",
     # Alert daemon (today's incident path — OMN-8870/OMN-8841)
     "scripts/monitor_logs.py",
-    # omnimarket node handlers
+    # omnimarket node handlers + runtime-touching paths only
     "src/omnimarket/nodes/*/handlers/*.py",
     "src/omnimarket/nodes/*/contract.yaml",
-    # Any pip-installable package source (direct children or nested)
-    "src/omnibase_*/*.py",
-    "src/omnibase_*/**/*.py",
-    "src/omnimarket/*.py",
-    "src/omnimarket/**/*.py",
+    "src/omnimarket/nodes/*/runtime/**/*.py",
+    "src/omnimarket/services/**/*.py",
+    # Cross-repo node handlers and runtime paths (OMN-9685: narrowed from catch-all)
+    # Use both flat and nested forms since ** requires at least one path segment
+    "src/*/nodes/**/*.py",
+    "src/*/runtime/*.py",
+    "src/*/runtime/**/*.py",
+    "src/*/handlers/*.py",
+    "src/*/handlers/**/*.py",
+    "src/*/services/*.py",
+    "src/*/services/**/*.py",
+    "src/*/cli/*.py",
+    "src/*/cli/**/*.py",
+    # Contract files trigger deploy (behavior change)
+    "**/contract.yaml",
 ]
 
 # Deploy evidence: a dod_evidence check whose check_value contains one of these.
 DEPLOY_KEYWORDS = ["docker exec", "rpk topic produce", "deploy"]
+
 
 def _glob_to_regex(pattern: str) -> Pattern[str]:
     """Convert a glob pattern (with ** support) to a compiled regex."""
@@ -84,9 +96,6 @@ _COMPILED_RUNTIME_PATTERNS: list[Pattern[str]] = [
 ]
 
 
-# Override token in PR body (case-insensitive, logs friction)
-OVERRIDE_PATTERN = re.compile(r"\[skip-deploy-gate:\s*(.+?)\]", re.IGNORECASE)
-
 # Ticket ID pattern in PR body / commit messages
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
 
@@ -95,7 +104,6 @@ TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
 class DeployGateResult:
     passed: bool
     skipped: bool = False
-    friction_logged: bool = False
     message: str = ""
     runtime_paths_hit: list[str] = field(default_factory=list)
     tickets_checked: list[str] = field(default_factory=list)
@@ -148,21 +156,6 @@ def validate_pr_deploy_gate(
             message="No runtime paths touched — deploy gate skipped.",
         )
 
-    # Check for override token
-    override_match = OVERRIDE_PATTERN.search(pr_body)
-    if override_match:
-        reason = override_match.group(1).strip()
-        return DeployGateResult(
-            passed=True,
-            skipped=False,
-            friction_logged=True,
-            runtime_paths_hit=runtime_hits,
-            message=(
-                f"[skip-deploy-gate] override accepted: {reason!r}. "
-                "FRICTION: deploy gate bypassed — ensure manual deploy is tracked."
-            ),
-        )
-
     # Extract cited ticket IDs from PR body
     ticket_ids = [f"OMN-{m}" for m in TICKET_PATTERN.findall(pr_body)]
 
@@ -173,8 +166,9 @@ def validate_pr_deploy_gate(
             message=(
                 "DEPLOY GATE FAILED: PR touches runtime paths but cites no OMN-XXXX ticket. "
                 f"Runtime paths: {runtime_hits}. "
-                "Add a ticket with a deploy DoD item or use [skip-deploy-gate: <reason>]. "
-                "See OMN-8912 and today's incident (OMN-8841)."
+                "Add a dod_evidence item with check_value containing 'deploy', "
+                "'docker exec', or 'rpk topic produce' to the cited ticket contract. "
+                "See OMN-8912 and OMN-9685."
             ),
         )
 
@@ -195,13 +189,12 @@ def validate_pr_deploy_gate(
             )
 
     # No ticket had deploy evidence
-    missing = [
-        t for t in ticket_ids
-        if not (contracts_dir / f"{t}.yaml").exists()
-    ]
+    missing = [t for t in ticket_ids if not (contracts_dir / f"{t}.yaml").exists()]
     no_deploy = [
-        t for t in ticket_ids
-        if (contracts_dir / f"{t}.yaml").exists() and not has_deploy_evidence(contracts_dir / f"{t}.yaml")
+        t
+        for t in ticket_ids
+        if (contracts_dir / f"{t}.yaml").exists()
+        and not has_deploy_evidence(contracts_dir / f"{t}.yaml")
     ]
 
     parts: list[str] = [
@@ -216,7 +209,8 @@ def validate_pr_deploy_gate(
             f"'docker exec', 'rpk topic produce', or 'deploy'): {no_deploy}."
         )
     parts.append(
-        "Add a dod_evidence item with deploy check_value, or use [skip-deploy-gate: <reason>]. "
+        "Add a dod_evidence item with check_value containing 'deploy', 'docker exec', or "
+        "'rpk topic produce' to the cited ticket contract. "
         "Root cause: OMN-8841 (deploy-agent inactive 2 days post-Dockerfile change). "
         "Gate: OMN-8912."
     )
@@ -259,9 +253,7 @@ def main(argv: list[str] | None = None) -> int:
         contracts_dir=contracts_dir,
     )
 
-    if result.friction_logged:
-        print(f"::warning::{result.message}")
-    elif result.passed:
+    if result.passed:
         print(f"::notice::{result.message}")
     else:
         print(f"::error::{result.message}")

--- a/tests/unit/scripts/validation/test_validate_pr_deploy_required.py
+++ b/tests/unit/scripts/validation/test_validate_pr_deploy_required.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for validate_pr_deploy_required.py (OMN-9685).
+
+Covers:
+- Enum/model/protocol-only diffs do NOT trigger the gate
+- Runtime diffs (nodes, handlers, runtime kernel) DO trigger the gate
+- skip-token in PR body is NOT a bypass (gate still fires)
+- Real dod_evidence with deploy check_value → gate passes
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validation.validate_pr_deploy_required import (
+    find_runtime_paths,
+    validate_pr_deploy_gate,
+)
+
+# ---------------------------------------------------------------------------
+# find_runtime_paths — unit tests for pattern matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFindRuntimePaths:
+    def test_enum_only_diff_not_matched(self) -> None:
+        files = [
+            "src/omnibase_core/enums/enum_node_kind.py",
+            "src/omnibase_core/enums/enum_hook_bit.py",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_model_only_diff_not_matched(self) -> None:
+        files = [
+            "src/omnibase_core/models/model_event_envelope.py",
+            "src/omnibase_core/models/core/model_deployment_topology.py",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_protocol_only_diff_not_matched(self) -> None:
+        files = [
+            "src/omnibase_core/protocols/protocol_event_bus.py",
+            "src/omnibase_spi/protocols/protocol_logger.py",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_dto_only_diff_not_matched(self) -> None:
+        files = [
+            "src/omnibase_compat/dto/dto_event_wire.py",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_tests_not_matched(self) -> None:
+        files = [
+            "tests/unit/models/test_model_foo.py",
+            "tests/integration/test_service_bar.py",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_docs_not_matched(self) -> None:
+        files = [
+            "docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md",
+            "README.md",
+        ]
+        assert find_runtime_paths(files) == []
+
+    def test_node_handler_matched(self) -> None:
+        files = ["src/omnibase_core/nodes/node_merge_sweep/handlers/handler_merge.py"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+        assert hits[0] == files[0]
+
+    def test_runtime_kernel_matched(self) -> None:
+        files = ["src/omnibase_infra/runtime/service_kernel.py"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+
+    def test_docker_file_matched(self) -> None:
+        assert find_runtime_paths(["docker/Dockerfile.runtime"]) != []
+
+    def test_contract_yaml_matched(self) -> None:
+        files = ["src/omnibase_core/nodes/node_x/contract.yaml"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+
+    def test_cli_file_matched(self) -> None:
+        files = ["src/omnibase_core/cli/cli_commands.py"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+
+    def test_services_file_matched(self) -> None:
+        files = ["src/omnibase_core/services/service_handler_registry.py"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+
+    def test_mixed_diff_returns_only_runtime_hits(self) -> None:
+        files = [
+            "src/omnibase_core/enums/enum_node_kind.py",
+            "src/omnibase_core/nodes/node_x/handlers/handler_x.py",
+        ]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+        assert "handler" in hits[0]
+
+
+# ---------------------------------------------------------------------------
+# validate_pr_deploy_gate — integration tests using tmp contracts dir
+# ---------------------------------------------------------------------------
+
+
+def _write_contract(contracts_dir: Path, ticket_id: str, has_deploy: bool) -> None:
+    data: dict = {"dod_evidence": []}
+    if has_deploy:
+        data["dod_evidence"] = [
+            {"checks": [{"check_value": "deploy omnibase_core to .201"}]}
+        ]
+    (contracts_dir / f"{ticket_id}.yaml").write_text(yaml.dump(data))
+
+
+@pytest.mark.unit
+class TestValidatePrDeployGate:
+    def test_enum_only_diff_gate_skipped(self, tmp_path: Path) -> None:
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/enums/enum_node_kind.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert result.skipped
+
+    def test_model_only_diff_gate_skipped(self, tmp_path: Path) -> None:
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/models/model_event_envelope.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert result.skipped
+
+    def test_protocol_only_diff_gate_skipped(self, tmp_path: Path) -> None:
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/protocols/protocol_event_bus.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert result.skipped
+
+    def test_runtime_diff_without_dod_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+        assert "DEPLOY GATE FAILED" in result.message
+
+    def test_skip_token_in_body_does_not_bypass(self, tmp_path: Path) -> None:
+        """skip-deploy-gate token must NOT be a bypass (OMN-9685 Bug 2)."""
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="[skip-deploy-gate: emergency hotfix] Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+        assert "DEPLOY GATE FAILED" in result.message
+
+    def test_real_deploy_evidence_passes(self, tmp_path: Path) -> None:
+        _write_contract(tmp_path, "OMN-9000", has_deploy=True)
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert result.passed
+        assert not result.skipped
+        assert "DEPLOY GATE PASSED" in result.message
+
+    def test_ticket_without_deploy_evidence_fails(self, tmp_path: Path) -> None:
+        _write_contract(tmp_path, "OMN-9000", has_deploy=False)
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+        assert "DEPLOY GATE FAILED" in result.message
+        assert "OMN-9000" in result.message
+
+    def test_error_message_does_not_suggest_skip_token(self, tmp_path: Path) -> None:
+        """Error message must not teach the skip-token bypass (OMN-9685 Bug 2)."""
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="Closes OMN-9000",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+        assert "skip-deploy-gate" not in result.message
+
+    def test_no_ticket_cited_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_deploy_gate(
+            changed_files=["src/omnibase_core/nodes/node_x/handlers/handler_x.py"],
+            pr_body="Fix the thing without a ticket reference",
+            contracts_dir=tmp_path,
+        )
+        assert not result.passed
+        assert "cites no OMN-XXXX ticket" in result.message

--- a/tests/unit/scripts/validation/test_validate_pr_deploy_required.py
+++ b/tests/unit/scripts/validation/test_validate_pr_deploy_required.py
@@ -108,6 +108,11 @@ class TestFindRuntimePaths:
         assert len(hits) == 1
         assert "handler" in hits[0]
 
+    def test_top_level_node_module_matched(self) -> None:
+        files = ["src/omnibase_core/nodes/node_contract_resolve_compute.py"]
+        hits = find_runtime_paths(files)
+        assert len(hits) == 1
+
 
 # ---------------------------------------------------------------------------
 # validate_pr_deploy_gate — integration tests using tmp contracts dir


### PR DESCRIPTION
Closes OMN-9685

Fixes two bugs in `scripts/validation/validate_pr_deploy_required.py` surfaced by the Track B merge sweep and OMN-9620 A2A bridge epic.

## Bug 1: Over-broad RUNTIME_PATH_PATTERNS

The catch-all globs `src/omnibase_*/*.py` and `src/omnibase_*/**/*.py` matched every Python file in every omnibase package — including pure enums, models, protocols, and DTOs with no runtime deploy surface. Narrowed to specific runtime paths: nodes, runtime, handlers, services, cli, docker.

## Bug 2: Skip-token bypass

The gate's own error message taught workers to bypass with `[skip-deploy-gate: <reason>]`. Removed the branch entirely. Error messages now point only to the legitimate path: adding real `dod_evidence` with a `deploy` check_value.

## Rationale

Four PRs across two sessions (#894, #898, #1399, epic-9620 wave) each independently added skip tokens because the validator's own error log suggested them. Workers were following the tool. Tool was wrong.

## Test plan

- `test_enum_only_diff_not_matched` — enum diff → gate does NOT fire
- `test_model_only_diff_not_matched` — model diff → gate does NOT fire
- `test_protocol_only_diff_not_matched` — protocol diff → gate does NOT fire
- `test_runtime_diff_without_dod_fails` — handler diff + no evidence → gate fires
- `test_skip_token_in_body_does_not_bypass` — skip-token → gate still fires (no longer a bypass)
- `test_real_deploy_evidence_passes` — real dod_evidence with deploy check_value → gate passes
- `test_error_message_does_not_suggest_skip_token` — error message contains no mention of skip-deploy-gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment Gate Validation**
  * Removed PR-body bypass for deployment gates; success now requires explicit deploy evidence (e.g., "deploy", "docker exec", "rpk topic produce"). Updated messaging and incident guidance; added contract.yaml as a deploy-triggering path and refined runtime-related path matching.

* **Tests**
  * Added regression tests covering runtime-path detection and gate behavior, ensuring bypass tokens no longer skip the gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->