### PR TITLE
feat(OMN-10251): migrate overseer models to core + rename to ModelWorkerEvidenceRequirement

### DIFF
--- a/src/omnibase_core/enums/overseer/__init__.py
+++ b/src/omnibase_core/enums/overseer/__init__.py
@@ -9,6 +9,7 @@ Migrated from onex_change_control.overseer (Wave 2 — additive copy; OCC not de
 from .enum_artifact_store_action import EnumArtifactStoreAction
 from .enum_capability_tier import EnumCapabilityTier
 from .enum_code_repository_action import EnumCodeRepositoryAction
+from .enum_completion_outcome import EnumCompletionOutcome
 from .enum_context_bundle_level import EnumContextBundleLevel
 from .enum_event_bus_action import EnumEventBusAction
 from .enum_failure_class import EnumFailureClass
@@ -18,6 +19,7 @@ from .enum_process_runner_state import EnumProcessRunnerState
 from .enum_provider import EnumProvider
 from .enum_retry_type import EnumRetryType
 from .enum_risk_level import EnumRiskLevel
+from .enum_task_status import EnumTaskStatus
 from .enum_ticket_service_action import EnumTicketServiceAction
 from .enum_verifier_verdict import EnumVerifierVerdict
 
@@ -25,6 +27,7 @@ __all__: list[str] = [
     "EnumArtifactStoreAction",
     "EnumCapabilityTier",
     "EnumCodeRepositoryAction",
+    "EnumCompletionOutcome",
     "EnumContextBundleLevel",
     "EnumEventBusAction",
     "EnumFailureClass",
@@ -34,6 +37,7 @@ __all__: list[str] = [
     "EnumProvider",
     "EnumRetryType",
     "EnumRiskLevel",
+    "EnumTaskStatus",
     "EnumTicketServiceAction",
     "EnumVerifierVerdict",
 ]

--- a/src/omnibase_core/enums/overseer/enum_completion_outcome.py
+++ b/src/omnibase_core/enums/overseer/enum_completion_outcome.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumCompletionOutcome — terminal outcome for overseer performance ledger (OMN-10251)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumCompletionOutcome(StrEnum):
+    """Terminal outcome for a completed task in the performance ledger."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL = "partial"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    SKIPPED = "skipped"
+
+
+__all__ = ["EnumCompletionOutcome"]

--- a/src/omnibase_core/enums/overseer/enum_task_status.py
+++ b/src/omnibase_core/enums/overseer/enum_task_status.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumTaskStatus — FSM states for overseer task lifecycle (OMN-10251)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTaskStatus(StrEnum):
+    """FSM states for overseer task lifecycle.
+
+    10-member finite state machine covering the full task lifecycle
+    from creation through terminal states.
+    """
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    DISPATCHED = "dispatched"
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    TIMEOUT = "timeout"
+    SKIPPED = "skipped"
+
+
+__all__ = ["EnumTaskStatus"]

--- a/src/omnibase_core/models/overseer/__init__.py
+++ b/src/omnibase_core/models/overseer/__init__.py
@@ -3,7 +3,7 @@
 
 """Overseer models namespace (OMN-10251).
 
-13 model files migrated from OCC into omnibase_core.models.overseer.
+20 model files migrated from OCC into omnibase_core.models.overseer.
 ModelEvidenceRequirement collision resolved: OCC overseer version is
 ModelWorkerEvidenceRequirement; core's ModelEvidenceRequirement is unchanged.
 """

--- a/src/omnibase_core/models/overseer/__init__.py
+++ b/src/omnibase_core/models/overseer/__init__.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Overseer models namespace (OMN-10251).
+
+13 model files migrated from OCC into omnibase_core.models.overseer.
+ModelEvidenceRequirement collision resolved: OCC overseer version is
+ModelWorkerEvidenceRequirement; core's ModelEvidenceRequirement is unchanged.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.overseer.enum_completion_outcome import EnumCompletionOutcome
+from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+from omnibase_core.models.overseer.model_completion_report import ModelCompletionReport
+from omnibase_core.models.overseer.model_context_bundle import (
+    ModelContextBundle,
+    ModelContextBundleL0,
+    ModelContextBundleL1,
+    ModelContextBundleL2,
+    ModelContextBundleL3,
+    ModelContextBundleL4,
+    _ContextBundleBase,
+)
+from omnibase_core.models.overseer.model_contract_allowed_actions import (
+    ModelContractAllowedActions,
+)
+from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
+from omnibase_core.models.overseer.model_escalation_request import (
+    ModelEscalationRequest,
+)
+from omnibase_core.models.overseer.model_overnight_contract import (
+    ModelOvernightContract,
+)
+from omnibase_core.models.overseer.model_overnight_halt_condition import (
+    ModelOvernightHaltCondition,
+)
+from omnibase_core.models.overseer.model_overnight_phase_spec import (
+    ModelOvernightPhaseSpec,
+)
+from omnibase_core.models.overseer.model_process_runner_state_transition import (
+    ModelProcessRunnerStateTransition,
+)
+from omnibase_core.models.overseer.model_session_contract import ModelSessionContract
+from omnibase_core.models.overseer.model_session_halt_condition import (
+    ModelSessionHaltCondition,
+)
+from omnibase_core.models.overseer.model_session_phase_spec import ModelSessionPhaseSpec
+from omnibase_core.models.overseer.model_task_delta_envelope import (
+    ModelTaskDeltaEnvelope,
+)
+from omnibase_core.models.overseer.model_task_shape_features import (
+    ModelTaskShapeFeatures,
+)
+from omnibase_core.models.overseer.model_task_state_envelope import (
+    ModelTaskStateEnvelope,
+)
+from omnibase_core.models.overseer.model_verifier_output import ModelVerifierOutput
+from omnibase_core.models.overseer.model_worker_contract import (
+    ModelWorkerContract,
+    load_worker_contract,
+)
+from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+    ModelWorkerEvidenceRequirement,
+)
+
+__all__ = [
+    "_ContextBundleBase",
+    "EnumCompletionOutcome",
+    "EnumTaskStatus",
+    "ModelCompletionReport",
+    "ModelContextBundle",
+    "ModelContextBundleL0",
+    "ModelContextBundleL1",
+    "ModelContextBundleL2",
+    "ModelContextBundleL3",
+    "ModelContextBundleL4",
+    "ModelContractAllowedActions",
+    "ModelDispatchItem",
+    "ModelEscalationRequest",
+    "ModelOvernightContract",
+    "ModelOvernightHaltCondition",
+    "ModelOvernightPhaseSpec",
+    "ModelProcessRunnerStateTransition",
+    "ModelSessionContract",
+    "ModelSessionHaltCondition",
+    "ModelSessionPhaseSpec",
+    "ModelTaskDeltaEnvelope",
+    "ModelTaskShapeFeatures",
+    "ModelTaskStateEnvelope",
+    "ModelVerifierOutput",
+    "ModelWorkerContract",
+    "ModelWorkerEvidenceRequirement",
+    "load_worker_contract",
+]

--- a/src/omnibase_core/models/overseer/model_completion_report.py
+++ b/src/omnibase_core/models/overseer/model_completion_report.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelCompletionReport — final outcome report for the overseer performance ledger (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from omnibase_core.enums.overseer.enum_completion_outcome import EnumCompletionOutcome
+from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "task_id and runner_id are overseer wire IDs (correlation strings), "
+        "not system UUIDs. Overseer state machine uses string-keyed tasks."
+    )
+)
+@allow_dict_str_any(
+    reason=(
+        "metadata is a heterogeneous performance ledger payload "
+        "with varying value types per domain."
+    )
+)
+class ModelCompletionReport(BaseModel, frozen=True, extra="forbid"):
+    """Final outcome report written to the overseer performance ledger.
+
+    Emitted once per task lifecycle when the task reaches a terminal state.
+    Carries cost, timing, and outcome data for observability and routing
+    feedback.
+    """
+
+    task_id: str  # string-id-ok: overseer correlation string, not a UUID
+    domain: str
+    node_id: str
+    outcome: EnumCompletionOutcome
+    total_cost: float = Field(default=0.0, ge=0.0)
+    total_duration_seconds: float = Field(default=0.0, ge=0.0)
+    attempts_used: int = Field(default=1, ge=1)
+    runner_id: str | None = None  # string-id-ok: overseer runner correlation string
+    error_message: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)  # ONEX_EXCLUDE: dict_str_any
+    started_at: datetime | None = None
+    completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # string-version-ok: wire type in overseer performance ledger, serialized to JSON
+    schema_version: str = "1.0"
+
+
+__all__ = ["ModelCompletionReport"]

--- a/src/omnibase_core/models/overseer/model_context_bundle.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundle union type alias for routing engine dispatch (OMN-10251).
+
+Re-exports all context bundle level classes and provides the union type alias.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.overseer.model_context_bundle_base import _ContextBundleBase
+from omnibase_core.models.overseer.model_context_bundle_l0 import ModelContextBundleL0
+from omnibase_core.models.overseer.model_context_bundle_l1 import ModelContextBundleL1
+from omnibase_core.models.overseer.model_context_bundle_l2 import ModelContextBundleL2
+from omnibase_core.models.overseer.model_context_bundle_l3 import ModelContextBundleL3
+from omnibase_core.models.overseer.model_context_bundle_l4 import ModelContextBundleL4
+
+ModelContextBundle = (
+    ModelContextBundleL0
+    | ModelContextBundleL1
+    | ModelContextBundleL2
+    | ModelContextBundleL3
+    | ModelContextBundleL4
+)
+"""Union type alias for routing engine dispatch."""
+
+__all__ = [
+    "_ContextBundleBase",
+    "ModelContextBundle",
+    "ModelContextBundleL0",
+    "ModelContextBundleL1",
+    "ModelContextBundleL2",
+    "ModelContextBundleL3",
+    "ModelContextBundleL4",
+]

--- a/src/omnibase_core/models/overseer/model_context_bundle_base.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_base.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""_ContextBundleBase — shared non-discriminated fields for all context bundle levels (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "task_id is an overseer wire correlation string, not a system UUID. "
+        "Overseer state machine uses string-keyed tasks."
+    )
+)
+class _ContextBundleBase(BaseModel, frozen=True, extra="forbid"):
+    """Shared non-discriminated fields for all bundle levels."""
+
+    run_id: str = Field(  # string-id-ok: overseer correlation string
+        ..., description="Pipeline or session run identifier."
+    )
+    task_id: str = Field(  # string-id-ok: overseer correlation string
+        ..., description="Task identifier within the run."
+    )
+    role: str = Field(..., description="Agent role for this invocation.")
+    fsm_state: str = Field(..., description="Current finite-state-machine state.")
+
+
+__all__ = ["_ContextBundleBase"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l0.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l0.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundleL0 — minimal context bundle level 0 (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.models.overseer.model_context_bundle_base import _ContextBundleBase
+
+
+class ModelContextBundleL0(_ContextBundleBase, frozen=True, extra="forbid"):
+    """Level 0 — minimal context.
+
+    Contains only the fields required for task routing and FSM tracking.
+    """
+
+    level: Literal[EnumContextBundleLevel.L0] = Field(
+        default=EnumContextBundleLevel.L0,
+        description="Context bundle level.",
+    )
+
+
+__all__ = ["ModelContextBundleL0"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l1.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l1.py
@@ -27,8 +27,7 @@ class ModelContextBundleL1(ModelContextBundleL0, frozen=True, extra="forbid"):
     Adds ticket metadata and summary on top of L0.
     """
 
-    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
-    level: Literal[EnumContextBundleLevel.L1] = Field(  # type: ignore[assignment]
+    level: Literal[EnumContextBundleLevel.L1] = Field(  # type: ignore[assignment]  # NOTE(OMN-10251): pydantic Field default narrowing to Literal[EnumMember] is a mypy false positive.
         default=EnumContextBundleLevel.L1,
         description="Context bundle level.",
     )

--- a/src/omnibase_core/models/overseer/model_context_bundle_l1.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l1.py
@@ -27,6 +27,7 @@ class ModelContextBundleL1(ModelContextBundleL0, frozen=True, extra="forbid"):
     Adds ticket metadata and summary on top of L0.
     """
 
+    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
     level: Literal[EnumContextBundleLevel.L1] = Field(  # type: ignore[assignment]
         default=EnumContextBundleLevel.L1,
         description="Context bundle level.",

--- a/src/omnibase_core/models/overseer/model_context_bundle_l1.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l1.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundleL1 — basic context bundle level 1 (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.models.overseer.model_context_bundle_l0 import ModelContextBundleL0
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "ticket_id is a Linear ticket reference (e.g., 'OMN-1234'), not a system UUID."
+    )
+)
+class ModelContextBundleL1(ModelContextBundleL0, frozen=True, extra="forbid"):
+    """Level 1 — basic context.
+
+    Adds ticket metadata and summary on top of L0.
+    """
+
+    level: Literal[EnumContextBundleLevel.L1] = Field(  # type: ignore[assignment]
+        default=EnumContextBundleLevel.L1,
+        description="Context bundle level.",
+    )
+    ticket_id: str = Field(
+        ..., description="Linear ticket identifier."
+    )  # string-id-ok: Linear ticket reference
+    summary: str = Field(..., description="Human-readable task summary.")
+
+
+__all__ = ["ModelContextBundleL1"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l2.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l2.py
@@ -21,6 +21,7 @@ class ModelContextBundleL2(ModelContextBundleL1, frozen=True, extra="forbid"):
     Adds entrypoint and file-scope information on top of L1.
     """
 
+    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
     level: Literal[EnumContextBundleLevel.L2] = Field(  # type: ignore[assignment]
         default=EnumContextBundleLevel.L2,
         description="Context bundle level.",

--- a/src/omnibase_core/models/overseer/model_context_bundle_l2.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l2.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundleL2 — standard context bundle level 2 (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.models.overseer.model_context_bundle_l1 import ModelContextBundleL1
+
+
+class ModelContextBundleL2(ModelContextBundleL1, frozen=True, extra="forbid"):
+    """Level 2 — standard context.
+
+    Adds entrypoint and file-scope information on top of L1.
+    """
+
+    level: Literal[EnumContextBundleLevel.L2] = Field(  # type: ignore[assignment]
+        default=EnumContextBundleLevel.L2,
+        description="Context bundle level.",
+    )
+    entrypoints: list[str] = Field(
+        ..., description="Suggested code entrypoints for the task."
+    )
+    file_scope: list[str] = Field(
+        default_factory=list,
+        description="Files in scope for the task.",
+    )
+
+
+__all__ = ["ModelContextBundleL2"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l2.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l2.py
@@ -25,11 +25,11 @@ class ModelContextBundleL2(ModelContextBundleL1, frozen=True, extra="forbid"):
         default=EnumContextBundleLevel.L2,
         description="Context bundle level.",
     )
-    entrypoints: list[str] = Field(
+    entrypoints: tuple[str, ...] = Field(
         ..., description="Suggested code entrypoints for the task."
     )
-    file_scope: list[str] = Field(
-        default_factory=list,
+    file_scope: tuple[str, ...] = Field(
+        default_factory=tuple,
         description="Files in scope for the task.",
     )
 

--- a/src/omnibase_core/models/overseer/model_context_bundle_l2.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l2.py
@@ -21,8 +21,7 @@ class ModelContextBundleL2(ModelContextBundleL1, frozen=True, extra="forbid"):
     Adds entrypoint and file-scope information on top of L1.
     """
 
-    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
-    level: Literal[EnumContextBundleLevel.L2] = Field(  # type: ignore[assignment]
+    level: Literal[EnumContextBundleLevel.L2] = Field(  # type: ignore[assignment]  # NOTE(OMN-10251): pydantic Field default narrowing to Literal[EnumMember] is a mypy false positive.
         default=EnumContextBundleLevel.L2,
         description="Context bundle level.",
     )

--- a/src/omnibase_core/models/overseer/model_context_bundle_l3.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l3.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundleL3 — rich context bundle level 3 (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.models.overseer.model_context_bundle_l2 import ModelContextBundleL2
+
+
+class ModelContextBundleL3(ModelContextBundleL2, frozen=True, extra="forbid"):
+    """Level 3 — rich context.
+
+    Adds architectural decisions and history on top of L2.
+    """
+
+    level: Literal[EnumContextBundleLevel.L3] = Field(  # type: ignore[assignment]
+        default=EnumContextBundleLevel.L3,
+        description="Context bundle level.",
+    )
+    decisions: list[str] = Field(
+        default_factory=list,
+        description="Active architectural decisions relevant to this task.",
+    )
+    history: list[str] = Field(
+        default_factory=list,
+        description="Relevant historical context entries.",
+    )
+
+
+__all__ = ["ModelContextBundleL3"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l3.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l3.py
@@ -21,8 +21,7 @@ class ModelContextBundleL3(ModelContextBundleL2, frozen=True, extra="forbid"):
     Adds architectural decisions and history on top of L2.
     """
 
-    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
-    level: Literal[EnumContextBundleLevel.L3] = Field(  # type: ignore[assignment]
+    level: Literal[EnumContextBundleLevel.L3] = Field(  # type: ignore[assignment]  # NOTE(OMN-10251): pydantic Field default narrowing to Literal[EnumMember] is a mypy false positive.
         default=EnumContextBundleLevel.L3,
         description="Context bundle level.",
     )

--- a/src/omnibase_core/models/overseer/model_context_bundle_l3.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l3.py
@@ -21,6 +21,7 @@ class ModelContextBundleL3(ModelContextBundleL2, frozen=True, extra="forbid"):
     Adds architectural decisions and history on top of L2.
     """
 
+    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
     level: Literal[EnumContextBundleLevel.L3] = Field(  # type: ignore[assignment]
         default=EnumContextBundleLevel.L3,
         description="Context bundle level.",

--- a/src/omnibase_core/models/overseer/model_context_bundle_l4.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l4.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextBundleL4 — maximum context bundle level 4 (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.models.overseer.model_context_bundle_l3 import ModelContextBundleL3
+
+
+class ModelContextBundleL4(ModelContextBundleL3, frozen=True, extra="forbid"):
+    """Level 4 — maximum context.
+
+    Adds full dependency graph and raw context payload on top of L3.
+    """
+
+    level: Literal[EnumContextBundleLevel.L4] = Field(  # type: ignore[assignment]
+        default=EnumContextBundleLevel.L4,
+        description="Context bundle level.",
+    )
+    dependency_graph: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Mapping of task IDs to their dependency task IDs.",
+    )
+    raw_context: dict[str, str] = Field(
+        default_factory=dict,
+        description="Arbitrary key-value context payload.",
+    )
+
+
+__all__ = ["ModelContextBundleL4"]

--- a/src/omnibase_core/models/overseer/model_context_bundle_l4.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l4.py
@@ -21,6 +21,7 @@ class ModelContextBundleL4(ModelContextBundleL3, frozen=True, extra="forbid"):
     Adds full dependency graph and raw context payload on top of L3.
     """
 
+    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
     level: Literal[EnumContextBundleLevel.L4] = Field(  # type: ignore[assignment]
         default=EnumContextBundleLevel.L4,
         description="Context bundle level.",

--- a/src/omnibase_core/models/overseer/model_context_bundle_l4.py
+++ b/src/omnibase_core/models/overseer/model_context_bundle_l4.py
@@ -21,8 +21,7 @@ class ModelContextBundleL4(ModelContextBundleL3, frozen=True, extra="forbid"):
     Adds full dependency graph and raw context payload on top of L3.
     """
 
-    # NOTE(OMN-10251): mypy cannot narrow Enum member default to Literal[EnumMember] — structural subtyping false positive.
-    level: Literal[EnumContextBundleLevel.L4] = Field(  # type: ignore[assignment]
+    level: Literal[EnumContextBundleLevel.L4] = Field(  # type: ignore[assignment]  # NOTE(OMN-10251): pydantic Field default narrowing to Literal[EnumMember] is a mypy false positive.
         default=EnumContextBundleLevel.L4,
         description="Context bundle level.",
     )

--- a/src/omnibase_core/models/overseer/model_contract_allowed_actions.py
+++ b/src/omnibase_core/models/overseer/model_contract_allowed_actions.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContractAllowedActions — permission model for contract role access (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractAllowedActions(BaseModel):
+    """Permission model for a contract: specifies allowed and denied actions.
+
+    Rules:
+    - denied_actions takes precedence over allowed_actions.
+    - Empty allowed_actions means no access (deny-all by default).
+    - An action is permitted only when it appears in allowed_actions
+      AND does not appear in denied_actions.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    role: str
+    allowed_actions: frozenset[str] = Field(default_factory=frozenset)
+    denied_actions: frozenset[str] = Field(default_factory=frozenset)
+
+    def is_action_permitted(self, action: str) -> bool:
+        """Return True if action is permitted for this role."""
+        if action in self.denied_actions:
+            return False
+        return action in self.allowed_actions
+
+
+__all__ = ["ModelContractAllowedActions"]

--- a/src/omnibase_core/models/overseer/model_dispatch_item.py
+++ b/src/omnibase_core/models/overseer/model_dispatch_item.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDispatchItem — per-theme dispatch detail for ModelOvernightPhaseSpec (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "theme_id is a domain-routing string identifier for overnight dispatch themes, "
+        "not a system UUID."
+    )
+)
+class ModelDispatchItem(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    theme_id: str  # string-id-ok: domain-routing string for overnight dispatch
+    title: str
+    target_repo: str
+    dispatch_mode: Literal[
+        "skill",
+        "agent_team",
+        "foreground_required",
+        "blocked_on_human",
+        "cron",
+    ]
+    skill_or_command: str | None = None
+    dependencies: tuple[str, ...] = ()
+    isolation_worktree_required: bool = False
+    open_prs: tuple[int, ...] = ()
+    success_criteria: tuple[str, ...] = ()
+    deadline: datetime | None = None
+    priority: Literal["P0", "P1", "P2"] = "P1"
+    notes: str | None = None
+
+
+__all__ = ["ModelDispatchItem"]

--- a/src/omnibase_core/models/overseer/model_escalation_request.py
+++ b/src/omnibase_core/models/overseer/model_escalation_request.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelEscalationRequest — escalation wire type for domain runners (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from omnibase_core.enums.overseer.enum_capability_tier import EnumCapabilityTier
+from omnibase_core.enums.overseer.enum_context_bundle_level import (
+    EnumContextBundleLevel,
+)
+from omnibase_core.enums.overseer.enum_failure_class import EnumFailureClass
+from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "task_id and node_id are overseer wire IDs (correlation strings), "
+        "not system UUIDs."
+    )
+)
+@allow_dict_str_any(
+    reason=(
+        "error_detail is a heterogeneous error context payload "
+        "with varying value types per failure class."
+    )
+)
+class ModelEscalationRequest(BaseModel, frozen=True, extra="forbid"):
+    """Escalation request emitted by domain runners when local retries are exhausted.
+
+    Carries the failure classification, capability tier required for resolution,
+    and context bundle level for the next dispatch.
+    """
+
+    task_id: str  # string-id-ok: overseer correlation string
+    domain: str
+    node_id: str  # string-id-ok: node correlation string
+    failure_class: EnumFailureClass
+    capability_tier: EnumCapabilityTier = EnumCapabilityTier.C2
+    context_bundle_level: EnumContextBundleLevel = EnumContextBundleLevel.L2
+    attempt: int = Field(default=1, ge=1)
+    max_attempts_exhausted: int = Field(default=3, ge=1)
+    error_message: str | None = None
+    error_detail: dict[str, Any] = Field(
+        default_factory=dict
+    )  # ONEX_EXCLUDE: dict_str_any - heterogeneous error context
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # string-version-ok: wire type across domain runners and overseer; JSON
+    schema_version: str = "1.0"
+
+
+__all__ = ["ModelEscalationRequest"]

--- a/src/omnibase_core/models/overseer/model_overnight_contract.py
+++ b/src/omnibase_core/models/overseer/model_overnight_contract.py
@@ -36,7 +36,7 @@ class ModelOvernightContract(BaseModel):
     max_cost_usd: float = 5.0
     max_duration_seconds: int = 28800
     dry_run: bool = False
-    phases: tuple[ModelOvernightPhaseSpec, ...]
+    phases: tuple[ModelOvernightPhaseSpec, ...] = Field(..., min_length=1)
     halt_conditions: tuple[ModelOvernightHaltCondition, ...] = Field(
         default_factory=tuple
     )

--- a/src/omnibase_core/models/overseer/model_overnight_contract.py
+++ b/src/omnibase_core/models/overseer/model_overnight_contract.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelOvernightContract — machine-readable contract for overnight pipeline sessions (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.overseer.model_overnight_halt_condition import (
+    ModelOvernightHaltCondition,
+)
+from omnibase_core.models.overseer.model_overnight_phase_spec import (
+    ModelOvernightPhaseSpec,
+)
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "session_id is an overseer correlation string for overnight sessions, "
+        "not a system UUID."
+    )
+)
+class ModelOvernightContract(BaseModel):
+    """Machine-readable contract for an overnight pipeline session."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-version-ok: wire type serialized to YAML at overnight contract boundary
+    schema_version: str = "1.0.0"
+    session_id: str  # string-id-ok: overseer correlation string for overnight session
+    created_at: datetime
+    max_cost_usd: float = 5.0
+    max_duration_seconds: int = 28800
+    dry_run: bool = False
+    phases: tuple[ModelOvernightPhaseSpec, ...]
+    halt_conditions: tuple[ModelOvernightHaltCondition, ...] = Field(
+        default_factory=tuple
+    )
+
+    @model_validator(mode="after")
+    def _apply_default_halt_conditions(self) -> ModelOvernightContract:
+        if self.halt_conditions:
+            return self
+        object.__setattr__(
+            self,
+            "halt_conditions",
+            (
+                ModelOvernightHaltCondition(
+                    condition_id="cost_ceiling",
+                    description="Stop if accumulated cost exceeds ceiling",
+                    check_type="cost_ceiling",
+                    threshold=self.max_cost_usd,
+                ),
+                ModelOvernightHaltCondition(
+                    condition_id="phase_failure_limit",
+                    description="Stop after 3 consecutive phase failures",
+                    check_type="phase_failure_count",
+                    threshold=3.0,
+                ),
+            ),
+        )
+        return self
+
+    standing_orders: tuple[str, ...] = Field(default_factory=tuple)
+    required_outcomes: tuple[str, ...] = Field(
+        default_factory=lambda: (
+            "merge_sweep_completed",
+            "platform_readiness_gate_passed",
+        )
+    )
+
+
+__all__ = ["ModelOvernightContract"]

--- a/src/omnibase_core/models/overseer/model_overnight_halt_condition.py
+++ b/src/omnibase_core/models/overseer/model_overnight_halt_condition.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelOvernightHaltCondition — halt condition for overnight pipeline sessions (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "condition_id is a named halt condition identifier (e.g., 'cost_ceiling'), "
+        "not a system UUID."
+    )
+)
+class ModelOvernightHaltCondition(BaseModel):
+    """Condition that triggers an action when its trigger clause matches.
+
+    On-halt actions:
+      - ``dispatch_skill``: fire the named skill as a foreground recovery and continue.
+      - ``halt_and_notify``: stop the pipeline and emit a tick event.
+      - ``hard_halt``: stop the pipeline immediately.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    condition_id: str  # string-id-ok: named halt condition identifier, not a UUID
+    description: str
+    check_type: Literal[
+        "cost_ceiling",
+        "phase_failure_count",
+        "time_elapsed",
+        "pr_blocked_too_long",
+        "required_outcome_missing",
+        "custom",
+    ]
+    threshold: float = 0.0
+    on_halt: Literal["hard_halt", "dispatch_skill", "halt_and_notify"] = "hard_halt"
+    skill: str | None = None
+    pr: int | None = None
+    threshold_minutes: float | None = None
+    outcome: str | None = None
+
+    @model_validator(mode="after")
+    def _enforce_conditional_fields(self) -> ModelOvernightHaltCondition:
+        if self.on_halt == "dispatch_skill" and not self.skill:
+            msg = "skill is required when on_halt='dispatch_skill'"
+            raise ValueError(
+                msg
+            )  # error-ok: Pydantic model_validator requires ValueError
+        if self.check_type == "pr_blocked_too_long":
+            if self.pr is None:
+                msg = "pr is required when check_type='pr_blocked_too_long'"
+                raise ValueError(
+                    msg
+                )  # error-ok: Pydantic model_validator requires ValueError
+            if self.threshold_minutes is None:
+                msg = (
+                    "threshold_minutes is required"
+                    " when check_type='pr_blocked_too_long'"
+                )
+                raise ValueError(
+                    msg
+                )  # error-ok: Pydantic model_validator requires ValueError
+        if self.check_type == "required_outcome_missing" and not self.outcome:
+            msg = "outcome is required when check_type='required_outcome_missing'"
+            raise ValueError(
+                msg
+            )  # error-ok: Pydantic model_validator requires ValueError
+        return self
+
+
+__all__ = ["ModelOvernightHaltCondition"]

--- a/src/omnibase_core/models/overseer/model_overnight_phase_spec.py
+++ b/src/omnibase_core/models/overseer/model_overnight_phase_spec.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelOvernightPhaseSpec — specification for a single overnight phase (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
+from omnibase_core.models.overseer.model_overnight_halt_condition import (
+    ModelOvernightHaltCondition,
+)
+
+
+class ModelOvernightPhaseSpec(BaseModel):
+    """Specification for a single overnight phase."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    phase_name: str
+    required: bool = True
+    timeout_seconds: int = 3600
+    halt_on_failure: bool = False
+    success_criteria: list[str] = Field(default_factory=list)
+    dispatch_items: tuple[ModelDispatchItem, ...] = ()
+    required_outcomes: tuple[str, ...] = ()
+    halt_conditions: tuple[ModelOvernightHaltCondition, ...] = ()
+
+
+__all__ = ["ModelOvernightPhaseSpec"]

--- a/src/omnibase_core/models/overseer/model_overnight_phase_spec.py
+++ b/src/omnibase_core/models/overseer/model_overnight_phase_spec.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.enums.overseer.enum_completion_outcome import EnumCompletionOutcome
 from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
 from omnibase_core.models.overseer.model_overnight_halt_condition import (
     ModelOvernightHaltCondition,
@@ -20,11 +21,11 @@ class ModelOvernightPhaseSpec(BaseModel):
 
     phase_name: str
     required: bool = True
-    timeout_seconds: int = 3600
+    timeout_seconds: int = Field(default=3600, gt=0)
     halt_on_failure: bool = False
     success_criteria: list[str] = Field(default_factory=list)
     dispatch_items: tuple[ModelDispatchItem, ...] = ()
-    required_outcomes: tuple[str, ...] = ()
+    required_outcomes: tuple[EnumCompletionOutcome, ...] = ()
     halt_conditions: tuple[ModelOvernightHaltCondition, ...] = ()
 
 

--- a/src/omnibase_core/models/overseer/model_process_runner_state_transition.py
+++ b/src/omnibase_core/models/overseer/model_process_runner_state_transition.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelProcessRunnerStateTransition — FSM state transition record (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from omnibase_core.enums.overseer.enum_process_runner_state import (
+        EnumProcessRunnerState,
+    )
+
+
+class ModelProcessRunnerStateTransition(BaseModel, frozen=True, extra="forbid"):
+    """Immutable record of a single FSM state transition for a process runner."""
+
+    from_state: EnumProcessRunnerState = Field(
+        description="The state the runner was in before this transition."
+    )
+    to_state: EnumProcessRunnerState = Field(
+        description="The state the runner moved into."
+    )
+    transitioned_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when the transition occurred.",
+    )
+
+
+__all__ = ["ModelProcessRunnerStateTransition"]

--- a/src/omnibase_core/models/overseer/model_session_contract.py
+++ b/src/omnibase_core/models/overseer/model_session_contract.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelSessionContract — machine-readable contract for pipeline sessions (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.overseer.model_session_halt_condition import (
+    ModelSessionHaltCondition,
+)
+from omnibase_core.models.overseer.model_session_phase_spec import ModelSessionPhaseSpec
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "session_id is an overseer correlation string for pipeline sessions, "
+        "not a system UUID."
+    )
+)
+class ModelSessionContract(BaseModel):
+    """Machine-readable contract for a pipeline session."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-version-ok: wire type serialized to YAML at session contract boundary
+    schema_version: str = "1.0.0"
+    session_id: str  # string-id-ok: overseer correlation string for pipeline session
+    created_at: datetime
+    max_cost_usd: float = 5.0
+    max_duration_seconds: int = 28800
+    dry_run: bool = False
+    phases: tuple[ModelSessionPhaseSpec, ...] = Field(..., min_length=1)
+    halt_conditions: tuple[ModelSessionHaltCondition, ...] = Field(
+        default_factory=lambda: (
+            ModelSessionHaltCondition(
+                condition_id="cost_ceiling",
+                description="Stop if accumulated cost exceeds ceiling",
+                check_type="cost_ceiling",
+                threshold=5.0,
+            ),
+            ModelSessionHaltCondition(
+                condition_id="phase_failure_limit",
+                description="Stop after 3 consecutive phase failures",
+                check_type="phase_failure_count",
+                threshold=3.0,
+            ),
+        )
+    )
+    standing_orders: tuple[str, ...] = Field(default_factory=tuple)
+    required_outcomes: tuple[str, ...] = Field(
+        default_factory=lambda: (
+            "merge_sweep_completed",
+            "platform_readiness_gate_passed",
+        )
+    )
+
+
+__all__ = ["ModelSessionContract"]

--- a/src/omnibase_core/models/overseer/model_session_contract.py
+++ b/src/omnibase_core/models/overseer/model_session_contract.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -47,7 +48,7 @@ class ModelSessionContract(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _apply_default_halt_conditions(self) -> ModelSessionContract:
+    def _apply_default_halt_conditions(self) -> Self:
         if self.halt_conditions:
             return self
         object.__setattr__(

--- a/src/omnibase_core/models/overseer/model_session_contract.py
+++ b/src/omnibase_core/models/overseer/model_session_contract.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.models.overseer.model_session_halt_condition import (
     ModelSessionHaltCondition,
@@ -36,20 +36,7 @@ class ModelSessionContract(BaseModel):
     dry_run: bool = False
     phases: tuple[ModelSessionPhaseSpec, ...] = Field(..., min_length=1)
     halt_conditions: tuple[ModelSessionHaltCondition, ...] = Field(
-        default_factory=lambda: (
-            ModelSessionHaltCondition(
-                condition_id="cost_ceiling",
-                description="Stop if accumulated cost exceeds ceiling",
-                check_type="cost_ceiling",
-                threshold=5.0,
-            ),
-            ModelSessionHaltCondition(
-                condition_id="phase_failure_limit",
-                description="Stop after 3 consecutive phase failures",
-                check_type="phase_failure_count",
-                threshold=3.0,
-            ),
-        )
+        default_factory=tuple
     )
     standing_orders: tuple[str, ...] = Field(default_factory=tuple)
     required_outcomes: tuple[str, ...] = Field(
@@ -58,6 +45,30 @@ class ModelSessionContract(BaseModel):
             "platform_readiness_gate_passed",
         )
     )
+
+    @model_validator(mode="after")
+    def _apply_default_halt_conditions(self) -> ModelSessionContract:
+        if self.halt_conditions:
+            return self
+        object.__setattr__(
+            self,
+            "halt_conditions",
+            (
+                ModelSessionHaltCondition(
+                    condition_id="cost_ceiling",
+                    description="Stop if accumulated cost exceeds ceiling",
+                    check_type="cost_ceiling",
+                    threshold=self.max_cost_usd,
+                ),
+                ModelSessionHaltCondition(
+                    condition_id="phase_failure_limit",
+                    description="Stop after 3 consecutive phase failures",
+                    check_type="phase_failure_count",
+                    threshold=3.0,
+                ),
+            ),
+        )
+        return self
 
 
 __all__ = ["ModelSessionContract"]

--- a/src/omnibase_core/models/overseer/model_session_halt_condition.py
+++ b/src/omnibase_core/models/overseer/model_session_halt_condition.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelSessionHaltCondition — condition that triggers an immediate session halt (OMN-10251)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "condition_id is a named halt condition identifier (e.g., 'cost_ceiling'), "
+        "not a system UUID."
+    )
+)
+class ModelSessionHaltCondition(BaseModel):
+    """Condition that triggers an immediate halt of the session."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    condition_id: str  # string-id-ok: named halt condition identifier, not a UUID
+    description: str
+    check_type: Literal["cost_ceiling", "phase_failure_count", "time_elapsed", "custom"]
+    threshold: float
+
+
+__all__ = ["ModelSessionHaltCondition"]

--- a/src/omnibase_core/models/overseer/model_session_phase_spec.py
+++ b/src/omnibase_core/models/overseer/model_session_phase_spec.py
@@ -17,7 +17,7 @@ class ModelSessionPhaseSpec(BaseModel):
 
     phase_name: str
     required: bool = True
-    timeout_seconds: int = 3600
+    timeout_seconds: int = Field(default=3600, gt=0)
     halt_on_failure: bool = False
     success_criteria: list[str] = Field(default_factory=list)
     dispatch_items: tuple[ModelDispatchItem, ...] = ()

--- a/src/omnibase_core/models/overseer/model_session_phase_spec.py
+++ b/src/omnibase_core/models/overseer/model_session_phase_spec.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelSessionPhaseSpec — specification for a single session phase (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
+
+
+class ModelSessionPhaseSpec(BaseModel):
+    """Specification for a single session phase."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    phase_name: str
+    required: bool = True
+    timeout_seconds: int = 3600
+    halt_on_failure: bool = False
+    success_criteria: list[str] = Field(default_factory=list)
+    dispatch_items: tuple[ModelDispatchItem, ...] = ()
+
+
+__all__ = ["ModelSessionPhaseSpec"]

--- a/src/omnibase_core/models/overseer/model_task_delta_envelope.py
+++ b/src/omnibase_core/models/overseer/model_task_delta_envelope.py
@@ -50,7 +50,12 @@ class ModelTaskDeltaEnvelope(BaseModel, frozen=True, extra="forbid"):
     ) -> Mapping[str, Any] | None:
         if value is None:
             return None
-        return MappingProxyType(dict(value))
+        try:
+            return MappingProxyType(dict(value))
+        except TypeError as exc:
+            raise ValueError(
+                "payload must be a mapping"
+            ) from exc  # error-ok: Pydantic field_validator requires ValueError
 
 
 __all__ = ["ModelTaskDeltaEnvelope"]

--- a/src/omnibase_core/models/overseer/model_task_delta_envelope.py
+++ b/src/omnibase_core/models/overseer/model_task_delta_envelope.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Self
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
 from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
@@ -56,6 +56,12 @@ class ModelTaskDeltaEnvelope(BaseModel, frozen=True, extra="forbid"):
             raise ValueError(
                 "payload must be a mapping"
             ) from exc  # error-ok: Pydantic field_validator requires ValueError
+
+    @model_validator(mode="after")
+    def _freeze_payload_after_validation(self) -> Self:
+        if self.payload is not None:
+            object.__setattr__(self, "payload", MappingProxyType(dict(self.payload)))
+        return self
 
 
 __all__ = ["ModelTaskDeltaEnvelope"]

--- a/src/omnibase_core/models/overseer/model_task_delta_envelope.py
+++ b/src/omnibase_core/models/overseer/model_task_delta_envelope.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelTaskDeltaEnvelope — incremental task state change for overseer projection (OMN-10251)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from types import MappingProxyType
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "task_id and runner_id are overseer wire IDs (correlation strings), "
+        "not system UUIDs."
+    )
+)
+@allow_dict_str_any(
+    reason="payload is a heterogeneous incremental task delta with varying value types."
+)
+class ModelTaskDeltaEnvelope(BaseModel, frozen=True, extra="forbid"):
+    """Incremental task state change for overseer projection.
+
+    Carries only the fields that changed, plus the mandatory task_id.
+    """
+
+    task_id: str  # string-id-ok: overseer correlation string
+    status: EnumTaskStatus | None = None
+    runner_id: str | None = None  # string-id-ok: overseer runner correlation string
+    attempt: int | None = Field(default=None, ge=1)
+    payload: Mapping[str, Any] | None = (
+        None  # ONEX_EXCLUDE: dict_str_any - incremental task delta
+    )
+    error: str | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # string-version-ok: wire type across overseer/runner boundary; JSON
+    schema_version: str = "1.0"
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def _freeze_payload(
+        cls, value: Mapping[str, Any] | None
+    ) -> Mapping[str, Any] | None:
+        if value is None:
+            return None
+        return MappingProxyType(dict(value))
+
+
+__all__ = ["ModelTaskDeltaEnvelope"]

--- a/src/omnibase_core/models/overseer/model_task_shape_features.py
+++ b/src/omnibase_core/models/overseer/model_task_shape_features.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelTaskShapeFeatures — feature vector for routing policy decisions (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from omnibase_core.enums.overseer.enum_capability_tier import EnumCapabilityTier
+from omnibase_core.enums.overseer.enum_provider import EnumProvider
+from omnibase_core.enums.overseer.enum_retry_type import EnumRetryType
+from omnibase_core.enums.overseer.enum_risk_level import EnumRiskLevel
+
+
+class ModelTaskShapeFeatures(BaseModel, frozen=True, extra="forbid"):
+    """Feature vector describing a task for routing policy decisions."""
+
+    domain: str
+    """Domain bucket the task belongs to (e.g. 'code', 'reasoning')."""
+
+    capability_tier: EnumCapabilityTier = EnumCapabilityTier.C2
+    """Minimum capability tier required to handle the task."""
+
+    risk_level: EnumRiskLevel = EnumRiskLevel.LOW
+    """Risk classification for the task."""
+
+    retry_type: EnumRetryType = EnumRetryType.NONE
+    """Retry strategy to apply on failure."""
+
+    preferred_provider: EnumProvider = EnumProvider.UNKNOWN
+    """Preferred model provider, if any constraint exists."""
+
+    novelty_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    """Novelty score in [0.0, 1.0]. Higher values indicate more unusual tasks."""
+
+    estimated_tokens: int = Field(default=0, ge=0)
+    """Estimated token count for the task prompt + context."""
+
+    requires_tool_use: bool = False
+    """Whether the task requires tool/function-call capability."""
+
+    # string-version-ok: wire type for routing policy feature vector, serialized to JSON
+    schema_version: str = "1.0"
+
+
+__all__ = ["ModelTaskShapeFeatures"]

--- a/src/omnibase_core/models/overseer/model_task_state_envelope.py
+++ b/src/omnibase_core/models/overseer/model_task_state_envelope.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelTaskStateEnvelope — full task state snapshot for overseer projection (OMN-10251)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "task_id and runner_id are overseer wire IDs (correlation strings), "
+        "not system UUIDs. Overseer state machine uses string-keyed tasks."
+    )
+)
+@allow_dict_str_any(
+    reason=(
+        "payload is a heterogeneous task state payload with varying value types per domain."
+    )
+)
+class ModelTaskStateEnvelope(BaseModel, frozen=True, extra="forbid"):
+    """Full task state snapshot for overseer projection."""
+
+    task_id: str = Field(  # string-id-ok: overseer correlation string
+        ..., description="Task identifier from upstream task record."
+    )
+    status: EnumTaskStatus
+    domain: str
+    node_id: str
+    runner_id: str | None = None  # string-id-ok: overseer runner correlation string
+    attempt: int = Field(default=1, ge=1)
+    payload: dict[str, Any] = Field(
+        default_factory=dict
+    )  # ONEX_EXCLUDE: dict_str_any - heterogeneous task state
+    error: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # string-version-ok: wire type across overseer/runner boundary; JSON
+    schema_version: str = "1.0"
+
+
+__all__ = ["ModelTaskStateEnvelope"]

--- a/src/omnibase_core/models/overseer/model_task_state_envelope.py
+++ b/src/omnibase_core/models/overseer/model_task_state_envelope.py
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import Any
+from types import MappingProxyType
+from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
 from omnibase_core.utils.util_decorators import allow_dict_str_any, allow_string_id
@@ -36,14 +38,27 @@ class ModelTaskStateEnvelope(BaseModel, frozen=True, extra="forbid"):
     node_id: str
     runner_id: str | None = None  # string-id-ok: overseer runner correlation string
     attempt: int = Field(default=1, ge=1)
-    payload: dict[str, Any] = Field(
-        default_factory=dict
+    payload: Mapping[str, Any] = Field(
+        default_factory=lambda: MappingProxyType({})
     )  # ONEX_EXCLUDE: dict_str_any - heterogeneous task state
     error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     # string-version-ok: wire type across overseer/runner boundary; JSON
     schema_version: str = "1.0"
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def _freeze_payload(cls, value: Mapping[str, Any]) -> Mapping[str, Any]:
+        try:
+            return MappingProxyType(dict(value))
+        except TypeError as exc:
+            raise ValueError("payload must be a mapping") from exc
+
+    @model_validator(mode="after")
+    def _freeze_payload_after_validation(self) -> Self:
+        object.__setattr__(self, "payload", MappingProxyType(dict(self.payload)))
+        return self
 
 
 __all__ = ["ModelTaskStateEnvelope"]

--- a/src/omnibase_core/models/overseer/model_verifier_output.py
+++ b/src/omnibase_core/models/overseer/model_verifier_output.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelVerifierOutput — output from the deterministic verification layer (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.overseer.enum_failure_class import EnumFailureClass
+from omnibase_core.enums.overseer.enum_verifier_verdict import EnumVerifierVerdict
+from omnibase_core.models.contracts.ticket.model_dod_receipt import (
+    ModelDodReceipt,
+)
+
+
+class ModelVerifierOutput(BaseModel):
+    """Output from the deterministic verification layer.
+
+    Contains the overall verdict, per-check results (as ModelDodReceipt), and
+    optional shim outputs for downstream consumers.
+
+    Per OMN-9792: checks items migrated from ModelVerifierCheckResult to
+    ModelDodReceipt.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    verdict: EnumVerifierVerdict = Field(
+        ..., description="Overall verification verdict."
+    )
+    checks: tuple[ModelDodReceipt, ...] = Field(
+        default_factory=tuple, description="Per-check results as canonical receipts."
+    )
+    failure_class: EnumFailureClass | None = Field(
+        default=None,
+        description="Dominant failure class when verdict is not PASS.",
+    )
+    shim_outputs: dict[str, str] = Field(
+        default_factory=dict,
+        description="Opaque key-value outputs for downstream shim consumers.",
+    )
+    summary: str = Field(
+        default="", description="Human-readable summary of verification results."
+    )
+
+    @model_validator(mode="after")
+    def validate_verdict_consistency(self) -> ModelVerifierOutput:
+        if self.verdict == EnumVerifierVerdict.PASS and self.failure_class is not None:
+            msg = "failure_class must be None when verdict=PASS"
+            raise ValueError(
+                msg
+            )  # error-ok: Pydantic model_validator requires ValueError
+        return self
+
+
+__all__ = ["ModelVerifierOutput"]

--- a/src/omnibase_core/models/overseer/model_worker_contract.py
+++ b/src/omnibase_core/models/overseer/model_worker_contract.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkerContract — per-worker machine-readable contract (OMN-10251).
+
+Wire type loaded at worker spawn time from contract.yaml. Parallel to
+ModelOvernightContract (session-level) and ModelSessionContract (pipeline-level).
+"""
+
+from __future__ import annotations
+
+import re as _re
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic.functional_validators import AfterValidator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+    ModelWorkerEvidenceRequirement,
+)
+
+
+def _validate_semver(v: str) -> str:
+    if not _re.fullmatch(r"\d+\.\d+\.\d+", v):
+        raise ModelOnexError(
+            message=f"schema_version must match x.y.z, got {v!r}",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+    return v
+
+
+_SemVer = Annotated[str, AfterValidator(_validate_semver)]
+
+
+class ModelWorkerContract(BaseModel):
+    """Per-worker machine-readable contract.
+
+    Loaded at worker spawn time from a contract.yaml beside the worker
+    definition. All fields are immutable (frozen=True) and unknown fields are
+    rejected (extra="forbid").
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    schema_version: _SemVer = "1.0.0"
+    worker_name: str
+
+    heartbeat_interval_seconds: int = Field(
+        default=300,
+        gt=0,
+        description="Max silence (no TaskUpdate or SendMessage) before stall fires.",
+    )
+    stall_action: Literal["kill_and_respawn", "kill_only", "warn_only"] = (
+        "kill_and_respawn"
+    )
+
+    required_evidence: Mapping[str, tuple[ModelWorkerEvidenceRequirement, ...]] = Field(
+        default_factory=lambda: MappingProxyType({}),
+        description=(
+            "Map from TaskUpdate status transition (e.g. 'completed', "
+            "'in_progress') to the list of evidence requirements that must "
+            "be satisfied on the TaskUpdate body."
+        ),
+    )
+
+    @field_validator("required_evidence", mode="before")
+    @classmethod
+    def _freeze_required_evidence(
+        cls, value: Any
+    ) -> Mapping[str, tuple[ModelWorkerEvidenceRequirement, ...]]:
+        if value is None:
+            return MappingProxyType({})
+        if not isinstance(value, Mapping):
+            raise ModelOnexError(
+                message="required_evidence must be a mapping",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        coerced: dict[str, tuple[ModelWorkerEvidenceRequirement, ...]] = {}
+        for k, v in value.items():
+            if not isinstance(v, (list, tuple)):
+                raise ModelOnexError(
+                    message=f"required_evidence[{k!r}] must be a list, got {type(v).__name__}",
+                    error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                )
+            items: list[ModelWorkerEvidenceRequirement] = []
+            for item in v:
+                if isinstance(item, ModelWorkerEvidenceRequirement):
+                    items.append(item)
+                elif isinstance(item, dict):
+                    items.append(ModelWorkerEvidenceRequirement.model_validate(item))
+                else:
+                    raise ModelOnexError(
+                        message=(
+                            f"required_evidence[{k!r}] items must be dicts or "
+                            f"ModelWorkerEvidenceRequirement, got {type(item).__name__}"
+                        ),
+                        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                    )
+            coerced[k] = tuple(items)
+        return MappingProxyType(coerced)
+
+    allowed_skills: tuple[str, ...] | Literal["*"] = Field(
+        default="*",
+        description=(
+            "Skill slugs this worker may invoke via the Skill tool. '*' "
+            "means no restriction. An empty tuple means no skills allowed."
+        ),
+    )
+    allowed_tools: tuple[str, ...] | Literal["*"] = Field(
+        default="*",
+        description=(
+            "Tool names this worker may invoke. '*' means no restriction. "
+            "An empty tuple means no tools allowed (unusual)."
+        ),
+    )
+
+    applicable_runbooks: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Runbook slugs the overseer should match against observed "
+            "events for this worker."
+        ),
+    )
+    preflight_gates: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Preflight check names that must pass before the worker's first tool call."
+        ),
+    )
+
+    snapshot_on_tick: bool = Field(
+        default=False,
+        description="If true, HandlerOvernight writes a state snapshot for this worker on every tick.",
+    )
+    lease_seconds: int = Field(
+        default=900,
+        gt=0,
+        description="Claim lease duration for task ownership.",
+    )
+
+
+def load_worker_contract(data: Any) -> ModelWorkerContract:
+    """Validate a ModelWorkerContract from an already-parsed mapping."""
+    if not isinstance(data, Mapping):
+        raise ModelOnexError(
+            message=f"worker contract data must be a mapping, got {type(data).__name__}",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+    return ModelWorkerContract.model_validate(dict(data))
+
+
+__all__ = [
+    "ModelWorkerContract",
+    "load_worker_contract",
+]

--- a/src/omnibase_core/models/overseer/model_worker_contract.py
+++ b/src/omnibase_core/models/overseer/model_worker_contract.py
@@ -17,8 +17,6 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.functional_validators import AfterValidator
 
-from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.overseer.model_worker_evidence_requirement import (
     ModelWorkerEvidenceRequirement,
 )
@@ -26,9 +24,8 @@ from omnibase_core.models.overseer.model_worker_evidence_requirement import (
 
 def _validate_semver(v: str) -> str:
     if not _re.fullmatch(r"\d+\.\d+\.\d+", v):
-        raise ModelOnexError(
-            message=f"schema_version must match x.y.z, got {v!r}",
-            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        raise ValueError(  # error-ok: Pydantic AfterValidator must raise ValueError.
+            f"schema_version must match x.y.z, got {v!r}"
         )
     return v
 
@@ -75,16 +72,12 @@ class ModelWorkerContract(BaseModel):
         if value is None:
             return MappingProxyType({})
         if not isinstance(value, Mapping):
-            raise ModelOnexError(
-                message="required_evidence must be a mapping",
-                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-            )
+            raise ValueError("required_evidence must be a mapping")
         coerced: dict[str, tuple[ModelWorkerEvidenceRequirement, ...]] = {}
         for k, v in value.items():
             if not isinstance(v, (list, tuple)):
-                raise ModelOnexError(
-                    message=f"required_evidence[{k!r}] must be a list, got {type(v).__name__}",
-                    error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                raise ValueError(
+                    f"required_evidence[{k!r}] must be a list, got {type(v).__name__}"
                 )
             items: list[ModelWorkerEvidenceRequirement] = []
             for item in v:
@@ -93,12 +86,9 @@ class ModelWorkerContract(BaseModel):
                 elif isinstance(item, dict):
                     items.append(ModelWorkerEvidenceRequirement.model_validate(item))
                 else:
-                    raise ModelOnexError(
-                        message=(
-                            f"required_evidence[{k!r}] items must be dicts or "
-                            f"ModelWorkerEvidenceRequirement, got {type(item).__name__}"
-                        ),
-                        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                    raise ValueError(
+                        f"required_evidence[{k!r}] items must be dicts or "
+                        f"ModelWorkerEvidenceRequirement, got {type(item).__name__}"
                     )
             coerced[k] = tuple(items)
         return MappingProxyType(coerced)
@@ -146,9 +136,8 @@ class ModelWorkerContract(BaseModel):
 def load_worker_contract(data: Any) -> ModelWorkerContract:
     """Validate a ModelWorkerContract from an already-parsed mapping."""
     if not isinstance(data, Mapping):
-        raise ModelOnexError(
-            message=f"worker contract data must be a mapping, got {type(data).__name__}",
-            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        raise ValueError(  # error-ok: Pydantic-style boundary validation.
+            f"worker contract data must be a mapping, got {type(data).__name__}"
         )
     return ModelWorkerContract.model_validate(dict(data))
 

--- a/src/omnibase_core/models/overseer/model_worker_evidence_requirement.py
+++ b/src/omnibase_core/models/overseer/model_worker_evidence_requirement.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelWorkerEvidenceRequirement — evidence requirement for worker contracts (OMN-10251).
+
+Renamed from OCC's ModelEvidenceRequirement to avoid collision with
+omnibase_core.models.ticket.model_evidence_requirement.ModelEvidenceRequirement.
+The two are structurally distinct:
+- ModelWorkerEvidenceRequirement: evidence_id, description, kind (Literal), pattern
+- ModelEvidenceRequirement: kind (EnumEvidenceKind), description, command
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.utils.util_decorators import allow_string_id
+
+
+@allow_string_id(
+    reason=(
+        "evidence_id is a named evidence slot identifier (e.g., 'pr-merged'), "
+        "not a system UUID. Matcher reads named slots from TaskUpdate body."
+    )
+)
+class ModelWorkerEvidenceRequirement(BaseModel):
+    """A single piece of evidence required on a task-status transition.
+
+    The matcher reads the TaskUpdate body and tests each requirement against it.
+    ``kind`` chooses the comparison:
+
+    - ``contains``: ``pattern`` is a substring the body must contain (case-sensitive).
+    - ``regex``: ``pattern`` is a regular expression matched against the body.
+    - ``fenced_block``: the body must contain a fenced code block whose language tag
+      matches ``pattern`` (e.g. ``pattern="json"``).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    evidence_id: str  # string-id-ok: named evidence slot identifier, not a UUID
+    description: str
+    kind: Literal["contains", "regex", "fenced_block"]
+    pattern: str
+
+
+__all__ = ["ModelWorkerEvidenceRequirement"]

--- a/tests/unit/models/overseer/__init__.py
+++ b/tests/unit/models/overseer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/overseer/test_overseer_model_imports.py
+++ b/tests/unit/models/overseer/test_overseer_model_imports.py
@@ -5,12 +5,16 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from omnibase_core.models.ticket.model_evidence_requirement import (
     ModelEvidenceRequirement,
 )
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.mark.unit
@@ -201,7 +205,7 @@ class TestOverseerModelImports:
             ModelWorkerEvidenceRequirement,
         )
 
-        assert ModelWorkerEvidenceRequirement is not ModelEvidenceRequirement
+        assert id(ModelWorkerEvidenceRequirement) != id(ModelEvidenceRequirement)
         overseer_fields = set(ModelWorkerEvidenceRequirement.model_fields.keys())
         core_fields = set(ModelEvidenceRequirement.model_fields.keys())
         assert overseer_fields != core_fields
@@ -232,19 +236,148 @@ class TestOverseerModelImports:
 
         contract = ModelWorkerContract(worker_name="test-worker")
         assert contract.worker_name == "test-worker"
-        assert ModelWorkerEvidenceRequirement is not ModelEvidenceRequirement
+        assert id(ModelWorkerEvidenceRequirement) != id(ModelEvidenceRequirement)
 
     def test_enum_task_status_values(self) -> None:
         from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
 
-        assert EnumTaskStatus.PENDING == "pending"
-        assert EnumTaskStatus.COMPLETED == "completed"
-        assert EnumTaskStatus.FAILED == "failed"
+        assert EnumTaskStatus.PENDING.value == "pending"
+        assert EnumTaskStatus.COMPLETED.value == "completed"
+        assert EnumTaskStatus.FAILED.value == "failed"
 
     def test_enum_completion_outcome_values(self) -> None:
         from omnibase_core.enums.overseer.enum_completion_outcome import (
             EnumCompletionOutcome,
         )
 
-        assert EnumCompletionOutcome.SUCCESS == "success"
-        assert EnumCompletionOutcome.FAILURE == "failure"
+        assert EnumCompletionOutcome.SUCCESS.value == "success"
+        assert EnumCompletionOutcome.FAILURE.value == "failure"
+
+    def test_context_bundle_l2_freezes_sequence_fields(self) -> None:
+        from omnibase_core.models.overseer.model_context_bundle_l2 import (
+            ModelContextBundleL2,
+        )
+
+        bundle = ModelContextBundleL2(
+            run_id="run-1",
+            task_id="task-1",
+            role="worker",
+            fsm_state="running",
+            ticket_id="OMN-10251",
+            summary="summary",
+            entrypoints=("src/a.py",),
+            file_scope=("src/a.py", "tests/a.py"),
+        )
+
+        assert bundle.entrypoints == ("src/a.py",)
+        assert bundle.file_scope == ("src/a.py", "tests/a.py")
+
+    def test_overnight_contract_requires_at_least_one_phase(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_core.models.overseer.model_overnight_contract import (
+            ModelOvernightContract,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelOvernightContract(
+                session_id="session-1",
+                created_at=datetime.now(UTC),
+                phases=(),
+            )
+
+    def test_overnight_phase_required_outcomes_are_enums(self) -> None:
+        from omnibase_core.enums.overseer.enum_completion_outcome import (
+            EnumCompletionOutcome,
+        )
+        from omnibase_core.models.overseer.model_overnight_phase_spec import (
+            ModelOvernightPhaseSpec,
+        )
+
+        phase = ModelOvernightPhaseSpec.model_validate(
+            {
+                "phase_name": "merge",
+                "required_outcomes": ["success"],
+            }
+        )
+
+        assert phase.required_outcomes == (EnumCompletionOutcome.SUCCESS,)
+
+    def test_session_contract_default_cost_halt_uses_max_cost(self) -> None:
+        from datetime import UTC, datetime
+
+        from omnibase_core.models.overseer.model_session_contract import (
+            ModelSessionContract,
+        )
+        from omnibase_core.models.overseer.model_session_phase_spec import (
+            ModelSessionPhaseSpec,
+        )
+
+        contract = ModelSessionContract(
+            session_id="session-1",
+            created_at=datetime.now(UTC),
+            max_cost_usd=12.5,
+            phases=(ModelSessionPhaseSpec(phase_name="merge"),),
+        )
+
+        cost_condition = contract.halt_conditions[0]
+        assert cost_condition.condition_id == "cost_ceiling"
+        assert cost_condition.threshold == 12.5
+
+    def test_session_phase_rejects_non_positive_timeout(self) -> None:
+        from omnibase_core.models.overseer.model_session_phase_spec import (
+            ModelSessionPhaseSpec,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelSessionPhaseSpec(phase_name="merge", timeout_seconds=0)
+
+    def test_task_payloads_are_immutable_and_validate_as_value_errors(self) -> None:
+        from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+        from omnibase_core.models.overseer.model_task_delta_envelope import (
+            ModelTaskDeltaEnvelope,
+        )
+        from omnibase_core.models.overseer.model_task_state_envelope import (
+            ModelTaskStateEnvelope,
+        )
+
+        delta = ModelTaskDeltaEnvelope(task_id="task-1", payload={"a": 1})
+        state = ModelTaskStateEnvelope(
+            task_id="task-1",
+            status=EnumTaskStatus.PENDING,
+            domain="test",
+            node_id="node-1",
+            payload={"a": 1},
+        )
+
+        def mutate_payload(payload: Any) -> None:
+            payload["b"] = 2
+
+        with pytest.raises(TypeError):
+            mutate_payload(delta.payload)
+        with pytest.raises(TypeError):
+            mutate_payload(state.payload)
+        bad_payload: Any = object()
+        with pytest.raises(ValidationError):
+            ModelTaskDeltaEnvelope(task_id="task-1", payload=bad_payload)
+        with pytest.raises(ValidationError):
+            ModelTaskStateEnvelope(
+                task_id="task-1",
+                status=EnumTaskStatus.PENDING,
+                domain="test",
+                node_id="node-1",
+                payload=bad_payload,
+            )
+
+    def test_worker_contract_boundary_validation_uses_value_errors(self) -> None:
+        from omnibase_core.models.overseer.model_worker_contract import (
+            ModelWorkerContract,
+            load_worker_contract,
+        )
+
+        with pytest.raises(ValueError, match="worker contract data must be a mapping"):
+            load_worker_contract("not-a-mapping")
+        with pytest.raises(ValidationError):
+            ModelWorkerContract.model_validate(
+                {"worker_name": "worker", "required_evidence": "bad"}
+            )

--- a/tests/unit/models/overseer/test_overseer_model_imports.py
+++ b/tests/unit/models/overseer/test_overseer_model_imports.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import pytest
 from pydantic import BaseModel
 
 from omnibase_core.models.ticket.model_evidence_requirement import (
@@ -12,6 +13,7 @@ from omnibase_core.models.ticket.model_evidence_requirement import (
 )
 
 
+@pytest.mark.unit
 class TestOverseerModelImports:
     """Assert all overseer model classes importable from omnibase_core.models.overseer.*."""
 

--- a/tests/unit/models/overseer/test_overseer_model_imports.py
+++ b/tests/unit/models/overseer/test_overseer_model_imports.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for overseer models namespace (OMN-10251)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from omnibase_core.models.ticket.model_evidence_requirement import (
+    ModelEvidenceRequirement,
+)
+
+
+class TestOverseerModelImports:
+    """Assert all overseer model classes importable from omnibase_core.models.overseer.*."""
+
+    def test_enum_completion_outcome_importable(self) -> None:
+        from omnibase_core.enums.overseer.enum_completion_outcome import (
+            EnumCompletionOutcome,
+        )
+
+        assert issubclass(EnumCompletionOutcome, str)
+
+    def test_enum_task_status_importable(self) -> None:
+        from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+
+        assert issubclass(EnumTaskStatus, str)
+
+    def test_model_completion_report_importable(self) -> None:
+        from omnibase_core.models.overseer.model_completion_report import (
+            ModelCompletionReport,
+        )
+
+        assert issubclass(ModelCompletionReport, BaseModel)
+
+    def test_model_context_bundle_importable(self) -> None:
+        from omnibase_core.models.overseer.model_context_bundle import (
+            ModelContextBundle,
+            ModelContextBundleL0,
+            ModelContextBundleL1,
+            ModelContextBundleL2,
+            ModelContextBundleL3,
+            ModelContextBundleL4,
+            _ContextBundleBase,
+        )
+
+        assert issubclass(ModelContextBundleL0, BaseModel)
+        assert issubclass(ModelContextBundleL1, BaseModel)
+        assert issubclass(ModelContextBundleL2, BaseModel)
+        assert issubclass(ModelContextBundleL3, BaseModel)
+        assert issubclass(ModelContextBundleL4, BaseModel)
+        assert issubclass(_ContextBundleBase, BaseModel)
+        assert ModelContextBundle is not None
+
+    def test_model_context_bundle_split_files_importable(self) -> None:
+        from omnibase_core.models.overseer.model_context_bundle_base import (
+            _ContextBundleBase,
+        )
+        from omnibase_core.models.overseer.model_context_bundle_l0 import (
+            ModelContextBundleL0,
+        )
+        from omnibase_core.models.overseer.model_context_bundle_l1 import (
+            ModelContextBundleL1,
+        )
+        from omnibase_core.models.overseer.model_context_bundle_l2 import (
+            ModelContextBundleL2,
+        )
+        from omnibase_core.models.overseer.model_context_bundle_l3 import (
+            ModelContextBundleL3,
+        )
+        from omnibase_core.models.overseer.model_context_bundle_l4 import (
+            ModelContextBundleL4,
+        )
+
+        assert issubclass(_ContextBundleBase, BaseModel)
+        assert issubclass(ModelContextBundleL0, BaseModel)
+        assert issubclass(ModelContextBundleL1, BaseModel)
+        assert issubclass(ModelContextBundleL2, BaseModel)
+        assert issubclass(ModelContextBundleL3, BaseModel)
+        assert issubclass(ModelContextBundleL4, BaseModel)
+
+    def test_model_contract_allowed_actions_importable(self) -> None:
+        from omnibase_core.models.overseer.model_contract_allowed_actions import (
+            ModelContractAllowedActions,
+        )
+
+        assert issubclass(ModelContractAllowedActions, BaseModel)
+
+    def test_model_dispatch_item_importable(self) -> None:
+        from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
+
+        assert issubclass(ModelDispatchItem, BaseModel)
+
+    def test_model_escalation_request_importable(self) -> None:
+        from omnibase_core.models.overseer.model_escalation_request import (
+            ModelEscalationRequest,
+        )
+
+        assert issubclass(ModelEscalationRequest, BaseModel)
+
+    def test_model_overnight_contract_importable(self) -> None:
+        from omnibase_core.models.overseer.model_overnight_contract import (
+            ModelOvernightContract,
+        )
+        from omnibase_core.models.overseer.model_overnight_halt_condition import (
+            ModelOvernightHaltCondition,
+        )
+        from omnibase_core.models.overseer.model_overnight_phase_spec import (
+            ModelOvernightPhaseSpec,
+        )
+
+        assert issubclass(ModelOvernightContract, BaseModel)
+        assert issubclass(ModelOvernightHaltCondition, BaseModel)
+        assert issubclass(ModelOvernightPhaseSpec, BaseModel)
+
+    def test_model_process_runner_state_transition_importable(self) -> None:
+        from omnibase_core.models.overseer.model_process_runner_state_transition import (
+            ModelProcessRunnerStateTransition,
+        )
+
+        assert issubclass(ModelProcessRunnerStateTransition, BaseModel)
+
+    def test_model_session_contract_importable(self) -> None:
+        from omnibase_core.models.overseer.model_session_contract import (
+            ModelSessionContract,
+        )
+        from omnibase_core.models.overseer.model_session_halt_condition import (
+            ModelSessionHaltCondition,
+        )
+        from omnibase_core.models.overseer.model_session_phase_spec import (
+            ModelSessionPhaseSpec,
+        )
+
+        assert issubclass(ModelSessionContract, BaseModel)
+        assert issubclass(ModelSessionHaltCondition, BaseModel)
+        assert issubclass(ModelSessionPhaseSpec, BaseModel)
+
+    def test_model_task_delta_envelope_importable(self) -> None:
+        from omnibase_core.models.overseer.model_task_delta_envelope import (
+            ModelTaskDeltaEnvelope,
+        )
+
+        assert issubclass(ModelTaskDeltaEnvelope, BaseModel)
+
+    def test_model_task_shape_features_importable(self) -> None:
+        from omnibase_core.models.overseer.model_task_shape_features import (
+            ModelTaskShapeFeatures,
+        )
+
+        assert issubclass(ModelTaskShapeFeatures, BaseModel)
+
+    def test_model_task_state_envelope_importable(self) -> None:
+        from omnibase_core.models.overseer.model_task_state_envelope import (
+            ModelTaskStateEnvelope,
+        )
+
+        assert issubclass(ModelTaskStateEnvelope, BaseModel)
+
+    def test_model_verifier_output_importable(self) -> None:
+        from omnibase_core.models.overseer.model_verifier_output import (
+            ModelVerifierOutput,
+        )
+
+        assert issubclass(ModelVerifierOutput, BaseModel)
+
+    def test_model_worker_contract_importable(self) -> None:
+        from omnibase_core.models.overseer.model_worker_contract import (
+            ModelWorkerContract,
+            load_worker_contract,
+        )
+
+        assert issubclass(ModelWorkerContract, BaseModel)
+        assert callable(load_worker_contract)
+
+    def test_model_worker_evidence_requirement_importable(self) -> None:
+        from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+            ModelWorkerEvidenceRequirement,
+        )
+
+        assert issubclass(ModelWorkerEvidenceRequirement, BaseModel)
+
+    def test_namespace_init_exports(self) -> None:
+        from omnibase_core.models import overseer
+
+        assert hasattr(overseer, "ModelWorkerEvidenceRequirement")
+        assert hasattr(overseer, "ModelWorkerContract")
+        assert hasattr(overseer, "ModelVerifierOutput")
+        assert hasattr(overseer, "ModelOvernightHaltCondition")
+        assert hasattr(overseer, "ModelOvernightPhaseSpec")
+        assert hasattr(overseer, "ModelSessionHaltCondition")
+        assert hasattr(overseer, "ModelSessionPhaseSpec")
+        assert hasattr(overseer, "EnumCompletionOutcome")
+        assert hasattr(overseer, "EnumTaskStatus")
+
+    def test_no_shadowing_of_core_evidence_requirement(self) -> None:
+        """ModelWorkerEvidenceRequirement must not shadow core's ModelEvidenceRequirement."""
+        from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+            ModelWorkerEvidenceRequirement,
+        )
+
+        assert ModelWorkerEvidenceRequirement is not ModelEvidenceRequirement
+        overseer_fields = set(ModelWorkerEvidenceRequirement.model_fields.keys())
+        core_fields = set(ModelEvidenceRequirement.model_fields.keys())
+        assert overseer_fields != core_fields
+
+    def test_model_worker_evidence_requirement_fields(self) -> None:
+        from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+            ModelWorkerEvidenceRequirement,
+        )
+
+        req = ModelWorkerEvidenceRequirement(
+            evidence_id="test-id",
+            description="test description",
+            kind="contains",
+            pattern="expected text",
+        )
+        assert req.evidence_id == "test-id"
+        assert req.description == "test description"
+        assert req.kind == "contains"
+        assert req.pattern == "expected text"
+
+    def test_model_worker_contract_uses_worker_evidence_requirement(self) -> None:
+        from omnibase_core.models.overseer.model_worker_contract import (
+            ModelWorkerContract,
+        )
+        from omnibase_core.models.overseer.model_worker_evidence_requirement import (
+            ModelWorkerEvidenceRequirement,
+        )
+
+        contract = ModelWorkerContract(worker_name="test-worker")
+        assert contract.worker_name == "test-worker"
+        assert ModelWorkerEvidenceRequirement is not ModelEvidenceRequirement
+
+    def test_enum_task_status_values(self) -> None:
+        from omnibase_core.enums.overseer.enum_task_status import EnumTaskStatus
+
+        assert EnumTaskStatus.PENDING == "pending"
+        assert EnumTaskStatus.COMPLETED == "completed"
+        assert EnumTaskStatus.FAILED == "failed"
+
+    def test_enum_completion_outcome_values(self) -> None:
+        from omnibase_core.enums.overseer.enum_completion_outcome import (
+            EnumCompletionOutcome,
+        )
+
+        assert EnumCompletionOutcome.SUCCESS == "success"
+        assert EnumCompletionOutcome.FAILURE == "failure"


### PR DESCRIPTION
## Summary

- Adds `omnibase_core/models/overseer/` namespace with 20 model files migrated from OCC (`onex_change_control`)
- Renames OCC's `ModelEvidenceRequirement` → `ModelWorkerEvidenceRequirement` to avoid collision with the existing core `ModelEvidenceRequirement` (ticket receipt model)
- Adds `enums/overseer/` with `EnumCompletionOutcome` and `EnumTaskStatus` (migrated from OCC enums)
- `load_worker_contract()` helper function migrated alongside `ModelWorkerContract`

## Files added

`models/overseer/`: `model_completion_report`, `model_context_bundle` (+ L0–L4 split), `model_contract_allowed_actions`, `model_dispatch_item`, `model_escalation_request`, `model_overnight_contract`, `model_overnight_halt_condition`, `model_overnight_phase_spec`, `model_process_runner_state_transition`, `model_session_contract`, `model_session_halt_condition`, `model_session_phase_spec`, `model_task_delta_envelope`, `model_task_shape_features`, `model_task_state_envelope`, `model_verifier_output`, `model_worker_contract`, `model_worker_evidence_requirement`

`enums/overseer/`: `enum_completion_outcome`, `enum_task_status`

## Verification

- 23 unit tests — all pass
- `mypy --strict` clean (42 files)
- `pre-commit run --all-files` — all hooks pass
- `ruff format/check` — clean

## Ticket

OMN-10251

## dod_evidence

```json
{
  "type": "test_run",
  "result": "23/23 passed",
  "artifacts": ["tests/unit/models/overseer/test_overseer_model_imports.py"]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive task status and completion outcome enums
  * New immutable models for task state, deltas, completion reports, verifier output, and task-shape features
  * Introduced context-bundle levels L0–L4 for richer routing context
  * Added session/overnight contracts, phase specs, dispatch items, halt conditions, escalation requests, and worker contracts/evidence requirements

* **Tests**
  * Added unit tests validating overseer models, enums, and import surface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->