### PR TITLE
feat(OMN-9765): add normalize_omnimarket_v0_contract — v0 block rewrite

### DIFF
--- a/src/omnibase_core/normalization/__init__.py
+++ b/src/omnibase_core/normalization/__init__.py
@@ -6,10 +6,22 @@
 Pre-validation pipeline that buckets contract YAML files (``corpus_classifier``)
 and applies per-family normalization functions before strict Pydantic
 ``model_validate()`` runs against the canonical contract models.
+
+Each normalization function (see ``contract_normalizer``) handles a single
+migration family — see
+:class:`omnibase_core.enums.enum_normalization_family.EnumNormalizationFamily`.
 """
 
 from __future__ import annotations
 
+from omnibase_core.normalization.contract_normalizer import (
+    is_omnimarket_v0,
+    normalize_omnimarket_v0_contract,
+)
 from omnibase_core.normalization.corpus_classifier import classify_contract_path
 
-__all__ = ["classify_contract_path"]
+__all__ = [
+    "classify_contract_path",
+    "is_omnimarket_v0",
+    "normalize_omnimarket_v0_contract",
+]

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract normalizer (parent epic OMN-9757).
+
+Pure dict→dict transforms that rewrite legacy contract shapes into the
+canonical representation. Each function targets a single migration
+family. Functions never mutate their input.
+"""
+
+from __future__ import annotations
+
+import copy as _copy
+
+
+def is_omnimarket_v0(raw: dict[str, object]) -> bool:
+    """Return True iff ``raw`` carries the omnimarket v0 contract shape.
+
+    The v0 shape is identified by a top-level ``handler`` dict that
+    declares a ``class`` field. This is the legacy shape used by the
+    82-file omnimarket cohort prior to the canonical contract layout.
+    """
+    handler = raw.get("handler")
+    return isinstance(handler, dict) and "class" in handler
+
+
+def normalize_omnimarket_v0_contract(raw: dict[str, object]) -> dict[str, object]:
+    """Rewrite an omnimarket v0 contract dict to the canonical shape.
+
+    Compatibility-stripping transform — NOT a semantic migration. The
+    ``handler``, ``descriptor``, and ``terminal_event`` blocks are dropped
+    entirely; ``descriptor.node_archetype``, ``descriptor.timeout_ms``,
+    and the ``terminal_event`` topic string are NOT carried forward.
+    Callers that need this information must extract it before running
+    the normalizer.
+
+    The only field salvaged is ``handler.input_model``, which is hoisted
+    to a root-level ``input_model`` when not already present.
+    """
+    result = _copy.deepcopy(raw)
+    handler_block = result.pop("handler", None)
+    result.pop("descriptor", None)
+    result.pop("terminal_event", None)
+    if (
+        isinstance(handler_block, dict)
+        and "input_model" in handler_block
+        and "input_model" not in result
+    ):
+        result["input_model"] = handler_block["input_model"]
+    return result

--- a/tests/unit/normalization/__init__.py
+++ b/tests/unit/normalization/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
+"""Unit tests for the contract normalization layer."""

--- a/tests/unit/normalization/test_contract_normalizer.py
+++ b/tests/unit/normalization/test_contract_normalizer.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for contract_normalizer (OMN-9765, parent epic OMN-9757).
+
+Phase 2 Task 8: ``normalize_omnimarket_v0_contract`` rewrites the
+legacy omnimarket v0 contract shape (top-level ``handler``,
+``descriptor``, ``terminal_event`` blocks) into the canonical
+contract layout.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from omnibase_core.normalization.contract_normalizer import (
+    is_omnimarket_v0,
+    normalize_omnimarket_v0_contract,
+)
+
+
+@pytest.mark.unit
+class TestIsOmnimarketV0:
+    """Detection helper for the legacy omnimarket v0 contract shape."""
+
+    def test_detects_omnimarket_v0_shape(self) -> None:
+        raw = {
+            "handler": {
+                "module": "omnimarket.nodes.x.handlers.h",
+                "class": "NodeX",
+                "input_model": "...",
+            },
+            "descriptor": {"node_archetype": "compute"},
+            "terminal_event": "onex.evt.omnimarket.x-completed.v1",
+        }
+        assert is_omnimarket_v0(raw) is True
+
+    def test_non_omnimarket_v0_shape(self) -> None:
+        raw = {"name": "node_foo", "node_type": "EFFECT_GENERIC"}
+        assert is_omnimarket_v0(raw) is False
+
+
+@pytest.mark.unit
+class TestNormalizeOmnimarketV0Contract:
+    """Rewrite legacy v0 contract dicts to the canonical layout."""
+
+    def test_extracts_input_model_from_handler(self) -> None:
+        raw = {
+            "name": "node_aislop_sweep",
+            "handler": {
+                "module": "omnimarket.nodes.node_aislop_sweep.handlers.h",
+                "class": "NodeAislopSweep",
+                "input_model": "omnimarket.nodes.node_aislop_sweep.handlers.h.AislopSweepRequest",
+            },
+            "descriptor": {"node_archetype": "compute", "timeout_ms": 120000},
+            "terminal_event": "onex.evt.omnimarket.aislop-sweep-completed.v1",
+        }
+        result = normalize_omnimarket_v0_contract(raw)
+        assert (
+            result.get("input_model")
+            == "omnimarket.nodes.node_aislop_sweep.handlers.h.AislopSweepRequest"
+        )
+        assert "handler" not in result
+        assert "descriptor" not in result
+        assert "terminal_event" not in result
+
+    def test_does_not_mutate_input(self) -> None:
+        raw = {
+            "handler": {"module": "m", "class": "C", "input_model": "m.M"},
+            "descriptor": {},
+        }
+        raw_copy = copy.deepcopy(raw)
+        normalize_omnimarket_v0_contract(raw)
+        assert raw == raw_copy


### PR DESCRIPTION
Refs: OMN-9765 (parent epic OMN-9757 — corpus classification and normalization layer, Phase 2)

## Summary

Adds the first member of the new `omnibase_core.normalization` package and its mirror under `tests/unit/normalization/`:

- `is_omnimarket_v0(raw)` — detects the legacy omnimarket v0 contract shape (top-level `handler` dict with a `class` field).
- `normalize_omnimarket_v0_contract(raw)` — pure dict→dict transform that drops `handler`, `descriptor`, and `terminal_event` blocks and hoists `handler.input_model` to root-level `input_model`.

This is a compatibility-stripping transform, not a semantic migration: `descriptor.node_archetype`, `descriptor.timeout_ms`, and the `terminal_event` topic string are intentionally NOT carried forward. Callers that need this data must extract it before normalization.

The `omnibase_core/normalization/__init__.py` and `tests/unit/normalization/__init__.py` packages are introduced here. Sibling Phase 2 PRs (OMN-9761 strip_legacy_metadata, OMN-9762 event_bus, OMN-9763 io_model_ref, OMN-9764 handler_routing, OMN-9766 dod_evidence + compose_normalization_pipeline) extend the same `contract_normalizer.py` module and will trivially merge alongside this one.

## DoD evidence

Unit test (per OMN-9765 ModelTicketContract.dod_evidence):

```
uv run pytest tests/unit/normalization/test_contract_normalizer.py -v
============================== 4 passed in 0.16s ===============================
```

Pre-push gates locally:
- `uv run ruff format src/ tests/` — clean
- `uv run ruff check --fix src/ tests/` — all checks passed
- `uv run mypy src/omnibase_core/normalization/ --strict` — no issues
- `pre-commit run --all-files` — all hooks passed

## Acceptance criteria (from OMN-9765)

- [x] `is_omnimarket_v0(raw)` returns True only when `handler` is a dict containing `class`
- [x] Moves `handler.input_model` → root `input_model` (only when not already present at root)
- [x] Drops `handler`, `descriptor`, `terminal_event` blocks
- [x] Does not mutate input
- [x] 4 new unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy contract format detection and automatic normalization to the public API.

* **Documentation**
  * Clarified normalization docs and examples to explain behavior and preservation guarantees.

* **Tests**
  * Added comprehensive unit tests covering legacy detection, normalization behavior, immutability, and model hoisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->