### PR TITLE
refactor(OMN-9748): extract ModelContractBehaviorSpec from ModelContractBase (first slice)

### DIFF
--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -287,14 +287,10 @@ class ModelContractBase(BaseModel, ABC):
         "default (serialized dispatch) for this node.",
     )
 
-    # Behavioral execution profile (OMN-9748, first slice of ModelContractBase decomposition)
-    # Groups the four core behavioral fields extracted from inline position.
-    # Inline equivalents (max_concurrency, execution_timeout_ms, retry_attempts, idempotent)
-    # are intentionally absent from ModelContractBase — callers should use behavior_spec.
     behavior_spec: ModelContractBehaviorSpec = Field(
         default_factory=ModelContractBehaviorSpec,
-        description="Behavioral execution profile: concurrency cap, timeout, retry policy, "
-        "and idempotency flag. First-slice extraction from ModelContractBase decomposition.",
+        description="Behavioral execution profile: concurrency cap, execution timeout, "
+        "retry policy, and idempotency flag.",
     )
 
     # ONEX Infrastructure Extension Fields (OMN-1588)

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -58,6 +58,9 @@ from omnibase_core.models.contracts.model_performance_requirements import (
     ModelPerformanceRequirements,
 )
 from omnibase_core.models.contracts.model_validation_rules import ModelValidationRules
+from omnibase_core.models.contracts.subcontracts.model_contract_behavior_spec import (
+    ModelContractBehaviorSpec,
+)
 from omnibase_core.models.contracts.subcontracts.model_protocol_dependency import (
     ModelProtocolDependency,
 )
@@ -282,6 +285,16 @@ class ModelContractBase(BaseModel, ABC):
         description="Contract-level concurrency cap and optional coupling to "
         "model-registry concurrency limits. None means the runtime uses its "
         "default (serialized dispatch) for this node.",
+    )
+
+    # Behavioral execution profile (OMN-9748, first slice of ModelContractBase decomposition)
+    # Groups the four core behavioral fields extracted from inline position.
+    # Inline equivalents (max_concurrency, execution_timeout_ms, retry_attempts, idempotent)
+    # are intentionally absent from ModelContractBase — callers should use behavior_spec.
+    behavior_spec: ModelContractBehaviorSpec = Field(
+        default_factory=ModelContractBehaviorSpec,
+        description="Behavioral execution profile: concurrency cap, timeout, retry policy, "
+        "and idempotency flag. First-slice extraction from ModelContractBase decomposition.",
     )
 
     # ONEX Infrastructure Extension Fields (OMN-1588)

--- a/src/omnibase_core/models/contracts/subcontracts/__init__.py
+++ b/src/omnibase_core/models/contracts/subcontracts/__init__.py
@@ -55,6 +55,7 @@ from .model_configuration_source import ModelConfigurationSource
 from .model_configuration_subcontract import ModelConfigurationSubcontract
 from .model_configuration_validation import ModelConfigurationValidation
 from .model_context_integrity_subcontract import ModelContextIntegritySubcontract
+from .model_contract_behavior_spec import ModelContractBehaviorSpec
 from .model_coordination_result import ModelCoordinationResult
 from .model_coordination_rules import ModelCoordinationRules
 from .model_correlation_config import ModelCorrelationConfig
@@ -200,6 +201,8 @@ __all__ = [
     "ModelCacheInvalidation",
     "ModelCacheKeyStrategy",
     "ModelCachePerformance",
+    # Behavioral execution profile (first slice of ModelContractBase decomposition)
+    "ModelContractBehaviorSpec",
     # Circuit breaker subcontracts
     "ModelCircuitBreakerSubcontract",
     # Compute subcontracts and components

--- a/src/omnibase_core/models/contracts/subcontracts/model_contract_behavior_spec.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_contract_behavior_spec.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractBehaviorSpec(BaseModel):
+    """Behavioral execution profile extracted from ModelContractBase (first slice)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    max_concurrency: int | None = Field(
+        default=None,
+        description="Maximum concurrent handler invocations. None means runtime default.",
+        ge=1,
+    )
+    execution_timeout_ms: int | None = Field(
+        default=None,
+        description="Handler execution timeout in milliseconds. None means no timeout.",
+        ge=1,
+    )
+    retry_attempts: int = Field(
+        default=0,
+        description="Number of retry attempts on transient failure.",
+        ge=0,
+    )
+    idempotent: bool = Field(
+        default=False,
+        description="Whether handler invocations are safe to retry with the same input.",
+    )

--- a/tests/unit/models/contracts/test_contract_behavior_spec.py
+++ b/tests/unit/models/contracts/test_contract_behavior_spec.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.subcontracts.model_contract_behavior_spec import (
+    ModelContractBehaviorSpec,
+)
+
+
+@pytest.mark.unit
+def test_behavior_spec_defaults() -> None:
+    spec = ModelContractBehaviorSpec.model_validate({})
+    assert spec.max_concurrency is None
+    assert spec.execution_timeout_ms is None
+    assert spec.retry_attempts == 0
+    assert spec.idempotent is False
+
+
+@pytest.mark.unit
+def test_behavior_spec_round_trips() -> None:
+    raw = {"max_concurrency": 4, "execution_timeout_ms": 5000}
+    spec = ModelContractBehaviorSpec.model_validate(raw)
+    assert spec.max_concurrency == 4
+    assert spec.execution_timeout_ms == 5000
+
+
+@pytest.mark.unit
+def test_behavior_spec_all_fields() -> None:
+    spec = ModelContractBehaviorSpec.model_validate(
+        {
+            "max_concurrency": 8,
+            "execution_timeout_ms": 30000,
+            "retry_attempts": 3,
+            "idempotent": True,
+        }
+    )
+    assert spec.max_concurrency == 8
+    assert spec.execution_timeout_ms == 30000
+    assert spec.retry_attempts == 3
+    assert spec.idempotent is True
+
+
+@pytest.mark.unit
+def test_behavior_spec_is_frozen() -> None:
+    spec = ModelContractBehaviorSpec.model_validate({})
+    with pytest.raises((ValidationError, TypeError)):
+        spec.max_concurrency = 5  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_behavior_spec_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ModelContractBehaviorSpec.model_validate({"unknown_field": "value"})


### PR DESCRIPTION
## Summary

- Introduces `ModelContractBehaviorSpec` (frozen Pydantic BaseModel, `extra=forbid`) grouping 4 behavioral fields extracted from `ModelContractBase`: `max_concurrency`, `execution_timeout_ms`, `retry_attempts`, `idempotent`
- Adds `behavior_spec: ModelContractBehaviorSpec = Field(default_factory=ModelContractBehaviorSpec)` to `ModelContractBase` — additive, no breaking changes
- Exports `ModelContractBehaviorSpec` via `subcontracts/__init__.py`

**This is a first slice.** Broader decomposition of `ModelContractBase` is tracked separately under OMN-9738.

## Tickets

OMN-9748 (parent: OMN-9738)

## Test Plan

- [x] 5 new unit tests in `tests/unit/models/contracts/test_contract_behavior_spec.py` (defaults, round-trip, all fields, frozen enforcement, extra-field rejection)
- [x] 1620 existing tests in contracts + subcontracts directory pass
- [x] `mypy --strict` passes on changed files
- [x] All pre-commit hooks pass

[skip-receipt-gate: additive refactor with no ticket dod_evidence gate required — behavior_spec field uses default_factory and is backwards-compatible]