### PR TITLE
fix(OMN-9892): unpin orphan SHA in deploy-gate caller — unblock merge queue

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -3,7 +3,8 @@
 #
 # Wave D CI gate: runtime-change PRs must cite a ticket with deploy evidence.
 # Ticket: OMN-8912 | DGM-Phase6 (OMN-9734): thin caller — validator lives in omniclaude.
-# Ref pinned to SHA 16d9355f (omniclaude jonah/omn-9734-dgm-phase6-dedupe); update to @main after omniclaude PR #1418 merges.
+# Ref points at @main; omniclaude PR #1418 merged 2026-04-25 and the prior pinned SHA
+# (16d9355f) is on a deleted branch and unreachable to Actions cross-repo `uses:` (OMN-9892).
 #
 # Required status check: "deploy-gate"
 # Must pass before merging to main on all repos with runtime code.
@@ -21,6 +22,6 @@ concurrency:
 
 jobs:
   deploy-gate:
-    uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@16d9355f0e53592bc3b88893d31fb093d6c2f38f
+    uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@main
     with:
       contracts-dir: contracts


### PR DESCRIPTION
## Summary

Unpin `deploy-gate.yml` from omniclaude SHA `16d9355f` (orphan, deleted-branch) and point at `@main` (the canonical pattern used by `cr-thread-gate-caller.yml`). This unblocks the omnibase_core merge queue, which has been popping every PR at queue position 1 since 2026-04-25 17:12Z.

## Root cause

* `omnibase_core/.github/workflows/deploy-gate.yml` line 24 pinned `OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@16d9355f0e53592bc3b88893d31fb093d6c2f38f`.
* That SHA sits on the deleted branch `jonah/omn-9734-dgm-phase6-dedupe`. PR #1418 in omniclaude squash-merged a different SHA (`501971aa0`) to `main` and the source branch was deleted.
* GitHub Actions enforces ref-reachability for cross-repo `uses:`. Once the branch was deleted, the SHA was no longer reachable from any default-branch tip, so the workflow file is rejected at parse — `referenced_workflows: []`, zero `check_runs`, zero seconds wall-clock.
* The merge queue evaluates the full check suite on each merge_group head, so a missing/failed Deploy Gate run pops every queued PR even though branch protection only requires `CI Summary`.

## Evidence

* All 100 most recent Deploy Gate runs in this repo: failure (both `pull_request` and `merge_group`).
* Last success: `2026-04-25T17:12:30Z`. First failure with the new caller: `2026-04-25T17:12:31Z` — the merge_group run for PR #909 itself, which was the caller-rewrite that introduced the SHA pin.
* `gh api repos/OmniNode-ai/omnibase_core/actions/runs/24987635964 --jq '.referenced_workflows'` → `[]`.
* `gh api repos/OmniNode-ai/omnibase_core/commits/<merge_group_head>/check-runs` → no `deploy-gate` entry.
* omniclaude main HEAD `6dabd364a` contains the equivalent reusable workflow at commit `501971aa0` — it adds an optional `pr-number` input that defaults to `github.event.pull_request.number` when not supplied (this caller doesn't pass one), so behaviour is identical for our use.

## Fix

```diff
-    uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@16d9355f0e53592bc3b88893d31fb093d6c2f38f
+    uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@main
```

`actionlint` clean. Header comment updated to record the rationale.

## Companion

OCC #438 — adds `OMN-9892` ModelTicketContract + receipts.

## DoD Evidence

- `dod-001`: `deploy-gate.yml@24` references `@main`, not the orphan SHA — receipt at `drift/dod_receipts/OMN-9892/dod-001/file_exists.yaml` (PASS).
- `dod-002`: `actionlint` passes on the updated workflow file — receipt at `drift/dod_receipts/OMN-9892/dod-002/file_exists.yaml` (PASS).

## Test plan

- [x] `actionlint` clean
- [x] Pre-commit hooks pass
- [ ] CI green (Deploy Gate must register a `deploy-gate` check-run with non-zero duration this time)
- [ ] After merge: subsequent merge_group Deploy Gate runs pass; PRs in queue actually merge

OMN-9892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to reference the latest branch version instead of a previously pinned version. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->