### PR TITLE
feat(OMN-9767): add EnumValidatorMode + ModelCorpusValidationReport

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -413,6 +413,9 @@ from .enum_skill_result_status import EnumSkillResultStatus, SkillResultStatus
 # State update operation enum
 from .enum_state_update_operation import EnumStateUpdateOperation
 
+# Validator mode enum (OMN-9767 — corpus classification/normalization layer Phase 3, parent OMN-9757)
+from .enum_validator_mode import EnumValidatorMode
+
 # Event enums (contract registration - OMN-1651)
 from .events.enum_deregistration_reason import EnumDeregistrationReason
 
@@ -584,6 +587,8 @@ __all__ = [
     "EnumNondeterminismClass",
     # Normalization family (OMN-9759 — corpus classification, parent OMN-9757)
     "EnumNormalizationFamily",
+    # Validator mode (OMN-9767 — corpus classification Phase 3, parent OMN-9757)
+    "EnumValidatorMode",
     # Node domain
     "EnumNodeArchetype",
     "EnumNodeArchitectureType",

--- a/src/omnibase_core/enums/enum_validator_mode.py
+++ b/src/omnibase_core/enums/enum_validator_mode.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validator mode enum (OMN-9767, parent OMN-9757).
+
+Phase 3 of the corpus classification and normalization layer.
+
+Selects the validation mode applied to a contract YAML file:
+
+- ``STRICT``         → enforces all required fields; the gate applied to
+                       new or edited contracts (CI hard fail on missing
+                       required fields).
+- ``MIGRATION_AUDIT`` → relaxed mode used for batch sweeps over the
+                        legacy corpus during normalization; tolerates the
+                        well-known set of historically-optional fields so
+                        legacy files surface only their substantive
+                        validation failures, not pre-existing schema
+                        debt.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class EnumValidatorMode(str, Enum):
+    """Mode flag for the corpus contract validator.
+
+    Inherits from ``str`` so values JSON-serialize without extra logic.
+    """
+
+    STRICT = "strict"
+    MIGRATION_AUDIT = "migration_audit"
+
+
+__all__ = ["EnumValidatorMode"]

--- a/src/omnibase_core/models/contracts/model_corpus_validation_report.py
+++ b/src/omnibase_core/models/contracts/model_corpus_validation_report.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-file corpus validation report (OMN-9767, parent OMN-9757).
+
+Phase 3 of the corpus classification and normalization layer.
+
+``ModelCorpusValidationReport`` is the per-file outcome record produced
+by the corpus contract validator. One instance per ``contract.yaml``
+walked. Aggregates of these power the migration-audit summary (counts
+by bucket, by mode, pass/fail rates, normalized-vs-not breakdowns).
+
+Distinct from:
+
+- ``ModelValidationReport`` (omnibase_core/models/validation) — a
+  generic validator-framework aggregator with severity precedence,
+  metrics, and provenance (OMN-2362). Different semantic domain.
+- ``ModelContractValidationResult`` — a scoring/feedback artifact for
+  code-generation systems with score + suggestions fields.
+
+This model is intentionally narrow to the corpus-sweep use case:
+``path``, ``bucket``, ``mode``, ``passed``, ``errors``, ``normalized``,
+``normalization_flags``. No score, no suggestions, no severity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+
+
+class ModelCorpusValidationReport(BaseModel):
+    """Single-file outcome record from the corpus contract validator.
+
+    Frozen, extra=forbid: instances are immutable evidence rows that the
+    batch validator collects into a list and the audit summarizer
+    aggregates without further mutation.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    path: Path
+    bucket: EnumContractBucket
+    mode: EnumValidatorMode
+    passed: bool
+    errors: list[str] = Field(default_factory=list)
+    normalized: bool
+    normalization_flags: list[str] = Field(default_factory=list)
+
+
+__all__ = ["ModelCorpusValidationReport"]

--- a/tests/unit/normalization/__init__.py
+++ b/tests/unit/normalization/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/normalization/test_validator_mode.py
+++ b/tests/unit/normalization/test_validator_mode.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumValidatorMode + ModelCorpusValidationReport (OMN-9767, parent OMN-9757).
+
+Phase 3 — validator mode selection and per-file outcome record for the
+corpus classification + normalization layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+from omnibase_core.models.contracts.model_corpus_validation_report import (
+    ModelCorpusValidationReport,
+)
+
+
+@pytest.mark.unit
+class TestEnumValidatorModeStructure:
+    """Test enum membership, types, and lookup behavior."""
+
+    def test_two_modes_exist(self) -> None:
+        assert hasattr(EnumValidatorMode, "STRICT")
+        assert hasattr(EnumValidatorMode, "MIGRATION_AUDIT")
+
+    def test_member_count_is_two(self) -> None:
+        assert len(list(EnumValidatorMode)) == 2
+
+    def test_wire_values(self) -> None:
+        assert EnumValidatorMode.STRICT.value == "strict"
+        assert EnumValidatorMode.MIGRATION_AUDIT.value == "migration_audit"
+
+    def test_mode_is_str_enum(self) -> None:
+        assert isinstance(EnumValidatorMode.STRICT, str)
+
+    def test_enum_is_unique(self) -> None:
+        values = [m.value for m in EnumValidatorMode]
+        assert len(values) == len(set(values))
+
+    def test_enum_from_value(self) -> None:
+        assert EnumValidatorMode("strict") is EnumValidatorMode.STRICT
+        assert EnumValidatorMode("migration_audit") is EnumValidatorMode.MIGRATION_AUDIT
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EnumValidatorMode("not_a_real_mode")
+
+    def test_enum_equality_with_string(self) -> None:
+        assert EnumValidatorMode.STRICT == "strict"
+        assert EnumValidatorMode.MIGRATION_AUDIT == "migration_audit"
+
+
+@pytest.mark.unit
+class TestEnumValidatorModeSerialization:
+    """Test JSON / YAML / Pydantic round-trip safety."""
+
+    def test_json_serialization_via_value(self) -> None:
+        data = {"mode": EnumValidatorMode.STRICT.value}
+        assert json.dumps(data) == '{"mode": "strict"}'
+
+    def test_yaml_round_trip(self) -> None:
+        data = {"mode": EnumValidatorMode.MIGRATION_AUDIT.value}
+        loaded = yaml.safe_load(yaml.dump(data))
+        assert loaded["mode"] == "migration_audit"
+        assert EnumValidatorMode(loaded["mode"]) is EnumValidatorMode.MIGRATION_AUDIT
+
+    def test_pydantic_field_assignment(self) -> None:
+        class M(BaseModel):
+            mode: EnumValidatorMode
+
+        m = M(mode=EnumValidatorMode.STRICT)
+        assert m.mode is EnumValidatorMode.STRICT
+
+    def test_pydantic_string_coercion(self) -> None:
+        class M(BaseModel):
+            mode: EnumValidatorMode
+
+        m = M(mode="migration_audit")
+        assert m.mode is EnumValidatorMode.MIGRATION_AUDIT
+
+    def test_pydantic_invalid_raises(self) -> None:
+        class M(BaseModel):
+            mode: EnumValidatorMode
+
+        with pytest.raises(ValidationError):
+            M(mode="bogus_mode")
+
+    def test_pydantic_model_dump(self) -> None:
+        class M(BaseModel):
+            mode: EnumValidatorMode
+
+        m = M(mode=EnumValidatorMode.STRICT)
+        assert m.model_dump() == {"mode": "strict"}
+
+    def test_pydantic_model_dump_json(self) -> None:
+        class M(BaseModel):
+            mode: EnumValidatorMode
+
+        m = M(mode=EnumValidatorMode.MIGRATION_AUDIT)
+        assert m.model_dump_json() == '{"mode":"migration_audit"}'
+
+
+@pytest.mark.unit
+class TestEnumValidatorModeExports:
+    """Confirm the enum import path resolves."""
+
+    def test_import_via_module(self) -> None:
+        from omnibase_core.enums import enum_validator_mode
+
+        assert enum_validator_mode.EnumValidatorMode is EnumValidatorMode
+
+
+@pytest.mark.unit
+class TestModelCorpusValidationReportConstruction:
+    """Test construction with required and optional fields."""
+
+    def test_minimal_pass_record(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("foo/contract.yaml"),
+            bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=True,
+            normalized=False,
+        )
+        assert report.passed is True
+        assert report.errors == []
+        assert report.normalization_flags == []
+        assert report.normalized is False
+
+    def test_minimal_fail_record_with_errors(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("bar/contract.yaml"),
+            bucket=EnumContractBucket.HANDLER_CONTRACT,
+            mode=EnumValidatorMode.MIGRATION_AUDIT,
+            passed=False,
+            errors=["Field required: input_model"],
+            normalized=True,
+            normalization_flags=["legacy_input_output_model"],
+        )
+        assert report.passed is False
+        assert report.errors == ["Field required: input_model"]
+        assert report.normalized is True
+        assert report.normalization_flags == ["legacy_input_output_model"]
+
+    def test_path_is_path_object(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("baz/contract.yaml"),
+            bucket=EnumContractBucket.PACKAGE_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=True,
+            normalized=False,
+        )
+        assert isinstance(report.path, Path)
+
+    def test_pydantic_string_path_coercion(self) -> None:
+        report = ModelCorpusValidationReport(
+            path="qux/contract.yaml",  # type: ignore[arg-type]
+            bucket=EnumContractBucket.PACKAGE_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=True,
+            normalized=False,
+        )
+        assert report.path == Path("qux/contract.yaml")
+
+
+@pytest.mark.unit
+class TestModelCorpusValidationReportImmutability:
+    """Frozen + extra=forbid invariants."""
+
+    def test_frozen_blocks_setattr(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("foo/contract.yaml"),
+            bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=False,
+            errors=["err"],
+            normalized=False,
+        )
+        with pytest.raises(ValidationError):
+            report.passed = True  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelCorpusValidationReport(
+                path=Path("foo/contract.yaml"),
+                bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+                mode=EnumValidatorMode.STRICT,
+                passed=True,
+                normalized=False,
+                bogus_extra="nope",  # type: ignore[call-arg]
+            )
+
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelCorpusValidationReport(  # type: ignore[call-arg]
+                path=Path("foo/contract.yaml"),
+                bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+                mode=EnumValidatorMode.STRICT,
+                # passed missing
+                normalized=False,
+            )
+
+
+@pytest.mark.unit
+class TestModelCorpusValidationReportSerialization:
+    """JSON / dict round-trip safety; from_attributes wiring."""
+
+    def test_model_dump_preserves_wire_shape(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("foo/contract.yaml"),
+            bucket=EnumContractBucket.NODE_ROOT_CONTRACT,
+            mode=EnumValidatorMode.STRICT,
+            passed=True,
+            normalized=False,
+        )
+        dumped = report.model_dump(mode="json")
+        assert dumped["bucket"] == "node_root_contract"
+        assert dumped["mode"] == "strict"
+        assert dumped["passed"] is True
+        assert dumped["normalized"] is False
+        assert dumped["errors"] == []
+        assert dumped["normalization_flags"] == []
+
+    def test_round_trip_via_model_validate(self) -> None:
+        report = ModelCorpusValidationReport(
+            path=Path("foo/contract.yaml"),
+            bucket=EnumContractBucket.HANDLER_CONTRACT,
+            mode=EnumValidatorMode.MIGRATION_AUDIT,
+            passed=False,
+            errors=["e1", "e2"],
+            normalized=True,
+            normalization_flags=["legacy_event_bus"],
+        )
+        round_tripped = ModelCorpusValidationReport.model_validate(
+            report.model_dump(mode="json")
+        )
+        assert round_tripped == report
+
+    def test_from_attributes_construction(self) -> None:
+        class _Source:
+            path = Path("foo/contract.yaml")
+            bucket = EnumContractBucket.NODE_ROOT_CONTRACT
+            mode = EnumValidatorMode.STRICT
+            passed = True
+            errors: list[str] = []
+            normalized = False
+            normalization_flags: list[str] = []
+
+        report = ModelCorpusValidationReport.model_validate(
+            _Source(), from_attributes=True
+        )
+        assert report.passed is True
+        assert report.bucket is EnumContractBucket.NODE_ROOT_CONTRACT
+        assert report.mode is EnumValidatorMode.STRICT


### PR DESCRIPTION
## Summary

Phase 3 Task 10 of the corpus classification + normalization layer (parent epic OMN-9757). Pairs with OMN-9768 (W2a — `validate_contract_file()` consumer).

- `EnumValidatorMode { STRICT, MIGRATION_AUDIT }` — selects between strict CI-gate validation and the relaxed migration-audit sweep used during legacy-corpus normalization.
- `ModelCorpusValidationReport` — frozen, `extra=forbid` per-file outcome record produced by the corpus contract validator (`path`, `bucket`, `mode`, `passed`, `errors`, `normalized`, `normalization_flags`). Aggregates of these power the migration-audit summary.
- Re-exported from `omnibase_core.enums.__init__` as `EnumValidatorMode`.
- 26 unit tests passing.

## Plan deviation (one)

The OMN-9767 spec named the new model `ModelValidationReport` at `omnibase_core/models/contracts/model_validation_report.py`. That filename + class name already exists at `omnibase_core/models/validation/model_validation_report.py` for an unrelated validator-framework aggregator (OMN-2362), and the `validate-no-duplicate-models` pre-commit hook blocks the collision. Renamed to `ModelCorpusValidationReport` (file: `model_corpus_validation_report.py`) to avoid ambiguity in cross-module imports. Public API otherwise matches the spec (same fields, same config, same enum types).

W2a (OMN-9768) has been notified of the rename via SendMessage and pre-merge so they can pin imports correctly.

## Test plan

- [x] `uv run pytest tests/unit/normalization/test_validator_mode.py` — 26 passed
- [x] `uv run mypy --strict src/omnibase_core/enums/enum_validator_mode.py src/omnibase_core/models/contracts/model_corpus_validation_report.py` — clean
- [x] `pre-commit run --files <staged>` — all hooks pass (duplicate-models hook clears after rename)
- [x] `uv run pytest tests/unit/normalization tests/unit/enums/test_enum_contract_bucket.py tests/unit/enums/test_enum_normalization_family.py` — 49 passed (regression check on adjacent W1a/W1b enums)
- [ ] Full `uv run pytest tests/ -v` — sandboxed local runner OOMs on the 38K-test omnibase_core suite; CI will run the full suite

## DoD evidence (OCC contract — to be added in follow-up PR per overnight-plan workflow)

- `dod-001` file_exists: `omnibase_core/src/omnibase_core/enums/enum_validator_mode.py`
- `dod-002` file_exists: `omnibase_core/src/omnibase_core/models/contracts/model_corpus_validation_report.py`
- `dod-003` file_exists: `omnibase_core/src/omnibase_core/enums/__init__.py` (export wiring)

Refs: OMN-9767 (parent OMN-9757, Phase 3 Task 10)
Plan: docs/plans/2026-04-25-corpus-classification-and-normalization-layer.md (Task 10)