### PR TITLE
feat(OMN-9885): ModelDispatchLifecycleEvent state machine + transition validators

### DIFF
--- a/src/omnibase_core/enums/enum_dispatch_lifecycle_emitter.py
+++ b/src/omnibase_core/enums/enum_dispatch_lifecycle_emitter.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dispatch Lifecycle Emitter enum for ModelDispatchLifecycleEvent (OMN-9885)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumDispatchLifecycleEmitter(StrValueHelper, str, Enum):
+    """Identifies which actor emitted a lifecycle event.
+
+    Per the Task 10 emitter responsibility table:
+    - DISPATCHER: emits ACCEPTED only
+    - CONSUMER: emits STARTED, HEARTBEAT, TERMINAL_SUCCESS, TERMINAL_FAILURE
+    - ORCHESTRATOR: emits TIMEOUT, CANCELLED
+    - DLQ_WRITER: emits DLQ
+    """
+
+    DISPATCHER = "dispatcher"
+    CONSUMER = "consumer"
+    ORCHESTRATOR = "orchestrator"
+    DLQ_WRITER = "dlq_writer"
+
+
+__all__ = ["EnumDispatchLifecycleEmitter"]

--- a/src/omnibase_core/enums/enum_dispatch_lifecycle_state.py
+++ b/src/omnibase_core/enums/enum_dispatch_lifecycle_state.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dispatch Lifecycle State enum for ModelDispatchLifecycleEvent (OMN-9885)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumDispatchLifecycleState(StrValueHelper, str, Enum):
+    """Canonical lifecycle states for a dispatched command.
+
+    Eliminates self-attested dispatch success: every dispatch must reach
+    one of TERMINAL_SUCCESS, TERMINAL_FAILURE, TIMEOUT, CANCELLED, or DLQ
+    via the documented emitter responsibility table.
+    """
+
+    ACCEPTED = "accepted"
+    STARTED = "started"
+    HEARTBEAT = "heartbeat"
+    TERMINAL_SUCCESS = "terminal_success"
+    TERMINAL_FAILURE = "terminal_failure"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    DLQ = "dlq"
+
+    def is_terminal(self) -> bool:
+        """True if no further transitions are valid from this state."""
+        return self in {
+            EnumDispatchLifecycleState.TERMINAL_SUCCESS,
+            EnumDispatchLifecycleState.TIMEOUT,
+            EnumDispatchLifecycleState.CANCELLED,
+            EnumDispatchLifecycleState.DLQ,
+        }
+
+
+__all__ = ["EnumDispatchLifecycleState"]

--- a/src/omnibase_core/errors/error_lifecycle_emitter.py
+++ b/src/omnibase_core/errors/error_lifecycle_emitter.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""LifecycleEmitterError — raised when a state is emitted by the wrong actor
+(OMN-9885)."""
+
+
+class LifecycleEmitterError(ValueError):
+    """Raised when a lifecycle state is emitted by an actor that is not its owner."""
+
+
+__all__ = ["LifecycleEmitterError"]

--- a/src/omnibase_core/errors/error_lifecycle_transition.py
+++ b/src/omnibase_core/errors/error_lifecycle_transition.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""LifecycleTransitionError — raised when a chain transition violates FSM rules
+(OMN-9885)."""
+
+
+class LifecycleTransitionError(ValueError):
+    """Raised when a chain transition violates the dispatch lifecycle FSM rules."""
+
+
+__all__ = ["LifecycleTransitionError"]

--- a/src/omnibase_core/models/dispatch/__init__.py
+++ b/src/omnibase_core/models/dispatch/__init__.py
@@ -113,7 +113,7 @@ from omnibase_core.models.dispatch.model_handler_registration import (
 from omnibase_core.models.dispatch.model_lifecycle_chain import (
     DEFAULT_HEARTBEAT_REQUIRED_SECONDS,
     HEARTBEAT_REQUIRED_ENV_VAR,
-    LifecycleChain,
+    ModelLifecycleChain,
 )
 from omnibase_core.models.dispatch.model_topic_parser import (
     EnumTopicStandard,
@@ -134,7 +134,7 @@ __all__ = [
     "LifecycleEmitterError",
     "LifecycleTransitionError",
     # Models
-    "LifecycleChain",
+    "ModelLifecycleChain",
     "ModelDispatchClaim",
     "ModelDispatchLifecycleEvent",
     "ModelDispatchResult",

--- a/src/omnibase_core/models/dispatch/__init__.py
+++ b/src/omnibase_core/models/dispatch/__init__.py
@@ -86,16 +86,34 @@ See Also:
     omnibase_core.models.events.ModelEventEnvelope: Event wrapper with routing info
 """
 
+from omnibase_core.enums.enum_dispatch_lifecycle_emitter import (
+    EnumDispatchLifecycleEmitter,
+)
+from omnibase_core.enums.enum_dispatch_lifecycle_state import (
+    EnumDispatchLifecycleState,
+)
 from omnibase_core.enums.enum_dispatch_status import EnumDispatchStatus
+from omnibase_core.errors.error_lifecycle_emitter import LifecycleEmitterError
+from omnibase_core.errors.error_lifecycle_transition import (
+    LifecycleTransitionError,
+)
 from omnibase_core.models.dispatch.model_dispatch_claim import (
     ModelDispatchClaim,
     compute_blocker_id,
+)
+from omnibase_core.models.dispatch.model_dispatch_lifecycle_event import (
+    ModelDispatchLifecycleEvent,
 )
 from omnibase_core.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_core.models.dispatch.model_dispatch_route import ModelDispatchRoute
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from omnibase_core.models.dispatch.model_handler_registration import (
     ModelHandlerRegistration,
+)
+from omnibase_core.models.dispatch.model_lifecycle_chain import (
+    DEFAULT_HEARTBEAT_REQUIRED_SECONDS,
+    HEARTBEAT_REQUIRED_ENV_VAR,
+    LifecycleChain,
 )
 from omnibase_core.models.dispatch.model_topic_parser import (
     EnumTopicStandard,
@@ -104,11 +122,21 @@ from omnibase_core.models.dispatch.model_topic_parser import (
 )
 
 __all__ = [
+    # Constants
+    "DEFAULT_HEARTBEAT_REQUIRED_SECONDS",
+    "HEARTBEAT_REQUIRED_ENV_VAR",
     # Enums
+    "EnumDispatchLifecycleEmitter",
+    "EnumDispatchLifecycleState",
     "EnumDispatchStatus",
     "EnumTopicStandard",
+    # Errors
+    "LifecycleEmitterError",
+    "LifecycleTransitionError",
     # Models
+    "LifecycleChain",
     "ModelDispatchClaim",
+    "ModelDispatchLifecycleEvent",
     "ModelDispatchResult",
     "ModelDispatchRoute",
     "ModelHandlerOutput",

--- a/src/omnibase_core/models/dispatch/model_dispatch_lifecycle_event.py
+++ b/src/omnibase_core/models/dispatch/model_dispatch_lifecycle_event.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDispatchLifecycleEvent + per-state required-fields validators (OMN-9885 /
+Wave 4 of runtime-lifecycle-hardening plan).
+
+Eliminates self-attested dispatch success: dispatchers cannot mark a run as
+SUCCESS; only the consumer that actually emitted the terminal event can. The
+orchestrator owns TIMEOUT and CANCELLED; a separate DLQ writer owns DLQ — and
+DLQ is reachable only after a TERMINAL_FAILURE with the retry budget exhausted.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from omnibase_core.enums.enum_dispatch_lifecycle_emitter import (
+    EnumDispatchLifecycleEmitter,
+)
+from omnibase_core.enums.enum_dispatch_lifecycle_state import (
+    EnumDispatchLifecycleState,
+)
+from omnibase_core.errors.error_lifecycle_emitter import LifecycleEmitterError
+
+_EMITTER_BY_STATE: dict[EnumDispatchLifecycleState, EnumDispatchLifecycleEmitter] = {
+    EnumDispatchLifecycleState.ACCEPTED: EnumDispatchLifecycleEmitter.DISPATCHER,
+    EnumDispatchLifecycleState.STARTED: EnumDispatchLifecycleEmitter.CONSUMER,
+    EnumDispatchLifecycleState.HEARTBEAT: EnumDispatchLifecycleEmitter.CONSUMER,
+    EnumDispatchLifecycleState.TERMINAL_SUCCESS: EnumDispatchLifecycleEmitter.CONSUMER,
+    EnumDispatchLifecycleState.TERMINAL_FAILURE: EnumDispatchLifecycleEmitter.CONSUMER,
+    EnumDispatchLifecycleState.TIMEOUT: EnumDispatchLifecycleEmitter.ORCHESTRATOR,
+    EnumDispatchLifecycleState.CANCELLED: EnumDispatchLifecycleEmitter.ORCHESTRATOR,
+    EnumDispatchLifecycleState.DLQ: EnumDispatchLifecycleEmitter.DLQ_WRITER,
+}
+
+_REQUIRED_FIELDS_BY_STATE: dict[EnumDispatchLifecycleState, tuple[str, ...]] = {
+    EnumDispatchLifecycleState.ACCEPTED: (
+        "dispatched_at",
+        "command_topic",
+        "target_node_id",
+    ),
+    EnumDispatchLifecycleState.STARTED: (
+        "started_at",
+        "consumer_group",
+        "consumer_host",
+    ),
+    EnumDispatchLifecycleState.HEARTBEAT: ("heartbeat_at", "consumer_host"),
+    EnumDispatchLifecycleState.TERMINAL_SUCCESS: (
+        "terminated_at",
+        "terminal_event_topic",
+        "result_payload_hash",
+    ),
+    EnumDispatchLifecycleState.TERMINAL_FAILURE: (
+        "terminated_at",
+        "terminal_event_topic",
+        "failure_reason",
+    ),
+    EnumDispatchLifecycleState.TIMEOUT: (
+        "timed_out_at",
+        "budget_seconds",
+        "last_observed_state",
+    ),
+    EnumDispatchLifecycleState.CANCELLED: (
+        "cancelled_at",
+        "cancel_reason",
+        "cancelled_by",
+    ),
+    EnumDispatchLifecycleState.DLQ: (
+        "dlq_at",
+        "dlq_topic",
+        "retry_attempts_used",
+        "final_failure_reason",
+    ),
+}
+
+
+class ModelDispatchLifecycleEvent(BaseModel):
+    """Typed lifecycle event for a single dispatched command.
+
+    Every event carries `correlation_id`, `state`, `emitter`, `emitted_at`
+    plus the per-state required fields documented in the Task 10 emitter
+    responsibility table.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str = Field(
+        min_length=1, description="Identifier shared across every event in a chain."
+    )
+    state: EnumDispatchLifecycleState = Field(
+        description="Lifecycle state this event represents."
+    )
+    emitter: EnumDispatchLifecycleEmitter = Field(
+        description="Actor that emitted this event."
+    )
+    emitted_at: datetime = Field(description="UTC timestamp the event was emitted.")
+
+    # ACCEPTED-state fields
+    dispatched_at: datetime | None = None
+    command_topic: str | None = None
+    target_node_id: str | None = None
+
+    # STARTED-state fields
+    started_at: datetime | None = None
+    consumer_group: str | None = None
+    consumer_host: str | None = None
+
+    # HEARTBEAT-state fields
+    heartbeat_at: datetime | None = None
+    progress_percent: float | None = Field(default=None, ge=0.0, le=100.0)
+
+    # TERMINAL_SUCCESS / TERMINAL_FAILURE shared fields
+    terminated_at: datetime | None = None
+    terminal_event_topic: str | None = None
+    result_payload_hash: str | None = None
+    failure_reason: str | None = None
+
+    # TIMEOUT-state fields
+    timed_out_at: datetime | None = None
+    budget_seconds: int | None = Field(default=None, ge=1)
+    last_observed_state: EnumDispatchLifecycleState | None = None
+
+    # CANCELLED-state fields
+    cancelled_at: datetime | None = None
+    cancel_reason: str | None = None
+    cancelled_by: str | None = None
+
+    # DLQ-state fields
+    dlq_at: datetime | None = None
+    dlq_topic: str | None = None
+    retry_attempts_used: int | None = Field(default=None, ge=0)
+    final_failure_reason: str | None = None
+
+    def __init__(self, **data: Any) -> None:
+        try:
+            super().__init__(**data)
+        except ValidationError as exc:
+            for err in exc.errors():
+                ctx = err.get("ctx") or {}
+                inner = ctx.get("error")
+                if isinstance(inner, LifecycleEmitterError):
+                    raise inner
+            raise
+
+    @model_validator(mode="after")
+    def _validate_emitter_owns_state(self) -> "ModelDispatchLifecycleEvent":
+        expected = _EMITTER_BY_STATE[self.state]
+        if self.emitter is not expected:
+            raise LifecycleEmitterError(
+                f"state {self.state.value!r} must be emitted by {expected.value!r}, "
+                f"got {self.emitter.value!r}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_required_fields_for_state(self) -> "ModelDispatchLifecycleEvent":
+        missing = [
+            field
+            for field in _REQUIRED_FIELDS_BY_STATE[self.state]
+            if getattr(self, field) in (None, "")
+        ]
+        if missing:
+            # error-ok: pydantic model_validator contract requires ValueError.
+            raise ValueError(
+                f"state {self.state.value!r} missing required fields: {missing}"
+            )
+        return self
+
+
+__all__ = ["ModelDispatchLifecycleEvent"]

--- a/src/omnibase_core/models/dispatch/model_lifecycle_chain.py
+++ b/src/omnibase_core/models/dispatch/model_lifecycle_chain.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""LifecycleChain — ordered sequence of dispatch lifecycle events for a single
+correlation_id, with FSM transition rules (OMN-9885 / Wave 4 of
+runtime-lifecycle-hardening plan)."""
+
+import os
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from omnibase_core.enums.enum_dispatch_lifecycle_state import (
+    EnumDispatchLifecycleState,
+)
+from omnibase_core.errors.error_lifecycle_transition import (
+    LifecycleTransitionError,
+)
+from omnibase_core.models.dispatch.model_dispatch_lifecycle_event import (
+    ModelDispatchLifecycleEvent,
+)
+
+HEARTBEAT_REQUIRED_ENV_VAR = "LIFECYCLE_HEARTBEAT_REQUIRED_SECONDS"
+DEFAULT_HEARTBEAT_REQUIRED_SECONDS = 60
+
+
+def _heartbeat_required_seconds() -> int:
+    raw = os.environ.get(HEARTBEAT_REQUIRED_ENV_VAR)
+    if raw is None:
+        return DEFAULT_HEARTBEAT_REQUIRED_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        # error-ok: env-var parse boundary; ValueError is the contract for callers.
+        raise ValueError(
+            f"{HEARTBEAT_REQUIRED_ENV_VAR}={raw!r} is not an integer"
+        ) from exc
+    if value < 1:
+        # error-ok: env-var validation boundary.
+        raise ValueError(f"{HEARTBEAT_REQUIRED_ENV_VAR} must be >= 1, got {value}")
+    return value
+
+
+class LifecycleChain(BaseModel):
+    """Ordered sequence of lifecycle events for a single correlation_id.
+
+    Mutable on purpose: callers append events via `transition_to` so the FSM
+    rules (terminal_failure-before-dlq, retry budget gate, terminal-state
+    closure) can be enforced as the chain grows.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    events: list[ModelDispatchLifecycleEvent] = Field(default_factory=list)
+    duration_seconds_override: int | None = Field(
+        default=None,
+        description="Test/inspection hook: when set, overrides the wall-clock "
+        "duration computed from emitted_at deltas.",
+    )
+
+    def __init__(self, **data: Any) -> None:
+        try:
+            super().__init__(**data)
+        except ValidationError as exc:
+            for err in exc.errors():
+                ctx = err.get("ctx") or {}
+                inner = ctx.get("error")
+                if isinstance(inner, LifecycleTransitionError):
+                    raise inner
+            raise
+
+    @model_validator(mode="after")
+    def _validate_initial_chain(self) -> "LifecycleChain":
+        if not self.events:
+            return self
+        if self.events[0].state is not EnumDispatchLifecycleState.ACCEPTED:
+            raise LifecycleTransitionError(
+                "lifecycle chain must start with state 'accepted', "
+                f"got {self.events[0].state.value!r}"
+            )
+        first_corr = self.events[0].correlation_id
+        for event in self.events[1:]:
+            if event.correlation_id != first_corr:
+                raise LifecycleTransitionError(
+                    f"correlation_id mismatch in chain: expected {first_corr!r}, "
+                    f"got {event.correlation_id!r}"
+                )
+        return self
+
+    @property
+    def terminal(self) -> EnumDispatchLifecycleState | None:
+        if not self.events:
+            return None
+        last = self.events[-1].state
+        return last if last.is_terminal() else None
+
+    @property
+    def observed_duration_seconds(self) -> float:
+        if self.duration_seconds_override is not None:
+            return float(self.duration_seconds_override)
+        if len(self.events) < 2:
+            return 0.0
+        delta = self.events[-1].emitted_at - self.events[0].emitted_at
+        return delta.total_seconds()
+
+    @property
+    def heartbeat_required(self) -> bool:
+        return self.observed_duration_seconds > _heartbeat_required_seconds()
+
+    def transition_to(
+        self,
+        event: ModelDispatchLifecycleEvent,
+        retry_budget_remaining: int,
+    ) -> None:
+        if self.terminal is not None:
+            raise LifecycleTransitionError(
+                f"chain already terminal in state {self.terminal.value!r}; "
+                "no further transitions allowed"
+            )
+        if self.events and event.correlation_id != self.events[0].correlation_id:
+            raise LifecycleTransitionError(
+                f"correlation_id mismatch: chain={self.events[0].correlation_id!r}, "
+                f"event={event.correlation_id!r}"
+            )
+        if event.state is EnumDispatchLifecycleState.DLQ:
+            prior_states = [e.state for e in self.events]
+            if EnumDispatchLifecycleState.TERMINAL_FAILURE not in prior_states:
+                raise LifecycleTransitionError(
+                    "dlq requires a prior terminal_failure event"
+                )
+            if retry_budget_remaining > 0:
+                raise LifecycleTransitionError(
+                    f"dlq requires exhausted retry budget; "
+                    f"remaining={retry_budget_remaining}"
+                )
+        self.events.append(event)
+
+
+__all__ = [
+    "DEFAULT_HEARTBEAT_REQUIRED_SECONDS",
+    "HEARTBEAT_REQUIRED_ENV_VAR",
+    "LifecycleChain",
+]

--- a/src/omnibase_core/models/dispatch/model_lifecycle_chain.py
+++ b/src/omnibase_core/models/dispatch/model_lifecycle_chain.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""LifecycleChain — ordered sequence of dispatch lifecycle events for a single
+"""ModelLifecycleChain — ordered sequence of dispatch lifecycle events for a single
 correlation_id, with FSM transition rules (OMN-9885 / Wave 4 of
 runtime-lifecycle-hardening plan)."""
 
@@ -41,7 +41,7 @@ def _heartbeat_required_seconds() -> int:
     return value
 
 
-class LifecycleChain(BaseModel):
+class ModelLifecycleChain(BaseModel):
     """Ordered sequence of lifecycle events for a single correlation_id.
 
     Mutable on purpose: callers append events via `transition_to` so the FSM
@@ -70,7 +70,7 @@ class LifecycleChain(BaseModel):
             raise
 
     @model_validator(mode="after")
-    def _validate_initial_chain(self) -> "LifecycleChain":
+    def _validate_initial_chain(self) -> "ModelLifecycleChain":
         if not self.events:
             return self
         if self.events[0].state is not EnumDispatchLifecycleState.ACCEPTED:
@@ -139,5 +139,5 @@ class LifecycleChain(BaseModel):
 __all__ = [
     "DEFAULT_HEARTBEAT_REQUIRED_SECONDS",
     "HEARTBEAT_REQUIRED_ENV_VAR",
-    "LifecycleChain",
+    "ModelLifecycleChain",
 ]

--- a/tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py
+++ b/tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py
@@ -24,7 +24,7 @@ from omnibase_core.models.dispatch.model_dispatch_lifecycle_event import (
 from omnibase_core.models.dispatch.model_lifecycle_chain import (
     DEFAULT_HEARTBEAT_REQUIRED_SECONDS,
     HEARTBEAT_REQUIRED_ENV_VAR,
-    LifecycleChain,
+    ModelLifecycleChain,
 )
 
 
@@ -104,7 +104,7 @@ def test_lifecycle_event_state_enum_exact() -> None:
 @pytest.mark.unit
 def test_dlq_only_after_terminal_failure_and_budget_exhausted() -> None:
     """Plan acceptance: dlq requires terminal_failure first AND retry budget == 0."""
-    chain = LifecycleChain(events=[_accepted(), _started(), _terminal_failure()])
+    chain = ModelLifecycleChain(events=[_accepted(), _started(), _terminal_failure()])
 
     with pytest.raises(LifecycleTransitionError, match="retry budget"):
         chain.transition_to(_dlq(), retry_budget_remaining=2)
@@ -115,7 +115,7 @@ def test_dlq_only_after_terminal_failure_and_budget_exhausted() -> None:
 
 @pytest.mark.unit
 def test_dlq_without_prior_terminal_failure_rejected() -> None:
-    chain = LifecycleChain(events=[_accepted(), _started()])
+    chain = ModelLifecycleChain(events=[_accepted(), _started()])
     with pytest.raises(LifecycleTransitionError, match="terminal_failure"):
         chain.transition_to(_dlq(), retry_budget_remaining=0)
 
@@ -125,7 +125,7 @@ def test_heartbeat_required_only_above_60s(monkeypatch: pytest.MonkeyPatch) -> N
     """Plan acceptance: heartbeat required iff wall-clock duration > 60s (default)."""
     monkeypatch.delenv(HEARTBEAT_REQUIRED_ENV_VAR, raising=False)
 
-    long_chain = LifecycleChain(
+    long_chain = ModelLifecycleChain(
         events=[
             _accepted(),
             _started(),
@@ -134,7 +134,7 @@ def test_heartbeat_required_only_above_60s(monkeypatch: pytest.MonkeyPatch) -> N
     long_chain.duration_seconds_override = 90
     assert long_chain.heartbeat_required is True
 
-    short_chain = LifecycleChain(events=[_accepted(), _started()])
+    short_chain = ModelLifecycleChain(events=[_accepted(), _started()])
     short_chain.duration_seconds_override = 10
     assert short_chain.heartbeat_required is False
 
@@ -146,7 +146,7 @@ def test_heartbeat_threshold_configurable_via_env(
     """Default threshold of 60s can be overridden by env var."""
     monkeypatch.setenv(HEARTBEAT_REQUIRED_ENV_VAR, "5")
 
-    chain = LifecycleChain(events=[_accepted(), _started()])
+    chain = ModelLifecycleChain(events=[_accepted(), _started()])
     chain.duration_seconds_override = 10
     assert chain.heartbeat_required is True
 
@@ -275,18 +275,18 @@ def test_emitter_consumer_for_started_passes() -> None:
 @pytest.mark.unit
 def test_chain_must_start_with_accepted() -> None:
     with pytest.raises(LifecycleTransitionError, match="must start with"):
-        LifecycleChain(events=[_started()])
+        ModelLifecycleChain(events=[_started()])
 
 
 @pytest.mark.unit
 def test_chain_correlation_id_mismatch_rejected() -> None:
     with pytest.raises(LifecycleTransitionError, match="correlation_id"):
-        LifecycleChain(events=[_accepted("a"), _started("b")])
+        ModelLifecycleChain(events=[_accepted("a"), _started("b")])
 
 
 @pytest.mark.unit
 def test_chain_terminal_state_blocks_further_transitions() -> None:
-    chain = LifecycleChain(
+    chain = ModelLifecycleChain(
         events=[
             _accepted(),
             _started(),
@@ -336,5 +336,5 @@ def test_chain_observed_duration_uses_emitted_at_when_no_override() -> None:
         consumer_group="g",
         consumer_host="h",
     )
-    chain = LifecycleChain(events=[accepted, started])
+    chain = ModelLifecycleChain(events=[accepted, started])
     assert chain.observed_duration_seconds == 120

--- a/tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py
+++ b/tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelDispatchLifecycleEvent state machine (OMN-9885)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_dispatch_lifecycle_emitter import (
+    EnumDispatchLifecycleEmitter,
+)
+from omnibase_core.enums.enum_dispatch_lifecycle_state import (
+    EnumDispatchLifecycleState,
+)
+from omnibase_core.errors.error_lifecycle_emitter import LifecycleEmitterError
+from omnibase_core.errors.error_lifecycle_transition import (
+    LifecycleTransitionError,
+)
+from omnibase_core.models.dispatch.model_dispatch_lifecycle_event import (
+    ModelDispatchLifecycleEvent,
+)
+from omnibase_core.models.dispatch.model_lifecycle_chain import (
+    DEFAULT_HEARTBEAT_REQUIRED_SECONDS,
+    HEARTBEAT_REQUIRED_ENV_VAR,
+    LifecycleChain,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _accepted(correlation_id: str = "corr-1") -> ModelDispatchLifecycleEvent:
+    return ModelDispatchLifecycleEvent(
+        correlation_id=correlation_id,
+        state=EnumDispatchLifecycleState.ACCEPTED,
+        emitter=EnumDispatchLifecycleEmitter.DISPATCHER,
+        emitted_at=_now(),
+        dispatched_at=_now(),
+        command_topic="onex.cmd.omnimarket.build-loop-orchestrator-start.v1",
+        target_node_id="node_build_loop_orchestrator",
+    )
+
+
+def _started(correlation_id: str = "corr-1") -> ModelDispatchLifecycleEvent:
+    return ModelDispatchLifecycleEvent(
+        correlation_id=correlation_id,
+        state=EnumDispatchLifecycleState.STARTED,
+        emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+        emitted_at=_now(),
+        started_at=_now(),
+        consumer_group="onex-build-loop-projection-compute",
+        consumer_host="omninode-runtime-effects-1",
+    )
+
+
+def _terminal_failure(correlation_id: str = "corr-1") -> ModelDispatchLifecycleEvent:
+    return ModelDispatchLifecycleEvent(
+        correlation_id=correlation_id,
+        state=EnumDispatchLifecycleState.TERMINAL_FAILURE,
+        emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+        emitted_at=_now(),
+        terminated_at=_now(),
+        terminal_event_topic="onex.evt.omnimarket.build-loop-orchestrator-completed.v1",
+        failure_reason="handler raised RuntimeError",
+    )
+
+
+def _dlq(correlation_id: str = "corr-1") -> ModelDispatchLifecycleEvent:
+    return ModelDispatchLifecycleEvent(
+        correlation_id=correlation_id,
+        state=EnumDispatchLifecycleState.DLQ,
+        emitter=EnumDispatchLifecycleEmitter.DLQ_WRITER,
+        emitted_at=_now(),
+        dlq_at=_now(),
+        dlq_topic="onex.dlq.omnimarket.build-loop.v1",
+        retry_attempts_used=3,
+        final_failure_reason="exceeded retry budget after handler errors",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan-mandated test cases (Task 10 acceptance contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_lifecycle_event_state_enum_exact() -> None:
+    """Plan acceptance: enum membership must be exactly the eight states."""
+    assert {state.value for state in EnumDispatchLifecycleState} == {
+        "accepted",
+        "started",
+        "heartbeat",
+        "terminal_success",
+        "terminal_failure",
+        "timeout",
+        "cancelled",
+        "dlq",
+    }
+
+
+@pytest.mark.unit
+def test_dlq_only_after_terminal_failure_and_budget_exhausted() -> None:
+    """Plan acceptance: dlq requires terminal_failure first AND retry budget == 0."""
+    chain = LifecycleChain(events=[_accepted(), _started(), _terminal_failure()])
+
+    with pytest.raises(LifecycleTransitionError, match="retry budget"):
+        chain.transition_to(_dlq(), retry_budget_remaining=2)
+
+    chain.transition_to(_dlq(), retry_budget_remaining=0)
+    assert chain.terminal == EnumDispatchLifecycleState.DLQ
+
+
+@pytest.mark.unit
+def test_dlq_without_prior_terminal_failure_rejected() -> None:
+    chain = LifecycleChain(events=[_accepted(), _started()])
+    with pytest.raises(LifecycleTransitionError, match="terminal_failure"):
+        chain.transition_to(_dlq(), retry_budget_remaining=0)
+
+
+@pytest.mark.unit
+def test_heartbeat_required_only_above_60s(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plan acceptance: heartbeat required iff wall-clock duration > 60s (default)."""
+    monkeypatch.delenv(HEARTBEAT_REQUIRED_ENV_VAR, raising=False)
+
+    long_chain = LifecycleChain(
+        events=[
+            _accepted(),
+            _started(),
+        ]
+    )
+    long_chain.duration_seconds_override = 90
+    assert long_chain.heartbeat_required is True
+
+    short_chain = LifecycleChain(events=[_accepted(), _started()])
+    short_chain.duration_seconds_override = 10
+    assert short_chain.heartbeat_required is False
+
+
+@pytest.mark.unit
+def test_heartbeat_threshold_configurable_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default threshold of 60s can be overridden by env var."""
+    monkeypatch.setenv(HEARTBEAT_REQUIRED_ENV_VAR, "5")
+
+    chain = LifecycleChain(events=[_accepted(), _started()])
+    chain.duration_seconds_override = 10
+    assert chain.heartbeat_required is True
+
+
+@pytest.mark.unit
+def test_emitter_responsibility_enforced() -> None:
+    """Plan acceptance: terminal_success emitted by dispatcher must raise."""
+    with pytest.raises(LifecycleEmitterError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.TERMINAL_SUCCESS,
+            emitter=EnumDispatchLifecycleEmitter.DISPATCHER,
+            emitted_at=_now(),
+            terminated_at=_now(),
+            terminal_event_topic="onex.evt.foo.v1",
+            result_payload_hash="abc123",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-state required-fields validation (responsibility table from Task 10)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_accepted_requires_dispatched_at_and_command_topic() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.ACCEPTED,
+            emitter=EnumDispatchLifecycleEmitter.DISPATCHER,
+            emitted_at=_now(),
+            command_topic="onex.cmd.foo.v1",
+            target_node_id="node_foo",
+        )
+
+
+@pytest.mark.unit
+def test_started_requires_consumer_group_and_host() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.STARTED,
+            emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+            emitted_at=_now(),
+            started_at=_now(),
+        )
+
+
+@pytest.mark.unit
+def test_terminal_success_requires_result_payload_hash() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.TERMINAL_SUCCESS,
+            emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+            emitted_at=_now(),
+            terminated_at=_now(),
+            terminal_event_topic="onex.evt.foo.v1",
+        )
+
+
+@pytest.mark.unit
+def test_terminal_failure_requires_failure_reason() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.TERMINAL_FAILURE,
+            emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+            emitted_at=_now(),
+            terminated_at=_now(),
+            terminal_event_topic="onex.evt.foo.v1",
+        )
+
+
+@pytest.mark.unit
+def test_timeout_requires_budget_and_last_state() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.TIMEOUT,
+            emitter=EnumDispatchLifecycleEmitter.ORCHESTRATOR,
+            emitted_at=_now(),
+            timed_out_at=_now(),
+        )
+
+
+@pytest.mark.unit
+def test_cancelled_requires_reason_and_actor() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.CANCELLED,
+            emitter=EnumDispatchLifecycleEmitter.ORCHESTRATOR,
+            emitted_at=_now(),
+            cancelled_at=_now(),
+        )
+
+
+@pytest.mark.unit
+def test_dlq_requires_retry_attempts_and_topic() -> None:
+    with pytest.raises(ValidationError):
+        ModelDispatchLifecycleEvent(
+            correlation_id="corr-1",
+            state=EnumDispatchLifecycleState.DLQ,
+            emitter=EnumDispatchLifecycleEmitter.DLQ_WRITER,
+            emitted_at=_now(),
+            dlq_at=_now(),
+            dlq_topic="onex.dlq.foo.v1",
+            final_failure_reason="x",
+        )
+
+
+@pytest.mark.unit
+def test_emitter_consumer_for_started_passes() -> None:
+    event = _started()
+    assert event.state is EnumDispatchLifecycleState.STARTED
+    assert event.emitter is EnumDispatchLifecycleEmitter.CONSUMER
+
+
+# ---------------------------------------------------------------------------
+# Chain transition rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_chain_must_start_with_accepted() -> None:
+    with pytest.raises(LifecycleTransitionError, match="must start with"):
+        LifecycleChain(events=[_started()])
+
+
+@pytest.mark.unit
+def test_chain_correlation_id_mismatch_rejected() -> None:
+    with pytest.raises(LifecycleTransitionError, match="correlation_id"):
+        LifecycleChain(events=[_accepted("a"), _started("b")])
+
+
+@pytest.mark.unit
+def test_chain_terminal_state_blocks_further_transitions() -> None:
+    chain = LifecycleChain(
+        events=[
+            _accepted(),
+            _started(),
+            ModelDispatchLifecycleEvent(
+                correlation_id="corr-1",
+                state=EnumDispatchLifecycleState.TERMINAL_SUCCESS,
+                emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+                emitted_at=_now(),
+                terminated_at=_now(),
+                terminal_event_topic="onex.evt.foo.v1",
+                result_payload_hash="hash",
+            ),
+        ]
+    )
+    assert chain.terminal == EnumDispatchLifecycleState.TERMINAL_SUCCESS
+
+    with pytest.raises(LifecycleTransitionError, match="already terminal"):
+        chain.transition_to(_started(), retry_budget_remaining=0)
+
+
+@pytest.mark.unit
+def test_default_heartbeat_seconds_constant_is_60() -> None:
+    """Plan acceptance: default heartbeat threshold is 60 seconds."""
+    assert DEFAULT_HEARTBEAT_REQUIRED_SECONDS == 60
+
+
+@pytest.mark.unit
+def test_chain_observed_duration_uses_emitted_at_when_no_override() -> None:
+    accepted_at = datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC)
+    started_at = accepted_at + timedelta(seconds=120)
+
+    accepted = ModelDispatchLifecycleEvent(
+        correlation_id="corr-1",
+        state=EnumDispatchLifecycleState.ACCEPTED,
+        emitter=EnumDispatchLifecycleEmitter.DISPATCHER,
+        emitted_at=accepted_at,
+        dispatched_at=accepted_at,
+        command_topic="onex.cmd.foo.v1",
+        target_node_id="node_foo",
+    )
+    started = ModelDispatchLifecycleEvent(
+        correlation_id="corr-1",
+        state=EnumDispatchLifecycleState.STARTED,
+        emitter=EnumDispatchLifecycleEmitter.CONSUMER,
+        emitted_at=started_at,
+        started_at=started_at,
+        consumer_group="g",
+        consumer_host="h",
+    )
+    chain = LifecycleChain(events=[accepted, started])
+    assert chain.observed_duration_seconds == 120


### PR DESCRIPTION
## Summary

Implements **Wave 4 / Task 10** of `docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md`: a typed lifecycle FSM that eliminates self-attested dispatch success.

Resolves [OMN-9885](https://linear.app/omninode/issue/OMN-9885) under parent epic [OMN-9878](https://linear.app/omninode/issue/OMN-9878) (Readiness Track 2: Dispatch and Lifecycle Truth).

## What changed

- `EnumDispatchLifecycleState` — exact 8 states: `accepted`, `started`, `heartbeat`, `terminal_success`, `terminal_failure`, `timeout`, `cancelled`, `dlq`
- `EnumDispatchLifecycleEmitter` — `dispatcher`, `consumer`, `orchestrator`, `dlq_writer`
- `ModelDispatchLifecycleEvent` — typed event with per-state required-fields validation and emitter responsibility enforcement
- `ModelLifecycleChain` — ordered chain with FSM transition rules (terminal-blocks-further, dlq-after-terminal_failure-and-budget-exhausted, heartbeat-required-iff-duration>60s)
- Typed exceptions: `LifecycleEmitterError`, `LifecycleTransitionError` in `errors/`
- `LIFECYCLE_HEARTBEAT_REQUIRED_SECONDS` env var (default 60) controls heartbeat threshold

## Lifecycle level

**L1** — import/entry point. Pure model + transition validators only; no runtime wiring (Task 11 — separate ticket).

## Test plan

- [x] 19 unit tests in `tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py` — all passing
- [x] All 4 plan-mandated tests pass: `test_lifecycle_event_state_enum_exact`, `test_dlq_only_after_terminal_failure_and_budget_exhausted`, `test_heartbeat_required_only_above_60s`, `test_emitter_responsibility_enforced`
- [x] `uv run mypy --strict` — passes
- [x] Full dispatch test suite (204 tests) — passes
- [x] `pre-commit run --all-files` on touched files — passes

## Out of scope (future tickets)

- Wiring emitters into `node_build_loop_orchestrator` (Task 11 of plan)
- Persistence to session ledger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command dispatch lifecycle state tracking with automated validation and state machine enforcement.
  * Implemented heartbeat monitoring with configurable timeout thresholds.
  * Added Dead Letter Queue (DLQ) handling with retry budget validation.

* **Tests**
  * Comprehensive test coverage for dispatch lifecycle validation and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->