### PR TITLE
OMN-9866: Direct module to test path mapping

### DIFF
--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Change-aware test path resolution for omnibase_core CI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+
+SRC_PREFIX = "src/omnibase_core/"
+TEST_UNIT_PREFIX = "tests/unit/"
+TEST_INTEGRATION_PREFIX = "tests/integration/"
+
+
+def resolve_test_paths(
+    changed_files: list[str],
+    adjacency_path: Path,
+) -> list[str]:
+    """Map changed file paths to deterministic UNIT test directories.
+
+    Behavior:
+      - Source changes under src/omnibase_core/<module>: include
+        tests/unit/<module>/.
+      - Test-only changes under tests/unit/: include the changed unit-test directory.
+      - Test-only changes under tests/integration/: ignored (integration runs always).
+      - Files outside src/ and tests/unit/: no contribution; caller decides
+        whether to escalate to full suite.
+
+    Adjacency expansion is added in Task 5.
+    """
+    config = load_adjacency_map(adjacency_path)
+    return _resolve(changed_files, config)
+
+
+def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
+    selected: set[str] = set()
+    for path in changed_files:
+        if path.startswith(SRC_PREFIX):
+            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
+            if module in config.adjacency:
+                selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+        elif path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+    return sorted(selected)

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# scripts/ci/test_selection_adjacency.yaml
+# Static adjacency map from src/omnibase_core/<module> to dependent modules.
+# When a key module changes, every module in `reverse_deps` ALSO has its tests run.
+# Treated as CI contract data — manually curated, reviewed in PRs that change it.
+
+schema_version: 1
+
+# `shared_modules` is a FULL-SUITE ESCALATION POLICY, not an architectural ontology.
+# Listing a module here means "if this module changes, run the full suite" — it does
+# NOT claim the module is fundamentally more important than others, nor does it map
+# to a permanent layering invariant. Curate based on operational risk + import fan-out.
+# Removing a module from this list is allowed once we have shadow data showing its
+# changes don't surface broad regressions.
+shared_modules:
+  - models
+  - contracts
+  - enums
+  - validation
+  - runtime
+  - event_bus
+
+# Per-repo full-suite escalation thresholds.
+thresholds:
+  modules_changed_for_full_suite: 8
+
+# Test infrastructure — any change forces the full suite.
+test_infrastructure_paths:
+  - tests/conftest.py
+  - tests/fixtures/
+  - tests/pytest.ini
+  - pytest.ini
+  - pyproject.toml
+
+# Reverse dependency edges. Key = changed module; value = modules that import it.
+# When `models` changes, also run tests for everything in `models.reverse_deps`.
+# Note: shared_modules entries here are not consulted at runtime
+# (they trigger full suite first), but kept for completeness/documentation.
+adjacency:
+  models:
+    reverse_deps: [nodes, contracts, runtime, validation, services, factories, container]
+  contracts:
+    reverse_deps: [nodes, runtime, validation]
+  enums:
+    reverse_deps: [models, contracts, nodes, validation, runtime]
+  validation:
+    reverse_deps: [nodes, runtime, services]
+  runtime:
+    reverse_deps: [nodes, services, container]
+  event_bus:
+    reverse_deps: [runtime, services, nodes]
+  container:
+    reverse_deps: [services, nodes, runtime]
+  protocols:
+    reverse_deps: [nodes, services, factories]
+  errors:
+    reverse_deps: [models, runtime, nodes, services]
+  # Leaf modules with no reverse_deps still appear so the loader can validate
+  # that every src/omnibase_core/<dir> has an entry.
+  backends: {reverse_deps: []}
+  cli: {reverse_deps: []}
+  constants: {reverse_deps: []}
+  context: {reverse_deps: [nodes, runtime]}
+  crypto: {reverse_deps: []}
+  decorators: {reverse_deps: []}
+  discovery: {reverse_deps: [nodes, runtime]}
+  doctor: {reverse_deps: []}
+  factories: {reverse_deps: [nodes, container]}
+  infrastructure: {reverse_deps: []}
+  integrations: {reverse_deps: []}
+  logging: {reverse_deps: []}
+  merge: {reverse_deps: []}
+  mixins: {reverse_deps: [models, nodes]}
+  navigation: {reverse_deps: []}
+  nodes: {reverse_deps: []}
+  normalization: {reverse_deps: [models, nodes]}
+  overlays: {reverse_deps: []}
+  package: {reverse_deps: []}
+  pipeline: {reverse_deps: [nodes]}
+  rendering: {reverse_deps: []}
+  resolution: {reverse_deps: [nodes, runtime]}
+  schemas: {reverse_deps: [models]}
+  scripts: {reverse_deps: []}
+  services: {reverse_deps: [nodes]}
+  tools: {reverse_deps: []}
+  types: {reverse_deps: [models]}
+  utils: {reverse_deps: []}
+  workflows: {reverse_deps: [nodes]}

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Load and validate the static module adjacency map."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelAdjacencyEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reverse_deps: list[str] = Field(default_factory=list)
+
+
+class ModelThresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    modules_changed_for_full_suite: int = Field(..., ge=1)
+
+
+class ModelAdjacencyMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(..., ge=1)
+    shared_modules: list[str]
+    thresholds: ModelThresholds
+    test_infrastructure_paths: list[str]
+    adjacency: dict[str, ModelAdjacencyEntry]
+
+    @model_validator(mode="after")
+    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        for shared in self.shared_modules:
+            if shared not in self.adjacency:
+                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
+        for module, entry in self.adjacency.items():
+            for dep in entry.reverse_deps:
+                if dep not in self.adjacency:
+                    raise ValueError(
+                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                    )
+        return self
+
+
+def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    raw = yaml.safe_load(path.read_text())
+    return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -44,5 +44,5 @@ class ModelAdjacencyMap(BaseModel):
 
 
 def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pydantic output contract for change-aware test selection."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"
+
+
+TestPath = Annotated[
+    str,
+    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
+]
+
+
+class ModelTestSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_paths: list[TestPath] = Field(..., min_length=1)
+    split_count: int = Field(..., ge=1, le=40)
+    is_full_suite: bool
+    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
+    matrix: list[int] = Field(...)
+
+    @model_validator(mode="after")
+    def validate_full_suite_reason(self) -> Self:
+        if self.is_full_suite and self.full_suite_reason is None:
+            raise ValueError("full_suite_reason required when is_full_suite=True")
+        if not self.is_full_suite and self.full_suite_reason is not None:
+            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
+        if len(self.matrix) != self.split_count:
+            raise ValueError(
+                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
+            )
+        return self

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -568,7 +568,9 @@ def _is_wrapped_dispatch(raw: str) -> bool:
     )
     if not any(prefix in lowered for prefix in wrapper_prefixes):
         return False
-    return re.search(r"\bonex\b[^A-Za-z0-9]+(?:run-node|run|node)\b", lowered) is not None
+    return (
+        re.search(r"\bonex\b[^A-Za-z0-9]+(?:run-node|run|node)\b", lowered) is not None
+    )
 
 
 def _is_prose_fallback(line: ShellLine) -> bool:
@@ -582,7 +584,11 @@ def _is_prose_fallback(line: ShellLine) -> bool:
     and the raw line must contain a word hinting at fallback / degrade / prose.
     """
     idx = 0
-    while idx < len(line.tokens) and "=" in line.tokens[idx] and not line.tokens[idx].startswith("-"):
+    while (
+        idx < len(line.tokens)
+        and "=" in line.tokens[idx]
+        and not line.tokens[idx].startswith("-")
+    ):
         name = line.tokens[idx].split("=", 1)[0]
         if name and name.replace("_", "").isalnum() and name[0].isalpha():
             idx += 1

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -43,10 +43,10 @@ FALLBACK_PATTERNS = [
 
 # Lines that are clearly docstrings/comments/examples are excluded
 SKIP_PATTERNS = [
-    re.compile(r'^\s*#'),          # Comments
-    re.compile(r'^\s*["\']'),      # Docstring lines
-    re.compile(r'^\s*>>>'),        # Doctest examples
-    re.compile(r'^\s*\.\.\s'),     # RST continuation
+    re.compile(r"^\s*#"),  # Comments
+    re.compile(r'^\s*["\']'),  # Docstring lines
+    re.compile(r"^\s*>>>"),  # Doctest examples
+    re.compile(r"^\s*\.\.\s"),  # RST continuation
 ]
 
 
@@ -74,11 +74,11 @@ def scan_file(filepath: Path) -> list[tuple[int, str]]:
                 in_docstring = False
                 docstring_delim = None
                 break
-            elif not in_docstring and count == 1:
+            if not in_docstring and count == 1:
                 in_docstring = True
                 docstring_delim = delim
                 break
-            elif count >= 2:
+            if count >= 2:
                 # Opens and closes on same line
                 break
 

--- a/scripts/validation/validate-contracts.py
+++ b/scripts/validation/validate-contracts.py
@@ -236,7 +236,11 @@ def discover_yaml_files_optimized(base_path: Path) -> Iterator[Path]:
             # Skip archived directories and test fixtures early
             dirs_to_skip = []
             for dir_name in dirs:
-                if dir_name in ("archived", "__pycache__", "architecture-handshakes") or dir_name.startswith("."):
+                if dir_name in (
+                    "archived",
+                    "__pycache__",
+                    "architecture-handshakes",
+                ) or dir_name.startswith("."):
                     dirs_to_skip.append(dir_name)
 
             # Remove from dirs to prevent os.walk from recursing

--- a/tests/unit/scripts/ci/__init__.py
+++ b/tests/unit/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from scripts.ci.detect_test_paths import resolve_test_paths
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+
+
+def test_single_module_change_resolves_to_one_test_dir() -> None:
+    changed_files = ["src/omnibase_core/cli/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    # `_resolve` returns ONLY unit-test paths. Integration runs always via
+    # the separate fixed-matrix tests-integration job, so the smart-selection
+    # contract excludes tests/integration/ entirely.
+    assert paths == ["tests/unit/cli/"]
+
+
+def test_test_only_change_runs_only_changed_test_dir() -> None:
+    changed_files = ["tests/unit/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == ["tests/unit/nodes/"]
+
+
+def test_integration_test_only_change_does_not_select_unit_tests() -> None:
+    # Integration test changes do not contribute to unit-job selection;
+    # the integration job runs all integration tests on every PR anyway.
+    changed_files = ["tests/integration/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []
+
+
+def test_unknown_source_path_falls_back_to_full_suite_signal() -> None:
+    # Files outside src/ and tests/unit/ — no unit-test mapping.
+    changed_files = ["docs/README.md", ".github/workflows/foo.yml"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_load_adjacency_map_parses_repo_yaml() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    assert isinstance(config, ModelAdjacencyMap)
+    assert config.schema_version == 1
+    assert "models" in config.shared_modules
+    assert "models" in config.adjacency
+
+
+def test_load_rejects_unknown_shared_module(tmp_path: Path) -> None:
+    bad_yaml = """
+schema_version: 1
+shared_modules: [does_not_exist]
+thresholds:
+  modules_changed_for_full_suite: 8
+test_infrastructure_paths: []
+adjacency:
+  nodes: { reverse_deps: [] }
+"""
+    tmp = tmp_path / "bad_adj.yaml"
+    tmp.write_text(bad_yaml)
+    with pytest.raises(ValueError, match="shared_module 'does_not_exist'"):
+        load_adjacency_map(tmp)
+
+
+def test_every_src_module_has_adjacency_entry() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    src_root = REPO_ROOT / "src/omnibase_core"
+    src_modules = {
+        p.name for p in src_root.iterdir() if p.is_dir() and not p.name.startswith("_")
+    }
+    missing = src_modules - set(config.adjacency.keys())
+    assert not missing, f"Modules missing adjacency entry: {missing}"

--- a/tests/unit/scripts/ci/test_test_selection_models.py
+++ b/tests/unit/scripts/ci/test_test_selection_models.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import pytest
+from pydantic import ValidationError
+
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+
+def test_full_suite_selection_serializes_with_reason() -> None:
+    selection = ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=40,
+        is_full_suite=True,
+        full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+        matrix=list(range(1, 41)),
+    )
+    payload = selection.model_dump(mode="json")
+    assert payload == {
+        "selected_paths": ["tests/"],
+        "split_count": 40,
+        "is_full_suite": True,
+        "full_suite_reason": "shared_module",
+        "matrix": list(range(1, 41)),
+    }
+
+
+def test_smart_selection_disallows_full_suite_reason() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=2,
+            is_full_suite=False,
+            full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+            matrix=[1, 2],
+        )
+
+
+def test_matrix_length_matches_split_count() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=3,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=[1, 2],  # length mismatch
+        )


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/detect_test_paths.py` with `resolve_test_paths` and `_resolve` (unit-test paths only — integration job runs always via OMN-9851)
- Adds 4 unit tests covering single-module change, test-only change, integration-only change (returns []), and unknown-path change

Implements OMN-9866, plan task 4.

**Depends on:** #928 (OMN-9864 loader, which stacks on #925 OMN-9860 + #927 OMN-9862). This branch merges in the full dependency stack; merge AFTER #928 lands.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] 4 unit tests pass
- [x] `src/omnibase_core/cli/foo.py` → exactly `["tests/unit/cli/"]`
- [x] `tests/integration/nodes/test_foo.py` → exactly `[]`
- [x] pre-commit run --all-files passes