### PR TITLE
feat(OMN-10361): add analysis/ package with CoChangeMatrix and build_cochange_matrix

### DIFF
--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -59,6 +59,7 @@ adjacency:
     reverse_deps: [models, runtime, nodes, services]
   # Leaf modules with no reverse_deps still appear so the loader can validate
   # that every src/omnibase_core/<dir> has an entry.
+  analysis: {reverse_deps: []}
   backends: {reverse_deps: []}
   cli: {reverse_deps: []}
   constants: {reverse_deps: []}

--- a/src/omnibase_core/analysis/__init__.py
+++ b/src/omnibase_core/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CoChangeMatrix:
+    pair_count: dict[tuple[str, str], int]
+    file_count: dict[str, int]
+    total_commits: int
+
+
+def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
+    pair_count: Counter[tuple[str, str]] = Counter()
+    file_count: Counter[str] = Counter()
+    for files in commits:
+        unique = sorted(set(files))
+        for f in unique:
+            file_count[f] += 1
+        for i in range(len(unique)):
+            for j in range(i + 1, len(unique)):
+                pair_count[(unique[i], unique[j])] += 1
+    return CoChangeMatrix(dict(pair_count), dict(file_count), len(commits))

--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+import math
 from collections import Counter
 from dataclasses import dataclass
 
@@ -22,3 +23,17 @@ def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
             for j in range(i + 1, len(unique)):
                 pair_count[(unique[i], unique[j])] += 1
     return CoChangeMatrix(dict(pair_count), dict(file_count), len(commits))
+
+
+def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_ab <= 0:
+        return -1.0
+    pmi = math.log(p_ab) - math.log(p_a * p_b)
+    npmi = pmi / -math.log(p_ab)
+    return max(-1.0, min(1.0, npmi))
+
+
+def compute_lift(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_a == 0 or p_b == 0:
+        return 0.0
+    return p_ab / (p_a * p_b)

--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -6,6 +6,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
 
 @dataclass(frozen=True)
 class CoChangeMatrix:
@@ -51,13 +54,27 @@ def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
 def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
     """Normalised pointwise mutual information in [-1, 1].
 
+    All three arguments must be valid probabilities in [0.0, 1.0] and
+    p_ab must satisfy p_ab <= min(p_a, p_b).
     Returns -1.0 when p_ab <= 0 (no co-occurrence signal).
+    Returns 1.0 when p_ab == 1.0 (perfect correlation; avoids log(0) in denominator).
     Returns 0.0 for statistical independence (p_ab == p_a * p_b).
-    Returns 1.0 for perfect correlation (p_ab == p_a == p_b).
     Formula: PMI / -log(p_ab), clamped to [-1, 1].
     """
-    if p_ab <= 0:
+    if not (0.0 <= p_a <= 1.0 and 0.0 <= p_b <= 1.0 and 0.0 <= p_ab <= 1.0):
+        raise ModelOnexError(
+            "p_a, p_b, and p_ab must each be in [0.0, 1.0].",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+    if p_ab > min(p_a, p_b):
+        raise ModelOnexError(
+            "p_ab cannot exceed min(p_a, p_b).",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+    if p_ab <= 0.0:
         return -1.0
+    if p_ab >= 1.0:
+        return 1.0
     pmi = math.log(p_ab) - math.log(p_a * p_b)
     npmi = pmi / -math.log(p_ab)
     return max(-1.0, min(1.0, npmi))
@@ -66,10 +83,22 @@ def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
 def compute_lift(p_a: float, p_b: float, p_ab: float) -> float:
     """Lift: observed co-occurrence divided by expected under independence.
 
-    Returns 0.0 when p_a == 0 or p_b == 0 (degenerate case).
+    All three arguments must be valid probabilities in [0.0, 1.0] and
+    p_ab must satisfy p_ab <= min(p_a, p_b).
+    Returns 0.0 when p_a == 0.0 or p_b == 0.0 (degenerate case, avoids division by zero).
     Values > 1.0 indicate positive correlation; < 1.0 negative correlation.
     Formula: p_ab / (p_a * p_b).
     """
-    if p_a == 0 or p_b == 0:
+    if not (0.0 <= p_a <= 1.0 and 0.0 <= p_b <= 1.0 and 0.0 <= p_ab <= 1.0):
+        raise ModelOnexError(
+            "p_a, p_b, and p_ab must each be in [0.0, 1.0].",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+    if p_ab > min(p_a, p_b):
+        raise ModelOnexError(
+            "p_ab cannot exceed min(p_a, p_b).",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+    if p_a == 0.0 or p_b == 0.0:
         return 0.0
     return p_ab / (p_a * p_b)

--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -2,17 +2,36 @@
 # SPDX-License-Identifier: MIT
 import math
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 
 
 @dataclass(frozen=True)
 class CoChangeMatrix:
-    pair_count: dict[tuple[str, str], int]
-    file_count: dict[str, int]
+    """Immutable co-change statistics for a set of commits.
+
+    pair_count: sorted (a, b) file pairs mapped to co-occurrence count.
+      Keys are always ordered (a < b) to avoid duplicate pair representations.
+    file_count: per-file commit count across all analysed commits.
+    total_commits: total number of commits included in the analysis.
+
+    All mapping fields use MappingProxyType to prevent item-level mutation,
+    which frozen=True alone does not guard against.
+    """
+
+    pair_count: Mapping[tuple[str, str], int]
+    file_count: Mapping[str, int]
     total_commits: int
 
 
 def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
+    """Build a co-change matrix from a list of per-commit file lists.
+
+    Files within each commit are deduplicated before counting; pairs are stored
+    as sorted (a, b) tuples with a < b. Returns a frozen CoChangeMatrix whose
+    mapping fields are wrapped in MappingProxyType.
+    """
     pair_count: Counter[tuple[str, str]] = Counter()
     file_count: Counter[str] = Counter()
     for files in commits:
@@ -22,10 +41,21 @@ def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
         for i in range(len(unique)):
             for j in range(i + 1, len(unique)):
                 pair_count[(unique[i], unique[j])] += 1
-    return CoChangeMatrix(dict(pair_count), dict(file_count), len(commits))
+    return CoChangeMatrix(
+        MappingProxyType(dict(pair_count)),
+        MappingProxyType(dict(file_count)),
+        len(commits),
+    )
 
 
 def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
+    """Normalised pointwise mutual information in [-1, 1].
+
+    Returns -1.0 when p_ab <= 0 (no co-occurrence signal).
+    Returns 0.0 for statistical independence (p_ab == p_a * p_b).
+    Returns 1.0 for perfect correlation (p_ab == p_a == p_b).
+    Formula: PMI / -log(p_ab), clamped to [-1, 1].
+    """
     if p_ab <= 0:
         return -1.0
     pmi = math.log(p_ab) - math.log(p_a * p_b)
@@ -34,6 +64,12 @@ def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
 
 
 def compute_lift(p_a: float, p_b: float, p_ab: float) -> float:
+    """Lift: observed co-occurrence divided by expected under independence.
+
+    Returns 0.0 when p_a == 0 or p_b == 0 (degenerate case).
+    Values > 1.0 indicate positive correlation; < 1.0 negative correlation.
+    Formula: p_ab / (p_a * p_b).
+    """
     if p_a == 0 or p_b == 0:
         return 0.0
     return p_ab / (p_a * p_b)

--- a/tests/unit/analysis/__init__.py
+++ b/tests/unit/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/analysis/test_co_change_matrix.py
+++ b/tests/unit/analysis/test_co_change_matrix.py
@@ -4,6 +4,8 @@ import pytest
 
 from omnibase_core.analysis.co_change_matrix import build_cochange_matrix
 
+pytestmark = pytest.mark.unit
+
 
 def test_pair_counts() -> None:
     commits = [

--- a/tests/unit/analysis/test_co_change_matrix.py
+++ b/tests/unit/analysis/test_co_change_matrix.py
@@ -51,4 +51,5 @@ def test_pairs_are_sorted_tuples() -> None:
 def test_matrix_is_frozen() -> None:
     m = build_cochange_matrix([["a.py", "b.py"]])
     with pytest.raises((AttributeError, TypeError)):
+        # NOTE(OMN-10361): intentional forbidden assignment to verify frozen dataclass behavior.
         m.total_commits = 99  # type: ignore[misc]

--- a/tests/unit/analysis/test_co_change_matrix.py
+++ b/tests/unit/analysis/test_co_change_matrix.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import pytest
+
+from omnibase_core.analysis.co_change_matrix import build_cochange_matrix
+
+
+def test_pair_counts() -> None:
+    commits = [
+        ["a.py", "b.py"],
+        ["a.py", "b.py", "c.py"],
+        ["a.py"],
+    ]
+    m = build_cochange_matrix(commits)
+    assert m.pair_count[("a.py", "b.py")] == 2
+    assert m.pair_count[("a.py", "c.py")] == 1
+    assert m.file_count["a.py"] == 3
+    assert m.total_commits == 3
+
+
+def test_single_file_commit_no_pairs() -> None:
+    commits = [["a.py"], ["b.py"]]
+    m = build_cochange_matrix(commits)
+    assert len(m.pair_count) == 0
+    assert m.file_count["a.py"] == 1
+    assert m.file_count["b.py"] == 1
+    assert m.total_commits == 2
+
+
+def test_empty_commits() -> None:
+    m = build_cochange_matrix([])
+    assert m.pair_count == {}
+    assert m.file_count == {}
+    assert m.total_commits == 0
+
+
+def test_duplicate_files_in_commit_counted_once() -> None:
+    commits = [["a.py", "a.py", "b.py"]]
+    m = build_cochange_matrix(commits)
+    assert m.file_count["a.py"] == 1
+    assert m.pair_count[("a.py", "b.py")] == 1
+
+
+def test_pairs_are_sorted_tuples() -> None:
+    commits = [["z.py", "a.py"]]
+    m = build_cochange_matrix(commits)
+    assert ("a.py", "z.py") in m.pair_count
+    assert ("z.py", "a.py") not in m.pair_count
+
+
+def test_matrix_is_frozen() -> None:
+    m = build_cochange_matrix([["a.py", "b.py"]])
+    with pytest.raises((AttributeError, TypeError)):
+        m.total_commits = 99  # type: ignore[misc]

--- a/tests/unit/analysis/test_co_change_metrics.py
+++ b/tests/unit/analysis/test_co_change_metrics.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import math
+
+from omnibase_core.analysis.co_change_matrix import compute_lift, compute_npmi
+
+
+def test_npmi_perfect_correlation() -> None:
+    # both files always co-occur: p_ab == p_a == p_b
+    npmi = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.5)
+    assert math.isclose(npmi, 1.0, abs_tol=1e-9)
+
+
+def test_npmi_independence() -> None:
+    # independent: p_ab = p_a * p_b
+    npmi = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.25)
+    assert math.isclose(npmi, 0.0, abs_tol=1e-9)
+
+
+def test_npmi_clamped() -> None:
+    result = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.0001)
+    assert -1.0 <= result <= 1.0
+
+
+def test_npmi_zero_p_ab_returns_minus_one() -> None:
+    assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.0) == -1.0
+
+
+def test_npmi_negative_p_ab_returns_minus_one() -> None:
+    assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=-0.1) == -1.0
+
+
+def test_lift_above_one_when_correlated() -> None:
+    assert compute_lift(p_a=0.5, p_b=0.5, p_ab=0.5) > 1.0
+
+
+def test_lift_one_when_independent() -> None:
+    result = compute_lift(p_a=0.5, p_b=0.5, p_ab=0.25)
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_lift_zero_when_p_a_is_zero() -> None:
+    assert compute_lift(p_a=0.0, p_b=0.5, p_ab=0.0) == 0.0
+
+
+def test_lift_zero_when_p_b_is_zero() -> None:
+    assert compute_lift(p_a=0.5, p_b=0.0, p_ab=0.0) == 0.0

--- a/tests/unit/analysis/test_co_change_metrics.py
+++ b/tests/unit/analysis/test_co_change_metrics.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: MIT
 import math
 
+import pytest
+
 from omnibase_core.analysis.co_change_matrix import compute_lift, compute_npmi
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+pytestmark = pytest.mark.unit
 
 
 def test_npmi_perfect_correlation() -> None:
@@ -26,8 +32,20 @@ def test_npmi_zero_p_ab_returns_minus_one() -> None:
     assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.0) == -1.0
 
 
-def test_npmi_negative_p_ab_returns_minus_one() -> None:
-    assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=-0.1) == -1.0
+def test_npmi_p_ab_one_returns_one() -> None:
+    assert compute_npmi(p_a=1.0, p_b=1.0, p_ab=1.0) == 1.0
+
+
+def test_npmi_out_of_range_raises() -> None:
+    with pytest.raises(ModelOnexError) as exc_info:
+        compute_npmi(p_a=0.5, p_b=0.5, p_ab=-0.1)
+    assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_INPUT
+
+
+def test_npmi_p_ab_exceeds_min_pa_pb_raises() -> None:
+    with pytest.raises(ModelOnexError) as exc_info:
+        compute_npmi(p_a=0.3, p_b=0.4, p_ab=0.35)
+    assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_INPUT
 
 
 def test_lift_above_one_when_correlated() -> None:
@@ -45,3 +63,15 @@ def test_lift_zero_when_p_a_is_zero() -> None:
 
 def test_lift_zero_when_p_b_is_zero() -> None:
     assert compute_lift(p_a=0.5, p_b=0.0, p_ab=0.0) == 0.0
+
+
+def test_lift_out_of_range_raises() -> None:
+    with pytest.raises(ModelOnexError) as exc_info:
+        compute_lift(p_a=1.5, p_b=0.5, p_ab=0.5)
+    assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_INPUT
+
+
+def test_lift_p_ab_exceeds_min_pa_pb_raises() -> None:
+    with pytest.raises(ModelOnexError) as exc_info:
+        compute_lift(p_a=0.3, p_b=0.4, p_ab=0.35)
+    assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_INPUT


### PR DESCRIPTION
## Summary

- Creates the `analysis/` package in `omnibase_core` (new `src/omnibase_core/analysis/__init__.py`) — foundation for Tasks 10–13 and 19–22 in epic OMN-10350
- Implements `CoChangeMatrix` as a `@dataclass(frozen=True)` with `pair_count`, `file_count`, and `total_commits` fields
- Implements `build_cochange_matrix(commits)` using `Counter`-based pair/file counting with sorted deduplication

## Ticket

OMN-10361

## dod_evidence

- `uv run pytest tests/unit/analysis/ -v` → 6 passed (pair counts, empty commits, single-file commits, dedup, sorted tuples, frozen enforcement)
- `uv run mypy src/omnibase_core/analysis/co_change_matrix.py --strict` → no issues
- `uv run ruff check src/omnibase_core/analysis/ tests/unit/analysis/` → all checks passed
- `uv run pre-commit run --all-files` → all hooks passed including SPDX, aislop, naming conventions

## Test plan

- [ ] CI green on `jonah/omn-10361-co-change-matrix`
- [ ] 6 unit tests pass covering: pair counting, empty input, single-file commits, duplicate-file dedup within a commit, sorted-tuple key invariant, frozen dataclass mutation rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analysis functionality to compute co-change metrics between files, enabling measurement of relationships and correlation patterns to better understand file dependencies and change behaviors.

* **Tests**
  * Introduced comprehensive test coverage for the new analysis module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->