### PR TITLE
feat(OMN-9759): add EnumNormalizationFamily for migration family tracking

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -291,6 +291,9 @@ from .enum_node_type import EnumNodeType
 
 # Nondeterminism classification (OMN-1115 — mixin-to-handler migration)
 from .enum_nondeterminism_class import EnumNondeterminismClass
+
+# Normalization family enum (OMN-9759 — corpus classification/normalization layer, parent OMN-9757)
+from .enum_normalization_family import EnumNormalizationFamily
 from .enum_notification_method import EnumNotificationMethod
 from .enum_numeric_value_type import EnumNumericValueType
 
@@ -576,6 +579,8 @@ __all__ = [
     "EnumNodeStatus",
     # Nondeterminism classification
     "EnumNondeterminismClass",
+    # Normalization family (OMN-9759 — corpus classification, parent OMN-9757)
+    "EnumNormalizationFamily",
     # Node domain
     "EnumNodeArchetype",
     "EnumNodeArchitectureType",

--- a/src/omnibase_core/enums/enum_normalization_family.py
+++ b/src/omnibase_core/enums/enum_normalization_family.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Normalization Family Enum (OMN-9759).
+
+Phase 1 of the corpus classification and normalization layer
+(parent epic OMN-9757).
+
+Classifies the family of contract migration being applied during
+normalization. Each member tags a single, well-defined cohort of
+contract changes so the migration audit can group, count, and report
+findings by family.
+
+Families:
+    - family_legacy_input_output_model: legacy input/output model schema renames
+    - family_legacy_event_bus: legacy event bus block migrations
+    - family_legacy_metadata: legacy top-level metadata fields
+    - family_legacy_handler_routing: legacy handler routing/dispatch shapes
+    - family_required_now_optional: fields that flipped required → optional
+    - family_misc_extra_fields: miscellaneous extra fields tolerated by the model
+    - family_handler_block: handler block additions/normalization
+    - family_descriptor_block: descriptor block additions/normalization
+    - family_terminal_event: terminal event declaration additions
+    - family_event_schema_evolution: schema evolution within event payloads
+    - family_state_machine: FSM/state-machine block additions
+    - family_dod_evidence_schema: dod_evidence schema migrations
+    - family_custom_validator: custom validator block additions
+    - family_node_type_alias: bare EFFECT/COMPUTE/REDUCER aliases promoted to typed enum
+"""
+
+from enum import Enum, unique
+
+
+@unique
+class EnumNormalizationFamily(str, Enum):
+    """Canonical migration families for contract normalization."""
+
+    FAMILY_LEGACY_INPUT_OUTPUT_MODEL = "family_legacy_input_output_model"
+    FAMILY_LEGACY_EVENT_BUS = "family_legacy_event_bus"
+    FAMILY_LEGACY_METADATA = "family_legacy_metadata"
+    FAMILY_LEGACY_HANDLER_ROUTING = "family_legacy_handler_routing"
+    FAMILY_REQUIRED_NOW_OPTIONAL = "family_required_now_optional"
+    FAMILY_MISC_EXTRA_FIELDS = "family_misc_extra_fields"
+    FAMILY_HANDLER_BLOCK = "family_handler_block"
+    FAMILY_DESCRIPTOR_BLOCK = "family_descriptor_block"
+    FAMILY_TERMINAL_EVENT = "family_terminal_event"
+    FAMILY_EVENT_SCHEMA_EVOLUTION = "family_event_schema_evolution"
+    FAMILY_STATE_MACHINE = "family_state_machine"
+    FAMILY_DOD_EVIDENCE_SCHEMA = "family_dod_evidence_schema"
+    FAMILY_CUSTOM_VALIDATOR = "family_custom_validator"
+    FAMILY_NODE_TYPE_ALIAS = "family_node_type_alias"

--- a/tests/unit/enums/test_enum_normalization_family.py
+++ b/tests/unit/enums/test_enum_normalization_family.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for EnumNormalizationFamily enum (OMN-9759).
+
+Phase 1 of the corpus classification and normalization layer
+(parent epic OMN-9757). EnumNormalizationFamily classifies the family
+of contract migrations being applied during normalization.
+"""
+
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_normalization_family import EnumNormalizationFamily
+
+
+@pytest.mark.unit
+class TestEnumNormalizationFamily:
+    """Test cases for EnumNormalizationFamily enum."""
+
+    def test_top_families_present(self) -> None:
+        """Required top-level migration families are present (per plan spec)."""
+        required = {
+            "family_legacy_input_output_model",
+            "family_legacy_event_bus",
+            "family_legacy_metadata",
+            "family_legacy_handler_routing",
+            "family_required_now_optional",
+            "family_misc_extra_fields",
+            "family_handler_block",
+            "family_descriptor_block",
+            "family_terminal_event",
+            "family_event_schema_evolution",
+            "family_state_machine",
+            "family_dod_evidence_schema",
+            "family_custom_validator",
+            "family_node_type_alias",
+        }
+        actual = {f.value for f in EnumNormalizationFamily}
+        assert required.issubset(actual)
+
+    def test_member_count_is_fourteen(self) -> None:
+        """Acceptance criterion: exactly 14 members."""
+        assert len(list(EnumNormalizationFamily)) == 14
+
+    def test_enum_inheritance(self) -> None:
+        """Inherits from str and Enum (canonical pattern)."""
+        assert issubclass(EnumNormalizationFamily, str)
+        assert issubclass(EnumNormalizationFamily, Enum)
+
+    def test_enum_string_behavior(self) -> None:
+        """Members behave as strings."""
+        family = EnumNormalizationFamily.FAMILY_LEGACY_INPUT_OUTPUT_MODEL
+        assert isinstance(family, str)
+        assert family == "family_legacy_input_output_model"
+
+    def test_enum_membership(self) -> None:
+        """Membership lookup by value."""
+        assert "family_legacy_event_bus" in EnumNormalizationFamily
+        assert "family_does_not_exist" not in EnumNormalizationFamily
+
+    def test_enum_deserialization(self) -> None:
+        """Constructible from value string."""
+        family = EnumNormalizationFamily("family_state_machine")
+        assert family is EnumNormalizationFamily.FAMILY_STATE_MACHINE
+
+    def test_enum_invalid_value_raises(self) -> None:
+        """Invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            EnumNormalizationFamily("family_invalid")
+
+    def test_exported_from_enums_package(self) -> None:
+        """Enum is re-exported from omnibase_core.enums."""
+        from omnibase_core import enums
+
+        assert hasattr(enums, "EnumNormalizationFamily")
+        assert enums.EnumNormalizationFamily is EnumNormalizationFamily
+        assert "EnumNormalizationFamily" in enums.__all__

--- a/tests/unit/enums/test_enum_normalization_family.py
+++ b/tests/unit/enums/test_enum_normalization_family.py
@@ -57,8 +57,9 @@ class TestEnumNormalizationFamily:
 
     def test_enum_membership(self) -> None:
         """Membership lookup by value."""
-        assert "family_legacy_event_bus" in EnumNormalizationFamily
-        assert "family_does_not_exist" not in EnumNormalizationFamily
+        values = {member.value for member in EnumNormalizationFamily}
+        assert "family_legacy_event_bus" in values
+        assert "family_does_not_exist" not in values
 
     def test_enum_deserialization(self) -> None:
         """Constructible from value string."""


### PR DESCRIPTION
## Summary

Phase 1 (Task 2) of the **corpus classification and normalization layer** (parent epic [OMN-9757](https://linear.app/omninode/issue/OMN-9757)).

Adds `EnumNormalizationFamily` — a 14-member str-Enum that classifies the family of contract migration being applied during normalization. The migration audit can now group, count, and report findings by family.

Pure additive change:
- Net: 3 files changed, 135 insertions, 0 deletions
- New file: `src/omnibase_core/enums/enum_normalization_family.py`
- Modified: `src/omnibase_core/enums/__init__.py` (re-export + `__all__` entry)
- New test: `tests/unit/enums/test_enum_normalization_family.py`
- No call sites yet (introduced by later tickets in the epic)

## Ticket

- Linear: [OMN-9759](https://linear.app/omninode/issue/OMN-9759)
- Parent epic: [OMN-9757](https://linear.app/omninode/issue/OMN-9757)
- Plan: `docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md` (Task 2)

## Acceptance Criteria

- [x] Exactly 14 members covering all documented families including `FAMILY_NODE_TYPE_ALIAS` (EFFECT/COMPUTE/REDUCER bare aliases)
- [x] Exported from `enums/__init__.py` and listed in `__all__`
- [x] Required unit test (`test_top_families_present`) passes
- [x] Member naming follows local UPPER_SNAKE_CASE convention enforced by `check-enum-member-casing` pre-commit hook (string `value` matches the lowercase identifier from the plan spec verbatim, so external callers using `EnumNormalizationFamily("family_state_machine")` work unchanged)

## DoD Evidence

OMN-9759 dod_evidence (from ticket contract):
1. **unit_test**: `uv run pytest omnibase_core/tests/unit/enums/test_enum_normalization_family.py -v` — expected `1 passed`, actual **8 passed** (plan's required test plus 7 additional invariants)
2. **file_exists**: `omnibase_core/src/omnibase_core/enums/enum_normalization_family.py` — created

Additional verification:
- `pre-commit run --files <changed>` on all 3 files → every ONEX hook passes (SPDX, single-class, enum-member-casing, governance, etc.)
- `mypy --strict` on the new enum file → no issues
- `pytest tests/unit/enums/` (full enum module regression, 3920 tests) → all green

## Test plan

- [x] `uv run pytest tests/unit/enums/test_enum_normalization_family.py -v` (target test, 8 passed)
- [x] `uv run pytest tests/unit/enums/` (regression on whole enum module, 3920 passed)
- [x] `uv run ruff format` + `uv run ruff check` on changed files
- [x] `uv run mypy --strict` on new enum file
- [x] `pre-commit run --files <changed>` (full hook set passes)
- [ ] CI green (`gh pr checks --watch`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enumeration for normalization family identifiers covering 14 different contract normalization categories.

* **Tests**
  * Added comprehensive unit tests for the new normalization family enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->