### PR TITLE
OMN-9865: Add detect-changes job to ci.yml (shadow mode)

### DIFF
--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
+import pytest
+
 from scripts.ci.detect_test_paths import resolve_test_paths
+
+pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -9,6 +9,8 @@ from scripts.ci.test_selection_loader import (
     load_adjacency_map,
 )
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 


### PR DESCRIPTION
## Summary
- Adds `detect-changes` job between Phase 1.5 `quality-gate` and Phase 2 `test-parallel`
- Job runs `scripts/ci/detect_test_paths.py` and emits 5 outputs (`is_full_suite`, `full_suite_reason`, `split_count`, `matrix`, `selected_paths`)
- Uploads `selection.json` as artifact `test-selection` for shadow-mode comparison
- **Matrix UNCHANGED** — 40-split test-parallel still authoritative until OMN-9852 wires the dynamic matrix
- Stable gate names (`Quality Gate`, `Tests Gate`, `CI Summary`) untouched

Implements OMN-9865, plan task 8.

**Depends on:** #932 (OMN-9863 stack). Merge after #932 lands.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] actionlint passes (only pre-existing SC2086/SC2129 info/style warnings present on original file)
- [x] yaml.safe_load passes
- [x] Job named "Detect Changes (shadow)" with `needs: quality-gate`
- [x] Outputs exactly 5 keys: `is_full_suite`, `full_suite_reason`, `split_count`, `matrix`, `selected_paths`
- [x] Uploads `selection.json` artifact `test-selection`
- [x] 40-split test-parallel matrix unchanged
- [x] 19/19 unit tests pass (`tests/unit/scripts/ci/`)
- [x] pre-commit run --files .github/workflows/ci.yml passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved categorization markers for unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->