### PR TITLE
feat(OMN-10203): add pattern b dispatch bus client

### DIFF
--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -65,6 +65,7 @@ adjacency:
   context: {reverse_deps: [nodes, runtime]}
   crypto: {reverse_deps: []}
   decorators: {reverse_deps: []}
+  dispatch: {reverse_deps: []}
   discovery: {reverse_deps: [nodes, runtime]}
   doctor: {reverse_deps: []}
   factories: {reverse_deps: [nodes, container]}

--- a/src/omnibase_core/dispatch/__init__.py
+++ b/src/omnibase_core/dispatch/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pattern B broker client surfaces."""
+
+from omnibase_core.dispatch.dispatch_bus_client import (
+    DispatchBusClient,
+    load_dispatch_bus_route,
+)
+
+__all__ = [
+    "DispatchBusClient",
+    "load_dispatch_bus_route",
+]

--- a/src/omnibase_core/dispatch/dispatch_bus_client.py
+++ b/src/omnibase_core/dispatch/dispatch_bus_client.py
@@ -174,6 +174,7 @@ class DispatchBusClient:
         timeout_seconds: int,
     ) -> ModelDispatchBusTerminalResult:
         """Wait for the correlated terminal result on the broker route."""
+        parsed_correlation_id = command_uuid(correlation_id)
         unsubscribe, result_queue = await self.wait_for_result(
             route,
             correlation_id=correlation_id,
@@ -182,7 +183,7 @@ class DispatchBusClient:
             return await asyncio.wait_for(result_queue.get(), timeout=timeout_seconds)
         except TimeoutError:
             return ModelDispatchBusTerminalResult(
-                correlation_id=command_uuid(correlation_id),
+                correlation_id=parsed_correlation_id,
                 status="timeout",
                 error_message=(
                     "Timed out waiting for Pattern B broker terminal result."

--- a/src/omnibase_core/dispatch/dispatch_bus_client.py
+++ b/src/omnibase_core/dispatch/dispatch_bus_client.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed Pattern B broker client over ProtocolEventBus."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.core.model_generic_yaml import ModelGenericYaml
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.dispatch.model_dispatch_bus_route import ModelDispatchBusRoute
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.protocols.event_bus.protocol_dispatch_bus_client_transport import (
+    ProtocolDispatchBusClientTransport,
+)
+from omnibase_core.protocols.event_bus.protocol_node_identity import (
+    ProtocolNodeIdentity,
+)
+from omnibase_core.types.type_json import JsonType
+from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+
+def _as_mapping(raw: ModelGenericYaml) -> dict[str, object]:
+    """Return a plain mapping from a validated generic YAML model."""
+    data = raw.model_dump(mode="json", exclude_none=True)
+    if not isinstance(data, dict):
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message="Broker contract YAML must decode to a mapping.",
+        )
+    return data
+
+
+def _resolve_command_topic(raw: dict[str, object]) -> str:
+    publish_topics = raw.get("publish_topics")
+    if isinstance(publish_topics, list) and publish_topics:
+        first = publish_topics[0]
+        if isinstance(first, str) and first:
+            return first
+
+    event_bus = raw.get("event_bus")
+    if isinstance(event_bus, dict):
+        nested_publish = event_bus.get("publish_topics")
+        if isinstance(nested_publish, list) and nested_publish:
+            first_nested = nested_publish[0]
+            if isinstance(first_nested, str) and first_nested:
+                return first_nested
+
+    raise ModelOnexError(
+        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        message="Broker contract must declare a publish topic for the command path.",
+    )
+
+
+def _resolve_terminal_topic(raw: dict[str, object]) -> str:
+    terminal_event = raw.get("terminal_event")
+    if isinstance(terminal_event, str) and terminal_event:
+        return terminal_event
+    if isinstance(terminal_event, dict):
+        topic = terminal_event.get("topic")
+        if isinstance(topic, str) and topic:
+            return topic
+
+    raise ModelOnexError(
+        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        message="Broker contract must declare a terminal_event topic.",
+    )
+
+
+def load_dispatch_bus_route(contract_path: Path) -> ModelDispatchBusRoute:
+    """Load broker command and terminal topics from a contract YAML file."""
+    raw = load_and_validate_yaml_model(contract_path, ModelGenericYaml)
+    data = _as_mapping(raw)
+    return ModelDispatchBusRoute(
+        contract_path=contract_path.resolve(),
+        command_topic=_resolve_command_topic(data),
+        terminal_topic=_resolve_terminal_topic(data),
+    )
+
+
+def command_uuid(raw: str) -> UUID:
+    """Parse a correlation id string into the UUID type used by the models."""
+    return UUID(raw)
+
+
+class DispatchBusClient:
+    """Thin typed client for the Pattern B broker request/result path."""
+
+    def __init__(
+        self, event_bus: ProtocolDispatchBusClientTransport, *, source: str
+    ) -> None:
+        self._event_bus = event_bus
+        self._source = source
+
+    async def publish_command(
+        self,
+        route: ModelDispatchBusRoute,
+        command: ModelDispatchBusCommand,
+    ) -> None:
+        """Publish a broker command envelope to the route command topic."""
+        envelope = ModelEventEnvelope[ModelDispatchBusCommand](
+            payload=command,
+            correlation_id=command.correlation_id,
+            source_tool=self._source,
+            target_tool="pattern-b-broker",
+            event_type=route.command_topic,
+            payload_type=ModelDispatchBusCommand.__name__,
+            timeout_seconds=command.timeout_seconds,
+        )
+        await self._event_bus.publish(
+            route.command_topic,
+            None,
+            envelope.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+    async def wait_for_result(
+        self,
+        route: ModelDispatchBusRoute,
+        *,
+        correlation_id: str,
+    ) -> tuple[
+        Callable[[], Awaitable[None]], asyncio.Queue[ModelDispatchBusTerminalResult]
+    ]:
+        """Subscribe to the terminal topic and return its queue plus unsubscribe."""
+        result_queue: asyncio.Queue[ModelDispatchBusTerminalResult] = asyncio.Queue(
+            maxsize=1
+        )
+        subscriber_identity = cast(
+            ProtocolNodeIdentity,
+            SimpleNamespace(
+                env="local",
+                service="pattern-b-client",
+                node_name=f"terminal-wait-{correlation_id}",
+                version="v1",
+            ),
+        )
+
+        async def on_message(message: ModelEventMessage) -> None:
+            envelope = ModelEventEnvelope[
+                ModelDispatchBusTerminalResult
+            ].model_validate_json(message.value)
+            if str(envelope.payload.correlation_id) != correlation_id:
+                return
+            if result_queue.empty():
+                await result_queue.put(envelope.payload)
+
+        unsubscribe = await self._event_bus.subscribe(
+            route.terminal_topic,
+            subscriber_identity,
+            on_message=on_message,
+        )
+        return unsubscribe, result_queue
+
+    async def await_result(
+        self,
+        route: ModelDispatchBusRoute,
+        *,
+        correlation_id: str,
+        timeout_seconds: int,
+    ) -> ModelDispatchBusTerminalResult:
+        """Wait for the correlated terminal result on the broker route."""
+        unsubscribe, result_queue = await self.wait_for_result(
+            route,
+            correlation_id=correlation_id,
+        )
+        try:
+            return await asyncio.wait_for(result_queue.get(), timeout=timeout_seconds)
+        except TimeoutError:
+            return ModelDispatchBusTerminalResult(
+                correlation_id=command_uuid(correlation_id),
+                status="timeout",
+                error_message=(
+                    "Timed out waiting for Pattern B broker terminal result."
+                ),
+            )
+        finally:
+            await unsubscribe()
+
+    async def request(
+        self,
+        route: ModelDispatchBusRoute,
+        *,
+        command_name: str,
+        payload: JsonType,
+        timeout_seconds: int = 120,
+    ) -> ModelDispatchBusTerminalResult:
+        """Publish a broker command and wait for the correlated terminal result."""
+        command = ModelDispatchBusCommand(
+            command_name=command_name,
+            requester=self._source,
+            payload=payload,
+            response_topic=route.terminal_topic,
+            timeout_seconds=timeout_seconds,
+        )
+        unsubscribe, result_queue = await self.wait_for_result(
+            route,
+            correlation_id=str(command.correlation_id),
+        )
+        try:
+            await self.publish_command(route, command)
+            return await asyncio.wait_for(result_queue.get(), timeout=timeout_seconds)
+        except TimeoutError:
+            return ModelDispatchBusTerminalResult(
+                correlation_id=command.correlation_id,
+                status="timeout",
+                error_message=(
+                    "Timed out waiting for Pattern B broker terminal result."
+                ),
+            )
+        finally:
+            await unsubscribe()
+
+
+__all__ = [
+    "DispatchBusClient",
+    "load_dispatch_bus_route",
+]

--- a/src/omnibase_core/models/dispatch/__init__.py
+++ b/src/omnibase_core/models/dispatch/__init__.py
@@ -97,6 +97,15 @@ from omnibase_core.errors.error_lifecycle_emitter import LifecycleEmitterError
 from omnibase_core.errors.error_lifecycle_transition import (
     LifecycleTransitionError,
 )
+from omnibase_core.models.dispatch.model_dispatch_bus_command import (
+    ModelDispatchBusCommand,
+)
+from omnibase_core.models.dispatch.model_dispatch_bus_route import (
+    ModelDispatchBusRoute,
+)
+from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
+    ModelDispatchBusTerminalResult,
+)
 from omnibase_core.models.dispatch.model_dispatch_claim import (
     ModelDispatchClaim,
     compute_blocker_id,
@@ -136,6 +145,9 @@ __all__ = [
     # Models
     "ModelLifecycleChain",
     "ModelDispatchClaim",
+    "ModelDispatchBusCommand",
+    "ModelDispatchBusRoute",
+    "ModelDispatchBusTerminalResult",
     "ModelDispatchLifecycleEvent",
     "ModelDispatchResult",
     "ModelDispatchRoute",

--- a/src/omnibase_core/models/dispatch/model_dispatch_bus_command.py
+++ b/src/omnibase_core/models/dispatch/model_dispatch_bus_command.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pattern B broker command payload model."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelDispatchBusCommand(BaseModel):
+    """Command payload published to the Pattern B broker."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    command_name: str = Field(
+        ...,
+        min_length=1,
+        description="Logical command name for the broker request.",
+    )
+    requester: str = Field(
+        ...,
+        min_length=1,
+        description="Originating surface, e.g. codex or opencode.",
+    )
+    payload: JsonType = Field(
+        ...,
+        description="JSON-serializable broker command payload.",
+    )
+    correlation_id: UUID = Field(
+        default_factory=uuid4,
+        description="Correlation identifier shared with the terminal result.",
+    )
+    response_topic: str = Field(
+        ...,
+        min_length=1,
+        description="Terminal topic the broker should publish the result to.",
+    )
+    timeout_seconds: int = Field(
+        default=120,
+        ge=1,
+        le=600,
+        description="Requested timeout for the broker round-trip.",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when the broker request was created.",
+    )
+
+
+__all__ = ["ModelDispatchBusCommand"]

--- a/src/omnibase_core/models/dispatch/model_dispatch_bus_route.py
+++ b/src/omnibase_core/models/dispatch/model_dispatch_bus_route.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pattern B broker route metadata loaded from contract YAML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDispatchBusRoute(BaseModel):
+    """Resolved broker route for the Pattern B dispatch bus client."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    contract_path: Path = Field(
+        ...,
+        description="Contract file used to resolve the broker route.",
+    )
+    command_topic: str = Field(
+        ...,
+        min_length=1,
+        description="Broker command topic to publish the request to.",
+    )
+    terminal_topic: str = Field(
+        ...,
+        min_length=1,
+        description="Broker terminal topic to wait on for the correlated result.",
+    )
+
+
+__all__ = ["ModelDispatchBusRoute"]

--- a/src/omnibase_core/models/dispatch/model_dispatch_bus_terminal_result.py
+++ b/src/omnibase_core/models/dispatch/model_dispatch_bus_terminal_result.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pattern B broker terminal result payload model."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelDispatchBusTerminalResult(BaseModel):
+    """Terminal result returned by the Pattern B broker."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation identifier copied from the originating request.",
+    )
+    status: Literal["completed", "failed", "timeout"] = Field(
+        ...,
+        description="Terminal broker request state.",
+    )
+    payload: JsonType | None = Field(
+        default=None,
+        description="JSON-serializable terminal payload when the broker succeeds.",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Failure or timeout message when the broker does not complete cleanly.",
+    )
+    completed_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when the terminal result was created.",
+    )
+
+
+__all__ = ["ModelDispatchBusTerminalResult"]

--- a/src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py
+++ b/src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Minimal event-bus surface required by the Pattern B dispatch client."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.models.event_bus.model_event_headers import ModelEventHeaders
+from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
+from omnibase_core.protocols.event_bus.protocol_node_identity import (
+    ProtocolNodeIdentity,
+)
+
+
+@runtime_checkable
+class ProtocolDispatchBusClientTransport(Protocol):
+    """Duck-typed publish/subscribe surface used by DispatchBusClient."""
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: ModelEventHeaders | None = None,
+    ) -> None: ...
+
+    async def subscribe(
+        self,
+        topic: str,
+        node_identity: ProtocolNodeIdentity | None = None,
+        on_message: Callable[[ModelEventMessage], Awaitable[None]] | None = None,
+        *,
+        group_id: str | None = None,
+        purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+        required_for_readiness: bool = False,
+    ) -> Callable[[], Awaitable[None]]: ...
+
+
+__all__ = ["ProtocolDispatchBusClientTransport"]

--- a/src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py
+++ b/src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py
@@ -26,7 +26,8 @@ class ProtocolDispatchBusClientTransport(Protocol):
         key: bytes | None,
         value: bytes,
         headers: ModelEventHeaders | None = None,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def subscribe(
         self,
@@ -37,7 +38,8 @@ class ProtocolDispatchBusClientTransport(Protocol):
         group_id: str | None = None,
         purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
         required_for_readiness: bool = False,
-    ) -> Callable[[], Awaitable[None]]: ...
+    ) -> Callable[[], Awaitable[None]]:
+        pass
 
 
 __all__ = ["ProtocolDispatchBusClientTransport"]

--- a/tests/unit/dispatch/test_dispatch_bus_client.py
+++ b/tests/unit/dispatch/test_dispatch_bus_client.py
@@ -59,55 +59,56 @@ async def test_dispatch_bus_client_request_round_trips_on_inmemory_bus(
 
     bus = EventBusInmemory(environment="test", group="pattern-b")
     await bus.start()
+    try:
 
-    async def broker(message: ModelEventMessage) -> None:
-        command_envelope = ModelEventEnvelope[
-            ModelDispatchBusCommand
-        ].model_validate_json(message.value)
-        terminal_payload = ModelDispatchBusTerminalResult(
-            correlation_id=command_envelope.payload.correlation_id,
-            status="completed",
-            payload={
-                "accepted": True,
-                "command_name": command_envelope.payload.command_name,
-            },
+        async def broker(message: ModelEventMessage) -> None:
+            command_envelope = ModelEventEnvelope[
+                ModelDispatchBusCommand
+            ].model_validate_json(message.value)
+            terminal_payload = ModelDispatchBusTerminalResult(
+                correlation_id=command_envelope.payload.correlation_id,
+                status="completed",
+                payload={
+                    "accepted": True,
+                    "command_name": command_envelope.payload.command_name,
+                },
+            )
+            terminal_envelope = ModelEventEnvelope[ModelDispatchBusTerminalResult](
+                payload=terminal_payload,
+                correlation_id=command_envelope.payload.correlation_id,
+                event_type=route.terminal_topic,
+                payload_type=ModelDispatchBusTerminalResult.__name__,
+                source_tool="pattern-b-broker",
+            )
+            headers = ModelEventHeaders(
+                source="pattern-b-broker",
+                event_type=route.terminal_topic,
+                timestamp=datetime.now(UTC),
+                correlation_id=command_envelope.payload.correlation_id,
+            )
+            await bus.publish(
+                route.terminal_topic,
+                None,
+                terminal_envelope.model_dump_json().encode("utf-8"),
+                headers,
+            )
+
+        await bus.subscribe(
+            route.command_topic, group_id="pattern-b-broker", on_message=broker
         )
-        terminal_envelope = ModelEventEnvelope[ModelDispatchBusTerminalResult](
-            payload=terminal_payload,
-            correlation_id=command_envelope.payload.correlation_id,
-            event_type=route.terminal_topic,
-            payload_type=ModelDispatchBusTerminalResult.__name__,
-            source_tool="pattern-b-broker",
-        )
-        headers = ModelEventHeaders(
-            source="pattern-b-broker",
-            event_type=route.terminal_topic,
-            timestamp=datetime.now(UTC),
-            correlation_id=command_envelope.payload.correlation_id,
-        )
-        await bus.publish(
-            route.terminal_topic,
-            None,
-            terminal_envelope.model_dump_json().encode("utf-8"),
-            headers,
+
+        client = DispatchBusClient(bus, source="codex")
+        result = await client.request(
+            route,
+            command_name="delegate-task",
+            payload={"prompt": "test prompt"},
+            timeout_seconds=1,
         )
 
-    await bus.subscribe(
-        route.command_topic, group_id="pattern-b-broker", on_message=broker
-    )
-
-    client = DispatchBusClient(bus, source="codex")
-    result = await client.request(
-        route,
-        command_name="delegate-task",
-        payload={"prompt": "test prompt"},
-        timeout_seconds=1,
-    )
-
-    assert result.status == "completed"
-    assert result.payload == {"accepted": True, "command_name": "delegate-task"}
-
-    await bus.close()
+        assert result.status == "completed"
+        assert result.payload == {"accepted": True, "command_name": "delegate-task"}
+    finally:
+        await bus.close()
 
 
 @pytest.mark.unit
@@ -119,17 +120,17 @@ async def test_dispatch_bus_client_returns_timeout_result(tmp_path: Path) -> Non
 
     bus = EventBusInmemory(environment="test", group="pattern-b")
     await bus.start()
+    try:
+        client = DispatchBusClient(bus, source="codex")
+        result = await client.request(
+            route,
+            command_name="delegate-task",
+            payload={"prompt": "test prompt"},
+            timeout_seconds=1,
+        )
 
-    client = DispatchBusClient(bus, source="codex")
-    result = await client.request(
-        route,
-        command_name="delegate-task",
-        payload={"prompt": "test prompt"},
-        timeout_seconds=1,
-    )
-
-    assert result.status == "timeout"
-    assert result.error_message is not None
-    assert "Timed out" in result.error_message
-
-    await bus.close()
+        assert result.status == "timeout"
+        assert result.error_message is not None
+        assert "Timed out" in result.error_message
+    finally:
+        await bus.close()

--- a/tests/unit/dispatch/test_dispatch_bus_client.py
+++ b/tests/unit/dispatch/test_dispatch_bus_client.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.dispatch.dispatch_bus_client import (
+    DispatchBusClient,
+    load_dispatch_bus_route,
+)
+from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.models.dispatch import (
+    ModelDispatchBusCommand,
+    ModelDispatchBusTerminalResult,
+)
+from omnibase_core.models.event_bus.model_event_headers import ModelEventHeaders
+from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+
+def _write_contract(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                'name: "pattern-b-broker"',
+                "publish_topics:",
+                "  - onex.cmd.pattern-b.dispatch.v1",
+                "terminal_event: onex.evt.pattern-b.dispatch-completed.v1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.unit
+def test_load_dispatch_bus_route_uses_contract_topics(tmp_path: Path) -> None:
+    contract_path = tmp_path / "contract.yaml"
+    _write_contract(contract_path)
+
+    route = load_dispatch_bus_route(contract_path)
+
+    assert route.command_topic == "onex.cmd.pattern-b.dispatch.v1"
+    assert route.terminal_topic == "onex.evt.pattern-b.dispatch-completed.v1"
+    assert route.contract_path == contract_path.resolve()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_bus_client_request_round_trips_on_inmemory_bus(
+    tmp_path: Path,
+) -> None:
+    contract_path = tmp_path / "contract.yaml"
+    _write_contract(contract_path)
+    route = load_dispatch_bus_route(contract_path)
+
+    bus = EventBusInmemory(environment="test", group="pattern-b")
+    await bus.start()
+
+    async def broker(message: ModelEventMessage) -> None:
+        command_envelope = ModelEventEnvelope[
+            ModelDispatchBusCommand
+        ].model_validate_json(message.value)
+        terminal_payload = ModelDispatchBusTerminalResult(
+            correlation_id=command_envelope.payload.correlation_id,
+            status="completed",
+            payload={
+                "accepted": True,
+                "command_name": command_envelope.payload.command_name,
+            },
+        )
+        terminal_envelope = ModelEventEnvelope[ModelDispatchBusTerminalResult](
+            payload=terminal_payload,
+            correlation_id=command_envelope.payload.correlation_id,
+            event_type=route.terminal_topic,
+            payload_type=ModelDispatchBusTerminalResult.__name__,
+            source_tool="pattern-b-broker",
+        )
+        headers = ModelEventHeaders(
+            source="pattern-b-broker",
+            event_type=route.terminal_topic,
+            timestamp=datetime.now(UTC),
+            correlation_id=command_envelope.payload.correlation_id,
+        )
+        await bus.publish(
+            route.terminal_topic,
+            None,
+            terminal_envelope.model_dump_json().encode("utf-8"),
+            headers,
+        )
+
+    await bus.subscribe(
+        route.command_topic, group_id="pattern-b-broker", on_message=broker
+    )
+
+    client = DispatchBusClient(bus, source="codex")
+    result = await client.request(
+        route,
+        command_name="delegate-task",
+        payload={"prompt": "test prompt"},
+        timeout_seconds=1,
+    )
+
+    assert result.status == "completed"
+    assert result.payload == {"accepted": True, "command_name": "delegate-task"}
+
+    await bus.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_bus_client_returns_timeout_result(tmp_path: Path) -> None:
+    contract_path = tmp_path / "contract.yaml"
+    _write_contract(contract_path)
+    route = load_dispatch_bus_route(contract_path)
+
+    bus = EventBusInmemory(environment="test", group="pattern-b")
+    await bus.start()
+
+    client = DispatchBusClient(bus, source="codex")
+    result = await client.request(
+        route,
+        command_name="delegate-task",
+        payload={"prompt": "test prompt"},
+        timeout_seconds=1,
+    )
+
+    assert result.status == "timeout"
+    assert result.error_message is not None
+    assert "Timed out" in result.error_message
+
+    await bus.close()


### PR DESCRIPTION
## Summary
- add typed Pattern B dispatch command, route, and terminal result models
- add a thin dispatch bus client that loads route topics from contract YAML and round-trips over the event bus
- add in-memory proof coverage for route loading, successful terminal completion, and timeout behavior

## Verification
- `env -u PYTHONPATH uv run pytest tests/unit/dispatch/test_dispatch_bus_client.py -q`
- `env -u PYTHONPATH uv run ruff check src/omnibase_core/dispatch src/omnibase_core/models/dispatch src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py tests/unit/dispatch/test_dispatch_bus_client.py`
- `env -u PYTHONPATH uv run mypy src/omnibase_core/dispatch/dispatch_bus_client.py src/omnibase_core/protocols/event_bus/protocol_dispatch_bus_client_transport.py tests/unit/dispatch/test_dispatch_bus_client.py`
- pre-commit and pre-push hooks passed during commit/push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-response messaging client for distributed command processing
  * YAML-based configuration for message routing
  * Automatic tracking and matching of requests with their responses
  * Timeout handling with configurable durations (1–600 seconds, default 120)
  * Status reporting for operation completion, failures, and timeouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->