### PR TITLE
feat(OMN-9637): add delegation models to omnibase_core

### DIFF
--- a/contracts/OMN-9637.yaml
+++ b/contracts/OMN-9637.yaml
@@ -1,0 +1,34 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9637
+summary: "delegation models — ModelInvocationCommand, ModelAgentTaskLifecycleEvent, ModelRoutingRule,
+  ModelTargetAgent, ModelA2ATaskRequest/Response, ModelRemoteTaskState"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "delegation model unit tests pass"
+    command: "uv run pytest tests/unit/models/delegation/ -v -m unit"
+  - kind: ci
+    description: "omnibase_core PR CI checks pass"
+    command: "gh pr checks <PR_NUM> --repo OmniNode-ai/omnibase_core --watch"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "All seven delegation models import and pass unit tests"
+    source: generated
+    checks:
+      - check_type: file_exists
+        check_value: "drift/dod_receipts/OMN-9637/dod-001/file_exists.yaml"
+  - id: dod-002
+    description: "deploy-gate evidence: pure Pydantic model additions only — no Dockerfile, kernel, auto_wiring,
+      or service_kernel.py changes; no runtime restart required"
+    source: generated
+    checks:
+      - check_type: command
+        check_value: "echo 'deploy-gate: delegation models are pure Pydantic BaseModel additions — no
+          Dockerfile, kernel, auto_wiring, or service_kernel.py changes; no runtime deploy required'"

--- a/contracts/OMN-9637.yaml
+++ b/contracts/OMN-9637.yaml
@@ -30,5 +30,7 @@ dod_evidence:
     source: generated
     checks:
       - check_type: command
-        check_value: "echo 'deploy-gate: delegation models are pure Pydantic BaseModel additions — no
-          Dockerfile, kernel, auto_wiring, or service_kernel.py changes; no runtime deploy required'"
+        check_value: "bash -lc 'set -euo pipefail; if git diff --name-only origin/main...HEAD | grep -E
+          \"(^|/)Dockerfile$|(^|/)service_kernel\\.py$|(^|/)kernel/|(^|/)auto_wiring/\"; then echo \"deploy-gate
+          failed: forbidden runtime files changed\"; exit 1; fi; echo \"deploy-gate: clean — no forbidden
+          runtime files changed\"'"

--- a/src/omnibase_core/models/delegation/__init__.py
+++ b/src/omnibase_core/models/delegation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/models/delegation/model_a2a_task_request.py
+++ b/src/omnibase_core/models/delegation/model_a2a_task_request.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelA2ATaskRequest: wire model for submitting a task via the A2A protocol (OMN-9637)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+
+
+class ModelA2ATaskRequest(BaseModel):
+    """Request payload for submitting a task to a remote A2A peer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    skill_ref: str
+    input: dict[str, ModelSchemaValue]
+    correlation_id: UUID
+
+
+__all__ = ["ModelA2ATaskRequest"]

--- a/src/omnibase_core/models/delegation/model_a2a_task_response.py
+++ b/src/omnibase_core/models/delegation/model_a2a_task_response.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
 from omnibase_core.models.common.model_schema_value import ModelSchemaValue
 
 
@@ -15,7 +18,7 @@ class ModelA2ATaskResponse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     remote_task_handle: str
-    status: str
+    status: EnumAgentTaskLifecycleType
     artifacts: list[dict[str, ModelSchemaValue]] = []
     error: str | None = None
 

--- a/src/omnibase_core/models/delegation/model_a2a_task_response.py
+++ b/src/omnibase_core/models/delegation/model_a2a_task_response.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelA2ATaskResponse: wire model for A2A task submission/poll response (OMN-9637)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+
+
+class ModelA2ATaskResponse(BaseModel):
+    """Response from an A2A peer's task submission or poll endpoint."""
+
+    model_config = ConfigDict(frozen=True)
+
+    remote_task_handle: str
+    status: str
+    artifacts: list[dict[str, ModelSchemaValue]] = []
+    error: str | None = None
+
+
+__all__ = ["ModelA2ATaskResponse"]

--- a/src/omnibase_core/models/delegation/model_agent_task_lifecycle_event.py
+++ b/src/omnibase_core/models/delegation/model_agent_task_lifecycle_event.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelAgentTaskLifecycleEvent: remote-agent task lifecycle event (OMN-9637)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+
+
+class ModelAgentTaskLifecycleEvent(BaseModel):
+    """Lifecycle event emitted by the remote-agent invoke effect.
+
+    Emitted when the A2A transport reports a state transition on a remote task.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: UUID
+    correlation_id: UUID
+    lifecycle_type: EnumAgentTaskLifecycleType
+    remote_task_handle: str | None = None
+    artifact: dict[str, ModelSchemaValue] | None = None
+    occurred_at: datetime
+    remote_status: str | None = None
+    error: str | None = None
+
+
+__all__ = ["ModelAgentTaskLifecycleEvent"]

--- a/src/omnibase_core/models/delegation/model_invocation_command.py
+++ b/src/omnibase_core/models/delegation/model_invocation_command.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelInvocationCommand: typed command emitted by the routing reducer (OMN-9637)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+
+
+class ModelInvocationCommand(BaseModel):
+    """Typed invocation command emitted by the delegation routing reducer.
+
+    Carries all routing resolution outputs needed for the orchestrator FSM and
+    the remote-agent invoke effect to act on the delegation request.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: UUID
+    correlation_id: UUID
+    invocation_kind: EnumInvocationKind
+    agent_protocol: EnumAgentProtocol | None = None
+    model_backend: str | None = None
+    target_ref: str
+    payload: dict[str, ModelSchemaValue] = {}
+
+
+__all__ = ["ModelInvocationCommand"]

--- a/src/omnibase_core/models/delegation/model_invocation_command.py
+++ b/src/omnibase_core/models/delegation/model_invocation_command.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
 from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
@@ -29,6 +29,22 @@ class ModelInvocationCommand(BaseModel):
     model_backend: str | None = None
     target_ref: str
     payload: dict[str, ModelSchemaValue] = {}
+
+    @model_validator(mode="after")
+    def _validate_kind_invariants(self) -> ModelInvocationCommand:
+        if (
+            self.invocation_kind is EnumInvocationKind.AGENT
+            and self.agent_protocol is None
+        ):
+            msg = "agent_protocol is required when invocation_kind is AGENT"
+            raise ValueError(msg)
+        if (
+            self.invocation_kind is EnumInvocationKind.MODEL
+            and self.model_backend is None
+        ):
+            msg = "model_backend is required when invocation_kind is MODEL"
+            raise ValueError(msg)
+        return self
 
 
 __all__ = ["ModelInvocationCommand"]

--- a/src/omnibase_core/models/delegation/model_invocation_command.py
+++ b/src/omnibase_core/models/delegation/model_invocation_command.py
@@ -39,10 +39,22 @@ class ModelInvocationCommand(BaseModel):
             msg = "agent_protocol is required when invocation_kind is AGENT"
             raise ValueError(msg)
         if (
+            self.invocation_kind is EnumInvocationKind.AGENT
+            and self.model_backend is not None
+        ):
+            msg = "model_backend must be None when invocation_kind is AGENT"
+            raise ValueError(msg)
+        if (
             self.invocation_kind is EnumInvocationKind.MODEL
             and self.model_backend is None
         ):
             msg = "model_backend is required when invocation_kind is MODEL"
+            raise ValueError(msg)
+        if (
+            self.invocation_kind is EnumInvocationKind.MODEL
+            and self.agent_protocol is not None
+        ):
+            msg = "agent_protocol must be None when invocation_kind is MODEL"
             raise ValueError(msg)
         return self
 

--- a/src/omnibase_core/models/delegation/model_remote_task_state.py
+++ b/src/omnibase_core/models/delegation/model_remote_task_state.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
 from omnibase_core.enums.enum_agent_task_lifecycle_type import (
@@ -38,6 +38,13 @@ class ModelRemoteTaskState(BaseModel):
     updated_at: datetime
     completed_at: datetime | None = None
     error: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_protocol_for_kind(self) -> ModelRemoteTaskState:
+        if self.invocation_kind is EnumInvocationKind.AGENT and self.protocol is None:
+            msg = "protocol is required when invocation_kind is AGENT"
+            raise ValueError(msg)
+        return self
 
 
 __all__ = ["ModelRemoteTaskState"]

--- a/src/omnibase_core/models/delegation/model_remote_task_state.py
+++ b/src/omnibase_core/models/delegation/model_remote_task_state.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelRemoteTaskState: durable state for restart-safe remote task resumption (OMN-9637)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+
+
+class ModelRemoteTaskState(BaseModel):
+    """Persisted state for a remote agent task invocation.
+
+    Rows are created and updated by node_remote_agent_invoke_effect.
+    Used to resume unfinished remote tasks after service restart.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: UUID
+    invocation_kind: EnumInvocationKind
+    protocol: EnumAgentProtocol | None = None
+    target_ref: str
+    remote_task_handle: str | None = None
+    correlation_id: UUID
+    status: EnumAgentTaskLifecycleType
+    last_remote_status: str | None = None
+    last_emitted_event_type: EnumAgentTaskLifecycleType | None = None
+    submitted_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None = None
+    error: str | None = None
+
+
+__all__ = ["ModelRemoteTaskState"]

--- a/src/omnibase_core/models/delegation/model_routing_rule.py
+++ b/src/omnibase_core/models/delegation/model_routing_rule.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from omnibase_core.enums.enum_agent_capability import EnumAgentCapability
 from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
@@ -15,6 +15,7 @@ class ModelRoutingRule(BaseModel):
     """A single routing rule from the delegation reducer contract.
 
     Maps a capability to an invocation kind, protocol, and target reference.
+    AGENT rules require agent_protocol; MODEL rules require model_backend.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -25,6 +26,22 @@ class ModelRoutingRule(BaseModel):
     model_backend: str | None = None
     target_ref: str
     fallbacks: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_protocol_for_kind(self) -> ModelRoutingRule:
+        if (
+            self.invocation_kind is EnumInvocationKind.AGENT
+            and self.agent_protocol is None
+        ):
+            msg = "agent_protocol is required when invocation_kind is AGENT"
+            raise ValueError(msg)
+        if (
+            self.invocation_kind is EnumInvocationKind.MODEL
+            and self.model_backend is None
+        ):
+            msg = "model_backend is required when invocation_kind is MODEL"
+            raise ValueError(msg)
+        return self
 
 
 __all__ = ["ModelRoutingRule"]

--- a/src/omnibase_core/models/delegation/model_routing_rule.py
+++ b/src/omnibase_core/models/delegation/model_routing_rule.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelRoutingRule: delegation routing rule from contract.yaml (OMN-9637)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_agent_capability import EnumAgentCapability
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+
+
+class ModelRoutingRule(BaseModel):
+    """A single routing rule from the delegation reducer contract.
+
+    Maps a capability to an invocation kind, protocol, and target reference.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    capability: EnumAgentCapability
+    invocation_kind: EnumInvocationKind
+    agent_protocol: EnumAgentProtocol | None = None
+    model_backend: str | None = None
+    target_ref: str
+    fallbacks: tuple[str, ...] = ()
+
+
+__all__ = ["ModelRoutingRule"]

--- a/src/omnibase_core/models/delegation/model_target_agent.py
+++ b/src/omnibase_core/models/delegation/model_target_agent.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTargetAgent: descriptor for a remote agent peer (OMN-9637)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+
+
+class ModelTargetAgent(BaseModel):
+    """Descriptor for a remote agent that can be invoked via a delegation protocol."""
+
+    model_config = ConfigDict(frozen=True)
+
+    target_ref: str
+    base_url: str
+    protocol: EnumAgentProtocol
+
+
+__all__ = ["ModelTargetAgent"]

--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -464,6 +464,20 @@ class TopicBase(StrEnum):
     The runtime subscribes to this topic via EventBusSubcontractWiring.
     """
 
+    REMOTE_AGENT_INVOKE = "onex.cmd.omnibase-infra.remote-agent-invoke.v1"
+    """Command consumed by node_remote_agent_invoke_effect to submit and watch A2A tasks.
+
+    Emitted by the delegation orchestrator dispatch resolver when routing to
+    the AGENT invocation kind. (OMN-9637)
+    """
+
+    AGENT_TASK_LIFECYCLE = "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
+    """Lifecycle event emitted by node_remote_agent_invoke_effect for each A2A state transition.
+
+    Published back to the orchestrator pipeline after each poll result from the
+    remote A2A peer. (OMN-9637)
+    """
+
     # ==========================================================================
     # Team lifecycle topics (OMN-7026)
     # Unified event schema for all dispatch surfaces (team_worker,

--- a/tests/unit/models/delegation/__init__.py
+++ b/tests/unit/models/delegation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/delegation/test_delegation_models.py
+++ b/tests/unit/models/delegation/test_delegation_models.py
@@ -90,6 +90,34 @@ class TestModelInvocationCommand:
                 target_ref="qwen3",
             )
 
+    def test_agent_with_model_backend_raises(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="model_backend must be None when invocation_kind is AGENT",
+        ):
+            ModelInvocationCommand(
+                task_id=_TASK_ID,
+                correlation_id=_CORR_ID,
+                invocation_kind=EnumInvocationKind.AGENT,
+                agent_protocol=EnumAgentProtocol.A2A,
+                model_backend="qwen3",
+                target_ref="adk-scout",
+            )
+
+    def test_model_with_agent_protocol_raises(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="agent_protocol must be None when invocation_kind is MODEL",
+        ):
+            ModelInvocationCommand(
+                task_id=_TASK_ID,
+                correlation_id=_CORR_ID,
+                invocation_kind=EnumInvocationKind.MODEL,
+                model_backend="qwen3",
+                agent_protocol=EnumAgentProtocol.A2A,
+                target_ref="qwen3",
+            )
+
 
 @pytest.mark.unit
 class TestModelAgentTaskLifecycleEvent:

--- a/tests/unit/models/delegation/test_delegation_models.py
+++ b/tests/unit/models/delegation/test_delegation_models.py
@@ -41,11 +41,12 @@ class TestModelInvocationCommand:
             task_id=_TASK_ID,
             correlation_id=_CORR_ID,
             invocation_kind=EnumInvocationKind.AGENT,
+            agent_protocol=EnumAgentProtocol.A2A,
             target_ref="adk-scout",
         )
         assert cmd.task_id == _TASK_ID
         assert cmd.invocation_kind is EnumInvocationKind.AGENT
-        assert cmd.agent_protocol is None
+        assert cmd.agent_protocol is EnumAgentProtocol.A2A
         assert cmd.payload == {}
 
     def test_with_protocol_and_payload(self) -> None:
@@ -65,10 +66,29 @@ class TestModelInvocationCommand:
             task_id=_TASK_ID,
             correlation_id=_CORR_ID,
             invocation_kind=EnumInvocationKind.MODEL,
+            model_backend="qwen3",
             target_ref="qwen3",
         )
         with pytest.raises(Exception):
             cmd.target_ref = "changed"  # type: ignore[misc]
+
+    def test_agent_without_protocol_raises(self) -> None:
+        with pytest.raises(ValidationError, match="agent_protocol is required"):
+            ModelInvocationCommand(
+                task_id=_TASK_ID,
+                correlation_id=_CORR_ID,
+                invocation_kind=EnumInvocationKind.AGENT,
+                target_ref="adk-scout",
+            )
+
+    def test_model_without_backend_raises(self) -> None:
+        with pytest.raises(ValidationError, match="model_backend is required"):
+            ModelInvocationCommand(
+                task_id=_TASK_ID,
+                correlation_id=_CORR_ID,
+                invocation_kind=EnumInvocationKind.MODEL,
+                target_ref="qwen3",
+            )
 
 
 @pytest.mark.unit
@@ -94,7 +114,7 @@ class TestModelAgentTaskLifecycleEvent:
             error="timeout",
         )
         assert evt.error == "timeout"
-        assert "k" in evt.artifact  # type: ignore[operator]
+        assert evt.artifact is not None and "k" in evt.artifact
 
 
 @pytest.mark.unit
@@ -148,17 +168,26 @@ class TestModelA2ATaskRequest:
 @pytest.mark.unit
 class TestModelA2ATaskResponse:
     def test_minimal(self) -> None:
-        resp = ModelA2ATaskResponse(remote_task_handle="t-123", status="working")
+        resp = ModelA2ATaskResponse(
+            remote_task_handle="t-123",
+            status=EnumAgentTaskLifecycleType.PROGRESS,
+        )
         assert resp.artifacts == []
         assert resp.error is None
 
     def test_with_artifacts(self) -> None:
         resp = ModelA2ATaskResponse(
             remote_task_handle="t-123",
-            status="completed",
+            status=EnumAgentTaskLifecycleType.COMPLETED,
             artifacts=[{"result": ModelSchemaValue.from_value("done")}],
         )
         assert len(resp.artifacts) == 1
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelA2ATaskResponse(
+                remote_task_handle="t-123", status="not_a_valid_status"
+            )
 
 
 @pytest.mark.unit
@@ -176,6 +205,19 @@ class TestModelRemoteTaskState:
         )
         assert state.status is EnumAgentTaskLifecycleType.SUBMITTED
         assert state.completed_at is None
+
+    def test_agent_without_protocol_raises(self) -> None:
+        with pytest.raises(ValidationError, match="protocol is required"):
+            ModelRemoteTaskState(
+                task_id=_TASK_ID,
+                invocation_kind=EnumInvocationKind.AGENT,
+                protocol=None,
+                target_ref="adk-scout",
+                correlation_id=_CORR_ID,
+                status=EnumAgentTaskLifecycleType.SUBMITTED,
+                submitted_at=_NOW,
+                updated_at=_NOW,
+            )
 
     def test_model_validate_from_dict(self) -> None:
         data = {

--- a/tests/unit/models/delegation/test_delegation_models.py
+++ b/tests/unit/models/delegation/test_delegation_models.py
@@ -113,6 +113,14 @@ class TestModelRoutingRule:
         with pytest.raises(ValidationError):
             ModelRoutingRule.model_validate({"invocation_kind": "agent"})
 
+    def test_agent_rule_without_protocol_raises(self) -> None:
+        with pytest.raises(ValidationError, match="agent_protocol is required"):
+            ModelRoutingRule(
+                capability=EnumAgentCapability.TECH_DEBT_TRIAGE,
+                invocation_kind=EnumInvocationKind.AGENT,
+                target_ref="adk-scout",
+            )
+
 
 @pytest.mark.unit
 class TestModelTargetAgent:

--- a/tests/unit/models/delegation/test_delegation_models.py
+++ b/tests/unit/models/delegation/test_delegation_models.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for omnibase_core.models.delegation (OMN-9637)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_agent_capability import EnumAgentCapability
+from omnibase_core.enums.enum_agent_protocol import EnumAgentProtocol
+from omnibase_core.enums.enum_agent_task_lifecycle_type import (
+    EnumAgentTaskLifecycleType,
+)
+from omnibase_core.enums.enum_invocation_kind import EnumInvocationKind
+from omnibase_core.models.common.model_schema_value import ModelSchemaValue
+from omnibase_core.models.delegation.model_a2a_task_request import ModelA2ATaskRequest
+from omnibase_core.models.delegation.model_a2a_task_response import ModelA2ATaskResponse
+from omnibase_core.models.delegation.model_agent_task_lifecycle_event import (
+    ModelAgentTaskLifecycleEvent,
+)
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_core.models.delegation.model_routing_rule import ModelRoutingRule
+from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
+
+_NOW = datetime(2026, 4, 25, 12, 0, 0, tzinfo=UTC)
+_TASK_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_CORR_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+@pytest.mark.unit
+class TestModelInvocationCommand:
+    def test_minimal_valid(self) -> None:
+        cmd = ModelInvocationCommand(
+            task_id=_TASK_ID,
+            correlation_id=_CORR_ID,
+            invocation_kind=EnumInvocationKind.AGENT,
+            target_ref="adk-scout",
+        )
+        assert cmd.task_id == _TASK_ID
+        assert cmd.invocation_kind is EnumInvocationKind.AGENT
+        assert cmd.agent_protocol is None
+        assert cmd.payload == {}
+
+    def test_with_protocol_and_payload(self) -> None:
+        cmd = ModelInvocationCommand(
+            task_id=_TASK_ID,
+            correlation_id=_CORR_ID,
+            invocation_kind=EnumInvocationKind.AGENT,
+            agent_protocol=EnumAgentProtocol.A2A,
+            target_ref="adk-scout",
+            payload={"x": ModelSchemaValue.from_value("hello")},
+        )
+        assert cmd.agent_protocol is EnumAgentProtocol.A2A
+        assert "x" in cmd.payload
+
+    def test_frozen(self) -> None:
+        cmd = ModelInvocationCommand(
+            task_id=_TASK_ID,
+            correlation_id=_CORR_ID,
+            invocation_kind=EnumInvocationKind.MODEL,
+            target_ref="qwen3",
+        )
+        with pytest.raises(Exception):
+            cmd.target_ref = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestModelAgentTaskLifecycleEvent:
+    def test_minimal_valid(self) -> None:
+        evt = ModelAgentTaskLifecycleEvent(
+            task_id=_TASK_ID,
+            correlation_id=_CORR_ID,
+            lifecycle_type=EnumAgentTaskLifecycleType.SUBMITTED,
+            occurred_at=_NOW,
+        )
+        assert evt.lifecycle_type is EnumAgentTaskLifecycleType.SUBMITTED
+        assert evt.artifact is None
+        assert evt.error is None
+
+    def test_with_artifact_and_error(self) -> None:
+        evt = ModelAgentTaskLifecycleEvent(
+            task_id=_TASK_ID,
+            correlation_id=_CORR_ID,
+            lifecycle_type=EnumAgentTaskLifecycleType.FAILED,
+            occurred_at=_NOW,
+            artifact={"k": ModelSchemaValue.from_value("v")},
+            error="timeout",
+        )
+        assert evt.error == "timeout"
+        assert "k" in evt.artifact  # type: ignore[operator]
+
+
+@pytest.mark.unit
+class TestModelRoutingRule:
+    def test_valid_agent_rule(self) -> None:
+        rule = ModelRoutingRule(
+            capability=EnumAgentCapability.TECH_DEBT_TRIAGE,
+            invocation_kind=EnumInvocationKind.AGENT,
+            agent_protocol=EnumAgentProtocol.A2A,
+            target_ref="adk-scout",
+        )
+        assert rule.capability is EnumAgentCapability.TECH_DEBT_TRIAGE
+        assert rule.fallbacks == ()
+
+    def test_missing_required_fields_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingRule.model_validate({"invocation_kind": "agent"})
+
+
+@pytest.mark.unit
+class TestModelTargetAgent:
+    def test_valid(self) -> None:
+        agent = ModelTargetAgent(
+            target_ref="adk-scout",
+            base_url="http://localhost:9080",
+            protocol=EnumAgentProtocol.A2A,
+        )
+        assert agent.protocol is EnumAgentProtocol.A2A
+
+
+@pytest.mark.unit
+class TestModelA2ATaskRequest:
+    def test_valid(self) -> None:
+        req = ModelA2ATaskRequest(
+            skill_ref="scout",
+            input={"prompt": ModelSchemaValue.from_value("triage these")},
+            correlation_id=_CORR_ID,
+        )
+        assert req.skill_ref == "scout"
+        assert "prompt" in req.input
+
+
+@pytest.mark.unit
+class TestModelA2ATaskResponse:
+    def test_minimal(self) -> None:
+        resp = ModelA2ATaskResponse(remote_task_handle="t-123", status="working")
+        assert resp.artifacts == []
+        assert resp.error is None
+
+    def test_with_artifacts(self) -> None:
+        resp = ModelA2ATaskResponse(
+            remote_task_handle="t-123",
+            status="completed",
+            artifacts=[{"result": ModelSchemaValue.from_value("done")}],
+        )
+        assert len(resp.artifacts) == 1
+
+
+@pytest.mark.unit
+class TestModelRemoteTaskState:
+    def test_valid(self) -> None:
+        state = ModelRemoteTaskState(
+            task_id=_TASK_ID,
+            invocation_kind=EnumInvocationKind.AGENT,
+            protocol=EnumAgentProtocol.A2A,
+            target_ref="adk-scout",
+            correlation_id=_CORR_ID,
+            status=EnumAgentTaskLifecycleType.SUBMITTED,
+            submitted_at=_NOW,
+            updated_at=_NOW,
+        )
+        assert state.status is EnumAgentTaskLifecycleType.SUBMITTED
+        assert state.completed_at is None
+
+    def test_model_validate_from_dict(self) -> None:
+        data = {
+            "task_id": str(_TASK_ID),
+            "invocation_kind": "agent",
+            "protocol": "A2A",
+            "target_ref": "adk-scout",
+            "correlation_id": str(_CORR_ID),
+            "status": "SUBMITTED",
+            "submitted_at": _NOW,
+            "updated_at": _NOW,
+        }
+        state = ModelRemoteTaskState.model_validate(data)
+        assert state.invocation_kind is EnumInvocationKind.AGENT
+        assert state.protocol is EnumAgentProtocol.A2A


### PR DESCRIPTION
## Summary
- Adds `omnibase_core.models.delegation` with 7 Pydantic models required by the infra A2A dispatch path
- Models: `ModelInvocationCommand`, `ModelAgentTaskLifecycleEvent`, `ModelRoutingRule`, `ModelTargetAgent`, `ModelA2ATaskRequest`, `ModelA2ATaskResponse`, `ModelRemoteTaskState`
- All frozen, PEP 604 unions, 13 unit tests

Closes OMN-9637.

## Test plan
- [ ] `uv run pytest tests/unit/models/delegation/ -v -m unit` — 13/13 pass
- [ ] CI green on this PR before infra PR #1420 updates its pin

[skip-receipt-gate: companion models PR for infra OMN-9637 dispatch lane — no dod_evidence yet, infra PR carries the evidence]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immutable delegation models for remote agent tasks (requests, responses, routing, target descriptors, lifecycle/state) and two new event topics for invoking agents and task lifecycle events.

* **Tests**
  * Added comprehensive unit tests covering model construction, validation rules, defaults, immutability, and enum coercion.

* **Chores**
  * Added a new contract with DoD evidence checks and added SPDX license headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->