### PR TITLE
feat(OMN-10362): add compute_npmi and compute_lift to co_change_matrix

### DIFF
--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+import math
 from collections import Counter
 from dataclasses import dataclass
 
@@ -22,3 +23,17 @@ def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
             for j in range(i + 1, len(unique)):
                 pair_count[(unique[i], unique[j])] += 1
     return CoChangeMatrix(dict(pair_count), dict(file_count), len(commits))
+
+
+def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_ab <= 0:
+        return -1.0
+    pmi = math.log(p_ab) - math.log(p_a * p_b)
+    npmi = pmi / -math.log(p_ab)
+    return max(-1.0, min(1.0, npmi))
+
+
+def compute_lift(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_a == 0 or p_b == 0:
+        return 0.0
+    return p_ab / (p_a * p_b)

--- a/tests/unit/analysis/test_co_change_metrics.py
+++ b/tests/unit/analysis/test_co_change_metrics.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import math
+
+from omnibase_core.analysis.co_change_matrix import compute_lift, compute_npmi
+
+
+def test_npmi_perfect_correlation() -> None:
+    # both files always co-occur: p_ab == p_a == p_b
+    npmi = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.5)
+    assert math.isclose(npmi, 1.0, abs_tol=1e-9)
+
+
+def test_npmi_independence() -> None:
+    # independent: p_ab = p_a * p_b
+    npmi = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.25)
+    assert math.isclose(npmi, 0.0, abs_tol=1e-9)
+
+
+def test_npmi_clamped() -> None:
+    result = compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.0001)
+    assert -1.0 <= result <= 1.0
+
+
+def test_npmi_zero_p_ab_returns_minus_one() -> None:
+    assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=0.0) == -1.0
+
+
+def test_npmi_negative_p_ab_returns_minus_one() -> None:
+    assert compute_npmi(p_a=0.5, p_b=0.5, p_ab=-0.1) == -1.0
+
+
+def test_lift_above_one_when_correlated() -> None:
+    assert compute_lift(p_a=0.5, p_b=0.5, p_ab=0.5) > 1.0
+
+
+def test_lift_one_when_independent() -> None:
+    result = compute_lift(p_a=0.5, p_b=0.5, p_ab=0.25)
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_lift_zero_when_p_a_is_zero() -> None:
+    assert compute_lift(p_a=0.0, p_b=0.5, p_ab=0.0) == 0.0
+
+
+def test_lift_zero_when_p_b_is_zero() -> None:
+    assert compute_lift(p_a=0.5, p_b=0.0, p_ab=0.0) == 0.0


### PR DESCRIPTION
## Summary

- Adds `compute_npmi(p_a, p_b, p_ab)` — NPMI clamped to [-1, 1], returns -1.0 when p_ab <= 0
- Adds `compute_lift(p_a, p_b, p_ab)` — p_ab / (p_a * p_b), returns 0.0 when p_a or p_b is 0
- Adds 9 unit tests in `tests/unit/analysis/test_co_change_metrics.py`

## Ticket

OMN-10362

## DoD Evidence

- 9 unit tests pass (test_co_change_metrics.py): `env -u PYTHONPATH uv run pytest tests/unit/analysis/test_co_change_metrics.py -v`
- `mypy --strict` clean: `Success: no issues found in 1 source file`
- `ruff check` clean, pre-commit all-files green

## Stacking

This PR is stacked on `jonah/omn-10361-co-change-matrix` (PR #989). Target that branch, not main.