### PR TITLE
feat(OMN-10359): add resolve_file_targets with path-escape guard

### DIFF
--- a/src/omnibase_core/validation/completion_verify.py
+++ b/src/omnibase_core/validation/completion_verify.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import re
+from pathlib import Path
 
 _BACKTICK = re.compile(r"`([A-Za-z_][\w.]*)`")
 _CAMEL = re.compile(r"\b([a-z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]*)\b")
@@ -29,4 +30,36 @@ def extract_identifiers(text: str) -> list[str]:
         if m not in seen:
             seen.add(m)
             out.append(m)
+    return out
+
+
+_PATH_PAT = re.compile(r'["`]([^"`\s]+)["`]')
+
+
+def resolve_file_targets(
+    text: str,
+    project_root: Path,
+    files_touched: list[str] | None = None,
+) -> list[Path]:
+    candidates: list[str] = []
+    if files_touched:
+        candidates.extend(files_touched)
+    # Extract quoted strings that look like file paths (contain / or . or ..)
+    for m in _PATH_PAT.findall(text):
+        if "/" in m or m.startswith(".."):
+            candidates.append(m)
+    project_root = project_root.resolve()
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for c in candidates:
+        p = (project_root / c).resolve()
+        try:
+            p.relative_to(project_root)
+        except ValueError:
+            raise ValueError(  # error-ok: path-escape is a boundary-validation signal, not a framework error
+                f"path {c!r} escapes project root {project_root}"
+            )
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
     return out

--- a/tests/validation/test_completion_verify_targets.py
+++ b/tests/validation/test_completion_verify_targets.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validation.completion_verify import resolve_file_targets
+
+
+def test_extracts_quoted_paths():
+    out = resolve_file_targets(
+        'Touch "src/foo.py" and `tests/bar.py`', project_root=Path()
+    )
+    paths = {p.name for p in out}
+    assert paths == {"foo.py", "bar.py"}
+
+
+def test_rejects_path_traversal(tmp_path):
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_file_targets('Touch "../../etc/passwd"', project_root=tmp_path)
+
+
+def test_uses_files_touched_field():
+    out = resolve_file_targets("done", project_root=Path(), files_touched=["src/x.py"])
+    assert out == [Path("src/x.py").resolve()]
+
+
+def test_deduplicates_paths():
+    out = resolve_file_targets(
+        'Touch "src/foo.py" and "src/foo.py"', project_root=Path()
+    )
+    names = [p.name for p in out]
+    assert names.count("foo.py") == 1
+
+
+def test_no_paths_returns_empty():
+    out = resolve_file_targets("nothing here", project_root=Path())
+    assert out == []
+
+
+def test_files_touched_combined_with_text(tmp_path):
+    out = resolve_file_targets(
+        'Touch "src/other.py"', project_root=tmp_path, files_touched=["src/real.py"]
+    )
+    names = {p.name for p in out}
+    assert "real.py" in names
+    assert "other.py" in names


### PR DESCRIPTION
## Summary

- Adds `resolve_file_targets(text, project_root, files_touched)` to `src/omnibase_core/validation/completion_verify.py`
- Extracts quoted file paths (`"..."` and `` `...` `` containing `/` or `..`) from task description text
- Merges with `files_touched` list when provided (both sources combined)
- Deduplicates resolved paths
- Raises `ValueError` (with `# error-ok:` annotation) on any path that escapes the project root via traversal (e.g. `../../etc/passwd`)
- 6 unit tests covering: extraction, path traversal rejection, files_touched merge, deduplication, empty case

## Ticket

OMN-10359

## Stack

Stacked on PR #990 (`jonah/omn-10358-completion-verify-extract-identifiers`). Target base is Task 6 branch — do NOT merge to main until Task 6 merges first.

## Test plan

- [x] `uv run pytest tests/validation/test_completion_verify_targets.py -v` — 6 passed
- [x] `uv run pytest tests/validation/test_completion_verify_extract.py -v` — no regressions
- [x] `uv run mypy src/omnibase_core/validation/completion_verify.py --strict` — clean
- [x] `pre-commit run --all-files` — all hooks pass