### PR TITLE
feat(OMN-9786): add adversarial invariants to ModelDodReceipt

### DIFF
--- a/src/omnibase_core/enums/ticket/enum_receipt_status.py
+++ b/src/omnibase_core/enums/ticket/enum_receipt_status.py
@@ -11,13 +11,36 @@ from enum import StrEnum
 class EnumReceiptStatus(StrEnum):
     """Terminal status of a dod_evidence check execution.
 
-    Used by `ModelDodReceipt` to declare whether the check proved the
-    claim it was supposed to prove. Only PASS receipts satisfy the
-    receipt-gate CI check; FAIL and any missing receipt both block merge.
+    Used by :class:`ModelDodReceipt` to declare whether the check proved the
+    claim it was supposed to prove. Only ``PASS`` receipts satisfy the
+    receipt-gate CI check; ``FAIL`` and any missing receipt both block merge.
+
+    Members
+    -------
+    PASS
+        The probe executed and the observed result matched the claim.
+        This is the only status that satisfies the receipt-gate.
+    FAIL
+        The probe executed and the observed result contradicted the claim.
+        Treated identically to absence of a receipt — blocks merge.
+    ADVISORY
+        The probe executed but the proof is structurally weak. Set by the
+        Centralized Transition Policy when (a) ``verifier == runner`` (the
+        author self-attested) or (b) ``check_type == "file_exists"`` (the
+        only proof is that a file was written, not that the underlying
+        behavior was exercised). Advisory receipts are recorded for audit
+        but do not satisfy the receipt-gate.
+    PENDING
+        The probe was allocated (e.g. by a pipeline that planned the run)
+        but has not yet executed. Receipts in PENDING state never satisfy
+        the receipt-gate; they exist so the absence of execution is
+        explicit rather than inferred from missing files.
     """
 
     PASS = "PASS"
     FAIL = "FAIL"
+    ADVISORY = "ADVISORY"
+    PENDING = "PENDING"
 
 
 __all__ = ["EnumReceiptStatus"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -47,9 +47,17 @@ from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 
 _TICKET_ID_RE = re.compile(r"^OMN-\d+$")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
-# Mirrors `SEMVER_PATTERN` in `omnibase_core.validation.phases.validator_expanded_contract`.
-# Inlined here to avoid a contracts-models → validation circular import.
-_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$")
+# SemVer 2.0.0 — official regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# Rejects leading zeros in numeric core (e.g. "01.0.0"), allows pre-release
+# identifiers with dot-separated alphanumerics and hyphens (e.g. "1.0.0-rc.1"),
+# and allows build metadata containing hyphens (e.g. "1.0.0+build-7"). Inlined
+# here to avoid a contracts-models → validation circular import.
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
 
 # check_types whose proof requires captured stdout. Listed here (not in the
 # validator body) so the policy is grep-able and easy to extend.
@@ -86,11 +94,11 @@ class ModelDodReceipt(BaseModel):
 
     schema_version: str = Field(
         ...,
-        max_length=20,
         description=(
-            "SemVer for the receipt schema. Pins downstream consumers so "
-            "future field additions can negotiate compatibility instead of "
-            "silently dropping fields."
+            "SemVer 2.0.0 string for the receipt schema. Pins downstream "
+            "consumers so future field additions can negotiate compatibility "
+            "instead of silently dropping fields. Validated by the official "
+            "SemVer 2.0.0 regex (see ``_SEMVER_RE``)."
         ),
     )
     ticket_id: str = Field(
@@ -238,34 +246,44 @@ class ModelDodReceipt(BaseModel):
         Order matters:
 
         1. Executable check_types with empty stdout raise immediately —
-           the receipt is structurally invalid, not just weak.
-        2. Self-attestation (verifier == runner) downgrades to ADVISORY.
-        3. file_exists (and other weak proof types) downgrade to ADVISORY.
-           Applied after self-attestation so "weak proof" wins over "PASS"
-           even when verifier and runner are independent.
+           the receipt is structurally invalid, not just weak. PENDING
+           is exempt: by definition the probe was allocated but not yet
+           executed, so empty stdout is the expected representation.
+        2. Self-attestation (verifier == runner) downgrades PASS to
+           ADVISORY. FAIL and PENDING outcomes are preserved — they
+           carry distinct meaning (probe ran and failed; probe queued
+           but unexecuted) that ADVISORY would erase.
+        3. file_exists (and other weak proof types) downgrade PASS to
+           ADVISORY. FAIL and PENDING are preserved for the same reason
+           as Rule 2.
 
         Rule (4) — schema_version SemVer match — is enforced as a field
         validator above, before this method runs.
         """
         # Rule 3: executable check_types must have non-empty probe_stdout.
-        if self.check_type in EXECUTABLE_CHECK_TYPES and not self.probe_stdout.strip():
+        # PENDING is exempt — an unexecuted probe has no stdout by definition.
+        if (
+            self.status is not EnumReceiptStatus.PENDING
+            and self.check_type in EXECUTABLE_CHECK_TYPES
+            and not self.probe_stdout.strip()
+        ):
             raise ValueError(
                 f"probe_stdout required for executable check_type "
                 f"{self.check_type!r}; receipts with empty stdout are "
                 f"indistinguishable from probes that never ran"
             )
 
-        # Rule 1: self-attestation downgrades to ADVISORY.
-        if (
-            self.verifier == self.runner
-            and self.status is not EnumReceiptStatus.ADVISORY
-        ):
+        # Rule 1: self-attestation downgrades PASS to ADVISORY.
+        # FAIL and PENDING are preserved — collapsing them into ADVISORY
+        # would erase meaningful outcomes (probe failed, probe queued).
+        if self.verifier == self.runner and self.status is EnumReceiptStatus.PASS:
             object.__setattr__(self, "status", EnumReceiptStatus.ADVISORY)
 
-        # Rule 2: weak-proof check_types downgrade to ADVISORY.
+        # Rule 2: weak-proof check_types downgrade PASS to ADVISORY.
+        # FAIL and PENDING are preserved for the same reason.
         if (
             self.check_type in WEAK_PROOF_CHECK_TYPES
-            and self.status is not EnumReceiptStatus.ADVISORY
+            and self.status is EnumReceiptStatus.PASS
         ):
             object.__setattr__(self, "status", EnumReceiptStatus.ADVISORY)
 

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -17,6 +17,22 @@ Receipts are stored at:
 
 The path encodes ticket → evidence item → check, mirroring the contract
 structure so lookup is O(1) path traversal, not search.
+
+Adversarial invariants (OMN-9786, Centralized Transition Policy)
+----------------------------------------------------------------
+The receipt is the canonical "did this actually happen" probe artifact.
+Four invariants are enforced by ``enforce_adversarial_invariants`` to keep
+self-attested or structurally-weak proof from satisfying the gate:
+
+1. ``verifier == runner`` (self-attestation) → status auto-downgraded to
+   ``ADVISORY``. Independent verification is required for PASS.
+2. ``check_type == "file_exists"`` → status auto-downgraded to ``ADVISORY``.
+   File presence proves a write, not that the behavior under test occurred.
+3. ``check_type in {command, test_passes, endpoint, grep}`` AND empty
+   ``probe_stdout`` → ``ValueError``. An executable check that produced no
+   captured output is indistinguishable from "never ran".
+4. ``schema_version`` must be a valid SemVer string (per the canonical
+   ``SEMVER_PATTERN`` in :mod:`omnibase_core.validation.phases`).
 """
 
 from __future__ import annotations
@@ -25,24 +41,41 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 
 _TICKET_ID_RE = re.compile(r"^OMN-\d+$")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+# Mirrors `SEMVER_PATTERN` in `omnibase_core.validation.phases.validator_expanded_contract`.
+# Inlined here to avoid a contracts-models → validation circular import.
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$")
+
+# check_types whose proof requires captured stdout. Listed here (not in the
+# validator body) so the policy is grep-able and easy to extend.
+EXECUTABLE_CHECK_TYPES = frozenset({"command", "test_passes", "endpoint", "grep"})
+
+# check_types whose proof is structurally weak (file presence only). The
+# transition policy demotes these to ADVISORY regardless of verifier identity.
+WEAK_PROOF_CHECK_TYPES = frozenset({"file_exists"})
 
 
 class ModelDodReceipt(BaseModel):
     """Receipt proving a single dod_evidence check was run for a ticket.
 
-    Frozen. Every field except ``actual_output`` is required — there is no
-    such thing as an "aspirational" receipt. If a receipt exists on disk,
-    it asserts the check ran with the recorded outcome.
+    Frozen. Every field except ``actual_output``, ``exit_code``,
+    ``duration_ms``, and ``pr_number`` is required — there is no such thing
+    as an "aspirational" receipt. If a receipt exists on disk, it asserts
+    the check ran with the recorded outcome.
 
     A receipt is consumed by the receipt-gate CI check at PR merge time
     and by ``node_dod_verify`` at ticket-close time. Both treat absence
     as identical to FAIL.
+
+    The four adversarial fields (``schema_version``, ``verifier``,
+    ``probe_command``, ``probe_stdout``) make the receipt resistant to
+    self-attestation and "file written = work done" loopholes. See module
+    docstring for the policy enforced by ``enforce_adversarial_invariants``.
     """
 
     model_config = ConfigDict(
@@ -51,6 +84,15 @@ class ModelDodReceipt(BaseModel):
         from_attributes=True,
     )
 
+    schema_version: str = Field(
+        ...,
+        max_length=20,
+        description=(
+            "SemVer for the receipt schema. Pins downstream consumers so "
+            "future field additions can negotiate compatibility instead of "
+            "silently dropping fields."
+        ),
+    )
     ticket_id: str = Field(
         ..., description="Linear ticket this receipt proves (e.g., OMN-9084)"
     )
@@ -69,7 +111,12 @@ class ModelDodReceipt(BaseModel):
         description="The original check_value from the contract (for audit parity)",
     )
     status: EnumReceiptStatus = Field(
-        ..., description="PASS or FAIL — absence is also treated as FAIL"
+        ...,
+        description=(
+            "PASS, FAIL, ADVISORY, or PENDING. Absence of a receipt is also "
+            "treated as FAIL. May be auto-downgraded to ADVISORY by the "
+            "transition policy (see module docstring)."
+        ),
     )
     run_timestamp: datetime = Field(
         ..., description="UTC timestamp when the check was executed"
@@ -89,12 +136,43 @@ class ModelDodReceipt(BaseModel):
             "CI job identifier. Used for audit + friction attribution."
         ),
     )
+    verifier: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description=(
+            "Identity that verified the probe output. Must differ from "
+            "``runner`` for non-ADVISORY status — self-attestation "
+            "(verifier == runner) auto-downgrades to ADVISORY."
+        ),
+    )
+    probe_command: str = Field(
+        ...,
+        max_length=10000,
+        description=(
+            "Literal command/probe executed (e.g., 'gh pr checks 123'). "
+            "Recorded so audits can replay the probe."
+        ),
+    )
+    probe_stdout: str = Field(
+        ...,
+        max_length=1_000_000,
+        description=(
+            "Literal captured stdout from the probe. Required (non-empty) "
+            "for executable check_types: command, test_passes, endpoint, "
+            "grep. May be empty for file_exists and other check_types that "
+            "produce no output."
+        ),
+    )
     actual_output: str | None = Field(
         default=None,
         description=(
             "Truncated output from the check (stdout, HTTP body, file content). "
             "Large outputs should be stored in a sibling file and referenced here "
-            "via path. None is allowed when the check produces no output."
+            "via path. None is allowed when the check produces no output. "
+            "Distinct from ``probe_stdout`` (the literal captured stream); "
+            "``actual_output`` may be a structured / truncated rendering for "
+            "legacy classifiers that read it instead of ``probe_stdout``."
         ),
     )
     exit_code: int | None = Field(
@@ -144,5 +222,58 @@ class ModelDodReceipt(BaseModel):
             raise ValueError("run_timestamp must be timezone-aware (UTC)")
         return v.astimezone(UTC)
 
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_RE.match(v):
+            raise ValueError(
+                f"schema_version must be valid SemVer (e.g. '1.0.0'), got: {v!r}"
+            )
+        return v
 
-__all__ = ["ModelDodReceipt"]
+    @model_validator(mode="after")
+    def enforce_adversarial_invariants(self) -> ModelDodReceipt:
+        """Apply the four-rule Centralized Transition Policy.
+
+        Order matters:
+
+        1. Executable check_types with empty stdout raise immediately —
+           the receipt is structurally invalid, not just weak.
+        2. Self-attestation (verifier == runner) downgrades to ADVISORY.
+        3. file_exists (and other weak proof types) downgrade to ADVISORY.
+           Applied after self-attestation so "weak proof" wins over "PASS"
+           even when verifier and runner are independent.
+
+        Rule (4) — schema_version SemVer match — is enforced as a field
+        validator above, before this method runs.
+        """
+        # Rule 3: executable check_types must have non-empty probe_stdout.
+        if self.check_type in EXECUTABLE_CHECK_TYPES and not self.probe_stdout.strip():
+            raise ValueError(
+                f"probe_stdout required for executable check_type "
+                f"{self.check_type!r}; receipts with empty stdout are "
+                f"indistinguishable from probes that never ran"
+            )
+
+        # Rule 1: self-attestation downgrades to ADVISORY.
+        if (
+            self.verifier == self.runner
+            and self.status is not EnumReceiptStatus.ADVISORY
+        ):
+            object.__setattr__(self, "status", EnumReceiptStatus.ADVISORY)
+
+        # Rule 2: weak-proof check_types downgrade to ADVISORY.
+        if (
+            self.check_type in WEAK_PROOF_CHECK_TYPES
+            and self.status is not EnumReceiptStatus.ADVISORY
+        ):
+            object.__setattr__(self, "status", EnumReceiptStatus.ADVISORY)
+
+        return self
+
+
+__all__ = [
+    "EXECUTABLE_CHECK_TYPES",
+    "ModelDodReceipt",
+    "WEAK_PROOF_CHECK_TYPES",
+]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -24,14 +24,25 @@ The receipt is the canonical "did this actually happen" probe artifact.
 Four invariants are enforced by ``enforce_adversarial_invariants`` to keep
 self-attested or structurally-weak proof from satisfying the gate:
 
-1. ``verifier == runner`` (self-attestation) → status auto-downgraded to
-   ``ADVISORY``. Independent verification is required for PASS.
-2. ``check_type == "file_exists"`` → status auto-downgraded to ``ADVISORY``.
-   File presence proves a write, not that the behavior under test occurred.
+1. ``verifier == runner`` (self-attestation) AND ``status == PASS`` →
+   status auto-downgraded to ``ADVISORY``. Independent verification is
+   required for PASS. ``FAIL`` and ``PENDING`` are preserved — they
+   carry distinct meaning that ADVISORY would erase. Identity strings
+   are compared after stripping surrounding whitespace, so
+   ``"worker-A"`` and ``"worker-A "`` cannot be used to bypass this
+   rule.
+2. ``check_type == "file_exists"`` AND ``status == PASS`` → status
+   auto-downgraded to ``ADVISORY``. File presence proves a write, not
+   that the behavior under test occurred. ``FAIL`` and ``PENDING`` are
+   preserved for the same reason as Rule 1.
 3. ``check_type in {command, test_passes, endpoint, grep}`` AND empty
-   ``probe_stdout`` → ``ValueError``. An executable check that produced no
-   captured output is indistinguishable from "never ran".
-4. ``schema_version`` must be a valid SemVer string (per the canonical
+   ``probe_stdout`` AND ``status != PENDING`` → ``ValueError``. An
+   executable check that produced no captured output is
+   indistinguishable from "never ran". ``PENDING`` is exempt because by
+   definition the probe was allocated but not yet executed — empty
+   stdout is the correct representation.
+4. ``schema_version`` must be a valid SemVer 2.0.0 string (per the
+   official regex inlined as ``_SEMVER_RE``; mirrors
    ``SEMVER_PATTERN`` in :mod:`omnibase_core.validation.phases`).
 """
 
@@ -149,9 +160,11 @@ class ModelDodReceipt(BaseModel):
         min_length=1,
         max_length=200,
         description=(
-            "Identity that verified the probe output. Must differ from "
-            "``runner`` for non-ADVISORY status — self-attestation "
-            "(verifier == runner) auto-downgrades to ADVISORY."
+            "Identity that verified the probe output. For ``PASS`` "
+            "receipts it must differ from ``runner`` — self-attestation "
+            "(verifier == runner, comparison is whitespace-stripped) "
+            "auto-downgrades to ADVISORY. ``FAIL`` and ``PENDING`` are "
+            "preserved regardless of verifier identity."
         ),
     )
     probe_command: str = Field(
@@ -200,6 +213,22 @@ class ModelDodReceipt(BaseModel):
             "to merge gate invocations. None for receipts not tied to a PR."
         ),
     )
+
+    @field_validator("runner", "verifier")
+    @classmethod
+    def _normalize_identity(cls, v: str) -> str:
+        """Strip surrounding whitespace and reject whitespace-only identities.
+
+        Without normalization, ``runner="worker-A"`` and
+        ``verifier="worker-A "`` (note trailing space) would compare
+        unequal under Rule 1, allowing self-attestation to bypass the
+        ADVISORY downgrade. Normalizing here means every consumer of the
+        receipt sees a single canonical form.
+        """
+        normalized = v.strip()
+        if not normalized:
+            raise ValueError("runner/verifier must contain non-whitespace characters")
+        return normalized
 
     @field_validator("ticket_id")
     @classmethod
@@ -276,6 +305,9 @@ class ModelDodReceipt(BaseModel):
         # Rule 1: self-attestation downgrades PASS to ADVISORY.
         # FAIL and PENDING are preserved — collapsing them into ADVISORY
         # would erase meaningful outcomes (probe failed, probe queued).
+        # ``runner`` and ``verifier`` have already been normalized
+        # (whitespace-stripped) by ``_normalize_identity``, so a raw ``==``
+        # is sufficient and cannot be bypassed by trailing-space padding.
         if self.verifier == self.runner and self.status is EnumReceiptStatus.PASS:
             object.__setattr__(self, "status", EnumReceiptStatus.ADVISORY)
 

--- a/tests/unit/models/contracts/test_model_dod_receipt.py
+++ b/tests/unit/models/contracts/test_model_dod_receipt.py
@@ -388,3 +388,31 @@ class TestModelDodReceiptAdversarialInvariants:
         fields["probe_stdout"] = ""
         receipt = ModelDodReceipt(**fields)
         assert receipt.status is EnumReceiptStatus.PENDING
+
+    def test_self_attestation_not_bypassable_by_whitespace(self) -> None:
+        """``runner="worker-A"`` and ``verifier="worker-A "`` must not slip
+        past Rule 1 — identity strings are whitespace-stripped before the
+        equality comparison so trailing/leading spaces cannot be used to
+        evade the ADVISORY downgrade."""
+        fields = _base_fields()
+        fields["runner"] = "worker-A"
+        fields["verifier"] = "worker-A "  # trailing space
+        receipt = ModelDodReceipt(**fields)
+        # Both identity strings normalized to "worker-A"; Rule 1 fires.
+        assert receipt.runner == "worker-A"
+        assert receipt.verifier == "worker-A"
+        assert receipt.status is EnumReceiptStatus.ADVISORY
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n  \t"])
+    def test_whitespace_only_identity_rejected(self, blank: str) -> None:
+        """Whitespace-only ``runner`` or ``verifier`` must be rejected at
+        construction — silently empty identities would make every receipt
+        self-attest under Rule 1 (both normalize to '')."""
+        fields = _base_fields()
+        fields["runner"] = blank
+        with pytest.raises(ValidationError):
+            ModelDodReceipt(**fields)
+        fields = _base_fields()
+        fields["verifier"] = blank
+        with pytest.raises(ValidationError):
+            ModelDodReceipt(**fields)

--- a/tests/unit/models/contracts/test_model_dod_receipt.py
+++ b/tests/unit/models/contracts/test_model_dod_receipt.py
@@ -284,7 +284,17 @@ class TestModelDodReceiptAdversarialInvariants:
 
     @pytest.mark.parametrize(
         "bad_version",
-        ["1.0", "v1.0.0", "1", "abc", "", "1.0.0.0"],
+        [
+            "1.0",
+            "v1.0.0",
+            "1",
+            "abc",
+            "",
+            "1.0.0.0",
+            "01.0.0",  # SemVer 2.0.0: leading zero in MAJOR rejected
+            "1.02.0",  # leading zero in MINOR
+            "1.0.03",  # leading zero in PATCH
+        ],
     )
     def test_invalid_schema_version_rejected(self, bad_version: str) -> None:
         fields = _base_fields()
@@ -294,7 +304,19 @@ class TestModelDodReceiptAdversarialInvariants:
 
     @pytest.mark.parametrize(
         "good_version",
-        ["1.0.0", "0.0.0", "1.2.3-beta.1", "2.10.99+build.123"],
+        [
+            "1.0.0",
+            "0.0.0",
+            "1.2.3-beta.1",
+            "2.10.99+build.123",
+            "1.0.0-rc.1+build-7",  # SemVer 2.0.0: build metadata may contain hyphens
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-0.3.7",
+            "1.0.0-x.7.z.92",
+            "10.20.30",
+            "1.1.2-prerelease+meta",
+        ],
     )
     def test_valid_schema_version_accepted(self, good_version: str) -> None:
         fields = _base_fields()
@@ -310,11 +332,59 @@ class TestModelDodReceiptAdversarialInvariants:
         receipt = ModelDodReceipt(**fields)
         assert receipt.status is EnumReceiptStatus.ADVISORY
 
-    def test_pending_status_accepted(self) -> None:
+    def test_pending_status_accepted_with_stdout(self) -> None:
         fields = _base_fields()
         fields["status"] = EnumReceiptStatus.PENDING
-        # PENDING for an executable check_type still requires probe_stdout
-        # (the check has been "allocated" with captured output even if it's
-        # not yet a terminal PASS/FAIL); leave probe_stdout populated.
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.PENDING
+
+    def test_pending_executable_check_allows_empty_probe_stdout(self) -> None:
+        """PENDING means probe was allocated but not yet executed — empty stdout
+        is the correct representation. Without this exemption, callers would
+        be forced to invent fake stdout to express the pending state."""
+        fields = _base_fields()
+        fields["status"] = EnumReceiptStatus.PENDING
+        fields["probe_stdout"] = ""
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.PENDING
+        assert receipt.probe_stdout == ""
+
+    def test_self_attestation_preserves_fail_status(self) -> None:
+        """FAIL must survive verifier == runner — collapsing FAIL into
+        ADVISORY would erase the meaning of the failure outcome."""
+        fields = _base_fields()
+        fields["status"] = EnumReceiptStatus.FAIL
+        fields["runner"] = "worker-X"
+        fields["verifier"] = "worker-X"  # self-attestation
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.FAIL
+
+    def test_self_attestation_preserves_pending_status(self) -> None:
+        """PENDING must survive verifier == runner — a queued probe with
+        a single-identity verifier is still pending, not advisory."""
+        fields = _base_fields()
+        fields["status"] = EnumReceiptStatus.PENDING
+        fields["runner"] = "worker-X"
+        fields["verifier"] = "worker-X"
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.PENDING
+
+    def test_file_exists_preserves_fail_status(self) -> None:
+        """FAIL must survive a weak-proof check_type — the probe ran and the
+        file was not present; that outcome must remain visible as FAIL."""
+        fields = _base_fields()
+        fields["check_type"] = "file_exists"
+        fields["status"] = EnumReceiptStatus.FAIL
+        fields["probe_stdout"] = ""  # file_exists has no stdout
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.FAIL
+
+    def test_file_exists_preserves_pending_status(self) -> None:
+        """PENDING must survive a weak-proof check_type — a queued
+        file_exists probe is still pending, not advisory."""
+        fields = _base_fields()
+        fields["check_type"] = "file_exists"
+        fields["status"] = EnumReceiptStatus.PENDING
+        fields["probe_stdout"] = ""
         receipt = ModelDodReceipt(**fields)
         assert receipt.status is EnumReceiptStatus.PENDING

--- a/tests/unit/models/contracts/test_model_dod_receipt.py
+++ b/tests/unit/models/contracts/test_model_dod_receipt.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -14,8 +15,16 @@ from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
 
 
-def _base_fields() -> dict:
+def _base_fields() -> dict[str, Any]:
+    """Return a baseline kwargs dict for a valid PASS receipt.
+
+    Independent verifier and runner identities and a non-empty
+    ``probe_stdout`` keep this fixture out of the ADVISORY downgrade paths
+    so callers that only test unrelated invariants (e.g. ticket_id format)
+    see PASS as the resulting status.
+    """
     return {
+        "schema_version": "1.0.0",
         "ticket_id": "OMN-9084",
         "evidence_item_id": "dod-001",
         "check_type": "command",
@@ -24,6 +33,9 @@ def _base_fields() -> dict:
         "run_timestamp": datetime.now(tz=UTC),
         "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
         "runner": "ci-receipt-gate",
+        "verifier": "foreground-receipt-gate-2026-04-26",
+        "probe_command": "gh pr view --json state -q .state",
+        "probe_stdout": "OPEN\n",
     }
 
 
@@ -151,3 +163,158 @@ class TestModelDodReceiptStatusEnum:
         fields["status"] = "MAYBE"
         with pytest.raises(ValidationError):
             ModelDodReceipt(**fields)
+
+
+@pytest.mark.unit
+class TestEnumReceiptStatusMembers:
+    """OMN-9786: enum exposes exactly {PASS, FAIL, ADVISORY, PENDING}."""
+
+    def test_enum_receipt_status_values(self) -> None:
+        assert {s.value for s in EnumReceiptStatus} == {
+            "PASS",
+            "FAIL",
+            "ADVISORY",
+            "PENDING",
+        }
+
+
+@pytest.mark.unit
+class TestModelDodReceiptAdversarialInvariants:
+    """OMN-9786: Centralized Transition Policy enforced by model validator."""
+
+    def test_receipt_with_distinct_verifier_and_runner_is_pass(self) -> None:
+        receipt = ModelDodReceipt(
+            schema_version="1.0.0",
+            ticket_id="OMN-9762",
+            evidence_item_id="dod-001",
+            check_type="command",
+            check_value="gh pr checks 916 --repo OmniNode-ai/omnibase_core",
+            runner="worker-N1762",
+            verifier="foreground-2026-04-26-session-abc",
+            probe_command="gh pr checks 916 --repo OmniNode-ai/omnibase_core",
+            probe_stdout="...all checks passed...",
+            exit_code=0,
+            run_timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+            status=EnumReceiptStatus.PASS,
+            commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
+        )
+        assert receipt.status is EnumReceiptStatus.PASS
+
+    def test_receipt_with_verifier_equal_runner_is_advisory(self) -> None:
+        # Even if caller passes status=PASS, model must downgrade to ADVISORY.
+        receipt = ModelDodReceipt(
+            schema_version="1.0.0",
+            ticket_id="OMN-9762",
+            evidence_item_id="dod-001",
+            check_type="command",
+            check_value="gh pr checks 916",
+            runner="worker-N1762",
+            verifier="worker-N1762",
+            probe_command="gh pr checks 916",
+            probe_stdout="all green",
+            exit_code=0,
+            run_timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+            status=EnumReceiptStatus.PASS,
+            commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
+        )
+        assert receipt.status is EnumReceiptStatus.ADVISORY
+
+    def test_receipt_with_empty_probe_stdout_for_command_type_fails(self) -> None:
+        with pytest.raises(ValidationError, match="probe_stdout"):
+            ModelDodReceipt(
+                schema_version="1.0.0",
+                ticket_id="OMN-9762",
+                evidence_item_id="dod-001",
+                check_type="command",
+                check_value="gh pr checks 916",
+                runner="worker-N1762",
+                verifier="foreground-X",
+                probe_command="gh pr checks 916",
+                probe_stdout="",  # empty stdout for a command check is rejected
+                exit_code=0,
+                run_timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+                status=EnumReceiptStatus.PASS,
+                commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
+            )
+
+    @pytest.mark.parametrize(
+        "executable_check_type", ["command", "test_passes", "endpoint", "grep"]
+    )
+    def test_empty_probe_stdout_fails_for_all_executable_check_types(
+        self, executable_check_type: str
+    ) -> None:
+        with pytest.raises(ValidationError, match="probe_stdout"):
+            ModelDodReceipt(
+                schema_version="1.0.0",
+                ticket_id="OMN-9762",
+                evidence_item_id="dod-001",
+                check_type=executable_check_type,
+                check_value="probe",
+                runner="worker-A",
+                verifier="foreground-B",
+                probe_command="probe",
+                probe_stdout="   \n  ",  # whitespace-only also rejected
+                run_timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+                status=EnumReceiptStatus.PASS,
+                commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
+            )
+
+    def test_receipt_file_exists_check_alone_demoted_to_advisory(self) -> None:
+        # file_exists is weak proof; status downgrades to ADVISORY regardless
+        # of verifier/runner identity. Empty probe_stdout is allowed for this
+        # check_type because file_exists has no stdout.
+        receipt = ModelDodReceipt(
+            schema_version="1.0.0",
+            ticket_id="OMN-9762",
+            evidence_item_id="dod-001",
+            check_type="file_exists",
+            check_value="drift/dod_receipts/OMN-9762/dod-001/file_exists.yaml",
+            runner="worker-N1762",
+            verifier="foreground-X",
+            probe_command=(
+                "test -f drift/dod_receipts/OMN-9762/dod-001/file_exists.yaml"
+            ),
+            probe_stdout="",  # file_exists has no stdout; allowed for this check_type
+            exit_code=0,
+            run_timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+            status=EnumReceiptStatus.PASS,
+            commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
+        )
+        assert receipt.status is EnumReceiptStatus.ADVISORY
+
+    @pytest.mark.parametrize(
+        "bad_version",
+        ["1.0", "v1.0.0", "1", "abc", "", "1.0.0.0"],
+    )
+    def test_invalid_schema_version_rejected(self, bad_version: str) -> None:
+        fields = _base_fields()
+        fields["schema_version"] = bad_version
+        with pytest.raises(ValidationError, match="schema_version"):
+            ModelDodReceipt(**fields)
+
+    @pytest.mark.parametrize(
+        "good_version",
+        ["1.0.0", "0.0.0", "1.2.3-beta.1", "2.10.99+build.123"],
+    )
+    def test_valid_schema_version_accepted(self, good_version: str) -> None:
+        fields = _base_fields()
+        fields["schema_version"] = good_version
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.schema_version == good_version
+
+    def test_advisory_status_passes_through_when_set_explicitly(self) -> None:
+        # Caller asks for ADVISORY directly — the validator must not error,
+        # and downgrade rules become no-ops because status is already ADVISORY.
+        fields = _base_fields()
+        fields["status"] = EnumReceiptStatus.ADVISORY
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.ADVISORY
+
+    def test_pending_status_accepted(self) -> None:
+        fields = _base_fields()
+        fields["status"] = EnumReceiptStatus.PENDING
+        # PENDING for an executable check_type still requires probe_stdout
+        # (the check has been "allocated" with captured output even if it's
+        # not yet a terminal PASS/FAIL); leave probe_stdout populated.
+        receipt = ModelDodReceipt(**fields)
+        assert receipt.status is EnumReceiptStatus.PENDING

--- a/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
+++ b/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
@@ -47,7 +47,10 @@ def _base_receipt(
     status: EnumReceiptStatus = EnumReceiptStatus.PASS,
     actual_output: str | None = None,
 ) -> ModelDodReceipt:
+    # `runtime_sha_match` is not in EXECUTABLE_CHECK_TYPES, so probe_stdout
+    # may be empty without violating the adversarial invariants.
     return ModelDodReceipt(
+        schema_version="1.0.0",
         ticket_id="OMN-9356",
         evidence_item_id="dod-sha-001",
         check_type=check_type,
@@ -56,6 +59,9 @@ def _base_receipt(
         run_timestamp=datetime.now(tz=UTC),
         commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
         runner="integration-sweep-verifier",
+        verifier="foreground-runtime-sha-verifier",
+        probe_command=_PROBE_CMD,
+        probe_stdout=actual_output or "abc123def456\n",  # pragma: allowlist secret
         actual_output=actual_output,
     )
 
@@ -236,6 +242,7 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
 
     def test_pass_receipt_clears_guard(self) -> None:
         receipt = ModelDodReceipt(
+            schema_version="1.0.0",
             ticket_id="OMN-9356",
             evidence_item_id="dod-sha-001",
             check_type="runtime_sha_match",
@@ -244,6 +251,9 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
             run_timestamp=datetime.now(tz=UTC),
             commit_sha="abc123def456",  # pragma: allowlist secret
             runner="ci",
+            verifier="dod-guard-verifier",
+            probe_command=_PROBE_CMD,
+            probe_stdout="abc123def456\n",  # pragma: allowlist secret
             actual_output=_make_output_json(
                 deployed_sha="abc123def456",  # pragma: allowlist secret
                 merge_sha="abc123def456",  # pragma: allowlist secret
@@ -259,6 +269,7 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
 
     def test_fail_receipt_still_blocks(self) -> None:
         receipt = ModelDodReceipt(
+            schema_version="1.0.0",
             ticket_id="OMN-9356",
             evidence_item_id="dod-sha-001",
             check_type="runtime_sha_match",
@@ -267,6 +278,9 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
             run_timestamp=datetime.now(tz=UTC),
             commit_sha="abc123def456",  # pragma: allowlist secret
             runner="ci",
+            verifier="dod-guard-verifier",
+            probe_command=_PROBE_CMD,
+            probe_stdout="mismatch detected\n",
             actual_output=_make_output_json(
                 deployed_sha="aaaaaaaaaaaa",  # pragma: allowlist secret
                 merge_sha="bbbbbbbbbbbb",  # pragma: allowlist secret

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -54,6 +54,7 @@ def _write_receipt(
     p = receipts_dir / ticket_id / evidence_item_id / f"{check_type}.yaml"
     p.parent.mkdir(parents=True, exist_ok=True)
     data = {
+        "schema_version": "1.0.0",
         "ticket_id": ticket_id,
         "evidence_item_id": evidence_item_id,
         "check_type": check_type,
@@ -62,6 +63,13 @@ def _write_receipt(
         "run_timestamp": datetime.now(tz=UTC).isoformat(),
         "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
         "runner": "test-runner",
+        # OMN-9786 adversarial fields. verifier must differ from runner so
+        # the transition policy does not auto-downgrade PASS → ADVISORY.
+        "verifier": "test-verifier",
+        "probe_command": check_value,
+        # Non-empty stdout so executable check_types ("command", etc.) do
+        # not raise "probe_stdout required for executable check_type".
+        "probe_stdout": "test stdout",
     }
     if overrides:
         data.update(overrides)


### PR DESCRIPTION
## Summary

Implements Task 6 (Wave B) of `docs/plans/2026-04-26-session-process-and-change-control.md`. Extends the existing `ModelDodReceipt` and `EnumReceiptStatus` in `omnibase_core` (the canonical location consumed by the receipt-gate) with the four-rule Centralized Transition Policy.

Closes OMN-9786.

## Changes

**`EnumReceiptStatus`** — add two members:
- `ADVISORY` — receipt ran but proof is structurally weak (self-attestation or sole `file_exists`)
- `PENDING` — probe was allocated but not yet executed

**`ModelDodReceipt`** — add four required fields enforced by a `model_validator(mode="after")` named `enforce_adversarial_invariants`:
- `schema_version: str` — SemVer-validated, pins downstream consumers
- `verifier: str` — identity that verified the probe; must differ from `runner` for non-ADVISORY status
- `probe_command: str` — literal command executed (max 10K chars)
- `probe_stdout: str` — literal captured stdout (max 1MB); required non-empty for executable check_types

**Centralized Transition Policy:**
1. `verifier == runner` (self-attestation) → auto-downgrade to `ADVISORY`
2. `check_type == "file_exists"` → auto-downgrade to `ADVISORY`
3. `check_type in {command, test_passes, endpoint, grep}` AND empty `probe_stdout` → `ValueError`
4. `schema_version` must match SemVer regex (field validator)

The downgrade is achieved via `object.__setattr__` because the model is frozen.

## Backwards compatibility

Existing receipts on disk lack the four new fields and will fail `ModelDodReceipt.model_validate` with a `ValidationError` that names each missing field by name. The migration in **OMN-9790** will backfill them with sentinel values (`verifier="legacy-self-attested"`, `probe_command=""`, `probe_stdout=""`, `schema_version="0.0.0"`) so legacy receipts validate with `status` auto-downgraded to `ADVISORY` per Rule 1.

This PR intentionally does NOT add Optional defaults — the plan explicitly requires them as `Field(...)` so future receipts cannot regress.

## Tests

- 9 new tests in `TestEnumReceiptStatusMembers` and `TestModelDodReceiptAdversarialInvariants` covering each rule (distinct verifier/runner → PASS, verifier == runner → ADVISORY, empty `probe_stdout` for each executable check_type → `ValidationError`, `file_exists` → ADVISORY, frozen, exact enum membership, SemVer good and bad cases, explicit ADVISORY/PENDING pass-through).
- Existing `_base_fields()` / `_base_receipt()` / `_write_receipt()` fixtures in `test_model_dod_receipt.py`, `test_runtime_sha_match_dod_gate.py`, and `test_validate_pr_receipts.py` updated to supply the new required fields.

## Pre-push gates

- `uv run ruff format src/ tests/` — clean
- `uv run ruff check --fix src/ tests/` — `All checks passed!`
- `uv run mypy --strict src/omnibase_core/enums/ticket/enum_receipt_status.py src/omnibase_core/models/contracts/ticket/model_dod_receipt.py` — `Success: no issues found`
- `uv run pytest tests/unit/models/contracts/ tests/unit/scripts/validation/` — **3256 passed**, 0 failed
- `pre-commit run --files <changed>` — all hooks passed (no `--no-verify`)

The full `tests/` suite was not run end-to-end here due to its multi-thousand-test runtime; the changes only touch `model_dod_receipt.py` + `enum_receipt_status.py`, and every importer of those modules is in the targeted scope above.

## Test plan

- [x] EnumReceiptStatus exposes exactly {PASS, FAIL, ADVISORY, PENDING}
- [x] verifier == runner downgrades PASS → ADVISORY
- [x] check_type == "file_exists" downgrades PASS → ADVISORY
- [x] Empty probe_stdout for command/test_passes/endpoint/grep raises ValidationError
- [x] schema_version SemVer regex enforced
- [x] Receipt is frozen (cannot mutate after construction)
- [x] Existing receipt-gate tests (test_validate_pr_receipts.py) still pass with new fields
- [x] runtime_sha_match DoD gate tests still pass with new fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two receipt statuses: ADVISORY and PENDING.
  * Added schema-version tracking and probe metadata fields (verifier, probe command, probe output) on receipts.

* **Bug Fixes**
  * Stronger validation: require probe output for executable checks; auto-downgrade self-attested or weak proofs from PASS to ADVISORY while preserving FAIL/PENDING.

* **Tests**
  * Expanded tests and generators to cover new fields, status behavior, and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->