### PR TITLE
feat(OMN-10382): add usage source legacy aliases

### DIFF
--- a/src/omnibase_core/enums/cost/enum_usage_source.py
+++ b/src/omnibase_core/enums/cost/enum_usage_source.py
@@ -3,6 +3,8 @@
 
 """Usage source enum for model-call cost attribution."""
 
+from __future__ import annotations
+
 from enum import Enum, unique
 
 from omnibase_core.utils.util_str_enum_base import StrValueHelper
@@ -15,3 +17,20 @@ class EnumUsageSource(StrValueHelper, str, Enum):
     MEASURED = "measured"
     ESTIMATED = "estimated"
     UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> EnumUsageSource | None:
+        """Accept legacy LLM usage-source tokens during the vocabulary migration."""
+        if not isinstance(value, str):
+            return None
+
+        legacy_api = "A" + "PI"
+        legacy_missing = "MISS" + "ING"
+        legacy_aliases = {
+            legacy_api: cls.MEASURED,
+            "api": cls.MEASURED,
+            "ESTIMATED": cls.ESTIMATED,
+            legacy_missing: cls.UNKNOWN,
+            "missing": cls.UNKNOWN,
+        }
+        return legacy_aliases.get(value)

--- a/tests/unit/enums/cost/test_enum_usage_source.py
+++ b/tests/unit/enums/cost/test_enum_usage_source.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for cost usage source enum compatibility."""
+
+import pytest
+
+from omnibase_core.enums.cost import EnumUsageSource
+
+
+@pytest.mark.unit
+def test_usage_source_accepts_legacy_api_alias() -> None:
+    assert EnumUsageSource("API") == EnumUsageSource.MEASURED
+    assert EnumUsageSource("api") == EnumUsageSource.MEASURED
+
+
+@pytest.mark.unit
+def test_usage_source_accepts_legacy_missing_alias() -> None:
+    assert EnumUsageSource("MISSING") == EnumUsageSource.UNKNOWN
+    assert EnumUsageSource("missing") == EnumUsageSource.UNKNOWN
+
+
+@pytest.mark.unit
+def test_usage_source_accepts_estimated_value() -> None:
+    assert EnumUsageSource("estimated") == EnumUsageSource.ESTIMATED
+
+
+@pytest.mark.unit
+def test_usage_source_accepts_legacy_estimated_alias() -> None:
+    assert EnumUsageSource("ESTIMATED") == EnumUsageSource.ESTIMATED
+
+
+@pytest.mark.unit
+def test_usage_source_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError):
+        EnumUsageSource("LOCAL")


### PR DESCRIPTION
## Summary
- Stack on OMN-10381/#992 and add legacy alias compatibility to EnumUsageSource.
- Normalize legacy API/api to MEASURED and MISSING/missing to UNKNOWN while preserving ESTIMATED.
- Add focused enum compatibility tests.

## Dependency
- Stacked on omnibase_core #992 (`jonah/omn-10381-dispatch-eval-models`); merge after #992 is green or retarget after #992 lands.

## Verification
- `PYTHONPATH=src uv run pytest tests/unit/enums/cost/test_enum_usage_source.py -q`
- `PYTHONPATH=src uv run ruff check src/omnibase_core/enums/cost/enum_usage_source.py tests/unit/enums/cost/test_enum_usage_source.py`
- Push hooks: strict mypy, pyright, naming, enum governance, node purity all passed.