### PR TITLE
fix(OMN-9717): bust PR_EVENT_BODY cache on body update

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -236,8 +236,10 @@ jobs:
           set -e
           if [ -n "$PR_NUMBER" ]; then
             # pull_request event: always fetch live body so re-runs see edits.
-            if gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq '.body' > /tmp/pr_body.txt 2>/dev/null; then
-              gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title --jq '.title' > /tmp/pr_title.txt
+            # Single API call fetches both fields to minimise rate-limit consumption.
+            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title 2>/dev/null)"; then
+              printf '%s' "$pr_json" | jq -r '.body' > /tmp/pr_body.txt
+              printf '%s' "$pr_json" | jq -r '.title' > /tmp/pr_title.txt
             else
               # API unavailable — fall back to event payload with a warning.
               echo "::warning::gh pr view failed for PR #${PR_NUMBER}; using event payload (may be stale)"

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -218,19 +218,32 @@ jobs:
 
       - name: Resolve PR body
         id: resolve_body
-        # merge_group events do not carry pull_request.body. Fetch it from the
-        # merge_group head_ref (format: pr-<num>-<sha>) via the GitHub API so
-        # the gate evaluates the same body across pull_request and merge_group.
+        # Always fetch the PR body fresh from the GitHub API to avoid stale
+        # cached event payloads on re-runs (OMN-9717). github.event.pull_request.body
+        # is frozen at workflow trigger time — if the PR body is edited after CI
+        # fires, a re-run still reads the old body. Fetching via gh pr view
+        # guarantees the live body regardless of when the re-run happens.
+        #
+        # merge_group events do not carry pull_request.body. Derive the PR number
+        # from merge_group.head_ref (format: pr-<num>-<sha>) and fetch via API.
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_EVENT_BODY: ${{ github.event.pull_request.body }}
           PR_EVENT_TITLE: ${{ github.event.pull_request.title }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -e
-          if [ -n "$PR_EVENT_BODY" ]; then
-            printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
-            printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
+          if [ -n "$PR_NUMBER" ]; then
+            # pull_request event: always fetch live body so re-runs see edits.
+            if gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq '.body' > /tmp/pr_body.txt 2>/dev/null; then
+              gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title --jq '.title' > /tmp/pr_title.txt
+            else
+              # API unavailable — fall back to event payload with a warning.
+              echo "::warning::gh pr view failed for PR #${PR_NUMBER}; using event payload (may be stale)"
+              printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
+              printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
+            fi
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then
             pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
             if [ -n "$pr_num" ] && [ "$pr_num" != "$MERGE_GROUP_HEAD_REF" ]; then


### PR DESCRIPTION
## Summary

Fixes the phantom-failure cycle where the receipt-gate reads a stale PR body on re-runs after a body edit.

**Root cause:** `PR_EVENT_BODY: ${{ github.event.pull_request.body }}` is frozen at workflow trigger time. When a developer edits the PR body to add a ticket reference and re-runs CI, the gate still reads the original body — causing the gate to fail even though the body is correct.

**Fix:** On `pull_request` events, always re-fetch the body live via `gh pr view <PR_NUMBER>` instead of trusting the event payload. The `merge_group` branch already did this — this PR applies the same pattern to the `pull_request` branch. Falls back to the event payload only if the API call fails, with a warning annotation.

## Changes

- `.github/workflows/receipt-gate.yml` — `Resolve PR body` step: add `PR_NUMBER` env var; replace `if [ -n "$PR_EVENT_BODY" ]` branch with live API fetch; keep event payload as fallback with `::warning::` annotation.

## OMN-9717

Closes OMN-9717

```yaml
dod_evidence:
  - id: dod-001
    type: file_exists
    path: .github/workflows/receipt-gate.yml
  - id: dod-002
    type: command
    cmd: "gh run list --workflow receipt-gate.yml --repo OmniNode-ai/omnibase_core --limit 1 --json conclusion --jq '.[0].conclusion'"
    expect: "success"
```

## Test plan

- [ ] CI passes on this PR (receipt-gate reads OMN-9717 from this body via live API fetch)
- [ ] Verify re-running receipt-gate job after a body edit picks up the new body (the frozen event payload path is no longer used for pull_request events)

[skip-changeset-guard: single workflow file, hook false-positive on 23-file count]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now fetches live pull request title and body when a PR number is available, improving accuracy of PR metadata. If the live fetch fails, the workflow logs a warning and falls back to event-derived data. The previous unconditional use of event payload when present has been removed to favor live retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->