### PR TITLE
feat(OMN-10347): harden Receipt Gate to FAIL on [skip-*] tokens per Rule #10

### DIFF
--- a/scripts/validation/validate_pr_receipts.py
+++ b/scripts/validation/validate_pr_receipts.py
@@ -7,7 +7,7 @@
 See `omnibase_core.validation.receipt_gate` for the decision matrix.
 
 Exit codes:
-    0 — gate passed (all receipts present + PASS, or override accepted)
+    0 — gate passed (all receipts present + PASS, or approved skip token accepted)
     1 — gate failed (missing/failing receipts, no ticket ref, corrupt artifacts)
 
 Usage (CI):

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -67,7 +67,12 @@ CLOSING_KEYWORD_PATTERN = re.compile(
     r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
 )
-OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(.+?)\]", re.IGNORECASE)
+# Matches any [skip-*: ...] bypass token (OMN-10347: Rule #10 enforcement).
+SKIP_TOKEN_PATTERN = re.compile(r"\[skip-[a-zA-Z][^]]*\]", re.IGNORECASE)
+# Legacy alias kept for __all__ / external callers; same as SKIP_TOKEN_PATTERN.
+OVERRIDE_PATTERN = SKIP_TOKEN_PATTERN
+# Explicit user-approval escape hatch: # skip-token-allowed: <non-empty-receipt-id>
+ALLOWLIST_PATTERN = re.compile(r"#\s*skip-token-allowed:\s*(\S+)", re.IGNORECASE)
 
 
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
@@ -277,19 +282,35 @@ def validate_pr_receipts(
     pr_title: str | None = None,
 ) -> ModelReceiptGateResult:
     """Run the receipt-gate against a PR's body + the repo's contracts + receipts."""
-    override = OVERRIDE_PATTERN.search(pr_body)
-    if override:
-        reason = override.group(1).strip()
-        if reason:
+    # OMN-10347 (Rule #10): ANY [skip-*] token is a hard gate FAIL unless paired
+    # with an explicit # skip-token-allowed: <receipt-id> approval receipt.
+    skip_match = SKIP_TOKEN_PATTERN.search(pr_body)
+    if skip_match:
+        allowlist_match = ALLOWLIST_PATTERN.search(pr_body)
+        if allowlist_match:
+            receipt_id = allowlist_match.group(1).strip()
             return ModelReceiptGateResult(
                 passed=True,
                 friction_logged=True,
                 message=(
-                    f"[skip-receipt-gate] override accepted: {reason!r}. "
+                    f"[skip-*] token {skip_match.group(0)!r} present but explicit "
+                    f"approval receipt {receipt_id!r} found. "
                     "FRICTION LOGGED: receipt gate bypassed — every override must be "
                     "tracked and closed within 7 days."
                 ),
             )
+        return ModelReceiptGateResult(
+            passed=False,
+            message=(
+                f"RECEIPT GATE FAILED: PR body contains a [skip-*] bypass token "
+                f"({skip_match.group(0)!r}) without a valid approval receipt. "
+                "Per CLAUDE.md Rule #10, bypass tokens are not permitted without "
+                "explicit user approval. Fix: add dod_evidence proving the work, "
+                "OR add '# skip-token-allowed: <receipt-id>' with a traceable "
+                "approval receipt issued by the user. "
+                "Self-written justifications do NOT qualify."
+            ),
+        )
 
     ticket_ids = _extract_ticket_ids(pr_body, pr_title)
     if not ticket_ids:
@@ -381,8 +402,10 @@ def validate_pr_receipts(
 
 
 __all__ = [
+    "ALLOWLIST_PATTERN",
     "CLOSING_KEYWORD_PATTERN",
     "OVERRIDE_PATTERN",
+    "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",
     "validate_pr_receipts",
 ]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -319,8 +319,8 @@ def validate_pr_receipts(
             message=(
                 "RECEIPT GATE FAILED: PR body cites no OMN-XXXX ticket. "
                 "Every PR must cite a ticket whose dod_evidence proves the work. "
-                "Use [skip-receipt-gate: <reason>] if this is a truly ticket-less "
-                "change (rare — chore/docs/emergency hotfix)."
+                "Add a closing-keyword ticket reference and the corresponding "
+                "dod_evidence receipts before merging."
             ),
         )
 

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -4,7 +4,8 @@
 """Unit tests for the Receipt-Gate library (`omnibase_core.validation.receipt_gate`).
 
 Covers the full decision matrix: no-ticket, no-contract, missing-receipt,
-failing-receipt, corrupt-receipt, receipt-path-mismatch, all-PASS, override.
+failing-receipt, corrupt-receipt, receipt-path-mismatch, all-PASS, skip-token
+hardening.
 """
 
 from __future__ import annotations
@@ -359,25 +360,38 @@ class TestReceiptGateMultiTicket:
 
 @pytest.mark.unit
 class TestReceiptGateOverride:
-    def test_override_passes_with_friction(self, tmp_path: Path) -> None:
+    def test_skip_token_fails_without_approval_receipt(self, tmp_path: Path) -> None:
         result = validate_pr_receipts(
             pr_body="fix: emergency hotfix [skip-receipt-gate: prod down OMN-1]",
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
         )
+        assert not result.passed
+        assert not result.friction_logged
+        assert "skip-*" in result.message
+        assert "skip-token-allowed" in result.message
+
+    def test_skip_token_passes_with_approval_receipt(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body=(
+                "fix: emergency hotfix [skip-receipt-gate: prod down OMN-1]\n"
+                "# skip-token-allowed: USER-APPROVAL-OMN-10347"
+            ),
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+        )
         assert result.passed
         assert result.friction_logged
-        assert "prod down OMN-1" in result.message
+        assert "USER-APPROVAL-OMN-10347" in result.message
 
     def test_empty_reason_does_not_override(self, tmp_path: Path) -> None:
-        """Override must include a non-empty reason — empty falls through to FAIL."""
         result = validate_pr_receipts(
             pr_body="[skip-receipt-gate:     ]",
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
         )
-        # Empty/whitespace reason doesn't count as a legitimate override
-        assert not result.passed or result.friction_logged
+        assert not result.passed
+        assert not result.friction_logged
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_receipt_gate_skip_token_hardening.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_hardening.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-10347: Receipt-Gate [skip-*] token hardening tests.
+
+Rule #10 (CLAUDE.md): ANY [skip-*] bypass token in a PR body must FAIL the
+receipt gate unless paired with a valid '# skip-token-allowed: <receipt-id>'
+approval receipt.
+
+Previously the gate accepted [skip-receipt-gate:] with only a warning (exit 0).
+This test suite verifies that:
+  - [skip-receipt-gate:] alone FAILs
+  - [skip-deploy-gate:] alone FAILs (regression)
+  - [skip-anything-else:] alone FAILs
+  - Any [skip-*] with '# skip-token-allowed: <id>' PASSES with friction logged
+  - A clean PR body with a ticket and receipts still PASSes
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation.receipt_gate import (
+    ALLOWLIST_PATTERN,
+    OVERRIDE_PATTERN,
+    SKIP_TOKEN_PATTERN,
+    validate_pr_receipts,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pattern unit tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkipTokenPattern:
+    """Verify SKIP_TOKEN_PATTERN matches all [skip-*] variants."""
+
+    def test_matches_skip_receipt_gate(self) -> None:
+        assert SKIP_TOKEN_PATTERN.search("[skip-receipt-gate: docs only]")
+
+    def test_matches_skip_deploy_gate(self) -> None:
+        assert SKIP_TOKEN_PATTERN.search("[skip-deploy-gate: correctness fix]")
+
+    def test_matches_skip_anything(self) -> None:
+        assert SKIP_TOKEN_PATTERN.search("[skip-anything: some reason]")
+
+    def test_no_match_on_clean_body(self) -> None:
+        assert not SKIP_TOKEN_PATTERN.search("Closes OMN-9999\nNormal PR body.")
+
+    def test_case_insensitive_skip_receipt_gate(self) -> None:
+        assert SKIP_TOKEN_PATTERN.search("[Skip-Receipt-Gate: reason]")
+
+    def test_case_insensitive_skip_deploy_gate(self) -> None:
+        assert SKIP_TOKEN_PATTERN.search("[SKIP-DEPLOY-GATE: reason]")
+
+    def test_override_pattern_alias_matches_same(self) -> None:
+        # OVERRIDE_PATTERN is an alias for SKIP_TOKEN_PATTERN (OMN-10347).
+        assert OVERRIDE_PATTERN is SKIP_TOKEN_PATTERN
+
+
+class TestAllowlistPattern:
+    """Verify ALLOWLIST_PATTERN matches the escape-hatch form."""
+
+    def test_matches_escape_hatch(self) -> None:
+        assert ALLOWLIST_PATTERN.search(
+            "# skip-token-allowed: USER-APPROVAL-2026-04-30"
+        )
+
+    def test_no_match_on_empty_receipt_id(self) -> None:
+        assert not ALLOWLIST_PATTERN.search("# skip-token-allowed:")
+
+    def test_no_match_on_whitespace_only_receipt_id(self) -> None:
+        assert not ALLOWLIST_PATTERN.search("# skip-token-allowed:   ")
+
+    def test_case_insensitive(self) -> None:
+        assert ALLOWLIST_PATTERN.search("# Skip-Token-Allowed: some-receipt")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Gate integration tests — no contracts/receipts on disk needed for skip-token
+# paths because the skip-token check fires before ticket resolution.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _empty_dir(tmp_path: Path, name: str) -> Path:
+    d = tmp_path / name
+    d.mkdir()
+    return d
+
+
+class TestSkipReceiptGateTokenFails:
+    """[skip-receipt-gate:] without allowlist receipt must FAIL the gate."""
+
+    def test_skip_receipt_gate_alone_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: docs only, no receipts needed]",
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert not result.passed
+        assert (
+            "skip-*" in result.message or "skip-receipt-gate" in result.message.lower()
+        )
+
+    def test_skip_deploy_gate_alone_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="[skip-deploy-gate: correctness fix, no deployable artifact]",
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert not result.passed
+        assert (
+            "skip-*" in result.message or "skip-deploy-gate" in result.message.lower()
+        )
+
+    def test_skip_anything_alone_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="[skip-anything: arbitrary reason]",
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert not result.passed
+
+    def test_case_insensitive_skip_fails(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="[Skip-Receipt-Gate: reason here]",
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert not result.passed
+
+    def test_rule10_mentioned_in_failure_message(self, tmp_path: Path) -> None:
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: some reason]",
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "rule #10" in msg_lower or "rule" in msg_lower
+
+
+class TestSkipTokenWithAllowlistPasses:
+    """[skip-*] paired with # skip-token-allowed: <id> must PASS with friction."""
+
+    def test_skip_receipt_gate_with_allowlist_passes(self, tmp_path: Path) -> None:
+        body = (
+            "[skip-receipt-gate: chore only]\n"
+            "# skip-token-allowed: USER-APPROVAL-2026-04-30-jonah"
+        )
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert result.passed
+        assert result.friction_logged
+
+    def test_skip_deploy_gate_with_allowlist_passes(self, tmp_path: Path) -> None:
+        body = (
+            "[skip-deploy-gate: correctness fix]\n"
+            "# skip-token-allowed: USER-APPROVAL-2026-04-25-jonah"
+        )
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        assert result.passed
+        assert result.friction_logged
+
+    def test_allowlist_with_empty_receipt_id_still_fails(self, tmp_path: Path) -> None:
+        body = "[skip-receipt-gate: reason]\n# skip-token-allowed:"
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=_empty_dir(tmp_path, "contracts"),
+            receipts_dir=_empty_dir(tmp_path, "receipts"),
+        )
+        # No valid receipt ID → FAIL
+        assert not result.passed
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Regression: clean PR with proper ticket + receipt still passes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _write_contract(contracts_dir: Path, ticket_id: str) -> None:
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "ticket_id": ticket_id,
+        "schema_version": "1.0.0",
+        "summary": "test",
+        "dod_evidence": [
+            {
+                "id": "dod-001",
+                "description": "test check",
+                "checks": [{"check_type": "command", "check_value": "echo ok"}],
+            }
+        ],
+    }
+    (contracts_dir / f"{ticket_id}.yaml").write_text(yaml.safe_dump(body))
+
+
+def _write_pass_receipt(receipts_dir: Path, ticket_id: str) -> None:
+    p = receipts_dir / ticket_id / "dod-001" / "command.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    receipt = {
+        "schema_version": "1.0.0",
+        "ticket_id": ticket_id,
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "echo ok",
+        "status": "PASS",
+        "run_timestamp": datetime.now(tz=UTC).isoformat(),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "worker-A",
+        "verifier": "foreground-claude-X",
+        "probe_command": "echo ok",
+        "probe_stdout": "ok\n",
+    }
+    p.write_text(yaml.safe_dump(receipt))
+
+
+class TestCleanPrStillPasses:
+    """A clean PR body with a valid ticket + receipts must still pass."""
+
+    def test_clean_pr_passes(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-9999")
+        _write_pass_receipt(receipts, "OMN-9999")
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-9999\n\nFixes the thing.",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed
+        assert not result.friction_logged


### PR DESCRIPTION
## Summary

Closes OMN-10347

- `validate_pr_receipts()` now returns `passed=False` when any `[skip-*]` token is found without `# skip-token-allowed: <receipt-id>`
- Previously `[skip-receipt-gate:]` returned `passed=True, friction_logged=True` (exit 0) — this violated Rule #10
- Adds `SKIP_TOKEN_PATTERN` + `ALLOWLIST_PATTERN` constants; `OVERRIDE_PATTERN` becomes an alias for backwards compat
- 20 new unit tests covering all cases

## Problem

OMN-9608 remediation: GHA run 25132166746 accepted `[skip-receipt-gate:]` with only a warning. The escape hatch (`# skip-token-allowed: <id>`) continues to work — it must be paired with a non-empty receipt ID from the user.

## DoD evidence

### pytest (receipt gate tests)
```
tests/unit/validation/test_receipt_gate_adversarial.py — 18 passed
tests/unit/validation/test_receipt_gate_cli.py — 1 passed
tests/unit/validation/test_receipt_gate_workflow_shape.py — 7 passed
tests/unit/validation/test_receipt_gate_skip_token_hardening.py — 20 passed
Total: 46 passed
```

### Key behavioral verification
- `[skip-receipt-gate: docs only]` → `passed=False` ✓
- `[skip-deploy-gate: reason]` → `passed=False` ✓ (regression)
- `[skip-anything: reason]` → `passed=False` ✓
- `[skip-receipt-gate: ...]` + `# skip-token-allowed: USER-APPROVAL-2026-04-30-jonah` → `passed=True, friction_logged=True` ✓
- `# skip-token-allowed:` (empty id) → `passed=False` ✓

### pre-commit
`pre-commit run --all-files` — all passed