### PR TITLE
test(OMN-10062): red tests for merged ModelTicketContract schema

### DIFF
--- a/tests/unit/models/ticket/test_model_ticket_contract_merged.py
+++ b/tests/unit/models/ticket/test_model_ticket_contract_merged.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Red tests for merged ModelTicketContract schema (OMN-10062).
+
+These tests define the expected shape of the merged core ModelTicketContract
+after absorbing all OCC-local fields (OMN-9582, Task 1).
+
+All tests are marked xfail because the fields do not yet exist on the core model.
+OMN-10064 will extend the model and remove the xfail markers.
+
+Test inventory:
+    T1 — New merged fields are accepted by the model
+    T2 — schema_version rejects non-SemVer values
+    T3 — interfaces_touched with interface_change=False raises ValidationError
+    T4 — Existing fields are unaffected by the merge
+    T5 — YAML round-trip preserves new merged fields
+    T6 — On-disk YAML sample (OMN-6238.yaml fields) loads without error
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.ticket.model_ticket_contract import ModelTicketContract
+
+# ============================================================================
+# T1 — New merged fields are accepted by the model
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason=(
+        "OMN-10064 will promote merged fields from pydantic_extra to typed model fields. "
+        "Currently extra='allow' stores them as raw dicts; post-merge they must be "
+        "declared schema fields with proper types (ModelEmergencyBypass, etc.)."
+    ),
+    strict=True,
+)
+def test_merged_fields_accepted() -> None:
+    """ModelTicketContract accepts all new OCC-origin fields as typed model fields.
+
+    Fields under test:
+      schema_version, summary, is_seam_ticket, interface_change,
+      interfaces_touched, evidence_requirements, emergency_bypass,
+      golden_path, dod_evidence, contract_completeness.
+
+    The post-merge model must store these as declared schema fields (present in
+    ModelTicketContract.model_fields), not as raw extras in model_extra. In
+    particular, emergency_bypass must be a ModelEmergencyBypass instance (not a
+    dict), and contract_completeness must be an EnumContractCompleteness instance.
+    """
+    from omnibase_core.models.ticket.model_emergency_bypass import (  # type: ignore[import]
+        ModelEmergencyBypass,
+    )
+
+    from omnibase_core.enums.enum_contract_completeness import (  # type: ignore[import]
+        EnumContractCompleteness,
+    )
+
+    contract = ModelTicketContract(
+        ticket_id="OMN-10062",
+        title="Merged schema smoke test",
+        schema_version="1.0.0",  # type: ignore[call-arg]
+        summary="Verify merged fields are accepted",  # type: ignore[call-arg]
+        is_seam_ticket=False,  # type: ignore[call-arg]
+        interface_change=False,  # type: ignore[call-arg]
+        interfaces_touched=[],  # type: ignore[call-arg]
+        evidence_requirements=[  # type: ignore[call-arg]
+            {
+                "kind": "tests",
+                "description": "Unit test coverage",
+                "command": "uv run pytest tests/ -v",
+            }
+        ],
+        emergency_bypass={  # type: ignore[call-arg]
+            "enabled": False,
+            "justification": "",
+            "follow_up_ticket_id": "",
+        },
+        golden_path=None,  # type: ignore[call-arg]
+        dod_evidence=[],  # type: ignore[call-arg]
+        contract_completeness="STUB",  # type: ignore[call-arg]
+    )
+
+    # Fields must be declared schema fields, NOT raw extras
+    declared_fields = ModelTicketContract.model_fields
+    assert "schema_version" in declared_fields, (
+        "schema_version must be a declared field, not stored in model_extra"
+    )
+    assert "summary" in declared_fields, (
+        "summary must be a declared field, not stored in model_extra"
+    )
+    assert "is_seam_ticket" in declared_fields, (
+        "is_seam_ticket must be a declared field, not stored in model_extra"
+    )
+    assert "interface_change" in declared_fields, (
+        "interface_change must be a declared field, not stored in model_extra"
+    )
+    assert "interfaces_touched" in declared_fields, (
+        "interfaces_touched must be a declared field, not stored in model_extra"
+    )
+    assert "evidence_requirements" in declared_fields, (
+        "evidence_requirements must be a declared field, not stored in model_extra"
+    )
+    assert "emergency_bypass" in declared_fields, (
+        "emergency_bypass must be a declared field, not stored in model_extra"
+    )
+    assert "dod_evidence" in declared_fields, (
+        "dod_evidence must be a declared field, not stored in model_extra"
+    )
+    assert "contract_completeness" in declared_fields, (
+        "contract_completeness must be a declared field, not stored in model_extra"
+    )
+
+    # emergency_bypass must be coerced to the typed model (not remain a raw dict)
+    assert isinstance(contract.emergency_bypass, ModelEmergencyBypass), (  # type: ignore[attr-defined]
+        f"emergency_bypass must be ModelEmergencyBypass, got {type(contract.emergency_bypass)}"
+    )
+
+    # contract_completeness must be an EnumContractCompleteness instance
+    assert isinstance(contract.contract_completeness, EnumContractCompleteness), (  # type: ignore[attr-defined]
+        f"contract_completeness must be EnumContractCompleteness, got {type(contract.contract_completeness)}"
+    )
+    assert contract.contract_completeness == EnumContractCompleteness.STUB  # type: ignore[attr-defined]
+
+    # Basic value checks
+    assert contract.schema_version == "1.0.0"  # type: ignore[attr-defined]
+    assert contract.summary == "Verify merged fields are accepted"  # type: ignore[attr-defined]
+    assert contract.is_seam_ticket is False  # type: ignore[attr-defined]
+    assert contract.interface_change is False  # type: ignore[attr-defined]
+    assert contract.interfaces_touched == []  # type: ignore[attr-defined]
+    assert len(contract.evidence_requirements) == 1  # type: ignore[attr-defined]
+    assert contract.golden_path is None  # type: ignore[attr-defined]
+    assert contract.dod_evidence == []  # type: ignore[attr-defined]
+
+
+# ============================================================================
+# T2 — schema_version rejects non-SemVer values
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason="OMN-10064 will add schema_version with SemVer validator; field absent now",
+    strict=True,
+)
+def test_schema_version_rejects_non_semver() -> None:
+    """schema_version field must reject non-SemVer strings.
+
+    Valid SemVer: major.minor.patch with no leading zeros (e.g. "1.0.0", "2.3.14").
+    Rejected: "abc", "01.0.0", "1.0", "1.0.0-alpha", "".
+    """
+    invalid_versions = [
+        "abc",
+        "01.0.0",  # Leading zero in major
+        "1.0",  # Missing patch segment
+        "1.0.0-alpha",  # Pre-release suffix not supported
+        "1.0.0+build",  # Build metadata not supported
+        "",  # Empty string
+    ]
+
+    for bad_version in invalid_versions:
+        with pytest.raises(ValidationError, match="schema_version"):
+            ModelTicketContract(
+                ticket_id="OMN-TEST",
+                title="SemVer rejection test",
+                schema_version=bad_version,  # type: ignore[call-arg]
+                summary="",
+                is_seam_ticket=False,
+                interface_change=False,
+                emergency_bypass={
+                    "enabled": False,
+                    "justification": "",
+                    "follow_up_ticket_id": "",
+                },
+            )
+
+
+# ============================================================================
+# T3 — interfaces_touched with interface_change=False raises ValidationError
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason=(
+        "OMN-10064 will add interface_change cross-field validator; fields absent now"
+    ),
+    strict=True,
+)
+def test_interfaces_touched_requires_interface_change_true() -> None:
+    """interfaces_touched must be empty when interface_change=False.
+
+    Cross-field validator from OCC ported to core: if interface_change is False
+    and interfaces_touched is non-empty, raise ValidationError.
+    """
+    with pytest.raises(ValidationError):
+        ModelTicketContract(
+            ticket_id="OMN-TEST",
+            title="Interface constraint test",
+            schema_version="1.0.0",  # type: ignore[call-arg]
+            summary="",
+            is_seam_ticket=False,
+            interface_change=False,
+            interfaces_touched=["events"],  # Non-empty with interface_change=False
+            emergency_bypass={
+                "enabled": False,
+                "justification": "",
+                "follow_up_ticket_id": "",
+            },
+        )
+
+
+# ============================================================================
+# T4 — Existing fields are unaffected by the merge
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason=(
+        "OMN-10064 changes extra='allow' to extra='forbid' on ModelTicketContract; "
+        "post-merge model has extra='forbid' so the extra-field test will flip. "
+        "All other existing-field assertions must still pass."
+    ),
+    strict=True,
+)
+def test_existing_fields_unaffected() -> None:
+    """All existing core ModelTicketContract fields continue to work after merge.
+
+    Checks: ticket_id, title, description, phase, context, questions,
+    requirements, verification_steps, gates, interfaces_provided,
+    interfaces_consumed, contract_fingerprint, created_at, updated_at.
+
+    Also checks that extra='forbid' is now in effect (post-merge schema change).
+    """
+    contract = ModelTicketContract(
+        ticket_id="OMN-EXISTING",
+        title="Existing fields check",
+        description="A description",
+        phase="intake",  # type: ignore[arg-type]
+        context={"key": "value"},
+        questions=[],
+        requirements=[],
+        verification_steps=[],
+        gates=[],
+        interfaces_provided=[],
+        interfaces_consumed=[],
+    )
+
+    assert contract.ticket_id == "OMN-EXISTING"
+    assert contract.title == "Existing fields check"
+    assert contract.description == "A description"
+    assert contract.context == {"key": "value"}
+    assert contract.questions == []
+    assert contract.requirements == []
+    assert contract.verification_steps == []
+    assert contract.gates == []
+    assert contract.interfaces_provided == []
+    assert contract.interfaces_consumed == []
+
+    # Post-merge: extra="forbid" must be in effect
+    with pytest.raises(ValidationError):
+        ModelTicketContract.model_validate(
+            {
+                "ticket_id": "OMN-EXTRA",
+                "title": "Extra field test",
+                "schema_version": "1.0.0",
+                "summary": "",
+                "is_seam_ticket": False,
+                "interface_change": False,
+                "emergency_bypass": {
+                    "enabled": False,
+                    "justification": "",
+                    "follow_up_ticket_id": "",
+                },
+                "unknown_extra_field": "should_be_rejected",
+            }
+        )
+
+
+# ============================================================================
+# T5 — YAML round-trip preserves new merged fields
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason="OMN-10064 will add merged fields; to_yaml/from_yaml not exercisable yet",
+    strict=True,
+)
+def test_yaml_round_trip_preserves_merged_fields() -> None:
+    """Merged fields survive a to_yaml() → from_yaml() round-trip.
+
+    Constructs a ModelTicketContract with the new fields set to non-default
+    values, serializes to YAML, deserializes back, and asserts all new fields
+    are preserved with their original values.
+    """
+    original = ModelTicketContract(
+        ticket_id="OMN-ROUNDTRIP",
+        title="Round-trip test",
+        schema_version="1.0.0",  # type: ignore[call-arg]
+        summary="Testing YAML round-trip of merged fields",
+        is_seam_ticket=True,
+        interface_change=True,
+        interfaces_touched=["events", "topics"],
+        evidence_requirements=[
+            {
+                "kind": "tests",
+                "description": "Round-trip evidence",
+                "command": "uv run pytest",
+            }
+        ],
+        emergency_bypass={
+            "enabled": False,
+            "justification": "",
+            "follow_up_ticket_id": "",
+        },
+        golden_path=None,
+        dod_evidence=[
+            {
+                "id": "dod-001",
+                "description": "Test exists",
+                "source": "generated",
+                "checks": [
+                    {
+                        "check_type": "test_passes",
+                        "check_value": "tests/unit/models/ticket/",
+                    }
+                ],
+                "status": "pending",
+            }
+        ],
+        contract_completeness="ENRICHED",
+    )
+
+    yaml_str = original.to_yaml()
+    restored = ModelTicketContract.from_yaml(yaml_str)
+
+    # All new fields must survive round-trip
+    assert restored.schema_version == "1.0.0"  # type: ignore[attr-defined]
+    assert restored.summary == "Testing YAML round-trip of merged fields"  # type: ignore[attr-defined]
+    assert restored.is_seam_ticket is True  # type: ignore[attr-defined]
+    assert restored.interface_change is True  # type: ignore[attr-defined]
+    assert restored.interfaces_touched == ["events", "topics"]  # type: ignore[attr-defined]
+    assert len(restored.evidence_requirements) == 1  # type: ignore[attr-defined]
+    assert restored.emergency_bypass.enabled is False  # type: ignore[attr-defined]
+    assert len(restored.dod_evidence) == 1  # type: ignore[attr-defined]
+    assert restored.dod_evidence[0].id == "dod-001"  # type: ignore[attr-defined]
+    assert str(restored.contract_completeness) == "ENRICHED"  # type: ignore[attr-defined]
+
+    # Existing fields also survive
+    assert restored.ticket_id == "OMN-ROUNDTRIP"
+    assert restored.title == "Round-trip test"
+
+
+# ============================================================================
+# T6 — On-disk YAML sample (OMN-6238.yaml fields) loads without error
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason=(
+        "OMN-10064 will add merged fields; OMN-6238.yaml uses OCC schema fields "
+        "(schema_version, summary, etc.) that the core model doesn't have yet. "
+        "With extra='forbid', these fields cause ValidationError until the merge lands."
+    ),
+    strict=True,
+)
+def test_on_disk_yaml_sample_loads() -> None:
+    """Representative OMN-6238.yaml on-disk contract loads against core model.
+
+    Uses a verbatim copy of the OMN-6238.yaml fields from
+    onex_change_control/contracts/OMN-6238.yaml (observed 2026-04-27).
+    After the merge, core ModelTicketContract must accept this exact structure.
+    """
+    omn_6238_yaml = textwrap.dedent(
+        """\
+        schema_version: "1.0.0"
+        ticket_id: OMN-6238
+        summary: "Build Contract-Driven Multi-Repo Verification Agents"
+        is_seam_ticket: true
+        interface_change: false
+        interfaces_touched: []
+        evidence_requirements:
+          - kind: "ci"
+            description: "CI passes on merge PR"
+            command: "gh pr checks"
+        emergency_bypass:
+          enabled: false
+          justification: ""
+          follow_up_ticket_id: ""
+        dod_evidence:
+          - id: "dod-001"
+            description: "PR opened against main branch"
+            source: "generated"
+            checks:
+              - check_type: "command"
+                check_value: "gh pr view --json state -q .state"
+          - id: "dod-002"
+            description: "PR merged to main"
+            source: "generated"
+            checks:
+              - check_type: "command"
+                check_value: "gh pr view --json mergedAt -q .mergedAt"
+          - id: "dod-003"
+            description: "Tests pass in CI"
+            source: "generated"
+            checks:
+              - check_type: "command"
+                check_value: "gh pr checks --watch"
+          - id: "dod-004"
+            description: "Pre-commit hooks clean"
+            source: "generated"
+            checks:
+              - check_type: "command"
+                check_value: "pre-commit run --all-files"
+          - id: "dod-005"
+            description: "Contract/schema artifact file exists"
+            source: "generated"
+            checks:
+              - check_type: "command"
+                check_value: "contracts/OMN-6238.yaml"
+        """
+    )
+
+    # The core model must accept this YAML without raising after the merge
+    contract = ModelTicketContract.from_yaml(omn_6238_yaml)
+
+    # Verify key fields round-tripped correctly
+    assert contract.ticket_id == "OMN-6238"
+    assert contract.schema_version == "1.0.0"  # type: ignore[attr-defined]
+    assert contract.summary == "Build Contract-Driven Multi-Repo Verification Agents"  # type: ignore[attr-defined]
+    assert contract.is_seam_ticket is True  # type: ignore[attr-defined]
+    assert contract.interface_change is False  # type: ignore[attr-defined]
+    assert contract.interfaces_touched == []  # type: ignore[attr-defined]
+    assert len(contract.evidence_requirements) == 1  # type: ignore[attr-defined]
+    assert contract.emergency_bypass.enabled is False  # type: ignore[attr-defined]
+    assert len(contract.dod_evidence) == 5  # type: ignore[attr-defined]
+    assert contract.dod_evidence[0].id == "dod-001"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Adds \`tests/unit/models/ticket/test_model_ticket_contract_merged.py\` with 6 xfail tests defining the expected shape of the merged core \`ModelTicketContract\` (OMN-9582 Task 1)
- All tests marked \`@pytest.mark.xfail(strict=True)\` — CI passes green; xfail is removed by OMN-10064 when the model is extended
- Zero regressions: 233 existing ticket model tests still pass

## TDD Red Phase

This is the **red half** of TDD for OMN-9582 Task 1. The tests assert behavior the model does not yet have. OMN-10064 (Task 2) will extend \`ModelTicketContract\` with the merged fields and remove the xfail markers.

[skip-receipt-gate: TDD red phase — tests only, no implementation; OMN-10064 will provide dod_evidence when model is implemented]

## Test Inventory

| Test | Asserts |
|------|---------|
| \`test_merged_fields_accepted\` | New fields are declared typed schema fields (not in \`model_extra\`) |
| \`test_schema_version_rejects_non_semver\` | SemVer validator rejects \`\"abc\"\`, \`\"01.0.0\"\`, \`\"1.0\"\`, etc. |
| \`test_interfaces_touched_requires_interface_change_true\` | Cross-field validator: non-empty \`interfaces_touched\` with \`interface_change=False\` raises |
| \`test_existing_fields_unaffected\` | All existing fields preserved; \`extra=\"forbid\"\` enforced post-merge |
| \`test_yaml_round_trip_preserves_merged_fields\` | All new fields survive \`to_yaml()\` → \`from_yaml()\` round-trip |
| \`test_on_disk_yaml_sample_loads\` | Representative \`OMN-6238.yaml\` structure loads against merged core model |

## dod_evidence

\`\`\`yaml
ticket_id: \"OMN-10062\"
evidence_requirements:
  - kind: \"tests\"
    description: \"6 xfail tests in test_model_ticket_contract_merged.py confirming red state\"
    command: \"uv run pytest tests/unit/models/ticket/test_model_ticket_contract_merged.py -v\"
  - kind: \"ci\"
    description: \"CI pipeline green on PR\"
    command: \"gh pr checks\"
\`\`\`

OMN-10062