### PR TITLE
fix(OMN-9715): use confluent_kafka in cli_run_node — remove kafka-python dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,11 @@ spi = ["omnibase-spi>=0.20.2"]
 # model_onex_container falls back to an inline equivalent when not installed.
 compat = ["omnibase-compat>=0.3.1,<1.0.0"]
 cli = ["psutil>=7.2.1"]
+kafka = ["confluent-kafka>=2.12.0,<3.0.0"]
 cache = ["redis>=5.0.0,<8.0.0"]
 metrics = ["prometheus-client>=0.21.0,<1.0.0"]
 sql-parser = ["sqlglot>=26.0.0,<31.0.0"]
-full = ["omnibase-spi>=0.20.2", "omnibase-compat>=0.3.1,<1.0.0", "psutil>=7.2.1", "redis>=5.0.0,<8.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
+full = ["omnibase-spi>=0.20.2", "omnibase-compat>=0.3.1,<1.0.0", "psutil>=7.2.1", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<8.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
 
 [dependency-groups]
 dev = [
@@ -123,6 +124,7 @@ dev = [
     "interrogate>=1.7.0",
     "hypothesis>=6.150",
     "psutil>=7.2.1",
+    "confluent-kafka>=2.12.0,<3.0.0",
     "prometheus-client>=0.21.0,<1.0.0",
     "types-psutil>=7.2.1.20260116",
     "sqlglot>=26.0.0,<31.0.0",

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -46,6 +46,7 @@ def publish_and_poll(
     """
     try:
         _ck = importlib.import_module("confluent_kafka")
+        # NOTE(OMN-9715): lazy importlib import preserves ADR-005 transport boundary; attr-defined suppressed because confluent_kafka stubs are incomplete
         Producer = _ck.Producer  # type: ignore[attr-defined]
         Consumer = _ck.Consumer  # type: ignore[attr-defined]
     except ImportError as exc:
@@ -66,6 +67,19 @@ def publish_and_poll(
         "timestamp": time.time(),
     }
 
+    # Subscribe consumer before producing so a fast responder cannot deliver
+    # the reply before partition assignment (auto.offset.reset="latest" would
+    # skip it otherwise).
+    consumer = Consumer(
+        {
+            "bootstrap.servers": bootstrap_servers,
+            "group.id": f"onex-run-node-{correlation_id}",
+            "auto.offset.reset": "latest",
+            "enable.auto.commit": False,
+        }
+    )
+    consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
+
     delivery_error: list[Exception] = []
 
     def _on_delivery(err: object, _msg: object) -> None:
@@ -83,20 +97,17 @@ def publish_and_poll(
         value=json.dumps(envelope).encode(),
         on_delivery=_on_delivery,
     )
-    producer.flush(timeout=10.0)
+    pending = producer.flush(timeout=10.0)
+    if pending:
+        consumer.close()
+        raise OnexError(
+            code=EnumCoreErrorCode.RUNTIME_ERROR,
+            message=f"Kafka flush timed out with {pending} queued message(s)",
+        )
 
     if delivery_error:
+        consumer.close()
         raise delivery_error[0]
-
-    consumer = Consumer(
-        {
-            "bootstrap.servers": bootstrap_servers,
-            "group.id": f"onex-run-node-{correlation_id}",
-            "auto.offset.reset": "latest",
-            "enable.auto.commit": False,
-        }
-    )
-    consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
 
     deadline = time.monotonic() + timeout
     try:

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -22,21 +22,6 @@ from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.errors import OnexError
 
 
-def _load_kafka_classes() -> tuple[type, type]:
-    """Load KafkaProducer and KafkaConsumer via importlib to satisfy ADR-005 boundary."""
-    try:
-        mod = importlib.import_module("kafka")
-    except ImportError as exc:
-        raise OnexError(
-            code=EnumCoreErrorCode.IMPORT_ERROR,
-            message=(
-                "kafka-python is required for run-node. "
-                "Install with: uv add kafka-python-ng"
-            ),
-        ) from exc
-    return mod.KafkaProducer, mod.KafkaConsumer
-
-
 def _emit_error(node_id: str, message: str, **extra: str | int) -> None:
     """Emit a SkillRoutingError JSON envelope and exit non-zero."""
     envelope: dict[str, str | int] = {
@@ -59,10 +44,20 @@ def publish_and_poll(
 
     Returns the response dict, or None on timeout.
     """
-    KafkaProducer, KafkaConsumer = _load_kafka_classes()
+    try:
+        _ck = importlib.import_module("confluent_kafka")
+        Producer = _ck.Producer  # type: ignore[attr-defined]
+        Consumer = _ck.Consumer  # type: ignore[attr-defined]
+    except ImportError as exc:
+        raise OnexError(
+            code=EnumCoreErrorCode.IMPORT_ERROR,
+            message=(
+                "confluent-kafka is required for run-node. "
+                "Install with: uv add omnibase-core[kafka]"
+            ),
+        ) from exc
 
     correlation_id = str(uuid.uuid4())
-    response_topic = TOPIC_CLI_RUN_NODE_RESPONSE
 
     envelope = {
         "correlation_id": correlation_id,
@@ -71,31 +66,56 @@ def publish_and_poll(
         "timestamp": time.time(),
     }
 
-    producer = KafkaProducer(
-        bootstrap_servers=bootstrap_servers,
-        value_serializer=lambda v: json.dumps(v).encode(),
-    )
-    producer.send(TOPIC_CLI_RUN_NODE_CMD, value=envelope)
-    producer.flush()
-    producer.close()
+    delivery_error: list[Exception] = []
 
-    consumer = KafkaConsumer(
-        response_topic,
-        bootstrap_servers=bootstrap_servers,
-        value_deserializer=lambda v: json.loads(v.decode()),
-        auto_offset_reset="latest",
-        consumer_timeout_ms=timeout * 1000,
-        group_id=f"onex-run-node-{correlation_id}",
+    def _on_delivery(err: object, _msg: object) -> None:
+        if err is not None:
+            delivery_error.append(
+                OnexError(
+                    code=EnumCoreErrorCode.RUNTIME_ERROR,
+                    message=f"Kafka delivery failed: {err}",
+                )
+            )
+
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    producer.produce(
+        topic=TOPIC_CLI_RUN_NODE_CMD,
+        value=json.dumps(envelope).encode(),
+        on_delivery=_on_delivery,
     )
+    producer.flush(timeout=10.0)
+
+    if delivery_error:
+        raise delivery_error[0]
+
+    consumer = Consumer(
+        {
+            "bootstrap.servers": bootstrap_servers,
+            "group.id": f"onex-run-node-{correlation_id}",
+            "auto.offset.reset": "latest",
+            "enable.auto.commit": False,
+        }
+    )
+    consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
 
     deadline = time.monotonic() + timeout
     try:
-        for message in consumer:
-            if message.value.get("correlation_id") == correlation_id:
-                value: dict[str, object] = dict(message.value)
-                return value
-            if time.monotonic() > deadline:
-                return None
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            msg = consumer.poll(timeout=min(remaining, 1.0))
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            raw = msg.value()
+            if raw is None:
+                continue
+            try:
+                data: dict[str, object] = json.loads(raw.decode())
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if data.get("correlation_id") == correlation_id:
+                return data
     finally:
         consumer.close()
 

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -69,7 +69,8 @@ def publish_and_poll(
 
     # Subscribe consumer before producing so a fast responder cannot deliver
     # the reply before partition assignment (auto.offset.reset="latest" would
-    # skip it otherwise).
+    # skip it otherwise). Consumer is created first so the finally block below
+    # always runs close() even if Producer/produce/flush raise synchronously.
     consumer = Consumer(
         {
             "bootstrap.servers": bootstrap_servers,
@@ -91,28 +92,29 @@ def publish_and_poll(
                 )
             )
 
-    producer = Producer({"bootstrap.servers": bootstrap_servers})
-    producer.produce(
-        topic=TOPIC_CLI_RUN_NODE_CMD,
-        value=json.dumps(envelope).encode(),
-        on_delivery=_on_delivery,
-    )
-    pending = producer.flush(timeout=10.0)
-    if pending:
-        consumer.close()
-        raise OnexError(
-            code=EnumCoreErrorCode.RUNTIME_ERROR,
-            message=f"Kafka flush timed out with {pending} queued message(s)",
-        )
-
-    if delivery_error:
-        consumer.close()
-        raise delivery_error[0]
-
     deadline = time.monotonic() + timeout
     try:
-        while time.monotonic() < deadline:
-            remaining = deadline - time.monotonic()
+        producer = Producer({"bootstrap.servers": bootstrap_servers})
+        producer.produce(
+            topic=TOPIC_CLI_RUN_NODE_CMD,
+            value=json.dumps(envelope).encode(),
+            on_delivery=_on_delivery,
+        )
+        pending = producer.flush(timeout=10.0)
+        if pending:
+            raise OnexError(
+                code=EnumCoreErrorCode.RUNTIME_ERROR,
+                message=f"Kafka flush timed out with {pending} queued message(s)",
+            )
+
+        if delivery_error:
+            raise delivery_error[0]
+
+        while True:
+            now = time.monotonic()
+            remaining = deadline - now
+            if remaining <= 0:
+                break
             msg = consumer.poll(timeout=min(remaining, 1.0))
             if msg is None:
                 continue

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -51,7 +51,7 @@ def publish_and_poll(
         Consumer = _ck.Consumer  # type: ignore[attr-defined]
     except ImportError as exc:
         raise ModelOnexError(
-            code=EnumCoreErrorCode.IMPORT_ERROR,
+            error_code=EnumCoreErrorCode.IMPORT_ERROR,
             message=(
                 "confluent-kafka is required for run-node. "
                 "Install with: uv add omnibase-core[kafka]"
@@ -73,7 +73,7 @@ def publish_and_poll(
         if err is not None:
             delivery_error.append(
                 ModelOnexError(
-                    code=EnumCoreErrorCode.RUNTIME_ERROR,
+                    error_code=EnumCoreErrorCode.RUNTIME_ERROR,
                     message=f"Kafka delivery failed: {err}",
                 )
             )
@@ -98,7 +98,7 @@ def publish_and_poll(
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ModelOnexError(
-                    code=EnumCoreErrorCode.RUNTIME_ERROR,
+                    error_code=EnumCoreErrorCode.RUNTIME_ERROR,
                     message="Timed out waiting for Kafka consumer partition assignment",
                 )
             consumer.poll(timeout=min(remaining, 0.1))
@@ -112,7 +112,7 @@ def publish_and_poll(
         pending = producer.flush(timeout=10.0)
         if pending:
             raise ModelOnexError(
-                code=EnumCoreErrorCode.RUNTIME_ERROR,
+                error_code=EnumCoreErrorCode.RUNTIME_ERROR,
                 message=f"Kafka flush timed out with {pending} queued message(s)",
             )
 

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -19,7 +19,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_CLI_RUN_NODE_RESPONSE,
 )
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
-from omnibase_core.errors import OnexError
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
 
 def _emit_error(node_id: str, message: str, **extra: str | int) -> None:
@@ -50,7 +50,7 @@ def publish_and_poll(
         Producer = _ck.Producer  # type: ignore[attr-defined]
         Consumer = _ck.Consumer  # type: ignore[attr-defined]
     except ImportError as exc:
-        raise OnexError(
+        raise ModelOnexError(
             code=EnumCoreErrorCode.IMPORT_ERROR,
             message=(
                 "confluent-kafka is required for run-node. "
@@ -81,12 +81,22 @@ def publish_and_poll(
     )
     consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
 
+    # Poll until partition assignment is complete before producing the request.
+    # subscribe() is asynchronous — assignment only happens during poll(). Without
+    # this, a fast responder can produce the reply before the consumer holds any
+    # partition, causing auto.offset.reset="latest" to skip it.
+    assign_deadline = time.monotonic() + 10.0
+    while not consumer.assignment():
+        if time.monotonic() >= assign_deadline:
+            break
+        consumer.poll(timeout=0.1)
+
     delivery_error: list[Exception] = []
 
     def _on_delivery(err: object, _msg: object) -> None:
         if err is not None:
             delivery_error.append(
-                OnexError(
+                ModelOnexError(
                     code=EnumCoreErrorCode.RUNTIME_ERROR,
                     message=f"Kafka delivery failed: {err}",
                 )
@@ -102,7 +112,7 @@ def publish_and_poll(
         )
         pending = producer.flush(timeout=10.0)
         if pending:
-            raise OnexError(
+            raise ModelOnexError(
                 code=EnumCoreErrorCode.RUNTIME_ERROR,
                 message=f"Kafka flush timed out with {pending} queued message(s)",
             )
@@ -171,7 +181,7 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
             timeout=timeout,
             bootstrap_servers=bootstrap_servers,
         )
-    except (ConnectionError, OSError, ImportError, OnexError) as exc:
+    except (ConnectionError, OSError, ImportError, ModelOnexError) as exc:
         _emit_error(node_id, str(exc))
 
     if response is None:

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -67,30 +67,6 @@ def publish_and_poll(
         "timestamp": time.time(),
     }
 
-    # Subscribe consumer before producing so a fast responder cannot deliver
-    # the reply before partition assignment (auto.offset.reset="latest" would
-    # skip it otherwise). Consumer is created first so the finally block below
-    # always runs close() even if Producer/produce/flush raise synchronously.
-    consumer = Consumer(
-        {
-            "bootstrap.servers": bootstrap_servers,
-            "group.id": f"onex-run-node-{correlation_id}",
-            "auto.offset.reset": "latest",
-            "enable.auto.commit": False,
-        }
-    )
-    consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
-
-    # Poll until partition assignment is complete before producing the request.
-    # subscribe() is asynchronous — assignment only happens during poll(). Without
-    # this, a fast responder can produce the reply before the consumer holds any
-    # partition, causing auto.offset.reset="latest" to skip it.
-    assign_deadline = time.monotonic() + 10.0
-    while not consumer.assignment():
-        if time.monotonic() >= assign_deadline:
-            break
-        consumer.poll(timeout=0.1)
-
     delivery_error: list[Exception] = []
 
     def _on_delivery(err: object, _msg: object) -> None:
@@ -103,7 +79,30 @@ def publish_and_poll(
             )
 
     deadline = time.monotonic() + timeout
+    consumer = Consumer(
+        {
+            "bootstrap.servers": bootstrap_servers,
+            "group.id": f"onex-run-node-{correlation_id}",
+            "auto.offset.reset": "latest",
+            "enable.auto.commit": False,
+        }
+    )
     try:
+        # Subscribe and wait for partition assignment before producing.
+        # subscribe() is asynchronous — assignment only happens during poll().
+        # Waiting here (within the caller's deadline) ensures a fast responder
+        # cannot produce the reply before this consumer holds partitions
+        # (auto.offset.reset="latest" would skip any pre-assignment messages).
+        consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
+        while not consumer.assignment():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ModelOnexError(
+                    code=EnumCoreErrorCode.RUNTIME_ERROR,
+                    message="Timed out waiting for Kafka consumer partition assignment",
+                )
+            consumer.poll(timeout=min(remaining, 0.1))
+
         producer = Producer({"bootstrap.servers": bootstrap_servers})
         producer.produce(
             topic=TOPIC_CLI_RUN_NODE_CMD,

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -26,9 +26,24 @@ class TestCliRunNodeNoKafkaPythonImport:
     """Assert that kafka-python (module ``kafka``) is NOT imported at module load time."""
 
     def test_kafka_python_not_imported_at_module_level(self) -> None:
-        assert "kafka" not in sys.modules, (
-            "kafka-python must not be imported at module level in cli_run_node"
-        )
+        import importlib
+
+        # Re-import the module in an isolated namespace to avoid false-positive
+        # from other test modules that may have imported kafka before this test.
+        import importlib.util
+
+        spec = importlib.util.find_spec("omnibase_core.cli.cli_run_node")
+        assert spec is not None
+        # Verify the module itself does not trigger a kafka-python import
+        saved = sys.modules.pop("kafka", None)
+        try:
+            importlib.reload(importlib.import_module("omnibase_core.cli.cli_run_node"))
+            assert "kafka" not in sys.modules, (
+                "kafka-python must not be imported at module level in cli_run_node"
+            )
+        finally:
+            if saved is not None:
+                sys.modules["kafka"] = saved
 
     def test_confluent_kafka_import_path_used(self) -> None:
         import importlib.util
@@ -63,6 +78,7 @@ class TestPublishAndPoll:
 
     def test_produce_call_shape(self) -> None:
         mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None  # timeout immediately
 
@@ -98,6 +114,7 @@ class TestPublishAndPoll:
             return uid
 
         mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0  # all messages delivered
 
         def _make_consumer(config: dict[str, object]) -> MagicMock:
             consumer = MagicMock()
@@ -132,6 +149,7 @@ class TestPublishAndPoll:
 
     def test_returns_none_on_timeout(self) -> None:
         mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None
 
@@ -156,6 +174,8 @@ class TestPublishAndPoll:
 
     def test_consumer_closed_on_match(self) -> None:
         mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0  # all messages delivered
+        captured_consumer: list[MagicMock] = []
 
         def _make_consumer(config: dict[str, object]) -> MagicMock:
             consumer = MagicMock()
@@ -163,6 +183,7 @@ class TestPublishAndPoll:
             corr = group_id.removeprefix("onex-run-node-")
             msg = self._make_mock_message(corr)
             consumer.poll.return_value = msg
+            captured_consumer.append(consumer)
             return consumer
 
         with (
@@ -182,6 +203,28 @@ class TestPublishAndPoll:
             )
 
         assert result is not None
+        assert len(captured_consumer) == 1
+        captured_consumer[0].close.assert_called_once()
+
+    def test_flush_pending_raises_onerror(self) -> None:
+        from omnibase_core.errors import OnexError
+
+        mock_producer = MagicMock()
+        mock_producer.flush.return_value = 1  # simulates queued message timeout
+        mock_consumer = MagicMock()
+
+        with (
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+        ):
+            with pytest.raises(OnexError, match="flush timed out"):
+                publish_and_poll(
+                    node_id="x",
+                    payload={},
+                    timeout=5,
+                    bootstrap_servers="localhost:19092",
+                )
+        mock_consumer.close.assert_called_once()
 
     def test_raises_onerror_when_confluent_kafka_missing(self) -> None:
         from omnibase_core.errors import OnexError
@@ -235,6 +278,7 @@ class TestRunNodeCommand:
     def test_timeout_response_exits_nonzero(self) -> None:
         runner = CliRunner()
         mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None
 

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for cli_run_node — confluent_kafka producer/consumer path (OMN-9715)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_core.cli.cli_run_node import publish_and_poll, run_node
+
+pytestmark = pytest.mark.unit
+
+# Producer and Consumer are imported inside publish_and_poll (lazy import), so
+# patch them at their source — confluent_kafka.Producer / confluent_kafka.Consumer.
+_PATCH_PRODUCER = "confluent_kafka.Producer"
+_PATCH_CONSUMER = "confluent_kafka.Consumer"
+
+
+class TestCliRunNodeNoKafkaPythonImport:
+    """Assert that kafka-python (module ``kafka``) is NOT imported at module load time."""
+
+    def test_kafka_python_not_imported_at_module_level(self) -> None:
+        assert "kafka" not in sys.modules, (
+            "kafka-python must not be imported at module level in cli_run_node"
+        )
+
+    def test_confluent_kafka_import_path_used(self) -> None:
+        import importlib.util
+
+        spec = importlib.util.find_spec("omnibase_core.cli.cli_run_node")
+        assert spec is not None
+        source = spec.origin
+        assert source is not None
+        with open(source) as f:
+            content = f.read()
+        assert "import kafka" not in content, (
+            "cli_run_node must not contain 'import kafka' (kafka-python)"
+        )
+        assert "confluent_kafka" in content, (
+            "cli_run_node must reference confluent_kafka"
+        )
+
+
+class TestPublishAndPoll:
+    """Test publish_and_poll with stubbed confluent_kafka Producer and Consumer."""
+
+    def _make_mock_message(
+        self, correlation_id: str, extra: dict[str, object] | None = None
+    ) -> MagicMock:
+        msg = MagicMock()
+        msg.error.return_value = None
+        data: dict[str, object] = {"correlation_id": correlation_id, "status": "ok"}
+        if extra:
+            data.update(extra)
+        msg.value.return_value = json.dumps(data).encode()
+        return msg
+
+    def test_produce_call_shape(self) -> None:
+        mock_producer = MagicMock()
+        mock_consumer = MagicMock()
+        mock_consumer.poll.return_value = None  # timeout immediately
+
+        with (
+            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            mock_time.time.return_value = 1234567890.0
+            start = 1000.0
+            mock_time.monotonic.side_effect = [start, start + 10.0]  # deadline exceeded
+
+            publish_and_poll(
+                node_id="test-node",
+                payload={"foo": "bar"},
+                timeout=5,
+                bootstrap_servers="localhost:19092",
+            )
+
+        mock_producer.produce.assert_called_once()
+        produce_kwargs = mock_producer.produce.call_args
+        assert produce_kwargs.kwargs.get("topic") or produce_kwargs.args[0]
+        mock_producer.flush.assert_called_once_with(timeout=10.0)
+
+    def test_returns_correlated_message(self) -> None:
+        original_uuid4 = __import__("uuid").uuid4
+
+        corr_id_holder: list[str] = []
+
+        def _capture_uuid4() -> object:
+            uid = original_uuid4()
+            corr_id_holder.append(str(uid))
+            return uid
+
+        mock_producer = MagicMock()
+
+        def _make_consumer(config: dict[str, object]) -> MagicMock:
+            consumer = MagicMock()
+            group_id = str(config.get("group.id", ""))
+            corr = group_id.removeprefix("onex-run-node-")
+            msg = self._make_mock_message(corr)
+            consumer.poll.side_effect = [None, msg]
+            return consumer
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node.uuid.uuid4", side_effect=_capture_uuid4
+            ),
+            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_CONSUMER, side_effect=_make_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            start = 1000.0
+            mock_time.time.return_value = 1234567890.0
+            # Use return_value so monotonic() never exhausts regardless of call count
+            mock_time.monotonic.return_value = start
+
+            result = publish_and_poll(
+                node_id="my-node",
+                payload={},
+                timeout=30,
+                bootstrap_servers="localhost:19092",
+            )
+
+        assert result is not None
+        assert result.get("status") == "ok"
+
+    def test_returns_none_on_timeout(self) -> None:
+        mock_producer = MagicMock()
+        mock_consumer = MagicMock()
+        mock_consumer.poll.return_value = None
+
+        with (
+            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            mock_time.time.return_value = 1234567890.0
+            start = 1000.0
+            mock_time.monotonic.side_effect = [start, start + 31.0]
+
+            result = publish_and_poll(
+                node_id="my-node",
+                payload={},
+                timeout=30,
+                bootstrap_servers="localhost:19092",
+            )
+
+        assert result is None
+        mock_consumer.close.assert_called_once()
+
+    def test_consumer_closed_on_match(self) -> None:
+        mock_producer = MagicMock()
+
+        def _make_consumer(config: dict[str, object]) -> MagicMock:
+            consumer = MagicMock()
+            group_id = str(config.get("group.id", ""))
+            corr = group_id.removeprefix("onex-run-node-")
+            msg = self._make_mock_message(corr)
+            consumer.poll.return_value = msg
+            return consumer
+
+        with (
+            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_CONSUMER, side_effect=_make_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            start = 1000.0
+            mock_time.time.return_value = 1234567890.0
+            mock_time.monotonic.side_effect = [start, start + 0.1, start + 0.2]
+
+            result = publish_and_poll(
+                node_id="my-node",
+                payload={},
+                timeout=30,
+                bootstrap_servers="localhost:19092",
+            )
+
+        assert result is not None
+
+    def test_raises_onerror_when_confluent_kafka_missing(self) -> None:
+        from omnibase_core.errors import OnexError
+
+        with patch.dict(sys.modules, {"confluent_kafka": None}):
+            with pytest.raises((OnexError, ImportError)):
+                publish_and_poll(
+                    node_id="x",
+                    payload={},
+                    timeout=5,
+                    bootstrap_servers="localhost:19092",
+                )
+
+    def test_delivery_failure_raises_onerror(self) -> None:
+        from omnibase_core.errors import OnexError
+
+        def _make_failing_producer(config: dict[str, object]) -> MagicMock:
+            producer = MagicMock()
+
+            def _produce(**kwargs: object) -> None:
+                on_delivery = kwargs.get("on_delivery")
+                if callable(on_delivery):
+                    on_delivery("simulated delivery error", None)
+
+            producer.produce.side_effect = _produce
+            return producer
+
+        mock_consumer = MagicMock()
+
+        with (
+            patch(_PATCH_PRODUCER, side_effect=_make_failing_producer),
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+        ):
+            with pytest.raises(OnexError):
+                publish_and_poll(
+                    node_id="x",
+                    payload={},
+                    timeout=5,
+                    bootstrap_servers="localhost:19092",
+                )
+
+
+class TestRunNodeCommand:
+    """Test the click run-node command via CliRunner."""
+
+    def test_invalid_json_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
+        assert result.exit_code != 0
+
+    def test_timeout_response_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        mock_producer = MagicMock()
+        mock_consumer = MagicMock()
+        mock_consumer.poll.return_value = None
+
+        with (
+            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            mock_time.time.return_value = 1234567890.0
+            start = 1000.0
+            mock_time.monotonic.side_effect = [start, start + 35.0]
+
+            result = runner.invoke(
+                run_node, ["test-node", "--input", '{"x": 1}', "--timeout", "30"]
+            )
+
+        assert result.exit_code != 0
+        output = json.loads(result.output)
+        assert output["error_type"] == "SkillRoutingError"
+        assert "Timeout" in output["message"]

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -12,8 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from omnibase_core.cli.cli_run_node import publish_and_poll, run_node
-
 pytestmark = pytest.mark.unit
 
 # Producer and Consumer are imported inside publish_and_poll (lazy import), so
@@ -22,19 +20,46 @@ _PATCH_PRODUCER = "confluent_kafka.Producer"
 _PATCH_CONSUMER = "confluent_kafka.Consumer"
 
 
+def _make_mock_message(
+    correlation_id: str, extra: dict[str, object] | None = None
+) -> MagicMock:
+    msg = MagicMock()
+    msg.error.return_value = None
+    data: dict[str, object] = {"correlation_id": correlation_id, "status": "ok"}
+    if extra:
+        data.update(extra)
+    msg.value.return_value = json.dumps(data).encode()
+    return msg
+
+
+def _make_assigned_consumer(
+    config: dict[str, object] | None = None,
+    poll_side_effect: object = None,
+    poll_return_value: object = None,
+) -> MagicMock:
+    """Return a mock Consumer whose assignment() is truthy (already assigned)."""
+    consumer = MagicMock()
+    consumer.assignment.return_value = [object()]
+    if poll_side_effect is not None:
+        consumer.poll.side_effect = poll_side_effect
+    elif poll_return_value is not None:
+        consumer.poll.return_value = poll_return_value
+    else:
+        consumer.poll.return_value = None
+    return consumer
+
+
 class TestCliRunNodeNoKafkaPythonImport:
     """Assert that kafka-python (module ``kafka``) is NOT imported at module load time."""
 
     def test_kafka_python_not_imported_at_module_level(self) -> None:
         import importlib
-
-        # Re-import the module in an isolated namespace to avoid false-positive
-        # from other test modules that may have imported kafka before this test.
         import importlib.util
 
+        # Import symbols locally so the module-level import below doesn't affect this test
         spec = importlib.util.find_spec("omnibase_core.cli.cli_run_node")
         assert spec is not None
-        # Verify the module itself does not trigger a kafka-python import
+        # Verify the module itself does not trigger a kafka-python import on reload
         saved = sys.modules.pop("kafka", None)
         try:
             importlib.reload(importlib.import_module("omnibase_core.cli.cli_run_node"))
@@ -65,28 +90,16 @@ class TestCliRunNodeNoKafkaPythonImport:
 class TestPublishAndPoll:
     """Test publish_and_poll with stubbed confluent_kafka Producer and Consumer."""
 
-    def _make_mock_message(
-        self, correlation_id: str, extra: dict[str, object] | None = None
-    ) -> MagicMock:
-        msg = MagicMock()
-        msg.error.return_value = None
-        data: dict[str, object] = {"correlation_id": correlation_id, "status": "ok"}
-        if extra:
-            data.update(extra)
-        msg.value.return_value = json.dumps(data).encode()
-        return msg
-
     def test_produce_call_shape(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0  # all messages delivered
-        mock_consumer = MagicMock()
-        mock_consumer.poll.return_value = None  # timeout immediately
-        mock_consumer.assignment.return_value = [
-            object()
-        ]  # already assigned — skip wait
+        mock_consumer = _make_assigned_consumer()
 
-        # Simulate: assign_deadline call → 1000, deadline call → 1000,
-        # first loop iteration now → 1050 (remaining = -45, breaks immediately)
+        # assign_deadline call → 1000, deadline call → 1000,
+        # assignment wait: remaining>0, consumer.assignment() truthy → skip loop body
+        # first poll-loop now → 1050 (remaining = -45, breaks immediately)
         _monotonic_values = iter([1000.0, 1000.0, 1050.0])
 
         with (
@@ -113,6 +126,8 @@ class TestPublishAndPoll:
         mock_producer.flush.assert_called_once_with(timeout=10.0)
 
     def test_returns_correlated_message(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+
         original_uuid4 = __import__("uuid").uuid4
 
         corr_id_holder: list[str] = []
@@ -129,8 +144,9 @@ class TestPublishAndPoll:
             consumer = MagicMock()
             group_id = str(config.get("group.id", ""))
             corr = group_id.removeprefix("onex-run-node-")
-            msg = self._make_mock_message(corr)
+            msg = _make_mock_message(corr)
             consumer.poll.side_effect = [None, msg]
+            consumer.assignment.return_value = [object()]
             return consumer
 
         with (
@@ -143,7 +159,7 @@ class TestPublishAndPoll:
         ):
             start = 1000.0
             mock_time.time.return_value = 1234567890.0
-            # Use return_value so monotonic() never exhausts regardless of call count
+            # return_value so monotonic() never exhausts regardless of call count
             mock_time.monotonic.return_value = start
 
             result = publish_and_poll(
@@ -157,15 +173,13 @@ class TestPublishAndPoll:
         assert result.get("status") == "ok"
 
     def test_returns_none_on_timeout(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0  # all messages delivered
-        mock_consumer = MagicMock()
-        mock_consumer.poll.return_value = None
-        mock_consumer.assignment.return_value = [
-            object()
-        ]  # already assigned — skip wait
+        mock_consumer = _make_assigned_consumer()
 
-        # assign_deadline → 1000, deadline → 1000, first now → 1050 (breaks)
+        # deadline call → 1000, first now → 1050 (remaining = -45, breaks)
         _monotonic_values = iter([1000.0, 1000.0, 1050.0])
 
         with (
@@ -190,6 +204,8 @@ class TestPublishAndPoll:
         mock_consumer.close.assert_called_once()
 
     def test_consumer_closed_on_match(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0  # all messages delivered
         captured_consumer: list[MagicMock] = []
@@ -198,15 +214,14 @@ class TestPublishAndPoll:
             consumer = MagicMock()
             group_id = str(config.get("group.id", ""))
             corr = group_id.removeprefix("onex-run-node-")
-            msg = self._make_mock_message(corr)
+            msg = _make_mock_message(corr)
             consumer.poll.return_value = msg
-            # assignment returns truthy so the assign-wait loop exits immediately
             consumer.assignment.return_value = [object()]
             captured_consumer.append(consumer)
             return consumer
 
-        # assign_deadline → 1000, deadline → 1000, first now → 999 (remaining=29>0, enters loop)
-        _monotonic_values = iter([1000.0, 1000.0, 999.0])
+        # deadline → 1000, first now → 999 (remaining=29>0, enters poll loop)
+        _monotonic_values = iter([1000.0, 999.0])
 
         with (
             patch(
@@ -231,11 +246,12 @@ class TestPublishAndPoll:
         captured_consumer[0].close.assert_called_once()
 
     def test_flush_pending_raises_onerror(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
         from omnibase_core.errors import OnexError
 
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 1  # simulates queued message timeout
-        mock_consumer = MagicMock()
+        mock_consumer = _make_assigned_consumer()
 
         with (
             patch(_PATCH_PRODUCER, return_value=mock_producer),
@@ -251,6 +267,7 @@ class TestPublishAndPoll:
         mock_consumer.close.assert_called_once()
 
     def test_raises_onerror_when_confluent_kafka_missing(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
         from omnibase_core.errors import OnexError
 
         with patch.dict(sys.modules, {"confluent_kafka": None}):
@@ -263,6 +280,7 @@ class TestPublishAndPoll:
                 )
 
     def test_delivery_failure_raises_onerror(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
         from omnibase_core.errors import OnexError
 
         def _make_failing_producer(config: dict[str, object]) -> MagicMock:
@@ -276,7 +294,7 @@ class TestPublishAndPoll:
             producer.produce.side_effect = _produce
             return producer
 
-        mock_consumer = MagicMock()
+        mock_consumer = _make_assigned_consumer()
 
         with (
             patch(_PATCH_PRODUCER, side_effect=_make_failing_producer),
@@ -295,22 +313,22 @@ class TestRunNodeCommand:
     """Test the click run-node command via CliRunner."""
 
     def test_invalid_json_exits_nonzero(self) -> None:
+        from omnibase_core.cli.cli_run_node import run_node
+
         runner = CliRunner()
         result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
         assert result.exit_code != 0
 
     def test_timeout_response_exits_nonzero(self) -> None:
+        from omnibase_core.cli.cli_run_node import run_node
+
         runner = CliRunner()
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0  # all messages delivered
-        mock_consumer = MagicMock()
-        mock_consumer.poll.return_value = None
-        mock_consumer.assignment.return_value = [
-            object()
-        ]  # already assigned — skip wait
+        mock_consumer = _make_assigned_consumer()
 
-        # assign_deadline → 1000, deadline → 1000, first now → 1050 (breaks)
-        _monotonic_values = iter([1000.0, 1000.0, 1050.0])
+        # deadline → 1000, first now → 1050 (breaks immediately)
+        _monotonic_values = iter([1000.0, 1050.0])
 
         with (
             patch(
@@ -331,3 +349,20 @@ class TestRunNodeCommand:
         output = json.loads(result.output)
         assert output["error_type"] == "SkillRoutingError"
         assert "Timeout" in output["message"]
+
+
+class TestCliRunNodeNoKafkaPythonImportIsolated:
+    """Verify kafka module isolation without top-level module import."""
+
+    def test_kafka_python_not_imported_at_module_level(self) -> None:
+        import importlib
+
+        saved = sys.modules.pop("kafka", None)
+        try:
+            importlib.reload(importlib.import_module("omnibase_core.cli.cli_run_node"))
+            assert "kafka" not in sys.modules, (
+                "kafka-python must not be imported at module level in cli_run_node"
+            )
+        finally:
+            if saved is not None:
+                sys.modules["kafka"] = saved

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -81,16 +81,25 @@ class TestPublishAndPoll:
         mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None  # timeout immediately
+        mock_consumer.assignment.return_value = [
+            object()
+        ]  # already assigned — skip wait
+
+        # Simulate: assign_deadline call → 1000, deadline call → 1000,
+        # first loop iteration now → 1050 (remaining = -45, breaks immediately)
+        _monotonic_values = iter([1000.0, 1000.0, 1050.0])
 
         with (
-            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
+            ),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
-            mock_time.time.return_value = 1234567890.0
-            start = 1000.0
-            mock_time.monotonic.side_effect = [start, start + 10.0]  # deadline exceeded
-
             publish_and_poll(
                 node_id="test-node",
                 payload={"foo": "bar"},
@@ -152,16 +161,24 @@ class TestPublishAndPoll:
         mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None
+        mock_consumer.assignment.return_value = [
+            object()
+        ]  # already assigned — skip wait
+
+        # assign_deadline → 1000, deadline → 1000, first now → 1050 (breaks)
+        _monotonic_values = iter([1000.0, 1000.0, 1050.0])
 
         with (
-            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
+            ),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
-            mock_time.time.return_value = 1234567890.0
-            start = 1000.0
-            mock_time.monotonic.side_effect = [start, start + 31.0]
-
             result = publish_and_poll(
                 node_id="my-node",
                 payload={},
@@ -183,18 +200,25 @@ class TestPublishAndPoll:
             corr = group_id.removeprefix("onex-run-node-")
             msg = self._make_mock_message(corr)
             consumer.poll.return_value = msg
+            # assignment returns truthy so the assign-wait loop exits immediately
+            consumer.assignment.return_value = [object()]
             captured_consumer.append(consumer)
             return consumer
 
+        # assign_deadline → 1000, deadline → 1000, first now → 999 (remaining=29>0, enters loop)
+        _monotonic_values = iter([1000.0, 1000.0, 999.0])
+
         with (
-            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
+            ),
             patch(_PATCH_CONSUMER, side_effect=_make_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
-            start = 1000.0
-            mock_time.time.return_value = 1234567890.0
-            mock_time.monotonic.side_effect = [start, start + 0.1, start + 0.2]
-
             result = publish_and_poll(
                 node_id="my-node",
                 payload={},
@@ -281,16 +305,24 @@ class TestRunNodeCommand:
         mock_producer.flush.return_value = 0  # all messages delivered
         mock_consumer = MagicMock()
         mock_consumer.poll.return_value = None
+        mock_consumer.assignment.return_value = [
+            object()
+        ]  # already assigned — skip wait
+
+        # assign_deadline → 1000, deadline → 1000, first now → 1050 (breaks)
+        _monotonic_values = iter([1000.0, 1000.0, 1050.0])
 
         with (
-            patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
+            ),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
-            mock_time.time.return_value = 1234567890.0
-            start = 1000.0
-            mock_time.monotonic.side_effect = [start, start + 35.0]
-
             result = runner.invoke(
                 run_node, ["test-node", "--input", '{"x": 1}', "--timeout", "30"]
             )

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -230,7 +230,7 @@ class TestPublishAndPoll:
         from omnibase_core.errors import OnexError
 
         with patch.dict(sys.modules, {"confluent_kafka": None}):
-            with pytest.raises((OnexError, ImportError)):
+            with pytest.raises(OnexError, match="confluent-kafka is required"):
                 publish_and_poll(
                     node_id="x",
                     payload={},

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -195,6 +195,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "confluent-kafka"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/52/2c71d8e0b2de51076f90cea05342dc9c20fa14ded11992827680db4bbdfa/confluent_kafka-2.14.0.tar.gz", hash = "sha256:34efddfd06766d1153d10a70c23a98f6035e253a906db8ed04cb0249fc3b0fd2", size = 287868, upload-time = "2026-04-02T11:28:57.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/05/f27091396c1e5fb98844e3e8b114ec7b896d1b54209e796e3946649de2cd/confluent_kafka-2.14.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:737b63f2389c9d63f3da0923681aa95abad1cb2f96b10f38192ef19ab727c883", size = 3650743, upload-time = "2026-04-02T11:28:07.697Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/49/b9de672412c4290b4719f99ac17b31ff35c64b221e4961a3047f6c1f334f/confluent_kafka-2.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1610aa31880c874bfa3351d898d6e6cdbfab2a0f9443598fd64425bbc815cb06", size = 3207894, upload-time = "2026-04-02T11:28:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/b6/d892b50a48bbd95e8937d557baf89ffa07fc48bc27f792141476a004334d/confluent_kafka-2.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9cca8929bbc3d68a3299b21239c48def860f04e4661c7a59efe3104ecaea0e08", size = 3739440, upload-time = "2026-04-02T11:28:11.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/27/04d0f106820219e2621cf9e9a3ab49e910b7a19e55a72a21768b82031a85/confluent_kafka-2.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4d2e4718371c06579f649835239d1acf6ab5386a88f70e9cb9b839855c83c4a9", size = 3995763, upload-time = "2026-04-02T11:28:14.46Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d9/46258cefee841d65dda31d20ce61d12f7573e07ef8d26f49169edfd0b0fa/confluent_kafka-2.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:c37aff51512e817316edd6eafa8a2e59745052a7d1e61e09931b1caa11803266", size = 4112399, upload-time = "2026-04-02T11:28:16.264Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a3/13ca4b42c580cb8e8d4bc0711467c7c501573f0133dcaf1ed6d7e34abb42/confluent_kafka-2.14.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:a6dc0e49e8ac99854bd89ec7ac16c54af4488c7617baa633e615320dfbe44b25", size = 3212698, upload-time = "2026-04-02T11:28:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f6/3b4744a8d1b7714500e830a615671d27f76bf64c15966740cc6ee1c960f7/confluent_kafka-2.14.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:308c972b23f44e4d0eb3e76b987872c9a7d04148a5a4f29313bbbec3841d75b4", size = 3654148, upload-time = "2026-04-02T11:28:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9b/928775785983a2840c1944a689308e346badb2475765030f8e2a0db21f7a/confluent_kafka-2.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9b0acf2fffa19a6ffc2d6f0b82f3b7f1771f5d3943312438f3532ae69b6f2e83", size = 3739774, upload-time = "2026-04-02T11:28:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/37/c2d7a24f0c12673c763b25c2b32defe3b47b8458ad54befd842b6a3a0cde/confluent_kafka-2.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0023a941dbd8a2325e9e0d13ed1b2236c7d4ff3279b3d99cf06cf1409ab26d22", size = 3996169, upload-time = "2026-04-02T11:28:24.639Z" },
+    { url = "https://files.pythonhosted.org/packages/be/fe/4c2e517a404110adbb5b560dafb5d0b3ba36c2af47d52b5508c90f65d5b0/confluent_kafka-2.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:3da898df3ebb866f61312365e9108cbadcfe74fb73af8d03add856542e715cfe", size = 4172080, upload-time = "2026-04-02T11:28:26.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/07/e217beea9a543c53484144164db337b33ec7f95912cc76f09f03fbc6ee7f/confluent_kafka-2.14.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:05bbf9745cadb1a6fd3b03508572d2cd5455d8d9960a437537ddac9d3f89ee49", size = 3212541, upload-time = "2026-04-02T11:28:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/cbb44df7afa3ac8746e0ebc37be5f457d0e91e32648c144226da26c5f682/confluent_kafka-2.14.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:32a72ff85d7b4428532aa477b8dfa4223a5c69f4e90fecaa64e1924cc99a06b6", size = 3653993, upload-time = "2026-04-02T11:28:31.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/49/49d9e62ff70a06e68c96dd65d8e621583e6b51682ccc08051ec585bfdf96/confluent_kafka-2.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:4fd75d53e0e36f7ff9c5454f7a3cf4a54790db3bfda169c3b582ddc97111f6f6", size = 3739535, upload-time = "2026-04-02T11:28:32.844Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/df467787418c24e063ed0c19e96aedf05c26eabc32d8adc75235d45d830b/confluent_kafka-2.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:eb17528ec7b177ec5e38214852f3dadb5d77172e0fb25c7c992c0cbc3dcfbaa2", size = 3995845, upload-time = "2026-04-02T11:28:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/c5ce2a48ece0ae2dd050ab28d4cd81b9efc610276a4e72f622582f5371d3/confluent_kafka-2.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:578afb532ded604cb98174a14a88847367191bcbe4f52a1661f5238dc5cf75dd", size = 4290326, upload-time = "2026-04-02T11:28:36.679Z" },
 ]
 
 [[package]]
@@ -661,12 +684,16 @@ compat = [
     { name = "omnibase-compat" },
 ]
 full = [
+    { name = "confluent-kafka" },
     { name = "omnibase-compat" },
     { name = "omnibase-spi" },
     { name = "prometheus-client" },
     { name = "psutil" },
     { name = "redis" },
     { name = "sqlglot" },
+]
+kafka = [
+    { name = "confluent-kafka" },
 ]
 metrics = [
     { name = "prometheus-client" },
@@ -680,6 +707,7 @@ sql-parser = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "confluent-kafka" },
     { name = "hypothesis" },
     { name = "interrogate" },
     { name = "mypy" },
@@ -707,6 +735,8 @@ dev = [
 requires-dist = [
     { name = "blake3", specifier = ">=1.0.8,<2.0.0" },
     { name = "click", specifier = ">=8.3.1,<9.0.0" },
+    { name = "confluent-kafka", marker = "extra == 'full'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.12.0,<3.0.0" },
     { name = "cryptography", specifier = ">=46.0.3,<47.0.0" },
     { name = "deepdiff", specifier = ">=8.0.0,<10.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.3,<5.0.0" },
@@ -728,10 +758,11 @@ requires-dist = [
     { name = "sqlglot", marker = "extra == 'full'", specifier = ">=26.0.0,<31.0.0" },
     { name = "sqlglot", marker = "extra == 'sql-parser'", specifier = ">=26.0.0,<31.0.0" },
 ]
-provides-extras = ["spi", "compat", "cli", "cache", "metrics", "sql-parser", "full"]
+provides-extras = ["spi", "compat", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "confluent-kafka", specifier = ">=2.12.0,<3.0.0" },
     { name = "hypothesis", specifier = ">=6.150" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.19.1" },


### PR DESCRIPTION
## Summary

- Replaces \`kafka-python\` dynamic import in \`cli_run_node.publish_and_poll\` with \`confluent_kafka\` via \`importlib.import_module("confluent_kafka")\` — preserving the ADR-005 transport-purity boundary enforced by the \`validate-no-transport-imports\` pre-commit hook (AST-based, rejects \`from confluent_kafka import X\` but permits string-based \`importlib\` calls)
- Adds \`confluent-kafka>=2.12.0,<3.0.0\` as \`[project.optional-dependencies] kafka\` and to \`[dependency-groups] dev\`; removes \`kafka-python-ng\` as the install target from the error message
- \`full\` optional extra now includes \`confluent-kafka\`
- Consumer now subscribes to response topic **before** publishing the request to avoid the race where a fast responder delivers the reply before partition assignment (\`auto.offset.reset=latest\` would skip it otherwise)
- \`producer.flush()\` return value is checked; non-zero raises \`OnexError\` (pending messages indicate flush timeout)
- Consumer is explicitly closed before raising on flush or delivery errors
- Producer uses \`producer.produce(topic, value, on_delivery)\` + \`producer.flush(timeout=10.0)\`; Consumer uses \`consumer.poll(timeout)\` loop — matching the pattern in \`omnibase_infra/cli/artifact_reconcile.py\` and \`diagnostics/bus_audit.py\`

**Surface chosen: raw \`confluent_kafka\` (not ProtocolEventBus).** The CLI is a standalone entry point with no DI container — \`ProtocolEventBus\` requires full container wiring that is not available here. Per \`feedback_reduce_complexity.md\` and \`feedback_contract_driven_handlers.md\`, using the canonical transport client directly is the right call for a thin CLI.

**Why Path B (not Path A / kafka-python-ng):** Per \`feedback_reduce_complexity.md\` ("never add a new X — fix the canonical path"), \`confluent_kafka\` is already the standard client across \`omnibase_infra\`. Adding \`kafka-python-ng\` would introduce a second Kafka client with a different API surface and increase dependency surface for no benefit.

## Test plan

- [x] \`tests/unit/cli/test_cli_run_node.py\` — 11 unit tests covering:
  - \`kafka\` module not in \`sys.modules\` after module reload (ADR-005 boundary, isolated from test ordering)
  - Source contains \`confluent_kafka\` reference, not \`import kafka\`
  - \`producer.produce(topic=..., value=..., on_delivery=...)\` call shape
  - \`producer.flush(timeout=10.0)\` called
  - Correlated message returned correctly
  - \`None\` returned on timeout, consumer closed
  - Consumer closed on correlated match (\`close.assert_called_once()\`)
  - Flush non-zero return raises \`OnexError\` with "flush timed out"
  - \`OnexError\` raised when \`confluent_kafka\` not installed
  - \`OnexError\` raised on delivery failure
  - Click command exits non-zero with correct JSON envelope on timeout
- [x] All CLI unit tests green: \`11 passed\`
- [x] All pre-commit hooks pass (including \`ONEX Transport Import Prevention\`)
- [x] \`uv run mypy src/ --strict\` — 0 errors in changed files; 5 pre-existing errors in \`discovery_external_nodes.py\` and \`model_onex_container.py\` (present on \`main\`)

[skip-deploy-gate: cli-only refactor, no runtime service deployment — cli_run_node.py is a thin CLI entry point, not a deployed service component]

Closes OMN-9715.
Parent epic: OMN-9695 (broken-shim children unblocked by this dep fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable Kafka messaging: deadline-bounded polling, stronger delivery verification, clearer error reporting for request/response flows.

* **Dependencies**
  * Added confluent-kafka>=2.12.0,<3.0.0 as an optional `kafka` extra, included it in the `full` bundle, and added it to the `dev` dependency group for local/dev installs.

* **Tests**
  * New unit tests covering Kafka transport behavior, timeouts, delivery failures, and CLI timeout/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->