### PR TITLE
feat(OMN-9886): runtime_profiles contract validator + allowlist

### DIFF
--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Runtime Profiles — ValidatorRuntimeProfiles gate [OMN-9886]
+#
+# Canonical CI gate for `omnibase_core.validation.validator_runtime_profiles`.
+# Required status check context: "Runtime Profiles / validate".
+#
+# Plan: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4,
+# Wave 1 core enforcement).
+#
+# This workflow runs on omnibase_core itself:
+#   1. unit pytest for the validator (regression guard)
+#   2. self-scan of omnibase_core's own contract.yaml files; must exit 0
+#
+# Consumer repos (omnimarket, omnibase_infra) wire this by adding the
+# validate-runtime-profiles hook entry to their own .pre-commit-config.yaml
+# and mirroring the `validate` job in their own CI.
+
+name: Runtime Profiles
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: runtime-profiles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ValidatorRuntimeProfiles unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validation/test_validator_runtime_profiles.py \
+            -v
+
+      - name: Self-scan omnibase_core contract.yaml files
+        run: uv run python -m omnibase_core.validation.validator_runtime_profiles src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -289,7 +289,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 
@@ -759,6 +759,18 @@ repos:
         name: Enforce validator-requirements.yaml (OMN-9115)
         entry: uv run python -m omnibase_core.validation.validator_requirements_consumer --repo omnibase_core
           --repo-root . --baseline architecture-handshakes/validator-requirements-baseline.yaml
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
+      # OMN-9886: ValidatorRuntimeProfiles — every command-consuming
+      # contract must declare runtime_profiles (top-level or under
+      # descriptor) or be on the explicit allowlist with a reason.
+      # Plan: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4).
+      - id: validate-runtime-profiles
+        name: Validate runtime_profiles on command-consuming contracts (OMN-9886)
+        entry: uv run python -m omnibase_core.validation.validator_runtime_profiles src/
         language: system
         pass_filenames: false
         always_run: true

--- a/src/omnibase_core/nodes/node_compliance_orchestrator/contract.yaml
+++ b/src/omnibase_core/nodes/node_compliance_orchestrator/contract.yaml
@@ -23,6 +23,11 @@ handler_routing:
 descriptor:
   node_archetype: orchestrator
   purity: impure
+  # OMN-9886 / runtime-lifecycle Wave 1: orchestrator with impure handler
+  # belongs to the effects runtime (matches build_loop_orchestrator
+  # precedent in omnimarket).
+  runtime_profiles:
+    - effects
   idempotent: false
   timeout_ms: 30000
 

--- a/src/omnibase_core/validation/contracts/runtime_profiles.validation.yaml
+++ b/src/omnibase_core/validation/contracts/runtime_profiles.validation.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+contract_kind: validation_subcontract
+validation:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  validator_id: runtime_profiles
+  validator_name: Runtime Profiles Validator
+  validator_description: |
+    Enforces that every node contract whose event_bus subscribes to at
+    least one onex.cmd.* topic also declares runtime_profiles (top-level
+    or under descriptor). Allowlist:
+      src/omnibase_core/validation/data/runtime_profiles_allowlist.yaml
+    Plan: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4).
+    Linear: OMN-9886.
+
+  target_patterns:
+    - "**/contract.yaml"
+    - "**/handler_contract.yaml"
+
+  exclude_patterns:
+    - "**/__pycache__/**"
+    - "**/.git/**"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+    - "**/venv/**"
+    - "**/archived/**"
+    - "**/archive/**"
+    - "**/tests/fixtures/**"
+
+  rules:
+    - rule_id: runtime_profiles_missing
+      description: >-
+        Reject command-consuming contracts (any event_bus subscription on onex.cmd.*) that omit runtime_profiles.
+        Declare 'runtime_profiles: [<profile>]' at the top level or under 'descriptor', or add the node
+        id to the allowlist with a reason.
+      severity: error
+      enabled: true
+
+  suppression_comments: []
+
+  fail_on_error: true
+  fail_on_warning: false
+  max_violations: 0
+  severity_default: error
+  parallel_execution: true

--- a/src/omnibase_core/validation/runtime_profiles_allowlist.yaml
+++ b/src/omnibase_core/validation/runtime_profiles_allowlist.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Runtime-profiles validator allowlist (OMN-9886).
+#
+# Each entry exempts a single node id from
+# `ValidatorRuntimeProfiles`. Every entry MUST carry a non-empty `reason`
+# string explaining WHY the node is allowed to subscribe to a `onex.cmd.*`
+# topic without declaring `runtime_profiles`. The loader rejects empty or
+# missing reasons (`ALLOWLIST_REASON_REQUIRED`).
+#
+# Adding a node id here is a deliberate ownership statement: someone has
+# audited the contract and decided that no specific runtime profile owns
+# its command-side handler. Drop-in additions to silence the gate are not
+# allowed and will be flagged in code review.
+#
+# Schema:
+#   allowlist:
+#     - node_id: <name from contract.yaml>
+#       reason: <free-text justification, non-empty>
+
+allowlist: []

--- a/src/omnibase_core/validation/validator_runtime_profiles.py
+++ b/src/omnibase_core/validation/validator_runtime_profiles.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorRuntimeProfiles -- enforce runtime_profiles on command-consuming contracts.
+
+Plan source: ``docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md`` (Task 4,
+Wave 1 core). Linear: OMN-9886.
+
+A node contract is "command-consuming" if its ``event_bus`` block subscribes
+to at least one topic matching ``onex.cmd.*``. The validator fails when such
+a contract has empty/absent ``runtime_profiles`` and the node id is not in
+the explicit allowlist.
+
+Both contract shapes for ``runtime_profiles`` are accepted (mirrors the
+canonical extractor in
+``omnibase_infra.runtime.auto_wiring.discovery._extract_runtime_profiles``):
+
+- top-level ``runtime_profiles: [str, ...]``
+- ``descriptor.runtime_profiles: [str, ...]``
+
+Both subscription shapes are accepted (Task 6 adds a typed parser; this
+validator must not under-detect command consumers in the meantime):
+
+- classic: ``event_bus.subscribe_topics: [str, ...]``
+- nested: ``event_bus.subscribe: [{topic: str, ...}, ...]``
+
+The allowlist is loaded from
+``src/omnibase_core/validation/runtime_profiles_allowlist.yaml``. Every
+entry MUST carry a non-empty ``reason`` string; the loader raises
+``ValueError`` on a blank reason so a "drop in to silence the gate" PR
+cannot land. Per-call overrides via the ``allowlist`` constructor argument
+are intended for tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import ClassVar
+
+import yaml
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.validation.validator_base import ValidatorBase
+from omnibase_core.validation.validator_topic_suffix import TOPIC_PREFIX
+
+RULE_RUNTIME_PROFILES_MISSING = "runtime_profiles_missing"
+ALLOWLIST_REASON_REQUIRED = (
+    "every allowlist entry must declare a non-empty 'reason' explaining why "
+    "the node is exempt from runtime_profiles enforcement"
+)
+
+_DEFAULT_ALLOWLIST_PATH = Path(__file__).parent / "runtime_profiles_allowlist.yaml"
+
+
+def load_default_allowlist(
+    path: Path | None = None,
+) -> dict[str, str]:
+    """Return mapping of allowlisted node id -> reason.
+
+    Raises ``ValueError`` if any entry is missing a non-empty ``reason``.
+    Returns an empty dict if the file does not exist (bootstrap-friendly so
+    new repos can adopt the validator before adding exemptions).
+    """
+    target = path or _DEFAULT_ALLOWLIST_PATH
+    if not target.is_file():
+        return {}
+    raw = yaml.safe_load(target.read_text(encoding="utf-8")) or {}
+    entries = raw.get("allowlist") if isinstance(raw, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    out: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ModelOnexError(
+                message=(
+                    f"runtime_profiles allowlist entries must be mappings; "
+                    f"got {entry!r}"
+                ),
+                error_code=EnumCoreErrorCode.INVALID_CONFIGURATION,
+                context={"allowlist_path": str(target)},
+            )
+        node_id = entry.get("node_id")
+        reason = entry.get("reason")
+        if not isinstance(node_id, str) or not node_id.strip():
+            raise ModelOnexError(
+                message="runtime_profiles allowlist entry missing non-empty 'node_id'",
+                error_code=EnumCoreErrorCode.INVALID_CONFIGURATION,
+                context={"allowlist_path": str(target)},
+            )
+        if not isinstance(reason, str) or not reason.strip():
+            raise ModelOnexError(
+                message=(
+                    f"runtime_profiles allowlist entry {node_id!r}: "
+                    f"{ALLOWLIST_REASON_REQUIRED}"
+                ),
+                error_code=EnumCoreErrorCode.INVALID_CONFIGURATION,
+                context={
+                    "allowlist_path": str(target),
+                    "node_id": node_id,
+                },
+            )
+        out[node_id.strip()] = reason.strip()
+    return out
+
+
+def _extract_runtime_profiles(raw: dict[str, object]) -> tuple[str, ...]:
+    """Return declared runtime_profiles from either supported location."""
+    profiles_raw = raw.get("runtime_profiles")
+    descriptor_raw = raw.get("descriptor")
+    if profiles_raw is None and isinstance(descriptor_raw, dict):
+        profiles_raw = descriptor_raw.get("runtime_profiles")
+    if profiles_raw is None:
+        return ()
+    if isinstance(profiles_raw, str):
+        candidates: tuple[object, ...] = (profiles_raw,)
+    elif isinstance(profiles_raw, (list, tuple)):
+        candidates = tuple(profiles_raw)
+    else:
+        return ()
+    return tuple(
+        str(p).strip().lower() for p in candidates if isinstance(p, str) and p.strip()
+    )
+
+
+def _iter_subscribe_topics(raw: dict[str, object]) -> tuple[str, ...]:
+    """Return all subscribed topics across both supported event_bus shapes."""
+    event_bus = raw.get("event_bus")
+    if not isinstance(event_bus, dict):
+        return ()
+    topics: list[str] = []
+    classic = event_bus.get("subscribe_topics")
+    if isinstance(classic, list):
+        topics.extend(t for t in classic if isinstance(t, str))
+    nested = event_bus.get("subscribe")
+    if isinstance(nested, list):
+        for item in nested:
+            if isinstance(item, dict):
+                topic = item.get("topic")
+                if isinstance(topic, str):
+                    topics.append(topic)
+            elif isinstance(item, str):
+                topics.append(item)
+    return tuple(topics)
+
+
+_COMMAND_TOPIC_PREFIX = f"{TOPIC_PREFIX}.cmd."
+
+
+def _is_command_consuming(raw: dict[str, object]) -> bool:
+    return any(t.startswith(_COMMAND_TOPIC_PREFIX) for t in _iter_subscribe_topics(raw))
+
+
+class ValidatorRuntimeProfiles(ValidatorBase):
+    """Reject command-consuming node contracts that omit runtime_profiles."""
+
+    validator_id: ClassVar[str] = "runtime_profiles"
+
+    def __init__(
+        self,
+        contract: ModelValidatorSubcontract | None = None,
+        allowlist: set[str] | None = None,
+        allowlist_path: Path | None = None,
+    ) -> None:
+        super().__init__(contract=contract)
+        if allowlist is not None:
+            self._allowlist: frozenset[str] = frozenset(allowlist)
+        else:
+            self._allowlist = frozenset(load_default_allowlist(allowlist_path).keys())
+
+    def _validate_file(
+        self,
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        if path.name != "contract.yaml" and path.name != "handler_contract.yaml":
+            return ()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return ()
+        try:
+            raw = yaml.safe_load(text)
+        except yaml.YAMLError:
+            return ()
+        if not isinstance(raw, dict):
+            return ()
+
+        if not _is_command_consuming(raw):
+            return ()
+        if _extract_runtime_profiles(raw):
+            return ()
+
+        node_id = raw.get("name")
+        if isinstance(node_id, str) and node_id in self._allowlist:
+            return ()
+
+        enabled, severity = self._get_rule_config(
+            RULE_RUNTIME_PROFILES_MISSING, contract
+        )
+        if not enabled:
+            return ()
+
+        message = (
+            "runtime_profiles missing on command-consuming contract "
+            f"{node_id!r}: declare 'runtime_profiles: [<profile>]' at the top "
+            "level or under 'descriptor', or add the node id to "
+            "validation/runtime_profiles_allowlist.yaml with a reason."
+        )
+        return (
+            ModelValidationIssue(
+                severity=severity,
+                message=message,
+                code=RULE_RUNTIME_PROFILES_MISSING,
+                file_path=path,
+                line_number=1,
+                rule_name=RULE_RUNTIME_PROFILES_MISSING,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(ValidatorRuntimeProfiles.main())

--- a/tests/unit/validation/test_validator_runtime_profiles.py
+++ b/tests/unit/validation/test_validator_runtime_profiles.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ValidatorRuntimeProfiles (OMN-9886, plan Task 4).
+
+Plan source: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4).
+
+A node contract is "command-consuming" if its event_bus block subscribes to
+at least one topic matching ``onex.cmd.*``. The validator fails when such a
+contract has empty/absent ``runtime_profiles`` and the node id is not in the
+explicit allowlist.
+
+Both contract shapes are accepted for ``runtime_profiles`` (mirrors the
+canonical extractor in
+``omnibase_infra/runtime/auto_wiring/discovery.py::_extract_runtime_profiles``):
+top-level ``runtime_profiles`` and ``descriptor.runtime_profiles``.
+
+Both subscription shapes are accepted (Task 6 hardens the parser, but the
+validator must not under-detect command consumers): classic
+``event_bus.subscribe_topics: [str, ...]`` and nested
+``event_bus.subscribe: [{topic: str, ...}, ...]``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums import EnumSeverity
+from omnibase_core.models.contracts.subcontracts.model_validator_rule import (
+    ModelValidatorRule,
+)
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.validation.validator_runtime_profiles import (
+    ALLOWLIST_REASON_REQUIRED,
+    RULE_RUNTIME_PROFILES_MISSING,
+    ValidatorRuntimeProfiles,
+    load_default_allowlist,
+)
+
+
+def _contract() -> ModelValidatorSubcontract:
+    return ModelValidatorSubcontract(
+        version=ModelSemVer(major=1, minor=0, patch=0),
+        validator_id="runtime_profiles",
+        validator_name="Runtime Profiles",
+        validator_description="Enforce descriptor.runtime_profiles on command-consuming contracts.",
+        target_patterns=["**/contract.yaml"],
+        exclude_patterns=[],
+        suppression_comments=[],
+        fail_on_error=True,
+        fail_on_warning=False,
+        max_violations=0,
+        severity_default=EnumSeverity.ERROR,
+        rules=[
+            ModelValidatorRule(
+                rule_id=RULE_RUNTIME_PROFILES_MISSING,
+                description="Reject command-consuming contracts without runtime_profiles.",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+        ],
+    )
+
+
+def _write(tmp_path: Path, payload: dict[str, object]) -> Path:
+    p = tmp_path / "contract.yaml"
+    p.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return p
+
+
+@pytest.mark.unit
+class TestValidatorRuntimeProfilesViolations:
+    """Command-consuming contracts must declare runtime_profiles."""
+
+    def test_classic_subscribe_topics_command_without_runtime_profiles_fails(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "event_bus": {
+                    "subscribe_topics": [
+                        "onex.cmd.demo.start.v1",
+                    ],
+                },
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+
+        issues = validator._validate_file(path, _contract())
+
+        assert len(issues) == 1
+        issue = issues[0]
+        assert issue.code == RULE_RUNTIME_PROFILES_MISSING
+        assert issue.severity == EnumSeverity.ERROR
+        assert "runtime_profiles missing" in issue.message
+        assert issue.file_path == path
+
+    def test_nested_subscribe_command_without_runtime_profiles_fails(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_consumer",
+                "node_type": "compute",
+                "event_bus": {
+                    "subscribe": [
+                        {"topic": "onex.cmd.demo.do.v1", "consumer_group": "g1"},
+                    ],
+                },
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+
+        issues = validator._validate_file(path, _contract())
+
+        assert len(issues) == 1
+        assert "runtime_profiles missing" in issues[0].message
+
+    def test_descriptor_block_without_runtime_profiles_still_fails(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "descriptor": {
+                    "purity": "effectful",
+                    # runtime_profiles intentionally absent
+                },
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert len(issues) == 1
+        assert "runtime_profiles missing" in issues[0].message
+
+    def test_empty_runtime_profiles_list_treated_as_missing(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "runtime_profiles": [],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert len(issues) == 1
+
+
+@pytest.mark.unit
+class TestValidatorRuntimeProfilesPasses:
+    """Compliant contracts and allowlisted read-only nodes must pass."""
+
+    def test_top_level_runtime_profiles_satisfies_validator(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "runtime_profiles": ["effects"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+    def test_descriptor_runtime_profiles_satisfies_validator(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_build_loop_orchestrator",
+                "node_type": "orchestrator",
+                "descriptor": {
+                    "purity": "effectful",
+                    "runtime_profiles": ["effects"],
+                },
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+    def test_event_only_contract_with_no_command_subscription_passes(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_projection",
+                "node_type": "compute",
+                "event_bus": {
+                    "subscribe_topics": ["onex.evt.demo.completed.v1"],
+                },
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+    def test_no_event_bus_block_passes(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_compute",
+                "node_type": "compute",
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+    def test_allowlisted_read_only_node_passes(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_readonly_demo",
+                "node_type": "compute",
+                "event_bus": {"subscribe_topics": ["onex.cmd.readonly.probe.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(
+            contract=_contract(), allowlist={"node_readonly_demo"}
+        )
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+
+@pytest.mark.unit
+class TestValidatorRuntimeProfilesAllowlistFile:
+    """The default allowlist YAML must require an explicit reason per entry."""
+
+    def test_default_allowlist_loads_with_reason_per_entry(self) -> None:
+        entries = load_default_allowlist()
+        for node_id, reason in entries.items():
+            assert isinstance(node_id, str) and node_id, (
+                "node_id must be non-empty string"
+            )
+            assert isinstance(reason, str) and reason.strip(), (
+                f"allowlist entry {node_id!r} missing a non-empty 'reason' "
+                f"({ALLOWLIST_REASON_REQUIRED})"
+            )


### PR DESCRIPTION
## Summary

Implements **Wave 1 core enforcement** from the runtime-lifecycle hardening plan ([Task 4](../../../omni_home/blob/main/docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md)): every node contract whose `event_bus` subscribes to a `onex.cmd.*` topic must declare `runtime_profiles` (top-level or under `descriptor`), or be listed in the explicit allowlist with a non-empty `reason`.

Linear: [OMN-9886](https://linear.app/omninode/issue/OMN-9886)
Parent epic: [OMN-9877](https://linear.app/omninode/issue/OMN-9877) (Runtime Ownership and Liveness)

**Lifecycle level claim: L1** (validator only — no runtime smoke yet).

## What changed

- `ValidatorRuntimeProfiles` in `src/omnibase_core/validation/`, modeled on the established `ValidatorBase` pattern (validator_id-driven contract loading, `ModelValidationIssue` results, CLI entry point).
- Both contract shapes for `runtime_profiles` are accepted (top-level and `descriptor.runtime_profiles`), mirroring `omnibase_infra.runtime.auto_wiring.discovery._extract_runtime_profiles` so the validator does not over-reject contracts the live runtime already accepts.
- Both `event_bus` subscription shapes are recognized (classic `subscribe_topics` list and nested `subscribe[*].topic`) so the validator does not under-detect command consumers ahead of plan Task 6.
- Allowlist YAML at `src/omnibase_core/validation/runtime_profiles_allowlist.yaml`. Loader raises `ModelOnexError(INVALID_CONFIGURATION)` on any blank `reason` or malformed entry — drop-in additions to silence the gate cannot land.
- Default validator subcontract registers the `runtime_profiles_missing` rule with severity `error` so the CLI runs ungated.
- Pre-commit hook `validate-runtime-profiles` wired in `.pre-commit-config.yaml`.
- CI workflow `validator-runtime-profiles.yml` runs unit tests + repo self-scan as a required status check.
- `node_compliance_orchestrator` (the only command-consuming contract shipping in `omnibase_core` today) declared as `effects`-runtime-owned per the `build_loop_orchestrator` precedent in `omnimarket`. Backfill of remaining repos is plan Task 5; follow-up tickets to be filed for `omnimarket` and `omnibase_infra` wiring.

## Test plan

- [x] 10 unit tests covering classic + nested subscribe shapes for violations, top-level + descriptor `runtime_profiles` for passes, allowlist passthrough, allowlist file reason-required loader contract, and the no-event-bus / event-only fast paths.
- [x] mypy --strict clean on the validator module.
- [x] Full validation unit suite (3667 tests) passes locally.
- [x] `pre-commit run --all-files` passes (no failures across the entire repo).
- [x] CLI self-scan on `src/` exits 0 after the `node_compliance_orchestrator` contract fix.
- [ ] CI green on this PR.

## Follow-ups (filed after merge)

- Wire validator as required-status CI gate in `omnimarket`.
- Wire validator as required-status CI gate in `omnibase_infra`.
- Plan Task 5 backfill: every command-consuming `omnimarket` and `omnibase_infra` contract declares `runtime_profiles`.