### PR TITLE
feat(OMN-10245): create core/models/governance/ namespace + batch A models

### DIFF
--- a/src/omnibase_core/models/governance/__init__.py
+++ b/src/omnibase_core/models/governance/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Governance models for the ONEX platform."""

--- a/src/omnibase_core/models/governance/model_contract_dependency_input.py
+++ b/src/omnibase_core/models/governance/model_contract_dependency_input.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for contract dependency computation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.governance.model_contract_entry import ModelContractEntry
+
+
+class ModelContractDependencyInput(BaseModel):
+    """Input to the contract dependency compute node."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entries: list[ModelContractEntry]
+    repo_filter: list[str] = []  # empty = all repos

--- a/src/omnibase_core/models/governance/model_contract_dependency_output.py
+++ b/src/omnibase_core/models/governance/model_contract_dependency_output.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Output model for contract dependency computation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.governance.model_contract_entry import ModelContractEntry
+from omnibase_core.models.governance.model_contract_overlap_edge import (
+    ModelContractOverlapEdge,
+)
+from omnibase_core.models.governance.model_dependency_wave import ModelDependencyWave
+from omnibase_core.models.governance.model_hotspot_topic import ModelHotspotTopic
+
+
+class ModelContractDependencyOutput(BaseModel):
+    """Contract overlap graph: dependency edges and parallel wave groups."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entries: list[ModelContractEntry]
+    edges: list[ModelContractOverlapEdge]
+    waves: list[ModelDependencyWave]
+    hotspot_topics: list[ModelHotspotTopic]

--- a/src/omnibase_core/models/governance/model_contract_drift_input.py
+++ b/src/omnibase_core/models/governance/model_contract_drift_input.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for contract drift detection."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_drift_sensitivity import EnumDriftSensitivity
+
+
+class ModelContractDriftInput(BaseModel):
+    """Input to the contract drift detector COMPUTE node."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    contract_name: str = Field(
+        description="Human-readable identifier for the contract being checked."
+    )
+    current_contract: dict[str, object] = Field(
+        description="Current contract content, e.g. as loaded by ContractLoader."
+    )
+    pinned_hash: str = Field(
+        description="SHA-256 hex digest of the previously accepted canonical form."
+    )
+    sensitivity: EnumDriftSensitivity = Field(
+        default=EnumDriftSensitivity.STANDARD,
+        description="Controls which change categories produce a non-NONE severity.",
+    )

--- a/src/omnibase_core/models/governance/model_contract_drift_output.py
+++ b/src/omnibase_core/models/governance/model_contract_drift_output.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Output model for contract drift detection."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_drift_severity import (
+    EnumDriftSeverity,
+)
+from omnibase_core.models.governance.model_field_change import ModelFieldChange
+
+
+class ModelContractDriftOutput(BaseModel):
+    """Full drift report produced by the contract drift COMPUTE node."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    contract_name: str
+    severity: EnumDriftSeverity
+    current_hash: str = Field(description="Canonical hash of the current contract.")
+    pinned_hash: str = Field(description="Hash supplied in the input (baseline).")
+    drift_detected: bool
+    field_changes: list[ModelFieldChange]
+    breaking_changes: list[str] = Field(
+        description="Human-readable summaries of breaking changes."
+    )
+    additive_changes: list[str] = Field(
+        description="Human-readable summaries of additive changes."
+    )
+    non_breaking_changes: list[str] = Field(
+        description="Human-readable summaries of non-breaking changes."
+    )
+    summary: str = Field(description="One-line summary of the drift report.")

--- a/src/omnibase_core/models/governance/model_contract_entry.py
+++ b/src/omnibase_core/models/governance/model_contract_entry.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract entry model — declared protocol surfaces for a single contract."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.governance.model_db_table_ref import ModelDbTableRef
+
+
+class ModelContractEntry(BaseModel):
+    """A single contract's declared protocol surfaces."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str
+    node_name: str
+    subscribe_topics: list[str]
+    publish_topics: list[str]
+    protocols: list[str]  # EnumInterfaceSurface values
+    db_tables: list[ModelDbTableRef] = []

--- a/src/omnibase_core/models/governance/model_contract_overlap_edge.py
+++ b/src/omnibase_core/models/governance/model_contract_overlap_edge.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract overlap edge model — overlap between two contracts sharing protocol surfaces."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, computed_field
+
+_EDGE_NAMESPACE = uuid.UUID("c3d4e5f6-a7b8-9012-cdef-234567890abc")
+
+
+class ModelContractOverlapEdge(BaseModel):
+    """An overlap edge between two contracts sharing protocol surfaces.
+
+    overlap_type values: "topic_producer_consumer", "topic_co_consumer",
+        "topic_co_producer", "db_table_shared_write", "db_table_read_write",
+        "protocol", "mixed"
+    direction values: "producer_to_consumer", "co_consumer",
+        "co_producer", "bidirectional"
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    node_a_repo: str
+    node_a_name: str
+    node_b_repo: str
+    node_b_name: str
+    shared_topics: list[str]
+    shared_protocols: list[str]
+    shared_db_tables: list[str] = []
+    overlap_type: str  # see docstring for valid values
+    # "producer_to_consumer", "co_consumer", "co_producer", "bidirectional"
+    direction: str
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def edge_id(self) -> uuid.UUID:
+        pair = sorted(
+            [
+                f"{self.node_a_repo}/{self.node_a_name}",
+                f"{self.node_b_repo}/{self.node_b_name}",
+            ]
+        )
+        surfaces = sorted(
+            self.shared_topics + self.shared_protocols + self.shared_db_tables
+        )
+        key = f"{pair[0]}|{pair[1]}|{self.direction}|{','.join(surfaces)}"
+        return uuid.uuid5(_EDGE_NAMESPACE, key)

--- a/src/omnibase_core/models/governance/model_db_table_ref.py
+++ b/src/omnibase_core/models/governance/model_db_table_ref.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Database table reference model for contract dependency tracking."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelDbTableRef(BaseModel):
+    """A database table reference with access mode."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    access: str  # "read", "write", "read_write"

--- a/src/omnibase_core/models/governance/model_dependency_history.py
+++ b/src/omnibase_core/models/governance/model_dependency_history.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dependency history — accumulated state from dependency reducer."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.governance.model_contract_dependency_output import (
+    ModelContractDependencyOutput,
+)
+from omnibase_core.models.governance.model_dependency_snapshot import (
+    ModelDependencySnapshot,
+)
+from omnibase_core.models.governance.model_hotspot_topic import ModelHotspotTopic
+
+
+class ModelDependencyHistory(BaseModel):
+    """Accumulated dependency state over time."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    state: str  # "stable" or "hotspot_detected"
+    snapshots: list[ModelDependencySnapshot]
+    persistent_hotspots: list[
+        ModelHotspotTopic
+    ]  # topics that are hotspots in 3+ consecutive snapshots
+    latest: ModelContractDependencyOutput | None = None

--- a/src/omnibase_core/models/governance/model_dependency_snapshot.py
+++ b/src/omnibase_core/models/governance/model_dependency_snapshot.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dependency snapshot model — a single dependency graph observation."""
+
+from __future__ import annotations
+
+from datetime import (
+    datetime,
+)
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelDependencySnapshot(BaseModel):
+    """A single dependency graph observation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    observed_at: datetime
+    edge_count: int
+    wave_count: int
+    hotspot_count: int

--- a/src/omnibase_core/models/governance/model_dependency_wave.py
+++ b/src/omnibase_core/models/governance/model_dependency_wave.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dependency wave model — conservative overlap-based parallel group of nodes."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelDependencyWave(BaseModel):
+    """A conservative overlap-based parallel group of nodes.
+
+    Nodes in the same wave have no detected overlap with each other.
+    Waves represent non-overlapping grouping, not guaranteed safe topological ordering.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    wave_number: int
+    node_refs: list[str]  # "repo/node_name" format

--- a/src/omnibase_core/models/governance/model_doc_cross_ref_check.py
+++ b/src/omnibase_core/models/governance/model_doc_cross_ref_check.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLAUDE.md cross-reference check result model."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDocCrossRefCheck(BaseModel):
+    """Result of checking a single CLAUDE.md instruction against repo state.
+
+    Used by the CLAUDE.md cross-reference checker to validate that
+    instructions (commands, paths, conventions, table entries) match
+    the actual state of the repository.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    instruction: str = Field(
+        ...,
+        description="The CLAUDE.md instruction being checked",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    line_number: int = Field(
+        ...,
+        description="Line number in the CLAUDE.md file",
+        ge=1,
+    )
+    check_type: str = Field(
+        ...,
+        description="Type of check: command, path, convention, table",
+    )
+    verified: bool = Field(
+        ...,
+        description="Whether the instruction was verified as correct",
+    )
+    evidence: str = Field(
+        ...,
+        description="What was checked and what was found",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_doc_reference.py
+++ b/src/omnibase_core/models/governance/model_doc_reference.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Document reference model for doc freshness scanning."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_doc_reference_type import EnumDocReferenceType
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDocReference(BaseModel):
+    """A single reference extracted from a documentation file.
+
+    Represents a code reference (file path, class name, function name,
+    command, URL, or env var) found in a .md file, along with resolution
+    status indicating whether the referenced target still exists.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    doc_path: str = Field(
+        ...,
+        description="Path to the .md file containing the reference",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    line_number: int = Field(
+        ...,
+        description="Line where reference appears",
+        ge=1,
+    )
+    reference_type: EnumDocReferenceType = Field(
+        ...,
+        description="What kind of reference this is",
+    )
+    raw_text: str = Field(
+        ...,
+        description="The raw text of the reference as it appears in the doc",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    resolved_target: str | None = Field(
+        default=None,
+        description="The absolute path or identifier the reference resolves to",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    exists: bool | None = Field(
+        default=None,
+        description="Whether the target exists (None = could not check)",
+    )

--- a/src/omnibase_core/models/governance/model_drift_history.py
+++ b/src/omnibase_core/models/governance/model_drift_history.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Drift history accumulation model for the REDUCER node."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_contract_drift_output import (
+    ModelContractDriftOutput,
+)
+
+
+class ModelDriftHistory(BaseModel):
+    """Accumulated drift state for a single contract over time."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    contract_name: str
+    state: str = Field(
+        default="clean",
+        description=(
+            "FSM state: clean, drifted. (Phase 1 — acknowledged/resolved deferred.)"
+        ),
+    )
+    drift_reports: list[ModelContractDriftOutput] = Field(
+        default_factory=list,
+        description="Ordered list of drift reports for this contract.",
+    )
+    transition_count: int = Field(
+        default=0,
+        description="Number of FSM state transitions.",
+    )

--- a/src/omnibase_core/models/governance/model_field_change.py
+++ b/src/omnibase_core/models/governance/model_field_change.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Field change model for contract drift detection."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelFieldChange(BaseModel):
+    """A single field-level change between current and pinned contract."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    path: str = Field(description="Dot-separated path to the changed field.")
+    change_type: str = Field(description="One of: 'added', 'removed', 'modified'.")
+    old_value: str | int | float | bool | list[object] | dict[str, object] | None = (
+        Field(default=None, description="Value in the pinned contract.")
+    )
+    new_value: str | int | float | bool | list[object] | dict[str, object] | None = (
+        Field(default=None, description="Value in the current contract.")
+    )
+    is_breaking: bool = Field(
+        description="True when this change is likely to break existing consumers."
+    )

--- a/src/omnibase_core/models/governance/model_handler_compliance_result.py
+++ b/src/omnibase_core/models/governance/model_handler_compliance_result.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Handler Compliance Result Model.
+
+Single handler audit result for contract compliance checks.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_compliance_verdict import EnumComplianceVerdict
+from omnibase_core.enums.governance.enum_compliance_violation import (
+    EnumComplianceViolation,
+)
+
+
+class ModelHandlerComplianceResult(BaseModel):
+    """Audit result for a single handler's contract compliance.
+
+    Captures the cross-reference between a handler's actual behavior
+    (topics used, transports imported, routing registration) and what
+    is declared in its contract.yaml.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    handler_path: str = Field(
+        ...,
+        description="Relative path to handler file",
+    )
+    node_dir: str = Field(
+        ...,
+        description="Parent node directory",
+    )
+    repo: str = Field(
+        ...,
+        description="Repository name",
+    )
+    contract_path: str | None = Field(
+        default=None,
+        description="Path to associated contract.yaml (None if missing)",
+    )
+    violations: list[EnumComplianceViolation] = Field(
+        default_factory=list,
+        description="Specific violations found",
+    )
+    violation_details: list[str] = Field(
+        default_factory=list,
+        description="Human-readable detail per violation",
+    )
+    declared_topics: list[str] = Field(
+        default_factory=list,
+        description="Topics declared in contract.yaml",
+    )
+    used_topics: list[str] = Field(
+        default_factory=list,
+        description="Topics referenced in handler source code",
+    )
+    undeclared_topics: list[str] = Field(
+        default_factory=list,
+        description="Topics used but not declared",
+    )
+    declared_transports: list[str] = Field(
+        default_factory=list,
+        description="Transports declared in contract capabilities",
+    )
+    used_transports: list[str] = Field(
+        default_factory=list,
+        description="Transports detected in handler imports/calls",
+    )
+    undeclared_transports: list[str] = Field(
+        default_factory=list,
+        description="Transports used but not declared",
+    )
+    handler_in_routing: bool = Field(
+        default=False,
+        description="Whether handler is registered in contract.yaml handler_routing",
+    )
+    verdict: EnumComplianceVerdict = Field(
+        ...,
+        description="Overall compliance verdict",
+    )
+    allowlisted: bool = Field(
+        default=False,
+        description="Whether this handler is in the allowlist",
+    )

--- a/src/omnibase_core/models/governance/model_hotspot_topic.py
+++ b/src/omnibase_core/models/governance/model_hotspot_topic.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Hotspot topic model — a topic appearing in multiple contract overlap edges."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelHotspotTopic(BaseModel):
+    """A topic that appears in multiple contract overlap edges."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    topic: str
+    overlap_count: int
+    node_refs: list[str]

--- a/tests/unit/models/governance/__init__.py
+++ b/tests/unit/models/governance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/governance/test_governance_model_batch_a.py
+++ b/tests/unit/models/governance/test_governance_model_batch_a.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Red tests for governance model Batch A — 7 simple models (OMN-10245)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+
+@pytest.mark.unit
+class TestGovernanceBatchAImports:
+    """Assert all Batch A governance models importable from omnibase_core.models.governance.*"""
+
+    def test_model_doc_cross_ref_check_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_doc_cross_ref_check import (
+            ModelDocCrossRefCheck,
+        )
+
+        assert issubclass(ModelDocCrossRefCheck, BaseModel)
+
+    def test_model_doc_reference_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_doc_reference import (
+            ModelDocReference,
+        )
+
+        assert issubclass(ModelDocReference, BaseModel)
+
+    def test_model_contract_drift_input_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_contract_drift_input import (
+            ModelContractDriftInput,
+        )
+
+        assert issubclass(ModelContractDriftInput, BaseModel)
+
+    def test_model_handler_compliance_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_handler_compliance_result import (
+            ModelHandlerComplianceResult,
+        )
+
+        assert issubclass(ModelHandlerComplianceResult, BaseModel)
+
+    def test_model_drift_history_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_drift_history import (
+            ModelDriftHistory,
+        )
+
+        assert issubclass(ModelDriftHistory, BaseModel)
+
+    def test_model_dependency_snapshot_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dependency_history import (
+            ModelDependencySnapshot,
+        )
+
+        assert issubclass(ModelDependencySnapshot, BaseModel)
+
+    def test_model_dependency_history_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dependency_history import (
+            ModelDependencyHistory,
+        )
+
+        assert issubclass(ModelDependencyHistory, BaseModel)


### PR DESCRIPTION
## Summary

Closes OMN-10245 (Wave 3, Task 5).

- Creates `omnibase_core/models/governance/` namespace (additive only — OCC untouched)
- Migrates 7 Batch A governance models from `onex_change_control`:
  - `ModelDocCrossRefCheck`, `ModelDocReference`, `ModelContractDriftInput`, `ModelHandlerComplianceResult`, `ModelDriftHistory`, `ModelDependencySnapshot`, `ModelDependencyHistory`
- Adds required supporting models (no OCC cross-deps):
  - `ModelFieldChange`, `ModelContractDriftOutput`
  - `ModelDbTableRef`, `ModelContractEntry`, `ModelContractDependencyInput`
  - `ModelContractOverlapEdge` (renamed from `ModelDependencyEdge` to avoid collision with `manifest/model_dependency_edge.py` — distinct concept)
  - `ModelDependencyWave`, `ModelHotspotTopic`, `ModelContractDependencyOutput`
- All imports updated: `onex_change_control.enums.*` → `omnibase_core.enums.governance.*`
- Single-class-per-file enforced throughout
- `dict[str, Any]` replaced with `dict[str, object]`

## Verification

- 7/7 TDD tests green (`tests/unit/models/governance/test_governance_model_batch_a.py`)
- `uv run mypy src/omnibase_core/models/governance/ --strict` → clean
- All 57 pre-commit hooks pass

## Test plan

- [ ] `uv run pytest tests/unit/models/governance/ -v` → 7 passed
- [ ] `uv run mypy src/omnibase_core/ --strict` → no issues
- [ ] CI green on this PR
- [ ] OCC sibling PR (`chore(OMN-10245): add ticket contract and receipts`) merges first or concurrently