### PR TITLE
feat(OMN-9758): add EnumContractBucket for corpus path classification

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -82,6 +82,9 @@ from .enum_compute_step_type import EnumComputeStepType
 
 # Consumer group purpose enum (event bus subscription - PR #476)
 from .enum_consumer_group_purpose import EnumConsumerGroupPurpose
+
+# Contract bucket enum (corpus classification + normalization layer - OMN-9758)
+from .enum_contract_bucket import EnumContractBucket
 from .enum_contract_compliance import EnumContractCompliance
 
 # Contract diff change type enum (semantic contract diffing)
@@ -678,6 +681,8 @@ __all__ = [
     # Version and contract domain
     "EnumVersionStatus",
     "EnumContractCompliance",
+    # Contract bucket domain (corpus classification + normalization - OMN-9758)
+    "EnumContractBucket",
     # Contract diff domain (semantic contract diffing)
     "EnumContractDiffChangeType",
     # State management domain

--- a/src/omnibase_core/enums/enum_contract_bucket.py
+++ b/src/omnibase_core/enums/enum_contract_bucket.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract bucket enum for corpus path classification (OMN-9758, parent OMN-9757).
+
+Classifies the role a contract YAML file plays in the corpus before
+validation. Distinct from ``EnumNodeType`` (which discriminates node
+implementation kind) — ``EnumContractBucket`` discriminates the file-path
+classification bucket used by the corpus classification + normalization
+pipeline introduced in the corpus-classification-and-normalization plan.
+
+Members (Python identifier → wire value):
+    NODE_ROOT_CONTRACT   → "node_root_contract"
+    HANDLER_CONTRACT     → "handler_contract"
+    PACKAGE_CONTRACT     → "package_contract"
+    INTEGRATION_CONTRACT → "integration_contract"
+    SERVICE_CONTRACT     → "service_contract"
+    FIXTURE_OR_TEST      → "fixture_or_test"
+    UNKNOWN              → "unknown"
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class EnumContractBucket(str, Enum):
+    """Corpus classification bucket for a contract YAML file.
+
+    Inherits from ``str`` so values JSON-serialize without extra logic.
+    Pre-validation classifier output; consumed by the per-family
+    normalization pipeline before strict Pydantic validation runs.
+    """
+
+    NODE_ROOT_CONTRACT = "node_root_contract"
+    HANDLER_CONTRACT = "handler_contract"
+    PACKAGE_CONTRACT = "package_contract"
+    INTEGRATION_CONTRACT = "integration_contract"
+    SERVICE_CONTRACT = "service_contract"
+    FIXTURE_OR_TEST = "fixture_or_test"
+    UNKNOWN = "unknown"
+
+
+__all__ = ["EnumContractBucket"]

--- a/tests/unit/enums/test_enum_contract_bucket.py
+++ b/tests/unit/enums/test_enum_contract_bucket.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumContractBucket (OMN-9758, parent OMN-9757).
+
+Validates the corpus-classification bucket enum used by the corpus
+classification + normalization layer.
+"""
+
+import json
+
+import pytest
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+
+
+@pytest.mark.unit
+class TestEnumContractBucketStructure:
+    """Test basic enum structure and values from the corpus plan spec."""
+
+    def test_all_expected_buckets_present(self) -> None:
+        expected = {
+            "node_root_contract",
+            "handler_contract",
+            "package_contract",
+            "integration_contract",
+            "service_contract",
+            "fixture_or_test",
+            "unknown",
+        }
+        actual = {b.value for b in EnumContractBucket}
+        assert actual == expected
+
+    def test_bucket_is_str_enum(self) -> None:
+        assert isinstance(EnumContractBucket.NODE_ROOT_CONTRACT, str)
+
+    def test_member_count_is_seven(self) -> None:
+        assert len(list(EnumContractBucket)) == 7
+
+    def test_enum_is_unique(self) -> None:
+        values = [m.value for m in EnumContractBucket]
+        assert len(values) == len(set(values))
+
+    def test_enum_from_value(self) -> None:
+        assert (
+            EnumContractBucket("node_root_contract")
+            is EnumContractBucket.NODE_ROOT_CONTRACT
+        )
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EnumContractBucket("not_a_real_bucket")
+
+    def test_enum_equality_with_string(self) -> None:
+        assert EnumContractBucket.HANDLER_CONTRACT == "handler_contract"
+
+
+@pytest.mark.unit
+class TestEnumContractBucketSerialization:
+    """Test JSON / YAML / Pydantic round-trip safety."""
+
+    def test_json_serialization_via_value(self) -> None:
+        data = {"bucket": EnumContractBucket.NODE_ROOT_CONTRACT.value}
+        assert json.dumps(data) == '{"bucket": "node_root_contract"}'
+
+    def test_yaml_round_trip(self) -> None:
+        data = {"bucket": EnumContractBucket.HANDLER_CONTRACT.value}
+        loaded = yaml.safe_load(yaml.dump(data))
+        assert loaded["bucket"] == "handler_contract"
+        assert (
+            EnumContractBucket(loaded["bucket"]) is EnumContractBucket.HANDLER_CONTRACT
+        )
+
+    def test_pydantic_field_assignment(self) -> None:
+        class M(BaseModel):
+            bucket: EnumContractBucket
+
+        m = M(bucket=EnumContractBucket.PACKAGE_CONTRACT)
+        assert m.bucket is EnumContractBucket.PACKAGE_CONTRACT
+
+    def test_pydantic_string_coercion(self) -> None:
+        class M(BaseModel):
+            bucket: EnumContractBucket
+
+        m = M(bucket="integration_contract")
+        assert m.bucket is EnumContractBucket.INTEGRATION_CONTRACT
+
+    def test_pydantic_invalid_raises(self) -> None:
+        class M(BaseModel):
+            bucket: EnumContractBucket
+
+        with pytest.raises(ValidationError):
+            M(bucket="bogus_bucket")
+
+    def test_pydantic_model_dump(self) -> None:
+        class M(BaseModel):
+            bucket: EnumContractBucket
+
+        m = M(bucket=EnumContractBucket.SERVICE_CONTRACT)
+        assert m.model_dump() == {"bucket": "service_contract"}
+
+    def test_pydantic_model_dump_json(self) -> None:
+        class M(BaseModel):
+            bucket: EnumContractBucket
+
+        m = M(bucket=EnumContractBucket.FIXTURE_OR_TEST)
+        assert m.model_dump_json() == '{"bucket":"fixture_or_test"}'
+
+
+@pytest.mark.unit
+class TestEnumContractBucketExports:
+    """Verify the enum is re-exported from the enums package __init__."""
+
+    def test_exported_from_enums_init(self) -> None:
+        from omnibase_core import enums as enums_pkg
+
+        assert hasattr(enums_pkg, "EnumContractBucket")
+        assert enums_pkg.EnumContractBucket is EnumContractBucket


### PR DESCRIPTION
## Summary

Adds `EnumContractBucket` — Phase 1 (Task 1) of the corpus-classification-and-normalization plan (parent **OMN-9757**, this ticket **OMN-9758**).

Pure additive enum. No consumers yet; classifies the role a `contract.yaml` file plays in the corpus before validation. Used by the upcoming `corpus_classifier` (Task 3, OMN-9760) and downstream validation pipeline (Wave 2).

Distinct from `EnumNodeType` (which discriminates node implementation kind) — `EnumContractBucket` discriminates file-path classification only.

### Members (Python identifier → wire value)

| Identifier | Wire value |
|---|---|
| `NODE_ROOT_CONTRACT` | `node_root_contract` |
| `HANDLER_CONTRACT` | `handler_contract` |
| `PACKAGE_CONTRACT` | `package_contract` |
| `INTEGRATION_CONTRACT` | `integration_contract` |
| `SERVICE_CONTRACT` | `service_contract` |
| `FIXTURE_OR_TEST` | `fixture_or_test` |
| `UNKNOWN` | `unknown` |

UPPER_SNAKE Python identifiers per the ONEX enum casing policy enforced by `check-enum-member-casing` pre-commit hook; lowercase wire values per the plan spec for the path discriminators.

## Plan reference

- Plan: `docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md` (Task 1)
- Parent epic: OMN-9757
- Phase: 1

## dod_evidence

- **unit_test**: `uv run pytest tests/unit/enums/test_enum_contract_bucket.py -v` → 15 passed
- **file_exists**: `src/omnibase_core/enums/enum_contract_bucket.py`
- **module_export**: `EnumContractBucket` re-exported from `omnibase_core.enums`

## Test plan

- [x] 15 unit tests pass (structure, JSON/YAML/Pydantic round-trip, exports)
- [x] All 3927 omnibase_core unit tests pass locally
- [x] `pre-commit run` passes on touched files (SPDX, single-class, enum casing, etc.)
- [ ] CI green across all 40 splits + receipt-gate + PR-title-check

Closes OMN-9758.