### PR TITLE
feat(OMN-10366): add EnumPrmPattern, ModelTrajectoryEntry, ModelPrmMatch

### DIFF
--- a/src/omnibase_core/enums/enum_prm_pattern.py
+++ b/src/omnibase_core/enums/enum_prm_pattern.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import StrEnum
+
+
+class EnumPrmPattern(StrEnum):
+    REPETITION_LOOP = "repetition_loop"
+    PING_PONG = "ping_pong"
+    EXPANSION_DRIFT = "expansion_drift"
+    STUCK_ON_TEST = "stuck_on_test"
+    CONTEXT_THRASH = "context_thrash"

--- a/src/omnibase_core/models/agents/model_prm_match.py
+++ b/src/omnibase_core/models/agents/model_prm_match.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_prm_pattern import EnumPrmPattern
+
+
+class ModelPrmMatch(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    pattern: EnumPrmPattern
+    affected_agents: tuple[str, ...]
+    affected_targets: tuple[str, ...]
+    step_range: tuple[int, int]
+    severity_level: Literal[1, 2, 3]
+    dedup_key: str

--- a/src/omnibase_core/models/agents/model_trajectory_entry.py
+++ b/src/omnibase_core/models/agents/model_trajectory_entry.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelTrajectoryEntry(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    step: int
+    agent: str
+    action: str
+    target: str
+    result: str

--- a/tests/unit/models/agents/test_prm_models.py
+++ b/tests/unit/models/agents/test_prm_models.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from omnibase_core.enums.enum_prm_pattern import EnumPrmPattern
+from omnibase_core.models.agents.model_prm_match import ModelPrmMatch
+from omnibase_core.models.agents.model_trajectory_entry import ModelTrajectoryEntry
+
+
+def test_enum_prm_pattern_members() -> None:
+    assert {p.value for p in EnumPrmPattern} == {
+        "repetition_loop",
+        "ping_pong",
+        "expansion_drift",
+        "stuck_on_test",
+        "context_thrash",
+    }
+
+
+def test_enum_prm_pattern_is_str_enum() -> None:
+    assert EnumPrmPattern.REPETITION_LOOP.value == "repetition_loop"
+    assert isinstance(EnumPrmPattern.REPETITION_LOOP, str)
+
+
+def test_trajectory_entry_fields() -> None:
+    entry = ModelTrajectoryEntry(
+        step=1,
+        agent="agent-a",
+        action="edit",
+        target="src/foo.py",
+        result="ok",
+    )
+    assert entry.step == 1
+    assert entry.agent == "agent-a"
+    assert entry.action == "edit"
+    assert entry.target == "src/foo.py"
+    assert entry.result == "ok"
+
+
+def test_trajectory_entry_is_frozen() -> None:
+    entry = ModelTrajectoryEntry(
+        step=1,
+        agent="agent-a",
+        action="edit",
+        target="src/foo.py",
+        result="ok",
+    )
+    with pytest.raises(Exception):
+        entry.step = 99  # type: ignore[misc]
+
+
+def test_prm_match_fields() -> None:
+    match = ModelPrmMatch(
+        pattern=EnumPrmPattern.REPETITION_LOOP,
+        affected_agents=("agent-a",),
+        affected_targets=("src/foo.py",),
+        step_range=(1, 5),
+        severity_level=2,
+        dedup_key="repetition_loop:agent-a:src/foo.py:1-5",
+    )
+    assert match.pattern == EnumPrmPattern.REPETITION_LOOP
+    assert match.affected_agents == ("agent-a",)
+    assert match.affected_targets == ("src/foo.py",)
+    assert match.step_range == (1, 5)
+    assert match.severity_level == 2
+    assert match.dedup_key == "repetition_loop:agent-a:src/foo.py:1-5"
+
+
+def test_prm_match_is_frozen() -> None:
+    match = ModelPrmMatch(
+        pattern=EnumPrmPattern.PING_PONG,
+        affected_agents=("agent-a", "agent-b"),
+        affected_targets=("src/bar.py",),
+        step_range=(2, 8),
+        severity_level=1,
+        dedup_key="ping_pong:agent-a,agent-b:src/bar.py:2-8",
+    )
+    with pytest.raises(Exception):
+        match.severity_level = 3  # type: ignore[misc]
+
+
+def test_prm_match_severity_must_be_1_2_or_3() -> None:
+    with pytest.raises(Exception):
+        ModelPrmMatch(
+            pattern=EnumPrmPattern.EXPANSION_DRIFT,
+            affected_agents=("agent-a",),
+            affected_targets=("src/baz.py",),
+            step_range=(0, 10),
+            severity_level=4,  # type: ignore[arg-type]
+            dedup_key="expansion_drift:agent-a:src/baz.py:0-10",
+        )


### PR DESCRIPTION
## Summary

- Adds `EnumPrmPattern` (StrEnum) with 5 values: `repetition_loop`, `ping_pong`, `expansion_drift`, `stuck_on_test`, `context_thrash`
- Adds `ModelTrajectoryEntry` (frozen Pydantic model): `step`, `agent`, `action`, `target`, `result`
- Adds `ModelPrmMatch` (frozen Pydantic model): `pattern`, `affected_agents`, `affected_targets`, `step_range`, `severity_level` (Literal[1,2,3]), `dedup_key`

Part of Wave 4 (PRM Trajectory Analysis) in the selective swarm pattern adoption epic OMN-10350.

These types ship their own result model rather than reusing `ModelWatchdogCheckResult` (private to an omnimarket node — layering violation) or `EnumTriageSeverity` (different semantics/value set).

## Ticket

OMN-10366

## dod_evidence

- 7 unit tests, all passing (`tests/unit/models/agents/test_prm_models.py`)
- mypy --strict: 0 errors on all 3 new source files
- ruff format + check: clean
- pre-commit run --all-files: all hooks passed (including SPDX, Pydantic conventions, enum governance)
- pre-push hooks (mypy strict, pyright): passed

## Test plan

- [x] `test_enum_prm_pattern_members` — verifies exact value set
- [x] `test_enum_prm_pattern_is_str_enum` — verifies StrEnum subtype
- [x] `test_trajectory_entry_fields` — verifies all fields
- [x] `test_trajectory_entry_is_frozen` — verifies mutation raises
- [x] `test_prm_match_fields` — verifies all fields including tuple types
- [x] `test_prm_match_is_frozen` — verifies mutation raises
- [x] `test_prm_match_severity_must_be_1_2_or_3` — verifies Literal[1,2,3] rejects 4