### PR TITLE
OMN-9864: Adjacency map loader with shape validation

### DIFF
--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -11,16 +11,22 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelAdjacencyEntry(BaseModel):
+    """Adjacency metadata for a module, including reverse dependencies."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
     reverse_deps: list[str] = Field(default_factory=list)
 
 
 class ModelThresholds(BaseModel):
+    """Thresholds that govern when CI escalates to full-suite execution."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
     modules_changed_for_full_suite: int = Field(..., ge=1)
 
 
 class ModelAdjacencyMap(BaseModel):
+    """Validated static adjacency-map contract loaded from YAML."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     schema_version: int = Field(..., ge=1)
@@ -31,6 +37,7 @@ class ModelAdjacencyMap(BaseModel):
 
     @model_validator(mode="after")
     def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        """Enforce cross-section integrity between shared modules and adjacency graph."""
         for shared in self.shared_modules:
             if shared not in self.adjacency:
                 raise ValueError(f"shared_module '{shared}' has no adjacency entry")
@@ -44,5 +51,6 @@ class ModelAdjacencyMap(BaseModel):
 
 
 def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    """Load adjacency YAML from `path` and return a validated `ModelAdjacencyMap`."""
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     return ModelAdjacencyMap.model_validate(raw)

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -12,6 +12,7 @@ from scripts.ci.test_selection_loader import (
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
+@pytest.mark.unit
 def test_load_adjacency_map_parses_repo_yaml() -> None:
     config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
     config = load_adjacency_map(config_path)
@@ -21,6 +22,7 @@ def test_load_adjacency_map_parses_repo_yaml() -> None:
     assert "models" in config.adjacency
 
 
+@pytest.mark.unit
 def test_load_rejects_unknown_shared_module(tmp_path: Path) -> None:
     bad_yaml = """
 schema_version: 1
@@ -37,6 +39,7 @@ adjacency:
         load_adjacency_map(tmp)
 
 
+@pytest.mark.unit
 def test_every_src_module_has_adjacency_entry() -> None:
     config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
     config = load_adjacency_map(config_path)

--- a/tests/unit/scripts/ci/test_test_selection_models.py
+++ b/tests/unit/scripts/ci/test_test_selection_models.py
@@ -9,6 +9,7 @@ from scripts.ci.test_selection_models import (
 )
 
 
+@pytest.mark.unit
 def test_full_suite_selection_serializes_with_reason() -> None:
     selection = ModelTestSelection(
         selected_paths=["tests/"],
@@ -27,6 +28,7 @@ def test_full_suite_selection_serializes_with_reason() -> None:
     }
 
 
+@pytest.mark.unit
 def test_smart_selection_disallows_full_suite_reason() -> None:
     with pytest.raises(ValidationError):
         ModelTestSelection(
@@ -38,6 +40,7 @@ def test_smart_selection_disallows_full_suite_reason() -> None:
         )
 
 
+@pytest.mark.unit
 def test_matrix_length_matches_split_count() -> None:
     with pytest.raises(ValidationError):
         ModelTestSelection(


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/test_selection_loader.py` with `ModelAdjacencyMap`, `ModelAdjacencyEntry`, `ModelThresholds`, `load_adjacency_map`
- Adds `tests/unit/scripts/ci/test_test_selection_loader.py` (3 tests: parse repo YAML, reject unknown shared module, every src module has adjacency entry)

Implements OMN-9864, plan task 3.

**Depends on:**
- #925 (OMN-9860) — adjacency YAML
- #927 (OMN-9862) — Pydantic output models

This branch merges both dependency branches; merge after #925 and #927 land.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] 3 unit tests pass
- [x] Loader rejects shared_modules entries not present in adjacency
- [x] Loader rejects reverse_deps references to unknown modules
- [x] pre-commit run --all-files passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation for development utilities.

* **Tests**
  * Improved test infrastructure with updated test markers.

**Note:** This release contains primarily internal improvements with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->