### PR TITLE
feat(OMN-10248): governance models batch D (day open/close, dogfood, doc freshness, dod sweep, integration)

### DIFF
--- a/src/omnibase_core/models/governance/__init__.py
+++ b/src/omnibase_core/models/governance/__init__.py
@@ -2,3 +2,103 @@
 # SPDX-License-Identifier: MIT
 
 """Governance models for the ONEX platform."""
+
+from omnibase_core.models.governance.model_day_close import ModelDayClose
+from omnibase_core.models.governance.model_day_close_actual_repo import (
+    ModelDayCloseActualRepo,
+)
+from omnibase_core.models.governance.model_day_close_drift_detected import (
+    ModelDayCloseDriftDetected,
+)
+from omnibase_core.models.governance.model_day_close_invariants_checked import (
+    ModelDayCloseInvariantsChecked,
+)
+from omnibase_core.models.governance.model_day_close_plan_item import (
+    ModelDayClosePlanItem,
+)
+from omnibase_core.models.governance.model_day_close_pr import ModelDayClosePR
+from omnibase_core.models.governance.model_day_close_process_change import (
+    ModelDayCloseProcessChange,
+)
+from omnibase_core.models.governance.model_day_close_risk import ModelDayCloseRisk
+from omnibase_core.models.governance.model_day_open import ModelDayOpen
+from omnibase_core.models.governance.model_day_open_finding import ModelDayOpenFinding
+from omnibase_core.models.governance.model_day_open_infra_service import (
+    ModelDayOpenInfraService,
+)
+from omnibase_core.models.governance.model_day_open_probe_result import (
+    ModelDayOpenProbeResult,
+)
+from omnibase_core.models.governance.model_day_open_repo_sync_entry import (
+    ModelDayOpenRepoSyncEntry,
+)
+from omnibase_core.models.governance.model_delegation_health import (
+    ModelDelegationHealth,
+)
+from omnibase_core.models.governance.model_doc_freshness_result import (
+    ModelDocFreshnessResult,
+)
+from omnibase_core.models.governance.model_doc_freshness_sweep_report import (
+    ModelDocFreshnessSweepReport,
+)
+from omnibase_core.models.governance.model_dod_sweep import ModelDodSweepResult
+from omnibase_core.models.governance.model_dod_sweep_check_result import (
+    ModelDodSweepCheckResult,
+)
+from omnibase_core.models.governance.model_dod_sweep_ticket_result import (
+    ModelDodSweepTicketResult,
+)
+from omnibase_core.models.governance.model_dogfood_regression import (
+    ModelDogfoodRegression,
+)
+from omnibase_core.models.governance.model_dogfood_scorecard import (
+    ModelDogfoodScorecard,
+)
+from omnibase_core.models.governance.model_endpoint_health import ModelEndpointHealth
+from omnibase_core.models.governance.model_golden_chain_health import (
+    ModelGoldenChainHealth,
+)
+from omnibase_core.models.governance.model_infrastructure_health import (
+    ModelInfrastructureHealth,
+)
+from omnibase_core.models.governance.model_integration_probe_result import (
+    ModelIntegrationProbeResult,
+)
+from omnibase_core.models.governance.model_integration_record import (
+    ModelIntegrationRecord,
+)
+from omnibase_core.models.governance.model_readiness_dimension import (
+    ModelReadinessDimension,
+)
+from omnibase_core.models.governance.model_repo_doc_summary import ModelRepoDocSummary
+
+__all__ = [
+    "ModelDayClose",
+    "ModelDayCloseActualRepo",
+    "ModelDayCloseDriftDetected",
+    "ModelDayCloseInvariantsChecked",
+    "ModelDayClosePR",
+    "ModelDayClosePlanItem",
+    "ModelDayCloseProcessChange",
+    "ModelDayCloseRisk",
+    "ModelDayOpen",
+    "ModelDayOpenFinding",
+    "ModelDayOpenInfraService",
+    "ModelDayOpenProbeResult",
+    "ModelDayOpenRepoSyncEntry",
+    "ModelDelegationHealth",
+    "ModelDocFreshnessResult",
+    "ModelDocFreshnessSweepReport",
+    "ModelDodSweepCheckResult",
+    "ModelDodSweepResult",
+    "ModelDodSweepTicketResult",
+    "ModelDogfoodRegression",
+    "ModelDogfoodScorecard",
+    "ModelEndpointHealth",
+    "ModelGoldenChainHealth",
+    "ModelInfrastructureHealth",
+    "ModelIntegrationProbeResult",
+    "ModelIntegrationRecord",
+    "ModelReadinessDimension",
+    "ModelRepoDocSummary",
+]

--- a/src/omnibase_core/models/governance/model_day_close.py
+++ b/src/omnibase_core/models/governance/model_day_close.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayClose — daily close report model."""
+
+import re
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.governance.model_day_close_actual_repo import (
+    ModelDayCloseActualRepo,
+)
+from omnibase_core.models.governance.model_day_close_drift_detected import (
+    ModelDayCloseDriftDetected,
+)
+from omnibase_core.models.governance.model_day_close_invariants_checked import (
+    ModelDayCloseInvariantsChecked,
+)
+from omnibase_core.models.governance.model_day_close_plan_item import (
+    ModelDayClosePlanItem,
+)
+from omnibase_core.models.governance.model_day_close_pr import ModelDayClosePR
+from omnibase_core.models.governance.model_day_close_process_change import (
+    ModelDayCloseProcessChange,
+)
+from omnibase_core.models.governance.model_day_close_risk import ModelDayCloseRisk
+
+# Basic SemVer (major.minor.patch only). Ported from onex_change_control.validation.patterns.
+_SEMVER_PATTERN: re.Pattern[str] = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_MAX_LIST_ITEMS = 1000
+
+__all__ = [
+    "ModelDayClose",
+    "ModelDayCloseActualRepo",
+    "ModelDayCloseDriftDetected",
+    "ModelDayCloseInvariantsChecked",
+    "ModelDayClosePR",
+    "ModelDayClosePlanItem",
+    "ModelDayCloseProcessChange",
+    "ModelDayCloseRisk",
+]
+
+
+class ModelDayClose(BaseModel):
+    """Daily close report model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-version-ok: YAML/JSON wire; format checked by field_validator
+    schema_version: str = Field(
+        ..., description="Schema version (SemVer format)", max_length=20
+    )
+    date: str = Field(..., description="ISO date (YYYY-MM-DD)")
+    process_changes_today: list[ModelDayCloseProcessChange] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    plan: list[ModelDayClosePlanItem] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    actual_by_repo: list[ModelDayCloseActualRepo] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    drift_detected: list[ModelDayCloseDriftDetected] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    invariants_checked: ModelDayCloseInvariantsChecked = Field(
+        ..., description="Invariants checked status"
+    )
+    corrections_for_tomorrow: list[str] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    risks: list[ModelDayCloseRisk] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_PATTERN.match(v):
+            msg = f"Invalid schema_version format: {v}. Expected SemVer (e.g., '1.0.0')"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("date")
+    @classmethod
+    def validate_date(cls, v: str) -> str:
+        if not _DATE_PATTERN.match(v):
+            msg = f"Invalid date format: {v}. Expected ISO format (YYYY-MM-DD)"
+            raise ValueError(msg)
+        try:
+            date.fromisoformat(v)
+        except ValueError as e:
+            msg = f"Invalid calendar date: {v}. {e!s}"
+            raise ValueError(msg) from e
+        return v

--- a/src/omnibase_core/models/governance/model_day_close_actual_repo.py
+++ b/src/omnibase_core/models/governance/model_day_close_actual_repo.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayCloseActualRepo — actual work by repository in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_day_close_pr import ModelDayClosePR
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 1000
+
+
+class ModelDayCloseActualRepo(BaseModel):
+    """Actual work by repository in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    repo: str = Field(..., description="Repository name", max_length=_MAX_STRING_LENGTH)
+    prs: list[ModelDayClosePR] = Field(
+        default_factory=list, description="List of PRs", max_length=_MAX_LIST_ITEMS
+    )

--- a/src/omnibase_core/models/governance/model_day_close_drift_detected.py
+++ b/src/omnibase_core/models/governance/model_day_close_drift_detected.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayCloseDriftDetected — drift detected entry in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_drift_category import EnumDriftCategory
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayCloseDriftDetected(BaseModel):
+    """Drift detected entry in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    drift_id: str = Field(  # string-id-ok: human-readable drift identifier slug, not a DB primary key
+        ..., description="Unique drift identifier", max_length=_MAX_STRING_LENGTH
+    )
+    category: EnumDriftCategory = Field(..., description="Drift category")
+    evidence: str = Field(
+        ...,
+        description="What changed / where (PRs, commits, files)",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    impact: str = Field(
+        ..., description="Why it matters", max_length=_MAX_STRING_LENGTH
+    )
+    correction_for_tomorrow: str = Field(
+        ...,
+        description="Specific fix / decision / ticket",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_day_close_invariants_checked.py
+++ b/src/omnibase_core/models/governance/model_day_close_invariants_checked.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayCloseInvariantsChecked — invariants checked in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+
+
+class ModelDayCloseInvariantsChecked(BaseModel):
+    """Invariants checked in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    reducers_pure: EnumInvariantStatus = Field(
+        ..., description="Reducers are pure (no I/O)"
+    )
+    orchestrators_no_io: EnumInvariantStatus = Field(
+        ..., description="Orchestrators perform no I/O"
+    )
+    topic_governance: EnumInvariantStatus = Field(
+        default=EnumInvariantStatus.UNKNOWN,
+        description="No raw topic literals in production code (OMN-3342)",
+    )
+    effects_do_io_only: EnumInvariantStatus = Field(
+        ..., description="Effects perform I/O only"
+    )
+    real_infra_proof_progressing: EnumInvariantStatus = Field(
+        ..., description="Real infrastructure proof is progressing"
+    )
+    integration_sweep: EnumInvariantStatus = Field(
+        default=EnumInvariantStatus.UNKNOWN,
+        description="Integration sweep result",
+    )

--- a/src/omnibase_core/models/governance/model_day_close_plan_item.py
+++ b/src/omnibase_core/models/governance/model_day_close_plan_item.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayClosePlanItem — plan item in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayClosePlanItem(BaseModel):
+    """Plan item in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-id-ok: governance plan artifact identifier (e.g., REQ-001), not a DB primary key
+    requirement_id: str = Field(
+        ..., description="Requirement identifier", max_length=_MAX_STRING_LENGTH
+    )
+    summary: str = Field(
+        ..., description="Summary of the requirement", max_length=_MAX_STRING_LENGTH
+    )

--- a/src/omnibase_core/models/governance/model_day_close_pr.py
+++ b/src/omnibase_core/models/governance/model_day_close_pr.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayClosePR — pull request entry in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_pr_state import EnumPRState
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayClosePR(BaseModel):
+    """Pull request entry in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    pr: int = Field(..., description="PR number", ge=1)
+    title: str = Field(..., description="PR title", max_length=_MAX_STRING_LENGTH)
+    state: EnumPRState = Field(..., description="PR state")
+    notes: str = Field(
+        ...,
+        description="Why it matters / what it unblocks",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_day_close_process_change.py
+++ b/src/omnibase_core/models/governance/model_day_close_process_change.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayCloseProcessChange — process change entry in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayCloseProcessChange(BaseModel):
+    """Process change entry in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    change: str = Field(
+        ...,
+        description="What changed in the process today",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    rationale: str = Field(
+        ..., description="Why we changed it", max_length=_MAX_STRING_LENGTH
+    )
+    replaces: str = Field(
+        ...,
+        description="What it replaces / previous behavior",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_day_close_risk.py
+++ b/src/omnibase_core/models/governance/model_day_close_risk.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayCloseRisk — risk entry in daily close report."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayCloseRisk(BaseModel):
+    """Risk entry in daily close report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    risk: str = Field(
+        ..., description="Short risk description", max_length=_MAX_STRING_LENGTH
+    )
+    mitigation: str = Field(
+        ..., description="Short mitigation description", max_length=_MAX_STRING_LENGTH
+    )

--- a/src/omnibase_core/models/governance/model_day_open.py
+++ b/src/omnibase_core/models/governance/model_day_open.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayOpen — daily morning investigation report model."""
+
+import re
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.governance.model_day_open_finding import ModelDayOpenFinding
+from omnibase_core.models.governance.model_day_open_infra_service import (
+    ModelDayOpenInfraService,
+)
+from omnibase_core.models.governance.model_day_open_probe_result import (
+    ModelDayOpenProbeResult,
+)
+from omnibase_core.models.governance.model_day_open_repo_sync_entry import (
+    ModelDayOpenRepoSyncEntry,
+)
+
+# Basic SemVer (major.minor.patch only). Ported from onex_change_control.validation.patterns.
+_SEMVER_PATTERN: re.Pattern[str] = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_MAX_LIST_ITEMS = 1000
+
+__all__ = [
+    "ModelDayOpen",
+    "ModelDayOpenFinding",
+    "ModelDayOpenInfraService",
+    "ModelDayOpenProbeResult",
+    "ModelDayOpenRepoSyncEntry",
+]
+
+
+class ModelDayOpen(BaseModel):
+    """Daily morning investigation report model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-version-ok: YAML/JSON wire; format checked by field_validator
+    schema_version: str = Field(
+        ..., description="Schema version (SemVer format)", max_length=20
+    )
+    date: str = Field(..., description="ISO date (YYYY-MM-DD)")
+    run_id: str = Field(
+        ..., description="Unique identifier for this begin-day run", max_length=1000
+    )
+    yesterday_corrections: list[str] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    repo_sync_status: list[ModelDayOpenRepoSyncEntry] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    infra_health: list[ModelDayOpenInfraService] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    probe_results: list[ModelDayOpenProbeResult] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    aggregated_findings: list[ModelDayOpenFinding] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    recommended_focus_areas: list[str] = Field(default_factory=list, max_length=10)
+    total_duration_seconds: float = Field(
+        default=0.0, description="Total wall-clock duration", ge=0.0
+    )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_PATTERN.match(v):
+            msg = f"Invalid schema_version format: {v}. Expected SemVer (e.g., '1.0.0')"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("date")
+    @classmethod
+    def validate_date(cls, v: str) -> str:
+        if not _DATE_PATTERN.match(v):
+            msg = f"Invalid date format: {v}. Expected ISO format (YYYY-MM-DD)"
+            raise ValueError(msg)
+        try:
+            date.fromisoformat(v)
+        except ValueError as e:
+            msg = f"Invalid calendar date: {v}. {e!s}"
+            raise ValueError(msg) from e
+        return v

--- a/src/omnibase_core/models/governance/model_day_open_finding.py
+++ b/src/omnibase_core/models/governance/model_day_open_finding.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayOpenFinding — individual finding from morning investigation."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_finding_severity import EnumFindingSeverity
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayOpenFinding(BaseModel):
+    """Individual finding from morning investigation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    finding_id: str = Field(  # string-id-ok: stable probe fingerprint slug ({probe}:{category}:{key}), not a DB UUID
+        ...,
+        description="Stable fingerprint: {probe_name}:{category}:{deterministic_key}",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    severity: EnumFindingSeverity = Field(
+        ..., description="Severity level of the finding"
+    )
+    source_probe: str = Field(
+        ...,
+        description="Name of the probe that generated this finding",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    title: str = Field(
+        ...,
+        description="Short description of the finding",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    detail: str = Field(
+        default="",
+        description="Detailed explanation of the finding",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    repo: str | None = Field(
+        default=None,
+        description="Affected repository, or None for platform-wide issues",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    suggested_action: str | None = Field(
+        default=None,
+        description="Recommended action to address the finding",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_day_open_infra_service.py
+++ b/src/omnibase_core/models/governance/model_day_open_infra_service.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayOpenInfraService — infrastructure service health entry from Phase 1."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayOpenInfraService(BaseModel):
+    """Infrastructure service health entry from Phase 1."""
+
+    model_config = ConfigDict(frozen=True)
+
+    service: str = Field(..., description="Service name", max_length=_MAX_STRING_LENGTH)
+    running: bool = Field(..., description="Whether the Docker container is running")
+    port_responding: bool = Field(
+        ..., description="Whether the service port is accepting connections"
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message if health check failed",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_day_open_probe_result.py
+++ b/src/omnibase_core/models/governance/model_day_open_probe_result.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayOpenProbeResult — result from a single Phase 2 investigation probe."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_probe_status import EnumProbeStatus
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayOpenProbeResult(BaseModel):
+    """Result from a single Phase 2 investigation probe."""
+
+    model_config = ConfigDict(frozen=True)
+
+    probe_name: str = Field(
+        ..., description="Probe identifier", max_length=_MAX_STRING_LENGTH
+    )
+    status: EnumProbeStatus = Field(..., description="Execution status of the probe")
+    artifact_path: str | None = Field(
+        default=None,
+        description="Path to the probe's JSON artifact file",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    summary: str | None = Field(
+        default=None,
+        description="Brief summary of probe results",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    finding_count: int = Field(
+        default=0, description="Number of findings from this probe", ge=0
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message if probe failed",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    duration_seconds: float = Field(
+        default=0.0, description="Wall-clock duration of probe execution", ge=0.0
+    )

--- a/src/omnibase_core/models/governance/model_day_open_repo_sync_entry.py
+++ b/src/omnibase_core/models/governance/model_day_open_repo_sync_entry.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDayOpenRepoSyncEntry — repository sync status entry from Phase 1 pull-all."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDayOpenRepoSyncEntry(BaseModel):
+    """Repository sync status entry from Phase 1 pull-all."""
+
+    model_config = ConfigDict(frozen=True)
+
+    repo: str = Field(..., description="Repository name", max_length=_MAX_STRING_LENGTH)
+    branch: str = Field(
+        ..., description="Branch that was synced", max_length=_MAX_STRING_LENGTH
+    )
+    up_to_date: bool = Field(..., description="Whether the repo was already up to date")
+    head_sha: str = Field(
+        ..., description="HEAD commit SHA after sync", max_length=_MAX_STRING_LENGTH
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message if sync failed",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_delegation_health.py
+++ b/src/omnibase_core/models/governance/model_delegation_health.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDelegationHealth — health of the delegation classifier and per-task-type routing."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+
+
+class ModelDelegationHealth(BaseModel):
+    """Health of the delegation classifier and per-task-type routing."""
+
+    model_config = ConfigDict(frozen=True)
+
+    task_type_coverage: dict[str, EnumDogfoodStatus] = Field(
+        default_factory=dict, description="Per-task-type classifier coverage status"
+    )
+    classifier_coverage_pct: float = Field(
+        ...,
+        description="Overall classifier coverage as a percentage (0.0-100.0)",
+        ge=0.0,
+        le=100.0,
+    )
+    model_health: EnumDogfoodStatus = Field(
+        ..., description="Health of the underlying inference model"
+    )
+    status: EnumDogfoodStatus = Field(
+        ..., description="Overall delegation health status"
+    )

--- a/src/omnibase_core/models/governance/model_doc_freshness_result.py
+++ b/src/omnibase_core/models/governance/model_doc_freshness_result.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Document freshness result model."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.governance.enum_doc_staleness_verdict import (
+    EnumDocStalenessVerdict,
+)
+from omnibase_core.models.governance.model_doc_reference import ModelDocReference
+
+_MAX_LIST_ITEMS = 10000
+_STALENESS_THRESHOLD = 0.3
+_STALE_DAYS_THRESHOLD = 30
+
+
+class ModelDocFreshnessResult(BaseModel):
+    """Freshness check result for a single documentation file."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    doc_path: str = Field(..., description="Path to the .md file")
+    repo: str = Field(..., description="Repository name")
+    doc_last_modified: datetime = Field(
+        ..., description="Last git commit that touched this file"
+    )
+    references: list[ModelDocReference] = Field(
+        default_factory=list,
+        description="All extracted references",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    broken_references: list[ModelDocReference] = Field(
+        default_factory=list,
+        description="References where exists == False",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    stale_references: list[ModelDocReference] = Field(
+        default_factory=list,
+        description="References where target was modified after doc",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    staleness_score: float = Field(
+        ..., description="0.0 (fresh) to 1.0 (completely stale)", ge=0.0, le=1.0
+    )
+    verdict: EnumDocStalenessVerdict = Field(
+        ..., description="Overall freshness verdict"
+    )
+    referenced_code_last_modified: datetime | None = Field(
+        default=None, description="Most recent change to any referenced code"
+    )
+
+    @model_validator(mode="after")
+    def validate_verdict_consistency(self) -> "ModelDocFreshnessResult":
+        if (
+            self.verdict == EnumDocStalenessVerdict.BROKEN
+            and not self.broken_references
+        ):
+            msg = "Verdict is BROKEN but no broken references found"
+            raise ValueError(msg)
+        return self

--- a/src/omnibase_core/models/governance/model_doc_freshness_sweep_report.py
+++ b/src/omnibase_core/models/governance/model_doc_freshness_sweep_report.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDocFreshnessSweepReport — full sweep report across all repositories."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.governance.model_doc_freshness_result import (
+    ModelDocFreshnessResult,
+)
+from omnibase_core.models.governance.model_repo_doc_summary import ModelRepoDocSummary
+
+_MAX_LIST_ITEMS = 10000
+
+__all__ = ["ModelDocFreshnessSweepReport", "ModelRepoDocSummary"]
+
+
+class ModelDocFreshnessSweepReport(BaseModel):
+    """Full sweep report across all repositories."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    timestamp: datetime = Field(..., description="When the sweep was run")
+    repos_scanned: list[str] = Field(
+        default_factory=list, description="List of repository names scanned"
+    )
+    total_docs: int = Field(..., description="Total documents scanned", ge=0)
+    fresh_count: int = Field(..., description="Documents with FRESH verdict", ge=0)
+    stale_count: int = Field(..., description="Documents with STALE verdict", ge=0)
+    broken_count: int = Field(..., description="Documents with BROKEN verdict", ge=0)
+    unknown_count: int = Field(..., description="Documents with UNKNOWN verdict", ge=0)
+    total_references: int = Field(..., description="Total references extracted", ge=0)
+    broken_reference_count: int = Field(
+        ..., description="Total broken references", ge=0
+    )
+    stale_reference_count: int = Field(..., description="Total stale references", ge=0)
+    per_repo: dict[str, ModelRepoDocSummary] = Field(
+        default_factory=dict, description="Per-repo summary"
+    )
+    results: list[ModelDocFreshnessResult] = Field(
+        default_factory=list, description="Per-doc results", max_length=_MAX_LIST_ITEMS
+    )
+    top_stale_docs: list[str] = Field(
+        default_factory=list,
+        description="Top 10 docs by staleness score",
+        max_length=10,
+    )

--- a/src/omnibase_core/models/governance/model_dod_sweep.py
+++ b/src/omnibase_core/models/governance/model_dod_sweep.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodSweepResult — aggregate DoD sweep report."""
+
+import re
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+from omnibase_core.models.governance.model_dod_sweep_check_result import (
+    ModelDodSweepCheckResult,
+)
+from omnibase_core.models.governance.model_dod_sweep_ticket_result import (
+    ModelDodSweepTicketResult,
+)
+
+# Basic SemVer (major.minor.patch only). Ported from onex_change_control.validation.patterns.
+_SEMVER_PATTERN: re.Pattern[str] = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 1000
+
+__all__ = [
+    "ModelDodSweepResult",
+    "ModelDodSweepCheckResult",
+    "ModelDodSweepTicketResult",
+]
+
+
+class ModelDodSweepResult(BaseModel):
+    """Aggregate DoD sweep report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-version-ok: YAML/JSON wire; format checked by field_validator
+    schema_version: str = Field(
+        ..., description="Schema version (SemVer)", max_length=20
+    )
+    date: str = Field(..., description="ISO date of sweep run")
+    run_id: str = Field(
+        ..., description="Unique sweep run identifier", max_length=_MAX_STRING_LENGTH
+    )
+    mode: Literal["batch", "targeted"] = Field(..., description="Sweep mode")
+    lookback_days: int | None = Field(
+        default=None, description="Look-back window for batch mode"
+    )
+    # string-id-ok: Linear epic/ticket ID for targeted mode (e.g., OMN-1234), not a DB UUID
+    target_id: str | None = Field(
+        default=None, description="Epic or ticket ID for targeted mode"
+    )
+    tickets: list[ModelDodSweepTicketResult] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    overall_status: EnumInvariantStatus = Field(default=EnumInvariantStatus.UNKNOWN)
+    total_tickets: int = Field(default=0)
+    passed: int = Field(default=0)
+    failed: int = Field(default=0)
+    exempted: int = Field(default=0)
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_PATTERN.match(v):
+            msg = f"Invalid schema_version: {v}. Expected SemVer (e.g., '1.0.0')"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("date")
+    @classmethod
+    def validate_date(cls, v: str) -> str:
+        if not _DATE_PATTERN.match(v):
+            msg = f"Invalid date format: {v}. Expected YYYY-MM-DD"
+            raise ValueError(msg)
+        date.fromisoformat(v)
+        return v
+
+    @model_validator(mode="after")
+    def derive_aggregates(self) -> "ModelDodSweepResult":
+        tickets = self.tickets
+        passed = sum(
+            1
+            for t in tickets
+            if t.overall_status == EnumInvariantStatus.PASS and not t.exempted
+        )
+        failed = sum(1 for t in tickets if t.overall_status == EnumInvariantStatus.FAIL)
+        exempted_count = sum(1 for t in tickets if t.exempted)
+
+        if failed > 0:
+            derived = EnumInvariantStatus.FAIL
+        elif passed > 0 and passed + exempted_count == len(tickets):
+            derived = EnumInvariantStatus.PASS
+        elif len(tickets) > 0 and exempted_count == len(tickets):
+            derived = EnumInvariantStatus.UNKNOWN
+        else:
+            derived = EnumInvariantStatus.UNKNOWN
+
+        object.__setattr__(self, "total_tickets", len(tickets))
+        object.__setattr__(self, "passed", passed)
+        object.__setattr__(self, "failed", failed)
+        object.__setattr__(self, "exempted", exempted_count)
+        object.__setattr__(self, "overall_status", derived)
+        return self

--- a/src/omnibase_core/models/governance/model_dod_sweep_check_result.py
+++ b/src/omnibase_core/models/governance/model_dod_sweep_check_result.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodSweepCheckResult — result for a single DoD compliance check."""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dod_sweep_check import EnumDodSweepCheck
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDodSweepCheckResult(BaseModel):
+    """Result for a single DoD compliance check."""
+
+    model_config = ConfigDict(frozen=True)
+
+    check: EnumDodSweepCheck = Field(
+        ..., description="Which of the 6 DoD checks this result is for"
+    )
+    status: EnumInvariantStatus = Field(
+        ..., description="Check result: PASS, FAIL, or UNKNOWN"
+    )
+    unknown_subtype: Literal[
+        "exempt", "linkage_inconclusive", "mixed_evidence", None
+    ] = Field(
+        default=None,
+        description="Structured subtype when status is UNKNOWN",
+    )
+    detail: Annotated[str | None, Field(max_length=_MAX_STRING_LENGTH)] = Field(
+        default=None, description="Human-readable detail about the check outcome"
+    )

--- a/src/omnibase_core/models/governance/model_dod_sweep_ticket_result.py
+++ b/src/omnibase_core/models/governance/model_dod_sweep_ticket_result.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDodSweepTicketResult — DoD compliance result for a single ticket."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+from omnibase_core.models.governance.model_dod_sweep_check_result import (
+    ModelDodSweepCheckResult,
+)
+
+
+class ModelDodSweepTicketResult(BaseModel):
+    """DoD compliance result for a single ticket."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-id-ok: Linear ticket ID (e.g., OMN-1234), not a DB UUID
+    ticket_id: str = Field(..., description="Linear ticket ID (e.g., OMN-1234)")
+    title: str = Field(..., description="Ticket title from Linear")
+    unknown_subtype: Literal[
+        "exempt", "mixed_evidence", "no_evidence_backed_passes", None
+    ] = Field(
+        default=None,
+        description="Structured subtype when overall_status is UNKNOWN",
+    )
+    completed_at: str | None = Field(
+        default=None, description="ISO date when ticket was completed"
+    )
+    checks: list[ModelDodSweepCheckResult] = Field(
+        ..., description="Results for all 6 DoD checks", max_length=10
+    )
+    overall_status: EnumInvariantStatus = Field(
+        default=EnumInvariantStatus.UNKNOWN,
+        description="Derived: FAIL if any check FAIL, PASS if all PASS.",
+    )
+    exempted: bool = Field(default=False, description="Whether this ticket is exempt")
+    exemption_reason: str | None = Field(
+        default=None, description="Why this ticket is exempt"
+    )
+    # string-id-ok: Linear follow-up ticket ID reference (e.g., OMN-1234), not a DB UUID
+    follow_up_ticket_id: str | None = Field(
+        default=None, description="Created follow-up ticket ID, if any"
+    )
+
+    @model_validator(mode="after")
+    def derive_overall_status(self) -> "ModelDodSweepTicketResult":
+        if self.exempted:
+            object.__setattr__(self, "overall_status", EnumInvariantStatus.UNKNOWN)
+            return self
+        statuses = [c.status for c in self.checks]
+        if not statuses:
+            derived = EnumInvariantStatus.UNKNOWN
+        elif any(s == EnumInvariantStatus.FAIL for s in statuses):
+            derived = EnumInvariantStatus.FAIL
+        elif all(s == EnumInvariantStatus.PASS for s in statuses):
+            derived = EnumInvariantStatus.PASS
+        else:
+            derived = EnumInvariantStatus.UNKNOWN
+        object.__setattr__(self, "overall_status", derived)
+        return self

--- a/src/omnibase_core/models/governance/model_dogfood_regression.py
+++ b/src/omnibase_core/models/governance/model_dogfood_regression.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDogfoodRegression — a single detected regression between two scorecard runs."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumRegressionSeverity
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelDogfoodRegression(BaseModel):
+    """A single detected regression between two scorecard runs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dimension: str = Field(
+        ...,
+        description="Which scorecard dimension the regression occurred in",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    field_path: str = Field(
+        ...,
+        description="Dotted path to the regressed field",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    severity: EnumRegressionSeverity = Field(..., description="CRITICAL or WARN")
+    previous_value: str = Field(
+        ...,
+        description="String representation of the previous value",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    current_value: str = Field(
+        ...,
+        description="String representation of the current value",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    description: str = Field(
+        ...,
+        description="Human-readable explanation of the regression",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_dogfood_scorecard.py
+++ b/src/omnibase_core/models/governance/model_dogfood_scorecard.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDogfoodScorecard — platform dogfood scorecard, a single timestamped health snapshot."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+from omnibase_core.models.governance.model_delegation_health import (
+    ModelDelegationHealth,
+)
+from omnibase_core.models.governance.model_dogfood_regression import (
+    ModelDogfoodRegression,
+)
+from omnibase_core.models.governance.model_endpoint_health import ModelEndpointHealth
+from omnibase_core.models.governance.model_golden_chain_health import (
+    ModelGoldenChainHealth,
+)
+from omnibase_core.models.governance.model_infrastructure_health import (
+    ModelInfrastructureHealth,
+)
+from omnibase_core.models.governance.model_readiness_dimension import (
+    ModelReadinessDimension,
+)
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 500
+
+__all__ = [
+    "ModelDogfoodScorecard",
+    "ModelDelegationHealth",
+    "ModelDogfoodRegression",
+    "ModelEndpointHealth",
+    "ModelGoldenChainHealth",
+    "ModelInfrastructureHealth",
+    "ModelReadinessDimension",
+]
+
+
+class ModelDogfoodScorecard(BaseModel):
+    """Platform dogfood scorecard — a single timestamped health snapshot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-version-ok: wire type serialized to YAML/JSON at scorecard boundary
+    schema_version: str = Field(
+        default="1.0.0", description="Scorecard schema version (SemVer)", max_length=20
+    )
+    captured_at: str = Field(
+        ...,
+        description="ISO 8601 timestamp when this scorecard was captured",
+        max_length=30,
+    )
+    run_id: str = Field(
+        ...,
+        description="Unique identifier for this scorecard run",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    readiness_dimensions: list[ModelReadinessDimension] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    golden_chains: list[ModelGoldenChainHealth] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    endpoints: list[ModelEndpointHealth] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    delegation: ModelDelegationHealth | None = Field(default=None)
+    infrastructure: ModelInfrastructureHealth | None = Field(default=None)
+    regressions: list[ModelDogfoodRegression] = Field(
+        default_factory=list, max_length=_MAX_LIST_ITEMS
+    )
+    overall_status: EnumDogfoodStatus = Field(
+        ..., description="Aggregate health status across all dimensions"
+    )

--- a/src/omnibase_core/models/governance/model_endpoint_health.py
+++ b/src/omnibase_core/models/governance/model_endpoint_health.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelEndpointHealth — health record for a single HTTP endpoint probe."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelEndpointHealth(BaseModel):
+    """Health record for a single HTTP endpoint probe."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str = Field(..., description="Endpoint path", max_length=_MAX_STRING_LENGTH)
+    http_code: int = Field(..., description="HTTP response status code", ge=100, le=599)
+    has_data: bool = Field(
+        ..., description="Whether the response body contained meaningful data"
+    )
+    response_schema_valid: bool = Field(
+        ..., description="Whether the response body matched the expected schema"
+    )
+    status: EnumDogfoodStatus = Field(..., description="Endpoint health status")

--- a/src/omnibase_core/models/governance/model_golden_chain_health.py
+++ b/src/omnibase_core/models/governance/model_golden_chain_health.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelGoldenChainHealth — health record for a single named golden chain."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelGoldenChainHealth(BaseModel):
+    """Health record for a single named golden chain."""
+
+    model_config = ConfigDict(frozen=True)
+
+    chain_name: str = Field(
+        ...,
+        description="Human-readable chain identifier",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    topic: str = Field(
+        ..., description="Kafka topic name", max_length=_MAX_STRING_LENGTH
+    )
+    table: str = Field(
+        ..., description="Downstream DB table name", max_length=_MAX_STRING_LENGTH
+    )
+    row_count: int = Field(
+        ..., description="Current row count in the downstream table", ge=0
+    )
+    status: EnumDogfoodStatus = Field(..., description="Chain health status")

--- a/src/omnibase_core/models/governance/model_infrastructure_health.py
+++ b/src/omnibase_core/models/governance/model_infrastructure_health.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelInfrastructureHealth — infrastructure component health snapshot."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+
+
+class ModelInfrastructureHealth(BaseModel):
+    """Infrastructure component health snapshot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kafka: EnumDogfoodStatus = Field(..., description="Kafka (Redpanda) broker health")
+    postgres: EnumDogfoodStatus = Field(..., description="PostgreSQL availability")
+    docker: EnumDogfoodStatus = Field(
+        ..., description="Docker daemon and required container health"
+    )
+    consumer_groups: EnumDogfoodStatus = Field(
+        ..., description="Kafka consumer group lag status"
+    )
+    status: EnumDogfoodStatus = Field(
+        ..., description="Aggregate infrastructure health status"
+    )

--- a/src/omnibase_core/models/governance/model_integration_probe_result.py
+++ b/src/omnibase_core/models/governance/model_integration_probe_result.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelIntegrationProbeResult — result for a single integration surface probe."""
+
+import re
+from datetime import date
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.governance.enum_integration_surface import (
+    EnumIntegrationSurface,
+)
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+from omnibase_core.enums.governance.enum_probe_reason import EnumProbeReason
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelIntegrationProbeResult(BaseModel):
+    """Result for a single integration surface probe."""
+
+    model_config = ConfigDict(frozen=True)
+
+    surface: EnumIntegrationSurface = Field(
+        ..., description="The integration surface being probed"
+    )
+    status: EnumInvariantStatus = Field(
+        ..., description="Probe result: PASS, FAIL, or UNKNOWN"
+    )
+    reason: EnumProbeReason | None = Field(
+        default=None, description="Reason code when status is UNKNOWN or skipped"
+    )
+    detail: Annotated[str | None, Field(max_length=_MAX_STRING_LENGTH)] = Field(
+        default=None, description="Human-readable detail about the probe outcome"
+    )
+    checked_at: str | None = Field(
+        default=None,
+        description="ISO date (YYYY-MM-DD) when the probe was run. None if probe did not execute.",
+        max_length=20,
+    )
+
+    @field_validator("checked_at")
+    @classmethod
+    def validate_checked_at(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not _DATE_PATTERN.match(v):
+            msg = f"Invalid date format: {v}. Expected ISO format (YYYY-MM-DD)"
+            raise ValueError(msg)
+        try:
+            date.fromisoformat(v)
+        except ValueError as e:
+            msg = f"Invalid calendar date: {v}. {e!s}"
+            raise ValueError(msg) from e
+        return v

--- a/src/omnibase_core/models/governance/model_integration_record.py
+++ b/src/omnibase_core/models/governance/model_integration_record.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelIntegrationRecord — aggregated /integration-sweep artifact."""
+
+import re
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.governance.enum_invariant_status import EnumInvariantStatus
+from omnibase_core.models.governance.model_integration_probe_result import (
+    ModelIntegrationProbeResult,
+)
+
+# Basic SemVer (major.minor.patch only). Ported from onex_change_control.validation.patterns.
+_SEMVER_PATTERN: re.Pattern[str] = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+)
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_MAX_STRING_LENGTH = 10000
+_MAX_LIST_ITEMS = 1000
+
+__all__ = ["ModelIntegrationRecord", "ModelIntegrationProbeResult"]
+
+
+class ModelIntegrationRecord(BaseModel):
+    """Aggregated /integration-sweep artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    # string-version-ok: YAML/JSON wire; format checked by field_validator
+    schema_version: str = Field(
+        ..., description="Schema version (SemVer format)", max_length=20
+    )
+    date: str = Field(..., description="ISO date (YYYY-MM-DD) of the sweep run")
+    run_id: str = Field(
+        ...,
+        description="Unique identifier for this sweep run",
+        max_length=_MAX_STRING_LENGTH,
+    )
+    tickets: list[ModelIntegrationProbeResult] = Field(
+        default_factory=list,
+        description="Per-surface probe results collected during this sweep",
+        max_length=_MAX_LIST_ITEMS,
+    )
+    overall_status: EnumInvariantStatus = Field(
+        default=EnumInvariantStatus.UNKNOWN,
+        description="Derived sweep status. Computed by model_validator — do not set manually.",
+    )
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_PATTERN.match(v):
+            msg = f"Invalid schema_version format: {v}. Expected SemVer (e.g., '1.0.0')"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("date")
+    @classmethod
+    def validate_date(cls, v: str) -> str:
+        if not _DATE_PATTERN.match(v):
+            msg = f"Invalid date format: {v}. Expected ISO format (YYYY-MM-DD)"
+            raise ValueError(msg)
+        try:
+            date.fromisoformat(v)
+        except ValueError as e:
+            msg = f"Invalid calendar date: {v}. {e!s}"
+            raise ValueError(msg) from e
+        return v
+
+    @model_validator(mode="after")
+    def derive_overall_status(self) -> "ModelIntegrationRecord":
+        statuses = [t.status for t in self.tickets]
+        if not statuses:
+            derived = EnumInvariantStatus.UNKNOWN
+        elif any(s == EnumInvariantStatus.FAIL for s in statuses):
+            derived = EnumInvariantStatus.FAIL
+        elif all(s == EnumInvariantStatus.PASS for s in statuses):
+            derived = EnumInvariantStatus.PASS
+        else:
+            derived = EnumInvariantStatus.UNKNOWN
+        object.__setattr__(self, "overall_status", derived)
+        return self

--- a/src/omnibase_core/models/governance/model_readiness_dimension.py
+++ b/src/omnibase_core/models/governance/model_readiness_dimension.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelReadinessDimension — per-dimension readiness verdict with supporting evidence."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.governance.enum_dogfood_status import EnumDogfoodStatus
+
+_MAX_STRING_LENGTH = 10000
+
+
+class ModelReadinessDimension(BaseModel):
+    """Per-dimension readiness verdict with supporting evidence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(..., description="Dimension name", max_length=_MAX_STRING_LENGTH)
+    status: EnumDogfoodStatus = Field(..., description="PASS/WARN/FAIL/UNKNOWN verdict")
+    evidence: str = Field(
+        default="",
+        description="Supporting evidence or failure reason",
+        max_length=_MAX_STRING_LENGTH,
+    )

--- a/src/omnibase_core/models/governance/model_repo_doc_summary.py
+++ b/src/omnibase_core/models/governance/model_repo_doc_summary.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRepoDocSummary — summary of doc freshness results for a single repository."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRepoDocSummary(BaseModel):
+    """Summary of doc freshness results for a single repository."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(..., description="Repository name")
+    total_docs: int = Field(..., description="Total docs scanned", ge=0)
+    fresh: int = Field(..., description="Count of fresh docs", ge=0)
+    stale: int = Field(..., description="Count of stale docs", ge=0)
+    broken: int = Field(..., description="Count of broken docs", ge=0)
+    broken_references: int = Field(
+        ..., description="Total broken references across docs", ge=0
+    )

--- a/tests/unit/models/governance/test_governance_model_batch_d.py
+++ b/tests/unit/models/governance/test_governance_model_batch_d.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Import-assertion tests for governance model Batch D (OMN-10248)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+
+@pytest.mark.unit
+class TestGovernanceBatchDImports:
+    """Assert all Batch D governance models importable from omnibase_core.models.governance.*"""
+
+    # model_day_close.py — 8 classes
+    def test_model_day_close_process_change_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayCloseProcessChange,
+        )
+
+        assert issubclass(ModelDayCloseProcessChange, BaseModel)
+
+    def test_model_day_close_plan_item_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayClosePlanItem,
+        )
+
+        assert issubclass(ModelDayClosePlanItem, BaseModel)
+
+    def test_model_day_close_pr_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayClosePR,
+        )
+
+        assert issubclass(ModelDayClosePR, BaseModel)
+
+    def test_model_day_close_actual_repo_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayCloseActualRepo,
+        )
+
+        assert issubclass(ModelDayCloseActualRepo, BaseModel)
+
+    def test_model_day_close_drift_detected_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayCloseDriftDetected,
+        )
+
+        assert issubclass(ModelDayCloseDriftDetected, BaseModel)
+
+    def test_model_day_close_invariants_checked_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayCloseInvariantsChecked,
+        )
+
+        assert issubclass(ModelDayCloseInvariantsChecked, BaseModel)
+
+    def test_model_day_close_risk_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayCloseRisk,
+        )
+
+        assert issubclass(ModelDayCloseRisk, BaseModel)
+
+    def test_model_day_close_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_close import (
+            ModelDayClose,
+        )
+
+        assert issubclass(ModelDayClose, BaseModel)
+
+    # model_day_open.py — 5 classes
+    def test_model_day_open_repo_sync_entry_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_open import (
+            ModelDayOpenRepoSyncEntry,
+        )
+
+        assert issubclass(ModelDayOpenRepoSyncEntry, BaseModel)
+
+    def test_model_day_open_infra_service_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_open import (
+            ModelDayOpenInfraService,
+        )
+
+        assert issubclass(ModelDayOpenInfraService, BaseModel)
+
+    def test_model_day_open_probe_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_open import (
+            ModelDayOpenProbeResult,
+        )
+
+        assert issubclass(ModelDayOpenProbeResult, BaseModel)
+
+    def test_model_day_open_finding_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_open import (
+            ModelDayOpenFinding,
+        )
+
+        assert issubclass(ModelDayOpenFinding, BaseModel)
+
+    def test_model_day_open_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_day_open import (
+            ModelDayOpen,
+        )
+
+        assert issubclass(ModelDayOpen, BaseModel)
+
+    # model_dogfood_scorecard.py — 7 classes
+    def test_model_readiness_dimension_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelReadinessDimension,
+        )
+
+        assert issubclass(ModelReadinessDimension, BaseModel)
+
+    def test_model_golden_chain_health_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelGoldenChainHealth,
+        )
+
+        assert issubclass(ModelGoldenChainHealth, BaseModel)
+
+    def test_model_endpoint_health_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelEndpointHealth,
+        )
+
+        assert issubclass(ModelEndpointHealth, BaseModel)
+
+    def test_model_delegation_health_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelDelegationHealth,
+        )
+
+        assert issubclass(ModelDelegationHealth, BaseModel)
+
+    def test_model_infrastructure_health_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelInfrastructureHealth,
+        )
+
+        assert issubclass(ModelInfrastructureHealth, BaseModel)
+
+    def test_model_dogfood_regression_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelDogfoodRegression,
+        )
+
+        assert issubclass(ModelDogfoodRegression, BaseModel)
+
+    def test_model_dogfood_scorecard_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dogfood_scorecard import (
+            ModelDogfoodScorecard,
+        )
+
+        assert issubclass(ModelDogfoodScorecard, BaseModel)
+
+    # model_doc_freshness_result.py — 1 class
+    def test_model_doc_freshness_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_doc_freshness_result import (
+            ModelDocFreshnessResult,
+        )
+
+        assert issubclass(ModelDocFreshnessResult, BaseModel)
+
+    # model_doc_freshness_sweep_report.py — 2 classes
+    def test_model_repo_doc_summary_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_doc_freshness_sweep_report import (
+            ModelRepoDocSummary,
+        )
+
+        assert issubclass(ModelRepoDocSummary, BaseModel)
+
+    def test_model_doc_freshness_sweep_report_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_doc_freshness_sweep_report import (
+            ModelDocFreshnessSweepReport,
+        )
+
+        assert issubclass(ModelDocFreshnessSweepReport, BaseModel)
+
+    # model_dod_sweep.py — 3 classes
+    def test_model_dod_sweep_check_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dod_sweep import (
+            ModelDodSweepCheckResult,
+        )
+
+        assert issubclass(ModelDodSweepCheckResult, BaseModel)
+
+    def test_model_dod_sweep_ticket_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dod_sweep import (
+            ModelDodSweepTicketResult,
+        )
+
+        assert issubclass(ModelDodSweepTicketResult, BaseModel)
+
+    def test_model_dod_sweep_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_dod_sweep import (
+            ModelDodSweepResult,
+        )
+
+        assert issubclass(ModelDodSweepResult, BaseModel)
+
+    # model_integration_record.py — 2 classes
+    def test_model_integration_probe_result_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_integration_record import (
+            ModelIntegrationProbeResult,
+        )
+
+        assert issubclass(ModelIntegrationProbeResult, BaseModel)
+
+    def test_model_integration_record_is_base_model(self) -> None:
+        from omnibase_core.models.governance.model_integration_record import (
+            ModelIntegrationRecord,
+        )
+
+        assert issubclass(ModelIntegrationRecord, BaseModel)


### PR DESCRIPTION
## Summary

Implements OMN-10248: migrate governance models Batch D into `omnibase_core`.

- `ModelDayClose` + 7 sub-models (plan item, process change, PR, actual repo, drift detected, invariants checked, risk)
- `ModelDayOpen` + 4 sub-models (repo sync entry, infra service, probe result, finding)
- `ModelDogfoodScorecard` + 6 sub-models (readiness dimension, golden chain health, endpoint health, delegation health, infrastructure health, dogfood regression)
- `ModelDocFreshnessResult`, `ModelRepoDocSummary`, `ModelDocFreshnessSweepReport`
- `ModelDodSweepResult` + 2 sub-models (check result, ticket result)
- `ModelIntegrationRecord` + `ModelIntegrationProbeResult`

All 28 classes follow one-class-per-file convention, hub files re-export sub-models, `ConfigDict(frozen=True)` throughout, string-id-ok annotations for Linear ticket ID fields.

## Test plan

- [x] 28 unit tests (one per class) added in `tests/unit/models/governance/test_governance_model_batch_d.py`
- [x] All 35 governance model tests pass (`pytest tests/unit/models/governance/ -v`)
- [x] `mypy src/ --strict` clean
- [x] `pre-commit run --all-files` passes all 50+ hooks

## DoD evidence

```yaml
ticket: OMN-10248
dod_evidence:
  - type: tests_passing
    detail: "35/35 governance unit tests pass including 28 new batch D tests"
  - type: mypy_clean
    detail: "mypy --strict clean on all 24 governance source files"
  - type: precommit_pass
    detail: "pre-commit run --all-files passed all hooks including ONEX Single Class Per File"
  - type: pr_filed
    detail: "PR filed against jonah/omn-10245-governance-models-batch-a base branch"
```

Stacks on PR #971 (batch A). Batch D base branch will rebase to main once batch A merges.