### PR TITLE
feat(OMN-10342): add cost snapshot topics

### DIFF
--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -24,9 +24,9 @@ from omnibase_core.models.errors import ModelOnexError
 # No leading/trailing dots, no consecutive dots, no special characters except dots
 _TOPIC_SEGMENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|i*).<service>.<event>.v<N>
+# Canonical ONEX topic pattern: onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>.v<N>
 _CANONICAL_TOPIC_PATTERN = re.compile(
-    r"^onex\.(cmd|evt|dlq|i[a-z0-9_-]*)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v\d+$"
+    r"^onex\.(cmd|evt|dlq|snapshot|i[a-z0-9_-]*)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*\.v\d+$"
 )
 
 
@@ -77,6 +77,10 @@ class TopicBase(StrEnum):
     LLM_CALL_COMPLETED = "onex.evt.omniintelligence.llm-call-completed.v1"
     # Savings estimation: cloud-vs-local counterfactual for projection/API consumers
     SAVINGS_ESTIMATED = "onex.evt.omnibase-infra.savings-estimated.v1"
+    # Cost-projection snapshot topics (consumed by omnidash widgets in OMN-10282)
+    PROJECTION_COST_SUMMARY = "onex.snapshot.projection.cost.summary.v1"
+    PROJECTION_COST_BY_REPO = "onex.snapshot.projection.cost.by_repo.v1"
+    PROJECTION_COST_TOKEN_USAGE = "onex.snapshot.projection.cost.token_usage.v1"
 
     # ==========================================================================
     # Hook adapter observability topics (migrated to ONEX format, OMN-1552)
@@ -707,7 +711,7 @@ def build_topic(base: str) -> str:
             error_code=EnumCoreErrorCode.INVALID_INPUT,
             message=(
                 f"Topic {base!r} does not match canonical ONEX format "
-                "onex.(cmd|evt|dlq|i*).<service>.<event>.v<N>"
+                "onex.(cmd|evt|dlq|snapshot|i*).<service>.<event>[.<event>...].v<N>"
             ),
         )
     return base

--- a/tests/unit/test_topic_base_cost_projection_snapshots.py
+++ b/tests/unit/test_topic_base_cost_projection_snapshots.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TopicBase coverage for cost projection snapshots."""
+
+from __future__ import annotations
+
+from omnibase_core.topics import TopicBase, build_topic
+
+
+def test_cost_projection_snapshot_topic_values() -> None:
+    assert (
+        TopicBase.PROJECTION_COST_SUMMARY == "onex.snapshot.projection.cost.summary.v1"
+    )
+    assert (
+        TopicBase.PROJECTION_COST_BY_REPO == "onex.snapshot.projection.cost.by_repo.v1"
+    )
+    assert (
+        TopicBase.PROJECTION_COST_TOKEN_USAGE
+        == "onex.snapshot.projection.cost.token_usage.v1"
+    )
+
+
+def test_cost_projection_snapshot_topics_build() -> None:
+    assert build_topic(TopicBase.PROJECTION_COST_SUMMARY) == (
+        "onex.snapshot.projection.cost.summary.v1"
+    )
+    assert build_topic(TopicBase.PROJECTION_COST_BY_REPO) == (
+        "onex.snapshot.projection.cost.by_repo.v1"
+    )
+    assert build_topic(TopicBase.PROJECTION_COST_TOKEN_USAGE) == (
+        "onex.snapshot.projection.cost.token_usage.v1"
+    )

--- a/tests/unit/test_topics.py
+++ b/tests/unit/test_topics.py
@@ -42,7 +42,7 @@ class TestTopicBase:
     def test_all_topics_match_onex_format(self) -> None:
         """Every TopicBase value matches onex.{kind}.{producer}.{event}.v{n}."""
         pattern = re.compile(
-            r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z-]+\.v\d+$"
+            r"^onex\.(cmd|evt|dlq|intent|snapshot)\.[a-z][a-z0-9-]*\.[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.v\d+$"
         )
         for topic in TopicBase:
             assert pattern.match(topic.value), (


### PR DESCRIPTION
Refs OMN-10342\nDepends on OMN-10340 and OMN-10341.\n\n## Summary\n- register cost.summary.v1, cost.by_repo.v1, and cost.token_usage.v1 snapshot topics in TopicBase\n- cover canonical wire strings and snapshot topic validation\n\n## Verification\n- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-10342/omnibase_core/src uv run pytest tests/unit/test_topic_base_cost_projection_snapshots.py tests/unit/test_topics.py -q\n- pre-push hooks passed