### PR TITLE
OMN-9855: Nightly full-suite schedule + keep push/merge_group full

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches: [main]
   merge_group:
   workflow_dispatch:
+  schedule:
+    - cron: "13 7 * * *"   # 07:13 UTC nightly
 
 # Prevent auto-cancellation of running workflows when new commits are pushed
 # This ensures test splits actually run to completion instead of being skipped

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
+import pytest
+
 from scripts.ci.detect_test_paths import resolve_test_paths
+
+pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
@@ -161,5 +165,36 @@ def test_feature_flag_off_returns_full_suite() -> None:
     )
     assert selection.is_full_suite is True
     assert selection.full_suite_reason == EnumFullSuiteReason.FEATURE_FLAG_OFF
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+# ---------------------------------------------------------------------------
+# OMN-9855: schedule + merge_group event escalation
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="schedule",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SCHEDULED
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+def test_merge_group_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="merge_group",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.MERGE_GROUP
     assert selection.split_count == 40
     assert selection.matrix == list(range(1, 41))


### PR DESCRIPTION
## Summary
- Adds `on.schedule.cron: "13 7 * * *"` to `.github/workflows/ci.yml`
- Retains `on.push.branches: [main]`, `on.pull_request.branches: [main]`, `on.merge_group`, and `workflow_dispatch` triggers
- Adds active unit coverage for schedule and merge_group full-suite escalation now that OMN-9862/OMN-9863 are on main

Implements OMN-9855, plan task 13.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] `uv run pytest tests/unit/scripts/ci/test_detect_test_paths.py -q` — 14 passed
- [x] `uv run ruff format --check tests/unit/scripts/ci/test_detect_test_paths.py`
- [x] `uv run ruff check tests/unit/scripts/ci/test_detect_test_paths.py`
- [x] YAML parse check for `.github/workflows/ci.yml` schedule trigger
- [x] pre-commit/pre-push hooks passed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI pipeline now includes automated nightly scheduled test runs in addition to existing push, pull request, and manual triggers.

* **Tests**
  * Added unit tests validating that scheduled runs and merge-group events trigger full-suite selection and expected test matrix splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->