### PR TITLE
OMN-9856: Adjacency expansion for shared-module changes

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -50,9 +50,17 @@ def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
 
     for path in changed_files:
         if path.startswith(SRC_PREFIX):
-            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
-            if module in config.adjacency:
-                direct_modules.add(module)
+            relative = path[len(SRC_PREFIX) :]
+            parts = relative.split("/", 1)
+            if len(parts) < 2:
+                continue
+            module = parts[0]
+            if module not in config.adjacency:
+                raise ValueError(
+                    f"Module '{module}' missing from adjacency map; "
+                    "update scripts/ci/test_selection_adjacency.yaml"
+                )
+            direct_modules.add(module)
         elif path.startswith(TEST_UNIT_PREFIX):
             parts = path.split("/")
             if len(parts) >= 3:

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -11,16 +11,22 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelAdjacencyEntry(BaseModel):
+    """Adjacency entry for a single source module."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
     reverse_deps: list[str] = Field(default_factory=list)
 
 
 class ModelThresholds(BaseModel):
+    """Threshold values that trigger full-suite behavior."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
     modules_changed_for_full_suite: int = Field(..., ge=1)
 
 
 class ModelAdjacencyMap(BaseModel):
+    """Validated static adjacency configuration used for CI test selection."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     schema_version: int = Field(..., ge=1)
@@ -44,5 +50,6 @@ class ModelAdjacencyMap(BaseModel):
 
 
 def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    """Load and validate adjacency YAML from disk."""
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     return ModelAdjacencyMap.model_validate(raw)

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
-from scripts.ci.detect_test_paths import resolve_test_paths
+import pytest
+
+from scripts.ci.detect_test_paths import compute_selection, resolve_test_paths
+from scripts.ci.test_selection_models import EnumFullSuiteReason
+
+pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
@@ -68,14 +73,21 @@ def test_change_in_protocols_expands_to_exact_set() -> None:
     assert paths == expected
 
 
+def test_unknown_module_fails_fast() -> None:
+    changed_files = ["src/omnibase_core/not_a_real_module/foo.py"]
+    with pytest.raises(ValueError, match="missing from adjacency map"):
+        resolve_test_paths(changed_files, adjacency_path=ADJ)
+
+
+def test_root_level_src_file_skipped() -> None:
+    changed_files = ["src/omnibase_core/__init__.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []
+
+
 # ---------------------------------------------------------------------------
 # Task 6: compute_selection escalation tests
 # ---------------------------------------------------------------------------
-
-from scripts.ci.detect_test_paths import compute_selection
-from scripts.ci.test_selection_models import (
-    EnumFullSuiteReason,
-)
 
 
 def test_shared_module_change_escalates_to_full_suite() -> None:

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -9,6 +9,8 @@ from scripts.ci.test_selection_loader import (
     load_adjacency_map,
 )
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 

--- a/tests/unit/scripts/ci/test_test_selection_models.py
+++ b/tests/unit/scripts/ci/test_test_selection_models.py
@@ -8,6 +8,8 @@ from scripts.ci.test_selection_models import (
     ModelTestSelection,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_full_suite_selection_serializes_with_reason() -> None:
     selection = ModelTestSelection(


### PR DESCRIPTION
## Summary
- Replaces `_resolve` body with adjacency expansion: changed source modules expand through their `reverse_deps` from `test_selection_adjacency.yaml`
- Adds 2 unit tests with exact-set assertions (models → 8 unit dirs; protocols → 4 unit dirs)

Implements OMN-9856, plan task 5.

**Depends on:** #929 (OMN-9866 mapping, which stacks on #928 → #927 → #925). Merge after #929 lands.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] 6 unit tests pass in test_detect_test_paths.py (4 from OMN-9866 + 2 new)
- [x] models change → exactly {tests/unit/<m>/ for m in [models, nodes, contracts, runtime, validation, services, factories, container]} (8 sorted entries)
- [x] protocols change → exactly {tests/unit/<m>/ for m in [protocols, nodes, services, factories]} (4 sorted entries; cli/ MUST NOT appear)
- [x] pre-commit run --all-files passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in module detection with clearer error messages for missing configurations.

* **Documentation**
  * Added comprehensive docstrings to model classes and utility functions.

* **Tests**
  * Enhanced test organization with unit test markers across CI test modules.
  * Expanded validation tests to cover missing module scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->