### PR TITLE
feat(OMN-9776): wire backend_overrides['event_bus']='kafka' through RuntimeLocal

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -20,6 +20,7 @@ __all__ = ["RuntimeLocal"]
 
 import asyncio
 import importlib
+import importlib.metadata
 import inspect
 import json
 import logging
@@ -39,9 +40,22 @@ from omnibase_core.models.errors.model_onex_error import ModelOnexError
 logger = logging.getLogger(__name__)
 
 # Known backend protocol keys that --backend can override.
+# kafka_bootstrap is a Kafka-specific tuning knob: when ``event_bus=kafka`` is
+# selected, callers may pass ``--backend kafka_bootstrap=host:port`` to override
+# the default bootstrap server (otherwise read from ``KAFKA_BOOTSTRAP_SERVERS``
+# env var or ``ModelKafkaEventBusConfig`` defaults).
 KNOWN_BACKEND_KEYS: frozenset[str] = frozenset(
-    {"event_bus", "state_store", "metrics", "tracing"}
+    {"event_bus", "state_store", "metrics", "tracing", "kafka_bootstrap"}
 )
+
+# Entry-point group that backend providers (e.g. omnibase_infra) register under.
+# omnibase_core MUST NOT import omnibase_infra directly (compat→core→spi→infra
+# layering is enforced by sdk-boundary-check CI). Instead, when the runtime
+# needs a non-default bus implementation it discovers the class via this
+# ``importlib.metadata`` group, which omnibase_infra populates in its
+# ``[project.entry-points."onex.backends"]`` table.
+_BACKEND_ENTRY_POINT_GROUP: str = "onex.backends"
+_KAFKA_EVENT_BUS_ENTRY_POINT: str = "event_bus_kafka"
 
 
 @dataclass(frozen=True)
@@ -1006,6 +1020,124 @@ class RuntimeLocal:
         )
 
     # ------------------------------------------------------------------
+    # Event bus construction
+    # ------------------------------------------------------------------
+
+    def _create_event_bus(self) -> Any:
+        """Construct the event bus implementation requested by ``backend_overrides``.
+
+        Default behavior (no override or ``event_bus`` not set) returns
+        ``EventBusInmemory(environment="local", group="runtime-local")`` —
+        identical to the pre-OMN-9776 hardcoded path.
+
+        When ``backend_overrides['event_bus'] == 'kafka'``, the bus class is
+        discovered via the ``onex.backends`` entry-point group (omnibase_infra
+        registers ``event_bus_kafka`` there). This indirection is mandatory:
+        omnibase_core cannot import omnibase_infra directly (compat→core→spi→infra
+        layering, enforced by sdk-boundary-check CI).
+
+        The Kafka bus is instantiated through its ``default()`` factory, which
+        applies ``KAFKA_BOOTSTRAP_SERVERS`` env var overrides. When
+        ``backend_overrides['kafka_bootstrap']`` is also supplied, it takes
+        precedence over the env var and over the default.
+
+        Raises:
+            ModelOnexError: If ``event_bus=kafka`` is requested but the
+                ``onex.backends:event_bus_kafka`` entry point is not installed
+                or fails to load — fail-fast rather than silently downgrading
+                to in-memory.
+        """
+        bus_kind = self.backend_overrides.get("event_bus", "inmemory")
+
+        if bus_kind == "kafka":
+            return self._create_kafka_event_bus()
+
+        from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+
+        bus = EventBusInmemory(environment="local", group="runtime-local")
+        logger.info("RuntimeLocal: event bus selected (inmemory)")
+        return bus
+
+    def _create_kafka_event_bus(self) -> Any:
+        """Discover and instantiate the Kafka event bus via entry points.
+
+        The provider (omnibase_infra) registers
+        ``event_bus_kafka = "omnibase_infra.event_bus.event_bus_kafka:EventBusKafka"``
+        under the ``onex.backends`` group. We look it up by name, instantiate
+        through ``EventBusKafka.default()`` (which resolves
+        ``KAFKA_BOOTSTRAP_SERVERS``), and apply a ``kafka_bootstrap`` override
+        when provided.
+        """
+        backend_eps = importlib.metadata.entry_points().select(
+            group=_BACKEND_ENTRY_POINT_GROUP
+        )
+
+        kafka_ep = next(
+            (ep for ep in backend_eps if ep.name == _KAFKA_EVENT_BUS_ENTRY_POINT),
+            None,
+        )
+        if kafka_ep is None:
+            msg = (
+                "Requested event_bus=kafka but no entry point named "
+                f"'{_KAFKA_EVENT_BUS_ENTRY_POINT}' is registered under "
+                f"'{_BACKEND_ENTRY_POINT_GROUP}'. Install omnibase-infra to "
+                "provide EventBusKafka."
+            )
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.CONFIGURATION_ERROR,
+                message=msg,
+            )
+
+        try:
+            bus_cls = kafka_ep.load()
+        except (ImportError, AttributeError, ModuleNotFoundError) as exc:
+            msg = (
+                f"Failed to load Kafka event bus entry point "
+                f"'{_KAFKA_EVENT_BUS_ENTRY_POINT}' from "
+                f"'{_BACKEND_ENTRY_POINT_GROUP}': {exc}"
+            )
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.CONFIGURATION_ERROR,
+                message=msg,
+            ) from exc
+
+        try:
+            default_factory = bus_cls.default
+        except AttributeError as exc:
+            msg = (
+                f"Kafka event bus class {bus_cls!r} has no default() factory; "
+                "cannot construct from RuntimeLocal."
+            )
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.CONFIGURATION_ERROR,
+                message=msg,
+            ) from exc
+
+        # ``default()`` reads ``KAFKA_BOOTSTRAP_SERVERS`` via
+        # ``apply_environment_overrides``. Surface ``--backend kafka_bootstrap=...``
+        # by setting that env var for the duration of construction so we do not
+        # reach into private attributes of the Kafka bus instance.
+        bootstrap_override = self.backend_overrides.get("kafka_bootstrap")
+        prior_env = os.environ.get("KAFKA_BOOTSTRAP_SERVERS")
+        try:
+            if bootstrap_override is not None:
+                os.environ["KAFKA_BOOTSTRAP_SERVERS"] = bootstrap_override
+            bus = default_factory()
+        finally:
+            if bootstrap_override is not None:
+                if prior_env is None:
+                    os.environ.pop("KAFKA_BOOTSTRAP_SERVERS", None)
+                else:
+                    os.environ["KAFKA_BOOTSTRAP_SERVERS"] = prior_env
+
+        logger.info(
+            "RuntimeLocal: event bus selected (kafka, bootstrap=%s)",
+            bootstrap_override
+            or os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "<default>"),
+        )
+        return bus
+
+    # ------------------------------------------------------------------
     # Main entry point
     # ------------------------------------------------------------------
 
@@ -1062,12 +1194,9 @@ class RuntimeLocal:
             terminal_topic,
         )
 
-        # 2. Create in-memory event bus
-        from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
-
-        bus = EventBusInmemory(environment="local", group="runtime-local")
+        # 2. Create event bus per backend_overrides (default: in-memory).
+        bus = self._create_event_bus()
         await bus.start()
-        logger.info("RuntimeLocal: event bus started (inmemory)")
 
         # 3. Dispatch to appropriate execution path
         try:

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -57,6 +57,14 @@ KNOWN_BACKEND_KEYS: frozenset[str] = frozenset(
 _BACKEND_ENTRY_POINT_GROUP: str = "onex.backends"
 _KAFKA_EVENT_BUS_ENTRY_POINT: str = "event_bus_kafka"
 
+# Whitelist of accepted ``backend_overrides['event_bus']`` values. Anything
+# outside this set is a typo (e.g. ``event_bus=kafak``) or a misconfigured
+# stack and is rejected with ``CONFIGURATION_ERROR`` rather than silently
+# downgrading to the in-memory bus. ``inmemory`` and the in-tree default
+# (no override) both resolve to ``EventBusInmemory``; ``kafka`` resolves via
+# the ``onex.backends`` entry-point group.
+SUPPORTED_EVENT_BUS_VALUES: frozenset[str] = frozenset({"inmemory", "kafka"})
+
 
 @dataclass(frozen=True)
 class _ResolvedRoutingEntry:
@@ -1026,9 +1034,9 @@ class RuntimeLocal:
     def _create_event_bus(self) -> Any:
         """Construct the event bus implementation requested by ``backend_overrides``.
 
-        Default behavior (no override or ``event_bus`` not set) returns
-        ``EventBusInmemory(environment="local", group="runtime-local")`` —
-        identical to the pre-OMN-9776 hardcoded path.
+        Default behavior (no override or explicit ``event_bus=inmemory``)
+        returns ``EventBusInmemory(environment="local", group="runtime-local")``
+        — identical to the pre-OMN-9776 hardcoded path.
 
         When ``backend_overrides['event_bus'] == 'kafka'``, the bus class is
         discovered via the ``onex.backends`` entry-point group (omnibase_infra
@@ -1041,13 +1049,30 @@ class RuntimeLocal:
         ``backend_overrides['kafka_bootstrap']`` is also supplied, it takes
         precedence over the env var and over the default.
 
+        Any other value (``"kafak"``, ``"redis"``, etc.) is rejected up-front:
+        silent fallback to in-memory hides typos and misconfigured stacks, and
+        running with the wrong backend is a far more dangerous failure mode
+        than a clear startup error.
+
         Raises:
-            ModelOnexError: If ``event_bus=kafka`` is requested but the
-                ``onex.backends:event_bus_kafka`` entry point is not installed
-                or fails to load — fail-fast rather than silently downgrading
-                to in-memory.
+            ModelOnexError: If ``event_bus`` is set to a value not in
+                ``SUPPORTED_EVENT_BUS_VALUES``. Also raised if ``event_bus=kafka``
+                is requested but the ``onex.backends:event_bus_kafka`` entry
+                point is not installed or fails to load — fail-fast rather
+                than silently downgrading to in-memory.
         """
         bus_kind = self.backend_overrides.get("event_bus", "inmemory")
+
+        if bus_kind not in SUPPORTED_EVENT_BUS_VALUES:
+            sorted_values = ", ".join(sorted(SUPPORTED_EVENT_BUS_VALUES))
+            msg = (
+                f"Unsupported backend override event_bus={bus_kind!r}. "
+                f"Supported values: {sorted_values}."
+            )
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.CONFIGURATION_ERROR,
+                message=msg,
+            )
 
         if bus_kind == "kafka":
             return self._create_kafka_event_bus()

--- a/tests/unit/runtime/test_runtime_local_event_bus_override.py
+++ b/tests/unit/runtime/test_runtime_local_event_bus_override.py
@@ -7,6 +7,8 @@ Covers ``RuntimeLocal._create_event_bus`` selection logic:
 - default (no override) returns ``EventBusInmemory``
 - ``event_bus=kafka`` discovers the entry point under ``onex.backends`` and
   instantiates the registered class via its ``default()`` factory
+- unsupported ``event_bus`` values are rejected up-front (no silent fallback,
+  per CodeRabbit MAJOR finding on PR #919)
 - missing entry point raises ``ModelOnexError`` (fail-fast, no silent fallback)
 - ``kafka_bootstrap`` override is surfaced via ``KAFKA_BOOTSTRAP_SERVERS`` env
   for the duration of construction and restored afterward
@@ -27,6 +29,7 @@ from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.runtime.runtime_local import (
     KNOWN_BACKEND_KEYS,
+    SUPPORTED_EVENT_BUS_VALUES,
     RuntimeLocal,
     parse_backend_overrides,
 )
@@ -89,6 +92,67 @@ def test_create_event_bus_explicit_inmemory(workflow_path: Path) -> None:
     )
     bus = runtime._create_event_bus()
     assert isinstance(bus, EventBusInmemory)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported event_bus values are rejected (no silent fallback) — CR MAJOR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_supported_event_bus_values_set() -> None:
+    """Whitelist matches the documented contract."""
+    assert frozenset({"inmemory", "kafka"}) == SUPPORTED_EVENT_BUS_VALUES
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_value",
+    ["kafak", "redis", "rabbitmq", "Kafka", "KAFKA", "in-memory", "", " "],
+)
+def test_create_event_bus_rejects_unsupported_value(
+    workflow_path: Path, bad_value: str
+) -> None:
+    """Typo or unsupported backend name fails fast — does NOT silently fall through to in-memory."""
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": bad_value},
+    )
+
+    with pytest.raises(ModelOnexError) as exc_info:
+        runtime._create_event_bus()
+
+    assert exc_info.value.error_code == EnumCoreErrorCode.CONFIGURATION_ERROR
+    # Error message must name the offending value AND list the supported set
+    # so operators can fix the typo without grepping the source.
+    assert repr(bad_value) in str(exc_info.value) or bad_value in str(exc_info.value)
+    assert "inmemory" in str(exc_info.value)
+    assert "kafka" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_create_event_bus_rejection_does_not_invoke_kafka_path(
+    workflow_path: Path,
+) -> None:
+    """Bad value must be caught BEFORE entry-point lookup runs."""
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafak"},  # typo for kafka
+    )
+
+    fake_eps = MagicMock()
+    fake_eps.select = MagicMock(return_value=[])
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        with pytest.raises(ModelOnexError):
+            runtime._create_event_bus()
+
+    # If the rejection short-circuits correctly, entry-point lookup is never
+    # invoked (proves the validation runs before the kafka dispatcher).
+    fake_eps.select.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_runtime_local_event_bus_override.py
+++ b/tests/unit/runtime/test_runtime_local_event_bus_override.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for RuntimeLocal backend_overrides['event_bus'] dispatch (OMN-9776).
+
+Covers ``RuntimeLocal._create_event_bus`` selection logic:
+- default (no override) returns ``EventBusInmemory``
+- ``event_bus=kafka`` discovers the entry point under ``onex.backends`` and
+  instantiates the registered class via its ``default()`` factory
+- missing entry point raises ``ModelOnexError`` (fail-fast, no silent fallback)
+- ``kafka_bootstrap`` override is surfaced via ``KAFKA_BOOTSTRAP_SERVERS`` env
+  for the duration of construction and restored afterward
+- ``parse_backend_overrides`` accepts the ``kafka_bootstrap`` key
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.runtime.runtime_local import (
+    KNOWN_BACKEND_KEYS,
+    RuntimeLocal,
+    parse_backend_overrides,
+)
+
+
+@pytest.fixture
+def workflow_path(tmp_path: Path) -> Path:
+    """A throwaway workflow contract path; never read by these tests."""
+    target = tmp_path / "workflow.yaml"
+    target.write_text("workflow_id: test\n", encoding="utf-8")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# parse_backend_overrides accepts kafka_bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_known_backend_keys_includes_kafka_bootstrap() -> None:
+    assert "kafka_bootstrap" in KNOWN_BACKEND_KEYS
+    assert "event_bus" in KNOWN_BACKEND_KEYS
+
+
+@pytest.mark.unit
+def test_parse_backend_overrides_accepts_kafka_bootstrap() -> None:
+    overrides = parse_backend_overrides(
+        ("event_bus=kafka", "kafka_bootstrap=192.168.86.201:19092")
+    )
+    assert overrides == {
+        "event_bus": "kafka",
+        "kafka_bootstrap": "192.168.86.201:19092",
+    }
+
+
+@pytest.mark.unit
+def test_parse_backend_overrides_rejects_unknown_key() -> None:
+    with pytest.raises(ModelOnexError) as exc_info:
+        parse_backend_overrides(("nonsense=value",))
+    assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_INPUT
+
+
+# ---------------------------------------------------------------------------
+# Default behavior unchanged: in-memory bus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_event_bus_default_is_inmemory(workflow_path: Path) -> None:
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    bus = runtime._create_event_bus()
+    assert isinstance(bus, EventBusInmemory)
+
+
+@pytest.mark.unit
+def test_create_event_bus_explicit_inmemory(workflow_path: Path) -> None:
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "inmemory"},
+    )
+    bus = runtime._create_event_bus()
+    assert isinstance(bus, EventBusInmemory)
+
+
+# ---------------------------------------------------------------------------
+# event_bus=kafka — entry-point dispatch
+# ---------------------------------------------------------------------------
+
+
+class _StubKafkaBus:
+    """Stand-in for omnibase_infra.EventBusKafka for unit-test isolation."""
+
+    def __init__(self) -> None:
+        self.bootstrap_seen: str | None = os.environ.get("KAFKA_BOOTSTRAP_SERVERS")
+
+    @classmethod
+    def default(cls) -> _StubKafkaBus:
+        return cls()
+
+
+def _stub_entry_points_with_kafka(stub_cls: type) -> Any:
+    """Build a fake importlib.metadata.entry_points() result returning *stub_cls*."""
+    fake_ep = MagicMock()
+    fake_ep.name = "event_bus_kafka"
+    fake_ep.load = MagicMock(return_value=stub_cls)
+
+    container = MagicMock()
+    container.select = MagicMock(return_value=[fake_ep])
+    return container
+
+
+@pytest.mark.unit
+def test_create_event_bus_kafka_uses_entry_point(workflow_path: Path) -> None:
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafka"},
+    )
+    fake_eps = _stub_entry_points_with_kafka(_StubKafkaBus)
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        bus = runtime._create_event_bus()
+
+    assert isinstance(bus, _StubKafkaBus)
+    fake_eps.select.assert_called_once_with(group="onex.backends")
+
+
+@pytest.mark.unit
+def test_create_event_bus_kafka_missing_entry_point_raises(
+    workflow_path: Path,
+) -> None:
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafka"},
+    )
+    empty_container = MagicMock()
+    empty_container.select = MagicMock(return_value=[])
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=empty_container,
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            runtime._create_event_bus()
+
+    assert exc_info.value.error_code == EnumCoreErrorCode.CONFIGURATION_ERROR
+
+
+@pytest.mark.unit
+def test_create_event_bus_kafka_load_failure_raises(workflow_path: Path) -> None:
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafka"},
+    )
+    bad_ep = MagicMock()
+    bad_ep.name = "event_bus_kafka"
+    bad_ep.load = MagicMock(side_effect=ImportError("no kafka here"))
+
+    container = MagicMock()
+    container.select = MagicMock(return_value=[bad_ep])
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=container,
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            runtime._create_event_bus()
+
+    assert exc_info.value.error_code == EnumCoreErrorCode.CONFIGURATION_ERROR
+
+
+@pytest.mark.unit
+def test_create_event_bus_kafka_no_default_factory_raises(
+    workflow_path: Path,
+) -> None:
+    """Entry point loads to a class without a ``default()`` factory."""
+
+    class _BogusBus:
+        pass
+
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafka"},
+    )
+    fake_eps = _stub_entry_points_with_kafka(_BogusBus)
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            runtime._create_event_bus()
+
+    assert exc_info.value.error_code == EnumCoreErrorCode.CONFIGURATION_ERROR
+
+
+# ---------------------------------------------------------------------------
+# kafka_bootstrap override surfaces via KAFKA_BOOTSTRAP_SERVERS env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_kafka_bootstrap_override_sets_env_for_default_factory(
+    workflow_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={
+            "event_bus": "kafka",
+            "kafka_bootstrap": "192.168.86.201:19092",
+        },
+    )
+    fake_eps = _stub_entry_points_with_kafka(_StubKafkaBus)
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        bus = runtime._create_event_bus()
+
+    assert isinstance(bus, _StubKafkaBus)
+    # _StubKafkaBus.__init__ snapshots os.environ during default() — proves the
+    # override was set when the bus was constructed.
+    assert bus.bootstrap_seen == "192.168.86.201:19092"
+    # Restored afterward (was unset before the call).
+    assert "KAFKA_BOOTSTRAP_SERVERS" not in os.environ
+
+
+@pytest.mark.unit
+def test_kafka_bootstrap_override_restores_prior_env_value(
+    workflow_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "prior:9092")
+
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={
+            "event_bus": "kafka",
+            "kafka_bootstrap": "override:19092",
+        },
+    )
+    fake_eps = _stub_entry_points_with_kafka(_StubKafkaBus)
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        bus = runtime._create_event_bus()
+
+    assert bus.bootstrap_seen == "override:19092"
+    # Prior env value restored after construction.
+    assert os.environ["KAFKA_BOOTSTRAP_SERVERS"] == "prior:9092"
+
+
+@pytest.mark.unit
+def test_kafka_default_path_does_not_touch_env(
+    workflow_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``kafka_bootstrap`` override → env left exactly as-is."""
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "from-env:9092")
+
+    runtime = RuntimeLocal(
+        workflow_path=workflow_path,
+        backend_overrides={"event_bus": "kafka"},
+    )
+    fake_eps = _stub_entry_points_with_kafka(_StubKafkaBus)
+
+    with patch(
+        "omnibase_core.runtime.runtime_local.importlib.metadata.entry_points",
+        return_value=fake_eps,
+    ):
+        bus = runtime._create_event_bus()
+
+    assert bus.bootstrap_seen == "from-env:9092"
+    assert os.environ["KAFKA_BOOTSTRAP_SERVERS"] == "from-env:9092"


### PR DESCRIPTION
## Summary

Completes the half-finished `backend_overrides['event_bus']='kafka'` plumbing in `RuntimeLocal`. The `--backend event_bus=kafka` flag was already accepted by `parse_backend_overrides` (`KNOWN_BACKEND_KEYS` since OMN-7068) but the bus instantiation at `runtime_local.py:1066-1070` was hardcoded to `EventBusInmemory`. This PR wires the conditional.

Linear: OMN-9776 (parent OMN-9775 / W2.5b — paired with OMN-9774 / W2.5a)

## Why entry-point dispatch (not direct import)

`omnibase_core` MUST NOT import `omnibase_infra` (compat → core → spi → infra layering, enforced by `sdk-boundary-check` CI and the `Prevent Kafka/listener APIs in omnibase_core` pre-commit hook). The hook is wired through the existing `onex.backends` `importlib.metadata` entry-point group, which `omnibase_infra/pyproject.toml:127` already populates with `event_bus_kafka = "omnibase_infra.event_bus.event_bus_kafka:EventBusKafka"`. This is the same indirection used by `auto_configure_registry` and `omnibase_infra.backends.auto_configure.select_event_bus`.

## Behavior

| Override                                        | Bus                                                                  |
|-------------------------------------------------|----------------------------------------------------------------------|
| (default / not set / `event_bus=inmemory`)      | `EventBusInmemory(environment="local", group="runtime-local")` — UNCHANGED |
| `event_bus=kafka`                               | Discovers via `onex.backends:event_bus_kafka` → `cls.default()`     |
| `event_bus=kafka, kafka_bootstrap=host:port`    | Same, with `KAFKA_BOOTSTRAP_SERVERS` set for the duration of `default()` (then restored) |

`kafka_bootstrap` is added to `KNOWN_BACKEND_KEYS` for `parse_backend_overrides`.

## Failure modes (explicit, no silent fallback)

- Missing entry point → `ModelOnexError(CONFIGURATION_ERROR)`: "Install omnibase-infra to provide EventBusKafka"
- Entry point `load()` raises ImportError/AttributeError/ModuleNotFoundError → `ModelOnexError(CONFIGURATION_ERROR)`
- Loaded class lacks `default()` factory → `ModelOnexError(CONFIGURATION_ERROR)`

## Why this matters

Unblocks **W2.5b** (OMN-9775) — the CP-E2E-Kafka headline proof in the 2026-04-25 overnight P0 plan. The `omnimarket` E2E test needs `RuntimeLocal + EventBusKafka` to publish a real terminal event over Redpanda on `.201` to the `omnibase_infra` `build_loop_runs` projection consumer.

## Tests

- 12 new unit tests in `tests/unit/runtime/test_runtime_local_event_bus_override.py`
- Default-path runtime suite still 394/394 green (`tests/unit/runtime/`)
- 5197 passing across runtime, container, event_bus, protocols, cli, enums

## Pre-push gates

- [x] `uv run ruff format src/ tests/`
- [x] `uv run ruff check --fix src/ tests/`
- [x] `uv run mypy src/omnibase_core/runtime/runtime_local.py --strict`
- [x] `pre-commit run --all-files` (incl. `Prevent Kafka/listener APIs in omnibase_core`, `sdk-boundary-check`)

## DoD evidence

- file_exists: `tests/unit/runtime/test_runtime_local_event_bus_override.py`
- file_exists: `src/omnibase_core/runtime/runtime_local.py` (`_create_event_bus`, `_create_kafka_event_bus`)
- pr_ci_green: this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime now supports configurable event bus backends, letting you choose in-memory or Kafka implementations.
  * Added Kafka bootstrap server configuration support and ensured the bootstrap setting is applied temporarily during bus initialization (original environment restored).
  * Implemented fail-fast validation with clear errors for missing or invalid event bus configurations.

* **Tests**
  * Added comprehensive tests for backend selection, configuration validation, error cases, and environment restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->