### PR TITLE
fix(OMN-9855): add nightly full-suite schedule cron to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches: [main]
   merge_group:
   workflow_dispatch:
+  schedule:
+    - cron: "13 7 * * *"   # 07:13 UTC nightly
 
 # Prevent auto-cancellation of running workflows when new commits are pushed
 # This ensures test splits actually run to completion instead of being skipped

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
+import pytest
+
 from scripts.ci.detect_test_paths import resolve_test_paths
+
+pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
@@ -161,5 +165,36 @@ def test_feature_flag_off_returns_full_suite() -> None:
     )
     assert selection.is_full_suite is True
     assert selection.full_suite_reason == EnumFullSuiteReason.FEATURE_FLAG_OFF
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+# ---------------------------------------------------------------------------
+# OMN-9855: schedule + merge_group event escalation
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="schedule",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SCHEDULED
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+def test_merge_group_event_escalates_to_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        event_name="merge_group",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.MERGE_GROUP
     assert selection.split_count == 40
     assert selection.matrix == list(range(1, 41))


### PR DESCRIPTION
## Summary

Adds the missing `on.schedule` cron to `omnibase_core/.github/workflows/ci.yml` so the `event_name == "schedule"` full-suite escalation branch in `scripts/ci/detect_test_paths.py` is actually reachable.

PR #926 (Task 13 / OMN-9855) originally introduced both the schedule cron *and* the escalation handler, but was excluded from the PR #940 Frankenstein squash that landed Task 13's adjacent work on main. Result: the escalation code is on main, the trigger is not — the nightly full-suite gate is dead.

## Changes

- `.github/workflows/ci.yml` — add `schedule: - cron: "13 7 * * *"` (07:13 UTC nightly) to the `on:` block alongside existing `push`/`pull_request`/`merge_group`/`workflow_dispatch` entries.
- `tests/unit/scripts/ci/test_detect_test_paths.py` — add `test_schedule_event_escalates_to_full_suite` plus the parallel `test_merge_group_event_escalates_to_full_suite` which had no coverage either; both assert `is_full_suite=True`, correct `EnumFullSuiteReason`, `split_count=40`, full matrix.

## DoD evidence (OMN-9855)

- [x] `dod_evidence`: workflow YAML diff shows `on.schedule.cron: "13 7 * * *"` present (file: `.github/workflows/ci.yml`).
- [x] `dod_evidence`: `uv run pytest tests/unit/scripts/ci/ -v` → 22 passed, 0 failed (includes new schedule + merge_group escalation tests).
- [x] `dod_evidence`: `actionlint .github/workflows/ci.yml` produces no new findings on the lines added (existing shellcheck info-level warnings on unrelated `run:` blocks pre-date this change and are out of scope).
- [x] `dod_evidence`: `pre-commit run --all-files` → all hooks pass.

## Test plan

- [x] Unit: `test_schedule_event_escalates_to_full_suite` — `event_name="schedule"` returns `EnumFullSuiteReason.SCHEDULED`, `split_count=40`, full 1..40 matrix.
- [x] Unit: `test_merge_group_event_escalates_to_full_suite` — `event_name="merge_group"` returns `EnumFullSuiteReason.MERGE_GROUP`, `split_count=40`, full 1..40 matrix.
- [x] Local: focused suite `tests/unit/scripts/ci/` — 22 passed.
- [ ] CI: `gh pr checks <num> --watch` confirming green before reporting "done".
- [ ] Live: first scheduled run at 07:13 UTC will produce a full-suite run on main (verify via Actions tab the next morning after merge).

Refs OMN-9855. Supersedes the schedule-cron portion of stalled PR #926.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * CI workflow has been enhanced with automatic nightly scheduled execution, running in addition to existing push, pull request, and merge group triggers.
* **Tests**
  * Added comprehensive unit test coverage ensuring full test suite execution when the workflow is triggered by scheduled events or merge groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->