### PR TITLE
feat(OMN-10244): create core/enums/overseer/ namespace + migrate 14 enums

### DIFF
--- a/contracts/OMN-10244.yaml
+++ b/contracts/OMN-10244.yaml
@@ -1,0 +1,50 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-10244
+summary: "Task 4: Create core/enums/overseer/ Namespace - 14 Enums [omnibase_core, Wave 2]"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "ci"
+    description: "omnibase_core PR #962 CI checks pass"
+    command: "gh pr checks 962 --repo OmniNode-ai/omnibase_core --watch"
+  - kind: "manual"
+    description: "All 15 overseer enum import tests pass"
+    command: "uv run pytest tests/unit/enums/overseer/ -v"
+  - kind: "manual"
+    description: "mypy --strict clean on overseer namespace"
+    command: "uv run mypy src/omnibase_core/enums/overseer/ --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "14 enum files created at src/omnibase_core/enums/overseer/enum_*.py with SPDX headers"
+    source: "manual"
+    receipt: "PASS"
+    checks:
+      - check_type: "command"
+        check_value: "ls src/omnibase_core/enums/overseer/enum_*.py | wc -l"
+  - id: "dod-002"
+    description: "All 15 TDD tests pass (RED confirmed before implementation, GREEN after)"
+    source: "manual"
+    receipt: "PASS"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/enums/overseer/test_overseer_enum_imports.py -v"
+  - id: "dod-003"
+    description: "mypy --strict passes on all 15 files in overseer namespace"
+    source: "manual"
+    receipt: "PASS"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/enums/overseer/ --strict"
+  - id: "dod-004"
+    description: "All pre-commit hooks pass including SPDX, ruff, mypy"
+    source: "manual"
+    receipt: "PASS"
+    checks:
+      - check_type: "command"
+        check_value: "pre-commit run --all-files"

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -523,6 +523,22 @@ from .enum_workflow_coordination import EnumFailureRecoveryStrategy
 from .enum_workflow_dependency_type import EnumWorkflowDependencyType
 from .enum_workflow_status import EnumWorkflowStatus
 
+# Overseer domain (Wave 2 migration from OCC - OMN-10244)
+from .overseer.enum_artifact_store_action import EnumArtifactStoreAction
+from .overseer.enum_capability_tier import EnumCapabilityTier
+from .overseer.enum_code_repository_action import EnumCodeRepositoryAction
+from .overseer.enum_context_bundle_level import EnumContextBundleLevel
+from .overseer.enum_event_bus_action import EnumEventBusAction
+from .overseer.enum_failure_class import EnumFailureClass
+from .overseer.enum_llm_provider_action import EnumLLMProviderAction
+from .overseer.enum_notification_action import EnumNotificationAction
+from .overseer.enum_process_runner_state import EnumProcessRunnerState
+from .overseer.enum_provider import EnumProvider
+from .overseer.enum_retry_type import EnumRetryType
+from .overseer.enum_risk_level import EnumRiskLevel
+from .overseer.enum_ticket_service_action import EnumTicketServiceAction
+from .overseer.enum_verifier_verdict import EnumVerifierVerdict
+
 # NOTE: ModelEnumStatusMigrator is defined in models.core.model_status_migrator
 # It was moved from enums to eliminate circular imports
 # Users should import it directly: from omnibase_core.models.core.model_status_migrator import ModelEnumStatusMigrator
@@ -889,4 +905,19 @@ __all__ = [
     # - "EnumToolHealthStatus" (module doesn't exist)
     # - "EnumToolMissingReason" (module doesn't exist)
     # - "EnumTreeSyncStatus" (module doesn't exist)
+    # Overseer domain (Wave 2 migration from OCC - OMN-10244)
+    "EnumArtifactStoreAction",
+    "EnumCapabilityTier",
+    "EnumCodeRepositoryAction",
+    "EnumContextBundleLevel",
+    "EnumEventBusAction",
+    "EnumFailureClass",
+    "EnumLLMProviderAction",
+    "EnumNotificationAction",
+    "EnumProcessRunnerState",
+    "EnumProvider",
+    "EnumRetryType",
+    "EnumRiskLevel",
+    "EnumTicketServiceAction",
+    "EnumVerifierVerdict",
 ]

--- a/src/omnibase_core/enums/overseer/__init__.py
+++ b/src/omnibase_core/enums/overseer/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Overseer enums for the ONEX platform.
+
+Migrated from onex_change_control.overseer (Wave 2 — additive copy; OCC not deleted).
+"""
+
+from .enum_artifact_store_action import EnumArtifactStoreAction
+from .enum_capability_tier import EnumCapabilityTier
+from .enum_code_repository_action import EnumCodeRepositoryAction
+from .enum_context_bundle_level import EnumContextBundleLevel
+from .enum_event_bus_action import EnumEventBusAction
+from .enum_failure_class import EnumFailureClass
+from .enum_llm_provider_action import EnumLLMProviderAction
+from .enum_notification_action import EnumNotificationAction
+from .enum_process_runner_state import EnumProcessRunnerState
+from .enum_provider import EnumProvider
+from .enum_retry_type import EnumRetryType
+from .enum_risk_level import EnumRiskLevel
+from .enum_ticket_service_action import EnumTicketServiceAction
+from .enum_verifier_verdict import EnumVerifierVerdict
+
+__all__: list[str] = [
+    "EnumArtifactStoreAction",
+    "EnumCapabilityTier",
+    "EnumCodeRepositoryAction",
+    "EnumContextBundleLevel",
+    "EnumEventBusAction",
+    "EnumFailureClass",
+    "EnumLLMProviderAction",
+    "EnumNotificationAction",
+    "EnumProcessRunnerState",
+    "EnumProvider",
+    "EnumRetryType",
+    "EnumRiskLevel",
+    "EnumTicketServiceAction",
+    "EnumVerifierVerdict",
+]

--- a/src/omnibase_core/enums/overseer/enum_artifact_store_action.py
+++ b/src/omnibase_core/enums/overseer/enum_artifact_store_action.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumArtifactStoreAction(StrEnum):
+    """Actions the overseer can request from an artifact store provider.
+
+    Used in protocol dispatch to blob/artifact storage integrations
+    (e.g. S3, GCS, local fs).
+    """
+
+    UPLOAD = "UPLOAD"
+    """Upload an artifact to the store."""
+
+    DOWNLOAD = "DOWNLOAD"
+    """Download an artifact from the store."""
+
+    DELETE = "DELETE"
+    """Delete an artifact from the store."""
+
+    LIST = "LIST"
+    """List artifacts at a given prefix or path."""
+
+    EXISTS = "EXISTS"
+    """Check whether an artifact exists at a given key."""
+
+    GET_METADATA = "GET_METADATA"
+    """Retrieve metadata for an artifact without downloading its content."""
+
+    COPY = "COPY"
+    """Copy an artifact to a new key within the store."""
+
+    MOVE = "MOVE"
+    """Move an artifact to a new key (copy + delete source)."""
+
+
+__all__: list[str] = ["EnumArtifactStoreAction"]

--- a/src/omnibase_core/enums/overseer/enum_capability_tier.py
+++ b/src/omnibase_core/enums/overseer/enum_capability_tier.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+from functools import total_ordering
+
+
+@total_ordering
+class EnumCapabilityTier(StrEnum):
+    """Capability tier for overseer routing decisions.
+
+    Ordered C0 (lowest) through C4 (highest). Supports comparison operators
+    via @total_ordering for tier-based routing logic.
+    """
+
+    C0 = "C0"
+    """Tier 0 — minimal capability."""
+
+    C1 = "C1"
+    """Tier 1 — basic capability."""
+
+    C2 = "C2"
+    """Tier 2 — standard capability."""
+
+    C3 = "C3"
+    """Tier 3 — advanced capability."""
+
+    C4 = "C4"
+    """Tier 4 — maximum capability."""
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, EnumCapabilityTier):
+            return NotImplemented
+        members = list(EnumCapabilityTier)
+        return members.index(self) < members.index(other)
+
+
+__all__: list[str] = ["EnumCapabilityTier"]

--- a/src/omnibase_core/enums/overseer/enum_code_repository_action.py
+++ b/src/omnibase_core/enums/overseer/enum_code_repository_action.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumCodeRepositoryAction(StrEnum):
+    """Actions the overseer can request from a code repository provider.
+
+    Used in protocol dispatch to code repo integrations (e.g. GitHub, GitLab).
+    """
+
+    CLONE = "CLONE"
+    """Clone a repository to local or remote workspace."""
+
+    FETCH = "FETCH"
+    """Fetch latest refs without merging."""
+
+    PULL = "PULL"
+    """Pull and fast-forward the working branch."""
+
+    PUSH = "PUSH"
+    """Push a branch or tag to origin."""
+
+    CREATE_BRANCH = "CREATE_BRANCH"
+    """Create a new branch from a given ref."""
+
+    DELETE_BRANCH = "DELETE_BRANCH"
+    """Delete a branch from origin."""
+
+    CREATE_PULL_REQUEST = "CREATE_PULL_REQUEST"
+    """Open a pull request for review."""
+
+    MERGE_PULL_REQUEST = "MERGE_PULL_REQUEST"
+    """Merge an approved pull request."""
+
+    CREATE_COMMIT = "CREATE_COMMIT"
+    """Stage and commit changes."""
+
+    GET_FILE = "GET_FILE"
+    """Retrieve file contents at a given ref."""
+
+    LIST_FILES = "LIST_FILES"
+    """List files at a given ref and path."""
+
+    GET_DIFF = "GET_DIFF"
+    """Retrieve a diff between two refs."""
+
+
+__all__: list[str] = ["EnumCodeRepositoryAction"]

--- a/src/omnibase_core/enums/overseer/enum_context_bundle_level.py
+++ b/src/omnibase_core/enums/overseer/enum_context_bundle_level.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+from functools import total_ordering
+
+
+@total_ordering
+class EnumContextBundleLevel(StrEnum):
+    """Context bundle verbosity level for overseer context injection.
+
+    Ordered L0 (minimal) through L4 (maximum). Controls how much context
+    is bundled for agent dispatch.
+    """
+
+    L0 = "L0"
+    """Level 0 — minimal context (ticket ID only)."""
+
+    L1 = "L1"
+    """Level 1 — basic context (ticket + summary)."""
+
+    L2 = "L2"
+    """Level 2 — standard context (ticket + summary + entrypoints)."""
+
+    L3 = "L3"
+    """Level 3 — rich context (standard + related decisions + history)."""
+
+    L4 = "L4"
+    """Level 4 — maximum context (everything available)."""
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, EnumContextBundleLevel):
+            return NotImplemented
+        members = list(EnumContextBundleLevel)
+        return members.index(self) < members.index(other)
+
+
+__all__: list[str] = ["EnumContextBundleLevel"]

--- a/src/omnibase_core/enums/overseer/enum_event_bus_action.py
+++ b/src/omnibase_core/enums/overseer/enum_event_bus_action.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumEventBusAction(StrEnum):
+    """Actions the overseer can request from an event bus provider.
+
+    Used in protocol dispatch to messaging integrations (e.g. Kafka/Redpanda).
+    """
+
+    PUBLISH = "PUBLISH"
+    """Publish a message to a topic."""
+
+    SUBSCRIBE = "SUBSCRIBE"
+    """Subscribe a consumer to a topic."""
+
+    UNSUBSCRIBE = "UNSUBSCRIBE"
+    """Remove a consumer subscription from a topic."""
+
+    CREATE_TOPIC = "CREATE_TOPIC"
+    """Create a new topic with given configuration."""
+
+    DELETE_TOPIC = "DELETE_TOPIC"
+    """Delete a topic and its retained messages."""
+
+    LIST_TOPICS = "LIST_TOPICS"
+    """List all available topics."""
+
+    GET_OFFSET = "GET_OFFSET"
+    """Retrieve the current consumer offset for a topic-partition."""
+
+    SEEK_OFFSET = "SEEK_OFFSET"
+    """Set the consumer offset to a specific position."""
+
+    DRAIN = "DRAIN"
+    """Consume and discard all pending messages on a topic."""
+
+
+__all__: list[str] = ["EnumEventBusAction"]

--- a/src/omnibase_core/enums/overseer/enum_failure_class.py
+++ b/src/omnibase_core/enums/overseer/enum_failure_class.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumFailureClass(StrEnum):
+    """Classification of failure types for overseer error routing.
+
+    Each failure class maps to a distinct recovery strategy in the overseer.
+    """
+
+    TRANSIENT = "transient"
+    """Temporary failure — retryable (network timeout, rate limit)."""
+
+    PERMANENT = "permanent"
+    """Unrecoverable failure — do not retry (invalid input, auth denied)."""
+
+    RESOURCE_EXHAUSTION = "resource_exhaustion"
+    """Resource limit hit — backoff or scale (OOM, disk full, quota)."""
+
+    TIMEOUT = "timeout"
+    """Operation exceeded time budget."""
+
+    DEPENDENCY = "dependency"
+    """Upstream dependency unavailable or failing."""
+
+    CONFIGURATION = "configuration"
+    """Misconfiguration detected — requires human intervention."""
+
+    DATA_INTEGRITY = "data_integrity"
+    """Data corruption or constraint violation."""
+
+    UNKNOWN = "unknown"
+    """Unclassified failure — fallback category."""
+
+
+__all__: list[str] = ["EnumFailureClass"]

--- a/src/omnibase_core/enums/overseer/enum_llm_provider_action.py
+++ b/src/omnibase_core/enums/overseer/enum_llm_provider_action.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumLLMProviderAction(StrEnum):
+    """Actions the overseer can request from an LLM provider.
+
+    Used in protocol dispatch to model inference integrations
+    (e.g. OpenAI, Anthropic, vLLM).
+    """
+
+    COMPLETE = "COMPLETE"
+    """Generate a completion for a prompt."""
+
+    CHAT = "CHAT"
+    """Generate a response in a multi-turn chat context."""
+
+    EMBED = "EMBED"
+    """Produce an embedding vector for input text."""
+
+    STREAM = "STREAM"
+    """Stream a completion token-by-token."""
+
+    COUNT_TOKENS = "COUNT_TOKENS"
+    """Count the number of tokens in a given prompt."""
+
+    LIST_MODELS = "LIST_MODELS"
+    """List available models from the provider."""
+
+    GET_MODEL_INFO = "GET_MODEL_INFO"
+    """Retrieve metadata for a specific model."""
+
+    CANCEL = "CANCEL"
+    """Cancel an in-flight inference request."""
+
+
+__all__: list[str] = ["EnumLLMProviderAction"]

--- a/src/omnibase_core/enums/overseer/enum_notification_action.py
+++ b/src/omnibase_core/enums/overseer/enum_notification_action.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumNotificationAction(StrEnum):
+    """Actions the overseer can request from a notification provider.
+
+    Used in protocol dispatch to alerting/messaging integrations
+    (e.g. Slack, PagerDuty, email).
+    """
+
+    SEND = "SEND"
+    """Send a notification message to a target."""
+
+    SEND_ALERT = "SEND_ALERT"
+    """Send a high-priority alert requiring acknowledgement."""
+
+    ACKNOWLEDGE = "ACKNOWLEDGE"
+    """Acknowledge a pending alert."""
+
+    RESOLVE = "RESOLVE"
+    """Mark an alert or incident as resolved."""
+
+    LIST_CHANNELS = "LIST_CHANNELS"
+    """List available notification channels or targets."""
+
+    GET_STATUS = "GET_STATUS"
+    """Retrieve delivery status of a previously sent notification."""
+
+
+__all__: list[str] = ["EnumNotificationAction"]

--- a/src/omnibase_core/enums/overseer/enum_process_runner_state.py
+++ b/src/omnibase_core/enums/overseer/enum_process_runner_state.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumProcessRunnerState(StrEnum):
+    """10-state FSM for process runner lifecycle.
+
+    Canonical state machine for all overseer task execution.
+    States progress from IDLE through terminal states COMPLETED and FAILED_TERMINAL.
+    """
+
+    IDLE = "idle"
+    """Runner is initialized and waiting for a task assignment."""
+
+    PLANNING = "planning"
+    """Runner is analyzing the task and building an execution plan."""
+
+    EXECUTING = "executing"
+    """Runner is actively executing the planned steps."""
+
+    VERIFYING = "verifying"
+    """Runner is validating outputs against acceptance criteria."""
+
+    RETRYING = "retrying"
+    """Runner encountered a transient failure and is re-attempting."""
+
+    WAITING_DEPENDENCY = "waiting_dependency"
+    """Runner is blocked on an upstream dependency to become available."""
+
+    ESCALATING = "escalating"
+    """Runner has exceeded retry budget and is escalating to the overseer."""
+
+    RECOVERING = "recovering"
+    """Runner is executing a recovery procedure after a failure."""
+
+    COMPLETED = "completed"
+    """Terminal: runner finished successfully."""
+
+    FAILED_TERMINAL = "failed_terminal"
+    """Terminal: runner exhausted all recovery paths; task cannot proceed."""
+
+
+__all__: list[str] = ["EnumProcessRunnerState"]

--- a/src/omnibase_core/enums/overseer/enum_provider.py
+++ b/src/omnibase_core/enums/overseer/enum_provider.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumProvider(StrEnum):
+    """Model provider identifiers for overseer routing decisions."""
+
+    ANTHROPIC = "anthropic"
+    """Anthropic Claude family."""
+
+    OPENAI = "openai"
+    """OpenAI GPT / o-series family."""
+
+    GOOGLE = "google"
+    """Google Gemini family."""
+
+    LOCAL = "local"
+    """Locally-hosted model (vLLM, Ollama, etc.)."""
+
+    UNKNOWN = "unknown"
+    """Provider cannot be determined."""
+
+
+__all__: list[str] = ["EnumProvider"]

--- a/src/omnibase_core/enums/overseer/enum_retry_type.py
+++ b/src/omnibase_core/enums/overseer/enum_retry_type.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumRetryType(StrEnum):
+    """Retry strategy for overseer task routing decisions."""
+
+    NONE = "none"
+    """No retry — fail immediately on first error."""
+
+    IMMEDIATE = "immediate"
+    """Retry immediately without delay."""
+
+    BACKOFF = "backoff"
+    """Exponential backoff between retries."""
+
+    ESCALATE = "escalate"
+    """Escalate to a higher-capability model on retry."""
+
+
+__all__: list[str] = ["EnumRetryType"]

--- a/src/omnibase_core/enums/overseer/enum_risk_level.py
+++ b/src/omnibase_core/enums/overseer/enum_risk_level.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumRiskLevel(StrEnum):
+    """Risk level for overseer routing policy decisions."""
+
+    LOW = "low"
+    """Low risk — minimal validation required."""
+
+    MEDIUM = "medium"
+    """Medium risk — standard validation applied."""
+
+    HIGH = "high"
+    """High risk — elevated scrutiny and human review gate."""
+
+    CRITICAL = "critical"
+    """Critical risk — requires explicit authorization before dispatch."""
+
+
+__all__: list[str] = ["EnumRiskLevel"]

--- a/src/omnibase_core/enums/overseer/enum_ticket_service_action.py
+++ b/src/omnibase_core/enums/overseer/enum_ticket_service_action.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumTicketServiceAction(StrEnum):
+    """Actions the overseer can request from a ticket service provider.
+
+    Used in protocol dispatch to issue-tracking integrations (e.g. Linear, Jira).
+    """
+
+    CREATE_ISSUE = "CREATE_ISSUE"
+    """Create a new issue or ticket."""
+
+    UPDATE_ISSUE = "UPDATE_ISSUE"
+    """Update fields on an existing issue."""
+
+    GET_ISSUE = "GET_ISSUE"
+    """Retrieve a single issue by identifier."""
+
+    LIST_ISSUES = "LIST_ISSUES"
+    """List issues matching a query or filter."""
+
+    TRANSITION_STATUS = "TRANSITION_STATUS"
+    """Move an issue to a new workflow status."""
+
+    ASSIGN_ISSUE = "ASSIGN_ISSUE"
+    """Assign an issue to a user."""
+
+    ADD_COMMENT = "ADD_COMMENT"
+    """Append a comment to an issue."""
+
+    DELETE_ISSUE = "DELETE_ISSUE"
+    """Delete or archive an issue."""
+
+    LINK_ISSUES = "LINK_ISSUES"
+    """Create a relation between two issues."""
+
+
+__all__: list[str] = ["EnumTicketServiceAction"]

--- a/src/omnibase_core/enums/overseer/enum_verifier_verdict.py
+++ b/src/omnibase_core/enums/overseer/enum_verifier_verdict.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumVerifierVerdict(StrEnum):
+    """Verdict from the deterministic verification layer.
+
+    Each verdict maps to a routing action in the overseer:
+    - PASS: proceed to next stage
+    - FAIL: halt and report
+    - RETRY_REQUIRED: re-run with adjusted parameters
+    - ESCALATE: route to higher-tier agent or human
+    """
+
+    PASS = "PASS"
+    """All checks passed — proceed."""
+
+    FAIL = "FAIL"
+    """One or more critical checks failed — halt."""
+
+    RETRY_REQUIRED = "RETRY_REQUIRED"
+    """Transient failure detected — retry with backoff."""
+
+    ESCALATE = "ESCALATE"
+    """Verification inconclusive — escalate to higher tier."""
+
+
+__all__: list[str] = ["EnumVerifierVerdict"]

--- a/tests/unit/enums/overseer/__init__.py
+++ b/tests/unit/enums/overseer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/enums/overseer/test_overseer_enum_imports.py
+++ b/tests/unit/enums/overseer/test_overseer_enum_imports.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""RED test: assert all 14 overseer enums exist at the new core path."""
+"""Assert all 14 overseer enums exist at the new core path."""
 
 import pytest
 

--- a/tests/unit/enums/overseer/test_overseer_enum_imports.py
+++ b/tests/unit/enums/overseer/test_overseer_enum_imports.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED test: assert all 14 overseer enums exist at the new core path."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestOverseerEnumImports:
+    def test_enum_artifact_store_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_artifact_store_action import (
+            EnumArtifactStoreAction,
+        )
+
+        assert EnumArtifactStoreAction.UPLOAD == "UPLOAD"
+        assert EnumArtifactStoreAction.DOWNLOAD == "DOWNLOAD"
+        assert EnumArtifactStoreAction.DELETE == "DELETE"
+        assert EnumArtifactStoreAction.LIST == "LIST"
+        assert EnumArtifactStoreAction.EXISTS == "EXISTS"
+        assert EnumArtifactStoreAction.GET_METADATA == "GET_METADATA"
+        assert EnumArtifactStoreAction.COPY == "COPY"
+        assert EnumArtifactStoreAction.MOVE == "MOVE"
+
+    def test_enum_capability_tier_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_capability_tier import EnumCapabilityTier
+
+        assert EnumCapabilityTier.C0 == "C0"
+        assert EnumCapabilityTier.C4 == "C4"
+        assert EnumCapabilityTier.C0 < EnumCapabilityTier.C4
+
+    def test_enum_code_repository_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_code_repository_action import (
+            EnumCodeRepositoryAction,
+        )
+
+        assert EnumCodeRepositoryAction.CLONE == "CLONE"
+        assert EnumCodeRepositoryAction.PUSH == "PUSH"
+        assert EnumCodeRepositoryAction.CREATE_PULL_REQUEST == "CREATE_PULL_REQUEST"
+
+    def test_enum_context_bundle_level_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_context_bundle_level import (
+            EnumContextBundleLevel,
+        )
+
+        assert EnumContextBundleLevel.L0 == "L0"
+        assert EnumContextBundleLevel.L4 == "L4"
+        assert EnumContextBundleLevel.L0 < EnumContextBundleLevel.L4
+
+    def test_enum_event_bus_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_event_bus_action import (
+            EnumEventBusAction,
+        )
+
+        assert EnumEventBusAction.PUBLISH == "PUBLISH"
+        assert EnumEventBusAction.SUBSCRIBE == "SUBSCRIBE"
+        assert EnumEventBusAction.DRAIN == "DRAIN"
+
+    def test_enum_failure_class_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_failure_class import EnumFailureClass
+
+        assert EnumFailureClass.TRANSIENT == "transient"
+        assert EnumFailureClass.PERMANENT == "permanent"
+        assert EnumFailureClass.UNKNOWN == "unknown"
+
+    def test_enum_llm_provider_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_llm_provider_action import (
+            EnumLLMProviderAction,
+        )
+
+        assert EnumLLMProviderAction.COMPLETE == "COMPLETE"
+        assert EnumLLMProviderAction.CHAT == "CHAT"
+        assert EnumLLMProviderAction.EMBED == "EMBED"
+
+    def test_enum_notification_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_notification_action import (
+            EnumNotificationAction,
+        )
+
+        assert EnumNotificationAction.SEND == "SEND"
+        assert EnumNotificationAction.SEND_ALERT == "SEND_ALERT"
+        assert EnumNotificationAction.RESOLVE == "RESOLVE"
+
+    def test_enum_process_runner_state_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_process_runner_state import (
+            EnumProcessRunnerState,
+        )
+
+        assert EnumProcessRunnerState.IDLE == "idle"
+        assert EnumProcessRunnerState.COMPLETED == "completed"
+        assert EnumProcessRunnerState.FAILED_TERMINAL == "failed_terminal"
+
+    def test_enum_provider_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_provider import EnumProvider
+
+        assert EnumProvider.ANTHROPIC == "anthropic"
+        assert EnumProvider.LOCAL == "local"
+        assert EnumProvider.UNKNOWN == "unknown"
+
+    def test_enum_retry_type_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_retry_type import EnumRetryType
+
+        assert EnumRetryType.NONE == "none"
+        assert EnumRetryType.BACKOFF == "backoff"
+        assert EnumRetryType.ESCALATE == "escalate"
+
+    def test_enum_risk_level_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_risk_level import EnumRiskLevel
+
+        assert EnumRiskLevel.LOW == "low"
+        assert EnumRiskLevel.CRITICAL == "critical"
+
+    def test_enum_ticket_service_action_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_ticket_service_action import (
+            EnumTicketServiceAction,
+        )
+
+        assert EnumTicketServiceAction.CREATE_ISSUE == "CREATE_ISSUE"
+        assert EnumTicketServiceAction.TRANSITION_STATUS == "TRANSITION_STATUS"
+        assert EnumTicketServiceAction.LINK_ISSUES == "LINK_ISSUES"
+
+    def test_enum_verifier_verdict_import(self) -> None:
+        from omnibase_core.enums.overseer.enum_verifier_verdict import (
+            EnumVerifierVerdict,
+        )
+
+        assert EnumVerifierVerdict.PASS == "PASS"
+        assert EnumVerifierVerdict.FAIL == "FAIL"
+        assert EnumVerifierVerdict.ESCALATE == "ESCALATE"
+
+    def test_overseer_namespace_init_imports(self) -> None:
+        from omnibase_core.enums.overseer import (
+            EnumArtifactStoreAction,
+            EnumCapabilityTier,
+            EnumCodeRepositoryAction,
+            EnumContextBundleLevel,
+            EnumEventBusAction,
+            EnumFailureClass,
+            EnumLLMProviderAction,
+            EnumNotificationAction,
+            EnumProcessRunnerState,
+            EnumProvider,
+            EnumRetryType,
+            EnumRiskLevel,
+            EnumTicketServiceAction,
+            EnumVerifierVerdict,
+        )
+
+        assert EnumArtifactStoreAction.UPLOAD == "UPLOAD"
+        assert EnumCapabilityTier.C0 == "C0"
+        assert EnumCodeRepositoryAction.CLONE == "CLONE"
+        assert EnumContextBundleLevel.L0 == "L0"
+        assert EnumEventBusAction.PUBLISH == "PUBLISH"
+        assert EnumFailureClass.TRANSIENT == "transient"
+        assert EnumLLMProviderAction.COMPLETE == "COMPLETE"
+        assert EnumNotificationAction.SEND == "SEND"
+        assert EnumProcessRunnerState.IDLE == "idle"
+        assert EnumProvider.ANTHROPIC == "anthropic"
+        assert EnumRetryType.NONE == "none"
+        assert EnumRiskLevel.LOW == "low"
+        assert EnumTicketServiceAction.CREATE_ISSUE == "CREATE_ISSUE"
+        assert EnumVerifierVerdict.PASS == "PASS"


### PR DESCRIPTION
## Summary

- Creates `omnibase_core/src/omnibase_core/enums/overseer/` namespace (Wave 2 of OCC-to-core migration)
- Copies 14 overseer enums from `onex_change_control.overseer` into core (additive only — OCC not deleted)
- Re-exports all 14 via `enums/overseer/__init__.py` and parent `enums/__init__.py`

## Enums migrated

`EnumArtifactStoreAction`, `EnumCapabilityTier`, `EnumCodeRepositoryAction`, `EnumContextBundleLevel`, `EnumEventBusAction`, `EnumFailureClass`, `EnumLLMProviderAction`, `EnumNotificationAction`, `EnumProcessRunnerState`, `EnumProvider`, `EnumRetryType`, `EnumRiskLevel`, `EnumTicketServiceAction`, `EnumVerifierVerdict`

## Ticket

OMN-10244

## dod_evidence

- 14 enum files at `src/omnibase_core/enums/overseer/enum_*.py`
- `src/omnibase_core/enums/overseer/__init__.py` re-exports all 14
- `src/omnibase_core/enums/__init__.py` updated with overseer imports + `__all__` entries
- 15 TDD tests at `tests/unit/enums/overseer/test_overseer_enum_imports.py` — RED confirmed, all 15 GREEN
- `uv run mypy src/omnibase_core/enums/overseer/ --strict` → `Success: no issues found in 15 source files`
- All 55 pre-commit hooks passed
- Pre-push hooks passed (mypy strict + pyright)

## Test plan

- [ ] CI passes `pytest tests/unit/enums/overseer/`
- [ ] mypy strict clean on overseer namespace
- [ ] No regressions in existing enum tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overseer enum namespace providing 14 standardized enums for artifact store, code repo, event bus, LLM provider, notifications, ticket service, process runner, retry/risk/capability tiers, failure classification, and verifier verdicts — including ordering support for tiers/levels.
* **Tests**
  * Added unit tests validating enum imports and expected values/ordering.
* **Chores**
  * Added a new contract describing schema/versioning and CI/DOD checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->