### PR TITLE
feat(OMN-9572): add FSM transition failure discriminator

### DIFF
--- a/contracts/OMN-9572.yaml
+++ b/contracts/OMN-9572.yaml
@@ -1,0 +1,46 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9572
+summary: "Add FSM transition failure discriminator and preserve typed failure handling"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: "Focused FSM executor and reducer metadata regression tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/models/fsm/test_model_fsm_transition_result.py tests/unit/utils/test_fsm_executor.py
+      tests/unit/models/reducer/test_model_reducer_fsm_metadata.py tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py
+      -q"
+  - kind: manual
+    description: "Strict mypy passes for util_fsm_executor typed exception handling"
+    command: "uv run mypy src/omnibase_core/utils/util_fsm_executor.py --strict"
+  - kind: ci
+    description: "omnibase_core PR #980 checks pass, including receipt and deploy gates"
+    command: "gh pr checks 980 --repo OmniNode-ai/omnibase_core --watch"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "Focused FSM executor and reducer metadata tests passed locally"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/models/fsm/test_model_fsm_transition_result.py
+          tests/unit/utils/test_fsm_executor.py tests/unit/models/reducer/test_model_reducer_fsm_metadata.py
+          tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py -q"
+  - id: dod-002
+    description: "Strict mypy passed for util_fsm_executor typed exception handling"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run mypy src/omnibase_core/utils/util_fsm_executor.py --strict"
+  - id: dod-deploy
+    description: "Post-merge deploy validation required for node_reducer runtime path: import NodeReducer
+      inside the runtime container"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "deploy: docker exec omninode-runtime python -c \"from omnibase_core.nodes.node_reducer
+          import NodeReducer; print('OMN-9572 node_reducer deploy validation import OK')\""

--- a/contracts/OMN-9572.yaml
+++ b/contracts/OMN-9572.yaml
@@ -1,6 +1,7 @@
 ---
 schema_version: "1.0.0"
 ticket_id: OMN-9572
+title: "Add FSM transition failure discriminator and preserve typed failure handling"
 summary: "Add FSM transition failure discriminator and preserve typed failure handling"
 is_seam_ticket: false
 interface_change: false

--- a/src/omnibase_core/models/fsm/model_fsm_transition_result.py
+++ b/src/omnibase_core/models/fsm/model_fsm_transition_result.py
@@ -16,6 +16,7 @@ Deep Immutability:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -56,6 +57,12 @@ class ModelFSMTransitionResult(BaseModel):
         intents: Tuple of intents generated for side effect execution.
         metadata: Sorted tuple of key-value pairs for deterministic hashing.
         error: Error message if the transition failed, None otherwise.
+        failure_type: Discriminates guard/condition rejections from unexpected
+            exceptions. "guard_rejection" when a required condition evaluated to
+            False; "exception" when an unhandled exception caused the failure.
+            None on success or when the failure path is unknown.
+        failed_conditions: Names of conditions that evaluated false and rejected
+            the transition. None on success or non-condition failures.
         timestamp: ISO-format UTC timestamp (timezone-aware) of result creation.
     """
 
@@ -88,6 +95,20 @@ class ModelFSMTransitionResult(BaseModel):
     error: str | None = Field(
         default=None,
         description="Error message if transition failed",
+    )
+    failure_type: Literal["guard_rejection", "exception"] | None = Field(
+        default=None,
+        description=(
+            "Discriminates failure category: 'guard_rejection' for condition failures, "
+            "'exception' for unexpected exceptions, None on success"
+        ),
+    )
+    failed_conditions: tuple[str, ...] | None = Field(
+        default=None,
+        description=(
+            "Names of required conditions that evaluated false. None on success "
+            "or non-condition failures."
+        ),
     )
     timestamp: str = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),
@@ -128,6 +149,16 @@ class ModelFSMTransitionResult(BaseModel):
             return tuple(sorted(v.items(), key=lambda x: x[0]))
         # If already tuple, sort for deterministic ordering
         return tuple(sorted(v, key=lambda x: x[0]))
+
+    @field_validator("failed_conditions", mode="before")
+    @classmethod
+    def _convert_failed_conditions_to_tuple(
+        cls, v: list[object] | tuple[object, ...] | None
+    ) -> tuple[object, ...] | None:
+        """Convert failed condition lists to tuples for deep immutability."""
+        if v is None:
+            return None
+        return convert_list_to_tuple(v)
 
     model_config = ConfigDict(
         extra="ignore",

--- a/src/omnibase_core/nodes/node_reducer.py
+++ b/src/omnibase_core/nodes/node_reducer.py
@@ -434,16 +434,21 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
         #   fsm_previous_state    -> fsm_result.old_state
         #   fsm_transition_success-> fsm_result.success
         #   fsm_transition_name   -> fsm_result.transition_name (None if no transition dispatched)
-        #   failure_reason        -> fsm_result.error when success=False and it reads as an
-        #                            expected rejection (guard/condition failure);
-        #                            None on success
-        #   failed_conditions     -> None at this layer (FSMTransitionResult does not expose
-        #                            the list today; follow-up to thread through
-        #                            util_fsm_executor — see ModelReducerFsmMetadata docstring)
-        #   error                 -> fsm_result.error when success=False and it represents
-        #                            an unexpected exception path; None on success
-        failure_reason = fsm_result.error if not fsm_result.success else None
-        error_value = fsm_result.error if not fsm_result.success else None
+        #   failure_reason        -> fsm_result.error when failure_type=="guard_rejection"
+        #                            (expected condition/guard rejection); None on success
+        #   failed_conditions     -> fsm_result.failed_conditions
+        #   error                 -> fsm_result.error when failure_type=="exception"
+        #                            (unexpected exception path); None on success
+        failure_reason = (
+            fsm_result.error
+            if not fsm_result.success and fsm_result.failure_type == "guard_rejection"
+            else None
+        )
+        error_value = (
+            fsm_result.error
+            if not fsm_result.success and fsm_result.failure_type == "exception"
+            else None
+        )
 
         # Build the typed FSM metadata model (OMN-597).
         # This is the single source of truth for all 7 contract keys; the dict
@@ -454,7 +459,7 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
             fsm_transition_success=fsm_result.success,
             fsm_transition_name=fsm_result.transition_name,
             failure_reason=failure_reason,
-            failed_conditions=None,
+            failed_conditions=fsm_result.failed_conditions,
             error=error_value,
         )
         # Derive the dict representation from the typed model.

--- a/src/omnibase_core/utils/util_fsm_executor.py
+++ b/src/omnibase_core/utils/util_fsm_executor.py
@@ -55,8 +55,6 @@ from omnibase_core.types.type_fsm_context import FSMContextType
 from omnibase_core.utils.util_fsm_expression_parser import parse_expression
 from omnibase_core.utils.util_fsm_operators import evaluate_equals, evaluate_not_equals
 
-TRANSITION_FAILURE_ERRORS = (*VALIDATION_ERRORS, ModelOnexError)
-
 
 async def execute_transition(
     fsm: ModelFSMSubcontract,
@@ -197,7 +195,17 @@ async def execute_transition(
             fsm, target_state_def, "entry", context
         )
         intents.extend(entry_intents)
-    except TRANSITION_FAILURE_ERRORS as exc:
+    except ModelOnexError as exc:
+        return FSMTransitionResult(
+            success=False,
+            new_state=current_state,
+            old_state=current_state,
+            transition_name=transition.transition_name,
+            intents=tuple(intents),
+            error=str(exc),
+            failure_type="exception",
+        )
+    except VALIDATION_ERRORS as exc:
         return FSMTransitionResult(
             success=False,
             new_state=current_state,

--- a/src/omnibase_core/utils/util_fsm_executor.py
+++ b/src/omnibase_core/utils/util_fsm_executor.py
@@ -139,8 +139,8 @@ async def execute_transition(
         )
 
     # 3. Evaluate transition conditions
-    conditions_met = await _evaluate_conditions(transition, context)
-    if not conditions_met:
+    failed_conditions = await _evaluate_failed_conditions(transition, context)
+    if failed_conditions:
         # Create intent to log condition failure
         intents.append(
             ModelIntent(
@@ -166,32 +166,45 @@ async def execute_transition(
             transition_name=transition.transition_name,
             intents=tuple(intents),  # Convert to tuple for immutability
             error="Transition conditions not met",
+            failure_type="guard_rejection",
+            failed_conditions=failed_conditions,
         )
 
-    # 4. Execute exit actions from current state
-    exit_intents = await _execute_state_actions(fsm, state_def, "exit", context)
-    intents.extend(exit_intents)
+    try:
+        # 4. Execute exit actions from current state
+        exit_intents = await _execute_state_actions(fsm, state_def, "exit", context)
+        intents.extend(exit_intents)
 
-    # 5. Execute transition actions
-    transition_intents = await _execute_transition_actions(
-        transition, context, correlation_id=fsm.correlation_id
-    )
-    intents.extend(transition_intents)
-
-    # 6. Get target state definition
-    target_state_def = _get_state_definition(fsm, transition.to_state)
-    if not target_state_def:
-        raise ModelOnexError(
-            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-            message=f"Invalid target state: {transition.to_state}",
-            context={"fsm": fsm.state_machine_name, "state": transition.to_state},
+        # 5. Execute transition actions
+        transition_intents = await _execute_transition_actions(
+            transition, context, correlation_id=fsm.correlation_id
         )
+        intents.extend(transition_intents)
 
-    # 7. Execute entry actions for new state
-    entry_intents = await _execute_state_actions(
-        fsm, target_state_def, "entry", context
-    )
-    intents.extend(entry_intents)
+        # 6. Get target state definition
+        target_state_def = _get_state_definition(fsm, transition.to_state)
+        if not target_state_def:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=f"Invalid target state: {transition.to_state}",
+                context={"fsm": fsm.state_machine_name, "state": transition.to_state},
+            )
+
+        # 7. Execute entry actions for new state
+        entry_intents = await _execute_state_actions(
+            fsm, target_state_def, "entry", context
+        )
+        intents.extend(entry_intents)
+    except VALIDATION_ERRORS as exc:
+        return FSMTransitionResult(
+            success=False,
+            new_state=current_state,
+            old_state=current_state,
+            transition_name=transition.transition_name,
+            intents=tuple(intents),
+            error=str(exc),
+            failure_type="exception",
+        )
 
     # 8. Create persistence intent if enabled
     if fsm.persistence_enabled:
@@ -423,9 +436,18 @@ async def _evaluate_conditions(
     Returns:
         True if all conditions met, False otherwise
     """
-    if not transition.conditions:
-        return True
+    return not await _evaluate_failed_conditions(transition, context)
 
+
+async def _evaluate_failed_conditions(
+    transition: ModelFSMStateTransition,
+    context: FSMContextType,
+) -> tuple[str, ...]:
+    """Return names of required transition conditions that evaluated false."""
+    if not transition.conditions:
+        return ()
+
+    failed: list[str] = []
     for condition in transition.conditions:
         # Skip optional conditions if not required
         if not condition.required:
@@ -435,9 +457,9 @@ async def _evaluate_conditions(
         condition_met = await _evaluate_single_condition(condition, context)
 
         if not condition_met:
-            return False
+            failed.append(condition.condition_name)
 
-    return True
+    return tuple(failed)
 
 
 def _get_nested_field_value(context: FSMContextType, field_path: str) -> object:

--- a/src/omnibase_core/utils/util_fsm_executor.py
+++ b/src/omnibase_core/utils/util_fsm_executor.py
@@ -55,6 +55,8 @@ from omnibase_core.types.type_fsm_context import FSMContextType
 from omnibase_core.utils.util_fsm_expression_parser import parse_expression
 from omnibase_core.utils.util_fsm_operators import evaluate_equals, evaluate_not_equals
 
+TRANSITION_FAILURE_ERRORS = (*VALIDATION_ERRORS, ModelOnexError)
+
 
 async def execute_transition(
     fsm: ModelFSMSubcontract,
@@ -195,7 +197,7 @@ async def execute_transition(
             fsm, target_state_def, "entry", context
         )
         intents.extend(entry_intents)
-    except VALIDATION_ERRORS as exc:
+    except TRANSITION_FAILURE_ERRORS as exc:
         return FSMTransitionResult(
             success=False,
             new_state=current_state,

--- a/tests/unit/models/fsm/test_model_fsm_transition_result.py
+++ b/tests/unit/models/fsm/test_model_fsm_transition_result.py
@@ -714,5 +714,100 @@ class TestModelFSMTransitionResultImport:
         assert result.new_state == "direct_import"
 
 
+@pytest.mark.unit
+class TestModelFSMTransitionResultFailureType:
+    """Tests for failure_type field on ModelFSMTransitionResult."""
+
+    def test_failure_type_none_on_success(self):
+        """failure_type must be None when transition succeeds."""
+        result = ModelFSMTransitionResult(
+            success=True,
+            new_state="running",
+            old_state="idle",
+        )
+        assert result.failure_type is None
+
+    def test_failure_type_guard_rejection(self):
+        """failure_type can be set to 'guard_rejection' on a failed transition."""
+        result = ModelFSMTransitionResult(
+            success=False,
+            new_state="idle",
+            old_state="idle",
+            error="Transition conditions not met",
+            failure_type="guard_rejection",
+        )
+        assert result.failure_type == "guard_rejection"
+        assert result.error == "Transition conditions not met"
+
+    def test_failure_type_exception(self):
+        """failure_type can be set to 'exception' on an unexpected-exception failure."""
+        result = ModelFSMTransitionResult(
+            success=False,
+            new_state="idle",
+            old_state="idle",
+            error="Unexpected error",
+            failure_type="exception",
+        )
+        assert result.failure_type == "exception"
+
+    def test_failure_type_none_on_failure_without_category(self):
+        """failure_type defaults to None even on failure when not explicitly set."""
+        result = ModelFSMTransitionResult(
+            success=False,
+            new_state="idle",
+            old_state="idle",
+            error="Some error",
+        )
+        assert result.failure_type is None
+
+    def test_failure_type_invalid_value_rejected(self):
+        """Invalid failure_type literals are rejected by Pydantic."""
+        with pytest.raises(ValidationError):
+            ModelFSMTransitionResult(
+                success=False,
+                new_state="idle",
+                old_state="idle",
+                failure_type="unknown_category",  # type: ignore[arg-type]
+            )
+
+    def test_failure_type_serialized_in_model_dump(self):
+        """failure_type is included in model_dump output."""
+        result = ModelFSMTransitionResult(
+            success=False,
+            new_state="idle",
+            old_state="idle",
+            error="Transition conditions not met",
+            failure_type="guard_rejection",
+        )
+        data = result.model_dump()
+        assert "failure_type" in data
+        assert data["failure_type"] == "guard_rejection"
+
+    def test_failure_type_roundtrip(self):
+        """failure_type survives serialize → model_validate roundtrip."""
+        original = ModelFSMTransitionResult(
+            success=False,
+            new_state="idle",
+            old_state="idle",
+            error="Transition conditions not met",
+            failure_type="guard_rejection",
+            failed_conditions=["has_data"],
+            timestamp="2024-01-01T00:00:00+00:00",
+        )
+        data = original.model_dump()
+        restored = ModelFSMTransitionResult.model_validate(data)
+        assert restored.failure_type == "guard_rejection"
+        assert restored.failed_conditions == ("has_data",)
+
+    def test_failed_conditions_default_none(self):
+        """failed_conditions defaults to None on success and non-condition failures."""
+        result = ModelFSMTransitionResult(
+            success=True,
+            new_state="running",
+            old_state="idle",
+        )
+        assert result.failed_conditions is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/utils/test_fsm_executor.py
+++ b/tests/unit/utils/test_fsm_executor.py
@@ -1234,6 +1234,57 @@ class TestExpressionValidation:
 
 
 @pytest.mark.unit
+class TestFSMFailureType:
+    """Test that failure_type is correctly populated by execute_transition."""
+
+    @pytest.mark.asyncio
+    async def test_success_has_no_failure_type(self, simple_fsm: ModelFSMSubcontract):
+        """On success, failure_type must be None."""
+        result = await execute_transition(simple_fsm, "idle", "start_event", {})
+        assert result.success
+        assert result.failure_type is None
+
+    @pytest.mark.asyncio
+    async def test_guard_rejection_sets_failure_type(
+        self, fsm_with_conditions: ModelFSMSubcontract
+    ):
+        """Condition-not-met path sets failure_type to 'guard_rejection'."""
+        context = {"data_count_len": 0}
+        result = await execute_transition(fsm_with_conditions, "idle", "start", context)
+        assert not result.success
+        assert result.failure_type == "guard_rejection"
+        assert result.failed_conditions == ("has_data",)
+
+    @pytest.mark.asyncio
+    async def test_guard_rejection_error_field_populated(
+        self, fsm_with_conditions: ModelFSMSubcontract
+    ):
+        """Guard rejection: error field is populated; failure_type discriminates category."""
+        context = {"data_count_len": 0}
+        result = await execute_transition(fsm_with_conditions, "idle", "start", context)
+        assert not result.success
+        assert result.failure_type == "guard_rejection"
+        assert result.error == "Transition conditions not met"
+
+    @pytest.mark.asyncio
+    async def test_exception_sets_failure_type(self, simple_fsm: ModelFSMSubcontract):
+        """Unexpected action-construction errors are categorized as exception failures."""
+        broken_state = simple_fsm.states[0].model_copy(
+            update={"exit_actions": [object()]}
+        )
+        broken_fsm = simple_fsm.model_copy(
+            update={"states": [broken_state, *simple_fsm.states[1:]]}
+        )
+
+        result = await execute_transition(broken_fsm, "idle", "start_event", {})
+
+        assert not result.success
+        assert result.failure_type == "exception"
+        assert result.failed_conditions is None
+        assert result.error is not None
+
+
+@pytest.mark.unit
 class TestCorrelationIdPropagation:
     """Test correlation_id propagation from FSMSubcontract to intent payloads.
 

--- a/tests/unit/utils/test_fsm_executor.py
+++ b/tests/unit/utils/test_fsm_executor.py
@@ -1283,6 +1283,29 @@ class TestFSMFailureType:
         assert result.failed_conditions is None
         assert result.error is not None
 
+    @pytest.mark.asyncio
+    async def test_invalid_target_state_returns_exception_failure(
+        self, simple_fsm: ModelFSMSubcontract
+    ):
+        """Runtime target-state errors are returned as failed transition results."""
+        broken_transition = simple_fsm.transitions[0].model_copy(
+            update={"to_state": "missing_state"}
+        )
+        broken_fsm = simple_fsm.model_copy(
+            update={"transitions": [broken_transition, *simple_fsm.transitions[1:]]}
+        )
+
+        result = await execute_transition(broken_fsm, "idle", "start_event", {})
+
+        assert not result.success
+        assert result.new_state == "idle"
+        assert result.old_state == "idle"
+        assert result.transition_name == "start"
+        assert result.failure_type == "exception"
+        assert result.failed_conditions is None
+        assert result.error is not None
+        assert "Invalid target state: missing_state" in result.error
+
 
 @pytest.mark.unit
 class TestCorrelationIdPropagation:


### PR DESCRIPTION
## Summary

- adds `failure_type` to `ModelFSMTransitionResult` to distinguish expected guard rejection from validation/action-construction failure paths
- threads failed condition names through FSM transition results into reducer FSM metadata
- routes reducer `failure_reason` vs `error` from the explicit failure discriminator
- restores and completes useful recovery work from the 2026-04-29 salvage sweep

## Verification

- `PYTHONPATH=src uv run pytest tests/unit/models/fsm/test_model_fsm_transition_result.py tests/unit/utils/test_fsm_executor.py tests/unit/models/reducer/test_model_reducer_fsm_metadata.py tests/unit/nodes/test_node_reducer_fsm_metadata_consistency.py -q` — 132 passed
- pre-commit hooks on commit — passed
- pre-push hooks — passed
- CodeRabbit follow-up: `uv run mypy src/omnibase_core/utils/util_fsm_executor.py --strict` — success

## Deploy validation

Post-merge deploy validation command for the `node_reducer.py` runtime-path touch:

`deploy: docker exec omninode-runtime python -c "from omnibase_core.nodes.node_reducer import NodeReducer; print(\"OMN-9572 node_reducer deploy validation import OK\")"`

## Recovery context

Recovered from `/Users/jonah/Code/omni_home/omni_worktrees/RECOVERY-2026-04-29` after Linear confirmed OMN-9572 is still Backlog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved state transition failure reporting with categorized failure types
  * Added tracking to show which specific conditions failed during transitions
  * Enhanced handling of validation errors during state transitions

* **Tests**
  * Added comprehensive unit tests for enhanced failure tracking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->