### PR TITLE
feat(OMN-9741): add ModelHookActivation typed contract

### DIFF
--- a/src/omnibase_core/models/contracts/subcontracts/__init__.py
+++ b/src/omnibase_core/models/contracts/subcontracts/__init__.py
@@ -105,6 +105,7 @@ from .model_fsm_subcontract import ModelFSMSubcontract
 from .model_handler_routing_entry import ModelHandlerRoutingEntry
 from .model_handler_routing_subcontract import ModelHandlerRoutingSubcontract
 from .model_health_check_subcontract import ModelHealthCheckSubcontract
+from .model_hook_activation import ModelHookActivation
 from .model_introspection_subcontract import ModelIntrospectionSubcontract
 from .model_lifecycle_subcontract import ModelLifecycleSubcontract
 from .model_load_balancing import ModelLoadBalancing
@@ -248,6 +249,7 @@ __all__ = [
     "ModelDependencyHealth",
     "ModelHealthCheckResult",
     "ModelHealthCheckSubcontract",
+    "ModelHookActivation",
     "ModelNodeHealthStatus",
     # Introspection subcontracts
     "ModelIntrospectionSubcontract",

--- a/src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit
+
+
+class ModelHookActivation(BaseModel):
+    """Declares a Claude Code hook that a package requires active."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    hook_bit: EnumHookBit
+    enabled_by_default: bool = True
+    description: str = ""
+
+    @field_validator("hook_bit", mode="before")
+    @classmethod
+    def coerce_hook_bit(cls, v: object) -> EnumHookBit:
+        if isinstance(v, EnumHookBit):
+            return v
+        if isinstance(v, str):
+            return EnumHookBit[v]
+        if isinstance(v, int):
+            return EnumHookBit(v)
+        raise ValueError(f"Cannot coerce {v!r} to EnumHookBit")

--- a/tests/unit/models/contracts/test_model_hook_activation.py
+++ b/tests/unit/models/contracts/test_model_hook_activation.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit
+from omnibase_core.models.contracts.subcontracts.model_hook_activation import (
+    ModelHookActivation,
+)
+
+
+def test_model_hook_activation_round_trips() -> None:
+    raw = {
+        "hook_bit": "BRANCH_PROTECTION_GUARD",
+        "enabled_by_default": True,
+        "description": "Enforces worktree discipline",
+    }
+    m = ModelHookActivation.model_validate(raw)
+    assert m.hook_bit == EnumHookBit.BRANCH_PROTECTION_GUARD
+    assert m.enabled_by_default is True
+
+
+def test_model_hook_activation_rejects_unknown_bit() -> None:
+    with pytest.raises(Exception):
+        ModelHookActivation.model_validate(
+            {"hook_bit": "DOES_NOT_EXIST", "enabled_by_default": True}
+        )
+
+
+def test_model_hook_activation_extra_fields_forbidden() -> None:
+    with pytest.raises(Exception):
+        ModelHookActivation.model_validate(
+            {
+                "hook_bit": "BRANCH_PROTECTION_GUARD",
+                "enabled_by_default": True,
+                "garbage": 1,
+            }
+        )
+
+
+def test_model_hook_activation_defaults() -> None:
+    m = ModelHookActivation.model_validate({"hook_bit": "BRANCH_PROTECTION_GUARD"})
+    assert m.enabled_by_default is True
+    assert m.description == ""
+
+
+def test_model_hook_activation_is_frozen() -> None:
+    m = ModelHookActivation.model_validate(
+        {"hook_bit": "BRANCH_PROTECTION_GUARD", "enabled_by_default": True}
+    )
+    with pytest.raises(Exception):
+        m.enabled_by_default = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `ModelHookActivation` to `omnibase_core/src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py`
- Frozen Pydantic model (`ConfigDict(frozen=True, extra="forbid", from_attributes=True)`) that declares a Claude Code hook a package requires active
- `hook_bit: EnumHookBit` coerced from string name, int value, or enum instance via `field_validator(mode="before")`
- Exported from subcontracts `__init__.py` (import + `__all__`)
- 5 unit tests covering round-trip, unknown-bit rejection, extra-field rejection, defaults, and frozen immutability

## Justification for new type (per plan Known Types Inventory)

Not reusing `ModelPipelineHook` (pipeline-phase hook scheduling — different semantic domain) or `ModelLifecycleSubcontract` (server-side lifecycle bare `list[str]`) or `ModelAgentConfig.hooks: dict[str, str]` (untyped escape hatch this plan replaces). This is the typed Claude Code hook enable/disable declaration surface.

## Evidence

```
dod_evidence:
  - type: file_exists
    path: src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py
  - type: pytest_receipt
    test: tests/unit/models/contracts/test_model_hook_activation.py
    result: 5 passed
  - type: mypy_strict
    result: Success: no issues found in 1 source file
```

Part of OMN-9741, parent OMN-9737.
[skip-receipt-gate: ticket OMN-9741 dod_evidence embedded above]