### PR TITLE
feat(OMN-10340): add savings estimated topic

### DIFF
--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -75,6 +75,8 @@ class TopicBase(StrEnum):
     UTILIZATION_SCORING_CMD = "onex.cmd.omniintelligence.utilization-scoring.v1"
     # LLM call completed: cost telemetry for omnidash llm_cost_aggregates (OMN-7570)
     LLM_CALL_COMPLETED = "onex.evt.omniintelligence.llm-call-completed.v1"
+    # Savings estimation: cloud-vs-local counterfactual for projection/API consumers
+    SAVINGS_ESTIMATED = "onex.evt.omnibase-infra.savings-estimated.v1"
 
     # ==========================================================================
     # Hook adapter observability topics (migrated to ONEX format, OMN-1552)

--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -24,9 +24,9 @@ from omnibase_core.models.errors import ModelOnexError
 # No leading/trailing dots, no consecutive dots, no special characters except dots
 _TOPIC_SEGMENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|i*).<service>.<event>.v<N>
+# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>.v<N>
 _CANONICAL_TOPIC_PATTERN = re.compile(
-    r"^onex\.(cmd|evt|dlq|i[a-z0-9_-]*)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v\d+$"
+    r"^onex\.(cmd|evt|dlq|snapshot|i[a-z0-9_-]*)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*\.v\d+$"
 )
 
 
@@ -77,6 +77,10 @@ class TopicBase(StrEnum):
     LLM_CALL_COMPLETED = "onex.evt.omniintelligence.llm-call-completed.v1"
     # Savings estimation: cloud-vs-local counterfactual for projection/API consumers
     SAVINGS_ESTIMATED = "onex.evt.omnibase-infra.savings-estimated.v1"
+    # Cost-projection snapshot topics (consumed by omnidash widgets in OMN-10282)
+    PROJECTION_COST_SUMMARY = "onex.snapshot.projection.cost.summary.v1"
+    PROJECTION_COST_BY_REPO = "onex.snapshot.projection.cost.by_repo.v1"
+    PROJECTION_COST_TOKEN_USAGE = "onex.snapshot.projection.cost.token_usage.v1"
 
     # ==========================================================================
     # Hook adapter observability topics (migrated to ONEX format, OMN-1552)
@@ -707,7 +711,7 @@ def build_topic(base: str) -> str:
             error_code=EnumCoreErrorCode.INVALID_INPUT,
             message=(
                 f"Topic {base!r} does not match canonical ONEX format "
-                "onex.(cmd|evt|dlq|i*).<service>.<event>.v<N>"
+                "onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>[.<event>...].v<N>"
             ),
         )
     return base

--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -24,9 +24,9 @@ from omnibase_core.models.errors import ModelOnexError
 # No leading/trailing dots, no consecutive dots, no special characters except dots
 _TOPIC_SEGMENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>.v<N>
+# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|snapshot|intent).<service>.<event>.v<N>
 _CANONICAL_TOPIC_PATTERN = re.compile(
-    r"^onex\.(cmd|evt|dlq|snapshot|i[a-z0-9_-]*)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*\.v\d+$"
+    r"^onex\.(cmd|evt|dlq|snapshot|intent)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*\.v\d+$"
 )
 
 
@@ -711,7 +711,7 @@ def build_topic(base: str) -> str:
             error_code=EnumCoreErrorCode.INVALID_INPUT,
             message=(
                 f"Topic {base!r} does not match canonical ONEX format "
-                "onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>[.<event>...].v<N>"
+                "onex.(cmd|evt|dlq|snapshot|intent).<service>.<event>[.<event>...].v<N>"
             ),
         )
     return base

--- a/tests/unit/test_topic_base_cost_projection_snapshots.py
+++ b/tests/unit/test_topic_base_cost_projection_snapshots.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TopicBase coverage for cost projection snapshots."""
+
+from __future__ import annotations
+
+from omnibase_core.topics import TopicBase, build_topic
+
+
+def test_cost_projection_snapshot_topic_values() -> None:
+    assert (
+        TopicBase.PROJECTION_COST_SUMMARY == "onex.snapshot.projection.cost.summary.v1"
+    )
+    assert (
+        TopicBase.PROJECTION_COST_BY_REPO == "onex.snapshot.projection.cost.by_repo.v1"
+    )
+    assert (
+        TopicBase.PROJECTION_COST_TOKEN_USAGE
+        == "onex.snapshot.projection.cost.token_usage.v1"
+    )
+
+
+def test_cost_projection_snapshot_topics_build() -> None:
+    assert build_topic(TopicBase.PROJECTION_COST_SUMMARY) == (
+        "onex.snapshot.projection.cost.summary.v1"
+    )
+    assert build_topic(TopicBase.PROJECTION_COST_BY_REPO) == (
+        "onex.snapshot.projection.cost.by_repo.v1"
+    )
+    assert build_topic(TopicBase.PROJECTION_COST_TOKEN_USAGE) == (
+        "onex.snapshot.projection.cost.token_usage.v1"
+    )

--- a/tests/unit/test_topic_base_cost_projection_snapshots.py
+++ b/tests/unit/test_topic_base_cost_projection_snapshots.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from omnibase_core.topics import TopicBase, build_topic
+
+pytestmark = pytest.mark.unit
 
 
 def test_cost_projection_snapshot_topic_values() -> None:

--- a/tests/unit/test_topic_base_savings.py
+++ b/tests/unit/test_topic_base_savings.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from omnibase_core.topics import TopicBase
+
+pytestmark = pytest.mark.unit
 
 
 def test_savings_estimated_topic_value() -> None:

--- a/tests/unit/test_topic_base_savings.py
+++ b/tests/unit/test_topic_base_savings.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TopicBase coverage for savings estimates."""
+
+from __future__ import annotations
+
+from omnibase_core.topics import TopicBase
+
+
+def test_savings_estimated_topic_value() -> None:
+    assert TopicBase.SAVINGS_ESTIMATED == "onex.evt.omnibase-infra.savings-estimated.v1"

--- a/tests/unit/test_topics.py
+++ b/tests/unit/test_topics.py
@@ -42,7 +42,7 @@ class TestTopicBase:
     def test_all_topics_match_onex_format(self) -> None:
         """Every TopicBase value matches onex.{kind}.{producer}.{event}.v{n}."""
         pattern = re.compile(
-            r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z-]+\.v\d+$"
+            r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.v\d+$"
         )
         for topic in TopicBase:
             assert pattern.match(topic.value), (

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -737,7 +737,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1,<9.0.0" },
     { name = "confluent-kafka", marker = "extra == 'full'", specifier = ">=2.12.0,<3.0.0" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.12.0,<3.0.0" },
-    { name = "cryptography", specifier = ">=46.0.3,<47.0.0" },
+    { name = "cryptography", specifier = ">=46.0.3,<48.0.0" },
     { name = "deepdiff", specifier = ">=8.0.0,<10.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.3,<5.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },


### PR DESCRIPTION
## Summary
- adds TopicBase.SAVINGS_ESTIMATED for the savings projection pipeline
- adds unit coverage for the exact topic value

## Verification
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10340/omnibase_core/src uv run pytest tests/unit/test_topic_base_savings.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `snapshot` topic type in event validation.
  * Introduced new event topic constants for savings estimation tracking.
  * Added cost projection snapshot topic constants for cost summaries, repository-level cost analysis, and token usage metrics.

* **Tests**
  * Added unit tests to verify new topic constants and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->