### PR TITLE
feat(OMN-10063): add EnumContractCompleteness enum

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -85,6 +85,9 @@ from .enum_consumer_group_purpose import EnumConsumerGroupPurpose
 
 # Contract bucket enum (corpus classification + normalization layer - OMN-9758)
 from .enum_contract_bucket import EnumContractBucket
+
+# Contract completeness enum (OMN-10063 / OMN-9582 — contract_completeness field)
+from .enum_contract_completeness import EnumContractCompleteness
 from .enum_contract_compliance import EnumContractCompliance
 
 # Contract diff change type enum (semantic contract diffing)
@@ -693,6 +696,8 @@ __all__ = [
     "EnumContractCompliance",
     # Contract bucket domain (corpus classification + normalization - OMN-9758)
     "EnumContractBucket",
+    # Contract completeness domain (OMN-10063 / OMN-9582)
+    "EnumContractCompleteness",
     # Contract diff domain (semantic contract diffing)
     "EnumContractDiffChangeType",
     # State management domain

--- a/src/omnibase_core/enums/enum_contract_completeness.py
+++ b/src/omnibase_core/enums/enum_contract_completeness.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract Completeness Enum.
+
+Defines the completeness level of a ticket contract:
+- STUB: skeleton generated at ticket creation time (minimal fields only)
+- ENRICHED: contract has dod_evidence and evidence_requirements populated
+- FULL: contract is fully specified with all fields, ready for execution
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumContractCompleteness(str, Enum):
+    """Completeness level of a ModelTicketContract.
+
+    Used by the contract_completeness field on ModelTicketContract (OMN-9582).
+    Values are uppercase strings to match YAML serialization convention used
+    across on-disk contracts in onex_change_control.
+    """
+
+    STUB = "STUB"
+    ENRICHED = "ENRICHED"
+    FULL = "FULL"
+
+
+__all__ = [
+    "EnumContractCompleteness",
+]

--- a/src/omnibase_core/enums/enum_contract_completeness.py
+++ b/src/omnibase_core/enums/enum_contract_completeness.py
@@ -18,9 +18,9 @@ from enum import Enum
 class EnumContractCompleteness(str, Enum):
     """Completeness level of a ModelTicketContract.
 
-    Used by the contract_completeness field on ModelTicketContract (OMN-9582).
-    Values are uppercase strings to match YAML serialization convention used
-    across on-disk contracts in onex_change_control.
+    Intended for use as the contract_completeness field on ModelTicketContract
+    (added in OMN-9582 Task 2). Values are uppercase strings to match YAML
+    serialization convention used across on-disk contracts in onex_change_control.
     """
 
     STUB = "STUB"

--- a/tests/unit/enums/test_enum_contract_completeness.py
+++ b/tests/unit/enums/test_enum_contract_completeness.py
@@ -10,6 +10,7 @@ Covers OMN-10063 (Task 1.5 of OMN-9582): Create EnumContractCompleteness in omni
 from enum import Enum
 
 import pytest
+
 from omnibase_core.enums.enum_contract_completeness import EnumContractCompleteness
 
 

--- a/tests/unit/enums/test_enum_contract_completeness.py
+++ b/tests/unit/enums/test_enum_contract_completeness.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for EnumContractCompleteness enum.
+
+Covers OMN-10063 (Task 1.5 of OMN-9582): Create EnumContractCompleteness in omnibase_core.
+"""
+
+from enum import Enum
+
+import pytest
+from omnibase_core.enums.enum_contract_completeness import EnumContractCompleteness
+
+
+@pytest.mark.unit
+class TestEnumContractCompleteness:
+    """Test cases for EnumContractCompleteness enum."""
+
+    def test_all_three_members_exist(self) -> None:
+        """Test that STUB, ENRICHED, and FULL members are present."""
+        assert EnumContractCompleteness.STUB is not None
+        assert EnumContractCompleteness.ENRICHED is not None
+        assert EnumContractCompleteness.FULL is not None
+
+    def test_member_values(self) -> None:
+        """Test that each member has the correct string value."""
+        assert EnumContractCompleteness.STUB.value == "STUB"
+        assert EnumContractCompleteness.ENRICHED.value == "ENRICHED"
+        assert EnumContractCompleteness.FULL.value == "FULL"
+
+    def test_is_str_subclass(self) -> None:
+        """Test that enum is a str subclass (enables YAML serialization round-trip)."""
+        assert issubclass(EnumContractCompleteness, str)
+        assert issubclass(EnumContractCompleteness, Enum)
+
+    def test_members_are_str_instances(self) -> None:
+        """Test that enum members behave as strings."""
+        assert isinstance(EnumContractCompleteness.STUB, str)
+        assert isinstance(EnumContractCompleteness.ENRICHED, str)
+        assert isinstance(EnumContractCompleteness.FULL, str)
+
+    def test_round_trip_from_string(self) -> None:
+        """Test that EnumContractCompleteness('STUB') round-trips without error."""
+        assert EnumContractCompleteness("STUB") == EnumContractCompleteness.STUB
+        assert EnumContractCompleteness("ENRICHED") == EnumContractCompleteness.ENRICHED
+        assert EnumContractCompleteness("FULL") == EnumContractCompleteness.FULL
+
+    def test_invalid_value_raises(self) -> None:
+        """Test that an unknown value raises ValueError."""
+        with pytest.raises(ValueError):
+            EnumContractCompleteness("stub")  # lowercase — invalid
+
+    def test_all_values_set(self) -> None:
+        """Test that exactly three values are defined."""
+        expected = {"STUB", "ENRICHED", "FULL"}
+        actual = {member.value for member in EnumContractCompleteness}
+        assert actual == expected
+
+    def test_exported_from_package_init(self) -> None:
+        """Test that EnumContractCompleteness is importable from omnibase_core.enums."""
+        from omnibase_core.enums import EnumContractCompleteness as ImportedEnum
+
+        assert ImportedEnum is EnumContractCompleteness


### PR DESCRIPTION
## Summary

- Adds `EnumContractCompleteness(str, Enum)` at `omnibase_core/src/omnibase_core/enums/enum_contract_completeness.py` with members `STUB`, `ENRICHED`, `FULL`
- Re-exported from `omnibase_core.enums.__init__` so `from omnibase_core.enums import EnumContractCompleteness` works
- 8 unit tests cover: member existence, string values, str subclass, round-trip construction, invalid-value raises, package-level import

## Ticket

OMN-10063 (Task 1.5 of OMN-9582: Contract Auto-Generation & Schema Reconciliation)

## dod_evidence

```yaml
- id: dod-001
  description: "EnumContractCompleteness enum created with STUB/ENRICHED/FULL members"
  source: "src/omnibase_core/enums/enum_contract_completeness.py"
  status: complete
  evidence_artifact: "8/8 tests pass: uv run pytest tests/unit/enums/test_enum_contract_completeness.py -v"
- id: dod-002
  description: "Exported from package __init__.py"
  source: "src/omnibase_core/enums/__init__.py"
  status: complete
  evidence_artifact: "python -c 'from omnibase_core.enums import EnumContractCompleteness; print(EnumContractCompleteness.STUB)' → EnumContractCompleteness.STUB"
- id: dod-003
  description: "All pre-commit hooks pass"
  source: "git commit output"
  status: complete
  evidence_artifact: "All 55 hooks passed on implementation commit 0656c43e"
- id: dod-004
  description: "mypy --strict passes on new file"
  source: "src/omnibase_core/enums/enum_contract_completeness.py"
  status: complete
  evidence_artifact: "Success: no issues found in 1 source file"
```

## Test plan

- [x] `uv run pytest tests/unit/enums/test_enum_contract_completeness.py -v` — 8/8 pass
- [x] `uv run mypy src/omnibase_core/enums/enum_contract_completeness.py --strict` — clean
- [x] All pre-commit hooks pass (both commits)
- [ ] CI green via `gh pr checks --watch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced EnumContractCompleteness to represent contract completeness with three states: STUB, ENRICHED, and FULL.
  * Enum is string-backed and intended for public use across the package.

* **Tests**
  * Added unit tests validating the enum's members, values, string behavior, construction from strings, error handling for invalid input, and public availability through the package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->