### PR TITLE
fix(OMN-9724): exclude .venv + generated paths from hardcoded-topic scan

### DIFF
--- a/src/omnibase_core/validation/validator_hardcoded_topics.py
+++ b/src/omnibase_core/validation/validator_hardcoded_topics.py
@@ -103,6 +103,23 @@ _APPROVED_SUFFIXES: frozenset[str] = frozenset(
 _RULE_TOPIC_LITERAL = "hardcoded_topic_literal"
 _RULE_TOPIC_ENV_VAR = "hardcoded_topic_env_var"
 
+# Path parts that are always excluded regardless of contract configuration.
+# This provides defense-in-depth for programmatic usage with minimal contracts
+# (e.g. tests that construct ModelValidatorSubcontract with exclude_patterns=[]).
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".git",
+    }
+)
+
 
 class ValidatorHardcodedTopics(ValidatorBase):
     """Reject hardcoded ONEX topic strings outside approved constant files.
@@ -113,6 +130,11 @@ class ValidatorHardcodedTopics(ValidatorBase):
     """
 
     validator_id: ClassVar[str] = "hardcoded_topics"
+
+    def _is_excluded(self, path: Path) -> bool:
+        if any(part in _EXCLUDED_PATH_PARTS for part in path.parts):
+            return True
+        return super()._is_excluded(path)
 
     def _validate_file(
         self,

--- a/tests/unit/validation/test_validator_hardcoded_topics.py
+++ b/tests/unit/validation/test_validator_hardcoded_topics.py
@@ -19,6 +19,7 @@ from omnibase_core.models.contracts.subcontracts.model_validator_subcontract imp
 )
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 from omnibase_core.validation.validator_hardcoded_topics import (
+    _EXCLUDED_PATH_PARTS,
     _RULE_TOPIC_ENV_VAR,
     _RULE_TOPIC_LITERAL,
     ValidatorHardcodedTopics,
@@ -479,3 +480,80 @@ class TestEdgeCases:
         result = v.validate_file(p)
         env_issues = [i for i in result.issues if i.code == _RULE_TOPIC_ENV_VAR]
         assert len(env_issues) == 0
+
+
+@pytest.mark.unit
+class TestGeneratedPathExclusion:
+    """Verify that generated/vendored directories are excluded regardless of contract config."""
+
+    def test_venv_site_packages_skipped(self, tmp_path: Path) -> None:
+        venv_file = (
+            tmp_path
+            / ".venv"
+            / "lib"
+            / "python3.12"
+            / "site-packages"
+            / "kafka"
+            / "topics.py"
+        )
+        venv_file.parent.mkdir(parents=True)
+        venv_file.write_text('TOPIC = "onex.evt.test.a.v1"\n')
+        v = ValidatorHardcodedTopics(
+            contract=_make_contract(
+                rules=[
+                    ModelValidatorRule(
+                        rule_id=_RULE_TOPIC_LITERAL,
+                        description="t",
+                        severity=EnumSeverity.ERROR,
+                        enabled=True,
+                    ),
+                ]
+            )
+        )
+        assert v._is_excluded(venv_file)
+        result = v.validate(tmp_path)
+        assert result.is_valid
+
+    def test_legitimate_src_file_scanned(self, tmp_path: Path) -> None:
+        src_file = tmp_path / "src" / "legitimate.py"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text('TOPIC = "onex.evt.test.a.v1"\n')
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        assert not v._is_excluded(src_file)
+        result = v.validate_file(src_file)
+        assert not result.is_valid
+
+    def test_nested_venv_skipped(self, tmp_path: Path) -> None:
+        nested = tmp_path / "pkg" / ".venv" / ".venv" / "site-packages" / "foo.py"
+        nested.parent.mkdir(parents=True)
+        nested.write_text('TOPIC = "onex.evt.test.a.v1"\n')
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        assert v._is_excluded(nested)
+
+    def test_excluded_path_parts_completeness(self) -> None:
+        expected = {
+            ".venv",
+            "__pycache__",
+            "build",
+            "dist",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".mypy_cache",
+            "node_modules",
+            ".git",
+        }
+        assert expected <= _EXCLUDED_PATH_PARTS
+
+    def test_pycache_skipped(self, tmp_path: Path) -> None:
+        pycache_file = tmp_path / "src" / "__pycache__" / "foo.cpython-312.pyc"
+        pycache_file.parent.mkdir(parents=True)
+        pycache_file.write_text('TOPIC = "onex.evt.test.a.v1"\n')
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        assert v._is_excluded(pycache_file)
+
+    def test_dot_git_skipped(self, tmp_path: Path) -> None:
+        git_file = tmp_path / ".git" / "COMMIT_EDITMSG"
+        git_file.parent.mkdir(parents=True)
+        git_file.write_text('TOPIC = "onex.evt.test.a.v1"\n')
+        v = ValidatorHardcodedTopics(contract=_make_contract())
+        assert v._is_excluded(git_file)


### PR DESCRIPTION
## Summary

- Adds `_EXCLUDED_PATH_PARTS` frozenset to `ValidatorHardcodedTopics` with the standard generated/vendored directory set: `.venv`, `__pycache__`, `build`, `dist`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`, `node_modules`, `.git`
- Overrides `_is_excluded` to check path parts before delegating to the contract-driven base implementation — defense-in-depth for programmatic usage with minimal contracts (e.g. test fixtures that construct `ModelValidatorSubcontract` with `exclude_patterns=[]`)
- Adds `TestGeneratedPathExclusion` test class (6 tests) covering `.venv` site-packages, legitimate src files, nested `.venv/.venv`, `__pycache__`, `.git`, and completeness of the exclusion set

## Ticket

OMN-9724 (refs OMN-9537)

## Test plan

- [ ] `uv run pytest tests/unit/validation/test_validator_hardcoded_topics.py -v` — 38 passed
- [ ] `pre-commit run --all-files` — all passed
- [ ] mypy strict — passed (pre-push hook)
- [ ] `.venv` site-packages path confirmed excluded via `v._is_excluded(venv_file)` assertion in tests

[skip-receipt-gate: pure validator code fix, no runtime node/contract artifact]