### PR TITLE
docs(OMN-10348): define ONEX (OmniNode eXecution) on first use in omnibase_core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to omnibase_core
 
-Thank you for your interest in contributing to omnibase_core! This document provides guidelines for contributing to the ONEX (OmniNode Execution System) core framework.
+Thank you for your interest in contributing to omnibase_core! This document provides guidelines for contributing to the ONEX (OmniNode eXecution) core framework.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # omnibase_core
 
-`omnibase_core` is the ONEX platform kernel. It owns node execution, contracts,
+`omnibase_core` is the ONEX (OmniNode eXecution) platform kernel. It owns node execution, contracts,
 core models, validation tooling, and the canonical architecture vocabulary used
 by downstream OmniNode repos.
 

--- a/contracts/OMN-10348.yaml
+++ b/contracts/OMN-10348.yaml
@@ -1,0 +1,44 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-10348
+title: "Define ONEX (OmniNode eXecution) on first use across all canonical repo docs"
+summary: "Add canonical ONEX expansion on first use in primary doc entrypoints; correct stale/wrong expansions
+  in secondary docs"
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: ci
+    description: "omnibase_core PR 985 checks pass"
+    command: "gh pr checks 985 --repo OmniNode-ai/omnibase_core"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-001
+    description: "README.md updated with ONEX (OmniNode eXecution) on first use"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "gh pr diff 985 --repo OmniNode-ai/omnibase_core | grep -q 'OmniNode eXecution'"
+  - id: dod-002
+    description: "CONTRIBUTING.md corrected from wrong expansion to canonical form"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "gh pr diff 985 --repo OmniNode-ai/omnibase_core | grep -q 'OmniNode eXecution'"
+  - id: dod-003
+    description: "docs/standards/onex_terminology.md corrected from hallucinated expansion to canonical
+      form"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "gh pr diff 985 --repo OmniNode-ai/omnibase_core | grep -q 'OmniNode eXecution'"
+  - id: dod-004
+    description: "Deploy-gate evidence: docs-only change, no Docker image or runtime service deploy required"
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "echo 'deploy-gate: OMN-10348 changes only markdown documentation; no Docker image,
+          runtime process, broker topic, or service deploy is required'"

--- a/docs/standards/onex_terminology.md
+++ b/docs/standards/onex_terminology.md
@@ -34,7 +34,7 @@
 
 ## Overview
 
-The ONEX (Open Node Execution) framework defines a structured vocabulary for building distributed, event-driven systems. This document provides canonical definitions for the 9 core concepts that form the foundation of the ONEX architecture.
+The ONEX (OmniNode eXecution) framework defines a structured vocabulary for building distributed, event-driven systems. This document provides canonical definitions for the 9 core concepts that form the foundation of the ONEX architecture.
 
 **Core Design Principles**:
 - **Unidirectional Data Flow**: EFFECT -> COMPUTE -> REDUCER -> ORCHESTRATOR


### PR DESCRIPTION
## Summary

Defines `ONEX (OmniNode eXecution)` on first use in `README.md` per OMN-10348, and corrects two stale/wrong expansions found in secondary docs.

## DoD evidence

**Ticket:** OMN-10348

| File | Before | After |
|---|---|---|
| `README.md:3` | `is the ONEX platform kernel` | `is the ONEX (OmniNode eXecution) platform kernel` |
| `CONTRIBUTING.md:3` | `ONEX (OmniNode Execution System)` | `ONEX (OmniNode eXecution)` |
| `docs/standards/onex_terminology.md:37` | `ONEX (Open Node Execution)` | `ONEX (OmniNode eXecution)` |

## Notes

- `CONTRIBUTING.md` had stale "OmniNode Execution System" expansion — corrected
- `docs/standards/onex_terminology.md` had "Open Node Execution" (doc hallucination, "Open" instead of "Omni") — corrected to canonical form