### PR TITLE
fix(receipt-gate): prefer closing keywords over arbitrary OMN mentions (OMN-9574)

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -224,26 +224,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_EVENT_BODY: ${{ github.event.pull_request.body }}
+          PR_EVENT_TITLE: ${{ github.event.pull_request.title }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -e
           if [ -n "$PR_EVENT_BODY" ]; then
             printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
+            printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then
             pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
             if [ -n "$pr_num" ] && [ "$pr_num" != "$MERGE_GROUP_HEAD_REF" ]; then
-              gh pr view "$pr_num" --repo "${{ github.repository }}" --json body --jq '.body' > /tmp/pr_body.txt
+              gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title --jq '.body' > /tmp/pr_body.txt
+              gh pr view "$pr_num" --repo "${{ github.repository }}" --json title --jq '.title' > /tmp/pr_title.txt
             else
               : > /tmp/pr_body.txt
+              : > /tmp/pr_title.txt
             fi
           else
             : > /tmp/pr_body.txt
+            : > /tmp/pr_title.txt
           fi
 
       - name: Run Receipt-Gate
         run: |
           PR_BODY="$(cat /tmp/pr_body.txt)"
+          PR_TITLE="$(cat /tmp/pr_title.txt)"
           python -m omnibase_core.validation.receipt_gate_cli \
             --pr-body "$PR_BODY" \
+            --pr-title "$PR_TITLE" \
             --contracts-dir ".onex_change_control/${{ inputs.contracts-dir }}" \
             --receipts-dir ".onex_change_control/${{ inputs.receipts-dir }}"

--- a/contracts/OMN-9574.yaml
+++ b/contracts/OMN-9574.yaml
@@ -1,0 +1,48 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9574
+summary: "Fix receipt-gate regex to prefer closing keywords over arbitrary OMN mentions"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Unit tests pass for CLOSING_KEYWORD_PATTERN word-boundary fix and _extract_ticket_ids
+      precedence logic"
+    command: "uv run pytest tests/unit/validation/test_receipt_gate.py -v"
+  - kind: ci
+    description: "omnibase_core PR #904 CI green"
+    command: "gh pr checks 904 --repo OmniNode-ai/omnibase_core --watch"
+  - kind: manual
+    description: "Regex does not match words containing closing keywords as substrings (e.g. 'discloses')"
+    command: "python3 -c \"import re; p=re.compile(r'\\\\b(?:Closes|Fixes|Resolves|Implements)\\\\b[:\\\\s]+OMN-(\\\\d+)\\\\b',
+      re.IGNORECASE); assert not p.search('discloses OMN-1234'); assert p.search('Closes: OMN-1234');
+      print('OK')\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "Unit tests for receipt_gate.py pass including closing-keyword word-boundary fix"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/validation/test_receipt_gate.py -v"
+  - id: dod-002
+    description: "Linting, formatting, and type checks pass on receipt_gate.py"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "PYTHONPATH=src uv run ruff check src/omnibase_core/validation/receipt_gate.py &&
+          PYTHONPATH=src uv run ruff format --check src/omnibase_core/validation/receipt_gate.py && PYTHONPATH=src
+          uv run mypy src/omnibase_core/validation/receipt_gate.py"
+  - id: dod-003
+    description: "Regex word-boundary fix confirmed: substrings like 'discloses' do not match; valid keywords
+      do"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "python3 -c \"import re; p=re.compile(r'\\\\b(?:Closes|Fixes|Resolves|Implements)\\\\b[:\\\\s]+OMN-(\\\\d+)\\\\b',
+          re.IGNORECASE); assert not p.search('discloses OMN-1234'); assert p.search('Closes: OMN-1234');
+          print('PASS')\""

--- a/contracts/OMN-9574.yaml
+++ b/contracts/OMN-9574.yaml
@@ -46,3 +46,12 @@ dod_evidence:
         check_value: "python3 -c \"import re; p=re.compile(r'\\\\b(?:Closes|Fixes|Resolves|Implements)\\\\b[:\\\\s]+OMN-(\\\\d+)\\\\b',
           re.IGNORECASE); assert not p.search('discloses OMN-1234'); assert p.search('Closes: OMN-1234');
           print('PASS')\""
+  - id: dod-004
+    description: "Closing-keyword regex verified on deployed runtime: import succeeds and CLOSING_KEYWORD_PATTERN
+      matches expected forms"
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "docker exec omninode-runtime python -c \"from omnibase_core.validation.receipt_gate
+          import CLOSING_KEYWORD_PATTERN; assert CLOSING_KEYWORD_PATTERN.search('Closes OMN-9574'); print('deploy-verify
+          OK')\""

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -43,13 +43,28 @@ from omnibase_core.models.contracts.ticket.model_receipt_gate_result import (
 
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
 CLOSING_KEYWORD_PATTERN = re.compile(
-    r"(?:Closes|Fixes|Resolves|Implements)[:\s]+OMN-(\d+)",
+    r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
 )
 OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(.+?)\]", re.IGNORECASE)
 
 
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
+    """Return sorted unique ticket IDs cited by this PR.
+
+    Precedence: body closing-keyword matches (CLOSING_KEYWORD_PATTERN) are
+    checked first; if any are found they are returned exclusively (sorted,
+    deduplicated, prefixed "OMN-").  Only when the body yields no matches does
+    the function fall back to scanning pr_title with TICKET_PATTERN.  Returns
+    [] when neither source yields a match.
+
+    Args:
+        pr_body: Full PR description text.
+        pr_title: Optional PR title used as fallback when body has no matches.
+
+    Returns:
+        Sorted list of "OMN-<N>" strings, empty if none found.
+    """
     closing_matches = CLOSING_KEYWORD_PATTERN.findall(pr_body)
     if closing_matches:
         return sorted({f"OMN-{m}" for m in closing_matches})

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -42,7 +42,22 @@ from omnibase_core.models.contracts.ticket.model_receipt_gate_result import (
 )
 
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
+CLOSING_KEYWORD_PATTERN = re.compile(
+    r"(?:Closes|Fixes|Resolves|Implements)[:\s]+OMN-(\d+)",
+    re.IGNORECASE,
+)
 OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(.+?)\]", re.IGNORECASE)
+
+
+def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
+    closing_matches = CLOSING_KEYWORD_PATTERN.findall(pr_body)
+    if closing_matches:
+        return sorted({f"OMN-{m}" for m in closing_matches})
+    if pr_title:
+        title_matches = TICKET_PATTERN.findall(pr_title)
+        if title_matches:
+            return sorted({f"OMN-{m}" for m in title_matches})
+    return []
 
 
 def _iter_dod_evidence(contract_data: object) -> list[tuple[str, str, str]]:
@@ -133,6 +148,7 @@ def validate_pr_receipts(
     pr_body: str,
     contracts_dir: Path,
     receipts_dir: Path,
+    pr_title: str | None = None,
 ) -> ModelReceiptGateResult:
     """Run the receipt-gate against a PR's body + the repo's contracts + receipts."""
     override = OVERRIDE_PATTERN.search(pr_body)
@@ -149,7 +165,7 @@ def validate_pr_receipts(
                 ),
             )
 
-    ticket_ids = sorted({f"OMN-{m}" for m in TICKET_PATTERN.findall(pr_body)})
+    ticket_ids = _extract_ticket_ids(pr_body, pr_title)
     if not ticket_ids:
         return ModelReceiptGateResult(
             passed=False,
@@ -239,6 +255,7 @@ def validate_pr_receipts(
 
 
 __all__ = [
+    "CLOSING_KEYWORD_PATTERN",
     "OVERRIDE_PATTERN",
     "TICKET_PATTERN",
     "validate_pr_receipts",

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -68,6 +68,7 @@ def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
     closing_matches = CLOSING_KEYWORD_PATTERN.findall(pr_body)
     if closing_matches:
         return sorted({f"OMN-{m}" for m in closing_matches})
+    # fallback-ok: Title ticket extraction is only used when body has no closing-keyword ticket.
     if pr_title:
         title_matches = TICKET_PATTERN.findall(pr_title)
         if title_matches:

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -32,6 +32,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--pr-body", required=True, help="Full PR description text.")
     parser.add_argument(
+        "--pr-title",
+        default=None,
+        help="PR title text (used as fallback when body has no closing keywords).",
+    )
+    parser.add_argument(
         "--contracts-dir",
         default="onex_change_control/contracts",
         help="Directory containing OMN-XXXX.yaml ticket contracts.",
@@ -47,6 +52,7 @@ def main(argv: list[str] | None = None) -> int:
         pr_body=args.pr_body,
         contracts_dir=Path(args.contracts_dir),
         receipts_dir=Path(args.receipts_dir),
+        pr_title=args.pr_title,
     )
 
     if result.friction_logged:

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -286,3 +286,93 @@ class TestReceiptGateOverride:
         # Regex requires at least one non-whitespace char in the reason — the
         # `.+?` greedy-but-at-least-one means whitespace matches a single space
         # minimum. The `.strip()` call catches the empty-after-strip case.
+
+
+@pytest.mark.unit
+class TestReceiptGateClosingKeywords:
+    def test_closing_keyword_preferred_over_mention(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-5678")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-5678",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="Related to OMN-1234, closes OMN-5678",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+        assert result.tickets_checked == ["OMN-5678"]
+
+    def test_no_closing_keyword_falls_back_to_all_mentions(
+        self, tmp_path: Path
+    ) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-1234")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-1234",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="Working on OMN-1234",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+        assert result.tickets_checked == ["OMN-1234"]
+
+    def test_pr_title_fallback_when_body_has_no_closing_keywords(
+        self, tmp_path: Path
+    ) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-9084")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-9084",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="See description in the title",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="fix(OMN-9084): some fix",
+        )
+        assert result.passed
+        assert result.tickets_checked == ["OMN-9084"]
+
+    def test_closing_keyword_variants(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-1111")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-1111",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        for keyword in ("Closes", "Fixes", "Resolves", "Implements"):
+            result = validate_pr_receipts(
+                pr_body=f"{keyword} OMN-1111",
+                contracts_dir=contracts,
+                receipts_dir=receipts,
+            )
+            assert result.passed, f"Failed for keyword: {keyword}"
+
+    def test_no_title_no_body_tickets_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="no tickets here",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            pr_title="also no tickets",
+        )
+        assert not result.passed
+        assert "cites no" in result.message.lower()

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -80,7 +80,7 @@ class TestReceiptGateTicketRef:
         assert not result.passed
         assert "cites no" in result.message.lower()
 
-    def test_ticket_ref_parsed_case_insensitive(self, tmp_path: Path) -> None:
+    def test_closing_keyword_case_insensitive(self, tmp_path: Path) -> None:
         contracts = tmp_path / "contracts"
         receipts = tmp_path / "receipts"
         _write_contract(contracts, "OMN-9084")
@@ -91,7 +91,94 @@ class TestReceiptGateTicketRef:
             check_type="command",
         )
         result = validate_pr_receipts(
-            pr_body="feat: thing [omn-9084]",
+            pr_body="closes omn-9084",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+
+
+@pytest.mark.unit
+class TestReceiptGateGreedyRegression:
+    """Regression tests for OMN-9574 — bare OMN-XXXX must NOT trigger receipt checks."""
+
+    def test_bare_omn_token_in_body_no_closing_keyword_does_not_require_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        """Bare OMN-1234 with no closing keyword → no citation → gate fails with 'no ticket ref'."""
+        result = validate_pr_receipts(
+            pr_body="This PR relates to OMN-1234 (see issue tracker)",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+        )
+        assert not result.passed
+        assert "cites no" in result.message.lower()
+
+    def test_bare_omn_token_does_not_require_receipt_even_when_contract_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """A bare mention must not trigger receipt check even if the contract file exists."""
+        contracts = tmp_path / "contracts"
+        _write_contract(contracts, "OMN-9600")
+        result = validate_pr_receipts(
+            pr_body="Related to OMN-9600 (no closing keyword)",
+            contracts_dir=contracts,
+            receipts_dir=tmp_path / "receipts",
+        )
+        assert not result.passed
+        assert "cites no" in result.message.lower()
+
+    def test_closes_keyword_required_for_receipt_check(self, tmp_path: Path) -> None:
+        """Closes OMN-1234 triggers the full receipt check."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-1234")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-1234",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-1234.",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+
+    def test_fixes_keyword_triggers_receipt_check(self, tmp_path: Path) -> None:
+        """Fixes OMN-1234 triggers the receipt check."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-1234")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-1234",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="Fixes OMN-1234",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+
+    def test_closes_keyword_lowercase_triggers_receipt_check(
+        self, tmp_path: Path
+    ) -> None:
+        """closes OMN-1234 (lowercase) triggers the receipt check (case-insensitive)."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-1234")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-1234",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+        result = validate_pr_receipts(
+            pr_body="closes OMN-1234",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -102,7 +189,7 @@ class TestReceiptGateTicketRef:
 class TestReceiptGateContractPresence:
     def test_missing_contract_fails(self, tmp_path: Path) -> None:
         result = validate_pr_receipts(
-            pr_body="OMN-9999",
+            pr_body="Closes OMN-9999",
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
         )
@@ -113,7 +200,7 @@ class TestReceiptGateContractPresence:
         contracts = tmp_path / "contracts"
         _write_contract(contracts, "OMN-9084", dod_evidence=[])
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=tmp_path / "receipts",
         )
@@ -125,7 +212,7 @@ class TestReceiptGateContractPresence:
         contracts.mkdir()
         (contracts / "OMN-9084.yaml").write_text("!!! not: valid: yaml: [")
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=tmp_path / "receipts",
         )
@@ -146,7 +233,7 @@ class TestReceiptGateReceiptPresence:
             check_type="command",
         )
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -157,7 +244,7 @@ class TestReceiptGateReceiptPresence:
         contracts = tmp_path / "contracts"
         _write_contract(contracts, "OMN-9084")
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=tmp_path / "receipts",
         )
@@ -176,7 +263,7 @@ class TestReceiptGateReceiptPresence:
             status="FAIL",
         )
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -191,7 +278,7 @@ class TestReceiptGateReceiptPresence:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text("!!! not: valid: [")
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -213,7 +300,7 @@ class TestReceiptGateReceiptPresence:
             overrides={"ticket_id": "OMN-DIFFERENT"},
         )
         result = validate_pr_receipts(
-            pr_body="OMN-9084",
+            pr_body="Closes OMN-9084",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -235,7 +322,7 @@ class TestReceiptGateMultiTicket:
         )
         # OMN-9085 receipt missing
         result = validate_pr_receipts(
-            pr_body="OMN-9084 OMN-9085",
+            pr_body="Closes OMN-9084. Closes OMN-9085",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -255,7 +342,7 @@ class TestReceiptGateMultiTicket:
                 check_type="command",
             )
         result = validate_pr_receipts(
-            pr_body="OMN-9084 OMN-9085",
+            pr_body="Closes OMN-9084. Closes OMN-9085",
             contracts_dir=contracts,
             receipts_dir=receipts,
         )
@@ -283,14 +370,12 @@ class TestReceiptGateOverride:
         )
         # Empty/whitespace reason doesn't count as a legitimate override
         assert not result.passed or result.friction_logged
-        # Regex requires at least one non-whitespace char in the reason — the
-        # `.+?` greedy-but-at-least-one means whitespace matches a single space
-        # minimum. The `.strip()` call catches the empty-after-strip case.
 
 
 @pytest.mark.unit
 class TestReceiptGateClosingKeywords:
-    def test_closing_keyword_preferred_over_mention(self, tmp_path: Path) -> None:
+    def test_closing_keyword_preferred_over_bare_mention(self, tmp_path: Path) -> None:
+        """When body has closing keyword, only the cited ticket is checked (not bare mentions)."""
         contracts = tmp_path / "contracts"
         receipts = tmp_path / "receipts"
         _write_contract(contracts, "OMN-5678")
@@ -308,29 +393,10 @@ class TestReceiptGateClosingKeywords:
         assert result.passed
         assert result.tickets_checked == ["OMN-5678"]
 
-    def test_no_closing_keyword_falls_back_to_all_mentions(
-        self, tmp_path: Path
-    ) -> None:
-        contracts = tmp_path / "contracts"
-        receipts = tmp_path / "receipts"
-        _write_contract(contracts, "OMN-1234")
-        _write_receipt(
-            receipts,
-            ticket_id="OMN-1234",
-            evidence_item_id="dod-001",
-            check_type="command",
-        )
-        result = validate_pr_receipts(
-            pr_body="Working on OMN-1234",
-            contracts_dir=contracts,
-            receipts_dir=receipts,
-        )
-        assert result.passed
-        assert result.tickets_checked == ["OMN-1234"]
-
     def test_pr_title_fallback_when_body_has_no_closing_keywords(
         self, tmp_path: Path
     ) -> None:
+        """No closing keyword in body → fall back to OMN-XXXX tokens in title."""
         contracts = tmp_path / "contracts"
         receipts = tmp_path / "receipts"
         _write_contract(contracts, "OMN-9084")
@@ -367,7 +433,8 @@ class TestReceiptGateClosingKeywords:
             )
             assert result.passed, f"Failed for keyword: {keyword}"
 
-    def test_no_title_no_body_tickets_fails(self, tmp_path: Path) -> None:
+    def test_no_title_no_closing_keyword_fails(self, tmp_path: Path) -> None:
+        """No closing keyword in body AND no title → no citation → FAIL."""
         result = validate_pr_receipts(
             pr_body="no tickets here",
             contracts_dir=tmp_path / "contracts",


### PR DESCRIPTION
## Summary

The receipt-gate regex previously matched any `OMN-XXXX` mention in the PR body, picking up cross-references (`see OMN-1234 for context`) and creating false blockers.

Now requires explicit closing keywords (`Closes`/`Fixes`/`Resolves`/`Implements`) in the body to identify cited tickets. Falls back to the PR title when no closing keywords are found (title is already enforced by `pr-title / check-title`).

### Changes

- `receipt_gate.py`: New `_extract_ticket_ids()` prefers `CLOSING_KEYWORD_PATTERN`, falls back to title via `TICKET_PATTERN`
- `receipt_gate_cli.py`: New `--pr-title` arg passed through to the gate
- `receipt-gate.yml`: Workflow now resolves and passes `PR_TITLE` alongside `PR_BODY`
- 23 tests (14 existing updated + 9 new including `TestReceiptGateGreedyRegression`)

Closes: OMN-9574

## Test plan

- [x] 23/23 unit tests pass (including 5 greedy-regression tests)
- [x] mypy --strict passes
- [x] ruff format + check passes
- [x] Pre-push hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receipt validation can use the PR title as a fallback to detect related tickets when the PR body lacks explicit closing keywords.

* **Improvements**
  * Ticket detection now prioritizes explicit closing keywords (Closes, Fixes, Resolves, Implements) over bare mentions for more accurate identification and precedence.

* **Tests**
  * Unit tests expanded to cover closing-keyword precedence, title-fallback behavior, and regression scenarios for bare ticket mentions.

* **Chores**
  * CI updated to forward the PR title into the receipt validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->