### PR TITLE
docs(OMN-10180): add substrate implementation ADRs

### DIFF
--- a/docs/decisions/adr-2026-04-28-dispatch-lifecycle-canonical.md
+++ b/docs/decisions/adr-2026-04-28-dispatch-lifecycle-canonical.md
@@ -1,0 +1,96 @@
+> **Navigation**: [Home](../INDEX.md) > [Decisions](README.md) > OMN-10180 Dispatch Lifecycle Canonical
+
+# ADR: Dispatch Lifecycle Canonical Source
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **Document Type** | Architecture Decision Record (ADR) |
+| **Status** | 🟢 **ACCEPTED** |
+| **Created** | 2026-04-28 |
+| **Last Updated** | 2026-04-28 |
+| **Author** | Codex (GPT-5) |
+| **Related Issue** | `OMN-10180` |
+| **Canonical Model** | `src/omnibase_core/models/dispatch/model_dispatch_lifecycle_event.py` |
+
+---
+
+## Executive Summary
+
+Typed lifecycle/FSM events are the canonical representation of dispatch lifecycle. In practice that means `ModelDispatchLifecycleEvent` in `omnibase_core` is the source of truth, while YAML or file-backed lifecycle records are projections and compatibility surfaces derived from those typed events.
+
+This ADR ratifies the existing `omnibase_core` model home rather than relocating it. The decision is about ownership and canonical semantics, not about removing every downstream projection surface.
+
+## Context
+
+The current dispatch substrate work references two abstractions for the same lifecycle:
+
+- typed lifecycle/FSM events via `ModelDispatchLifecycleEvent`
+- filesystem or YAML lifecycle records used as sidecars, receipts, or compatibility projections
+
+Without a declared canonical source, separate tickets can claim lifecycle correctness against different abstractions. That creates drift risk and makes it too easy to treat a local file artifact as authoritative proof instead of a projection of the actual lifecycle stream.
+
+The current user direction resolves that ambiguity:
+
+- implementation ADRs live in the owning repo
+- `omnibase_core` is the canonical home for typed lifecycle/FSM events
+- YAML or file-backed records are projections and compatibility surfaces
+
+That direction matches the code already in place:
+
+- `src/omnibase_core/models/dispatch/model_dispatch_lifecycle_event.py` defines `ModelDispatchLifecycleEvent` (commit `2ddc0971`)
+- `src/omnibase_core/models/dispatch/model_lifecycle_chain.py` composes typed lifecycle chains from those events (commit `2ddc0971`)
+- `tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py` exercises the state machine semantics (commit `2ddc0971`)
+
+## Decision
+
+Typed lifecycle/FSM events are canonical.
+
+`ModelDispatchLifecycleEvent` in `omnibase_core` is the authoritative representation of dispatch lifecycle state and transition semantics. Any YAML, file-backed, or sidecar lifecycle record is a projection of terminal or intermediate lifecycle state, not the source of truth.
+
+Concretely:
+
+- lifecycle validity is defined by the typed event model and its state-machine rules
+- projection writers must derive records from canonical typed events
+- downstream repos may keep compatibility records, but those records must not redefine lifecycle semantics
+- implementation ADR ownership for this surface remains in `omnibase_core`
+
+## Consequences
+
+### Positive
+
+- One canonical lifecycle model defines accepted states, emitters, and transition semantics.
+- Runtime, skill, and proof workflows can all point at the same typed surface when proving lifecycle behavior.
+- Projection records remain useful without being allowed to silently fork the lifecycle contract.
+
+### Negative
+
+- Downstream code that treated file records as authoritative must be reframed around typed events first.
+- Compatibility surfaces may require follow-up rename or cleanup work where older record types imply canonical ownership.
+
+### Neutral
+
+- YAML and file-backed lifecycle records may continue to exist as compatibility outputs, receipts, or derived views.
+- This ADR does not bundle any downstream rename or migration work into `OMN-10180`; it only establishes canonical ownership and semantics.
+
+## Alternatives Rejected
+
+### Keeping YAML or file records as canonical
+
+Rejected because a local record is too easy to self-attest and too weak to carry typed lifecycle semantics on its own.
+
+### Creating a second canonical lifecycle home outside `omnibase_core`
+
+Rejected because it would add indirection without improving ownership clarity or reducing drift.
+
+### Treating typed events and projections as co-equal
+
+Rejected because co-equal ownership leaves the same lifecycle open to inconsistent claims across tickets and repos.
+
+## References
+
+- Workspace ADR source: `/Users/jonah/Code/omni_home/docs/decisions/adr-2026-04-28-dispatch-lifecycle-canonical.md`
+- Canonical model: `src/omnibase_core/models/dispatch/model_dispatch_lifecycle_event.py` (commit `2ddc0971`)
+- Lifecycle chain model: `src/omnibase_core/models/dispatch/model_lifecycle_chain.py` (commit `2ddc0971`)
+- State-machine tests: `tests/unit/models/dispatch/test_model_dispatch_lifecycle_event.py` (commit `2ddc0971`)

--- a/docs/decisions/adr-2026-04-28-skill-liveness-validator-home.md
+++ b/docs/decisions/adr-2026-04-28-skill-liveness-validator-home.md
@@ -1,0 +1,92 @@
+> **Navigation**: [Home](../INDEX.md) > [Decisions](README.md) > OMN-10180 Validator Home
+
+# ADR: Skill Liveness Validator Home
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **Document Type** | Architecture Decision Record (ADR) |
+| **Status** | 🟢 **ACCEPTED** |
+| **Created** | 2026-04-28 |
+| **Last Updated** | 2026-04-28 |
+| **Author** | Codex (GPT-5) |
+| **Related Issue** | `OMN-10180` |
+| **Implementation Home** | `src/omnibase_core/validation/` |
+
+---
+
+## Executive Summary
+
+The skill-backing-node liveness validator is owned by `omnibase_core`. That keeps reusable validator logic with the existing validation substrate, while `omniclaude` and `omnimarket` remain invocation and enforcement surfaces rather than the code home.
+
+This ADR applies to the skill liveness validator surface only. It does not declare that every future validator must live in `omnibase_core`, but it does ratify `omnibase_core` as the correct owner for this cross-repo validator.
+
+## Context
+
+Two competing workspace plans placed the same validator in different homes:
+
+- `docs/plans/2026-04-27-skills-to-market-phase-2-validator-gates.md`
+- `docs/plans/2026-04-26-runtime-lifecycle-part-4-skill-shim-runtime-proof.md`
+
+On 2026-04-28 the user direction corrected that ambiguity: implementation ADRs live in the owning repo, and the validator home for this surface is `omnibase_core`.
+
+That direction is consistent with current repo precedent. `omnibase_core` already owns reusable validation surfaces such as:
+
+- `src/omnibase_core/nodes/node_validator.py` (commit `2ddc0971`)
+- `src/omnibase_core/mixins/mixin_node_type_validator.py` (commit `2ddc0971`)
+- `src/omnibase_core/models/core/model_node_action_validator.py` (commit `2ddc0971`)
+- `src/omnibase_core/validation/validator_runtime_profiles.py` (commit `2ddc0971`)
+
+Putting the new validator in `omnimarket` or `omniclaude` would make a cross-repo rule look like a consumer-local utility. Putting it in `omnibase_compat` would blur compat DTO boundaries with validator ownership.
+
+## Decision
+
+The skill-backing-node liveness validator lives in `omnibase_core`, under the repo's existing validation/validator surface.
+
+Execution surfaces remain split by audience:
+
+- `omniclaude` invokes the validator in pre-commit for local author feedback.
+- `omnimarket` invokes the validator in CI for shared enforcement.
+- `omnibase_core` owns the validator implementation, typed inputs, and rule semantics.
+
+The owning-repo ADR for this decision lives here in `omnibase_core`, not in `omni_home`, because the implementation and architectural ownership are both on the core side.
+
+## Consequences
+
+### Positive
+
+- Validator ownership is aligned with the repo that already carries validation infrastructure.
+- Cross-repo consumers share one implementation instead of growing repo-specific copies.
+- The corrected plan expectation is explicit: code lives in `omnibase_core`, while pre-commit and CI remain downstream enforcement surfaces.
+
+### Negative
+
+- Downstream repos must integrate a validator they do not own, which adds coordination work for invocation wiring.
+- Future validator proposals will still need an ownership decision; this ADR is scoped to the skill liveness surface only.
+
+### Neutral
+
+- Older workspace plans that proposed other homes should be treated as retired in favor of this repo-owned ADR.
+- No backwards-compatibility shim is implied for alternate validator homes.
+
+## Alternatives Rejected
+
+### `omnimarket` as code home
+
+Rejected because the validator is broader than a single consumer repo and should not be anchored to one CI surface.
+
+### `omniclaude` as code home
+
+Rejected because pre-commit is an invocation surface, not the correct architectural owner for reusable validator logic.
+
+### `omnibase_compat` as code home
+
+Rejected because compat should remain focused on DTOs and compatibility seams, not become a general validator bucket.
+
+## References
+
+- Workspace ADR source: `/Users/jonah/Code/omni_home/docs/decisions/adr-2026-04-28-skill-liveness-validator-home.md`
+- Validation ownership precedent: `src/omnibase_core/nodes/node_validator.py` (commit `2ddc0971`)
+- Validation ownership precedent: `src/omnibase_core/mixins/mixin_node_type_validator.py` (commit `2ddc0971`)
+- Validation ownership precedent: `src/omnibase_core/models/core/model_node_action_validator.py` (commit `2ddc0971`)


### PR DESCRIPTION
## Summary
- add the validator-home ADR in the owning implementation repo
- add the canonical dispatch lifecycle ADR in the owning implementation repo

## Verification
- docs-only review