### PR TITLE
feat(OMN-10345): add runtime address target models

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -388,6 +388,7 @@ from .enum_return_type import EnumReturnType
 
 # Reward target type enum (OMN-2537 — objective functions reward architecture)
 from .enum_reward_target_type import EnumRewardTargetType
+from .enum_runtime_selection_mode import EnumRuntimeSelectionMode
 
 # Security-related enums
 from .enum_security_profile import EnumSecurityProfile
@@ -643,6 +644,7 @@ __all__ = [
     "EnumNodeMetadataField",
     "EnumProtocolVersion",
     "EnumRuntimeLanguage",
+    "EnumRuntimeSelectionMode",
     "EnumMetadataToolComplexity",
     "EnumMetadataToolStatus",
     "EnumMetadataToolType",

--- a/src/omnibase_core/enums/enum_runtime_selection_mode.py
+++ b/src/omnibase_core/enums/enum_runtime_selection_mode.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime selection mode enum."""
+
+from enum import Enum, unique
+
+
+@unique
+class EnumRuntimeSelectionMode(str, Enum):
+    """Selection strategy for choosing a runtime target."""
+
+    EXPLICIT = "explicit"
+    """Target an exact runtime address."""
+
+    CAPABILITY = "capability"
+    """Target any runtime matching required capabilities."""
+
+    LOAD_BALANCED = "load_balanced"
+    """Target a load-balanced runtime from matching candidates."""
+
+    def __str__(self) -> str:
+        """Return the string value for serialization."""
+        return self.value
+
+
+__all__ = ["EnumRuntimeSelectionMode"]

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -16,6 +16,10 @@ from omnibase_core.models.runtime.model_handler_behavior import (
     ModelHandlerBehavior,
 )
 from omnibase_core.models.runtime.model_handler_metadata import ModelHandlerMetadata
+from omnibase_core.models.runtime.model_runtime_address import ModelRuntimeAddress
+from omnibase_core.models.runtime.model_runtime_address_registry import (
+    ModelRuntimeAddressRegistry,
+)
 from omnibase_core.models.runtime.model_runtime_aliveness_probe import (
     DEFAULT_TIMEOUT_SECONDS,
     TIMEOUT_ENV_VAR,
@@ -37,6 +41,9 @@ from omnibase_core.models.runtime.model_runtime_skill_request import (
 )
 from omnibase_core.models.runtime.model_runtime_skill_response import (
     ModelRuntimeSkillResponse,
+)
+from omnibase_core.models.runtime.model_runtime_target_selector import (
+    ModelRuntimeTargetSelector,
 )
 from omnibase_core.models.runtime.payloads import (
     ModelCancelExecutionPayload,
@@ -61,6 +68,9 @@ __all__ = [
     "ModelRuntimeSkillError",
     "ModelRuntimeSkillRequest",
     "ModelRuntimeSkillResponse",
+    "ModelRuntimeAddress",
+    "ModelRuntimeAddressRegistry",
+    "ModelRuntimeTargetSelector",
     # Aliveness probe contract (Wave 3)
     "ModelRuntimeAlivenessProbeCommand",
     "ModelRuntimeAlivenessProbeReceipt",

--- a/src/omnibase_core/models/runtime/model_runtime_address.py
+++ b/src/omnibase_core/models/runtime/model_runtime_address.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Address model for targeting concrete ONEX runtime instances."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, Self
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.types import JsonType
+
+RuntimeIngressTransport = Literal["unix_socket", "http"]
+
+_RUNTIME_ADDRESS_PATTERN = re.compile(
+    r"^runtime://(?P<box>[A-Za-z0-9._-]+)/(?P<runtime>[A-Za-z0-9._-]+)$"
+)
+_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+class ModelRuntimeAddress(BaseModel):
+    """Concrete address for a runtime that can receive routed work."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    address: str = Field(
+        ...,
+        min_length=1,
+        description="Stable runtime address, for example runtime://box/runtime-id.",
+    )
+    runtime_id: str = Field(  # string-id-ok: human-readable runtime address component, not a database UUID
+        ...,
+        min_length=1,
+        description="Runtime identity used by the gateway/signing layer.",
+    )
+    box_id: str = Field(  # string-id-ok: human-readable host or box name
+        ...,
+        min_length=1,
+        description="Host or box identity that owns this runtime instance.",
+    )
+    environment: str = Field(
+        ...,
+        min_length=1,
+        description="Routing environment or realm for this runtime.",
+    )
+    ingress_transport: RuntimeIngressTransport = Field(
+        ...,
+        description="Transport used to submit local runtime requests.",
+    )
+    ingress_address: str = Field(
+        ...,
+        min_length=1,
+        description="Unix socket path or HTTP URL for runtime ingress.",
+    )
+    bus_id: str = Field(  # string-id-ok: named event-bus identity, not a database UUID
+        ...,
+        min_length=1,
+        description="Event-bus identity used by this runtime.",
+    )
+    consumer_group_prefix: str = Field(
+        ...,
+        min_length=1,
+        description="Prefix for runtime-owned consumer groups.",
+    )
+    capabilities: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Capabilities this runtime can execute or broker.",
+    )
+    compose_project: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional Docker Compose project name for containerized runtimes.",
+    )
+    state_root: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional runtime state root path.",
+    )
+    metadata: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Small serializable metadata for operators and routers.",
+    )
+
+    @field_validator(
+        "runtime_id",
+        "box_id",
+        "environment",
+        "bus_id",
+        "consumer_group_prefix",
+        "compose_project",
+        mode="after",
+    )
+    @classmethod
+    def _validate_token(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("runtime address token must be non-empty")
+        if not _TOKEN_PATTERN.fullmatch(normalized):
+            raise ValueError(
+                "runtime address token must contain only letters, numbers, '.', '_', '-', or ':'"
+            )
+        return normalized
+
+    @field_validator("address")
+    @classmethod
+    def _validate_address(cls, value: str) -> str:
+        normalized = value.strip()
+        if not _RUNTIME_ADDRESS_PATTERN.fullmatch(normalized):
+            raise ValueError("address must match runtime://<box_id>/<runtime_id>")
+        return normalized
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def _coerce_capabilities(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("capabilities")
+    @classmethod
+    def _validate_capabilities(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            capability = item.strip()
+            if not capability:
+                raise ValueError("capability names must be non-empty")
+            if not _TOKEN_PATTERN.fullmatch(capability):
+                raise ValueError(f"invalid capability name: {capability}")
+            if capability in seen:
+                raise ValueError(f"duplicate capability name: {capability}")
+            seen.add(capability)
+            normalized.append(capability)
+        return tuple(normalized)
+
+    @field_validator("ingress_address")
+    @classmethod
+    def _validate_ingress_address(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("ingress_address must be non-empty")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_address_alignment(self) -> Self:
+        match = _RUNTIME_ADDRESS_PATTERN.fullmatch(self.address)
+        if match is None:
+            raise ValueError("address must match runtime://<box_id>/<runtime_id>")
+        if match.group("box") != self.box_id:
+            raise ValueError("address box_id must match box_id field")
+        if match.group("runtime") != self.runtime_id:
+            raise ValueError("address runtime_id must match runtime_id field")
+
+        if self.ingress_transport == "unix_socket":
+            if not self.ingress_address.startswith("/"):
+                raise ValueError("unix_socket ingress_address must be an absolute path")
+        elif self.ingress_transport == "http":
+            parsed = urlparse(self.ingress_address)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError("http ingress_address must be an http(s) URL")
+        return self
+
+    def has_capabilities(self, required: tuple[str, ...]) -> bool:
+        """Return whether this runtime satisfies all required capabilities."""
+        return set(required).issubset(self.capabilities)
+
+
+__all__ = ["ModelRuntimeAddress", "RuntimeIngressTransport"]

--- a/src/omnibase_core/models/runtime/model_runtime_address_registry.py
+++ b/src/omnibase_core/models/runtime/model_runtime_address_registry.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registry model for addressable ONEX runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.model_runtime_address import ModelRuntimeAddress
+
+
+class ModelRuntimeAddressRegistry(BaseModel):
+    """Validated set of runtimes that may be targeted by address or capability."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    runtimes: tuple[ModelRuntimeAddress, ...] = Field(
+        default_factory=tuple,
+        description="Known addressable runtime instances.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_unique_runtime_resources(self) -> Self:
+        self._assert_unique("address", [runtime.address for runtime in self.runtimes])
+        self._assert_unique(
+            "runtime_id", [runtime.runtime_id for runtime in self.runtimes]
+        )
+
+        scoped_ingress = [
+            (runtime.box_id, runtime.ingress_transport, runtime.ingress_address)
+            for runtime in self.runtimes
+        ]
+        self._assert_unique("box-scoped ingress", scoped_ingress)
+
+        scoped_groups = [
+            (runtime.box_id, runtime.consumer_group_prefix) for runtime in self.runtimes
+        ]
+        self._assert_unique("box-scoped consumer_group_prefix", scoped_groups)
+
+        scoped_state_roots = [
+            (runtime.box_id, runtime.state_root)
+            for runtime in self.runtimes
+            if runtime.state_root is not None
+        ]
+        self._assert_unique("box-scoped state_root", scoped_state_roots)
+
+        scoped_compose_projects = [
+            (runtime.box_id, runtime.compose_project)
+            for runtime in self.runtimes
+            if runtime.compose_project is not None
+        ]
+        self._assert_unique("box-scoped compose_project", scoped_compose_projects)
+        return self
+
+    @staticmethod
+    def _assert_unique(label: str, values: Iterable[Hashable]) -> None:
+        seen: set[Hashable] = set()
+        for value in values:
+            if value in seen:
+                # error-ok: Pydantic model_validator requires ValueError for aggregation
+                raise ValueError(f"duplicate runtime {label}: {value}")
+            seen.add(value)
+
+    def get(self, address: str) -> ModelRuntimeAddress:
+        """Return a runtime by exact address."""
+        for runtime in self.runtimes:
+            if runtime.address == address:
+                return runtime
+        raise ModelOnexError(
+            message=f"unknown runtime address: {address}",
+            error_code=EnumCoreErrorCode.RESOURCE_NOT_FOUND,
+            address=address,
+        )
+
+    def by_capabilities(
+        self,
+        required_capabilities: tuple[str, ...],
+        *,
+        box_id: str | None = None,
+    ) -> tuple[ModelRuntimeAddress, ...]:
+        """Return runtimes that satisfy the required capabilities."""
+        return tuple(
+            runtime
+            for runtime in self.runtimes
+            if runtime.has_capabilities(required_capabilities)
+            and (box_id is None or runtime.box_id == box_id)
+        )
+
+
+__all__ = ["ModelRuntimeAddressRegistry"]

--- a/src/omnibase_core/models/runtime/model_runtime_target_selector.py
+++ b/src/omnibase_core/models/runtime/model_runtime_target_selector.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Runtime target selector for explicit and load-balanced routing."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_runtime_selection_mode import EnumRuntimeSelectionMode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.model_runtime_address import ModelRuntimeAddress
+from omnibase_core.models.runtime.model_runtime_address_registry import (
+    ModelRuntimeAddressRegistry,
+)
+
+
+class ModelRuntimeTargetSelector(BaseModel):
+    """Selection request for choosing a target runtime."""
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    mode: EnumRuntimeSelectionMode = Field(
+        ...,
+        description="How a runtime should be selected.",
+    )
+    address: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Exact runtime address for explicit mode.",
+    )
+    required_capabilities: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Capabilities required from selected runtimes.",
+    )
+    # string-id-ok: human-readable host or box name
+    preferred_box_id: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional box preference for capability or load-balanced modes.",
+    )
+    allow_cross_box: bool = Field(
+        default=True,
+        description="Whether selection may fall back to runtimes on other boxes.",
+    )
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _coerce_mode(cls, value: object) -> object:
+        if isinstance(value, str):
+            return EnumRuntimeSelectionMode(value)
+        return value
+
+    @field_validator("required_capabilities", mode="before")
+    @classmethod
+    def _coerce_capabilities(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("required_capabilities")
+    @classmethod
+    def _validate_capabilities(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            capability = item.strip()
+            if not capability:
+                raise ValueError("required capability names must be non-empty")
+            if capability in seen:
+                raise ValueError(f"duplicate required capability: {capability}")
+            seen.add(capability)
+            normalized.append(capability)
+        return tuple(normalized)
+
+    @model_validator(mode="after")
+    def _validate_mode_shape(self) -> Self:
+        if self.mode is EnumRuntimeSelectionMode.EXPLICIT:
+            if self.address is None:
+                raise ValueError("explicit runtime selection requires address")
+            if self.required_capabilities:
+                raise ValueError(
+                    "explicit runtime selection must not include required_capabilities"
+                )
+        elif self.address is not None:
+            raise ValueError("address is only valid for explicit runtime selection")
+        return self
+
+    def candidates(
+        self, registry: ModelRuntimeAddressRegistry
+    ) -> tuple[ModelRuntimeAddress, ...]:
+        """Return candidate runtimes for this selector."""
+        if self.mode is EnumRuntimeSelectionMode.EXPLICIT:
+            if self.address is None:
+                raise ModelOnexError(
+                    message="explicit runtime selection requires address",
+                    error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                )
+            return (registry.get(self.address),)
+
+        preferred = registry.by_capabilities(
+            self.required_capabilities,
+            box_id=self.preferred_box_id,
+        )
+        if preferred or not self.allow_cross_box:
+            return preferred
+        return registry.by_capabilities(self.required_capabilities)
+
+    def select_first(
+        self, registry: ModelRuntimeAddressRegistry
+    ) -> ModelRuntimeAddress:
+        """Select the first deterministic candidate.
+
+        Runtime load-aware routing should sort candidates before calling this
+        method. This method intentionally keeps the core contract pure.
+        """
+        candidates = self.candidates(registry)
+        if not candidates:
+            raise ModelOnexError(
+                message="no runtime candidates matched selector",
+                error_code=EnumCoreErrorCode.RESOURCE_NOT_FOUND,
+                selection_mode=self.mode.value,
+                required_capabilities=self.required_capabilities,
+                preferred_box_id=self.preferred_box_id,
+            )
+        return candidates[0]
+
+
+__all__ = ["ModelRuntimeTargetSelector"]

--- a/tests/unit/models/runtime/test_model_runtime_address.py
+++ b/tests/unit/models/runtime/test_model_runtime_address.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.runtime import (
+    ModelRuntimeAddress,
+    ModelRuntimeAddressRegistry,
+    ModelRuntimeTargetSelector,
+)
+
+
+def _runtime(
+    runtime_id: str,
+    *,
+    ingress_address: str,
+    capabilities: tuple[str, ...] = ("market-skills",),
+    compose_project: str | None = None,
+    state_root: str | None = None,
+) -> ModelRuntimeAddress:
+    return ModelRuntimeAddress(
+        address=f"runtime://omninode-pc/{runtime_id}",
+        runtime_id=runtime_id,
+        box_id="omninode-pc",
+        environment="dev",
+        ingress_transport="unix_socket",
+        ingress_address=ingress_address,
+        bus_id=f"kafka-{runtime_id}",
+        consumer_group_prefix=f"onex-{runtime_id}",
+        capabilities=capabilities,
+        compose_project=compose_project,
+        state_root=state_root,
+    )
+
+
+def test_runtime_address_accepts_stability_lane_as_normal_address() -> None:
+    address = _runtime(
+        "stability-test",
+        ingress_address="/tmp/onex-runtime-stability.sock",
+        capabilities=("market-skills", "workflow-proof"),
+        compose_project="omnibase-infra-stability-test",
+        state_root="/app/data/.onex_state_stability_test",
+    )
+
+    assert address.address == "runtime://omninode-pc/stability-test"
+    assert address.has_capabilities(("market-skills",))
+    assert address.has_capabilities(("market-skills", "workflow-proof"))
+
+
+def test_runtime_address_rejects_address_that_does_not_match_identity() -> None:
+    with pytest.raises(ValidationError, match="address runtime_id must match"):
+        ModelRuntimeAddress(
+            address="runtime://omninode-pc/other",
+            runtime_id="stability-test",
+            box_id="omninode-pc",
+            environment="dev",
+            ingress_transport="unix_socket",
+            ingress_address="/tmp/onex-runtime-stability.sock",
+            bus_id="kafka-stability-test",
+            consumer_group_prefix="onex-stability-test",
+        )
+
+
+def test_runtime_address_validates_ingress_by_transport() -> None:
+    with pytest.raises(ValidationError, match="absolute path"):
+        _runtime("stability-test", ingress_address="relative.sock")
+
+    http_address = ModelRuntimeAddress(
+        address="runtime://omninode-pc/http-runtime",
+        runtime_id="http-runtime",
+        box_id="omninode-pc",
+        environment="dev",
+        ingress_transport="http",
+        ingress_address="http://127.0.0.1:18085/runtime",
+        bus_id="kafka-http-runtime",
+        consumer_group_prefix="onex-http-runtime",
+    )
+
+    assert http_address.ingress_address == "http://127.0.0.1:18085/runtime"
+
+
+def test_runtime_registry_rejects_colliding_box_resources() -> None:
+    production = _runtime(
+        "production",
+        ingress_address="/tmp/onex-runtime.sock",
+        compose_project="omnibase-infra",
+        state_root="/app/data/.onex_state",
+    )
+    duplicate_socket = _runtime(
+        "stability-test",
+        ingress_address="/tmp/onex-runtime.sock",
+        compose_project="omnibase-infra-stability-test",
+        state_root="/app/data/.onex_state_stability_test",
+    )
+
+    with pytest.raises(ValidationError, match="box-scoped ingress"):
+        ModelRuntimeAddressRegistry(runtimes=(production, duplicate_socket))
+
+
+def test_runtime_selector_targets_explicit_address() -> None:
+    production = _runtime("production", ingress_address="/tmp/onex-runtime.sock")
+    stability = _runtime(
+        "stability-test",
+        ingress_address="/tmp/onex-runtime-stability.sock",
+        capabilities=("market-skills", "workflow-proof"),
+    )
+    registry = ModelRuntimeAddressRegistry(runtimes=(production, stability))
+
+    selector = ModelRuntimeTargetSelector(
+        mode="explicit",
+        address="runtime://omninode-pc/stability-test",
+    )
+
+    assert selector.select_first(registry) == stability
+
+
+def test_runtime_selector_filters_by_capability_and_box_preference() -> None:
+    production = _runtime(
+        "production",
+        ingress_address="/tmp/onex-runtime.sock",
+        capabilities=("market-skills",),
+    )
+    stability = _runtime(
+        "stability-test",
+        ingress_address="/tmp/onex-runtime-stability.sock",
+        capabilities=("market-skills", "workflow-proof"),
+    )
+    registry = ModelRuntimeAddressRegistry(runtimes=(production, stability))
+
+    selector = ModelRuntimeTargetSelector(
+        mode="load_balanced",
+        required_capabilities=("workflow-proof",),
+        preferred_box_id="omninode-pc",
+    )
+
+    assert selector.candidates(registry) == (stability,)


### PR DESCRIPTION
## Summary

Adds first-class runtime address models so ONEX runtimes can be targeted by address, capability, or load-balanced selector instead of relying on special runtime-lane flags.

## What changed

- Add `ModelRuntimeAddress` for concrete runtime addresses such as `runtime://omninode-pc/stability-test`
- Add `ModelRuntimeAddressRegistry` with collision checks for ingress, consumer group prefixes, compose projects, and state roots
- Add `ModelRuntimeTargetSelector` for explicit, capability, and load-balanced candidate selection
- Re-export the new models from `omnibase_core.models.runtime`
- Add focused model tests for stability-test-as-address, collisions, ingress validation, and selector behavior

## Verification

- `uv run pytest tests/unit/models/runtime/test_model_runtime_address.py -q` -> 6 passed
- `uv run ruff check --fix ...` -> passed
- `uv run mypy src/omnibase_core/models/runtime/model_runtime_address_registry.py src/omnibase_core/models/runtime/model_runtime_target_selector.py src/omnibase_core/models/runtime/model_runtime_address.py` -> passed
- pre-commit hooks -> passed
- pre-push hooks -> passed

## Notes

This does not start or mutate `.201`. It establishes the shared core contract for representing production and stability-test runtimes as ordinary addressable runtimes.
