### PR TITLE
OMN-9852: Convert unit test-parallel to dynamic matrix gated by ENABLE_SMART_TESTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,6 +852,83 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Phase 1.6 - Detect Changes (shadow mode)
+  # ---------------------------------------------------------------------------
+  # Runs detect_test_paths and emits 5 outputs for shadow-mode comparison.
+  # The 40-split test-parallel matrix remains unchanged until OMN-9852 wires it.
+
+  detect-changes:
+    name: Detect Changes (shadow)
+    needs: quality-gate
+    runs-on: ubuntu-latest
+    if: always() && needs.quality-gate.result == 'success'
+    outputs:
+      is_full_suite: ${{ steps.detect.outputs.is_full_suite }}
+      full_suite_reason: ${{ steps.detect.outputs.full_suite_reason }}
+      split_count: ${{ steps.detect.outputs.split_count }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      selected_paths: ${{ steps.detect.outputs.selected_paths }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Compute changed files
+        id: diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            git fetch --no-tags --depth=1 origin "$base" || true
+            git diff --name-only "$base"...HEAD > changed.txt
+          else
+            git diff --name-only HEAD~1 HEAD > changed.txt || echo "" > changed.txt
+          fi
+          echo "Changed files:"
+          cat changed.txt
+
+      - name: Resolve test selection
+        id: detect
+        env:
+          FLAG: ${{ vars.ENABLE_SMART_TESTS == 'true' && 'on' || 'off' }}
+        run: |
+          uv run python -m scripts.ci.detect_test_paths \
+            --changed-files-from changed.txt \
+            --ref-name "${{ github.ref_name }}" \
+            --event-name "${{ github.event_name }}" \
+            --feature-flag "$FLAG" \
+            > selection.json
+          cat selection.json
+          is_full=$(jq -r '.is_full_suite' selection.json)
+          reason=$(jq -r '.full_suite_reason // ""' selection.json)
+          split_count=$(jq -r '.split_count' selection.json)
+          matrix=$(jq -c '.matrix' selection.json)
+          paths=$(jq -c '.selected_paths' selection.json)
+          echo "is_full_suite=$is_full" >> "$GITHUB_OUTPUT"
+          echo "full_suite_reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "split_count=$split_count" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "selected_paths=$paths" >> "$GITHUB_OUTPUT"
+
+      - name: Upload selection artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-selection
+          path: selection.json
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # Phase 2 - Full Test Suite
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,10 +855,10 @@ jobs:
   # Phase 1.6 - Detect Changes (shadow mode)
   # ---------------------------------------------------------------------------
   # Runs detect_test_paths and emits 5 outputs for shadow-mode comparison.
-  # The 40-split test-parallel matrix remains unchanged until OMN-9852 wires it.
+  # Outputs consumed by test-parallel (OMN-9852): matrix, split_count, is_full_suite, selected_paths.
 
   detect-changes:
-    name: Detect Changes (shadow)
+    name: Detect Changes
     needs: quality-gate
     runs-on: ubuntu-latest
     if: always() && needs.quality-gate.result == 'success'
@@ -932,21 +932,19 @@ jobs:
   # Phase 2 - Full Test Suite
   # ---------------------------------------------------------------------------
 
-  # Parallel test execution - split into 40 groups for speed and memory management
-  # Split strategy rationale:
-  #   - 38,805 total tests / 40 splits = ~970 tests/split on 2-CPU ubuntu-latest runners
-  #   - Target: 7-9 minutes per split (down from 14-18 min with 20 splits)
-  #   - 40x parallelization speedup vs sequential execution
-  #   - Increased from 20 to 40 splits: test count grew 3x (12K → 38K) since last bump
-  #   - Duration-aware splitting via .test_durations cache eliminates outlier splits
+  # Parallel test execution — matrix shape driven by detect-changes output (OMN-9852).
+  # When ENABLE_SMART_TESTS is off (default), detect-changes emits a 40-shard matrix
+  # with full_suite_reason=FEATURE_FLAG_OFF so the full-suite pytest step runs.
+  # When the flag is on and the change set is small, detect-changes emits a smaller
+  # matrix and selected_paths, activating the smart-selection pytest step instead.
   #
   # Dependency rationale (fail-fast optimization):
   #   - quality-gate: Aggregates all Phase 1 checks (lint, pyright, exports, etc.)
-  #   - This ensures quality failures are caught BEFORE spawning 40 test runners
-  #   - Saves ~120 runner-minutes on validation failures
+  #   - detect-changes: provides matrix shape, split_count, selected_paths, is_full_suite
+  #   - This ensures quality failures are caught BEFORE spawning N test runners
   test-parallel:
-    name: Tests (Split ${{ matrix.split }}/40)
-    needs: [quality-gate]
+    name: Tests (Split ${{ matrix.split }}/${{ needs.detect-changes.outputs.split_count }})
+    needs: [quality-gate, detect-changes]
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
@@ -957,11 +955,12 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
+    if: always() && needs.quality-gate.result == 'success'
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+        split: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
 
     steps:
       - name: Checkout code
@@ -992,7 +991,34 @@ jobs:
           restore-keys: |
             test-durations-
 
-      - name: Run test split ${{ matrix.split }}/40
+      - name: Run pytest (smart selection)
+        if: vars.ENABLE_SMART_TESTS == 'true' && needs.detect-changes.outputs.is_full_suite == 'false'
+        env:
+          # OMN-3327: Performance tests use CI_RUNNER_TYPE to relax thresholds on
+          # shared self-hosted runners (15-25% lower throughput vs dedicated runners)
+          CI_RUNNER_TYPE: >-
+            ${{
+              (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+               (github.event_name == 'push' ||
+                github.event_name == 'workflow_dispatch' ||
+                github.event_name == 'schedule'))
+              && 'self-hosted'
+              || 'github-hosted'
+            }}
+        run: |
+          paths=$(echo '${{ needs.detect-changes.outputs.selected_paths }}' | jq -r '.[]')
+          uv run pytest $paths \
+            --ignore=tests/integration \
+            --splits ${{ needs.detect-changes.outputs.split_count }} \
+            --group ${{ matrix.split }} \
+            -n auto \
+            --timeout=60 \
+            --timeout-method=thread \
+            --tb=short \
+            --junitxml=junit-${{ matrix.split }}.xml
+
+      - name: Run pytest (full suite)
+        if: vars.ENABLE_SMART_TESTS != 'true' || needs.detect-changes.outputs.is_full_suite == 'true'
         env:
           # OMN-3327: Performance tests use CI_RUNNER_TYPE to relax thresholds on
           # shared self-hosted runners (15-25% lower throughput vs dedicated runners)
@@ -1017,12 +1043,6 @@ jobs:
             --timeout-method=thread \
             --tb=short \
             --junitxml=junit-${{ matrix.split }}.xml
-          # Per-test timeout: 60 seconds prevents infinite hangs
-          # --store-durations: saves per-test timing so subsequent runs balance by
-          #   duration rather than count (eliminates outlier splits)
-          # All splits use -n auto (full parallelism) - shorter splits reduce
-          # resource pressure and runner cancellation probability
-          # Note: Coverage collection disabled - use local pytest-cov for coverage reports
 
       - name: Save test durations (split 1 only, after full suite data accumulated)
         if: matrix.split == 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,6 +1007,7 @@ jobs:
             }}
         run: |
           uv run pytest tests/ \
+            --ignore=tests/integration \
             --splits 40 \
             --group ${{ matrix.split }} \
             --store-durations \
@@ -1039,6 +1040,64 @@ jobs:
           retention-days: 7
 
   # ---------------------------------------------------------------------------
+  # Integration Tests — always-run 4-split matrix (OMN-9851)
+  # ---------------------------------------------------------------------------
+  tests-integration:
+    name: Integration Tests (Split ${{ matrix.split }}/4)
+    needs: [quality-gate, detect-changes]
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 30
+    if: always() && needs.quality-gate.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        split: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run integration tests (split ${{ matrix.split }}/4)
+        run: |
+          uv run pytest tests/integration/ \
+            --splits 4 --group ${{ matrix.split }} \
+            -n auto --timeout=120 --tb=short \
+            --junitxml=junit-int-${{ matrix.split }}.xml
+
+      - name: Upload junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-int-${{ matrix.split }}
+          path: junit-int-${{ matrix.split }}.xml
+
+  # ---------------------------------------------------------------------------
   # Phase 3 - Gates and Summary
   # ---------------------------------------------------------------------------
 
@@ -1057,7 +1116,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    needs: [test-parallel]
+    needs: [test-parallel, tests-integration]
     if: always()
 
     steps:
@@ -1067,23 +1126,26 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           parallel="${{ needs.test-parallel.result }}"
+          integration="${{ needs.tests-integration.result }}"
 
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Parallel Tests (40 splits) | $parallel |" >> $GITHUB_STEP_SUMMARY
+          echo "| Integration Tests (4 splits) | $integration |" >> $GITHUB_STEP_SUMMARY
 
           # Accept "success" (tests ran and passed) or "skipped" (tests correctly
           # skipped because upstream quality-gate was skipped, e.g. dependabot PRs
           # that only touch .github/ files and skip version-pin-check).
-          if [[ "$parallel" == "success" || "$parallel" == "skipped" ]]; then
+          if [[ ("$parallel" == "success" || "$parallel" == "skipped") && \
+                ("$integration" == "success" || "$integration" == "skipped") ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Tests Gate: PASSED** (matrix result: $parallel)" >> $GITHUB_STEP_SUMMARY
-            echo "Test matrix result: $parallel"
+            echo "**Tests Gate: PASSED** (unit=$parallel integration=$integration)" >> $GITHUB_STEP_SUMMARY
+            echo "Test matrix result: unit=$parallel integration=$integration"
             exit 0
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Tests Gate: FAILED**" >> $GITHUB_STEP_SUMMARY
-            echo "Test matrix result: $parallel"
+            echo "::error::tests gate failed (unit=$parallel integration=$integration)"
             exit 1
           fi
 

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Change-aware test path resolution for omnibase_core CI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+
+SRC_PREFIX = "src/omnibase_core/"
+TEST_UNIT_PREFIX = "tests/unit/"
+TEST_INTEGRATION_PREFIX = "tests/integration/"
+
+
+def resolve_test_paths(
+    changed_files: list[str],
+    adjacency_path: Path,
+) -> list[str]:
+    """Map changed file paths to deterministic UNIT test directories.
+
+    Behavior:
+      - Source changes under src/omnibase_core/<module>: include
+        tests/unit/<module>/.
+      - Test-only changes under tests/unit/: include the changed unit-test directory.
+      - Test-only changes under tests/integration/: ignored (integration runs always).
+      - Files outside src/ and tests/unit/: no contribution; caller decides
+        whether to escalate to full suite.
+
+    Adjacency expansion is added in Task 5.
+    """
+    config = load_adjacency_map(adjacency_path)
+    return _resolve(changed_files, config)
+
+
+def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
+    selected: set[str] = set()
+    for path in changed_files:
+        if path.startswith(SRC_PREFIX):
+            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
+            if module in config.adjacency:
+                selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+        elif path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+    return sorted(selected)

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -37,14 +37,24 @@ def resolve_test_paths(
 
 
 def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
+    direct_modules: set[str] = set()
     selected: set[str] = set()
+
     for path in changed_files:
         if path.startswith(SRC_PREFIX):
             module = path[len(SRC_PREFIX) :].split("/", 1)[0]
             if module in config.adjacency:
-                selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+                direct_modules.add(module)
         elif path.startswith(TEST_UNIT_PREFIX):
             parts = path.split("/")
             if len(parts) >= 3:
                 selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+
+    expanded: set[str] = set(direct_modules)
+    for module in direct_modules:
+        expanded.update(config.adjacency[module].reverse_deps)
+
+    for module in expanded:
+        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+
     return sorted(selected)

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -10,10 +10,16 @@ from scripts.ci.test_selection_loader import (
     ModelAdjacencyMap,
     load_adjacency_map,
 )
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
 
 SRC_PREFIX = "src/omnibase_core/"
 TEST_UNIT_PREFIX = "tests/unit/"
 TEST_INTEGRATION_PREFIX = "tests/integration/"
+
+FULL_SUITE_BRANCHES = {"main"}
 
 
 def resolve_test_paths(
@@ -58,3 +64,95 @@ def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
         selected.add(f"{TEST_UNIT_PREFIX}{module}/")
 
     return sorted(selected)
+
+
+def compute_selection(
+    changed_files: list[str],
+    adjacency_path: Path,
+    ref_name: str,
+    event_name: str = "pull_request",
+    feature_flag_enabled: bool = True,
+) -> ModelTestSelection:
+    config = load_adjacency_map(adjacency_path)
+
+    # 0. Feature flag short-circuit: off → legacy 40-split full suite.
+    if not feature_flag_enabled:
+        return _full_suite(EnumFullSuiteReason.FEATURE_FLAG_OFF)
+
+    # 1. Branch / event escalation.
+    if ref_name in FULL_SUITE_BRANCHES:
+        return _full_suite(EnumFullSuiteReason.MAIN_BRANCH)
+    if event_name == "merge_group":
+        return _full_suite(EnumFullSuiteReason.MERGE_GROUP)
+    if event_name == "schedule":
+        return _full_suite(EnumFullSuiteReason.SCHEDULED)
+
+    # 2. Test infrastructure escalation.
+    for changed in changed_files:
+        if any(
+            changed == infra or changed.startswith(infra.rstrip("/") + "/")
+            for infra in config.test_infrastructure_paths
+        ):
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
+    # 3. Shared module escalation.
+    changed_modules = {
+        path[len(SRC_PREFIX) :].split("/", 1)[0]
+        for path in changed_files
+        if path.startswith(SRC_PREFIX)
+    } & set(config.adjacency.keys())
+    if changed_modules & set(config.shared_modules):
+        return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
+
+    # 4. Threshold escalation: too many distinct modules.
+    if len(changed_modules) >= config.thresholds.modules_changed_for_full_suite:
+        return _full_suite(EnumFullSuiteReason.THRESHOLD_MODULES)
+
+    # 5. Smart selection.
+    selected = _resolve(changed_files, config)
+    if not selected:
+        # Conservative one-shard fallback over the full tests/unit/ tree. This
+        # is NOT a no-op — it runs ~3-5 min of unit tests. It fires for changes
+        # that have no unit-test mapping (doc-only, workflow-only, integration-
+        # only). Per Selector Truth Boundary: safer to run something than nothing.
+        selected = ["tests/unit/"]
+    split_count = _split_count_for(selected)
+
+    return ModelTestSelection(
+        selected_paths=selected,
+        split_count=split_count,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=list(range(1, split_count + 1)),
+    )
+
+
+def _full_suite(reason: EnumFullSuiteReason) -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=40,
+        is_full_suite=True,
+        full_suite_reason=reason,
+        matrix=list(range(1, 41)),
+    )
+
+
+def _split_count_for(selected_paths: list[str]) -> int:
+    """Initial conservative heuristic mapping path count to split count.
+
+    These thresholds are a *starting* point chosen to keep small PRs on a single
+    shard (cheap) while preventing pathologically slow runs when many paths
+    survive selection. They are NOT empirically derived. Path count and test
+    count are different things; refine from shadow-mode duration data once
+    available.
+    """
+    n = len(selected_paths)
+    if n <= 2:
+        return 1
+    if n <= 5:
+        return 2
+    if n <= 10:
+        return 3
+    if n <= 16:
+        return 4
+    return 5

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import argparse
+import sys
 from pathlib import Path
 
 from scripts.ci.test_selection_loader import (
@@ -156,3 +158,47 @@ def _split_count_for(selected_paths: list[str]) -> int:
     if n <= 16:
         return 4
     return 5
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve change-aware test paths")
+    parser.add_argument(
+        "--changed-files-from",
+        type=Path,
+        required=True,
+        help="Path to a file with one changed-file path per line.",
+    )
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--event-name", default="pull_request")
+    parser.add_argument(
+        "--adjacency",
+        type=Path,
+        default=Path(__file__).parent / "test_selection_adjacency.yaml",
+    )
+    parser.add_argument(
+        "--feature-flag",
+        choices=("on", "off"),
+        default="on",
+        help="When 'off', emit a FEATURE_FLAG_OFF full-suite selection regardless of changed files.",
+    )
+    args = parser.parse_args(argv)
+
+    changed = [
+        line.strip()
+        for line in args.changed_files_from.read_text().splitlines()
+        if line.strip()
+    ]
+    selection = compute_selection(
+        changed_files=changed,
+        adjacency_path=args.adjacency,
+        ref_name=args.ref_name,
+        event_name=args.event_name,
+        feature_flag_enabled=(args.feature_flag == "on"),
+    )
+    sys.stdout.write(selection.model_dump_json())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# scripts/ci/test_selection_adjacency.yaml
+# Static adjacency map from src/omnibase_core/<module> to dependent modules.
+# When a key module changes, every module in `reverse_deps` ALSO has its tests run.
+# Treated as CI contract data — manually curated, reviewed in PRs that change it.
+
+schema_version: 1
+
+# `shared_modules` is a FULL-SUITE ESCALATION POLICY, not an architectural ontology.
+# Listing a module here means "if this module changes, run the full suite" — it does
+# NOT claim the module is fundamentally more important than others, nor does it map
+# to a permanent layering invariant. Curate based on operational risk + import fan-out.
+# Removing a module from this list is allowed once we have shadow data showing its
+# changes don't surface broad regressions.
+shared_modules:
+  - models
+  - contracts
+  - enums
+  - validation
+  - runtime
+  - event_bus
+
+# Per-repo full-suite escalation thresholds.
+thresholds:
+  modules_changed_for_full_suite: 8
+
+# Test infrastructure — any change forces the full suite.
+test_infrastructure_paths:
+  - tests/conftest.py
+  - tests/fixtures/
+  - tests/pytest.ini
+  - pytest.ini
+  - pyproject.toml
+
+# Reverse dependency edges. Key = changed module; value = modules that import it.
+# When `models` changes, also run tests for everything in `models.reverse_deps`.
+# Note: shared_modules entries here are not consulted at runtime
+# (they trigger full suite first), but kept for completeness/documentation.
+adjacency:
+  models:
+    reverse_deps: [nodes, contracts, runtime, validation, services, factories, container]
+  contracts:
+    reverse_deps: [nodes, runtime, validation]
+  enums:
+    reverse_deps: [models, contracts, nodes, validation, runtime]
+  validation:
+    reverse_deps: [nodes, runtime, services]
+  runtime:
+    reverse_deps: [nodes, services, container]
+  event_bus:
+    reverse_deps: [runtime, services, nodes]
+  container:
+    reverse_deps: [services, nodes, runtime]
+  protocols:
+    reverse_deps: [nodes, services, factories]
+  errors:
+    reverse_deps: [models, runtime, nodes, services]
+  # Leaf modules with no reverse_deps still appear so the loader can validate
+  # that every src/omnibase_core/<dir> has an entry.
+  backends: {reverse_deps: []}
+  cli: {reverse_deps: []}
+  constants: {reverse_deps: []}
+  context: {reverse_deps: [nodes, runtime]}
+  crypto: {reverse_deps: []}
+  decorators: {reverse_deps: []}
+  discovery: {reverse_deps: [nodes, runtime]}
+  doctor: {reverse_deps: []}
+  factories: {reverse_deps: [nodes, container]}
+  infrastructure: {reverse_deps: []}
+  integrations: {reverse_deps: []}
+  logging: {reverse_deps: []}
+  merge: {reverse_deps: []}
+  mixins: {reverse_deps: [models, nodes]}
+  navigation: {reverse_deps: []}
+  nodes: {reverse_deps: []}
+  normalization: {reverse_deps: [models, nodes]}
+  overlays: {reverse_deps: []}
+  package: {reverse_deps: []}
+  pipeline: {reverse_deps: [nodes]}
+  rendering: {reverse_deps: []}
+  resolution: {reverse_deps: [nodes, runtime]}
+  schemas: {reverse_deps: [models]}
+  scripts: {reverse_deps: []}
+  services: {reverse_deps: [nodes]}
+  tools: {reverse_deps: []}
+  types: {reverse_deps: [models]}
+  utils: {reverse_deps: []}
+  workflows: {reverse_deps: [nodes]}

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Load and validate the static module adjacency map."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelAdjacencyEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reverse_deps: list[str] = Field(default_factory=list)
+
+
+class ModelThresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    modules_changed_for_full_suite: int = Field(..., ge=1)
+
+
+class ModelAdjacencyMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(..., ge=1)
+    shared_modules: list[str]
+    thresholds: ModelThresholds
+    test_infrastructure_paths: list[str]
+    adjacency: dict[str, ModelAdjacencyEntry]
+
+    @model_validator(mode="after")
+    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        for shared in self.shared_modules:
+            if shared not in self.adjacency:
+                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
+        for module, entry in self.adjacency.items():
+            for dep in entry.reverse_deps:
+                if dep not in self.adjacency:
+                    raise ValueError(
+                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                    )
+        return self
+
+
+def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    raw = yaml.safe_load(path.read_text())
+    return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -44,5 +44,5 @@ class ModelAdjacencyMap(BaseModel):
 
 
 def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
-    raw = yaml.safe_load(path.read_text())
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pydantic output contract for change-aware test selection."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"
+
+
+TestPath = Annotated[
+    str,
+    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
+]
+
+
+class ModelTestSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_paths: list[TestPath] = Field(..., min_length=1)
+    split_count: int = Field(..., ge=1, le=40)
+    is_full_suite: bool
+    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
+    matrix: list[int] = Field(...)
+
+    @model_validator(mode="after")
+    def validate_full_suite_reason(self) -> Self:
+        if self.is_full_suite and self.full_suite_reason is None:
+            raise ValueError("full_suite_reason required when is_full_suite=True")
+        if not self.is_full_suite and self.full_suite_reason is not None:
+            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
+        if len(self.matrix) != self.split_count:
+            raise ValueError(
+                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
+            )
+        return self

--- a/scripts/validate_deterministic_skill_routing.py
+++ b/scripts/validate_deterministic_skill_routing.py
@@ -568,7 +568,9 @@ def _is_wrapped_dispatch(raw: str) -> bool:
     )
     if not any(prefix in lowered for prefix in wrapper_prefixes):
         return False
-    return re.search(r"\bonex\b[^A-Za-z0-9]+(?:run-node|run|node)\b", lowered) is not None
+    return (
+        re.search(r"\bonex\b[^A-Za-z0-9]+(?:run-node|run|node)\b", lowered) is not None
+    )
 
 
 def _is_prose_fallback(line: ShellLine) -> bool:
@@ -582,7 +584,11 @@ def _is_prose_fallback(line: ShellLine) -> bool:
     and the raw line must contain a word hinting at fallback / degrade / prose.
     """
     idx = 0
-    while idx < len(line.tokens) and "=" in line.tokens[idx] and not line.tokens[idx].startswith("-"):
+    while (
+        idx < len(line.tokens)
+        and "=" in line.tokens[idx]
+        and not line.tokens[idx].startswith("-")
+    ):
         name = line.tokens[idx].split("=", 1)[0]
         if name and name.replace("_", "").isalnum() and name[0].isalpha():
             idx += 1

--- a/scripts/validate_no_env_fallbacks.py
+++ b/scripts/validate_no_env_fallbacks.py
@@ -43,10 +43,10 @@ FALLBACK_PATTERNS = [
 
 # Lines that are clearly docstrings/comments/examples are excluded
 SKIP_PATTERNS = [
-    re.compile(r'^\s*#'),          # Comments
-    re.compile(r'^\s*["\']'),      # Docstring lines
-    re.compile(r'^\s*>>>'),        # Doctest examples
-    re.compile(r'^\s*\.\.\s'),     # RST continuation
+    re.compile(r"^\s*#"),  # Comments
+    re.compile(r'^\s*["\']'),  # Docstring lines
+    re.compile(r"^\s*>>>"),  # Doctest examples
+    re.compile(r"^\s*\.\.\s"),  # RST continuation
 ]
 
 
@@ -74,11 +74,11 @@ def scan_file(filepath: Path) -> list[tuple[int, str]]:
                 in_docstring = False
                 docstring_delim = None
                 break
-            elif not in_docstring and count == 1:
+            if not in_docstring and count == 1:
                 in_docstring = True
                 docstring_delim = delim
                 break
-            elif count >= 2:
+            if count >= 2:
                 # Opens and closes on same line
                 break
 

--- a/scripts/validation/validate-contracts.py
+++ b/scripts/validation/validate-contracts.py
@@ -236,7 +236,11 @@ def discover_yaml_files_optimized(base_path: Path) -> Iterator[Path]:
             # Skip archived directories and test fixtures early
             dirs_to_skip = []
             for dir_name in dirs:
-                if dir_name in ("archived", "__pycache__", "architecture-handshakes") or dir_name.startswith("."):
+                if dir_name in (
+                    "archived",
+                    "__pycache__",
+                    "architecture-handshakes",
+                ) or dir_name.startswith("."):
                     dirs_to_skip.append(dir_name)
 
             # Remove from dirs to prevent os.walk from recursing

--- a/tests/unit/scripts/ci/__init__.py
+++ b/tests/unit/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -145,3 +145,21 @@ def test_small_change_returns_smart_selection_no_reason() -> None:
     assert "tests/unit/cli/" in selection.selected_paths
     assert 1 <= selection.split_count <= 5
     assert selection.matrix == list(range(1, selection.split_count + 1))
+
+
+# ---------------------------------------------------------------------------
+# Task 10: feature_flag_off branch
+# ---------------------------------------------------------------------------
+
+
+def test_feature_flag_off_returns_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        feature_flag_enabled=False,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.FEATURE_FLAG_OFF
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -36,3 +36,33 @@ def test_unknown_source_path_falls_back_to_full_suite_signal() -> None:
     changed_files = ["docs/README.md", ".github/workflows/foo.yml"]
     paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
     assert paths == []
+
+
+def test_change_in_models_expands_to_exact_set() -> None:
+    changed_files = ["src/omnibase_core/models/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    # models is in shared_modules — full-suite escalation lives in compute_selection
+    # (Task 6). resolve_test_paths returns the *expanded* unit-test dirs only.
+    expected = sorted(
+        f"tests/unit/{m}/"
+        for m in (
+            "models",
+            "nodes",
+            "contracts",
+            "runtime",
+            "validation",
+            "services",
+            "factories",
+            "container",
+        )
+    )
+    assert paths == expected
+
+
+def test_change_in_protocols_expands_to_exact_set() -> None:
+    changed_files = ["src/omnibase_core/protocols/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    expected = sorted(
+        f"tests/unit/{m}/" for m in ("protocols", "nodes", "services", "factories")
+    )
+    assert paths == expected

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from scripts.ci.detect_test_paths import resolve_test_paths
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+
+
+def test_single_module_change_resolves_to_one_test_dir() -> None:
+    changed_files = ["src/omnibase_core/cli/foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    # `_resolve` returns ONLY unit-test paths. Integration runs always via
+    # the separate fixed-matrix tests-integration job, so the smart-selection
+    # contract excludes tests/integration/ entirely.
+    assert paths == ["tests/unit/cli/"]
+
+
+def test_test_only_change_runs_only_changed_test_dir() -> None:
+    changed_files = ["tests/unit/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == ["tests/unit/nodes/"]
+
+
+def test_integration_test_only_change_does_not_select_unit_tests() -> None:
+    # Integration test changes do not contribute to unit-job selection;
+    # the integration job runs all integration tests on every PR anyway.
+    changed_files = ["tests/integration/nodes/test_foo.py"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []
+
+
+def test_unknown_source_path_falls_back_to_full_suite_signal() -> None:
+    # Files outside src/ and tests/unit/ — no unit-test mapping.
+    changed_files = ["docs/README.md", ".github/workflows/foo.yml"]
+    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
+    assert paths == []

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -66,3 +66,82 @@ def test_change_in_protocols_expands_to_exact_set() -> None:
         f"tests/unit/{m}/" for m in ("protocols", "nodes", "services", "factories")
     )
     assert paths == expected
+
+
+# ---------------------------------------------------------------------------
+# Task 6: compute_selection escalation tests
+# ---------------------------------------------------------------------------
+
+from scripts.ci.detect_test_paths import compute_selection
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+)
+
+
+def test_shared_module_change_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+def test_test_infrastructure_change_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["tests/conftest.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_threshold_module_count_escalates() -> None:
+    # 8 distinct, non-shared modules changed → THRESHOLD_MODULES.
+    changed_files = [
+        f"src/omnibase_core/{m}/x.py"
+        for m in [
+            "cli",
+            "constants",
+            "decorators",
+            "logging",
+            "merge",
+            "navigation",
+            "package",
+            "rendering",
+        ]
+    ]
+    selection = compute_selection(
+        changed_files=changed_files,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.THRESHOLD_MODULES
+
+
+def test_main_branch_always_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/x.py"],
+        adjacency_path=ADJ,
+        ref_name="main",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.MAIN_BRANCH
+
+
+def test_small_change_returns_smart_selection_no_reason() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert "tests/unit/cli/" in selection.selected_paths
+    assert 1 <= selection.split_count <= 5
+    assert selection.matrix == list(range(1, selection.split_count + 1))

--- a/tests/unit/scripts/ci/test_detect_test_paths_cli.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_cli.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CLI integration tests for detect_test_paths entry point."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_cli_emits_valid_model_test_selection_json(tmp_path: Path) -> None:
+    fake_diff = tmp_path / "diff.txt"
+    fake_diff.write_text("src/omnibase_core/cli/foo.py\n")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.ci.detect_test_paths",
+            "--changed-files-from",
+            str(fake_diff),
+            "--ref-name",
+            "feature-branch",
+            "--event-name",
+            "pull_request",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["is_full_suite"] is False
+    assert payload["full_suite_reason"] is None
+    assert "tests/unit/cli/" in payload["selected_paths"]
+    assert "matrix" in payload
+    assert isinstance(payload["matrix"], list)
+
+
+def test_cli_full_suite_on_main(tmp_path: Path) -> None:
+    fake_diff = tmp_path / "diff.txt"
+    fake_diff.write_text("src/omnibase_core/cli/foo.py\n")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.ci.detect_test_paths",
+            "--changed-files-from",
+            str(fake_diff),
+            "--ref-name",
+            "main",
+            "--event-name",
+            "push",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["is_full_suite"] is True
+    assert payload["full_suite_reason"] == "main_branch"
+    assert payload["split_count"] == 40

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_load_adjacency_map_parses_repo_yaml() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    assert isinstance(config, ModelAdjacencyMap)
+    assert config.schema_version == 1
+    assert "models" in config.shared_modules
+    assert "models" in config.adjacency
+
+
+def test_load_rejects_unknown_shared_module(tmp_path: Path) -> None:
+    bad_yaml = """
+schema_version: 1
+shared_modules: [does_not_exist]
+thresholds:
+  modules_changed_for_full_suite: 8
+test_infrastructure_paths: []
+adjacency:
+  nodes: { reverse_deps: [] }
+"""
+    tmp = tmp_path / "bad_adj.yaml"
+    tmp.write_text(bad_yaml)
+    with pytest.raises(ValueError, match="shared_module 'does_not_exist'"):
+        load_adjacency_map(tmp)
+
+
+def test_every_src_module_has_adjacency_entry() -> None:
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    src_root = REPO_ROOT / "src/omnibase_core"
+    src_modules = {
+        p.name for p in src_root.iterdir() if p.is_dir() and not p.name.startswith("_")
+    }
+    missing = src_modules - set(config.adjacency.keys())
+    assert not missing, f"Modules missing adjacency entry: {missing}"

--- a/tests/unit/scripts/ci/test_test_selection_models.py
+++ b/tests/unit/scripts/ci/test_test_selection_models.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import pytest
+from pydantic import ValidationError
+
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+
+def test_full_suite_selection_serializes_with_reason() -> None:
+    selection = ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=40,
+        is_full_suite=True,
+        full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+        matrix=list(range(1, 41)),
+    )
+    payload = selection.model_dump(mode="json")
+    assert payload == {
+        "selected_paths": ["tests/"],
+        "split_count": 40,
+        "is_full_suite": True,
+        "full_suite_reason": "shared_module",
+        "matrix": list(range(1, 41)),
+    }
+
+
+def test_smart_selection_disallows_full_suite_reason() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=2,
+            is_full_suite=False,
+            full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+            matrix=[1, 2],
+        )
+
+
+def test_matrix_length_matches_split_count() -> None:
+    with pytest.raises(ValidationError):
+        ModelTestSelection(
+            selected_paths=["tests/unit/nodes/"],
+            split_count=3,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=[1, 2],  # length mismatch
+        )


### PR DESCRIPTION
## Summary
- Replaces hardcoded `[1..40]` test-parallel matrix with `fromJson(needs.detect-changes.outputs.matrix)` dynamic shape
- Adds two conditional pytest steps: smart selection (when `vars.ENABLE_SMART_TESTS == 'true'` and not full-suite) vs full suite (default)
- Job name template includes both `matrix.split` and the dynamic split count from `detect-changes.outputs.split_count`
- Adds `test_feature_flag_off_returns_full_suite` unit test (20 total tests)
- **No `force_full` step** — feature-flag handling lives entirely in `compute_selection` + CLI per the revised plan

Implements OMN-9852, plan task 10.

**Depends on:** #937 (OMN-9851 stack). Merge after #937 lands.

Plan: docs/plans/change-aware-ci-omnibase-core.md

## Test plan
- [x] actionlint exits 0 (only pre-existing SC2086 shellcheck style warnings, no new errors)
- [x] yaml.safe_load passes
- [x] Matrix split reads from `fromJson(needs.detect-changes.outputs.matrix)`
- [x] When `ENABLE_SMART_TESTS != 'true'`, `compute_selection` emits `feature_flag_off` + 40-shard matrix
- [x] 20 unit tests pass (`uv run pytest tests/unit/scripts/ci/ -v`)
- [x] Stable gate names unchanged (Quality Gate, Tests Gate, CI Summary)
- [x] pre-commit run --all-files passes