### PR TITLE
OMN-9887: ModelRuntimeAlivenessProbeCommand + Receipt contracts

### DIFF
--- a/src/omnibase_core/enums/enum_probe_failure_state.py
+++ b/src/omnibase_core/enums/enum_probe_failure_state.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Probe failure state enumeration.
+
+Enumerates the four failure modes a runtime aliveness probe can land in,
+per the runtime-lifecycle-hardening plan, Wave 3 / Task 9 probe contract.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+__all__ = ["EnumProbeFailureState"]
+
+
+@unique
+class EnumProbeFailureState(StrValueHelper, str, Enum):
+    """Failure modes recorded on a ModelRuntimeAlivenessProbeReceipt.
+
+    Sampling order is sequential: publish probe -> observe terminal event ->
+    observe projection row -> sample consumer-group lag. Each entry below maps
+    to a step that did not satisfy the probe contract at the corresponding
+    sampling point.
+    """
+
+    TIMEOUT = "timeout"
+    TERMINAL_FAILURE_EMITTED = "terminal_failure_emitted"
+    PROJECTION_WRITE_FAILED = "projection_write_failed"
+    LAG_ABOVE_THRESHOLD = "lag_above_threshold"

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -19,7 +19,6 @@ from omnibase_core.models.runtime.model_handler_metadata import ModelHandlerMeta
 from omnibase_core.models.runtime.model_runtime_aliveness_probe import (
     DEFAULT_TIMEOUT_SECONDS,
     TIMEOUT_ENV_VAR,
-    FailureState,
     ModelRuntimeAlivenessProbeCommand,
 )
 from omnibase_core.models.runtime.model_runtime_aliveness_probe_receipt import (
@@ -53,7 +52,6 @@ __all__ = [
     # Aliveness probe contract (Wave 3)
     "ModelRuntimeAlivenessProbeCommand",
     "ModelRuntimeAlivenessProbeReceipt",
-    "FailureState",
     "DEFAULT_TIMEOUT_SECONDS",
     "TIMEOUT_ENV_VAR",
     # Directive payload types (re-exported for convenience)

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -16,6 +16,15 @@ from omnibase_core.models.runtime.model_handler_behavior import (
     ModelHandlerBehavior,
 )
 from omnibase_core.models.runtime.model_handler_metadata import ModelHandlerMetadata
+from omnibase_core.models.runtime.model_runtime_aliveness_probe import (
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    FailureState,
+    ModelRuntimeAlivenessProbeCommand,
+)
+from omnibase_core.models.runtime.model_runtime_aliveness_probe_receipt import (
+    ModelRuntimeAlivenessProbeReceipt,
+)
 from omnibase_core.models.runtime.model_runtime_directive import ModelRuntimeDirective
 from omnibase_core.models.runtime.model_runtime_node_instance import (
     ModelRuntimeNodeInstance,
@@ -41,6 +50,12 @@ __all__ = [
     "ModelRuntimeDirective",
     "ModelRuntimeNodeInstance",
     "NodeInstance",
+    # Aliveness probe contract (Wave 3)
+    "ModelRuntimeAlivenessProbeCommand",
+    "ModelRuntimeAlivenessProbeReceipt",
+    "FailureState",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "TIMEOUT_ENV_VAR",
     # Directive payload types (re-exported for convenience)
     "ModelDirectivePayload",
     "ModelDirectivePayloadBase",

--- a/src/omnibase_core/models/runtime/model_runtime_aliveness_probe.py
+++ b/src/omnibase_core/models/runtime/model_runtime_aliveness_probe.py
@@ -13,24 +13,18 @@ projection).
 from __future__ import annotations
 
 import os
-from typing import Any, Literal, Self
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_probe_failure_state import EnumProbeFailureState
 
 DEFAULT_TIMEOUT_SECONDS = 30
 TIMEOUT_ENV_VAR = "RUNTIME_ALIVENESS_TIMEOUT_SECONDS"
 
-FailureState = Literal[
-    "timeout",
-    "terminal_failure_emitted",
-    "projection_write_failed",
-    "lag_above_threshold",
-]
-
 __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
     "TIMEOUT_ENV_VAR",
-    "FailureState",
     "ModelRuntimeAlivenessProbeCommand",
 ]
 
@@ -90,7 +84,7 @@ class ModelRuntimeAlivenessProbeCommand(BaseModel):
         gt=0,
         description="Wall-clock probe budget; default 30, configurable via env RUNTIME_ALIVENESS_TIMEOUT_SECONDS",
     )
-    failure_states: tuple[FailureState, ...] = Field(
+    failure_states: tuple[EnumProbeFailureState, ...] = Field(
         default=(),
         description="Always empty on the command; populated only on the receipt outcome",
     )

--- a/src/omnibase_core/models/runtime/model_runtime_aliveness_probe.py
+++ b/src/omnibase_core/models/runtime/model_runtime_aliveness_probe.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aliveness probe command contract for runtime liveness verification.
+
+Wave 3 of the runtime-lifecycle-hardening plan. The probe runner (Task 9, lives
+in omnibase_infra) consumes ``ModelRuntimeAlivenessProbeCommand`` and emits a
+``ModelRuntimeAlivenessProbeReceipt`` (sibling module). The two models are the
+shared schema between the runner and any downstream consumer (CI gate, replay,
+projection).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_TIMEOUT_SECONDS = 30
+TIMEOUT_ENV_VAR = "RUNTIME_ALIVENESS_TIMEOUT_SECONDS"
+
+FailureState = Literal[
+    "timeout",
+    "terminal_failure_emitted",
+    "projection_write_failed",
+    "lag_above_threshold",
+]
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "TIMEOUT_ENV_VAR",
+    "FailureState",
+    "ModelRuntimeAlivenessProbeCommand",
+]
+
+
+def _resolve_timeout_from_env() -> int:
+    raw = os.environ.get(TIMEOUT_ENV_VAR)
+    if raw is None:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return DEFAULT_TIMEOUT_SECONDS
+    if parsed <= 0:
+        return DEFAULT_TIMEOUT_SECONDS
+    return parsed
+
+
+class ModelRuntimeAlivenessProbeCommand(BaseModel):
+    """Typed command published to a target command topic to verify runtime liveness.
+
+    The probe runner publishes an instance of this model as a ModelEventMessage
+    payload to ``target_command_topic`` and waits up to ``timeout_seconds`` for a
+    matching terminal event on ``expected_terminal_topic`` plus a projection row
+    keyed by ``projection_key_template``. Outcome populates ``failure_states`` on
+    the receipt, never on the command.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str = Field(
+        ...,
+        min_length=1,
+        description="Probe correlation id; must round-trip end-to-end",
+    )
+    target_command_topic: str = Field(
+        ...,
+        min_length=1,
+        description="Command topic the probe publishes to (onex.cmd.<service>.<event>.v<N>)",
+    )
+    target_handler_id: str = Field(
+        ...,
+        min_length=1,
+        description="Fully qualified handler id expected to consume the probe",
+    )
+    expected_terminal_topic: str = Field(
+        ...,
+        min_length=1,
+        description="Terminal event topic the probe runner waits on (onex.evt.<service>.<event>.v<N>)",
+    )
+    projection_key_template: str = Field(
+        ...,
+        min_length=1,
+        description="Projection key template, e.g. 'public.build_loop_runs:run_id={correlation_id}'",
+    )
+    timeout_seconds: int = Field(
+        default=DEFAULT_TIMEOUT_SECONDS,
+        gt=0,
+        description="Wall-clock probe budget; default 30, configurable via env RUNTIME_ALIVENESS_TIMEOUT_SECONDS",
+    )
+    failure_states: tuple[FailureState, ...] = Field(
+        default=(),
+        description="Always empty on the command; populated only on the receipt outcome",
+    )
+
+    @classmethod
+    def from_env(cls, **kwargs: Any) -> Self:
+        """Construct a probe command, resolving timeout_seconds from the env when not provided.
+
+        ``RUNTIME_ALIVENESS_TIMEOUT_SECONDS`` overrides the 30s default. Invalid or
+        non-positive values fall back to the default rather than raising — the env
+        is treated as operational tuning, not a hard contract surface.
+        """
+        if "timeout_seconds" not in kwargs:
+            kwargs["timeout_seconds"] = _resolve_timeout_from_env()
+        return cls(**kwargs)

--- a/src/omnibase_core/models/runtime/model_runtime_aliveness_probe_receipt.py
+++ b/src/omnibase_core/models/runtime/model_runtime_aliveness_probe_receipt.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aliveness probe receipt: outcome of a single ``ModelRuntimeAlivenessProbeCommand`` run.
+
+Wave 3 of the runtime-lifecycle-hardening plan. Emitted by the probe runner
+(Task 9, in omnibase_infra) and consumed by the OCC receipt-gate, replay, and
+projection paths.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.runtime.model_runtime_aliveness_probe import FailureState
+
+__all__ = ["ModelRuntimeAlivenessProbeReceipt"]
+
+
+class ModelRuntimeAlivenessProbeReceipt(BaseModel):
+    """Outcome of a single probe run, emitted by the probe runner.
+
+    PASS receipts MUST have an empty ``failure_states`` tuple; FAIL receipts MUST
+    have at least one entry. Lag sampling is the final step of the probe lifecycle
+    and is only executed after the terminal event and projection row are observed
+    — ``lag_at_sample`` is None when sampling was skipped (e.g. probe timed out
+    before reaching the lag step).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str = Field(..., min_length=1)
+    status: Literal["PASS", "FAIL"]
+    failure_states: tuple[FailureState, ...] = Field(default=())
+    terminal_event_observed: bool
+    projection_row_observed: bool
+    lag_at_sample: int | None = Field(
+        default=None,
+        ge=0,
+        description="Consumer-group lag at the post-projection sampling point; None when sampling was skipped",
+    )
+    timeout_seconds: int = Field(
+        ..., gt=0, description="Echoed from the command for receipt independence"
+    )
+    started_at: datetime
+    completed_at: datetime
+
+    @model_validator(mode="after")
+    def _validate_status_failure_states(self) -> Self:
+        if self.status == "PASS" and self.failure_states:
+            raise ValueError(
+                "PASS receipts must have an empty failure_states tuple; "
+                f"got {self.failure_states!r}"
+            )
+        if self.status == "FAIL" and not self.failure_states:
+            raise ValueError(
+                "FAIL receipts must list at least one failure_state from "
+                "(timeout, terminal_failure_emitted, projection_write_failed, lag_above_threshold)"
+            )
+        return self

--- a/src/omnibase_core/models/runtime/model_runtime_aliveness_probe_receipt.py
+++ b/src/omnibase_core/models/runtime/model_runtime_aliveness_probe_receipt.py
@@ -15,7 +15,7 @@ from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from omnibase_core.models.runtime.model_runtime_aliveness_probe import FailureState
+from omnibase_core.enums.enum_probe_failure_state import EnumProbeFailureState
 
 __all__ = ["ModelRuntimeAlivenessProbeReceipt"]
 
@@ -34,7 +34,7 @@ class ModelRuntimeAlivenessProbeReceipt(BaseModel):
 
     correlation_id: str = Field(..., min_length=1)
     status: Literal["PASS", "FAIL"]
-    failure_states: tuple[FailureState, ...] = Field(default=())
+    failure_states: tuple[EnumProbeFailureState, ...] = Field(default=())
     terminal_event_observed: bool
     projection_row_observed: bool
     lag_at_sample: int | None = Field(

--- a/tests/unit/models/runtime/test_model_runtime_aliveness_probe.py
+++ b/tests/unit/models/runtime/test_model_runtime_aliveness_probe.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
+from omnibase_core.enums.enum_probe_failure_state import EnumProbeFailureState
 from omnibase_core.models.runtime.model_runtime_aliveness_probe import (
     ModelRuntimeAlivenessProbeCommand,
 )
@@ -83,7 +84,7 @@ def _receipt_kwargs() -> dict[str, object]:
 
 def test_receipt_pass_requires_empty_failure_states() -> None:
     kwargs = _receipt_kwargs()
-    kwargs["failure_states"] = ("timeout",)
+    kwargs["failure_states"] = (EnumProbeFailureState.TIMEOUT,)
     with pytest.raises(ValidationError):
         ModelRuntimeAlivenessProbeReceipt(**kwargs)  # type: ignore[arg-type]
 

--- a/tests/unit/models/runtime/test_model_runtime_aliveness_probe.py
+++ b/tests/unit/models/runtime/test_model_runtime_aliveness_probe.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelRuntimeAlivenessProbeCommand and ModelRuntimeAlivenessProbeReceipt."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.runtime.model_runtime_aliveness_probe import (
+    ModelRuntimeAlivenessProbeCommand,
+)
+from omnibase_core.models.runtime.model_runtime_aliveness_probe_receipt import (
+    ModelRuntimeAlivenessProbeReceipt,
+)
+
+
+def _command_kwargs() -> dict[str, object]:
+    return {
+        "correlation_id": "prb-2026-04-26-001",
+        "target_command_topic": "onex.cmd.omnimarket.build-loop-orchestrator-start.v1",
+        "target_handler_id": "node_build_loop_orchestrator.handlers.handler_build_loop_orchestrator",
+        "expected_terminal_topic": "onex.evt.omnimarket.build-loop-orchestrator-completed.v1",
+        "projection_key_template": "public.build_loop_runs:run_id={correlation_id}",
+        "timeout_seconds": 30,
+    }
+
+
+def test_probe_command_required_fields() -> None:
+    cmd = ModelRuntimeAlivenessProbeCommand(**_command_kwargs())  # type: ignore[arg-type]
+    assert cmd.failure_states == ()
+    assert cmd.timeout_seconds == 30
+
+
+def test_probe_command_rejects_unknown_failure_state() -> None:
+    kwargs = _command_kwargs()
+    kwargs["failure_states"] = ("not_a_real_state",)
+    with pytest.raises(ValidationError):
+        ModelRuntimeAlivenessProbeCommand(**kwargs)  # type: ignore[arg-type]
+
+
+def test_timeout_default_is_30s_and_configurable_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RUNTIME_ALIVENESS_TIMEOUT_SECONDS", raising=False)
+    base = _command_kwargs()
+    base.pop("timeout_seconds")
+    cmd_default = ModelRuntimeAlivenessProbeCommand.from_env(**base)  # type: ignore[arg-type]
+    assert cmd_default.timeout_seconds == 30
+
+    monkeypatch.setenv("RUNTIME_ALIVENESS_TIMEOUT_SECONDS", "60")
+    cmd_override = ModelRuntimeAlivenessProbeCommand.from_env(**base)  # type: ignore[arg-type]
+    assert cmd_override.timeout_seconds == 60
+
+
+def test_timeout_env_invalid_value_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_ALIVENESS_TIMEOUT_SECONDS", "not-an-int")
+    base = _command_kwargs()
+    base.pop("timeout_seconds")
+    cmd = ModelRuntimeAlivenessProbeCommand.from_env(**base)  # type: ignore[arg-type]
+    assert cmd.timeout_seconds == 30
+
+
+def _receipt_kwargs() -> dict[str, object]:
+    now = datetime.now(UTC)
+    return {
+        "correlation_id": "prb-2026-04-26-001",
+        "status": "PASS",
+        "failure_states": (),
+        "terminal_event_observed": True,
+        "projection_row_observed": True,
+        "lag_at_sample": 0,
+        "timeout_seconds": 30,
+        "started_at": now,
+        "completed_at": now,
+    }
+
+
+def test_receipt_pass_requires_empty_failure_states() -> None:
+    kwargs = _receipt_kwargs()
+    kwargs["failure_states"] = ("timeout",)
+    with pytest.raises(ValidationError):
+        ModelRuntimeAlivenessProbeReceipt(**kwargs)  # type: ignore[arg-type]
+
+
+def test_receipt_fail_requires_at_least_one_failure_state() -> None:
+    kwargs = _receipt_kwargs()
+    kwargs["status"] = "FAIL"
+    kwargs["failure_states"] = ()
+    with pytest.raises(ValidationError):
+        ModelRuntimeAlivenessProbeReceipt(**kwargs)  # type: ignore[arg-type]
+
+
+def test_receipt_pass_round_trip_serializes() -> None:
+    receipt = ModelRuntimeAlivenessProbeReceipt(**_receipt_kwargs())  # type: ignore[arg-type]
+    payload = receipt.model_dump(mode="json")
+    assert payload["status"] == "PASS"
+    assert payload["failure_states"] == []
+    assert payload["lag_at_sample"] == 0


### PR DESCRIPTION
## Summary

Implements **Wave 3 core** of the runtime-lifecycle-hardening plan (`docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md`, Task 8). Adds the typed contract layer the Task 9 probe runner (omnibase_infra) consumes.

- **`ModelRuntimeAlivenessProbeCommand`** (frozen, `extra="forbid"`): required `correlation_id`, `target_command_topic`, `target_handler_id`, `expected_terminal_topic`, `projection_key_template`; default `timeout_seconds=30`; `failure_states: tuple[FailureState, ...]` with `FailureState = Literal["timeout","terminal_failure_emitted","projection_write_failed","lag_above_threshold"]`. `from_env()` classmethod resolves the timeout from `RUNTIME_ALIVENESS_TIMEOUT_SECONDS` (invalid / non-positive values fall back to the 30s default — env is operational tuning, not a hard contract).
- **`ModelRuntimeAlivenessProbeReceipt`** (frozen, `extra="forbid"`, separate file to satisfy the single-class-per-file rule): `correlation_id`, `status: Literal["PASS","FAIL"]`, `failure_states` (model_validator: must be empty on PASS, non-empty on FAIL), `terminal_event_observed` / `projection_row_observed` booleans, `lag_at_sample: int | None` (None when sampling was skipped per the post-projection sampling order in the plan), echoed `timeout_seconds`, and `started_at` / `completed_at` timestamps.

**Lifecycle level:** L1 (pure model + classmethod). No runtime wiring lands in this PR; the probe runner ships in Task 9 (`omnibase_infra/.../runtime/aliveness/probe_runner.py`).

## Tests (TDD)

7 cases, all PASS:

- `test_probe_command_required_fields`
- `test_probe_command_rejects_unknown_failure_state`
- `test_timeout_default_is_30s_and_configurable_via_env`
- `test_timeout_env_invalid_value_falls_back_to_default`
- `test_receipt_pass_requires_empty_failure_states`
- `test_receipt_fail_requires_at_least_one_failure_state`
- `test_receipt_pass_round_trip_serializes`

## Local pre-flight

- `uv run pytest tests/unit/models/runtime/ -v` -> **198 passed**
- `uv run mypy --strict` on both new modules -> **0 errors**
- `uv run ruff format` + `ruff check` -> clean
- `pre-commit run --files <staged>` -> all hooks green (SPDX, single-class-per-file, no-Kafka-in-core, no-hardcoded-topics, etc.)
- Full repo suite locally OOM'd with `-n 4` on this M-series box; CI runs the full matrix.

## DoD evidence

- **`code_change`** — Created `src/omnibase_core/models/runtime/model_runtime_aliveness_probe.py` and `model_runtime_aliveness_probe_receipt.py`; updated package `__init__.py`; created `tests/unit/models/runtime/test_model_runtime_aliveness_probe.py` with 7 validation tests.
- **`test_pass`** — 7 tests pass covering required-field enforcement, unknown-literal rejection, env-var override + invalid fallback, PASS/FAIL receipt invariants, JSON round-trip.
- **`acceptance_criteria`** — All five required command fields enforced; `timeout_seconds` env-configurable with 30s default; `failure_states` literal-typed; receipt PASS/FAIL invariants enforced; both models frozen with `extra="forbid"`.

## Linear

- **Ticket:** OMN-9887
- **Parent epic:** OMN-9878 ([Readiness Track 2] Dispatch and Lifecycle Truth)
- **Plan source:** `docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md` (Task 8)

## Out of scope

- The Task 9 probe **runner** (in `omnibase_infra/.../runtime/aliveness/probe_runner.py`) — separate ticket.
- Runtime wiring of `ModelDispatchLifecycleEvent` (Task 11) — separate ticket; OMN-9885 is the model-only ticket.

## Test plan

- [x] 7 new unit tests pass via `uv run pytest`
- [x] mypy --strict on both new modules
- [x] pre-commit clean on all touched files
- [ ] CI green