### PR TITLE
feat(OMN-9607): cross-repo docs validation gate

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -53,7 +53,10 @@
     ".ruff_cache/**",
     "build/**",
     "dist/**",
-    "htmlcov/**"
+    "htmlcov/**",
+    "omni_worktrees/**",
+    "plugins/**/.venv/**",
+    "plugins/**/lib/.venv/**"
   ],
   "checkExternal": false
 }

--- a/.onex_state/evidence/omn-9607-validation-matrix.md
+++ b/.onex_state/evidence/omn-9607-validation-matrix.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-29
 **Ticket:** OMN-9607 — Task 13: Cross-repo docs validation gate and freshness sweep wiring
 **Validator:** `uv run onex-validate-links --verbose` (per-repo) and cross-repo scan
-**Executed from:** `/Users/jonah/Code/omni_home/omnibase_core` (owner of `onex-validate-links`)
+**Executed from:** `$OMNI_HOME/omnibase_core` (owner of `onex-validate-links`)
 
 ---
 

--- a/.onex_state/evidence/omn-9607-validation-matrix.md
+++ b/.onex_state/evidence/omn-9607-validation-matrix.md
@@ -1,0 +1,125 @@
+# OMN-9607 — Cross-Repo Docs Validation Matrix
+
+**Date:** 2026-04-29
+**Ticket:** OMN-9607 — Task 13: Cross-repo docs validation gate and freshness sweep wiring
+**Validator:** `uv run onex-validate-links --verbose` (per-repo) and cross-repo scan
+**Executed from:** `/Users/jonah/Code/omni_home/omnibase_core` (owner of `onex-validate-links`)
+
+---
+
+## Phase A: Wave 2 Upstream PRs Verified
+
+| Ticket | PR | Repo | State | mergeCommit.oid |
+|--------|-----|------|-------|----------------|
+| OMN-9598 | #31 | omnidash | MERGED | 7145e80c4663d9bb4435d191a0d5eaf9aa6945eb |
+| OMN-9603 | #615 | omniintelligence | MERGED | 8bfd5037393eb5496748e2483719e5a5898fc2b0 |
+| OMN-9604 | #296 | omnimemory | MERGED | f88186d2fabda5a5e33f9fe93a9efbd85403b122 |
+| OMN-9605 | #529 | onex_change_control | MERGED | fa6ba81696b43843f9561c162b382c43fbbe7ca4 |
+| OMN-9606 | #1464 | omniclaude | MERGED | 9fb64533285529384aa555c4cb7f0663e178b2ca |
+
+All 5 Wave 2 Linear tickets confirmed Done. All 5 PRs confirmed MERGED with non-null mergeCommit.oid.
+
+---
+
+## Per-Repo Freshness Matrix (10 in-scope repos)
+
+### Legend
+- OK = passes check
+- GAP = documented gap / follow-up ticket filed
+- N/A = not applicable (documented exemption)
+
+| Repo | README exists | Links to docs index | docs/INDEX.md or docs/README.md | Commands verifiable | Referenced paths exist | Event-surface doc | validate-links result |
+|------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| omnibase_compat | OK | OK → docs/README.md | OK (docs/README.md) | OK | OK | N/A (no event bus) | PASS (1 gap: only in omni_worktrees, not main repo) |
+| omnibase_core | OK | OK → docs/INDEX.md | OK (docs/INDEX.md) | OK | OK | N/A (kernel, no bus) | PASS after config fix |
+| omnibase_infra | OK | OK → docs/INDEX.md | OK (docs/INDEX.md) | OK | GAP (anchor slugs) | OK (docs/architecture/EVENT_STREAMING_TOPICS.md) | FAIL — 53 broken anchors in new architecture docs (OMN-9608) |
+| omnibase_spi | OK | OK → docs/README.md | OK (docs/README.md) | OK | OK | N/A (protocol only) | PASS |
+| omnimarket | OK | OK → docs/README.md | OK (docs/README.md) | OK | OK | N/A (marketplace) | PASS (2 gaps: only in omni_worktrees .venv paths) |
+| omniintelligence | OK | OK → docs/INDEX.md | OK (docs/INDEX.md) | OK | GAP (3 broken cross-repo refs) | OK (docs/reference/EVENT_SURFACE.md per OMN-9603) | FAIL — 3 broken links in src/ sub-READMEs (OMN-9609) |
+| omnimemory | OK | OK → docs/INDEX.md | OK (docs/INDEX.md) | OK | OK | N/A (storage layer) | PASS |
+| onex_change_control | OK | GAP (links to docs/ dir only, no docs/INDEX.md) | GAP — no docs/INDEX.md or docs/README.md | OK | GAP (planning/IMPLEMENTATION_PLAN.md missing) | N/A | FAIL — 1 broken link (OMN-9610) |
+| omniclaude | OK | OK → docs/INDEX.md | OK (docs/INDEX.md) | OK | GAP (CONTRIBUTING.md ref, plugins/.venv paths) | N/A (thin wrapper) | FAIL — 25 broken links mostly in plugins/.venv (OMN-9611) |
+| omnidash | OK | GAP — no docs/INDEX.md or docs/README.md | GAP — no docs index | OK | OK | N/A (frontend) | N/A (npm repo, use npm run check) |
+
+---
+
+## Smoke Validation Results
+
+| Repo | README → docs index (≤2 clicks) | Install/run/test commands | Owns/doesn't-own boundary | Dated plans as context only |
+|------|:---:|:---:|:---:|:---:|
+| omnibase_compat | OK (links to docs/README.md) | OK (uv add omnibase-compat) | OK | OK |
+| omnibase_core | OK (links to docs/INDEX.md) | OK (uv sync && uv run pytest) | OK | OK |
+| omnibase_infra | OK (links to docs/INDEX.md) | OK (uv sync && uv run pytest) | OK | OK |
+| omnibase_spi | OK (links to docs/README.md) | OK (uv add omnibase-spi) | OK | OK |
+| omnimarket | OK (links to docs/README.md) | OK (uv run pytest) | OK | OK |
+| omniintelligence | OK (links to docs/INDEX.md) | OK | OK | OK |
+| omnimemory | OK (links to docs/INDEX.md) | OK | OK | OK |
+| onex_change_control | PARTIAL (links to docs/ dir) | OK | OK | OK |
+| omniclaude | OK (links to docs/INDEX.md) | OK | OK | OK |
+| omnidash | PARTIAL (no docs index) | OK (npm install && npm run dev) | OK | OK |
+
+---
+
+## Cross-Repo Validation Command
+
+```bash
+# Run from omnibase_core — it owns the onex-validate-links CLI
+cd /path/to/omnibase_core  # or use $OMNI_HOME/omnibase_core
+uv run onex-validate-links --verbose --cross-repo-root ${OMNI_HOME}
+```
+
+**Result with fix applied (omni_worktrees/** excluded):**
+- omnibase_core: PASS (189 files, 1816 links, 0 broken)
+- Cross-repo scan of omni_home root: 1 broken link before fix (pyright README in nested worktree .venv path) → 0 after fix
+
+---
+
+## CI Gate Status
+
+`onex-validate-links` is already wired as a blocking CI gate in `omnibase_core/ci.yml`:
+- Job: `docs-validation` (Phase 1, parallel with lint/pyright)
+- Gate: Part of `quality-gate` which blocks `test-parallel`
+- Reusable workflow: `validate-docs.yml` — callable by all repos
+
+Repos not yet using the reusable workflow: omnibase_infra, omnibase_spi, omnimarket, omniintelligence, omnimemory, onex_change_control, omniclaude, omnidash. Follow-up tickets filed.
+
+---
+
+## Broken Links: Root Cause Analysis
+
+### omnibase_infra (53 broken — all anchor slug mismatches)
+New architecture docs (LLM_INFRASTRUCTURE.md, MCP_SERVICE_ARCHITECTURE.md, TOPIC_CATALOG_ARCHITECTURE.md, MCP_INTEGRATION_GUIDE.md, HANDLER_AUTHORING_GUIDE.md, ERROR_HANDLING_BEST_PRACTICES.md, REGISTRATION_WORKFLOW.md) have ToC links using `## HandlerMCP — Server Lifecycle` → anchor `#handlermcp-server-lifecycle` but GitHub converts em-dash to `--` (double-hyphen), so the actual anchor slug is `#handlermcp--server-lifecycle`. The validator correctly flags these. Filed as OMN-9608.
+
+### omniintelligence (3 broken)
+- `src/omniintelligence/tools/README.md:550` — `./C_API.md` does not exist (third-party file reference)
+- `src/omniintelligence/tools/README.md:553` — `[OMN-6594]` reference-style link missing definition
+- `src/omniintelligence/audit/README.md:835` — `/path/to/omni_home/tests/audit/io_audit_whitelist.yaml` absolute path (violates no-hardcoded-paths rule)
+Filed as OMN-9609.
+
+### onex_change_control (1 broken + docs index gap)
+- `docs/VERSIONING_POLICY.md:96` — `planning/IMPLEMENTATION_PLAN.md` does not exist (was never created)
+- No docs/INDEX.md or docs/README.md
+Filed as OMN-9610.
+
+### omniclaude (25 broken — mostly plugins/.venv paths)
+- 22 in `plugins/onex/lib/.venv/` (onnxruntime, mdit_py_plugins, omniintelligence site-packages)
+- 2 in `omni_worktrees/OMN-10180/omniclaude/.venv/`
+- 1 genuine: `CONTRIBUTING.md` missing from root
+Fix: add `plugins/**/.venv/**` to omniclaude's `.markdown-link-check.json` + add root CONTRIBUTING.md
+Filed as OMN-9611.
+
+### omnidash (no docs index)
+omnidash README documents ADRs and CONTRIBUTING.md but has no `docs/INDEX.md` or `docs/README.md`. The docs/ directory contains plans/adr/audit but no canonical entrypoint. Filed as OMN-9612.
+
+---
+
+## Follow-up Tickets Filed
+
+| Ticket | Repo | Description |
+|--------|------|-------------|
+| OMN-9608 | omnibase_infra | Fix 53 anchor slug mismatches in architecture docs (em-dash → double-hyphen) |
+| OMN-9609 | omniintelligence | Fix 3 broken links in src/ sub-READMEs (C_API.md, missing ref, absolute path) |
+| OMN-9610 | onex_change_control | Add docs/INDEX.md and fix VERSIONING_POLICY.md broken link |
+| OMN-9611 | omniclaude | Add plugins/.venv to .markdown-link-check.json excludes, add CONTRIBUTING.md |
+| OMN-9612 | omnidash | Add docs/INDEX.md as canonical docs entrypoint |
+| OMN-9613 | all repos | Wire validate-docs.yml reusable workflow as required CI check in all 10 repos |

--- a/tests/unit/scripts/test_validate_markdown_links.py
+++ b/tests/unit/scripts/test_validate_markdown_links.py
@@ -900,6 +900,7 @@ class TestLinkInfoMissingReference:
         assert link.display_link == "[Link Text](./docs/readme.md)"
 
 
+@pytest.mark.unit
 class TestMarkdownLinkConfigExclusions:
     """Tests for MarkdownLinkConfig exclusion patterns.
 
@@ -934,9 +935,8 @@ class TestMarkdownLinkConfigExclusions:
         )
 
         found = list(find_markdown_files(tmp_path, config.exclude_files))
-        found_names = [f.name for f in found]
 
-        assert "README.md" in found_names, "Real doc should be found"
+        assert real_doc in found, "Real doc should be found"
         # The broken_md under omni_worktrees/ should NOT be in the found list
         assert broken_md not in found, "omni_worktrees path must be excluded"
 

--- a/tests/unit/scripts/test_validate_markdown_links.py
+++ b/tests/unit/scripts/test_validate_markdown_links.py
@@ -17,9 +17,11 @@ import pytest
 from omnibase_core.scripts.validate_markdown_links import (
     BrokenLink,
     LinkInfo,
+    MarkdownLinkConfig,
     ValidationResult,
     _heading_to_anchor,
     extract_headings_as_anchors,
+    find_markdown_files,
     is_external_link,
     is_http_link,
     normalize_url_for_validation,
@@ -896,3 +898,97 @@ class TestLinkInfoMissingReference:
             source_file=Path("test.md"),
         )
         assert link.display_link == "[Link Text](./docs/readme.md)"
+
+
+class TestMarkdownLinkConfigExclusions:
+    """Tests for MarkdownLinkConfig exclusion patterns.
+
+    OMN-9607: validates that omni_worktrees/** and plugins/**/.venv/**
+    exclusion patterns work correctly so that nested worktree .venv paths
+    (which contain third-party READMEs with broken links) are excluded from
+    the cross-repo docs validation scan.
+    """
+
+    def test_omni_worktrees_excluded(self, tmp_path: Path) -> None:
+        """Files under omni_worktrees/** must be excluded from scanning."""
+        # Build a directory structure that mimics a worktree .venv path
+        worktree_venv = (
+            tmp_path / "omni_worktrees" / "OMN-1234" / "somerepo" / ".venv" / "lib"
+        )
+        worktree_venv.mkdir(parents=True)
+        broken_md = worktree_venv / "README.md"
+        broken_md.write_text("[broken](./nonexistent.md)\n", encoding="utf-8")
+
+        # A real doc that should be included
+        real_doc = tmp_path / "docs" / "README.md"
+        real_doc.parent.mkdir(parents=True)
+        real_doc.write_text("# Real doc\n\nContent.\n", encoding="utf-8")
+
+        config = MarkdownLinkConfig.from_dict(
+            {
+                "excludeFiles": [
+                    "omni_worktrees/**",
+                    ".venv/**",
+                ],
+            }
+        )
+
+        found = list(find_markdown_files(tmp_path, config.exclude_files))
+        found_names = [f.name for f in found]
+
+        assert "README.md" in found_names, "Real doc should be found"
+        # The broken_md under omni_worktrees/ should NOT be in the found list
+        assert broken_md not in found, "omni_worktrees path must be excluded"
+
+    def test_plugins_venv_excluded(self, tmp_path: Path) -> None:
+        """Files under plugins/**/.venv/** must be excluded from scanning."""
+        plugin_venv = (
+            tmp_path / "plugins" / "onex" / "lib" / ".venv" / "lib" / "python3.13"
+        )
+        plugin_venv.mkdir(parents=True)
+        broken_md = plugin_venv / "Privacy.md"
+        broken_md.write_text(
+            "[broken](../README.md)\n[also broken](./C_API.md)\n", encoding="utf-8"
+        )
+
+        real_doc = tmp_path / "README.md"
+        real_doc.write_text("# Repo root\n\nContent.\n", encoding="utf-8")
+
+        config = MarkdownLinkConfig.from_dict(
+            {
+                "excludeFiles": [
+                    "plugins/**/.venv/**",
+                    ".venv/**",
+                ],
+            }
+        )
+
+        found = list(find_markdown_files(tmp_path, config.exclude_files))
+        assert real_doc in found, "Root README.md should be found"
+        assert broken_md not in found, "plugins/.venv path must be excluded"
+
+    def test_normal_docs_not_excluded(self, tmp_path: Path) -> None:
+        """Normal documentation files must not be excluded by worktree patterns."""
+        normal_docs = [
+            tmp_path / "README.md",
+            tmp_path / "docs" / "INDEX.md",
+            tmp_path / "docs" / "architecture" / "OVERVIEW.md",
+        ]
+        for doc in normal_docs:
+            doc.parent.mkdir(parents=True, exist_ok=True)
+            doc.write_text("# Doc\n\nContent.\n", encoding="utf-8")
+
+        config = MarkdownLinkConfig.from_dict(
+            {
+                "excludeFiles": [
+                    "omni_worktrees/**",
+                    ".venv/**",
+                    "plugins/**/.venv/**",
+                    "plugins/**/lib/.venv/**",
+                ],
+            }
+        )
+
+        found = set(find_markdown_files(tmp_path, config.exclude_files))
+        for doc in normal_docs:
+            assert doc in found, f"{doc.name} must not be excluded by worktree patterns"


### PR DESCRIPTION
## Summary

- Fixes `.markdown-link-check.json` to exclude `omni_worktrees/**` and `plugins/**/.venv/**` paths, eliminating false positives from nested worktree `.venv` directories containing third-party READMEs
- Adds 3 unit tests in `TestMarkdownLinkConfigExclusions` proving the new exclusion patterns work correctly and do not exclude real docs
- Evidence matrix at `.onex_state/evidence/omn-9607-validation-matrix.md` documenting the per-repo freshness audit across all 10 in-scope repos

## OMN-9607

Task 13 of the OMN-9594 doc overhaul epic: cross-repo docs validation gate and freshness sweep wiring.

## DoD evidence

| Check | Command | Result |
|-------|---------|--------|
| omnibase_core validate-links | `uv run onex-validate-links --verbose` | PASS (191 files, 1817 links, 0 broken) |
| New exclusion unit tests | `uv run pytest tests/unit/scripts/test_validate_markdown_links.py -v` | 74/74 PASS (3 new) |
| pre-commit | `pre-commit run --all-files` | All hooks PASS |
| ruff format + check | `uv run ruff format src/ tests/ && uv run ruff check src/ tests/` | Clean |
| Cross-repo scan (before fix) | `uv run onex-validate-links --cross-repo-root /Users/jonah/Code/omni_home` | 1 broken (pyright README in omni_worktrees/.venv) |
| Cross-repo scan (after fix) | Same command with new config | 0 broken |

## Per-repo freshness audit

| Repo | README | docs index | validate-links | Notes |
|------|:---:|:---:|:---:|------|
| omnibase_compat | OK | OK | PASS | |
| omnibase_core | OK | OK | PASS | This PR |
| omnibase_infra | OK | OK | FAIL | 53 anchor slug mismatches → OMN-9608 |
| omnibase_spi | OK | OK | PASS | |
| omnimarket | OK | OK | PASS | |
| omniintelligence | OK | OK | FAIL | 3 broken cross-repo refs → OMN-9609 |
| omnimemory | OK | OK | PASS | |
| onex_change_control | OK | GAP | FAIL | No docs/INDEX.md, 1 broken link → OMN-9610 |
| omniclaude | OK | OK | FAIL | plugins/.venv not excluded, 1 real broken link → OMN-9611 |
| omnidash | OK | GAP | N/A | No docs/INDEX.md → OMN-9612 |

## Follow-up tickets

- OMN-9608: omnibase_infra — fix 53 anchor slug mismatches (em-dash → double-hyphen)
- OMN-9609: omniintelligence — fix 3 broken links in src/ sub-READMEs
- OMN-9610: onex_change_control — add docs/INDEX.md and fix VERSIONING_POLICY.md broken link
- OMN-9611: omniclaude — add plugins/.venv to excludes, add CONTRIBUTING.md
- OMN-9612: omnidash — add docs/INDEX.md as canonical docs entrypoint
- OMN-9613: all repos — wire validate-docs.yml reusable workflow as required CI check

## CI gate

`onex-validate-links` is already wired as a blocking CI gate in `ci.yml` → `docs-validation` job → `quality-gate`. This PR makes that gate pass cleanly by correcting the exclusion config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a cross-repo validation matrix documenting link-check coverage, validation results, smoke checks, and follow-up items.

* **Chores**
  * Extended markdown link-check exclusions to skip worktree and virtual environment paths, reducing false positives.

* **Tests**
  * Added unit tests to verify the exclusion behavior and ensure other markdown files are still discovered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->