### PR TITLE
feat(OMN-9790): migration script for receipt schema

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -82,6 +82,15 @@ allowed_files:
     added: "2024-10-15"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/utils/util_dod_receipt_migration.py"
+    reason: >-
+      Legacy DoD receipt migration utility (OMN-9790). Pre-OMN-9786 receipts cannot validate against the
+      new ModelDodReceipt schema by definition - the migration's purpose is to backfill the missing fields
+      so they can. Raw yaml.safe_load is required to read the legacy payload before rewriting it as a
+      ModelDodReceipt-compatible mapping.
+    added: "2026-04-26"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/cli/cli_install.py"
     reason: >-
       onex pack/install CLI must parse heterogeneous third-party contract.yaml + metadata.yaml files from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,7 @@ ignore = [
 "scripts/pin_bump.py" = ["T201"]  # CLI output for publish-downstream-pin-bump workflow [OMN-9050]
 "scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation
 "scripts/validate_deterministic_skill_routing.py" = ["T201"]  # CLI output for CI gate report
+"scripts/migrate_dod_receipts.py" = ["T201"]  # CLI output for legacy DoD receipt migration [OMN-9790]
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]
 

--- a/scripts/migrate_dod_receipts.py
+++ b/scripts/migrate_dod_receipts.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI wrapper around :mod:`omnibase_core.utils.util_dod_receipt_migration`.
+
+Usage:
+    uv run python scripts/migrate_dod_receipts.py --root . [--dry-run]
+
+The script walks ``drift/dod_receipts/`` and ``.evidence/`` under the given
+root and rewrites any pre-OMN-9786 receipts into the extended
+``ModelDodReceipt`` shape, downgrading their status to ``ADVISORY`` while
+preserving the original status in ``original_status``. Idempotent.
+
+This file intentionally contains no business logic — it exists so the
+migration can be invoked as a one-off script (per OMN-9790 acceptance
+criteria) without forcing every consumer to import the CLI plumbing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from omnibase_core.utils.util_dod_receipt_migration import migrate_receipts_in_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill legacy DoD receipts into the OMN-9786 ModelDodReceipt "
+            "schema, downgrading status to ADVISORY."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repo root containing drift/dod_receipts/ and/or .evidence/.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report counts without writing to disk.",
+    )
+    args = parser.parse_args(argv)
+
+    modified, skipped = migrate_receipts_in_root(args.root, dry_run=args.dry_run)
+    verb = "would migrate" if args.dry_run else "migrated"
+    print(f"{verb}: {modified}, skipped: {skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/utils/util_dod_receipt_migration.py
+++ b/src/omnibase_core/utils/util_dod_receipt_migration.py
@@ -43,6 +43,7 @@ import yaml
 
 from omnibase_core.decorators.decorator_allow_dict_any import allow_dict_any
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
 # Sentinel values backfilled into legacy receipts. ``verifier`` is the
@@ -58,7 +59,7 @@ SENTINEL_SCHEMA_VERSION = "0.0.0"
 # Status assigned to migrated receipts. ADVISORY is non-blocking but
 # visible — exactly the right signal for "this came from before the
 # adversarial-invariants policy and cannot be retroactively trusted".
-_MIGRATED_STATUS = "ADVISORY"
+_MIGRATED_STATUS = EnumReceiptStatus.ADVISORY.value
 
 # Subdirectories under a repo root that hold receipts. Order matters only
 # for the deterministic walk in :func:`migrate_receipts_in_root`.
@@ -87,7 +88,22 @@ def _parse(path: Path) -> tuple[dict[str, Any], str]:
             context={"path": str(path)},
         )
 
-    text = path.read_text()
+    if not path.is_file():
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=f"receipt path is not a file: {path}",
+            context={"path": str(path)},
+        )
+
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=f"failed to read receipt {path}: {exc}",
+            context={"path": str(path), "error": str(exc)},
+        ) from exc
+
     suffix = path.suffix.lower()
     if suffix in _YAML_SUFFIXES:
         try:

--- a/src/omnibase_core/utils/util_dod_receipt_migration.py
+++ b/src/omnibase_core/utils/util_dod_receipt_migration.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Legacy DoD receipt migration utility (OMN-9790).
+
+The OMN-9786 PR added four required fields to ``ModelDodReceipt``:
+``verifier``, ``probe_command``, ``probe_stdout``, and ``schema_version``.
+Receipts on disk that pre-date that change cannot validate against the new
+schema and would silently degrade the receipt-gate to FAIL.
+
+This module rewrites legacy receipts in-place so they validate as ADVISORY
+(per the Centralized Transition Policy in :mod:`omnibase_core.models.contracts.ticket.model_dod_receipt`)
+while preserving the prior status in an ``original_status`` audit field.
+
+Two entry points are exposed:
+
+* :func:`migrate_receipt_file` — migrate a single receipt path
+* :func:`migrate_receipts_in_root` — walk ``drift/dod_receipts/`` and
+  ``.evidence/`` under a repo root and migrate every legacy receipt found
+
+Both functions are idempotent: a receipt that already carries a ``verifier``
+field is treated as already-migrated and left byte-identical.
+
+The CLI entry point lives in
+``omnibase_core/scripts/migrate_dod_receipts.py`` so this module can be
+imported without side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from omnibase_core.decorators.decorator_allow_dict_any import allow_dict_any
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+# Sentinel values backfilled into legacy receipts. ``verifier`` is the
+# only one with semantic weight — it triggers the ``verifier == runner``
+# check elsewhere in the gate, but legacy receipts use the dedicated
+# ``legacy-self-attested`` literal so audits can distinguish "self-attested
+# pre-policy" from "self-attested post-policy".
+LEGACY_VERIFIER_SENTINEL = "legacy-self-attested"
+SENTINEL_PROBE_COMMAND = ""
+SENTINEL_PROBE_STDOUT = ""
+SENTINEL_SCHEMA_VERSION = "0.0.0"
+
+# Status assigned to migrated receipts. ADVISORY is non-blocking but
+# visible — exactly the right signal for "this came from before the
+# adversarial-invariants policy and cannot be retroactively trusted".
+_MIGRATED_STATUS = "ADVISORY"
+
+# Subdirectories under a repo root that hold receipts. Order matters only
+# for the deterministic walk in :func:`migrate_receipts_in_root`.
+_RECEIPT_LOCATIONS: tuple[tuple[str, ...], ...] = (
+    ("drift", "dod_receipts"),
+    (".evidence",),
+)
+
+# File suffixes recognized as receipts. Anything else is a no-op so the
+# walker can be pointed at directories that contain other artifacts.
+_YAML_SUFFIXES = frozenset({".yaml", ".yml"})
+_JSON_SUFFIXES = frozenset({".json"})
+
+
+@allow_dict_any(reason="Receipt YAML/JSON payloads are heterogeneous by design")
+def _parse(path: Path) -> tuple[dict[str, Any], str]:
+    """Parse ``path`` and return (data, format_tag).
+
+    ``format_tag`` is ``"yaml"`` or ``"json"``. Raises ``ModelOnexError`` for
+    missing files, unparseable contents, or non-mapping top-level structures.
+    """
+    if not path.exists():
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=f"receipt path does not exist: {path}",
+            context={"path": str(path)},
+        )
+
+    text = path.read_text()
+    suffix = path.suffix.lower()
+    if suffix in _YAML_SUFFIXES:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=f"failed to parse YAML receipt {path}: {exc}",
+                context={"path": str(path)},
+            ) from exc
+        format_tag = "yaml"
+    elif suffix in _JSON_SUFFIXES:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=f"failed to parse JSON receipt {path}: {exc}",
+                context={"path": str(path)},
+            ) from exc
+        format_tag = "json"
+    else:  # pragma: no cover — guarded by caller
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=f"unsupported receipt suffix: {path.suffix}",
+            context={"path": str(path)},
+        )
+
+    if not isinstance(data, dict):
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=f"receipt {path} must be a mapping at the top level, got {type(data).__name__}",
+            context={"path": str(path), "actual_type": type(data).__name__},
+        )
+    return data, format_tag
+
+
+@allow_dict_any(reason="Receipt YAML/JSON payloads are heterogeneous by design")
+def _serialize(data: dict[str, Any], format_tag: str) -> str:
+    """Re-serialize ``data`` in its original format.
+
+    YAML uses ``sort_keys=False`` so the diff matches the human-edited
+    field order; JSON uses ``indent=2`` to match the existing receipts in
+    ``.evidence/`` (verified by spot check 2026-04-26).
+    """
+    if format_tag == "yaml":
+        return yaml.safe_dump(data, sort_keys=False)
+    if format_tag == "json":
+        return json.dumps(data, indent=2) + "\n"
+    raise ModelOnexError(  # pragma: no cover
+        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        message=f"unsupported format tag: {format_tag}",
+        context={"format_tag": format_tag},
+    )
+
+
+@allow_dict_any(reason="Migrating heterogeneous receipt YAML/JSON payloads in place")
+def migrate_receipt_file(path: Path) -> bool:
+    """Migrate a single receipt file in place.
+
+    Returns ``True`` if the file was rewritten, ``False`` if it was left
+    untouched (already migrated or unsupported suffix).
+
+    Raises:
+        ModelOnexError: if the file does not exist, fails to parse, or
+            contains a non-mapping top-level structure. Callers that need
+            to keep walking on bad input should catch this.
+    """
+    suffix = path.suffix.lower()
+    if suffix not in _YAML_SUFFIXES and suffix not in _JSON_SUFFIXES:
+        return False
+
+    data, format_tag = _parse(path)
+
+    # Idempotency: presence of ``verifier`` is the migration tombstone.
+    if "verifier" in data:
+        return False
+
+    original_status = data.get("status", "UNKNOWN")
+    # Backfill happens in a fresh dict so insertion order is deterministic
+    # and predictable across re-runs (important for byte-identical
+    # idempotency on the second pass — see test_running_migration_twice).
+    migrated: dict[str, Any] = dict(data)
+    migrated["status"] = _MIGRATED_STATUS
+    migrated["verifier"] = LEGACY_VERIFIER_SENTINEL
+    migrated["probe_command"] = SENTINEL_PROBE_COMMAND
+    migrated["probe_stdout"] = SENTINEL_PROBE_STDOUT
+    migrated["schema_version"] = SENTINEL_SCHEMA_VERSION
+    migrated["original_status"] = original_status
+    migrated["migrated_at"] = datetime.now(tz=UTC).isoformat()
+
+    path.write_text(_serialize(migrated, format_tag))
+    return True
+
+
+def migrate_receipts_in_root(root: Path, *, dry_run: bool = False) -> tuple[int, int]:
+    """Walk receipt locations under ``root`` and migrate every legacy receipt.
+
+    The walker visits ``drift/dod_receipts/`` and ``.evidence/`` recursively,
+    inspecting both ``*.yaml``/``*.yml`` and ``*.json`` files. Files that
+    raise ``ModelOnexError`` during migration are surfaced — callers that want
+    "skip and continue" semantics should catch the exception themselves.
+
+    Args:
+        root: repo root containing receipt directories.
+        dry_run: if True, count what *would* be migrated but do not write.
+            A dry-run still counts a legacy receipt as "would be modified",
+            i.e. the first element of the return tuple.
+
+    Returns:
+        ``(modified, skipped)`` — counts of files that were rewritten (or
+        would be, in dry-run mode) versus those left unchanged.
+    """
+    modified = 0
+    skipped = 0
+    for parts in _RECEIPT_LOCATIONS:
+        loc = root.joinpath(*parts)
+        if not loc.exists():
+            continue
+        for path in sorted(loc.rglob("*")):
+            if not path.is_file():
+                continue
+            suffix = path.suffix.lower()
+            if suffix not in _YAML_SUFFIXES and suffix not in _JSON_SUFFIXES:
+                continue
+            if dry_run:
+                # Re-parse to decide modified-vs-skipped without writing.
+                data, _ = _parse(path)
+                if "verifier" in data:
+                    skipped += 1
+                else:
+                    modified += 1
+                continue
+            if migrate_receipt_file(path):
+                modified += 1
+            else:
+                skipped += 1
+    return modified, skipped
+
+
+__all__ = [
+    "LEGACY_VERIFIER_SENTINEL",
+    "SENTINEL_PROBE_COMMAND",
+    "SENTINEL_PROBE_STDOUT",
+    "SENTINEL_SCHEMA_VERSION",
+    "migrate_receipt_file",
+    "migrate_receipts_in_root",
+]

--- a/src/omnibase_core/utils/util_dod_receipt_migration.py
+++ b/src/omnibase_core/utils/util_dod_receipt_migration.py
@@ -9,8 +9,15 @@ Receipts on disk that pre-date that change cannot validate against the new
 schema and would silently degrade the receipt-gate to FAIL.
 
 This module rewrites legacy receipts in-place so they validate as ADVISORY
-(per the Centralized Transition Policy in :mod:`omnibase_core.models.contracts.ticket.model_dod_receipt`)
-while preserving the prior status in an ``original_status`` audit field.
+(per the Centralized Transition Policy in :mod:`omnibase_core.models.contracts.ticket.model_dod_receipt`).
+
+The receipt itself is rewritten to satisfy the post-OMN-9786 schema. Audit
+metadata about the migration (the prior ``status`` value and the migration
+timestamp) is written to a sidecar file alongside the receipt — never into
+the receipt body, because ``ModelDodReceipt`` is configured with
+``extra="forbid"`` and would reject unknown top-level keys. The sidecar is
+named ``<receipt_stem>.migration.<format>`` (yaml or json, matching the
+receipt's own format).
 
 Two entry points are exposed:
 
@@ -21,9 +28,8 @@ Two entry points are exposed:
 Both functions are idempotent: a receipt that already carries a ``verifier``
 field is treated as already-migrated and left byte-identical.
 
-The CLI entry point lives in
-``omnibase_core/scripts/migrate_dod_receipts.py`` so this module can be
-imported without side effects.
+The CLI entry point lives in ``scripts/migrate_dod_receipts.py`` (at repo
+root) so this module can be imported without side effects.
 """
 
 from __future__ import annotations
@@ -138,9 +144,25 @@ def _serialize(data: dict[str, Any], format_tag: str) -> str:
     )
 
 
+def _sidecar_path(receipt_path: Path, format_tag: str) -> Path:
+    """Return the path for the migration audit sidecar next to ``receipt_path``.
+
+    The sidecar uses the same format as the receipt so a human inspecting
+    the directory sees a single consistent file format.
+    """
+    suffix = ".yaml" if format_tag == "yaml" else ".json"
+    return receipt_path.with_name(f"{receipt_path.stem}.migration{suffix}")
+
+
 @allow_dict_any(reason="Migrating heterogeneous receipt YAML/JSON payloads in place")
 def migrate_receipt_file(path: Path) -> bool:
     """Migrate a single receipt file in place.
+
+    The receipt body is rewritten to satisfy ``ModelDodReceipt`` (status
+    downgraded to ADVISORY plus the four OMN-9786 sentinel fields). Audit
+    metadata (``original_status``, ``migrated_at``) is written to a sidecar
+    file next to the receipt — ``ModelDodReceipt`` is configured with
+    ``extra="forbid"`` and would reject those keys on the receipt itself.
 
     Returns ``True`` if the file was rewritten, ``False`` if it was left
     untouched (already migrated or unsupported suffix).
@@ -170,10 +192,15 @@ def migrate_receipt_file(path: Path) -> bool:
     migrated["probe_command"] = SENTINEL_PROBE_COMMAND
     migrated["probe_stdout"] = SENTINEL_PROBE_STDOUT
     migrated["schema_version"] = SENTINEL_SCHEMA_VERSION
-    migrated["original_status"] = original_status
-    migrated["migrated_at"] = datetime.now(tz=UTC).isoformat()
+
+    audit: dict[str, Any] = {
+        "original_status": original_status,
+        "migrated_at": datetime.now(tz=UTC).isoformat(),
+        "receipt_file": path.name,
+    }
 
     path.write_text(_serialize(migrated, format_tag))
+    _sidecar_path(path, format_tag).write_text(_serialize(audit, format_tag))
     return True
 
 
@@ -206,6 +233,12 @@ def migrate_receipts_in_root(root: Path, *, dry_run: bool = False) -> tuple[int,
                 continue
             suffix = path.suffix.lower()
             if suffix not in _YAML_SUFFIXES and suffix not in _JSON_SUFFIXES:
+                continue
+            # Skip sidecar audit files written by previous migration runs;
+            # they are not receipts and would otherwise be misclassified.
+            if path.name.endswith(
+                (".migration.yaml", ".migration.yml", ".migration.json")
+            ):
                 continue
             if dry_run:
                 # Re-parse to decide modified-vs-skipped without writing.

--- a/tests/unit/utils/test_util_dod_receipt_migration.py
+++ b/tests/unit/utils/test_util_dod_receipt_migration.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``util_dod_receipt_migration``.
+
+These tests cover the legacy DoD receipt backfill utility introduced for
+OMN-9790. The utility rewrites pre-OMN-9786 receipts (lacking ``verifier``,
+``probe_command``, ``probe_stdout``, ``schema_version``) so that they
+validate against the extended ``ModelDodReceipt`` schema while preserving
+audit trail (``original_status``).
+
+The utility is invoked one file at a time via ``migrate_receipt_file``;
+the directory walk is exercised separately via ``migrate_receipts_in_root``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.utils.util_dod_receipt_migration import (
+    LEGACY_VERIFIER_SENTINEL,
+    SENTINEL_PROBE_COMMAND,
+    SENTINEL_PROBE_STDOUT,
+    SENTINEL_SCHEMA_VERSION,
+    migrate_receipt_file,
+    migrate_receipts_in_root,
+)
+
+
+def _legacy_yaml_payload() -> dict[str, Any]:
+    """Return a representative pre-9786 legacy receipt payload."""
+    return {
+        "ticket_id": "OMN-9409",
+        "evidence_item_id": "dod-001",
+        "check_type": "file_exists",
+        "check_value": "drift/dod_receipts/OMN-9409/dod-001/file_exists.yaml",
+        "status": "PASS",
+        "run_timestamp": "2026-04-23T23:15:00Z",
+        "commit_sha": "e22100e230d412379f798be58fd49234b4fb821a",
+        "runner": "polish-infra-1390",
+        "actual_output": "...",
+        "exit_code": 0,
+        "pr_number": 1390,
+    }
+
+
+@pytest.mark.unit
+class TestMigrateReceiptFileYaml:
+    def test_legacy_receipt_without_verifier_marked_advisory(
+        self, tmp_path: Path
+    ) -> None:
+        """A legacy receipt should be downgraded to ADVISORY and tagged."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+
+        modified = migrate_receipt_file(receipt_path)
+
+        assert modified is True
+        migrated = yaml.safe_load(receipt_path.read_text())
+        assert migrated["status"] == "ADVISORY"
+        assert migrated["verifier"] == LEGACY_VERIFIER_SENTINEL
+        assert migrated["probe_command"] == SENTINEL_PROBE_COMMAND
+        assert migrated["probe_stdout"] == SENTINEL_PROBE_STDOUT
+        assert migrated["schema_version"] == SENTINEL_SCHEMA_VERSION
+
+    def test_migration_preserves_original_status_in_history_field(
+        self, tmp_path: Path
+    ) -> None:
+        """``original_status`` must record the prior status verbatim."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+
+        migrate_receipt_file(receipt_path)
+
+        migrated = yaml.safe_load(receipt_path.read_text())
+        assert migrated["original_status"] == "PASS"
+        assert migrated["status"] == "ADVISORY"
+
+    def test_migration_records_iso_migrated_at_field(self, tmp_path: Path) -> None:
+        """``migrated_at`` must be an ISO-8601 string (timezone-aware)."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+
+        migrate_receipt_file(receipt_path)
+
+        migrated = yaml.safe_load(receipt_path.read_text())
+        # ISO-8601 strings include 'T' separator and a timezone marker.
+        assert "T" in migrated["migrated_at"]
+        assert migrated["migrated_at"].endswith("+00:00") or migrated[
+            "migrated_at"
+        ].endswith("Z")
+
+    def test_missing_status_filled_with_unknown_sentinel(self, tmp_path: Path) -> None:
+        """A legacy file with no ``status`` field still migrates cleanly."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump({"ticket_id": "OMN-9", "runner": "w"}))
+
+        migrate_receipt_file(receipt_path)
+
+        migrated = yaml.safe_load(receipt_path.read_text())
+        assert migrated["status"] == "ADVISORY"
+        assert migrated["original_status"] == "UNKNOWN"
+
+
+@pytest.mark.unit
+class TestMigrateReceiptFileJson:
+    def test_legacy_json_receipt_marked_advisory(self, tmp_path: Path) -> None:
+        receipt_path = tmp_path / "dod_report.json"
+        receipt_path.write_text(json.dumps(_legacy_yaml_payload()))
+
+        modified = migrate_receipt_file(receipt_path)
+
+        assert modified is True
+        migrated = json.loads(receipt_path.read_text())
+        assert migrated["status"] == "ADVISORY"
+        assert migrated["verifier"] == LEGACY_VERIFIER_SENTINEL
+        assert migrated["original_status"] == "PASS"
+
+
+@pytest.mark.unit
+class TestMigrateReceiptFileIdempotency:
+    def test_running_migration_twice_produces_identical_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        """Idempotency: a second run must emit byte-identical contents."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+
+        migrate_receipt_file(receipt_path)
+        after_first = receipt_path.read_bytes()
+        modified_second = migrate_receipt_file(receipt_path)
+        after_second = receipt_path.read_bytes()
+
+        assert modified_second is False
+        assert after_first == after_second
+
+    def test_already_migrated_receipt_not_modified(self, tmp_path: Path) -> None:
+        """Receipt with ``verifier`` already set must be left untouched."""
+        already_migrated = {
+            "ticket_id": "OMN-9",
+            "status": "ADVISORY",
+            "verifier": "ci-receipt-gate",
+            "runner": "worker-1",
+        }
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(already_migrated))
+        before = receipt_path.read_bytes()
+
+        modified = migrate_receipt_file(receipt_path)
+        after = receipt_path.read_bytes()
+
+        assert modified is False
+        assert before == after
+
+
+@pytest.mark.unit
+class TestMigrateReceiptFileMalformedInput:
+    def test_unsupported_extension_returns_false(self, tmp_path: Path) -> None:
+        """Files outside .yaml/.yml/.json are silently skipped."""
+        receipt_path = tmp_path / "report.txt"
+        receipt_path.write_text("not a receipt")
+
+        modified = migrate_receipt_file(receipt_path)
+
+        assert modified is False
+        assert receipt_path.read_text() == "not a receipt"
+
+    def test_yaml_top_level_list_raises_value_error(self, tmp_path: Path) -> None:
+        """Receipts must be mappings; lists raise a clean error."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump([{"ticket_id": "OMN-1"}]))
+
+        with pytest.raises(ModelOnexError, match="must be a mapping"):
+            migrate_receipt_file(receipt_path)
+
+    def test_invalid_yaml_raises_value_error(self, tmp_path: Path) -> None:
+        """Unparseable YAML raises ModelOnexError, not yaml.YAMLError."""
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text("{not: valid: yaml: at: all")
+
+        with pytest.raises(ModelOnexError, match="failed to parse"):
+            migrate_receipt_file(receipt_path)
+
+    def test_invalid_json_raises_value_error(self, tmp_path: Path) -> None:
+        receipt_path = tmp_path / "report.json"
+        receipt_path.write_text("not json at all")
+
+        with pytest.raises(ModelOnexError, match="failed to parse"):
+            migrate_receipt_file(receipt_path)
+
+    def test_missing_file_raises_value_error(self, tmp_path: Path) -> None:
+        receipt_path = tmp_path / "missing.yaml"
+
+        with pytest.raises(ModelOnexError, match="does not exist"):
+            migrate_receipt_file(receipt_path)
+
+
+@pytest.mark.unit
+class TestMigrateReceiptsInRoot:
+    def test_walks_drift_and_evidence_directories(self, tmp_path: Path) -> None:
+        """The walker must traverse drift/dod_receipts and .evidence."""
+        drift_dir = tmp_path / "drift" / "dod_receipts" / "OMN-1" / "dod-001"
+        drift_dir.mkdir(parents=True)
+        (drift_dir / "file_exists.yaml").write_text(
+            yaml.safe_dump(_legacy_yaml_payload())
+        )
+
+        evidence_dir = tmp_path / ".evidence" / "OMN-2"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "dod_report.json").write_text(
+            json.dumps(_legacy_yaml_payload())
+        )
+
+        modified, skipped = migrate_receipts_in_root(tmp_path)
+
+        assert modified == 2
+        assert skipped == 0
+
+    def test_walker_is_idempotent(self, tmp_path: Path) -> None:
+        drift_dir = tmp_path / "drift" / "dod_receipts" / "OMN-1" / "dod-001"
+        drift_dir.mkdir(parents=True)
+        (drift_dir / "file_exists.yaml").write_text(
+            yaml.safe_dump(_legacy_yaml_payload())
+        )
+
+        first = migrate_receipts_in_root(tmp_path)
+        second = migrate_receipts_in_root(tmp_path)
+
+        assert first == (1, 0)
+        assert second == (0, 1)
+
+    def test_walker_dry_run_does_not_modify(self, tmp_path: Path) -> None:
+        drift_dir = tmp_path / "drift" / "dod_receipts" / "OMN-1" / "dod-001"
+        drift_dir.mkdir(parents=True)
+        target = drift_dir / "file_exists.yaml"
+        target.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+        before = target.read_bytes()
+
+        modified, skipped = migrate_receipts_in_root(tmp_path, dry_run=True)
+
+        assert modified == 1
+        assert skipped == 0
+        assert target.read_bytes() == before
+
+    def test_missing_root_returns_zero_zero(self, tmp_path: Path) -> None:
+        """Walker must not raise when neither location exists."""
+        modified, skipped = migrate_receipts_in_root(tmp_path / "absent")
+
+        assert modified == 0
+        assert skipped == 0

--- a/tests/unit/utils/test_util_dod_receipt_migration.py
+++ b/tests/unit/utils/test_util_dod_receipt_migration.py
@@ -220,6 +220,30 @@ class TestMigrateReceiptFileMalformedInput:
         with pytest.raises(ModelOnexError, match="does not exist"):
             migrate_receipt_file(receipt_path)
 
+    def test_directory_path_raises_value_error(self, tmp_path: Path) -> None:
+        receipt_path = tmp_path / "directory.yaml"
+        receipt_path.mkdir()
+
+        with pytest.raises(ModelOnexError, match="is not a file"):
+            migrate_receipt_file(receipt_path)
+
+    def test_read_failure_raises_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receipt_path = tmp_path / "file_exists.yaml"
+        receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
+        original_read_text = Path.read_text
+
+        def fail_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+            if self == receipt_path:
+                raise OSError("permission denied")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+        with pytest.raises(ModelOnexError, match="failed to read receipt"):
+            migrate_receipt_file(receipt_path)
+
 
 @pytest.mark.unit
 class TestMigrateReceiptsInRoot:

--- a/tests/unit/utils/test_util_dod_receipt_migration.py
+++ b/tests/unit/utils/test_util_dod_receipt_migration.py
@@ -42,7 +42,7 @@ def _legacy_yaml_payload() -> dict[str, Any]:
         "check_value": "drift/dod_receipts/OMN-9409/dod-001/file_exists.yaml",
         "status": "PASS",
         "run_timestamp": "2026-04-23T23:15:00Z",
-        "commit_sha": "e22100e230d412379f798be58fd49234b4fb821a",
+        "commit_sha": "e22100e230d412379f798be58fd49234b4fb821a",  # pragma: allowlist secret
         "runner": "polish-infra-1390",
         "actual_output": "...",
         "exit_code": 0,
@@ -69,32 +69,46 @@ class TestMigrateReceiptFileYaml:
         assert migrated["probe_stdout"] == SENTINEL_PROBE_STDOUT
         assert migrated["schema_version"] == SENTINEL_SCHEMA_VERSION
 
-    def test_migration_preserves_original_status_in_history_field(
+    def test_migration_preserves_original_status_in_sidecar(
         self, tmp_path: Path
     ) -> None:
-        """``original_status`` must record the prior status verbatim."""
+        """``original_status`` must be recorded in the sidecar audit file.
+
+        The sidecar lives next to the receipt because ``ModelDodReceipt``
+        is ``extra="forbid"`` — writing audit metadata onto the receipt
+        itself would break model validation.
+        """
         receipt_path = tmp_path / "file_exists.yaml"
         receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
 
         migrate_receipt_file(receipt_path)
 
         migrated = yaml.safe_load(receipt_path.read_text())
-        assert migrated["original_status"] == "PASS"
         assert migrated["status"] == "ADVISORY"
+        # Audit metadata MUST NOT leak onto the receipt itself.
+        assert "original_status" not in migrated
+        assert "migrated_at" not in migrated
 
-    def test_migration_records_iso_migrated_at_field(self, tmp_path: Path) -> None:
-        """``migrated_at`` must be an ISO-8601 string (timezone-aware)."""
+        sidecar = tmp_path / "file_exists.migration.yaml"
+        assert sidecar.exists()
+        audit = yaml.safe_load(sidecar.read_text())
+        assert audit["original_status"] == "PASS"
+        assert audit["receipt_file"] == "file_exists.yaml"
+
+    def test_migration_records_iso_migrated_at_in_sidecar(self, tmp_path: Path) -> None:
+        """``migrated_at`` must be an ISO-8601 string in the sidecar."""
         receipt_path = tmp_path / "file_exists.yaml"
         receipt_path.write_text(yaml.safe_dump(_legacy_yaml_payload()))
 
         migrate_receipt_file(receipt_path)
 
-        migrated = yaml.safe_load(receipt_path.read_text())
+        sidecar = tmp_path / "file_exists.migration.yaml"
+        audit = yaml.safe_load(sidecar.read_text())
         # ISO-8601 strings include 'T' separator and a timezone marker.
-        assert "T" in migrated["migrated_at"]
-        assert migrated["migrated_at"].endswith("+00:00") or migrated[
-            "migrated_at"
-        ].endswith("Z")
+        assert "T" in audit["migrated_at"]
+        assert audit["migrated_at"].endswith("+00:00") or audit["migrated_at"].endswith(
+            "Z"
+        )
 
     def test_missing_status_filled_with_unknown_sentinel(self, tmp_path: Path) -> None:
         """A legacy file with no ``status`` field still migrates cleanly."""
@@ -105,7 +119,9 @@ class TestMigrateReceiptFileYaml:
 
         migrated = yaml.safe_load(receipt_path.read_text())
         assert migrated["status"] == "ADVISORY"
-        assert migrated["original_status"] == "UNKNOWN"
+        sidecar = tmp_path / "file_exists.migration.yaml"
+        audit = yaml.safe_load(sidecar.read_text())
+        assert audit["original_status"] == "UNKNOWN"
 
 
 @pytest.mark.unit
@@ -120,7 +136,11 @@ class TestMigrateReceiptFileJson:
         migrated = json.loads(receipt_path.read_text())
         assert migrated["status"] == "ADVISORY"
         assert migrated["verifier"] == LEGACY_VERIFIER_SENTINEL
-        assert migrated["original_status"] == "PASS"
+        # Audit metadata must live in the sidecar, not the receipt itself.
+        assert "original_status" not in migrated
+        sidecar = tmp_path / "dod_report.migration.json"
+        audit = json.loads(sidecar.read_text())
+        assert audit["original_status"] == "PASS"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Wave C Task 10 of the OMN-9790 plan. Adds a one-off migration utility that
rewrites pre-OMN-9786 DoD receipts into the extended `ModelDodReceipt` shape:

- `src/omnibase_core/utils/util_dod_receipt_migration.py` — pure migration
  helpers (`migrate_receipt_file`, `migrate_receipts_in_root`). Idempotent;
  the presence of `verifier` is the migration tombstone.
- `scripts/migrate_dod_receipts.py` — thin CLI wrapper, `--root` + `--dry-run`.
- Legacy receipts are downgraded to `ADVISORY` and stamped with
  `original_status` + `migrated_at` for audit, with `verifier =
  "legacy-self-attested"` so post-policy receipts remain distinguishable.
- Unit tests cover yaml/json formats, idempotency, dry-run counts, malformed
  input, and the walker over `drift/dod_receipts/` + `.evidence/`.

Plan: docs/plans/2026-04-26-session-process-and-change-control.md.

## Test plan

- [x] `pre-commit run --files <changed>` green locally
- [ ] Receipt-gate CI re-runs on this PR; any real issues land as a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DoD receipt migration to convert legacy receipts to the current schema with idempotent processing.
  * Creates adjacent audit sidecar files recording original status and migration timestamp.
  * Added a command-line tool for batch migrations with optional dry-run reporting.

* **Chores**
  * Updated YAML validation allowlist to permit safe parsing of legacy receipts.
  * Adjusted lint config to allow script output exceptions.

* **Tests**
  * Added comprehensive unit tests covering migration, idempotency, edge cases, and directory traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->