### PR TITLE
feat(OMN-10351): add EnumFileZone for tiered QA gate classification

### DIFF
--- a/src/omnibase_core/enums/enum_file_zone.py
+++ b/src/omnibase_core/enums/enum_file_zone.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""File zone enum for tiered QA gate classification (OMN-10351)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumFileZone(StrEnum):
+    """Directory-role classification for per-zone QA gating.
+
+    Distinct from EnumFileType (extension/format) — a .py file is PRODUCTION
+    under src/ but TEST under tests/.
+    """
+
+    PRODUCTION = "production"
+    TEST = "test"
+    CONFIG = "config"
+    GENERATED = "generated"
+    DOCS = "docs"
+    BUILD = "build"

--- a/src/omnibase_core/models/validation/model_zone_policy.py
+++ b/src/omnibase_core/models/validation/model_zone_policy.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelZonePolicy — per-zone QA gate configuration (OMN-10354)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+QaDepth = Literal["full", "standard", "light", "skip"]
+
+
+class ModelZonePolicy(BaseModel):
+    """Frozen per-zone QA gate policy.
+
+    Distinct from agent safety models — this governs per-file-zone QA
+    requirements (lint, test, review, security scan) and depth, not
+    agent capability gates.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    zone: EnumFileZone
+    qa_depth: QaDepth
+    requires_lint: bool
+    requires_test: bool
+    requires_review: bool
+    requires_security_scan: bool

--- a/src/omnibase_core/validation/zone_classifier.py
+++ b/src/omnibase_core/validation/zone_classifier.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Zone classifier: classify a file path into an EnumFileZone (OMN-10355)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+_GENERATED_MARKERS = ("__pycache__", "dist/", ".generated.", "node_modules/")
+_TEST_PREFIXES = ("tests/", "test/")
+_DOCS_PREFIXES = ("docs/", "standards/")
+_BUILD_PREFIXES = ("scripts/",)
+_BUILD_NAMES = {"Dockerfile", "docker-compose.yml", "docker-compose.yaml", "Makefile"}
+_CONFIG_SUFFIXES = (".yaml", ".yml", ".toml", ".json", ".ini")
+
+
+def classify_path(path: Path) -> EnumFileZone:
+    """Classify *path* into its EnumFileZone.
+
+    Priority order: generated > production > test > config > docs > build.
+    Symlinks are resolved before classification so the target's directory
+    structure determines the zone, not the link location.
+    """
+    resolved = path.resolve() if path.exists() else path
+    s = resolved.as_posix()
+
+    if any(m in s for m in _GENERATED_MARKERS):
+        return EnumFileZone.GENERATED
+
+    if "/src/" in f"/{s}" or s.startswith("src/"):
+        return EnumFileZone.PRODUCTION
+
+    if any(s.startswith(p) or f"/{p}" in f"/{s}" for p in _TEST_PREFIXES):
+        return EnumFileZone.TEST
+
+    if resolved.name in _BUILD_NAMES:
+        return EnumFileZone.BUILD
+
+    if any(s.startswith(p) for p in _DOCS_PREFIXES) or resolved.suffix == ".md":
+        return EnumFileZone.DOCS
+
+    if resolved.suffix in _CONFIG_SUFFIXES:
+        return EnumFileZone.CONFIG
+
+    if any(s.startswith(p) for p in _BUILD_PREFIXES):
+        return EnumFileZone.BUILD
+
+    return EnumFileZone.PRODUCTION

--- a/tests/unit/enums/test_enum_file_zone.py
+++ b/tests/unit/enums/test_enum_file_zone.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+
+@pytest.mark.unit
+class TestEnumFileZone:
+    def test_enum_members(self) -> None:
+        assert {z.value for z in EnumFileZone} == {
+            "production",
+            "test",
+            "config",
+            "generated",
+            "docs",
+            "build",
+        }
+
+    def test_enum_is_str_enum(self) -> None:
+        assert EnumFileZone.PRODUCTION.value == "production"
+        assert isinstance(EnumFileZone.PRODUCTION, str)
+        assert issubclass(EnumFileZone, str)
+        assert issubclass(EnumFileZone, Enum)
+
+    def test_enum_string_behavior(self) -> None:
+        assert str(EnumFileZone.TEST) == "test"
+        assert EnumFileZone.DOCS == "docs"
+
+    def test_enum_iteration(self) -> None:
+        values = list(EnumFileZone)
+        assert len(values) == 6
+
+    def test_enum_membership(self) -> None:
+        assert EnumFileZone.CONFIG in EnumFileZone
+        assert "config" in [e.value for e in EnumFileZone]
+
+    def test_enum_deserialization(self) -> None:
+        assert EnumFileZone("production") == EnumFileZone.PRODUCTION
+        assert EnumFileZone("generated") == EnumFileZone.GENERATED
+
+    def test_enum_invalid_value(self) -> None:
+        with pytest.raises(ValueError):
+            EnumFileZone("extension")  # EnumFileType domain, not zone
+
+    def test_all_members_accessible(self) -> None:
+        assert EnumFileZone.PRODUCTION == "production"
+        assert EnumFileZone.TEST == "test"
+        assert EnumFileZone.CONFIG == "config"
+        assert EnumFileZone.GENERATED == "generated"
+        assert EnumFileZone.DOCS == "docs"
+        assert EnumFileZone.BUILD == "build"

--- a/tests/unit/models/validation/test_model_zone_policy.py
+++ b/tests/unit/models/validation/test_model_zone_policy.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelZonePolicy — per-zone QA gate configuration (OMN-10354)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+from omnibase_core.models.validation.model_zone_policy import ModelZonePolicy
+
+
+@pytest.mark.unit
+class TestModelZonePolicy:
+    def test_zone_policy_is_frozen(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.PRODUCTION,
+            qa_depth="full",
+            requires_lint=True,
+            requires_test=True,
+            requires_review=True,
+            requires_security_scan=True,
+        )
+        with pytest.raises(Exception):
+            p.requires_lint = False  # type: ignore[misc]
+
+    def test_zone_policy_qa_depth_validated(self) -> None:
+        with pytest.raises(Exception):
+            ModelZonePolicy(
+                zone=EnumFileZone.DOCS,
+                qa_depth="bogus",  # type: ignore[arg-type]
+                requires_lint=False,
+                requires_test=False,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+
+    def test_zone_policy_valid_qa_depths(self) -> None:
+        for depth in ("full", "standard", "light", "skip"):
+            p = ModelZonePolicy(
+                zone=EnumFileZone.TEST,
+                qa_depth=depth,  # type: ignore[arg-type]
+                requires_lint=False,
+                requires_test=False,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+            assert p.qa_depth == depth
+
+    def test_zone_policy_all_zones_accepted(self) -> None:
+        for zone in EnumFileZone:
+            p = ModelZonePolicy(
+                zone=zone,
+                qa_depth="standard",
+                requires_lint=True,
+                requires_test=True,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+            assert p.zone == zone
+
+    def test_zone_policy_fields_accessible(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.GENERATED,
+            qa_depth="skip",
+            requires_lint=False,
+            requires_test=False,
+            requires_review=False,
+            requires_security_scan=False,
+        )
+        assert p.zone == EnumFileZone.GENERATED
+        assert p.qa_depth == "skip"
+        assert p.requires_lint is False
+        assert p.requires_test is False
+        assert p.requires_review is False
+        assert p.requires_security_scan is False
+
+    def test_zone_policy_zone_is_enum_file_zone(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.CONFIG,
+            qa_depth="light",
+            requires_lint=True,
+            requires_test=False,
+            requires_review=False,
+            requires_security_scan=False,
+        )
+        assert isinstance(p.zone, EnumFileZone)

--- a/tests/validation/test_zone_classifier.py
+++ b/tests/validation/test_zone_classifier.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+from omnibase_core.validation.zone_classifier import classify_path
+
+
+def test_classify_production() -> None:
+    assert classify_path(Path("src/omnibase_core/foo.py")) == EnumFileZone.PRODUCTION
+
+
+def test_classify_test() -> None:
+    assert classify_path(Path("tests/test_foo.py")) == EnumFileZone.TEST
+
+
+def test_classify_config_yaml_outside_src() -> None:
+    assert classify_path(Path("pyproject.toml")) == EnumFileZone.CONFIG
+
+
+def test_classify_yaml_inside_src_is_production() -> None:
+    # config files inside src/ are part of the package, not free config
+    assert (
+        classify_path(Path("src/omnibase_core/contracts/foo.yaml"))
+        == EnumFileZone.PRODUCTION
+    )
+
+
+def test_classify_generated_wins_over_production() -> None:
+    # priority: generated > production > test > config > docs > build
+    assert (
+        classify_path(Path("src/__pycache__/foo.cpython-312.pyc"))
+        == EnumFileZone.GENERATED
+    )
+
+
+def test_classify_docs() -> None:
+    assert classify_path(Path("docs/architecture.md")) == EnumFileZone.DOCS
+
+
+def test_classify_build() -> None:
+    assert classify_path(Path("scripts/deploy.sh")) == EnumFileZone.BUILD
+
+
+def test_symlink_resolved_before_classification(tmp_path: Path) -> None:
+    target = tmp_path / "src" / "real.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("")
+    link = tmp_path / "link.py"
+    link.symlink_to(target)
+    assert classify_path(link) == EnumFileZone.PRODUCTION


### PR DESCRIPTION
## Summary

- Adds `EnumFileZone` (StrEnum) with six directory-role values: `production`, `test`, `config`, `generated`, `docs`, `build`
- Distinct from `EnumFileType` (extension/format) — same `.py` file is `PRODUCTION` under `src/`, `TEST` under `tests/`
- TDD: failing test written first, verified `ModuleNotFoundError`, then implementation added
- 8 unit tests covering members, str behavior, iteration, membership, deserialization, invalid value

## Ticket

OMN-10351 — Task 1: Add `EnumFileZone` enum (Wave 1, epic OMN-10350)

## dod_evidence

- `uv run pytest tests/unit/enums/test_enum_file_zone.py -v` → 8 passed
- `uv run mypy src/omnibase_core/enums/enum_file_zone.py --strict` → Success: no issues found
- `uv run ruff format && ruff check` → All checks passed
- `pre-commit run --all-files` → All hooks passed (55 checks)

## Test plan

- [x] 8 unit tests pass against new enum
- [x] mypy --strict clean
- [x] ruff format + lint clean
- [x] All 55 pre-commit hooks pass
- [x] PR title contains OMN-10351