### PR TITLE
feat(OMN-10066): extend core ModelDodCheck with OCC fields

### DIFF
--- a/contracts/OMN-10066.yaml
+++ b/contracts/OMN-10066.yaml
@@ -1,0 +1,41 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-10066
+summary: "Extend core ModelDodCheck with check_type+check_value fields (Part A of 2)"
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - public_api
+evidence_requirements:
+  - kind: tests
+    description: "ModelDodCheck merged-fields tests pass (7 cases)"
+    command: "uv run pytest tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py -v"
+  - kind: ci
+    description: "omnibase_core PR #956 CI green"
+    command: "gh pr checks 956 --repo OmniNode-ai/omnibase_core --watch"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "ModelDodCheck merged-fields unit tests pass (7 cases)"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py
+          -v"
+  - id: dod-002
+    description: "Full contracts + ticket model tests pass with no regressions"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/models/contracts/ tests/unit/models/ticket/ --timeout=15
+          --tb=short -q"
+  - id: dod-003
+    description: "Lint, format, and mypy pass with zero new errors"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run mypy src/
+          --strict"

--- a/src/omnibase_core/models/contracts/ticket/model_dod_check.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_check.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodCheck — executable check entry for a DoD evidence item. OMN-10066
+
+Absorbs OCC's ModelDodCheck fields so OCC can re-export from core and delete
+its local definition (Part B of OMN-10066).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelDodCheck(BaseModel):
+    """A single executable check for a DoD evidence item.
+
+    Both fields default to empty string so existing core callers that omit
+    them continue to construct without error.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    check_type: str = ""
+    check_value: str = ""
+
+
+__all__ = ["ModelDodCheck"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.models.contracts.ticket.model_dod_check import ModelDodCheck
 from omnibase_core.models.contracts.ticket.model_dod_evidence_check import (
     ModelDodEvidenceCheck,
 )
@@ -103,4 +104,4 @@ class ModelDodEvidenceItem(BaseModel):
         return self
 
 
-__all__ = ["SOLE_FILE_EXISTS_ERROR_TOKEN", "ModelDodEvidenceItem"]
+__all__ = ["SOLE_FILE_EXISTS_ERROR_TOKEN", "ModelDodCheck", "ModelDodEvidenceItem"]

--- a/tests/unit/models/contracts/ticket/__init__.py
+++ b/tests/unit/models/contracts/ticket/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py
+++ b/tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelDodCheck merged fields (OMN-10066 Part A).
+
+Verifies that core's ModelDodCheck absorbs the two OCC-side fields
+(check_type, check_value) so OCC can re-export from core and delete its
+local definition.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.ticket.model_dod_check import ModelDodCheck
+
+
+@pytest.mark.unit
+class TestModelDodCheckMergedFields:
+    def test_occ_style_construction_succeeds(self) -> None:
+        check = ModelDodCheck(check_type="command", check_value="uv run pytest")
+        assert check.check_type == "command"
+        assert check.check_value == "uv run pytest"
+
+    def test_check_type_defaults_to_empty_string(self) -> None:
+        check = ModelDodCheck()
+        assert check.check_type == ""
+
+    def test_check_value_defaults_to_empty_string(self) -> None:
+        check = ModelDodCheck()
+        assert check.check_value == ""
+
+    def test_both_fields_optional_no_args(self) -> None:
+        check = ModelDodCheck()
+        assert isinstance(check, ModelDodCheck)
+
+    def test_check_type_rejects_non_string(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDodCheck(check_type=123, check_value="some value")  # type: ignore[arg-type]
+
+    def test_check_value_rejects_non_string(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDodCheck(check_type="command", check_value=42)  # type: ignore[arg-type]
+
+    def test_behavior_proven_construction(self) -> None:
+        check = ModelDodCheck(check_type="behavior_proven", check_value="test_name")
+        assert check.check_type == "behavior_proven"
+        assert check.check_value == "test_name"

--- a/tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py
+++ b/tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py
@@ -37,11 +37,17 @@ class TestModelDodCheckMergedFields:
 
     def test_check_type_rejects_non_string(self) -> None:
         with pytest.raises(ValidationError):
-            ModelDodCheck(check_type=123, check_value="some value")  # type: ignore[arg-type]
+            ModelDodCheck(  # NOTE(OMN-10066): intentional non-str input to assert validation
+                check_type=123,  # type: ignore[arg-type]
+                check_value="some value",
+            )
 
     def test_check_value_rejects_non_string(self) -> None:
         with pytest.raises(ValidationError):
-            ModelDodCheck(check_type="command", check_value=42)  # type: ignore[arg-type]
+            ModelDodCheck(  # NOTE(OMN-10066): intentional non-str input to assert validation
+                check_type="command",
+                check_value=42,  # type: ignore[arg-type]
+            )
 
     def test_behavior_proven_construction(self) -> None:
         check = ModelDodCheck(check_type="behavior_proven", check_value="test_name")


### PR DESCRIPTION
## Summary

- Adds `ModelDodCheck` to `omnibase_core` in a new canonical file `model_dod_check.py` with `check_type: str = ""` and `check_value: str = ""` fields
- Re-exports `ModelDodCheck` from `model_dod_evidence_item.__all__` for downstream import compat
- Ships 7 unit tests covering OCC-style construction, field defaults, and type validation

## OMN-10066

Part A of 2. Part B (OCC re-export + local delete) lands in `onex_change_control`.

```yaml
dod_evidence:
  - id: tests-pass
    description: ModelDodCheck merged-fields tests pass (7 cases)
    checks:
      - check_type: command
        check_value: "uv run pytest tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py -v"
```

## Test plan

- [x] `uv run pytest tests/unit/models/contracts/ticket/test_model_dod_check_merged_fields.py -v` — 7 passed
- [x] `uv run pytest tests/unit/models/contracts/ tests/unit/models/ticket/ -v` — 3265 passed, 0 failures
- [x] `uv run mypy src/ --strict` — 0 new errors (7 pre-existing errors unchanged)
- [x] `uv run ruff format src/ tests/ && uv run ruff check src/ tests/` — all checks passed
- [x] `pre-commit run --all-files` — all hooks passed (validate-deterministic-skill-routing pre-existing failure fixed via omniclaude PR #1449)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Definition of Done (DoD) check model for capturing DoD evidence entries with safe defaults and strict validation.

* **Tests**
  * Added unit tests verifying defaults, value preservation, and input validation for the new DoD check model.

* **Documentation**
  * Added a contract specification for the ticket and SPDX license header metadata to tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->