### PR TITLE
feat(OMN-9789): add re-probe verification mode

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -279,6 +279,16 @@ allowed_files:
     added: "2026-04-17"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/validation/validator_receipt_reprobe.py"
+    reason: >-
+      Re-probe verification mode (OMN-9789) walks legacy ModelDodReceipt YAML artifacts and re-runs each
+      recorded probe_command. Receipts may be older than the current ModelDodReceipt schema, so the verifier
+      intentionally inspects raw mappings to extract probe_command/exit_code without binding to the current
+      model. Schema enforcement is the receipt-gate's job (above); this verifier answers the narrower
+      question of whether the recorded probe still exits as recorded. (OMN-9789)
+    added: "2026-04-26"
+    review: "2026-06-13"
+
   - file: "src/omnibase_core/cli/cli_refresh_credentials.py"
     reason: >-
       Loads ~/.onex/config.yaml as free-form user configuration. No fixed Pydantic schema exists for this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,7 @@ ignore = [
 "src/omnibase_core/validation/validator_circular_import.py" = ["T201"]
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/receipt_gate_cli.py" = ["T201"]
+"src/omnibase_core/validation/validator_receipt_reprobe.py" = ["T201"]  # CLI output for re-probe verification (OMN-9789)
 "scripts/validation/validate_pr_receipts.py" = ["T201"]
 "scripts/validation/validate_pr_deploy_required.py" = ["T201"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]

--- a/src/omnibase_core/enums/enum_reprobe_status.py
+++ b/src/omnibase_core/enums/enum_reprobe_status.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Re-probe verification status enum (OMN-9789)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["EnumReprobeStatus"]
+
+
+class EnumReprobeStatus(StrEnum):
+    """Outcome values for re-probe verification."""
+
+    PASS = "PASS"
+    FAIL = "FAIL"

--- a/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_report.py
+++ b/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_report.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aggregate report model for re-probe verification (OMN-9789).
+
+Emitted by
+:func:`omnibase_core.validation.validator_receipt_reprobe.verify_receipts_by_reexecuting_probes`
+to summarise the outcome of re-running every recorded ``probe_command``
+under a directory tree of receipts. Frozen — once produced it is an
+audit artifact.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
+    ModelReceiptReprobeResult,
+)
+
+
+class ModelReceiptReprobeReport(BaseModel):
+    """Aggregate report of re-probing every receipt under a tree."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    receipts_dir: str = Field(
+        ...,
+        min_length=1,
+        description="Root directory that was walked.",
+    )
+    results: list[ModelReceiptReprobeResult] = Field(
+        default_factory=list,
+        description="One result per receipt file discovered. Empty if no receipts.",
+    )
+
+    @property
+    def passed(self) -> bool:
+        """True iff every result is PASS (or there are no results)."""
+        return all(r.status == "PASS" for r in self.results)
+
+    @property
+    def failures(self) -> list[ModelReceiptReprobeResult]:
+        """All non-PASS results, in walk order."""
+        return [r for r in self.results if r.status != "PASS"]
+
+
+__all__ = ["ModelReceiptReprobeReport"]

--- a/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_report.py
+++ b/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_report.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
     ModelReceiptReprobeResult,
+    ReprobeStatus,
 )
 
 
@@ -41,12 +42,12 @@ class ModelReceiptReprobeReport(BaseModel):
     @property
     def passed(self) -> bool:
         """True iff every result is PASS (or there are no results)."""
-        return all(r.status == "PASS" for r in self.results)
+        return all(r.status == ReprobeStatus.PASS for r in self.results)
 
     @property
     def failures(self) -> list[ModelReceiptReprobeResult]:
         """All non-PASS results, in walk order."""
-        return [r for r in self.results if r.status != "PASS"]
+        return [r for r in self.results if r.status != ReprobeStatus.PASS]
 
 
 __all__ = ["ModelReceiptReprobeReport"]

--- a/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_result.py
+++ b/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_result.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-receipt result model for the re-probe verification mode (OMN-9789).
+
+Emitted by
+:func:`omnibase_core.validation.validator_receipt_reprobe.verify_receipts_by_reexecuting_probes`
+to describe the outcome of re-running a single receipt's recorded
+``probe_command`` against current external state. Frozen — once produced
+it is an audit artifact.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# String literal status values mirror the plan's ``tuple[str, str]`` API and
+# avoid coupling re-probe outcomes to ``EnumReceiptStatus`` (which carries
+# extra meaning — ADVISORY, PENDING — that does not apply to re-probe).
+ReprobeStatus = Literal["PASS", "FAIL"]
+
+
+class ModelReceiptReprobeResult(BaseModel):
+    """Outcome of re-running a single receipt's recorded ``probe_command``."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    receipt_path: str = Field(
+        ...,
+        min_length=1,
+        description="Filesystem path to the receipt that was re-probed.",
+    )
+    ticket_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Linear ticket ID parsed from the receipt, or '*' if the receipt "
+            "could not be parsed."
+        ),
+    )
+    # string-id-ok: evidence item IDs are human-readable contract slugs (e.g., 'dod-001'), not UUIDs
+    evidence_item_id: str = Field(
+        ...,
+        min_length=1,
+        description="dod_evidence[].id from the receipt, or '*' if unparseable.",
+    )
+    check_type: str = Field(
+        ...,
+        min_length=1,
+        description="dod_evidence check_type from the receipt, or '*' if unparseable.",
+    )
+    status: ReprobeStatus = Field(
+        ...,
+        description=(
+            "PASS iff the recorded probe re-executed and exited with the "
+            "recorded exit_code; FAIL otherwise."
+        ),
+    )
+    detail: str = Field(
+        ...,
+        description=(
+            "Human-readable explanation. Always identifies the failure mode "
+            "(probe_command/allowlist/exit_code/timeout/etc.) on FAIL."
+        ),
+    )
+
+
+__all__ = [
+    "ModelReceiptReprobeResult",
+    "ReprobeStatus",
+]

--- a/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_result.py
+++ b/src/omnibase_core/models/contracts/ticket/model_receipt_reprobe_result.py
@@ -12,14 +12,9 @@ it is an audit artifact.
 
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseModel, ConfigDict, Field
 
-# String literal status values mirror the plan's ``tuple[str, str]`` API and
-# avoid coupling re-probe outcomes to ``EnumReceiptStatus`` (which carries
-# extra meaning — ADVISORY, PENDING — that does not apply to re-probe).
-ReprobeStatus = Literal["PASS", "FAIL"]
+from omnibase_core.enums.enum_reprobe_status import EnumReprobeStatus as ReprobeStatus
 
 
 class ModelReceiptReprobeResult(BaseModel):

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -9,9 +9,19 @@ the gate logic discoverable as a module (not buried under scripts/).
 See `omnibase_core.validation.receipt_gate.validate_pr_receipts` for the
 decision matrix.
 
+The optional ``--reexecute-probes`` flag (OMN-9789) chains in re-probe
+verification after the static gate passes: every recorded ``probe_command``
+is re-run and its current ``exit_code`` is compared against the recorded
+one. Default OFF in CI (slow; may have side effects), default ON in the
+manual scaffold's session-end ritual.
+
 Exit codes:
-    0  — gate passed (all receipts present + PASS, or override accepted)
-    1  — gate failed (missing/failing receipts, no ticket ref, corrupt artifacts)
+    0  — gate passed (all receipts present + PASS, or override accepted),
+         and (when ``--reexecute-probes`` is set) every recorded probe
+         re-verified
+    1  — gate failed (missing/failing receipts, no ticket ref, corrupt
+         artifacts, or — under ``--reexecute-probes`` — at least one probe
+         did not re-verify)
 """
 
 from __future__ import annotations
@@ -21,6 +31,9 @@ import sys
 from pathlib import Path
 
 from omnibase_core.validation.receipt_gate import validate_pr_receipts
+from omnibase_core.validation.validator_receipt_reprobe import (
+    verify_receipts_by_reexecuting_probes,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -46,6 +59,17 @@ def main(argv: list[str] | None = None) -> int:
         default="onex_change_control/drift/dod_receipts",
         help="Directory tree containing ModelDodReceipt YAML files.",
     )
+    parser.add_argument(
+        "--reexecute-probes",
+        action="store_true",
+        default=False,
+        help=(
+            "OMN-9789: after the static gate passes, re-run every recorded "
+            "probe_command and verify exit_code parity. Default OFF (slow; "
+            "may have side effects). Recommended ON in the manual "
+            "scaffold's session-end ritual; OFF in CI."
+        ),
+    )
     args = parser.parse_args(argv)
 
     result = validate_pr_receipts(
@@ -62,7 +86,33 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"::error::{result.message}")
 
-    return 0 if result.passed else 1
+    if not result.passed:
+        return 1
+
+    if args.reexecute_probes:
+        report = verify_receipts_by_reexecuting_probes(Path(args.receipts_dir))
+        for r in report.results:
+            line = (
+                f"{r.status}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
+                f"({r.receipt_path}): {r.detail}"
+            )
+            if r.status == "PASS":
+                print(f"::notice::{line}")
+            else:
+                print(f"::error::{line}")
+        if not report.passed:
+            failures = report.failures
+            print(
+                f"::error::RE-PROBE FAILED: {len(failures)} of "
+                f"{len(report.results)} receipt(s) did not re-verify "
+                "(active-drive lesson F92)."
+            )
+            return 1
+        print(
+            f"::notice::RE-PROBE PASSED: all {len(report.results)} receipt(s) "
+            "re-verified."
+        )
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from omnibase_core.validation.receipt_gate import validate_pr_receipts
 from omnibase_core.validation.validator_receipt_reprobe import (
+    ReprobeStatus,
     verify_receipts_by_reexecuting_probes,
 )
 
@@ -93,10 +94,10 @@ def main(argv: list[str] | None = None) -> int:
         report = verify_receipts_by_reexecuting_probes(Path(args.receipts_dir))
         for r in report.results:
             line = (
-                f"{r.status}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
+                f"{r.status.value}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
                 f"({r.receipt_path}): {r.detail}"
             )
-            if r.status == "PASS":
+            if r.status == ReprobeStatus.PASS:
                 print(f"::notice::{line}")
             else:
                 print(f"::error::{line}")

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -37,6 +37,11 @@ from omnibase_core.validation.validator_receipt_reprobe import (
 )
 
 
+def _escape_github_actions_message(message: str) -> str:
+    """Escape a GitHub Actions workflow command message payload."""
+    return message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -93,7 +98,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.reexecute_probes:
         report = verify_receipts_by_reexecuting_probes(Path(args.receipts_dir))
         for r in report.results:
-            line = (
+            line = _escape_github_actions_message(
                 f"{r.status.value}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
                 f"({r.receipt_path}): {r.detail}"
             )

--- a/src/omnibase_core/validation/validator_receipt_reprobe.py
+++ b/src/omnibase_core/validation/validator_receipt_reprobe.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Re-probe verification mode for ModelDodReceipt artifacts (OMN-9789).
+
+The Receipt Gate (``omnibase_core.validation.receipt_gate``) statically
+checks that every cited ticket has a PASS receipt on disk. That is a
+necessary but not sufficient guarantee: a fabricated receipt is
+indistinguishable from a real one if you only inspect the file.
+
+This module adds an *active* verification path. It re-runs each receipt's
+recorded ``probe_command`` and compares the current ``exit_code`` against
+the value the receipt claims. If the recorded probe still produces the
+recorded exit code, the receipt is **re-verified**. If not, the receipt is
+flagged as drifted (or fabricated).
+
+Truth boundary: this is re-probe verification, not full historical replay.
+It validates that a recorded ``probe_command`` can be rerun under current
+conditions and exits as recorded. It does not prove temporal correctness,
+environment equivalence, side-effect identity, or that the original claim
+was true at the original time.
+
+Active-drive lesson F92: "PR self-reported MERGED is unverified until probe
+confirms." A receipt is a self-attested artifact; rerunning the probe is
+the cheapest available externalization of trust.
+
+Safety: probes execute via ``subprocess.run(shell=False)`` with arguments
+split by ``shlex.split`` — there is no shell interpolation. Only commands
+whose stripped form starts with one of the prefixes in
+:data:`PROBE_COMMAND_ALLOWLIST` are allowed to run. Anything else fails
+fast with detail mentioning ``allowlist``. Each probe is wall-clock-capped
+at :data:`PROBE_REEXEC_TIMEOUT_SECONDS`.
+
+Public API: :func:`verify_receipt_by_reexecuting_probe` (single-receipt)
+and :func:`verify_receipts_by_reexecuting_probes` (batch, producing a
+:class:`ModelReceiptReprobeReport`).
+
+CLI: ``python -m omnibase_core.validation.validator_receipt_reprobe``
+exposes a ``--receipts-dir`` driver. The receipt-gate CLI in
+``receipt_gate_cli.py`` accepts ``--reexecute-probes`` (default OFF in CI;
+ON in the manual scaffold session-end ritual).
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.models.contracts.ticket.model_receipt_reprobe_report import (
+    ModelReceiptReprobeReport,
+)
+from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
+    ModelReceiptReprobeResult,
+    ReprobeStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Allowlist + constants
+# ---------------------------------------------------------------------------
+
+# Command-prefix allowlist for re-execution. A probe is permitted to run only
+# if its stripped form starts with one of these strings. Listing here (not in
+# code body) makes the policy grep-able and easy to extend by ticket review.
+#
+# Ordering is documentation, not semantics — the membership check is
+# whitespace-stripped prefix match.
+PROBE_COMMAND_ALLOWLIST: tuple[str, ...] = (
+    "gh pr view",
+    "gh pr checks",
+    "gh api",
+    "psql ",
+    "curl ",
+    "uv run pytest",
+    "test -f",
+    "test -d",
+    "true",  # for testing
+    "false",  # for testing
+)
+
+# Wall-clock cap per probe re-execution. Anything slower indicates the probe
+# is hung, not slow — fail closed.
+PROBE_REEXEC_TIMEOUT_SECONDS: int = 120
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _probe_in_allowlist(probe: str) -> bool:
+    """Return True iff the probe's stripped form starts with any allowlisted prefix."""
+    stripped = probe.strip()
+    return any(stripped.startswith(prefix) for prefix in PROBE_COMMAND_ALLOWLIST)
+
+
+# ---------------------------------------------------------------------------
+# Single-receipt verifier (plan-mandated dict-based signature)
+# ---------------------------------------------------------------------------
+
+
+def verify_receipt_by_reexecuting_probe(
+    receipt: dict[str, object],
+) -> tuple[ReprobeStatus, str]:
+    """Re-execute the receipt's probe_command and compare ``exit_code``.
+
+    The receipt is supplied as a raw mapping (the YAML/JSON form on disk)
+    rather than as a :class:`ModelDodReceipt` so this function can be called
+    against legacy receipts that may not validate against the current
+    schema. Schema enforcement is the receipt-gate's job; this function
+    answers the narrower question: does the recorded probe still exit as
+    recorded?
+
+    Args:
+        receipt: Raw receipt mapping. Must contain ``probe_command`` and
+            ``exit_code``.
+
+    Returns:
+        ``("PASS", detail)`` if and only if:
+
+        * ``probe_command`` is non-empty and allowlisted;
+        * the probe re-executes within :data:`PROBE_REEXEC_TIMEOUT_SECONDS`;
+        * the re-execution's return code equals the recorded ``exit_code``;
+        * the re-execution exited 0 (success).
+
+        ``("FAIL", detail)`` on every other path. ``detail`` always
+        identifies the failure mode (``probe_command``, ``allowlist``,
+        ``exit_code``, etc.) so the caller can render a useful CI message.
+    """
+    probe = receipt.get("probe_command", "")
+    if not isinstance(probe, str) or not probe:
+        return "FAIL", "receipt has no probe_command field"
+    if not _probe_in_allowlist(probe):
+        return "FAIL", f"probe_command not in allowlist: {probe!r}"
+
+    if "exit_code" not in receipt:
+        return (
+            "FAIL",
+            "receipt has no exit_code field; cannot verify re-execution parity",
+        )
+    expected_exit = receipt.get("exit_code")
+    if not isinstance(expected_exit, int):
+        return (
+            "FAIL",
+            f"receipt.exit_code must be int, got {type(expected_exit).__name__}",
+        )
+
+    try:
+        result = subprocess.run(
+            shlex.split(probe),
+            capture_output=True,
+            text=True,
+            timeout=PROBE_REEXEC_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        return (
+            "FAIL",
+            f"probe re-execution timed out after {PROBE_REEXEC_TIMEOUT_SECONDS}s: {e}",
+        )
+    except (OSError, ValueError) as e:
+        # OSError: binary not found, perms; ValueError: shlex unbalanced quotes
+        return "FAIL", f"probe re-execution failed: {e}"
+
+    if result.returncode != expected_exit:
+        return (
+            "FAIL",
+            (
+                f"re-execution exit_code={result.returncode} does not match "
+                f"receipt.exit_code={expected_exit}"
+            ),
+        )
+    if result.returncode != 0:
+        return (
+            "FAIL",
+            f"probe failed on re-execution (exit_code={result.returncode})",
+        )
+    return "PASS", "probe re-execution matches receipt"
+
+
+# ---------------------------------------------------------------------------
+# Batch verifier
+# ---------------------------------------------------------------------------
+
+
+def verify_receipts_by_reexecuting_probes(
+    receipts_dir: Path,
+) -> ModelReceiptReprobeReport:
+    """Walk ``receipts_dir`` and re-probe every receipt found.
+
+    Args:
+        receipts_dir: Root of the receipt tree
+            (``<root>/<ticket-id>/<evidence-item-id>/<check-type>.yaml``).
+
+    Returns:
+        A :class:`ModelReceiptReprobeReport` with one
+        :class:`ModelReceiptReprobeResult` per receipt file.
+    """
+    results: list[ModelReceiptReprobeResult] = []
+    if not receipts_dir.is_dir():
+        return ModelReceiptReprobeReport(
+            receipts_dir=str(receipts_dir),
+            results=[],
+        )
+
+    for receipt_path in sorted(receipts_dir.rglob("*.yaml")):
+        try:
+            with receipt_path.open(encoding="utf-8") as fh:
+                # yaml-ok: re-probe verifies raw legacy receipts that may not
+                # validate against the current ModelDodReceipt schema; schema
+                # enforcement is the receipt-gate's job, not this verifier's.
+                raw = yaml.safe_load(fh)
+        except (yaml.YAMLError, OSError) as e:
+            results.append(
+                ModelReceiptReprobeResult(
+                    receipt_path=str(receipt_path),
+                    ticket_id="*",
+                    evidence_item_id="*",
+                    check_type="*",
+                    status="FAIL",
+                    detail=f"corrupt receipt: {e}",
+                )
+            )
+            continue
+
+        if not isinstance(raw, dict):
+            results.append(
+                ModelReceiptReprobeResult(
+                    receipt_path=str(receipt_path),
+                    ticket_id="*",
+                    evidence_item_id="*",
+                    check_type="*",
+                    status="FAIL",
+                    detail=f"receipt root is not a mapping: {type(raw).__name__}",
+                )
+            )
+            continue
+
+        status, detail = verify_receipt_by_reexecuting_probe(raw)
+        ticket_id = raw.get("ticket_id", "*")
+        evidence_item_id = raw.get("evidence_item_id", "*")
+        check_type = raw.get("check_type", "*")
+        results.append(
+            ModelReceiptReprobeResult(
+                receipt_path=str(receipt_path),
+                ticket_id=ticket_id if isinstance(ticket_id, str) else "*",
+                evidence_item_id=(
+                    evidence_item_id if isinstance(evidence_item_id, str) else "*"
+                ),
+                check_type=check_type if isinstance(check_type, str) else "*",
+                status=status,
+                detail=detail,
+            )
+        )
+
+    return ModelReceiptReprobeReport(
+        receipts_dir=str(receipts_dir),
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI driver
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: re-probe every receipt under ``--receipts-dir``.
+
+    Exit codes:
+        0 — every receipt re-verifies (PASS)
+        1 — at least one receipt failed re-verification
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-probe verification — re-run every recorded probe_command "
+            "and verify the current exit_code matches the recorded one. "
+            "Defense against fabricated receipts (active-drive lesson F92)."
+        )
+    )
+    parser.add_argument(
+        "--receipts-dir",
+        default="onex_change_control/drift/dod_receipts",
+        help="Directory tree containing ModelDodReceipt YAML files.",
+    )
+    args = parser.parse_args(argv)
+
+    report = verify_receipts_by_reexecuting_probes(Path(args.receipts_dir))
+
+    if not report.results:
+        print(f"::notice::no receipts found under {args.receipts_dir}")
+        return 0
+
+    failures = [r for r in report.results if r.status != "PASS"]
+    for r in report.results:
+        line = (
+            f"{r.status}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
+            f"({r.receipt_path}): {r.detail}"
+        )
+        if r.status == "PASS":
+            print(f"::notice::{line}")
+        else:
+            print(f"::error::{line}")
+
+    if failures:
+        print(
+            f"::error::RE-PROBE FAILED: {len(failures)} of {len(report.results)} "
+            "receipt(s) did not re-verify. Receipts may be drifted or fabricated."
+        )
+        return 1
+    print(
+        f"::notice::RE-PROBE PASSED: all {len(report.results)} receipt(s) re-verified."
+    )
+    return 0
+
+
+__all__ = [
+    "PROBE_COMMAND_ALLOWLIST",
+    "PROBE_REEXEC_TIMEOUT_SECONDS",
+    "verify_receipt_by_reexecuting_probe",
+    "verify_receipts_by_reexecuting_probes",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/validation/validator_receipt_reprobe.py
+++ b/src/omnibase_core/validation/validator_receipt_reprobe.py
@@ -93,9 +93,19 @@ PROBE_REEXEC_TIMEOUT_SECONDS: int = 120
 
 
 def _probe_in_allowlist(probe: str) -> bool:
-    """Return True iff the probe's stripped form starts with any allowlisted prefix."""
+    """Return True iff the probe matches an allowlisted prefix on a command boundary.
+
+    Plain ``str.startswith`` is too permissive: ``"trueevil"`` would slip past a
+    ``"true"`` prefix, and ``"gh pr viewx"`` would slip past ``"gh pr view"``.
+    Each prefix is treated as a command form: the probe must equal the prefix or
+    be followed by whitespace.
+    """
     stripped = probe.strip()
-    return any(stripped.startswith(prefix) for prefix in PROBE_COMMAND_ALLOWLIST)
+    for prefix in PROBE_COMMAND_ALLOWLIST:
+        canonical = prefix.rstrip()
+        if stripped == canonical or stripped.startswith(f"{canonical} "):
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/src/omnibase_core/validation/validator_receipt_reprobe.py
+++ b/src/omnibase_core/validation/validator_receipt_reprobe.py
@@ -107,6 +107,11 @@ def _probe_in_allowlist(probe: str) -> bool:
     return False
 
 
+def _nonempty_or_star(value: object) -> str:
+    """Return stripped non-empty strings; use '*' for missing/invalid IDs."""
+    return value.strip() if isinstance(value, str) and value.strip() else "*"
+
+
 # ---------------------------------------------------------------------------
 # Single-receipt verifier (plan-mandated dict-based signature)
 # ---------------------------------------------------------------------------
@@ -142,19 +147,19 @@ def verify_receipt_by_reexecuting_probe(
     """
     probe = receipt.get("probe_command", "")
     if not isinstance(probe, str) or not probe:
-        return "FAIL", "receipt has no probe_command field"
+        return ReprobeStatus.FAIL, "receipt has no probe_command field"
     if not _probe_in_allowlist(probe):
-        return "FAIL", f"probe_command not in allowlist: {probe!r}"
+        return ReprobeStatus.FAIL, f"probe_command not in allowlist: {probe!r}"
 
     if "exit_code" not in receipt:
         return (
-            "FAIL",
+            ReprobeStatus.FAIL,
             "receipt has no exit_code field; cannot verify re-execution parity",
         )
     expected_exit = receipt.get("exit_code")
     if type(expected_exit) is not int:
         return (
-            "FAIL",
+            ReprobeStatus.FAIL,
             f"receipt.exit_code must be int, got {type(expected_exit).__name__}",
         )
 
@@ -168,16 +173,16 @@ def verify_receipt_by_reexecuting_probe(
         )
     except subprocess.TimeoutExpired as e:
         return (
-            "FAIL",
+            ReprobeStatus.FAIL,
             f"probe re-execution timed out after {PROBE_REEXEC_TIMEOUT_SECONDS}s: {e}",
         )
     except (OSError, ValueError) as e:
         # OSError: binary not found, perms; ValueError: shlex unbalanced quotes
-        return "FAIL", f"probe re-execution failed: {e}"
+        return ReprobeStatus.FAIL, f"probe re-execution failed: {e}"
 
     if result.returncode != expected_exit:
         return (
-            "FAIL",
+            ReprobeStatus.FAIL,
             (
                 f"re-execution exit_code={result.returncode} does not match "
                 f"receipt.exit_code={expected_exit}"
@@ -185,10 +190,10 @@ def verify_receipt_by_reexecuting_probe(
         )
     if result.returncode != 0:
         return (
-            "FAIL",
+            ReprobeStatus.FAIL,
             f"probe failed on re-execution (exit_code={result.returncode})",
         )
-    return "PASS", "probe re-execution matches receipt"
+    return ReprobeStatus.PASS, "probe re-execution matches receipt"
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +218,16 @@ def verify_receipts_by_reexecuting_probes(
     if not receipts_dir.is_dir():
         return ModelReceiptReprobeReport(
             receipts_dir=str(receipts_dir),
-            results=[],
+            results=[
+                ModelReceiptReprobeResult(
+                    receipt_path=str(receipts_dir),
+                    ticket_id="*",
+                    evidence_item_id="*",
+                    check_type="*",
+                    status=ReprobeStatus.FAIL,
+                    detail=f"receipts_dir is not a directory: {receipts_dir}",
+                )
+            ],
         )
 
     for receipt_path in sorted(receipts_dir.rglob("*.yaml")):
@@ -230,7 +244,7 @@ def verify_receipts_by_reexecuting_probes(
                     ticket_id="*",
                     evidence_item_id="*",
                     check_type="*",
-                    status="FAIL",
+                    status=ReprobeStatus.FAIL,
                     detail=f"corrupt receipt: {e}",
                 )
             )
@@ -243,7 +257,7 @@ def verify_receipts_by_reexecuting_probes(
                     ticket_id="*",
                     evidence_item_id="*",
                     check_type="*",
-                    status="FAIL",
+                    status=ReprobeStatus.FAIL,
                     detail=f"receipt root is not a mapping: {type(raw).__name__}",
                 )
             )
@@ -256,11 +270,9 @@ def verify_receipts_by_reexecuting_probes(
         results.append(
             ModelReceiptReprobeResult(
                 receipt_path=str(receipt_path),
-                ticket_id=ticket_id if isinstance(ticket_id, str) else "*",
-                evidence_item_id=(
-                    evidence_item_id if isinstance(evidence_item_id, str) else "*"
-                ),
-                check_type=check_type if isinstance(check_type, str) else "*",
+                ticket_id=_nonempty_or_star(ticket_id),
+                evidence_item_id=_nonempty_or_star(evidence_item_id),
+                check_type=_nonempty_or_star(check_type),
                 status=status,
                 detail=detail,
             )
@@ -304,13 +316,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::notice::no receipts found under {args.receipts_dir}")
         return 0
 
-    failures = [r for r in report.results if r.status != "PASS"]
+    failures = [r for r in report.results if r.status != ReprobeStatus.PASS]
     for r in report.results:
         line = (
-            f"{r.status}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
+            f"{r.status.value}: {r.ticket_id}/{r.evidence_item_id}/{r.check_type} "
             f"({r.receipt_path}): {r.detail}"
         )
-        if r.status == "PASS":
+        if r.status == ReprobeStatus.PASS:
             print(f"::notice::{line}")
         else:
             print(f"::error::{line}")
@@ -330,6 +342,7 @@ def main(argv: list[str] | None = None) -> int:
 __all__ = [
     "PROBE_COMMAND_ALLOWLIST",
     "PROBE_REEXEC_TIMEOUT_SECONDS",
+    "ReprobeStatus",
     "verify_receipt_by_reexecuting_probe",
     "verify_receipts_by_reexecuting_probes",
 ]

--- a/src/omnibase_core/validation/validator_receipt_reprobe.py
+++ b/src/omnibase_core/validation/validator_receipt_reprobe.py
@@ -26,10 +26,10 @@ the cheapest available externalization of trust.
 
 Safety: probes execute via ``subprocess.run(shell=False)`` with arguments
 split by ``shlex.split`` — there is no shell interpolation. Only commands
-whose stripped form starts with one of the prefixes in
-:data:`PROBE_COMMAND_ALLOWLIST` are allowed to run. Anything else fails
-fast with detail mentioning ``allowlist``. Each probe is wall-clock-capped
-at :data:`PROBE_REEXEC_TIMEOUT_SECONDS`.
+whose stripped form matches one of the command-boundary prefixes in
+:data:`PROBE_COMMAND_ALLOWLIST` are allowed to run. Anything else fails fast
+with detail mentioning ``allowlist``. Each probe is wall-clock-capped at
+:data:`PROBE_REEXEC_TIMEOUT_SECONDS`.
 
 Public API: :func:`verify_receipt_by_reexecuting_probe` (single-receipt)
 and :func:`verify_receipts_by_reexecuting_probes` (batch, producing a
@@ -64,11 +64,12 @@ from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
 # ---------------------------------------------------------------------------
 
 # Command-prefix allowlist for re-execution. A probe is permitted to run only
-# if its stripped form starts with one of these strings. Listing here (not in
-# code body) makes the policy grep-able and easy to extend by ticket review.
+# if its stripped form matches one of these prefixes on a command boundary.
+# Listing here (not in code body) makes the policy grep-able and easy to extend
+# by ticket review.
 #
 # Ordering is documentation, not semantics — the membership check is
-# whitespace-stripped prefix match.
+# whitespace-stripped command-boundary prefix match.
 PROBE_COMMAND_ALLOWLIST: tuple[str, ...] = (
     "gh pr view",
     "gh pr checks",
@@ -78,8 +79,6 @@ PROBE_COMMAND_ALLOWLIST: tuple[str, ...] = (
     "uv run pytest",
     "test -f",
     "test -d",
-    "true",  # for testing
-    "false",  # for testing
 )
 
 # Wall-clock cap per probe re-execution. Anything slower indicates the probe
@@ -153,7 +152,7 @@ def verify_receipt_by_reexecuting_probe(
             "receipt has no exit_code field; cannot verify re-execution parity",
         )
     expected_exit = receipt.get("exit_code")
-    if not isinstance(expected_exit, int):
+    if type(expected_exit) is not int:
         return (
             "FAIL",
             f"receipt.exit_code must be int, got {type(expected_exit).__name__}",
@@ -162,8 +161,8 @@ def verify_receipt_by_reexecuting_probe(
     try:
         result = subprocess.run(
             shlex.split(probe),
-            capture_output=True,
-            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             timeout=PROBE_REEXEC_TIMEOUT_SECONDS,
             check=False,
         )

--- a/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
+++ b/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
@@ -28,7 +28,9 @@ def test_result_is_frozen() -> None:
         status="PASS",
         detail="ok",
     )
-    with pytest.raises(ValidationError):
+    with pytest.raises(
+        Exception
+    ):  # NOTE(OMN-9789): Pydantic frozen-mutation exception class varies by version; assert rejection only
         result.status = "FAIL"  # type: ignore[misc]
 
 
@@ -42,7 +44,7 @@ def test_result_rejects_extra_fields() -> None:
             check_type="command",
             status="PASS",
             detail="ok",
-            extra_field="nope",  # type: ignore[call-arg]
+            extra_field="nope",  # type: ignore[call-arg]  # NOTE(OMN-9789): intentional extra-field rejection test
         )
 
 
@@ -54,7 +56,7 @@ def test_result_rejects_unknown_status() -> None:
             ticket_id="OMN-1",
             evidence_item_id="dod-001",
             check_type="command",
-            status="UNKNOWN",  # type: ignore[arg-type]
+            status="UNKNOWN",  # type: ignore[arg-type]  # NOTE(OMN-9789): intentional invalid Literal test
             detail="bad",
         )
 

--- a/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
+++ b/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelReceiptReprobeResult / ModelReceiptReprobeReport (OMN-9789)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.ticket.model_receipt_reprobe_report import (
+    ModelReceiptReprobeReport,
+)
+from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
+    ModelReceiptReprobeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_result_is_frozen() -> None:
+    """ModelReceiptReprobeResult must be immutable once created."""
+    result = ModelReceiptReprobeResult(
+        receipt_path="/tmp/r.yaml",
+        ticket_id="OMN-1",
+        evidence_item_id="dod-001",
+        check_type="command",
+        status="PASS",
+        detail="ok",
+    )
+    with pytest.raises(ValidationError):
+        result.status = "FAIL"  # type: ignore[misc]
+
+
+def test_result_rejects_extra_fields() -> None:
+    """extra='forbid' guards against schema drift."""
+    with pytest.raises(ValidationError):
+        ModelReceiptReprobeResult(
+            receipt_path="/tmp/r.yaml",
+            ticket_id="OMN-1",
+            evidence_item_id="dod-001",
+            check_type="command",
+            status="PASS",
+            detail="ok",
+            extra_field="nope",  # type: ignore[call-arg]
+        )
+
+
+def test_result_rejects_unknown_status() -> None:
+    """Status must be one of the Literal options."""
+    with pytest.raises(ValidationError):
+        ModelReceiptReprobeResult(
+            receipt_path="/tmp/r.yaml",
+            ticket_id="OMN-1",
+            evidence_item_id="dod-001",
+            check_type="command",
+            status="UNKNOWN",  # type: ignore[arg-type]
+            detail="bad",
+        )
+
+
+def test_report_passed_is_true_when_empty() -> None:
+    """Vacuous truth — no receipts = no failures."""
+    report = ModelReceiptReprobeReport(receipts_dir="/tmp", results=[])
+    assert report.passed is True
+    assert report.failures == []
+
+
+def test_report_passed_is_true_when_all_pass() -> None:
+    report = ModelReceiptReprobeReport(
+        receipts_dir="/tmp",
+        results=[
+            ModelReceiptReprobeResult(
+                receipt_path="/tmp/a.yaml",
+                ticket_id="OMN-1",
+                evidence_item_id="dod-001",
+                check_type="command",
+                status="PASS",
+                detail="ok",
+            ),
+            ModelReceiptReprobeResult(
+                receipt_path="/tmp/b.yaml",
+                ticket_id="OMN-2",
+                evidence_item_id="dod-001",
+                check_type="command",
+                status="PASS",
+                detail="ok",
+            ),
+        ],
+    )
+    assert report.passed is True
+    assert report.failures == []
+
+
+def test_report_passed_is_false_when_any_fail() -> None:
+    fail = ModelReceiptReprobeResult(
+        receipt_path="/tmp/b.yaml",
+        ticket_id="OMN-2",
+        evidence_item_id="dod-001",
+        check_type="command",
+        status="FAIL",
+        detail="exit_code mismatch",
+    )
+    report = ModelReceiptReprobeReport(
+        receipts_dir="/tmp",
+        results=[
+            ModelReceiptReprobeResult(
+                receipt_path="/tmp/a.yaml",
+                ticket_id="OMN-1",
+                evidence_item_id="dod-001",
+                check_type="command",
+                status="PASS",
+                detail="ok",
+            ),
+            fail,
+        ],
+    )
+    assert report.passed is False
+    assert report.failures == [fail]

--- a/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
+++ b/tests/unit/models/contracts/test_model_receipt_reprobe_result.py
@@ -13,6 +13,7 @@ from omnibase_core.models.contracts.ticket.model_receipt_reprobe_report import (
 )
 from omnibase_core.models.contracts.ticket.model_receipt_reprobe_result import (
     ModelReceiptReprobeResult,
+    ReprobeStatus,
 )
 
 pytestmark = pytest.mark.unit
@@ -25,13 +26,13 @@ def test_result_is_frozen() -> None:
         ticket_id="OMN-1",
         evidence_item_id="dod-001",
         check_type="command",
-        status="PASS",
+        status=ReprobeStatus.PASS,
         detail="ok",
     )
     with pytest.raises(
         Exception
     ):  # NOTE(OMN-9789): Pydantic frozen-mutation exception class varies by version; assert rejection only
-        result.status = "FAIL"  # type: ignore[misc]
+        result.status = ReprobeStatus.FAIL  # type: ignore[misc]  # NOTE(OMN-9789): intentional frozen-model mutation test
 
 
 def test_result_rejects_extra_fields() -> None:
@@ -42,21 +43,21 @@ def test_result_rejects_extra_fields() -> None:
             ticket_id="OMN-1",
             evidence_item_id="dod-001",
             check_type="command",
-            status="PASS",
+            status=ReprobeStatus.PASS,
             detail="ok",
             extra_field="nope",  # type: ignore[call-arg]  # NOTE(OMN-9789): intentional extra-field rejection test
         )
 
 
 def test_result_rejects_unknown_status() -> None:
-    """Status must be one of the Literal options."""
+    """Status must be one of the ReprobeStatus options."""
     with pytest.raises(ValidationError):
         ModelReceiptReprobeResult(
             receipt_path="/tmp/r.yaml",
             ticket_id="OMN-1",
             evidence_item_id="dod-001",
             check_type="command",
-            status="UNKNOWN",  # type: ignore[arg-type]  # NOTE(OMN-9789): intentional invalid Literal test
+            status="UNKNOWN",  # type: ignore[arg-type]  # NOTE(OMN-9789): intentional invalid ReprobeStatus test
             detail="bad",
         )
 
@@ -77,7 +78,7 @@ def test_report_passed_is_true_when_all_pass() -> None:
                 ticket_id="OMN-1",
                 evidence_item_id="dod-001",
                 check_type="command",
-                status="PASS",
+                status=ReprobeStatus.PASS,
                 detail="ok",
             ),
             ModelReceiptReprobeResult(
@@ -85,7 +86,7 @@ def test_report_passed_is_true_when_all_pass() -> None:
                 ticket_id="OMN-2",
                 evidence_item_id="dod-001",
                 check_type="command",
-                status="PASS",
+                status=ReprobeStatus.PASS,
                 detail="ok",
             ),
         ],
@@ -100,7 +101,7 @@ def test_report_passed_is_false_when_any_fail() -> None:
         ticket_id="OMN-2",
         evidence_item_id="dod-001",
         check_type="command",
-        status="FAIL",
+        status=ReprobeStatus.FAIL,
         detail="exit_code mismatch",
     )
     report = ModelReceiptReprobeReport(
@@ -111,7 +112,7 @@ def test_report_passed_is_false_when_any_fail() -> None:
                 ticket_id="OMN-1",
                 evidence_item_id="dod-001",
                 check_type="command",
-                status="PASS",
+                status=ReprobeStatus.PASS,
                 detail="ok",
             ),
             fail,

--- a/tests/unit/validation/test_receipt_gate_cli.py
+++ b/tests/unit/validation/test_receipt_gate_cli.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Receipt-Gate CLI."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.validation.receipt_gate_cli import _escape_github_actions_message
+
+pytestmark = pytest.mark.unit
+
+
+def test_escape_github_actions_message_payload() -> None:
+    """Workflow command payloads must escape percent and line separators."""
+    message = "PASS: OMN-1/dod-001/command (/tmp/r.yaml): 50%\r\nnext"
+
+    assert (
+        _escape_github_actions_message(message)
+        == "PASS: OMN-1/dod-001/command (/tmp/r.yaml): 50%25%0D%0Anext"
+    )

--- a/tests/unit/validation/test_validator_receipt_reprobe.py
+++ b/tests/unit/validation/test_validator_receipt_reprobe.py
@@ -10,8 +10,8 @@ MERGED is unverified until probe confirms"). It is **not** full historical
 replay: environment, side effects, time, and external state may differ.
 
 Coverage:
-- Allowlisted always-pass probe ("true") returns PASS.
-- Allowlisted always-fail probe ("false") returns FAIL with exit_code in detail.
+- Test-only always-pass probe ("true") returns PASS when fixture-allowlisted.
+- Test-only always-fail probe ("false") returns FAIL with exit_code in detail.
 - Non-allowlisted probe ("rm -rf /") returns FAIL with allowlist in detail.
 - Missing probe_command returns FAIL.
 - Exit-code mismatch returns FAIL.
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import pytest
 
+from omnibase_core.validation import validator_receipt_reprobe
 from omnibase_core.validation.validator_receipt_reprobe import (
     PROBE_COMMAND_ALLOWLIST,
     PROBE_REEXEC_TIMEOUT_SECONDS,
@@ -32,12 +33,24 @@ from omnibase_core.validation.validator_receipt_reprobe import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture
+def allow_test_probe_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Permit deterministic true/false probes only inside tests."""
+    monkeypatch.setattr(
+        validator_receipt_reprobe,
+        "PROBE_COMMAND_ALLOWLIST",
+        (*PROBE_COMMAND_ALLOWLIST, "true", "false"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Plan-mandated test cases (Task 9, Step 1)
 # ---------------------------------------------------------------------------
 
 
-def test_reexecute_passing_probe_returns_pass() -> None:
+def test_reexecute_passing_probe_returns_pass(
+    allow_test_probe_commands: None,
+) -> None:
     """A receipt whose probe is always-pass and whose recorded exit_code is 0
     should re-execute to PASS.
     """
@@ -59,7 +72,9 @@ def test_reexecute_passing_probe_returns_pass() -> None:
     assert status == "PASS", detail
 
 
-def test_reexecute_failing_probe_returns_fail() -> None:
+def test_reexecute_failing_probe_returns_fail(
+    allow_test_probe_commands: None,
+) -> None:
     """A receipt that records exit_code=0 but whose probe currently exits
     non-zero must FAIL with the mismatch reported in the detail.
     """
@@ -151,7 +166,9 @@ def test_reexecute_empty_probe_command_returns_fail() -> None:
     assert "probe_command" in detail.lower()
 
 
-def test_reexecute_exit_code_mismatch_returns_fail() -> None:
+def test_reexecute_exit_code_mismatch_returns_fail(
+    allow_test_probe_commands: None,
+) -> None:
     """Recorded exit_code=1 but probe currently returns 0 → FAIL.
 
     Even though "true" exits 0 successfully, the receipt claimed it exited 1,
@@ -176,7 +193,9 @@ def test_reexecute_exit_code_mismatch_returns_fail() -> None:
     assert "exit_code" in detail.lower()
 
 
-def test_reexecute_missing_exit_code_field_returns_fail() -> None:
+def test_reexecute_missing_exit_code_field_returns_fail(
+    allow_test_probe_commands: None,
+) -> None:
     """A receipt without exit_code cannot be checked for parity."""
     receipt: dict[str, object] = {
         "schema_version": "1.0.0",
@@ -194,6 +213,29 @@ def test_reexecute_missing_exit_code_field_returns_fail() -> None:
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
     assert status == "FAIL"
     assert "exit_code" in detail.lower()
+
+
+def test_reexecute_bool_exit_code_returns_fail(
+    allow_test_probe_commands: None,
+) -> None:
+    """A YAML bool is not a valid process exit-code integer."""
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "true",
+        "probe_command": "true",
+        "probe_stdout": "",
+        "exit_code": True,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "exit_code must be int, got bool" in detail
 
 
 # ---------------------------------------------------------------------------
@@ -214,8 +256,6 @@ def test_allowlist_contains_exact_plan_prefixes() -> None:
         "uv run pytest",
         "test -f",
         "test -d",
-        "true",
-        "false",
     }
     assert set(PROBE_COMMAND_ALLOWLIST) == expected
 
@@ -317,7 +357,10 @@ def test_non_allowlisted_probe_is_rejected(probe: str) -> None:
         "test -files /tmp/x",  # NOTE(OMN-9789): would pass naive startswith("test -f")
     ],
 )
-def test_command_boundary_prevents_prefix_smuggling(probe: str) -> None:
+def test_command_boundary_prevents_prefix_smuggling(
+    probe: str,
+    allow_test_probe_commands: None,
+) -> None:
     """Allowlist matching must be on a command boundary, not a raw substring.
 
     A naive ``str.startswith`` check would let ``trueevil`` slip past a

--- a/tests/unit/validation/test_validator_receipt_reprobe.py
+++ b/tests/unit/validation/test_validator_receipt_reprobe.py
@@ -27,7 +27,9 @@ from omnibase_core.validation import validator_receipt_reprobe
 from omnibase_core.validation.validator_receipt_reprobe import (
     PROBE_COMMAND_ALLOWLIST,
     PROBE_REEXEC_TIMEOUT_SECONDS,
+    ReprobeStatus,
     verify_receipt_by_reexecuting_probe,
+    verify_receipts_by_reexecuting_probes,
 )
 
 pytestmark = pytest.mark.unit
@@ -69,7 +71,7 @@ def test_reexecute_passing_probe_returns_pass(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "PASS", detail
+    assert status == ReprobeStatus.PASS, detail
 
 
 def test_reexecute_failing_probe_returns_fail(
@@ -93,7 +95,7 @@ def test_reexecute_failing_probe_returns_fail(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "exit_code" in detail.lower()
 
 
@@ -116,7 +118,7 @@ def test_reexecute_only_runs_probes_in_allowlist() -> None:
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "allowlist" in detail.lower()
 
 
@@ -141,7 +143,7 @@ def test_reexecute_missing_probe_command_returns_fail() -> None:
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "probe_command" in detail.lower()
 
 
@@ -162,7 +164,7 @@ def test_reexecute_empty_probe_command_returns_fail() -> None:
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "probe_command" in detail.lower()
 
 
@@ -189,7 +191,7 @@ def test_reexecute_exit_code_mismatch_returns_fail(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "exit_code" in detail.lower()
 
 
@@ -211,7 +213,7 @@ def test_reexecute_missing_exit_code_field_returns_fail(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "exit_code" in detail.lower()
 
 
@@ -234,8 +236,52 @@ def test_reexecute_bool_exit_code_returns_fail(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "exit_code must be int, got bool" in detail
+
+
+def test_batch_reprobe_fails_closed_for_missing_receipts_dir(tmp_path) -> None:
+    """A typoed receipts path must fail closed instead of passing vacuously."""
+    receipts_dir = tmp_path / "missing"
+
+    report = verify_receipts_by_reexecuting_probes(receipts_dir)
+
+    assert report.passed is False
+    assert len(report.results) == 1
+    result = report.results[0]
+    assert result.receipt_path == str(receipts_dir)
+    assert result.status == ReprobeStatus.FAIL
+    assert "not a directory" in result.detail
+
+
+def test_batch_reprobe_normalizes_empty_identifiers_to_star(tmp_path) -> None:
+    """Empty receipt identifiers must not abort report construction."""
+    receipts_dir = tmp_path / "receipts"
+    receipts_dir.mkdir()
+    receipt_path = receipts_dir / "receipt.yaml"
+    receipt_path.write_text(
+        "\n".join(
+            [
+                "ticket_id: '   '",
+                "evidence_item_id: ''",
+                "check_type: []",
+                "probe_command: not-allowlisted",
+                "exit_code: 0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = verify_receipts_by_reexecuting_probes(receipts_dir)
+
+    assert report.passed is False
+    assert len(report.results) == 1
+    result = report.results[0]
+    assert result.ticket_id == "*"
+    assert result.evidence_item_id == "*"
+    assert result.check_type == "*"
+    assert result.status == ReprobeStatus.FAIL
+    assert "allowlist" in result.detail
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +352,7 @@ def test_allowlisted_prefix_with_args_passes_allowlist(probe: str) -> None:
     assert "allowlist" not in detail.lower(), (
         f"Allowlisted probe was rejected: {detail}"
     )
-    assert status in ("PASS", "FAIL")
+    assert status in (ReprobeStatus.PASS, ReprobeStatus.FAIL)
 
 
 @pytest.mark.parametrize(
@@ -342,7 +388,7 @@ def test_non_allowlisted_probe_is_rejected(probe: str) -> None:
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "allowlist" in detail.lower()
 
 
@@ -383,7 +429,7 @@ def test_command_boundary_prevents_prefix_smuggling(
         "status": "PASS",
     }
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
-    assert status == "FAIL"
+    assert status == ReprobeStatus.FAIL
     assert "allowlist" in detail.lower(), (
         f"Boundary-smuggled probe should be rejected by allowlist: {detail}"
     )

--- a/tests/unit/validation/test_validator_receipt_reprobe.py
+++ b/tests/unit/validation/test_validator_receipt_reprobe.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the re-probe verification mode (OMN-9789).
+
+The re-probe verifier re-runs a receipt's recorded ``probe_command`` and
+checks that the current exit_code matches the receipt's recorded exit_code.
+It is a defense against fabricated receipts (lesson F92 — "PR self-reported
+MERGED is unverified until probe confirms"). It is **not** full historical
+replay: environment, side effects, time, and external state may differ.
+
+Coverage:
+- Allowlisted always-pass probe ("true") returns PASS.
+- Allowlisted always-fail probe ("false") returns FAIL with exit_code in detail.
+- Non-allowlisted probe ("rm -rf /") returns FAIL with allowlist in detail.
+- Missing probe_command returns FAIL.
+- Exit-code mismatch returns FAIL.
+- Allowlist contains the exact prefixes specified by the plan.
+- Constants module exposes the re-probe API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.validation.validator_receipt_reprobe import (
+    PROBE_COMMAND_ALLOWLIST,
+    PROBE_REEXEC_TIMEOUT_SECONDS,
+    verify_receipt_by_reexecuting_probe,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Plan-mandated test cases (Task 9, Step 1)
+# ---------------------------------------------------------------------------
+
+
+def test_reexecute_passing_probe_returns_pass() -> None:
+    """A receipt whose probe is always-pass and whose recorded exit_code is 0
+    should re-execute to PASS.
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "true",
+        "probe_command": "true",
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "PASS", detail
+
+
+def test_reexecute_failing_probe_returns_fail() -> None:
+    """A receipt that records exit_code=0 but whose probe currently exits
+    non-zero must FAIL with the mismatch reported in the detail.
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "false",
+        "probe_command": "false",
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "exit_code" in detail.lower()
+
+
+def test_reexecute_only_runs_probes_in_allowlist() -> None:
+    """A receipt whose probe_command is not in the allowlist must FAIL fast
+    with ``allowlist`` in the detail; the dangerous command must NOT execute.
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_command": "rm -rf /",
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "allowlist" in detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth coverage
+# ---------------------------------------------------------------------------
+
+
+def test_reexecute_missing_probe_command_returns_fail() -> None:
+    """A receipt with no ``probe_command`` field cannot be re-probed."""
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "probe_command" in detail.lower()
+
+
+def test_reexecute_empty_probe_command_returns_fail() -> None:
+    """Empty string is treated identically to missing field."""
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_command": "",
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "probe_command" in detail.lower()
+
+
+def test_reexecute_exit_code_mismatch_returns_fail() -> None:
+    """Recorded exit_code=1 but probe currently returns 0 → FAIL.
+
+    Even though "true" exits 0 successfully, the receipt claimed it exited 1,
+    so the receipt cannot be re-verified.
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "true",
+        "probe_command": "true",
+        "probe_stdout": "",
+        "exit_code": 1,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "exit_code" in detail.lower()
+
+
+def test_reexecute_missing_exit_code_field_returns_fail() -> None:
+    """A receipt without exit_code cannot be checked for parity."""
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "true",
+        "probe_command": "true",
+        "probe_stdout": "",
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "exit_code" in detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist canonical form
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_contains_exact_plan_prefixes() -> None:
+    """The plan's acceptance criteria require the allowlist to contain
+    exactly these prefixes — additions or removals require a new ticket.
+    """
+    expected = {
+        "gh pr view",
+        "gh pr checks",
+        "gh api",
+        "psql ",
+        "curl ",
+        "uv run pytest",
+        "test -f",
+        "test -d",
+        "true",
+        "false",
+    }
+    assert set(PROBE_COMMAND_ALLOWLIST) == expected
+
+
+def test_timeout_is_120_seconds() -> None:
+    """Plan acceptance: timeout cap of 120 seconds per probe."""
+    assert PROBE_REEXEC_TIMEOUT_SECONDS == 120
+
+
+# ---------------------------------------------------------------------------
+# Allowlist edge cases — membership semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "gh pr view 123 --repo OmniNode-ai/omnibase_core",
+        "gh pr checks 123",
+        "gh api repos/OmniNode-ai/omnibase_core/pulls/123",
+        "test -f /tmp/some-file",
+        "test -d /tmp/some-dir",
+    ],
+)
+def test_allowlisted_prefix_with_args_passes_allowlist(probe: str) -> None:
+    """An allowlisted prefix followed by arguments is accepted; only the
+    prefix match is required to clear the allowlist gate (the probe itself
+    may still fail at exit-code time).
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_command": probe,
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    # Either PASS or FAIL is acceptable; what we are asserting is that the
+    # allowlist gate did NOT veto this probe (so detail must not mention
+    # "allowlist").
+    assert "allowlist" not in detail.lower(), (
+        f"Allowlisted probe was rejected: {detail}"
+    )
+    assert status in ("PASS", "FAIL")
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "rm -rf /",
+        "sudo shutdown",
+        "echo gh pr view",  # prefix-substring shifted off-start
+        "gh pr merge 123",  # gh family but not in allowlist
+        " curl https://example.com",  # leading-whitespace stripped, but
+        # 'curl ' is allowlisted — this DOES pass; see strip-then-check note
+        # in implementation. Use a truly off-list command for negative case:
+    ],
+)
+def test_non_allowlisted_probe_is_rejected(probe: str) -> None:
+    """Non-allowlisted commands must fail fast before any subprocess runs."""
+    if probe.strip().startswith(("curl ", "true", "false")):
+        # The leading-whitespace case actually IS allowlisted because the
+        # implementation strips. Skip — covered separately.
+        pytest.skip("leading-whitespace allowlisted prefix")
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_command": probe,
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "allowlist" in detail.lower()

--- a/tests/unit/validation/test_validator_receipt_reprobe.py
+++ b/tests/unit/validation/test_validator_receipt_reprobe.py
@@ -304,3 +304,43 @@ def test_non_allowlisted_probe_is_rejected(probe: str) -> None:
     status, detail = verify_receipt_by_reexecuting_probe(receipt)
     assert status == "FAIL"
     assert "allowlist" in detail.lower()
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "trueevil",  # NOTE(OMN-9789): would pass naive startswith("true")
+        "falseflag --foo",  # NOTE(OMN-9789): would pass naive startswith("false")
+        "gh pr viewx 123",  # NOTE(OMN-9789): would pass naive startswith("gh pr view")
+        "gh pr checksum",  # NOTE(OMN-9789): would pass naive startswith("gh pr checks")
+        "gh apifoo",  # NOTE(OMN-9789): would pass naive startswith("gh api")
+        "test -files /tmp/x",  # NOTE(OMN-9789): would pass naive startswith("test -f")
+    ],
+)
+def test_command_boundary_prevents_prefix_smuggling(probe: str) -> None:
+    """Allowlist matching must be on a command boundary, not a raw substring.
+
+    A naive ``str.startswith`` check would let ``trueevil`` slip past a
+    ``"true"`` prefix and ``gh pr viewx`` slip past ``"gh pr view"``. The
+    allowlist gate must require the prefix to either equal the probe or be
+    followed by whitespace.
+    """
+    receipt: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-A",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "x",
+        "probe_command": probe,
+        "probe_stdout": "",
+        "exit_code": 0,
+        "runner": "worker",
+        "verifier": "foreground-X",
+        "run_timestamp": "2026-04-26T12:00:00Z",
+        "status": "PASS",
+    }
+    status, detail = verify_receipt_by_reexecuting_probe(receipt)
+    assert status == "FAIL"
+    assert "allowlist" in detail.lower(), (
+        f"Boundary-smuggled probe should be rejected by allowlist: {detail}"
+    )


### PR DESCRIPTION
## Summary

Wave B Task 9 of the session-process-and-change-control plan.

Adds an *active* verification path for `ModelDodReceipt` artifacts: re-runs each receipt's recorded `probe_command` and compares the current `exit_code` against the value the receipt claims. The receipt gate's static check is necessary but not sufficient — a fabricated receipt is indistinguishable from a real one if you only inspect the file. Re-probing externalises trust by rerunning the recorded command.

**Truth boundary**: this is re-probe verification, not full historical replay. It does not prove temporal correctness, environment equivalence, or side-effect identity.

## Changes

- `ModelReceiptReprobeResult` / `ModelReceiptReprobeReport` — frozen audit artifacts (separate files per single-class-per-file rule).
- `verify_receipt_by_reexecuting_probe` — single-receipt verifier matching the plan's `(receipt) -> (status, detail)` signature.
- `verify_receipts_by_reexecuting_probes` — batch verifier walking a receipt tree.
- `python -m omnibase_core.validation.validator_receipt_reprobe --receipts-dir ...` CLI driver.
- `receipt_gate_cli --reexecute-probes` flag (default OFF in CI; ON in manual scaffold session-end ritual).
- Allowlisted command prefixes (`gh pr view`, `gh pr checks`, `gh api`, `psql`, `curl`, `uv run pytest`, `test -f`, `test -d`).
- `subprocess.run(shell=False)` with `shlex.split`; 120s wall-clock cap per probe.
- Allowlist entry in `.yaml-validation-allowlist.yaml` (re-probe inspects raw legacy receipts that may pre-date the current `ModelDodReceipt` schema).

Plan: `docs/plans/2026-04-26-session-process-and-change-control.md`.

## Test plan

- [x] Unit: `tests/unit/models/contracts/test_model_receipt_reprobe_result.py` — frozen, extra="forbid", status-Literal, report passed/failures properties.
- [x] Unit: `tests/unit/validation/test_validator_receipt_reprobe.py` — allowlist enforcement, exit-code parity, timeout, missing fields, batch walk.
- [ ] CI verification on PR (mypy strict, ruff, pre-commit hooks all green locally pre-push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional re-probe mode to re-execute recorded probe commands and verify exit-code consistency
  * Aggregate re-probe reports and per-receipt pass/fail details surfaced to the CLI and CI annotations
  * New re-probe outcome type and immutable result/report models for clear pass/fail semantics

* **Tests**
  * Added comprehensive unit and end-to-end tests covering re-probe behavior, allowlist rules, and reporting

* **Chores**
  * Updated YAML allowlist and lint config to permit the re-probe tooling files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->