### PR TITLE
feat(OMN-9763): add normalize_io_model_ref — dict-shape to dotted-string

### DIFF
--- a/src/omnibase_core/normalization/__init__.py
+++ b/src/omnibase_core/normalization/__init__.py
@@ -13,7 +13,14 @@ per-function docstrings for what is dropped or rewritten.
 
 from __future__ import annotations
 
-from omnibase_core.normalization.contract_normalizer import strip_legacy_metadata
+from omnibase_core.normalization.contract_normalizer import (
+    normalize_io_model_ref,
+    strip_legacy_metadata,
+)
 from omnibase_core.normalization.corpus_classifier import classify_contract_path
 
-__all__ = ["classify_contract_path", "strip_legacy_metadata"]
+__all__ = [
+    "classify_contract_path",
+    "normalize_io_model_ref",
+    "strip_legacy_metadata",
+]

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Contract normalizer functions (OMN-9761, Phase 2 Task 4).
+"""Contract normalizer functions (OMN-9761, OMN-9763).
 
 Each function in this module is a pure dict→dict transform that takes a
 raw legacy contract dict (parsed YAML) and returns a new dict closer to
@@ -14,6 +14,8 @@ migrations. Content that is dropped here (e.g. ``metadata.author``)
 must be captured by the caller before normalization runs if it needs
 to be retained.
 """
+
+from __future__ import annotations
 
 from collections.abc import Mapping
 
@@ -45,3 +47,38 @@ def strip_legacy_metadata(raw: Mapping[str, object]) -> dict[str, object]:
         the raw dict before calling this function if it must be retained.
     """
     return {k: v for k, v in raw.items() if k not in _LEGACY_METADATA_KEYS}
+
+
+def _normalize_single_io_ref(value: dict[str, object] | str | None) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    module = str(value.get("module", "") or "")
+    name = str(value.get("name", "") or "")
+    if module and name:
+        return f"{module}.{name}"
+    return module or name or None
+
+
+def normalize_io_model_ref(raw: dict[str, object]) -> dict[str, object]:
+    """Convert dict-shaped ``input_model``/``output_model`` refs to dotted-string canonical form.
+
+    Legacy contracts often expressed model references as
+    ``{"name": "ModelFooRequest", "module": "foo.bar.models"}``. The canonical
+    typed contract model expects a single dotted string ``"foo.bar.models.ModelFooRequest"``.
+
+    Behavior:
+    - ``{name: X, module: Y}`` -> ``"Y.X"``
+    - String passthrough unchanged
+    - Missing field not injected
+    - Does not mutate input; idempotent
+    """
+    result = dict(raw)
+    for field in ("input_model", "output_model"):
+        if field not in result:
+            continue
+        value = result[field]
+        if value is None or isinstance(value, (str, dict)):
+            normalized = _normalize_single_io_ref(value)
+            if normalized is not None:
+                result[field] = normalized
+    return result

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -52,11 +52,11 @@ def strip_legacy_metadata(raw: Mapping[str, object]) -> dict[str, object]:
 def _normalize_single_io_ref(value: dict[str, object] | str | None) -> str | None:
     if value is None or isinstance(value, str):
         return value
-    module = str(value.get("module", "") or "")
-    name = str(value.get("name", "") or "")
-    if module and name:
+    module = value.get("module")
+    name = value.get("name")
+    if isinstance(module, str) and isinstance(name, str) and module and name:
         return f"{module}.{name}"
-    return module or name or None
+    return None
 
 
 def normalize_io_model_ref(raw: dict[str, object]) -> dict[str, object]:

--- a/tests/unit/normalization/test_contract_normalizer.py
+++ b/tests/unit/normalization/test_contract_normalizer.py
@@ -117,3 +117,31 @@ def test_idempotent() -> None:
     twice = normalize_io_model_ref(once)
     assert once == twice
     assert twice["input_model"] == "bar.Foo"
+
+
+@pytest.mark.unit
+def test_incomplete_dict_module_only_preserved() -> None:
+    raw: dict[str, object] = {"input_model": {"module": "foo.bar.models"}}
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == {"module": "foo.bar.models"}
+
+
+@pytest.mark.unit
+def test_incomplete_dict_name_only_preserved() -> None:
+    raw: dict[str, object] = {"input_model": {"name": "ModelFooRequest"}}
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == {"name": "ModelFooRequest"}
+
+
+@pytest.mark.unit
+def test_dict_with_empty_module_preserved() -> None:
+    raw: dict[str, object] = {"input_model": {"name": "ModelFoo", "module": ""}}
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == {"name": "ModelFoo", "module": ""}
+
+
+@pytest.mark.unit
+def test_dict_with_non_string_fields_preserved() -> None:
+    raw: dict[str, object] = {"input_model": {"name": "ModelFoo", "module": 42}}
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == {"name": "ModelFoo", "module": 42}

--- a/tests/unit/normalization/test_contract_normalizer.py
+++ b/tests/unit/normalization/test_contract_normalizer.py
@@ -1,21 +1,23 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for contract_normalizer.strip_legacy_metadata (OMN-9761).
+"""Unit tests for omnibase_core.normalization.contract_normalizer (OMN-9761, OMN-9763).
 
-Phase 2 Task 4 of the corpus classification and normalization layer
-(parent epic OMN-9757). strip_legacy_metadata is a compatibility-stripping
-function: it makes legacy YAML pass canonical validation by removing
-legacy top-level fields (metadata block, contract_name, node_name).
+Covers two compatibility-stripping normalizers:
 
-NOTE: this normalizer is migration scaffolding, not a semantic-preserving
-transform. Callers that need to retain dropped content (e.g. metadata.author)
-must capture it from the raw dict before invoking the normalizer.
+- ``strip_legacy_metadata`` (OMN-9761): removes legacy top-level fields
+  (metadata block, contract_name, node_name) so legacy YAML passes
+  canonical validation. Migration scaffolding, not semantic-preserving.
+- ``normalize_io_model_ref`` (OMN-9763): converts dict-shaped
+  ``input_model``/``output_model`` refs to canonical dotted-string form.
 """
 
 import pytest
 
-from omnibase_core.normalization.contract_normalizer import strip_legacy_metadata
+from omnibase_core.normalization.contract_normalizer import (
+    normalize_io_model_ref,
+    strip_legacy_metadata,
+)
 
 
 @pytest.mark.unit
@@ -62,3 +64,56 @@ class TestStripLegacyMetadata:
         raw_copy = {"name": "foo", "metadata": {"author": "x"}}
         strip_legacy_metadata(raw)
         assert raw == raw_copy
+
+
+@pytest.mark.unit
+def test_dict_shape_to_string() -> None:
+    raw: dict[str, object] = {
+        "name": "node_foo",
+        "input_model": {
+            "name": "ModelFooRequest",
+            "module": "foo.bar.models",
+            "description": "...",
+        },
+        "output_model": {"name": "ModelFooResult", "module": "foo.bar.models"},
+    }
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == "foo.bar.models.ModelFooRequest"
+    assert result["output_model"] == "foo.bar.models.ModelFooResult"
+
+
+@pytest.mark.unit
+def test_string_shape_passthrough() -> None:
+    raw: dict[str, object] = {
+        "name": "node_foo",
+        "input_model": "foo.bar.ModelFooRequest",
+    }
+    result = normalize_io_model_ref(raw)
+    assert result["input_model"] == "foo.bar.ModelFooRequest"
+
+
+@pytest.mark.unit
+def test_missing_field_not_added() -> None:
+    raw: dict[str, object] = {"name": "node_foo"}
+    result = normalize_io_model_ref(raw)
+    assert "input_model" not in result
+    assert "output_model" not in result
+
+
+@pytest.mark.unit
+def test_does_not_mutate_input() -> None:
+    raw: dict[str, object] = {"input_model": {"name": "Foo", "module": "bar"}}
+    raw_copy: dict[str, object] = {
+        "input_model": {"name": "Foo", "module": "bar"},
+    }
+    normalize_io_model_ref(raw)
+    assert raw == raw_copy
+
+
+@pytest.mark.unit
+def test_idempotent() -> None:
+    raw: dict[str, object] = {"input_model": {"name": "Foo", "module": "bar"}}
+    once = normalize_io_model_ref(raw)
+    twice = normalize_io_model_ref(once)
+    assert once == twice
+    assert twice["input_model"] == "bar.Foo"


### PR DESCRIPTION
## Summary

Phase 2 / Task 6 of OMN-9757 (corpus classification + migration normalization layer).

Pure `dict -> dict` transform converting legacy `input_model: {name: X, module: Y}` shape to the canonical dotted string `"Y.X"` form expected by the strict typed contract models (`extra="forbid"`).

- Non-mutating, idempotent
- String passthrough preserved
- Missing field never injected
- Bootstraps `omnibase_core/normalization/` package + `tests/unit/normalization/` for sibling Phase 2 tasks (OMN-9761/9762/9764/9765/9766)

Parent epic: OMN-9757
Plan: docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md (Task 6)

## Test plan

- [x] 5 unit tests pass (`uv run pytest tests/unit/normalization/test_contract_normalizer.py -v`)
- [x] mypy --strict clean (`uv run mypy src/omnibase_core/normalization/ tests/unit/normalization/ --strict`)
- [x] ruff format + check clean
- [x] pre-commit run --all-files passes
- [x] tests/unit/normalization/ + tests/unit/contracts/ — 793 passed locally
- [ ] Full CI green (gh pr checks --watch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contract normalization now standardizes input/output model references, converting structured refs into consistent dotted notation and leaving unsupported or missing values unchanged.

* **Tests**
  * New tests validate normalization behavior, edge cases, immutability, and idempotence to ensure reliable, predictable transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->