### PR TITLE
feat(OMN-10246): governance models batch B (autopilot, compliance, eval)

### DIFF
--- a/src/omnibase_core/enums/governance/enum_autopilot_mode.py
+++ b/src/omnibase_core/enums/governance/enum_autopilot_mode.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Autopilot Mode Enum.
+
+Closed set of operating modes for the autopilot close-out loop.
+"""
+
+from enum import Enum, unique
+
+
+@unique
+class EnumAutopilotMode(str, Enum):
+    """Operating modes for the autopilot pipeline.
+
+    - CLOSE_OUT: autopilot is merging, closing, and triaging completed work
+    - BUILD: autopilot is dispatching build workers for new tickets
+    """
+
+    CLOSE_OUT = "close_out"
+    """Merge, close, and triage completed work."""
+
+    BUILD = "build"
+    """Dispatch build workers for new or In Progress tickets."""
+
+    def __str__(self) -> str:
+        """Return the string value for serialization."""
+        return self.value

--- a/src/omnibase_core/models/governance/model_autopilot_cycle_record.py
+++ b/src/omnibase_core/models/governance/model_autopilot_cycle_record.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.enums.governance.enum_autopilot_cycle_status import (
     EnumAutopilotCycleStatus,
 )
+from omnibase_core.enums.governance.enum_autopilot_mode import EnumAutopilotMode
 from omnibase_core.models.governance.model_autopilot_step_result import (
     ModelAutopilotStepResult,
 )
@@ -27,10 +30,10 @@ class ModelAutopilotCycleRecord(BaseModel):
     schema_version: str = Field(..., description="Schema version (SemVer)")
     # string-id-ok: opaque autopilot cycle correlation identifier, not a DB primary key
     cycle_id: str = Field(..., description="Unique cycle identifier")
-    mode: str = Field(..., description="Autopilot mode: close-out or build")
-    started_at: str = Field(..., description="ISO datetime when cycle started")
-    completed_at: str | None = Field(
-        default=None, description="ISO datetime when cycle completed"
+    mode: EnumAutopilotMode = Field(..., description="Autopilot operating mode")
+    started_at: datetime = Field(..., description="When cycle started")
+    completed_at: datetime | None = Field(
+        default=None, description="When cycle completed"
     )
     steps: list[ModelAutopilotStepResult] = Field(
         default_factory=list, description="Per-step results"
@@ -40,5 +43,7 @@ class ModelAutopilotCycleRecord(BaseModel):
         description="Cycle completion status",
     )
     consecutive_noop_count: int = Field(
-        default=0, description="Prior consecutive cycles with zero tickets"
+        default=0,
+        description="Prior consecutive cycles with zero tickets",
+        ge=0,
     )

--- a/src/omnibase_core/models/governance/model_autopilot_cycle_record.py
+++ b/src/omnibase_core/models/governance/model_autopilot_cycle_record.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Autopilot cycle record model for tracking close-out cycle state."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_autopilot_cycle_status import (
+    EnumAutopilotCycleStatus,
+)
+from omnibase_core.models.governance.model_autopilot_step_result import (
+    ModelAutopilotStepResult,
+)
+
+
+class ModelAutopilotCycleRecord(BaseModel):
+    """Record of a single autopilot close-out cycle.
+
+    Written to: ``$ONEX_STATE_DIR/state/autopilot/{cycle_id}.yaml``
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-version-ok: wire type serialized to YAML at autopilot cycle boundary
+    schema_version: str = Field(..., description="Schema version (SemVer)")
+    # string-id-ok: opaque autopilot cycle correlation identifier, not a DB primary key
+    cycle_id: str = Field(..., description="Unique cycle identifier")
+    mode: str = Field(..., description="Autopilot mode: close-out or build")
+    started_at: str = Field(..., description="ISO datetime when cycle started")
+    completed_at: str | None = Field(
+        default=None, description="ISO datetime when cycle completed"
+    )
+    steps: list[ModelAutopilotStepResult] = Field(
+        default_factory=list, description="Per-step results"
+    )
+    overall_status: EnumAutopilotCycleStatus = Field(
+        default=EnumAutopilotCycleStatus.INCOMPLETE,
+        description="Cycle completion status",
+    )
+    consecutive_noop_count: int = Field(
+        default=0, description="Prior consecutive cycles with zero tickets"
+    )

--- a/src/omnibase_core/models/governance/model_autopilot_step_result.py
+++ b/src/omnibase_core/models/governance/model_autopilot_step_result.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Autopilot step result model for a single pipeline step."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from omnibase_core.enums.governance.enum_autopilot_step_status import (
+    EnumAutopilotStepStatus,
+)
+
+
+class ModelAutopilotStepResult(BaseModel):
+    """Result for a single autopilot pipeline step.
+
+    Skipped steps must provide a non-empty reason.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    step: str = Field(
+        ..., description="Step name (e.g., merge-sweep, integration-sweep)"
+    )
+    status: EnumAutopilotStepStatus = Field(..., description="Step completion status")
+    reason: str | None = Field(
+        default=None, description="Why step was skipped or failed"
+    )
+    duration_seconds: float = Field(
+        default=0.0, description="Wall-clock execution time"
+    )
+
+    @field_validator("reason")
+    @classmethod
+    def skipped_requires_reason(cls, v: str | None, info: ValidationInfo) -> str | None:
+        if info.data.get("status") == EnumAutopilotStepStatus.SKIPPED and not v:
+            raise ValueError("Skipped step must provide a non-empty reason")
+        return v

--- a/src/omnibase_core/models/governance/model_autopilot_step_result.py
+++ b/src/omnibase_core/models/governance/model_autopilot_step_result.py
@@ -28,12 +28,14 @@ class ModelAutopilotStepResult(BaseModel):
         default=None, description="Why step was skipped or failed"
     )
     duration_seconds: float = Field(
-        default=0.0, description="Wall-clock execution time"
+        default=0.0, description="Wall-clock execution time", ge=0.0
     )
 
     @field_validator("reason")
     @classmethod
     def skipped_requires_reason(cls, v: str | None, info: ValidationInfo) -> str | None:
-        if info.data.get("status") == EnumAutopilotStepStatus.SKIPPED and not v:
+        if info.data.get("status") == EnumAutopilotStepStatus.SKIPPED and (
+            v is None or not v.strip()
+        ):
             raise ValueError("Skipped step must provide a non-empty reason")
         return v

--- a/src/omnibase_core/models/governance/model_compliance_sweep_report.py
+++ b/src/omnibase_core/models/governance/model_compliance_sweep_report.py
@@ -32,7 +32,7 @@ class ModelComplianceSweepReport(BaseModel):
         ..., description="Missing contract handler count", ge=0
     )
     compliant_pct: float = Field(
-        ..., description="Percentage of compliant handlers (0-100)"
+        ..., description="Percentage of compliant handlers (0-100)", ge=0.0, le=100.0
     )
     violation_histogram: dict[str, int] = Field(
         default_factory=dict,

--- a/src/omnibase_core/models/governance/model_compliance_sweep_report.py
+++ b/src/omnibase_core/models/governance/model_compliance_sweep_report.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.models.governance.model_handler_compliance_result import (
     ModelHandlerComplianceResult,
@@ -50,3 +50,34 @@ class ModelComplianceSweepReport(BaseModel):
         default_factory=list,
         description="Handlers that gained violations since last sweep",
     )
+
+    @model_validator(mode="after")
+    def validate_aggregates(self) -> ModelComplianceSweepReport:
+        categorized = (
+            self.compliant_count
+            + self.imperative_count
+            + self.hybrid_count
+            + self.allowlisted_count
+            + self.missing_contract_count
+        )
+        if categorized != self.total_handlers:
+            raise ValueError(
+                f"total_handlers ({self.total_handlers}) must equal sum of all "
+                f"verdict counts ({categorized})"
+            )
+        if self.total_handlers == 0:
+            if self.compliant_pct != 0.0:
+                raise ValueError("compliant_pct must be 0 when total_handlers is 0")
+        else:
+            expected_pct = (self.compliant_count / self.total_handlers) * 100.0
+            if abs(self.compliant_pct - expected_pct) > 1e-6:
+                raise ValueError(
+                    f"compliant_pct ({self.compliant_pct}) must match "
+                    f"compliant_count/total_handlers ({expected_pct:.6f})"
+                )
+        for key, count in self.violation_histogram.items():
+            if count < 0:
+                raise ValueError(
+                    f"violation_histogram[{key!r}] must be non-negative, got {count}"
+                )
+        return self

--- a/src/omnibase_core/models/governance/model_compliance_sweep_report.py
+++ b/src/omnibase_core/models/governance/model_compliance_sweep_report.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Compliance sweep report model for aggregated handler compliance audits."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_handler_compliance_result import (
+    ModelHandlerComplianceResult,
+)
+from omnibase_core.models.governance.model_repo_compliance_breakdown import (
+    ModelRepoComplianceBreakdown,
+)
+
+
+class ModelComplianceSweepReport(BaseModel):
+    """Aggregated compliance sweep report across one or more repositories."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    timestamp: datetime = Field(..., description="When the sweep was performed")
+    total_handlers: int = Field(..., description="Total handlers scanned", ge=0)
+    compliant_count: int = Field(..., description="Compliant handler count", ge=0)
+    imperative_count: int = Field(..., description="Imperative handler count", ge=0)
+    hybrid_count: int = Field(..., description="Hybrid handler count", ge=0)
+    allowlisted_count: int = Field(..., description="Allowlisted handler count", ge=0)
+    missing_contract_count: int = Field(
+        ..., description="Missing contract handler count", ge=0
+    )
+    compliant_pct: float = Field(
+        ..., description="Percentage of compliant handlers (0-100)"
+    )
+    violation_histogram: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count per EnumComplianceViolation value",
+    )
+    per_repo: dict[str, ModelRepoComplianceBreakdown] = Field(
+        default_factory=dict,
+        description="Breakdown by repository",
+    )
+    results: list[ModelHandlerComplianceResult] = Field(
+        default_factory=list,
+        description="Full audit details",
+    )
+    new_violations_since_last: list[str] = Field(
+        default_factory=list,
+        description="Handlers that gained violations since last sweep",
+    )

--- a/src/omnibase_core/models/governance/model_eval_metric.py
+++ b/src/omnibase_core/models/governance/model_eval_metric.py
@@ -5,9 +5,20 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.governance.enum_eval_metric_type import EnumEvalMetricType
+
+_RATIO_METRICS = frozenset(
+    {EnumEvalMetricType.SUCCESS_RATE, EnumEvalMetricType.PATTERN_HIT_RATE}
+)
+_COUNT_METRICS = frozenset(
+    {
+        EnumEvalMetricType.TOKEN_COUNT,
+        EnumEvalMetricType.ERROR_COUNT,
+        EnumEvalMetricType.RETRY_COUNT,
+    }
+)
 
 
 class ModelEvalMetric(BaseModel):
@@ -20,3 +31,15 @@ class ModelEvalMetric(BaseModel):
     unit: str = Field(
         ..., description="Unit of measurement (e.g., ms, count, ratio)", max_length=50
     )
+
+    @model_validator(mode="after")
+    def validate_metric_contract(self) -> ModelEvalMetric:
+        if self.metric_type in _RATIO_METRICS and not (0.0 <= self.value <= 1.0):
+            raise ValueError(
+                f"{self.metric_type} must be in [0.0, 1.0], got {self.value}"
+            )
+        if self.metric_type in _COUNT_METRICS and self.value < 0:
+            raise ValueError(
+                f"{self.metric_type} must be non-negative, got {self.value}"
+            )
+        return self

--- a/src/omnibase_core/models/governance/model_eval_metric.py
+++ b/src/omnibase_core/models/governance/model_eval_metric.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval metric model for a single metric observation from an eval run."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_eval_metric_type import EnumEvalMetricType
+
+
+class ModelEvalMetric(BaseModel):
+    """A single metric observation from an eval run."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    metric_type: EnumEvalMetricType = Field(..., description="Type of metric")
+    value: float = Field(..., description="Measured value")
+    unit: str = Field(
+        ..., description="Unit of measurement (e.g., ms, count, ratio)", max_length=50
+    )

--- a/src/omnibase_core/models/governance/model_eval_report.py
+++ b/src/omnibase_core/models/governance/model_eval_report.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.models.governance.model_eval_run_pair import ModelEvalRunPair
 from omnibase_core.models.governance.model_eval_summary import ModelEvalSummary
@@ -33,3 +33,15 @@ class ModelEvalReport(BaseModel):
         ..., description="Individual task comparisons"
     )
     summary: ModelEvalSummary = Field(..., description="Aggregated summary statistics")
+
+    @model_validator(mode="after")
+    def validate_summary_alignment(self) -> ModelEvalReport:
+        if self.summary.total_tasks != len(self.pairs):
+            raise ValueError(
+                f"summary.total_tasks={self.summary.total_tasks} does not match "
+                f"len(pairs)={len(self.pairs)}"
+            )
+        task_ids = [pair.task_id for pair in self.pairs]
+        if len(task_ids) != len(set(task_ids)):
+            raise ValueError("pairs must contain unique task_id values")
+        return self

--- a/src/omnibase_core/models/governance/model_eval_report.py
+++ b/src/omnibase_core/models/governance/model_eval_report.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval report model for full A/B comparison results."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_eval_run_pair import ModelEvalRunPair
+from omnibase_core.models.governance.model_eval_summary import ModelEvalSummary
+
+
+class ModelEvalReport(BaseModel):
+    """Full A/B comparison report across all tasks in an eval suite."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: opaque eval report correlation identifier, not a DB primary key
+    report_id: str = Field(..., description="Unique report identifier", max_length=200)
+    # string-id-ok: user-facing suite identifier (e.g., eval-suite-alpha)
+    suite_id: str = Field(..., description="Which suite was evaluated", max_length=200)
+    # string-version-ok: semver stored as str for YAML wire serialization
+    suite_version: str = Field(
+        default="",
+        description="Version of the suite used for this report",
+        max_length=50,
+    )
+    generated_at: datetime = Field(..., description="When this report was generated")
+    pairs: list[ModelEvalRunPair] = Field(
+        ..., description="Individual task comparisons"
+    )
+    summary: ModelEvalSummary = Field(..., description="Aggregated summary statistics")

--- a/src/omnibase_core/models/governance/model_eval_run.py
+++ b/src/omnibase_core/models/governance/model_eval_run.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.governance.enum_eval_metric_type import EnumEvalMetricType
 from omnibase_core.enums.governance.enum_eval_mode import EnumEvalMode
@@ -47,6 +47,14 @@ class ModelEvalRun(BaseModel):
         default_factory=dict,
         description="Relevant ENABLE_* flags at time of run",
     )
+
+    @model_validator(mode="after")
+    def validate_timeline(self) -> ModelEvalRun:
+        if self.completed_at is not None and self.completed_at < self.started_at:
+            raise ValueError(
+                f"completed_at ({self.completed_at}) must not precede started_at ({self.started_at})"
+            )
+        return self
 
     def get_metric(self, metric_type: EnumEvalMetricType) -> float | None:
         """Return the value of a specific metric type, or None if not collected."""

--- a/src/omnibase_core/models/governance/model_eval_run.py
+++ b/src/omnibase_core/models/governance/model_eval_run.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval run model for a single task execution in one mode."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_eval_metric_type import EnumEvalMetricType
+from omnibase_core.enums.governance.enum_eval_mode import EnumEvalMode
+from omnibase_core.models.governance.model_eval_metric import ModelEvalMetric
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelEvalRun(BaseModel):
+    """A single eval run: one task executed in one mode."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: UUID stored as str for YAML wire serialization compatibility
+    run_id: str = Field(..., description="Unique run identifier (UUID)", max_length=200)
+    # string-id-ok: user-facing task identifier (e.g., eval-001-fix-import-error)
+    task_id: str = Field(
+        ..., description="References ModelEvalTask.task_id", max_length=200
+    )
+    mode: EnumEvalMode = Field(..., description="ONEX_ON or ONEX_OFF")
+    started_at: datetime = Field(..., description="When the run started")
+    completed_at: datetime | None = Field(
+        default=None,
+        description="When the run completed (None if still running or crashed)",
+    )
+    success: bool = Field(..., description="Whether all success criteria were met")
+    metrics: list[ModelEvalMetric] = Field(
+        default_factory=list, description="Collected metrics"
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error message if the run failed",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    git_sha: str = Field(..., description="Commit hash at time of run", max_length=64)
+    env_snapshot: dict[str, str] = Field(
+        default_factory=dict,
+        description="Relevant ENABLE_* flags at time of run",
+    )
+
+    def get_metric(self, metric_type: EnumEvalMetricType) -> float | None:
+        """Return the value of a specific metric type, or None if not collected."""
+        for m in self.metrics:
+            if m.metric_type == metric_type:
+                return m.value
+        return None

--- a/src/omnibase_core/models/governance/model_eval_run.py
+++ b/src/omnibase_core/models/governance/model_eval_run.py
@@ -50,10 +50,19 @@ class ModelEvalRun(BaseModel):
 
     @model_validator(mode="after")
     def validate_timeline(self) -> ModelEvalRun:
-        if self.completed_at is not None and self.completed_at < self.started_at:
-            raise ValueError(
-                f"completed_at ({self.completed_at}) must not precede started_at ({self.started_at})"
-            )
+        if self.completed_at is not None:
+            try:
+                invalid_order = self.completed_at < self.started_at
+            except TypeError as exc:
+                raise ValueError(
+                    f"Cannot compare completed_at ({self.completed_at!r}) and "
+                    f"started_at ({self.started_at!r}): mismatched tzinfo"
+                ) from exc
+            if invalid_order:
+                raise ValueError(
+                    f"completed_at ({self.completed_at}) must not precede "
+                    f"started_at ({self.started_at})"
+                )
         return self
 
     def get_metric(self, metric_type: EnumEvalMetricType) -> float | None:

--- a/src/omnibase_core/models/governance/model_eval_run_pair.py
+++ b/src/omnibase_core/models/governance/model_eval_run_pair.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval run pair model for paired A/B comparisons."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_eval_verdict import EnumEvalVerdict
+from omnibase_core.models.governance.model_eval_run import ModelEvalRun
+
+
+class ModelEvalRunPair(BaseModel):
+    """A paired A/B comparison: same task, ONEX ON vs OFF."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: user-facing task identifier (e.g., eval-001-fix-import-error)
+    task_id: str = Field(..., description="The task that was compared", max_length=200)
+    onex_on_run: ModelEvalRun = Field(..., description="Run with ONEX features enabled")
+    onex_off_run: ModelEvalRun = Field(
+        ..., description="Run with ONEX features disabled"
+    )
+    delta_metrics: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-metric delta (on - off). Negative = ONEX saves.",
+    )
+    verdict: EnumEvalVerdict = Field(..., description="Overall verdict for this pair")

--- a/src/omnibase_core/models/governance/model_eval_run_pair.py
+++ b/src/omnibase_core/models/governance/model_eval_run_pair.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.enums.governance.enum_eval_mode import EnumEvalMode
 from omnibase_core.enums.governance.enum_eval_verdict import EnumEvalVerdict
 from omnibase_core.models.governance.model_eval_run import ModelEvalRun
 
@@ -27,3 +28,18 @@ class ModelEvalRunPair(BaseModel):
         description="Per-metric delta (on - off). Negative = ONEX saves.",
     )
     verdict: EnumEvalVerdict = Field(..., description="Overall verdict for this pair")
+
+    @model_validator(mode="after")
+    def validate_pair_consistency(self) -> ModelEvalRunPair:
+        if (
+            self.onex_on_run.task_id != self.task_id
+            or self.onex_off_run.task_id != self.task_id
+        ):
+            raise ValueError(
+                "task_id must match both onex_on_run.task_id and onex_off_run.task_id"
+            )
+        if self.onex_on_run.mode != EnumEvalMode.ONEX_ON:
+            raise ValueError("onex_on_run.mode must be ONEX_ON")
+        if self.onex_off_run.mode != EnumEvalMode.ONEX_OFF:
+            raise ValueError("onex_off_run.mode must be ONEX_OFF")
+        return self

--- a/src/omnibase_core/models/governance/model_eval_suite.py
+++ b/src/omnibase_core/models/governance/model_eval_suite.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval suite model for a versioned collection of eval tasks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_eval_task import ModelEvalTask
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 500
+
+
+class ModelEvalSuite(BaseModel):
+    """A versioned collection of eval tasks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: user-facing suite identifier (e.g., eval-suite-alpha)
+    suite_id: str = Field(..., description="Unique suite identifier", max_length=200)
+    name: str = Field(..., description="Human-readable suite name", max_length=500)
+    description: str = Field(
+        default="", description="Suite description", max_length=_MAX_STRING_LENGTH
+    )
+    tasks: list[ModelEvalTask] = Field(
+        ..., description="Tasks in this suite", max_length=_MAX_LIST_ITEMS
+    )
+    created_at: datetime = Field(..., description="When the suite was created")
+    # string-version-ok: semver stored as str for YAML wire serialization
+    version: str = Field(..., description="Suite version (semver)", max_length=50)

--- a/src/omnibase_core/models/governance/model_eval_summary.py
+++ b/src/omnibase_core/models/governance/model_eval_summary.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval summary model for aggregated A/B comparison statistics."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelEvalSummary(BaseModel):
+    """Summary statistics for an eval report."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    total_tasks: int = Field(..., description="Total number of tasks compared", ge=0)
+    onex_better_count: int = Field(
+        ..., description="Tasks where ONEX improved outcomes", ge=0
+    )
+    onex_worse_count: int = Field(
+        ..., description="Tasks where ONEX degraded outcomes", ge=0
+    )
+    neutral_count: int = Field(
+        ..., description="Tasks with no significant difference", ge=0
+    )
+    avg_latency_delta_ms: float = Field(
+        ..., description="Average latency delta (negative = ONEX faster)"
+    )
+    avg_token_delta: float = Field(
+        ..., description="Average token count delta (negative = ONEX uses fewer tokens)"
+    )
+    avg_success_rate_on: float = Field(
+        ..., description="Average success rate with ONEX ON", ge=0.0, le=1.0
+    )
+    avg_success_rate_off: float = Field(
+        ..., description="Average success rate with ONEX OFF", ge=0.0, le=1.0
+    )
+    pattern_hit_rate_on: float = Field(
+        ..., description="How often patterns were used when ONEX is on", ge=0.0, le=1.0
+    )

--- a/src/omnibase_core/models/governance/model_eval_summary.py
+++ b/src/omnibase_core/models/governance/model_eval_summary.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelEvalSummary(BaseModel):
@@ -38,3 +38,15 @@ class ModelEvalSummary(BaseModel):
     pattern_hit_rate_on: float = Field(
         ..., description="How often patterns were used when ONEX is on", ge=0.0, le=1.0
     )
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> ModelEvalSummary:
+        categorized = (
+            self.onex_better_count + self.onex_worse_count + self.neutral_count
+        )
+        if categorized != self.total_tasks:
+            raise ValueError(
+                f"total_tasks ({self.total_tasks}) must equal "
+                f"onex_better_count + onex_worse_count + neutral_count ({categorized})"
+            )
+        return self

--- a/src/omnibase_core/models/governance/model_eval_task.py
+++ b/src/omnibase_core/models/governance/model_eval_task.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Eval task model for a single repeatable A/B comparison task."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 500
+
+
+class ModelEvalTask(BaseModel):
+    """A single eval task definition for repeatable A/B comparison."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: user-facing task identifier with human-readable slug format
+    task_id: str = Field(
+        ...,
+        description="Unique identifier (e.g., eval-001-fix-import-error)",
+        max_length=200,
+    )
+    name: str = Field(..., description="Human-readable task name", max_length=500)
+    category: str = Field(
+        ...,
+        description="Classification (e.g., bug-fix, refactor, feature, review)",
+        max_length=100,
+    )
+    prompt: str = Field(
+        ...,
+        description="The task prompt given to the agent",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    repo: str = Field(..., description="Target repository for the task", max_length=200)
+    setup_commands: list[str] = Field(
+        default_factory=list,
+        description="Commands to prepare the environment before each run",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    expected_files_changed: list[str] = Field(
+        default_factory=list,
+        description="Files expected to be modified (for success scoring)",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    success_criteria: list[str] = Field(
+        default_factory=list,
+        description="Machine-checkable criteria (e.g., 'tests pass', 'no lint errors')",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    max_duration_seconds: int = Field(
+        default=600, description="Timeout for a single run", ge=1, le=7200
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Tags for filtering/grouping",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    repeat_count: int = Field(
+        default=1,
+        description="Number of times to run the task (median metrics reported when >1)",
+        ge=1,
+        le=100,
+    )

--- a/src/omnibase_core/models/governance/model_repo_compliance_breakdown.py
+++ b/src/omnibase_core/models/governance/model_repo_compliance_breakdown.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-repo compliance breakdown model for compliance sweep reports."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRepoComplianceBreakdown(BaseModel):
+    """Per-repo breakdown of compliance results."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(..., description="Repository name")
+    total_handlers: int = Field(..., description="Total handlers scanned", ge=0)
+    compliant: int = Field(..., description="Compliant handler count", ge=0)
+    imperative: int = Field(..., description="Imperative handler count", ge=0)
+    hybrid: int = Field(..., description="Hybrid handler count", ge=0)
+    top_violations: list[str] = Field(
+        default_factory=list,
+        description="Most common violation types in this repo",
+    )

--- a/src/omnibase_core/models/governance/model_repo_compliance_breakdown.py
+++ b/src/omnibase_core/models/governance/model_repo_compliance_breakdown.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelRepoComplianceBreakdown(BaseModel):
@@ -22,3 +22,13 @@ class ModelRepoComplianceBreakdown(BaseModel):
         default_factory=list,
         description="Most common violation types in this repo",
     )
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> ModelRepoComplianceBreakdown:
+        categorized = self.compliant + self.imperative + self.hybrid
+        if categorized != self.total_handlers:
+            raise ValueError(
+                f"total_handlers ({self.total_handlers}) must equal "
+                f"compliant + imperative + hybrid ({categorized})"
+            )
+        return self

--- a/tests/unit/models/governance/test_governance_model_batch_b.py
+++ b/tests/unit/models/governance/test_governance_model_batch_b.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Red tests for governance model Batch B — autopilot, compliance, eval (OMN-10246)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+
+@pytest.mark.unit
+class TestGovernanceBatchBImports:
+    """Assert all Batch B governance models importable from omnibase_core.models.governance.*"""
+
+    def test_model_autopilot_step_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_autopilot_step_result import (
+            ModelAutopilotStepResult,
+        )
+
+        assert issubclass(ModelAutopilotStepResult, BaseModel)
+
+    def test_model_autopilot_cycle_record_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_autopilot_cycle_record import (
+            ModelAutopilotCycleRecord,
+        )
+
+        assert issubclass(ModelAutopilotCycleRecord, BaseModel)
+
+    def test_model_repo_compliance_breakdown_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_repo_compliance_breakdown import (
+            ModelRepoComplianceBreakdown,
+        )
+
+        assert issubclass(ModelRepoComplianceBreakdown, BaseModel)
+
+    def test_model_compliance_sweep_report_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_compliance_sweep_report import (
+            ModelComplianceSweepReport,
+        )
+
+        assert issubclass(ModelComplianceSweepReport, BaseModel)
+
+    def test_model_eval_summary_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_summary import (
+            ModelEvalSummary,
+        )
+
+        assert issubclass(ModelEvalSummary, BaseModel)
+
+    def test_model_eval_report_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_report import (
+            ModelEvalReport,
+        )
+
+        assert issubclass(ModelEvalReport, BaseModel)
+
+    def test_model_eval_metric_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_metric import (
+            ModelEvalMetric,
+        )
+
+        assert issubclass(ModelEvalMetric, BaseModel)
+
+    def test_model_eval_run_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_run import (
+            ModelEvalRun,
+        )
+
+        assert issubclass(ModelEvalRun, BaseModel)
+
+    def test_model_eval_run_pair_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_run_pair import (
+            ModelEvalRunPair,
+        )
+
+        assert issubclass(ModelEvalRunPair, BaseModel)
+
+    def test_model_eval_task_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_task import (
+            ModelEvalTask,
+        )
+
+        assert issubclass(ModelEvalTask, BaseModel)
+
+    def test_model_eval_suite_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_eval_suite import (
+            ModelEvalSuite,
+        )
+
+        assert issubclass(ModelEvalSuite, BaseModel)


### PR DESCRIPTION
## Summary

Migrates governance models **Batch B** from `onex_change_control` into `omnibase_core/src/omnibase_core/models/governance/` (additive only — OCC untouched).

Ticket: OMN-10246

### Models added

**Autopilot:**
- `ModelAutopilotStepResult` — single pipeline step result with skip-requires-reason validator
- `ModelAutopilotCycleRecord` — full close-out cycle record with step list and FSM status

**Compliance:**
- `ModelRepoComplianceBreakdown` — per-repo handler compliance counts
- `ModelComplianceSweepReport` — aggregated sweep report across all repos

**Eval:**
- `ModelEvalMetric` — single metric observation from an eval run
- `ModelEvalRun` — single task execution in one mode (ONEX_ON/OFF)
- `ModelEvalRunPair` — paired A/B comparison for one task
- `ModelEvalSummary` — aggregated summary statistics for an eval report
- `ModelEvalReport` — full A/B comparison report across all tasks
- `ModelEvalTask` — single repeatable A/B task definition
- `ModelEvalSuite` — versioned collection of eval tasks

### Branch-as-base

Branched from `jonah/omn-10245-governance-models-batch-a` (PR #971) so batch A models are present. Will rebase onto `main` after #971 lands.

### dod_evidence

- All 11 batch B import tests green (`tests/unit/models/governance/test_governance_model_batch_b.py`)
- All 18 governance tests (batch A + B) green
- `mypy src/omnibase_core/models/governance/ --strict` — no issues (22 source files)
- All 48 pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autopilot cycles tracked with detailed per-step results, statuses, and cycle metadata.
  * Compliance sweeps produce aggregated reports with violation histograms and per-repository breakdowns.
  * New evaluation framework: metrics, runs, paired A/B comparisons, summaries, reports, tasks, and suites for A/B testing and aggregated statistics.
  * New enum for autopilot operating modes.

* **Tests**
  * Added unit tests validating governance model classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->