### PR TITLE
feat(OMN-10372): add tree-sitter Python parser + symbol extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dependencies = [
     "httpx>=0.27.0,<1.0.0",
     "blake3>=1.0.8,<2.0.0",
     "ruamel-yaml>=0.18.0",
-    "tree-sitter>=0.25.2",
-    "tree-sitter-python>=0.25.0",
+    "tree-sitter>=0.25.2,<0.26",
+    "tree-sitter-python>=0.25.0,<0.26",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     "httpx>=0.27.0,<1.0.0",
     "blake3>=1.0.8,<2.0.0",
     "ruamel-yaml>=0.18.0",
+    "tree-sitter>=0.25.2",
+    "tree-sitter-python>=0.25.0",
 ]
 
 [project.urls]

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -40,11 +40,11 @@ test_infrastructure_paths:
 # (they trigger full suite first), but kept for completeness/documentation.
 adjacency:
   models:
-    reverse_deps: [nodes, contracts, runtime, validation, services, factories, container]
+    reverse_deps: [analysis, nodes, contracts, runtime, validation, services, factories, container]
   contracts:
     reverse_deps: [nodes, runtime, validation]
   enums:
-    reverse_deps: [models, contracts, nodes, validation, runtime]
+    reverse_deps: [analysis, models, contracts, nodes, validation, runtime]
   validation:
     reverse_deps: [nodes, runtime, services]
   runtime:

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import re
+
+from omnibase_core.analysis.symbol_extractor import extract_symbols
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+_GUARD_PATTERN = re.compile(
+    r"(?i)(guard|check|validate|verify|ensure|assert|require)",
+)
+
+_KIND_SEVERITY: dict[EnumChangeKind, EnumDiffSeverity] = {
+    EnumChangeKind.GUARD_REMOVED: EnumDiffSeverity.CRITICAL,
+    EnumChangeKind.SIGNATURE_CHANGE: EnumDiffSeverity.HIGH,
+    EnumChangeKind.API_CHANGE: EnumDiffSeverity.HIGH,
+    EnumChangeKind.DELETED_FUNCTION: EnumDiffSeverity.HIGH,
+    EnumChangeKind.LOGIC_CHANGE: EnumDiffSeverity.MEDIUM,
+    EnumChangeKind.REFACTOR: EnumDiffSeverity.MEDIUM,
+    EnumChangeKind.NEW_FUNCTION: EnumDiffSeverity.LOW,
+    EnumChangeKind.COSMETIC: EnumDiffSeverity.LOW,
+}
+
+
+def _line_count(sym: dict) -> int:  # type: ignore[type-arg]
+    return int(sym["end_line"]) - int(sym["start_line"]) + 1
+
+
+def _is_guard(name: str) -> bool:
+    return bool(_GUARD_PATTERN.search(name))
+
+
+def _strip_name(signature: str, name: str) -> str:
+    """Replace the first occurrence of the symbol name in the signature."""
+    return signature.replace(name, "__sym__", 1)
+
+
+def _rename_tolerance(
+    old_sym: dict,  # type: ignore[type-arg]
+    old_name: str,
+    new_sym: dict,  # type: ignore[type-arg]
+    new_name: str,
+) -> bool:
+    """True if name-normalized signatures match AND line counts are within 20%."""
+    old_sig = _strip_name(old_sym["signature"], old_name)
+    new_sig = _strip_name(new_sym["signature"], new_name)
+    if old_sig != new_sig:
+        return False
+    old_lines = _line_count(old_sym)
+    new_lines = _line_count(new_sym)
+    max_lines = max(old_lines, new_lines)
+    if max_lines == 0:
+        return True
+    return abs(old_lines - new_lines) / max_lines <= 0.20
+
+
+def _make_change(
+    kind: EnumChangeKind,
+    name: str,
+    file_path: str,
+    consumers_count: int,
+) -> ModelSymbolChange:
+    return ModelSymbolChange(
+        kind=kind,
+        severity=_KIND_SEVERITY[kind],
+        symbol_name=name,
+        file_path=file_path,
+        consumers_count=consumers_count,
+    )
+
+
+def compute_diff(
+    old_source: str,
+    new_source: str,
+    file_path: str,
+    consumers_count: int,
+) -> ModelSemanticDiffReport:
+    old_symbols = extract_symbols(old_source)
+    new_symbols = extract_symbols(new_source)
+
+    old_names = set(old_symbols)
+    new_names = set(new_symbols)
+
+    changes: list[ModelSymbolChange] = []
+
+    # Same-name symbols: classify by what changed
+    for name in old_names & new_names:
+        old_sym = old_symbols[name]
+        new_sym = new_symbols[name]
+        if old_sym["signature"] != new_sym["signature"]:
+            changes.append(
+                _make_change(
+                    EnumChangeKind.SIGNATURE_CHANGE, name, file_path, consumers_count
+                )
+            )
+        elif old_sym["body_hash"] != new_sym["body_hash"]:
+            changes.append(
+                _make_change(
+                    EnumChangeKind.LOGIC_CHANGE, name, file_path, consumers_count
+                )
+            )
+        # else: unchanged — no entry
+
+    # Removed symbols
+    removed = {name: old_symbols[name] for name in old_names - new_names}
+    # Added symbols
+    added = {name: new_symbols[name] for name in new_names - old_names}
+
+    # Rename detection: pair removed R with added A if signatures match + line tolerance
+    renamed_removed: set[str] = set()
+    renamed_added: set[str] = set()
+    for r_name, r_sym in removed.items():
+        for a_name, a_sym in added.items():
+            if a_name in renamed_added:
+                continue
+            if _rename_tolerance(r_sym, r_name, a_sym, a_name):
+                changes.append(
+                    _make_change(
+                        EnumChangeKind.REFACTOR, a_name, file_path, consumers_count
+                    )
+                )
+                renamed_removed.add(r_name)
+                renamed_added.add(a_name)
+                break
+
+    # Remaining removed symbols
+    for name in removed:
+        if name in renamed_removed:
+            continue
+        kind = (
+            EnumChangeKind.GUARD_REMOVED
+            if _is_guard(name)
+            else EnumChangeKind.DELETED_FUNCTION
+        )
+        changes.append(_make_change(kind, name, file_path, consumers_count))
+
+    # Remaining added symbols
+    for name in added:
+        if name in renamed_added:
+            continue
+        changes.append(
+            _make_change(EnumChangeKind.NEW_FUNCTION, name, file_path, consumers_count)
+        )
+
+    return ModelSemanticDiffReport(
+        changes=tuple(changes),
+        total_consumers_affected=consumers_count,
+    )

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -9,6 +9,7 @@ from omnibase_core.models.analysis.model_semantic_diff_report import (
     ModelSemanticDiffReport,
 )
 from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+from omnibase_core.types.typed_dict_symbol_metadata import TypedDictSymbolMetadata
 
 _GUARD_PATTERN = re.compile(
     r"(?i)(guard|check|validate|verify|ensure|assert|require)",
@@ -26,8 +27,8 @@ _KIND_SEVERITY: dict[EnumChangeKind, EnumDiffSeverity] = {
 }
 
 
-def _line_count(sym: dict) -> int:  # type: ignore[type-arg]
-    return int(sym["end_line"]) - int(sym["start_line"]) + 1
+def _line_count(sym: TypedDictSymbolMetadata) -> int:
+    return sym["end_line"] - sym["start_line"] + 1
 
 
 def _is_guard(name: str) -> bool:
@@ -40,9 +41,9 @@ def _strip_name(signature: str, name: str) -> str:
 
 
 def _rename_tolerance(
-    old_sym: dict,  # type: ignore[type-arg]
+    old_sym: TypedDictSymbolMetadata,
     old_name: str,
-    new_sym: dict,  # type: ignore[type-arg]
+    new_sym: TypedDictSymbolMetadata,
     new_name: str,
 ) -> bool:
     """True if name-normalized signatures match AND line counts are within 20%."""
@@ -79,6 +80,16 @@ def compute_diff(
     file_path: str,
     consumers_count: int,
 ) -> ModelSemanticDiffReport:
+    """Return a symbol-level semantic diff report for two Python source snapshots.
+
+    Raises:
+        ValueError: If ``consumers_count`` is negative.
+    """
+    if consumers_count < 0:
+        raise ValueError(  # error-ok: public API intentionally rejects bad input.
+            "consumers_count must be greater than or equal to 0",
+        )
+
     old_symbols = extract_symbols(old_source)
     new_symbols = extract_symbols(new_source)
 

--- a/src/omnibase_core/analysis/symbol_extractor.py
+++ b/src/omnibase_core/analysis/symbol_extractor.py
@@ -31,11 +31,22 @@ def _extract_signature_and_body(node: Node, source_lines: list[str]) -> tuple[st
 
     block = block_nodes[0]
     sig_line = source_lines[node.start_point[0]]
-    signature = _collapse_whitespace(sig_line.rstrip("\n"))
-
     body_start = block.start_point[0]
     body_end = node.end_point[0]
-    body_source = "".join(source_lines[body_start : body_end + 1])
+
+    if body_start == node.start_point[0]:
+        colon_index = sig_line.find(":", node.start_point[1])
+        if colon_index >= 0:
+            signature_source = sig_line[: colon_index + 1]
+            body_source = sig_line[colon_index + 1 :]
+        else:
+            signature_source = sig_line[: block.start_point[1]]
+            body_source = sig_line[block.start_point[1] :]
+    else:
+        signature_source = sig_line.rstrip("\n")
+        body_source = "".join(source_lines[body_start : body_end + 1])
+
+    signature = _collapse_whitespace(signature_source.rstrip("\n"))
     return signature, body_source
 
 

--- a/src/omnibase_core/analysis/symbol_extractor.py
+++ b/src/omnibase_core/analysis/symbol_extractor.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import re
+
+import tree_sitter_python as tspython
+from tree_sitter import Language, Node, Parser
+
+_PY_LANGUAGE = Language(tspython.language())
+_PARSER = Parser(_PY_LANGUAGE)
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _collapse_whitespace(text: str) -> str:
+    return _WHITESPACE.sub(" ", text).strip()
+
+
+def _body_hash(body_source: str) -> str:
+    return hashlib.sha256(body_source.encode()).hexdigest()
+
+
+def _extract_signature_and_body(node: Node, source_lines: list[str]) -> tuple[str, str]:
+    block_nodes = [c for c in node.children if c.type == "block"]
+    if not block_nodes:
+        sig_line = source_lines[node.start_point[0]]
+        return _collapse_whitespace(sig_line.rstrip("\n")), ""
+
+    block = block_nodes[0]
+    sig_line = source_lines[node.start_point[0]]
+    signature = _collapse_whitespace(sig_line.rstrip("\n"))
+
+    body_start = block.start_point[0]
+    body_end = node.end_point[0]
+    body_source = "".join(source_lines[body_start : body_end + 1])
+    return signature, body_source
+
+
+def _process_function(
+    node: Node,
+    source_lines: list[str],
+    result: dict[str, dict],  # type: ignore[type-arg]
+    class_name: str | None = None,
+) -> None:
+    name_nodes = [c for c in node.children if c.type == "identifier"]
+    if not name_nodes:
+        return
+    func_name = name_nodes[0].text.decode() if name_nodes[0].text else ""
+    full_name = f"{class_name}.{func_name}" if class_name else func_name
+
+    signature, body_source = _extract_signature_and_body(node, source_lines)
+    kind = "method" if class_name else "function"
+
+    result[full_name] = {
+        "kind": kind,
+        "signature": signature,
+        "body_hash": _body_hash(body_source),
+        "start_line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+    }
+
+
+def _process_class(
+    node: Node,
+    source_lines: list[str],
+    result: dict[str, dict],  # type: ignore[type-arg]
+) -> None:
+    name_nodes = [c for c in node.children if c.type == "identifier"]
+    if not name_nodes:
+        return
+    class_name = name_nodes[0].text.decode() if name_nodes[0].text else ""
+
+    signature, body_source = _extract_signature_and_body(node, source_lines)
+
+    result[class_name] = {
+        "kind": "class",
+        "signature": signature,
+        "body_hash": _body_hash(body_source),
+        "start_line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+    }
+
+    block_nodes = [c for c in node.children if c.type == "block"]
+    if not block_nodes:
+        return
+    block = block_nodes[0]
+    for child in block.children:
+        if child.type == "function_definition":
+            _process_function(child, source_lines, result, class_name=class_name)
+
+
+def extract_symbols(content: str) -> dict[str, dict]:  # type: ignore[type-arg]
+    """Parse Python source and return per-symbol metadata for all top-level functions, classes, and their methods."""
+    if not content.strip():
+        return {}
+
+    source_bytes = content.encode()
+    tree = _PARSER.parse(source_bytes)
+    root = tree.root_node
+    source_lines = content.splitlines(keepends=True)
+
+    result: dict[str, dict] = {}  # type: ignore[type-arg]
+    for node in root.children:
+        if node.type == "function_definition":
+            _process_function(node, source_lines, result)
+        elif node.type == "class_definition":
+            _process_class(node, source_lines, result)
+
+    return result

--- a/src/omnibase_core/analysis/symbol_extractor.py
+++ b/src/omnibase_core/analysis/symbol_extractor.py
@@ -7,6 +7,8 @@ import re
 import tree_sitter_python as tspython
 from tree_sitter import Language, Node, Parser
 
+from omnibase_core.types.typed_dict_symbol_metadata import SymbolKind, SymbolTable
+
 _PY_LANGUAGE = Language(tspython.language())
 _PARSER = Parser(_PY_LANGUAGE)
 
@@ -37,20 +39,34 @@ def _extract_signature_and_body(node: Node, source_lines: list[str]) -> tuple[st
     return signature, body_source
 
 
+def _node_text(node: Node) -> str:
+    return node.text.decode() if node.text else ""
+
+
+def _definition_node(node: Node) -> Node:
+    if node.type != "decorated_definition":
+        return node
+
+    for child in node.children:
+        if child.type in {"class_definition", "function_definition"}:
+            return child
+    return node
+
+
 def _process_function(
     node: Node,
     source_lines: list[str],
-    result: dict[str, dict],  # type: ignore[type-arg]
+    result: SymbolTable,
     class_name: str | None = None,
 ) -> None:
     name_nodes = [c for c in node.children if c.type == "identifier"]
     if not name_nodes:
         return
-    func_name = name_nodes[0].text.decode() if name_nodes[0].text else ""
+    func_name = _node_text(name_nodes[0])
     full_name = f"{class_name}.{func_name}" if class_name else func_name
 
     signature, body_source = _extract_signature_and_body(node, source_lines)
-    kind = "method" if class_name else "function"
+    kind: SymbolKind = "method" if class_name else "function"
 
     result[full_name] = {
         "kind": kind,
@@ -64,12 +80,12 @@ def _process_function(
 def _process_class(
     node: Node,
     source_lines: list[str],
-    result: dict[str, dict],  # type: ignore[type-arg]
+    result: SymbolTable,
 ) -> None:
     name_nodes = [c for c in node.children if c.type == "identifier"]
     if not name_nodes:
         return
-    class_name = name_nodes[0].text.decode() if name_nodes[0].text else ""
+    class_name = _node_text(name_nodes[0])
 
     signature, body_source = _extract_signature_and_body(node, source_lines)
 
@@ -86,11 +102,12 @@ def _process_class(
         return
     block = block_nodes[0]
     for child in block.children:
-        if child.type == "function_definition":
-            _process_function(child, source_lines, result, class_name=class_name)
+        definition = _definition_node(child)
+        if definition.type == "function_definition":
+            _process_function(definition, source_lines, result, class_name=class_name)
 
 
-def extract_symbols(content: str) -> dict[str, dict]:  # type: ignore[type-arg]
+def extract_symbols(content: str) -> SymbolTable:
     """Parse Python source and return per-symbol metadata for all top-level functions, classes, and their methods."""
     if not content.strip():
         return {}
@@ -100,11 +117,12 @@ def extract_symbols(content: str) -> dict[str, dict]:  # type: ignore[type-arg]
     root = tree.root_node
     source_lines = content.splitlines(keepends=True)
 
-    result: dict[str, dict] = {}  # type: ignore[type-arg]
+    result: SymbolTable = {}
     for node in root.children:
-        if node.type == "function_definition":
-            _process_function(node, source_lines, result)
-        elif node.type == "class_definition":
-            _process_class(node, source_lines, result)
+        definition = _definition_node(node)
+        if definition.type == "function_definition":
+            _process_function(definition, source_lines, result)
+        elif definition.type == "class_definition":
+            _process_class(definition, source_lines, result)
 
     return result

--- a/src/omnibase_core/types/typed_dict_symbol_metadata.py
+++ b/src/omnibase_core/types/typed_dict_symbol_metadata.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""TypedDict contract for Python symbol extraction metadata."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+type SymbolKind = Literal["function", "class", "method"]
+
+
+class TypedDictSymbolMetadata(TypedDict):
+    kind: SymbolKind
+    signature: str
+    body_hash: str
+    start_line: int
+    end_line: int
+
+
+type SymbolTable = dict[str, TypedDictSymbolMetadata]
+
+__all__ = ["SymbolKind", "SymbolTable", "TypedDictSymbolMetadata"]

--- a/src/omnibase_core/types/typed_dict_symbol_metadata.py
+++ b/src/omnibase_core/types/typed_dict_symbol_metadata.py
@@ -19,4 +19,4 @@ class TypedDictSymbolMetadata(TypedDict):
 
 type SymbolTable = dict[str, TypedDictSymbolMetadata]
 
-__all__ = ["SymbolKind", "SymbolTable", "TypedDictSymbolMetadata"]
+__all__ = ["TypedDictSymbolMetadata"]

--- a/tests/analysis/test_semantic_diff_classifier.py
+++ b/tests/analysis/test_semantic_diff_classifier.py
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
+import pytest
+
 from omnibase_core.analysis.semantic_diff import compute_diff
 from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
 from omnibase_core.models.analysis.model_semantic_diff_report import (
     ModelSemanticDiffReport,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def _kinds(report: ModelSemanticDiffReport) -> list[str]:
@@ -172,6 +176,11 @@ def test_total_consumers_affected():
     new = ""
     report = compute_diff(old, new, file_path="x.py", consumers_count=3)
     assert report.total_consumers_affected == 3
+
+
+def test_negative_consumers_count_rejected():
+    with pytest.raises(ValueError, match="consumers_count"):
+        compute_diff("", "", file_path="x.py", consumers_count=-1)
 
 
 # --- return type is correct ---

--- a/tests/analysis/test_semantic_diff_classifier.py
+++ b/tests/analysis/test_semantic_diff_classifier.py
@@ -72,6 +72,16 @@ def test_logic_change_detected():
     assert change.severity == EnumDiffSeverity.MEDIUM
 
 
+def test_one_line_body_only_change_is_logic_change():
+    old = "def foo(x): return x\n"
+    new = "def foo(x): return x * 2\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.SIGNATURE_CHANGE not in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.kind == EnumChangeKind.LOGIC_CHANGE
+
+
 # --- no change (same body + signature) ---
 
 

--- a/tests/analysis/test_semantic_diff_classifier.py
+++ b/tests/analysis/test_semantic_diff_classifier.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_core.analysis.semantic_diff import compute_diff
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+
+
+def _kinds(report: ModelSemanticDiffReport) -> list[str]:
+    return [c.kind for c in report.changes]
+
+
+def _by_name(report: ModelSemanticDiffReport, name: str):
+    return next((c for c in report.changes if c.symbol_name == name), None)
+
+
+# --- new function ---
+
+
+def test_new_function_detected():
+    old = ""
+    new = "def foo(x): return x\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.NEW_FUNCTION in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.LOW
+
+
+# --- deleted function ---
+
+
+def test_deleted_function_detected():
+    old = "def foo(x): return x\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.DELETED_FUNCTION in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.HIGH
+
+
+# --- signature change ---
+
+
+def test_signature_change_detected():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.SIGNATURE_CHANGE in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.HIGH
+
+
+# --- logic change (body differs, signature same) ---
+
+
+def test_logic_change_detected():
+    old = "def foo(x):\n    return x\n"
+    new = "def foo(x):\n    return x * 2\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.LOGIC_CHANGE in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.MEDIUM
+
+
+# --- no change (same body + signature) ---
+
+
+def test_no_change_produces_no_entry():
+    src = "def foo(x):\n    return x\n"
+    report = compute_diff(src, src, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "foo") is None
+
+
+# --- guard_removed: name matches guard pattern ---
+
+
+def test_guard_removed_on_guard_name():
+    old = "def validate_token(token):\n    if not token: raise ValueError\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "validate_token")
+    assert change is not None
+    assert change.kind == EnumChangeKind.GUARD_REMOVED
+    assert change.severity == EnumDiffSeverity.CRITICAL
+
+
+def test_guard_removed_check_prefix():
+    old = "def check_permissions(user):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "check_permissions")
+    assert change is not None
+    assert change.kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_guard_removed_ensure_prefix():
+    old = "def ensure_authenticated(req):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "ensure_authenticated").kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_guard_removed_assert_prefix():
+    old = "def assert_invariant(x):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "assert_invariant").kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_non_guard_delete_is_deleted_function_not_guard():
+    old = "def process_data(x):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "process_data")
+    assert change.kind == EnumChangeKind.DELETED_FUNCTION
+
+
+# --- rename detection ---
+
+
+def test_rename_detected_same_signature_similar_line_count():
+    # Same signature and body (just name changes) — should pair as rename
+    old = "def foo(x):\n    return x\n"
+    new = "def bar(x):\n    return x\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    # foo is removed, bar is added — should be merged as a rename (refactor)
+    change = _by_name(report, "bar")
+    assert change is not None
+    assert change.kind == EnumChangeKind.REFACTOR
+
+
+def test_rename_not_detected_when_line_count_diverges_too_much():
+    # bar has very different body size — no rename, should be separate add/delete
+    old = "def foo(x):\n    return x\n"
+    new = (
+        "def bar(x):\n"
+        "    y = x * 2\n"
+        "    z = y + 1\n"
+        "    w = z - 3\n"
+        "    v = w / 2\n"
+        "    return v\n"
+    )
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    # foo should be a delete, bar should be a new function (not rename)
+    foo_change = _by_name(report, "foo")
+    bar_change = _by_name(report, "bar")
+    assert foo_change is not None
+    assert bar_change is not None
+    assert bar_change.kind == EnumChangeKind.NEW_FUNCTION
+
+
+# --- consumers_count is carried through ---
+
+
+def test_consumers_count_on_deleted():
+    old = "def foo(x): return x\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=5)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.consumers_count == 5
+
+
+def test_total_consumers_affected():
+    old = "def foo(x): return x\ndef bar(y): return y\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=3)
+    assert report.total_consumers_affected == 3
+
+
+# --- return type is correct ---
+
+
+def test_returns_model_semantic_diff_report():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert isinstance(report, ModelSemanticDiffReport)
+    assert isinstance(report.changes, tuple)
+
+
+# --- file_path is propagated ---
+
+
+def test_file_path_in_changes():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="src/foo.py", consumers_count=0)
+    for change in report.changes:
+        assert change.file_path == "src/foo.py"

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -12,6 +12,8 @@ from omnibase_core.models.analysis.model_semantic_diff_report import (
 )
 from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
 
+pytestmark = pytest.mark.unit
+
 
 def test_enum_diff_severity_members() -> None:
     assert {v.value for v in EnumDiffSeverity} == {"critical", "high", "medium", "low"}
@@ -49,7 +51,8 @@ def test_model_symbol_change_frozen() -> None:
         consumers_count=3,
     )
     with pytest.raises(Exception):
-        sc.symbol_name = "other"  # type: ignore[misc]  # NOTE(OMN-10371): intentional frozen-model mutation check
+        # NOTE(OMN-10372): Intentional mutation verifies the frozen model contract.
+        sc.symbol_name = "other"  # type: ignore[misc]
 
 
 def test_model_symbol_change_fields() -> None:
@@ -77,7 +80,8 @@ def test_model_semantic_diff_report_frozen() -> None:
     )
     report = ModelSemanticDiffReport(changes=(sc,), total_consumers_affected=0)
     with pytest.raises(Exception):
-        report.total_consumers_affected = 5  # type: ignore[misc]  # NOTE(OMN-10371): intentional frozen-model mutation check
+        # NOTE(OMN-10372): Intentional mutation verifies the frozen model contract.
+        report.total_consumers_affected = 5  # type: ignore[misc]
 
 
 def test_model_semantic_diff_report_fields() -> None:

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -51,8 +51,7 @@ def test_model_symbol_change_frozen() -> None:
         consumers_count=3,
     )
     with pytest.raises(Exception):
-        # NOTE(OMN-10372): Intentional mutation verifies the frozen model contract.
-        sc.symbol_name = "other"  # type: ignore[misc]
+        sc.symbol_name = "other"  # type: ignore[misc,unused-ignore]  # NOTE(OMN-10372): intentional frozen-model mutation test.
 
 
 def test_model_symbol_change_fields() -> None:
@@ -80,8 +79,7 @@ def test_model_semantic_diff_report_frozen() -> None:
     )
     report = ModelSemanticDiffReport(changes=(sc,), total_consumers_affected=0)
     with pytest.raises(Exception):
-        # NOTE(OMN-10372): Intentional mutation verifies the frozen model contract.
-        report.total_consumers_affected = 5  # type: ignore[misc]
+        report.total_consumers_affected = 5  # type: ignore[misc,unused-ignore]  # NOTE(OMN-10372): intentional frozen-model mutation test.
 
 
 def test_model_semantic_diff_report_fields() -> None:

--- a/tests/unit/analysis/test_symbol_extractor.py
+++ b/tests/unit/analysis/test_symbol_extractor.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import hashlib
+
+import pytest
+
+from omnibase_core.analysis.symbol_extractor import extract_symbols
+
+SIMPLE_FUNCTION = """\
+def foo(x: int) -> int:
+    return x + 1
+"""
+
+CLASS_WITH_METHODS = """\
+class MyClass:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+    def method(self) -> int:
+        return self.x
+"""
+
+NESTED_FUNCTION = """\
+def outer(x: int) -> int:
+    def inner(y: int) -> int:
+        return y
+    return inner(x)
+"""
+
+MULTI_SYMBOL = """\
+def alpha():
+    pass
+
+class Beta:
+    def gamma(self):
+        pass
+
+def delta(x, y):
+    return x + y
+"""
+
+
+@pytest.mark.unit
+def test_simple_function_extracted():
+    result = extract_symbols(SIMPLE_FUNCTION)
+    assert "foo" in result
+    sym = result["foo"]
+    assert sym["kind"] == "function"
+    assert sym["start_line"] == 1
+    assert sym["end_line"] == 2
+
+
+@pytest.mark.unit
+def test_signature_whitespace_collapsed():
+    result = extract_symbols(SIMPLE_FUNCTION)
+    sig = result["foo"]["signature"]
+    assert sig == "def foo(x: int) -> int:"
+    assert "  " not in sig
+
+
+@pytest.mark.unit
+def test_body_hash_is_sha256_hex():
+    result = extract_symbols(SIMPLE_FUNCTION)
+    body_hash = result["foo"]["body_hash"]
+    assert len(body_hash) == 64
+    assert all(c in "0123456789abcdef" for c in body_hash)
+
+
+@pytest.mark.unit
+def test_body_hash_deterministic():
+    r1 = extract_symbols(SIMPLE_FUNCTION)
+    r2 = extract_symbols(SIMPLE_FUNCTION)
+    assert r1["foo"]["body_hash"] == r2["foo"]["body_hash"]
+
+
+@pytest.mark.unit
+def test_body_hash_changes_with_body():
+    modified = "def foo(x: int) -> int:\n    return x + 2\n"
+    r1 = extract_symbols(SIMPLE_FUNCTION)
+    r2 = extract_symbols(modified)
+    assert r1["foo"]["body_hash"] != r2["foo"]["body_hash"]
+
+
+@pytest.mark.unit
+def test_class_extracted():
+    result = extract_symbols(CLASS_WITH_METHODS)
+    assert "MyClass" in result
+    sym = result["MyClass"]
+    assert sym["kind"] == "class"
+    assert sym["start_line"] == 1
+
+
+@pytest.mark.unit
+def test_method_extracted():
+    result = extract_symbols(CLASS_WITH_METHODS)
+    assert "MyClass.method" in result
+    sym = result["MyClass.method"]
+    assert sym["kind"] == "method"
+
+
+@pytest.mark.unit
+def test_init_method_extracted():
+    result = extract_symbols(CLASS_WITH_METHODS)
+    assert "MyClass.__init__" in result
+
+
+@pytest.mark.unit
+def test_nested_function_not_extracted_as_top_level():
+    result = extract_symbols(NESTED_FUNCTION)
+    assert "outer" in result
+    assert "inner" not in result
+
+
+@pytest.mark.unit
+def test_multi_symbol_all_extracted():
+    result = extract_symbols(MULTI_SYMBOL)
+    assert "alpha" in result
+    assert "Beta" in result
+    assert "Beta.gamma" in result
+    assert "delta" in result
+
+
+@pytest.mark.unit
+def test_kind_values_valid():
+    result = extract_symbols(MULTI_SYMBOL)
+    valid_kinds = {"function", "class", "method"}
+    for sym in result.values():
+        assert sym["kind"] in valid_kinds
+
+
+@pytest.mark.unit
+def test_line_numbers_are_one_indexed():
+    result = extract_symbols(SIMPLE_FUNCTION)
+    assert result["foo"]["start_line"] >= 1
+    assert result["foo"]["end_line"] >= result["foo"]["start_line"]
+
+
+@pytest.mark.unit
+def test_empty_source_returns_empty():
+    assert extract_symbols("") == {}
+
+
+@pytest.mark.unit
+def test_body_hash_value_correct():
+    result = extract_symbols(SIMPLE_FUNCTION)
+    body_source = "    return x + 1\n"
+    expected = hashlib.sha256(body_source.encode()).hexdigest()
+    assert result["foo"]["body_hash"] == expected

--- a/tests/unit/analysis/test_symbol_extractor.py
+++ b/tests/unit/analysis/test_symbol_extractor.py
@@ -40,6 +40,18 @@ def delta(x, y):
     return x + y
 """
 
+DECORATED_SYMBOLS = """\
+@route("/items")
+def list_items():
+    return []
+
+@dataclass
+class Item:
+    @property
+    def name(self):
+        return "item"
+"""
+
 
 @pytest.mark.unit
 def test_simple_function_extracted():
@@ -119,6 +131,17 @@ def test_multi_symbol_all_extracted():
     assert "Beta" in result
     assert "Beta.gamma" in result
     assert "delta" in result
+
+
+@pytest.mark.unit
+def test_decorated_symbols_extracted():
+    result = extract_symbols(DECORATED_SYMBOLS)
+    assert "list_items" in result
+    assert "Item" in result
+    assert "Item.name" in result
+    assert result["list_items"]["kind"] == "function"
+    assert result["Item"]["kind"] == "class"
+    assert result["Item.name"]["kind"] == "method"
 
 
 @pytest.mark.unit

--- a/tests/unit/analysis/test_symbol_extractor.py
+++ b/tests/unit/analysis/test_symbol_extractor.py
@@ -95,6 +95,15 @@ def test_body_hash_changes_with_body():
 
 
 @pytest.mark.unit
+def test_one_line_function_body_not_in_signature():
+    r1 = extract_symbols("def foo(x): return x\n")
+    r2 = extract_symbols("def foo(x): return x * 2\n")
+    assert r1["foo"]["signature"] == "def foo(x):"
+    assert r2["foo"]["signature"] == "def foo(x):"
+    assert r1["foo"]["body_hash"] != r2["foo"]["body_hash"]
+
+
+@pytest.mark.unit
 def test_class_extracted():
     result = extract_symbols(CLASS_WITH_METHODS)
     assert "MyClass" in result

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -50,6 +50,7 @@ def test_change_in_models_expands_to_exact_set() -> None:
     expected = sorted(
         f"tests/unit/{m}/"
         for m in (
+            "analysis",
             "models",
             "nodes",
             "contracts",

--- a/uv.lock
+++ b/uv.lock
@@ -759,8 +759,8 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "sqlglot", marker = "extra == 'full'", specifier = ">=26.0.0,<31.0.0" },
     { name = "sqlglot", marker = "extra == 'sql-parser'", specifier = ">=26.0.0,<31.0.0" },
-    { name = "tree-sitter", specifier = ">=0.25.2" },
-    { name = "tree-sitter-python", specifier = ">=0.25.0" },
+    { name = "tree-sitter", specifier = ">=0.25.2,<0.26" },
+    { name = "tree-sitter-python", specifier = ">=0.25.0,<0.26" },
 ]
 provides-extras = ["spi", "compat", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -671,6 +671,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-python" },
 ]
 
 [package.optional-dependencies]
@@ -757,6 +759,8 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "sqlglot", marker = "extra == 'full'", specifier = ">=26.0.0,<31.0.0" },
     { name = "sqlglot", marker = "extra == 'sql-parser'", specifier = ">=26.0.0,<31.0.0" },
+    { name = "tree-sitter", specifier = ">=0.25.2" },
+    { name = "tree-sitter-python", specifier = ">=0.25.0" },
 ]
 provides-extras = ["spi", "compat", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
 
@@ -1372,6 +1376,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8b/c992ff0e768cb6768d5c96234579bf8842b3a633db641455d86dd30d5dac/tree_sitter_python-0.25.0.tar.gz", hash = "sha256:b13e090f725f5b9c86aa455a268553c65cadf325471ad5b65cd29cac8a1a68ac", size = 159845, upload-time = "2025-09-11T06:47:58.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/64/a4e503c78a4eb3ac46d8e72a29c1b1237fa85238d8e972b063e0751f5a94/tree_sitter_python-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14a79a47ddef72f987d5a2c122d148a812169d7484ff5c75a3db9609d419f361", size = 73790, upload-time = "2025-09-11T06:47:47.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/60d8c2a0cc63d6ec4ba4e99ce61b802d2e39ef9db799bdf2a8f932a6cd4b/tree_sitter_python-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:480c21dbd995b7fe44813e741d71fed10ba695e7caab627fb034e3828469d762", size = 76691, upload-time = "2025-09-11T06:47:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/d9b0b67d037922d60cbe0359e0c86457c2da721bc714381a63e2c8e35eba/tree_sitter_python-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:86f118e5eecad616ecdb81d171a36dde9bef5a0b21ed71ea9c3e390813c3baf5", size = 108133, upload-time = "2025-09-11T06:47:50.499Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bd/bf4787f57e6b2860f3f1c8c62f045b39fb32d6bac4b53d7a9e66de968440/tree_sitter_python-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be71650ca2b93b6e9649e5d65c6811aad87a7614c8c1003246b303f6b150f61b", size = 110603, upload-time = "2025-09-11T06:47:51.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/25/feff09f5c2f32484fbce15db8b49455c7572346ce61a699a41972dea7318/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e6d5b5799628cc0f24691ab2a172a8e676f668fe90dc60468bee14084a35c16d", size = 108998, upload-time = "2025-09-11T06:47:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements `extract_symbols(content: str) -> dict[str, dict]` in `src/omnibase_core/analysis/symbol_extractor.py` using tree-sitter
- Adds `tree-sitter` and `tree-sitter-python` to `pyproject.toml` dependencies
- Returns per-symbol metadata: `kind` ∈ {function, class, method}, `signature` (whitespace-collapsed def/class line), `body_hash` (sha256 of body source), `start_line`, `end_line`
- Nested functions are not extracted as top-level; methods are keyed as `ClassName.method_name`
- Creates `src/omnibase_core/analysis/` package with `__init__.py`

## Ticket

OMN-10372 — Task 20: [Wave 5 AST Diff] tree-sitter Python parser + symbol extraction
Epic: OMN-10350

## Test plan

- [x] 14 unit tests in `tests/unit/analysis/test_symbol_extractor.py` — all passing
- [x] `mypy --strict` clean
- [x] `ruff format` + `ruff check` clean
- [x] All pre-commit hooks pass (SPDX, naming, type checks, pydantic conventions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic analysis that extracts Python symbols and classifies changes (new, deleted, signature, logic, refactor, guard-removed) with severity levels and consumer-impact propagation.

* **Tests**
  * Added comprehensive unit tests covering symbol extraction, diff classification, severity mapping, rename detection, consumer counts, and edge cases.

* **Chores**
  * CI test-selection updated; runtime dependencies extended to include Tree-sitter Python parsing packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->