### PR TITLE
feat(OMN-10357): add ModelCompletionVerifyResult for completion-verify pattern

### DIFF
--- a/src/omnibase_core/models/validation/model_completion_verify_result.py
+++ b/src/omnibase_core/models/validation/model_completion_verify_result.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pre-receipt deterministic completion check result model."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelCompletionVerifyResult(BaseModel):
+    """Result of a pre-receipt identifier-vs-file completion check.
+
+    Captures which identifiers were searched, where each was found,
+    what is missing, and skip reasons. Operates before a worker claims done.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    task_id: str  # string-id-ok: external Linear ticket identifier (e.g. "OMN-1234")
+    checked_identifiers: list[str]
+    found: dict[str, str]
+    missing: list[str]
+    skipped: bool
+    skipped_reason: str | None

--- a/tests/unit/models/validation/__init__.py
+++ b/tests/unit/models/validation/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for validation models."""

--- a/tests/unit/models/validation/test_model_completion_verify_result.py
+++ b/tests/unit/models/validation/test_model_completion_verify_result.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelCompletionVerifyResult."""
+
+import pytest
+
+from omnibase_core.models.validation.model_completion_verify_result import (
+    ModelCompletionVerifyResult,
+)
+
+
+def test_result_required_fields() -> None:
+    r = ModelCompletionVerifyResult(
+        task_id="OMN-1",
+        checked_identifiers=["foo", "bar"],
+        found={"foo": "src/x.py"},
+        missing=["bar"],
+        skipped=False,
+        skipped_reason=None,
+    )
+    assert r.missing == ["bar"]
+    assert not r.skipped
+
+
+def test_result_is_frozen() -> None:
+    r = ModelCompletionVerifyResult(
+        task_id="OMN-1",
+        checked_identifiers=[],
+        found={},
+        missing=[],
+        skipped=True,
+        skipped_reason="no file targets",
+    )
+    with pytest.raises(Exception):
+        r.task_id = "X"  # type: ignore[misc]
+
+
+def test_result_all_found() -> None:
+    r = ModelCompletionVerifyResult(
+        task_id="OMN-2",
+        checked_identifiers=["foo", "bar"],
+        found={"foo": "src/x.py", "bar": "src/y.py"},
+        missing=[],
+        skipped=False,
+        skipped_reason=None,
+    )
+    assert r.found == {"foo": "src/x.py", "bar": "src/y.py"}
+    assert r.missing == []
+
+
+def test_result_skipped_with_reason() -> None:
+    r = ModelCompletionVerifyResult(
+        task_id="OMN-RESEARCH",
+        checked_identifiers=[],
+        found={},
+        missing=[],
+        skipped=True,
+        skipped_reason="no file targets resolved",
+    )
+    assert r.skipped
+    assert r.skipped_reason == "no file targets resolved"
+
+
+def test_result_skipped_reason_none_when_not_skipped() -> None:
+    r = ModelCompletionVerifyResult(
+        task_id="OMN-3",
+        checked_identifiers=["baz"],
+        found={},
+        missing=["baz"],
+        skipped=False,
+        skipped_reason=None,
+    )
+    assert r.skipped_reason is None


### PR DESCRIPTION
## Summary

- Adds `ModelCompletionVerifyResult` frozen Pydantic model to `omnibase_core/models/validation/`
- Captures pre-receipt identifier-vs-file check results: checked identifiers, found dict (identifier → file path), missing list, skipped flag, and skip reason
- Adds `__init__.py` to `tests/unit/models/validation/` (was missing, consistent with sibling test dirs)
- 5 unit tests covering frozen immutability, required fields, found/missing, skipped with reason

## Ticket

OMN-10357 — Task 5: [Wave 2 Completion-Verify] Add `ModelCompletionVerifyResult`
Epic: OMN-10350

## DoD Evidence

- `uv run pytest tests/unit/models/validation/test_model_completion_verify_result.py -v` → 5 passed
- `uv run mypy src/omnibase_core/models/validation/model_completion_verify_result.py --strict` → Success: no issues found
- `uv run ruff format && uv run ruff check` → all passed, no changes
- `pre-commit run --all-files` → all hooks passed
- `task_id: str` uses `# string-id-ok: external Linear ticket identifier` inline bypass per `python_ast_validator.py` exemption pattern

## Test plan

- [ ] CI passes on all checks
- [ ] `test_result_is_frozen` verifies Pydantic `frozen=True` raises on mutation
- [ ] `test_result_required_fields` verifies missing list and skipped flag
- [ ] `test_result_skipped_with_reason` verifies skip path