### PR TITLE
feat(OMN-10354): add ModelZonePolicy for per-zone QA gate config

### DIFF
--- a/src/omnibase_core/models/validation/model_zone_policy.py
+++ b/src/omnibase_core/models/validation/model_zone_policy.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelZonePolicy — per-zone QA gate configuration (OMN-10354)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+QaDepth = Literal["full", "standard", "light", "skip"]
+
+
+class ModelZonePolicy(BaseModel):
+    """Frozen per-zone QA gate policy.
+
+    Distinct from agent safety models — this governs per-file-zone QA
+    requirements (lint, test, review, security scan) and depth, not
+    agent capability gates.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    zone: EnumFileZone
+    qa_depth: QaDepth
+    requires_lint: bool
+    requires_test: bool
+    requires_review: bool
+    requires_security_scan: bool

--- a/tests/unit/models/validation/test_model_zone_policy.py
+++ b/tests/unit/models/validation/test_model_zone_policy.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelZonePolicy — per-zone QA gate configuration (OMN-10354)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+from omnibase_core.models.validation.model_zone_policy import ModelZonePolicy
+
+
+@pytest.mark.unit
+class TestModelZonePolicy:
+    def test_zone_policy_is_frozen(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.PRODUCTION,
+            qa_depth="full",
+            requires_lint=True,
+            requires_test=True,
+            requires_review=True,
+            requires_security_scan=True,
+        )
+        with pytest.raises(Exception):
+            p.requires_lint = False  # type: ignore[misc]
+
+    def test_zone_policy_qa_depth_validated(self) -> None:
+        with pytest.raises(Exception):
+            ModelZonePolicy(
+                zone=EnumFileZone.DOCS,
+                qa_depth="bogus",  # type: ignore[arg-type]
+                requires_lint=False,
+                requires_test=False,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+
+    def test_zone_policy_valid_qa_depths(self) -> None:
+        for depth in ("full", "standard", "light", "skip"):
+            p = ModelZonePolicy(
+                zone=EnumFileZone.TEST,
+                qa_depth=depth,  # type: ignore[arg-type]
+                requires_lint=False,
+                requires_test=False,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+            assert p.qa_depth == depth
+
+    def test_zone_policy_all_zones_accepted(self) -> None:
+        for zone in EnumFileZone:
+            p = ModelZonePolicy(
+                zone=zone,
+                qa_depth="standard",
+                requires_lint=True,
+                requires_test=True,
+                requires_review=False,
+                requires_security_scan=False,
+            )
+            assert p.zone == zone
+
+    def test_zone_policy_fields_accessible(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.GENERATED,
+            qa_depth="skip",
+            requires_lint=False,
+            requires_test=False,
+            requires_review=False,
+            requires_security_scan=False,
+        )
+        assert p.zone == EnumFileZone.GENERATED
+        assert p.qa_depth == "skip"
+        assert p.requires_lint is False
+        assert p.requires_test is False
+        assert p.requires_review is False
+        assert p.requires_security_scan is False
+
+    def test_zone_policy_zone_is_enum_file_zone(self) -> None:
+        p = ModelZonePolicy(
+            zone=EnumFileZone.CONFIG,
+            qa_depth="light",
+            requires_lint=True,
+            requires_test=False,
+            requires_review=False,
+            requires_security_scan=False,
+        )
+        assert isinstance(p.zone, EnumFileZone)


### PR DESCRIPTION
## Summary

- Adds `ModelZonePolicy` frozen Pydantic model to `omnibase_core/models/validation/`
- 6 fields: `zone:EnumFileZone`, `qa_depth:Literal["full","standard","light","skip"]`, `requires_lint:bool`, `requires_test:bool`, `requires_review:bool`, `requires_security_scan:bool`
- Stacked on `jonah/omn-10351-enum-file-zone` (PR #987); imports `EnumFileZone` from Task 1

## Ticket

OMN-10354

## dod_evidence

- `model_zone_policy.py` created with `ConfigDict(frozen=True)` and correct field types
- 6 unit tests pass: frozen immutability, qa_depth validation, all zones accepted, field access, zone type check
- mypy --strict passes on the new file
- All pre-commit hooks pass (55 checks)

## Test plan

- [x] `uv run pytest tests/unit/models/validation/test_model_zone_policy.py -v` → 6 passed
- [x] `uv run mypy src/omnibase_core/models/validation/model_zone_policy.py --strict` → no issues
- [x] `uv run ruff format && uv run ruff check` → clean
- [x] `pre-commit run --files ...` → all passed