### PR TITLE
feat(OMN-9760): add ModelCorpusClassification + corpus_classifier

### DIFF
--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -115,6 +115,7 @@ from .model_contract_orchestrator import ModelContractOrchestrator
 from .model_contract_patch import ModelContractPatch
 from .model_contract_reducer import ModelContractReducer
 from .model_contract_version import ModelContractVersion
+from .model_corpus_classification import ModelCorpusClassification
 
 # Database repository contract models (OMN-1782)
 from .model_db_operation import ModelDbOperation
@@ -204,6 +205,7 @@ __all__ = [
     "ModelContractNodeMetadata",
     "ModelContractNormalizationConfig",
     "ModelContractVersion",
+    "ModelCorpusClassification",
     "ModelDependency",
     "ModelDependencySpec",
     "DependencyType",

--- a/src/omnibase_core/models/contracts/model_corpus_classification.py
+++ b/src/omnibase_core/models/contracts/model_corpus_classification.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelCorpusClassification — pre-validation classification result (OMN-9760, parent OMN-9757).
+
+Output of the corpus classifier (see ``omnibase_core.normalization.corpus_classifier``).
+Records which bucket a contract YAML file maps to before the per-family
+normalization + strict Pydantic validation pipeline runs.
+
+Distinct from:
+    * ``ModelContractLoadResult`` — runtime loader result wrapper
+    * ``ModelCorpusStatistics`` — replay-domain corpus stats
+    * ``ModelContractValidationResult`` — code-generation scoring/feedback
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+
+
+class ModelCorpusClassification(BaseModel):
+    """Classification verdict for a single contract YAML file.
+
+    ``confidence`` is ``None`` when the classification is certain; populated
+    in [0.0, 1.0] when path/shape signals disagree or no glob matched. Path
+    classification is the primary signal — shape inspection adjusts confidence
+    and appends ``reasons`` but never overrides the path-derived bucket.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    path: Path
+    bucket: EnumContractBucket
+    raw_node_type: str | None = None
+    requires_validation: bool
+    reasons: list[str] = Field(default_factory=list)
+    confidence: float | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+__all__ = ["ModelCorpusClassification"]

--- a/src/omnibase_core/normalization/__init__.py
+++ b/src/omnibase_core/normalization/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Corpus classification + per-family normalization layer (OMN-9757).
+
+Pre-validation pipeline that buckets contract YAML files (``corpus_classifier``)
+and applies per-family normalization functions before strict Pydantic
+``model_validate()`` runs against the canonical contract models.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.normalization.corpus_classifier import classify_contract_path
+
+__all__ = ["classify_contract_path"]

--- a/src/omnibase_core/normalization/corpus_classifier.py
+++ b/src/omnibase_core/normalization/corpus_classifier.py
@@ -37,7 +37,6 @@ def classify_contract_path(
         when the classification is ambiguous.
     """
     parts = path.parts
-    path_str = path.as_posix()
     raw_dict: dict[str, object] = raw or {}
     raw_node_type_value = raw_dict.get("node_type")
     raw_node_type: str | None = (
@@ -46,7 +45,7 @@ def classify_contract_path(
     reasons: list[str] = []
     confidence: float | None = None
 
-    if "/integrations/" in path_str:
+    if "integrations" in parts:
         bucket = EnumContractBucket.INTEGRATION_CONTRACT
         reasons.append("matched */integrations/* glob")
     elif "nodes" not in parts:

--- a/src/omnibase_core/normalization/corpus_classifier.py
+++ b/src/omnibase_core/normalization/corpus_classifier.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Corpus classifier — path-based bucket assignment with secondary shape signals.
+
+Maps a contract YAML file path to an ``EnumContractBucket``. Path classification
+is primary; raw-dict shape inspection (when ``raw`` is supplied) acts as a
+secondary signal that adjusts ``confidence`` and appends ``reasons`` but never
+overrides the path-derived bucket.
+
+OMN-9760, parent OMN-9757.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+from omnibase_core.models.contracts.model_corpus_classification import (
+    ModelCorpusClassification,
+)
+
+
+def classify_contract_path(
+    path: Path,
+    raw: dict[str, object] | None = None,
+) -> ModelCorpusClassification:
+    """Classify a contract YAML file by its path with optional shape signals.
+
+    Args:
+        path: Filesystem path to a contract YAML (does not need to exist on disk).
+        raw: Optional already-loaded raw dict to enable secondary shape signals.
+
+    Returns:
+        ModelCorpusClassification with bucket, requires_validation flag,
+        always-non-empty ``reasons`` list, and optional ``confidence`` score
+        when the classification is ambiguous.
+    """
+    parts = path.parts
+    path_str = path.as_posix()
+    raw_dict: dict[str, object] = raw or {}
+    raw_node_type_value = raw_dict.get("node_type")
+    raw_node_type: str | None = (
+        raw_node_type_value if isinstance(raw_node_type_value, str) else None
+    )
+    reasons: list[str] = []
+    confidence: float | None = None
+
+    if "/integrations/" in path_str:
+        bucket = EnumContractBucket.INTEGRATION_CONTRACT
+        reasons.append("matched */integrations/* glob")
+    elif "nodes" not in parts:
+        bucket = EnumContractBucket.PACKAGE_CONTRACT
+        reasons.append("no 'nodes' segment in path")
+    else:
+        nodes_idx = max(i for i, p in enumerate(parts) if p == "nodes")
+        after_nodes = parts[nodes_idx + 1 :]
+        if len(after_nodes) == 2 and after_nodes[-1] == "contract.yaml":
+            bucket = EnumContractBucket.NODE_ROOT_CONTRACT
+            reasons.append("matched */nodes/<name>/contract.yaml glob")
+            if "node_type" in raw_dict:
+                reasons.append("shape contains node_type field (confirms node_root)")
+            elif raw_dict:
+                reasons.append(
+                    "shape missing node_type field (path match, shape mismatch)"
+                )
+                confidence = 0.7
+        elif len(after_nodes) >= 2 and "handlers" in after_nodes:
+            bucket = EnumContractBucket.HANDLER_CONTRACT
+            reasons.append("matched */nodes/*/handlers/* glob")
+            handler_block = raw_dict.get("handler")
+            if isinstance(handler_block, dict) and "class" in handler_block:
+                reasons.append(
+                    "shape contains handler.class block (confirms handler_contract)"
+                )
+        else:
+            bucket = EnumContractBucket.UNKNOWN
+            reasons.append("no glob matched under nodes/ hierarchy")
+            confidence = 0.3
+
+    if not reasons:
+        bucket = EnumContractBucket.UNKNOWN
+        reasons.append("no glob matched")
+        confidence = 0.3
+
+    requires_validation = bucket is EnumContractBucket.NODE_ROOT_CONTRACT
+
+    return ModelCorpusClassification(
+        path=path,
+        bucket=bucket,
+        raw_node_type=raw_node_type,
+        requires_validation=requires_validation,
+        reasons=reasons,
+        confidence=confidence,
+    )
+
+
+__all__ = ["classify_contract_path"]

--- a/tests/unit/normalization/__init__.py
+++ b/tests/unit/normalization/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/normalization/test_corpus_classifier.py
+++ b/tests/unit/normalization/test_corpus_classifier.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for corpus_classifier.classify_contract_path (OMN-9760, parent OMN-9757).
+
+Validates path-based bucket assignment with secondary shape signals per the
+corpus-classification-and-normalization plan:
+
+* path classification is primary (never overridden by shape)
+* ``reasons`` is always non-empty
+* ``confidence`` is None for certain classifications, < 0.5 for unknown-path
+  fallback, 0.7 when path matches but raw shape is missing expected fields
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+from omnibase_core.models.contracts.model_corpus_classification import (
+    ModelCorpusClassification,
+)
+from omnibase_core.normalization.corpus_classifier import classify_contract_path
+
+
+@pytest.mark.unit
+class TestBucketAssignment:
+    """Path globs map to the correct bucket."""
+
+    def test_node_root_contract_bucket(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.NODE_ROOT_CONTRACT
+        assert len(result.reasons) > 0
+
+    def test_handler_contract_bucket(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo/handlers/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.HANDLER_CONTRACT
+        assert len(result.reasons) > 0
+
+    def test_integration_contract_bucket(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/integrations/github_webhook/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.INTEGRATION_CONTRACT
+        assert len(result.reasons) > 0
+
+    def test_package_contract_not_under_nodes(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/contracts/verification/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.PACKAGE_CONTRACT
+        assert len(result.reasons) > 0
+
+
+@pytest.mark.unit
+class TestRequiresValidation:
+    """``requires_validation`` is True only for node_root_contract."""
+
+    def test_node_root_returns_requires_validation_true(self) -> None:
+        path = Path("omniclaude/src/omniclaude/nodes/node_bar_compute/contract.yaml")
+        result = classify_contract_path(path)
+        assert result.requires_validation is True
+        assert len(result.reasons) > 0
+
+    def test_non_node_bucket_skips_validation(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/integrations/github_webhook/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.requires_validation is False
+        assert len(result.reasons) > 0
+
+    def test_handler_contract_skips_validation(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo/handlers/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.requires_validation is False
+
+
+@pytest.mark.unit
+class TestRawNodeTypeExtraction:
+    """``raw_node_type`` is populated when a raw dict is provided."""
+
+    def test_node_type_extracted_from_raw(self) -> None:
+        raw = {"node_type": "EFFECT", "name": "node_foo_effect"}
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path, raw=raw)
+        assert result.raw_node_type == "EFFECT"
+
+    def test_no_raw_dict_yields_none_node_type(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.raw_node_type is None
+
+    def test_non_string_node_type_returns_none(self) -> None:
+        raw: dict[str, object] = {"node_type": 42, "name": "node_x"}
+        path = Path("omnibase_infra/src/omnibase_infra/nodes/node_x/contract.yaml")
+        result = classify_contract_path(path, raw=raw)
+        assert result.raw_node_type is None
+
+
+@pytest.mark.unit
+class TestConfidenceAndReasons:
+    """Confidence + reasons signal classification quality."""
+
+    def test_confidence_none_for_certain_classification(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.confidence is None
+
+    def test_confidence_set_for_unknown_path(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo/oddly/nested/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.UNKNOWN
+        assert result.confidence is not None
+        assert result.confidence < 0.5
+
+    def test_shape_signal_adds_reason(self) -> None:
+        raw = {"node_type": "EFFECT_GENERIC", "name": "node_foo_effect"}
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path, raw=raw)
+        assert any("node_type" in r for r in result.reasons)
+
+    def test_path_match_shape_mismatch_lowers_confidence(self) -> None:
+        raw = {"name": "node_foo_effect"}  # node_type missing
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path, raw=raw)
+        assert result.bucket is EnumContractBucket.NODE_ROOT_CONTRACT
+        assert result.confidence == 0.7
+
+    def test_handler_class_block_adds_reason(self) -> None:
+        raw = {"handler": {"class": "HandlerFoo"}}
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo/handlers/contract.yaml"
+        )
+        result = classify_contract_path(path, raw=raw)
+        assert any("handler.class" in r for r in result.reasons)
+
+
+@pytest.mark.unit
+class TestModelCorpusClassificationStructure:
+    """The returned model is the canonical Pydantic v2 type."""
+
+    def test_returns_model_corpus_classification(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        assert isinstance(result, ModelCorpusClassification)
+
+    def test_model_is_frozen(self) -> None:
+        path = Path(
+            "omnibase_infra/src/omnibase_infra/nodes/node_foo_effect/contract.yaml"
+        )
+        result = classify_contract_path(path)
+        with pytest.raises(Exception):
+            result.bucket = EnumContractBucket.UNKNOWN  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelCorpusClassification(
+                path=Path("a/b/contract.yaml"),
+                bucket=EnumContractBucket.UNKNOWN,
+                requires_validation=False,
+                bogus_field="x",  # type: ignore[call-arg]
+            )

--- a/tests/unit/normalization/test_corpus_classifier.py
+++ b/tests/unit/normalization/test_corpus_classifier.py
@@ -53,6 +53,11 @@ class TestBucketAssignment:
         assert result.bucket is EnumContractBucket.INTEGRATION_CONTRACT
         assert len(result.reasons) > 0
 
+    def test_integration_contract_bucket_relative_path(self) -> None:
+        path = Path("integrations/github_webhook/contract.yaml")
+        result = classify_contract_path(path)
+        assert result.bucket is EnumContractBucket.INTEGRATION_CONTRACT
+
     def test_package_contract_not_under_nodes(self) -> None:
         path = Path(
             "omnibase_infra/src/omnibase_infra/contracts/verification/contract.yaml"
@@ -177,7 +182,7 @@ class TestModelCorpusClassificationStructure:
         )
         result = classify_contract_path(path)
         with pytest.raises(Exception):
-            result.bucket = EnumContractBucket.UNKNOWN  # type: ignore[misc]
+            result.bucket = EnumContractBucket.UNKNOWN  # type: ignore[misc]  # NOTE(OMN-9760): intentional mutation attempt to verify frozen model
 
     def test_extra_fields_forbidden(self) -> None:
         from pydantic import ValidationError
@@ -187,5 +192,5 @@ class TestModelCorpusClassificationStructure:
                 path=Path("a/b/contract.yaml"),
                 bucket=EnumContractBucket.UNKNOWN,
                 requires_validation=False,
-                bogus_field="x",  # type: ignore[call-arg]
+                bogus_field="x",  # type: ignore[call-arg]  # NOTE(OMN-9760): intentional extra field to verify extra="forbid"
             )


### PR DESCRIPTION
## Summary

Adds `ModelCorpusClassification` and `corpus_classifier` — Phase 1 (Task 3) of the corpus-classification-and-normalization plan (parent **OMN-9757**, this ticket **OMN-9760**).

Builds on:
- **OMN-9758** (PR #913, merged) — `EnumContractBucket`
- **OMN-9759** (PR #914, merged) — `EnumNormalizationFamily`

Pure additive layer. No consumers wired yet; `classify_contract_path()` will be invoked by the per-family normalization pipeline (Task 4-10) and the dual-mode validator (Task 11+, OMN-9768).

## What lands

- `ModelCorpusClassification` (frozen, `extra=forbid`) under `src/omnibase_core/models/contracts/`, exported from the `contracts` package
- `omnibase_core.normalization` subpackage with `classify_contract_path()`
- 18 unit tests covering bucket assignment, `requires_validation` flag, `raw_node_type` extraction, confidence scoring, reasons generation, and Pydantic frozen/extra-forbid invariants

## Classifier design

- **Path is primary signal.** Raw-dict shape inspection (when supplied) is secondary — it adjusts `confidence` and appends to `reasons` but never overrides the path-derived bucket.
- `reasons: list[str]` always non-empty.
- `confidence: float | None` — `None` when certain; `< 0.5` for unknown-path fallback; `0.7` when the path matches but raw shape lacks expected fields (e.g., node-root path but no `node_type`).
- `requires_validation` is `True` only for `NODE_ROOT_CONTRACT` bucket.

Per the plan's "classifier strengthening" note (lines 144-160 of `docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md`).

## Plan reference

- Plan: `docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md` (Task 3)
- Parent epic: OMN-9757
- Phase: 1

## dod_evidence

- **unit_test**: `uv run pytest tests/unit/normalization/test_corpus_classifier.py -v` → 18 passed
- **file_exists**: `src/omnibase_core/normalization/corpus_classifier.py`
- **file_exists**: `src/omnibase_core/models/contracts/model_corpus_classification.py`
- **module_export**: `ModelCorpusClassification` re-exported from `omnibase_core.models.contracts`

## Test plan

- [x] 18 unit tests pass for `corpus_classifier` (bucket assignment, requires_validation, raw_node_type, confidence + reasons, structure)
- [x] mypy --strict clean on new files (no explicit Any)
- [x] pre-commit hooks pass on touched files (SPDX, single-class, enum casing, Pydantic conventions, etc.)
- [ ] CI green across all 40 splits + receipt-gate + PR-title-check

Closes OMN-9760.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced contract path classification functionality that categorizes contract YAML files into appropriate buckets (integrations, packages, node roots, handlers, unknown) and provides validation requirements, diagnostic reasons, and confidence scores for classification results.

* **Tests**
  * Added comprehensive test suite validating the path classification system, covering bucket assignment accuracy, validation requirement flags, confidence scoring logic, raw shape detection, model immutability, and field constraints enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->