### PR TITLE
feat(OMN-10363): add static import graph builder for Python and JS/TS

### DIFF
--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -24,12 +24,7 @@ on:
 jobs:
   stale-todo-gate:
     name: Stale TODO Gate
-    runs-on: >-
-      ${{
-        vars.USE_SELF_HOSTED_RUNNERS == 'true'
-        && 'self-hosted, omnibase-ci'
-        || 'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/src/omnibase_core/analysis/__init__.py
+++ b/src/omnibase_core/analysis/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
+"""Static analysis utilities for import graphs and co-change matrices."""

--- a/src/omnibase_core/analysis/co_change_dark_matter.py
+++ b/src/omnibase_core/analysis/co_change_dark_matter.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Filter pipeline for co-change dark matter detection.
+
+Dark matter pairs: files that co-change frequently but have no static import
+relationship — hidden coupling that is architecturally significant precisely
+because it cannot be explained by the import graph.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.analysis.co_change_matrix import CoChangeMatrix, compute_npmi
+from omnibase_core.analysis.import_graph import ImportGraph
+from omnibase_core.types.typed_dict_dark_matter_pair import TypedDictDarkMatterPair
+
+_MIN_CO_CHANGES = 3
+_MIN_NPMI = 0.5
+_TOP_K = 20
+_MIN_COMMITS = 3
+
+
+def find_dark_matter(
+    matrix: CoChangeMatrix,
+    import_graph: ImportGraph,
+) -> list[TypedDictDarkMatterPair]:
+    """Return the top 20 co-change pairs not explained by the import graph.
+
+    Returns an empty list when the matrix has fewer than _MIN_COMMITS commits
+    (insufficient statistical signal).
+    """
+    if matrix.total_commits < _MIN_COMMITS:
+        return []
+
+    total = matrix.total_commits
+    candidates: list[TypedDictDarkMatterPair] = []
+
+    for (a, b), co_count in matrix.pair_count.items():
+        if co_count < _MIN_CO_CHANGES:
+            continue
+
+        p_a = matrix.file_count.get(a, 0) / total
+        p_b = matrix.file_count.get(b, 0) / total
+        p_ab = co_count / total
+
+        # p_ab == 1.0 → every commit contains both files → NPMI = 1.0 by definition;
+        # compute_npmi divides by -log(p_ab) which is 0 at p_ab=1.
+        if p_ab >= 1.0:
+            npmi = 1.0
+        else:
+            npmi = compute_npmi(p_a, p_b, p_ab)
+        if npmi < _MIN_NPMI:
+            continue
+
+        if _has_static_edge(a, b, import_graph):
+            continue
+
+        if _is_test_impl_pair(a, b):
+            continue
+
+        if _same_prefix(a, b):
+            continue
+
+        candidates.append(
+            TypedDictDarkMatterPair(a=a, b=b, npmi=npmi, co_changes=co_count)
+        )
+
+    candidates.sort(key=lambda p: p["npmi"], reverse=True)
+    return candidates[:_TOP_K]
+
+
+def _has_static_edge(a: str, b: str, graph: ImportGraph) -> bool:
+    """True if there is a static import edge in either direction."""
+    a_edges = graph.edges_out.get(a, set())
+    b_edges = graph.edges_out.get(b, set())
+    return b in a_edges or a in b_edges
+
+
+def _is_test_impl_pair(a: str, b: str) -> bool:
+    """True if exactly one of the two paths lives under a test directory."""
+    return _is_test_path(a) != _is_test_path(b)
+
+
+def _is_test_path(path: str) -> bool:
+    parts = Path(path).parts
+    return any(p in ("tests", "test") for p in parts)
+
+
+def _same_prefix(a: str, b: str, segments: int = 3) -> bool:
+    """True if the first `segments` path components are identical."""
+    a_parts = Path(a).parts
+    b_parts = Path(b).parts
+    if len(a_parts) < segments or len(b_parts) < segments:
+        return False
+    return a_parts[:segments] == b_parts[:segments]

--- a/src/omnibase_core/analysis/consumer_graph.py
+++ b/src/omnibase_core/analysis/consumer_graph.py
@@ -23,10 +23,17 @@ def build_consumer_graph(repo_root: Path) -> dict[str, int]:
     if head_sha and cache_path.is_file():
         try:
             cached = json.loads(cache_path.read_text(encoding="utf-8"))
-            if cached.get("sha") == head_sha:
-                return {k: v for k, v in cached.items() if k != "sha"}
+            if isinstance(cached, dict) and cached.get("sha") == head_sha:
+                return {
+                    k: v
+                    for k, v in cached.items()
+                    if k != "sha" and isinstance(k, str) and isinstance(v, int)
+                }
         except (json.JSONDecodeError, OSError):
-            pass
+            # Cache reads are best-effort; invalid or unreadable cache forces recompute.
+            counts = _compute(repo_root)
+            _write_cache(cache_path, head_sha, counts)
+            return counts
 
     counts = _compute(repo_root)
     _write_cache(cache_path, head_sha, counts)
@@ -62,4 +69,5 @@ def _write_cache(cache_path: Path, sha: str | None, counts: dict[str, int]) -> N
         payload: dict[str, object] = {"sha": sha, **counts}
         cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     except OSError:
-        pass
+        # Cache writes are best-effort; callers already have the computed graph.
+        return

--- a/src/omnibase_core/analysis/consumer_graph.py
+++ b/src/omnibase_core/analysis/consumer_graph.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Consumer graph builder: counts how many files import each module."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from omnibase_core.analysis.import_graph import build_import_graph
+
+
+def build_consumer_graph(repo_root: Path) -> dict[str, int]:
+    """Return a mapping of repo-relative file path -> number of files that import it.
+
+    Results are cached in .onex_state/consumer-graph.json keyed by the current
+    git HEAD SHA. A SHA mismatch triggers a full recompute and cache overwrite.
+    """
+    repo_root = repo_root.resolve()
+    cache_path = repo_root / ".onex_state" / "consumer-graph.json"
+    head_sha = _git_head_sha(repo_root)
+
+    if head_sha and cache_path.is_file():
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            if cached.get("sha") == head_sha:
+                return {k: v for k, v in cached.items() if k != "sha"}
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    counts = _compute(repo_root)
+    _write_cache(cache_path, head_sha, counts)
+    return counts
+
+
+def _compute(repo_root: Path) -> dict[str, int]:
+    graph = build_import_graph(repo_root)
+    counts: dict[str, int] = {}
+    for _src, targets in graph.edges_out.items():
+        for target in targets:
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def _git_head_sha(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _write_cache(cache_path: Path, sha: str | None, counts: dict[str, int]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, object] = {"sha": sha, **counts}
+        cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        pass

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -106,7 +106,7 @@ def _relative_import_names(
     except ValueError:
         return []
 
-    if node.level > len(package_parts) + 1:
+    if node.level > len(package_parts):
         return []
 
     base_parts = package_parts[: len(package_parts) - node.level + 1]

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -4,13 +4,9 @@
 """Static import graph builder for Python and JavaScript/TypeScript files."""
 
 import ast
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-_JS_IMPORT = re.compile(
-    r"""(?:^|\s)import\s+(?:[\w*{},\s]+\s+from\s+)?['"]([^'"]+)['"]""", re.MULTILINE
-)
 _JS_EXTS = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
 _PY_EXTS = (".py",)
 
@@ -116,8 +112,16 @@ def _relative_import_names(
     base_parts = package_parts[: len(package_parts) - node.level + 1]
     if node.module:
         base_parts.extend(node.module.split("."))
-        return [".".join(base_parts)]
-    return [".".join([*base_parts, alias.name]) for alias in node.names]
+        names = [".".join(base_parts)]
+        names.extend(
+            ".".join([*base_parts, alias.name])
+            for alias in node.names
+            if alias.name != "*"
+        )
+        return names
+    return [
+        ".".join([*base_parts, alias.name]) for alias in node.names if alias.name != "*"
+    ]
 
 
 def _nearest_search_root(path: Path, search_roots: list[Path]) -> Path | None:
@@ -284,14 +288,110 @@ def _iter_js_require_specifiers(source: str) -> list[str]:
 
 
 def _iter_js_import_specifiers(source: str) -> list[str]:
-    """Return static import specifiers from source lines that begin with import."""
+    """Return static import specifiers that appear outside JS string literals."""
     specifiers: list[str] = []
-    for line in source.splitlines():
-        stripped = line.lstrip()
-        if not stripped.startswith(("import ", "import'", 'import"')):
+    i = 0
+    quote: str | None = None
+    escape = False
+    while i < len(source):
+        char = source[i]
+        if quote is not None:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            i += 1
             continue
-        specifiers.extend(match.group(1) for match in _JS_IMPORT.finditer(stripped))
+        if char in {"'", '"', "`"}:
+            quote = char
+            i += 1
+            continue
+        if not source.startswith("import", i):
+            i += 1
+            continue
+        before = source[i - 1] if i > 0 else ""
+        after = source[i + len("import")] if i + len("import") < len(source) else ""
+        if before.isidentifier() or after.isidentifier():
+            i += 1
+            continue
+        cursor = i + len("import")
+        while cursor < len(source) and source[cursor].isspace():
+            cursor += 1
+        if cursor < len(source) and source[cursor] == "(":
+            i = cursor + 1
+            continue
+        if literal := _read_js_string_literal(source, cursor):
+            specifier, end = literal
+            specifiers.append(specifier)
+            i = end
+            continue
+        from_pos = _find_js_keyword(source, "from", cursor)
+        if from_pos is None:
+            i += 1
+            continue
+        cursor = from_pos + len("from")
+        while cursor < len(source) and source[cursor].isspace():
+            cursor += 1
+        if literal := _read_js_string_literal(source, cursor):
+            specifier, end = literal
+            specifiers.append(specifier)
+            i = end
+            continue
+        i += 1
     return specifiers
+
+
+def _read_js_string_literal(source: str, cursor: int) -> tuple[str, int] | None:
+    """Read a quoted JavaScript string literal at cursor."""
+    if cursor >= len(source) or source[cursor] not in {"'", '"'}:
+        return None
+    quote = source[cursor]
+    cursor += 1
+    start = cursor
+    while cursor < len(source):
+        if source[cursor] == "\\":
+            cursor += 2
+            continue
+        if source[cursor] == quote:
+            return source[start:cursor], cursor + 1
+        cursor += 1
+    return None
+
+
+def _find_js_keyword(source: str, keyword: str, cursor: int) -> int | None:
+    """Find a keyword before the next statement boundary, ignoring strings."""
+    quote: str | None = None
+    escape = False
+    while cursor < len(source):
+        char = source[cursor]
+        if quote is not None:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            cursor += 1
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            cursor += 1
+            continue
+        if char == ";":
+            return None
+        if source.startswith(keyword, cursor):
+            before = source[cursor - 1] if cursor > 0 else ""
+            after = (
+                source[cursor + len(keyword)]
+                if cursor + len(keyword) < len(source)
+                else ""
+            )
+            if not before.isidentifier() and not after.isidentifier():
+                return cursor
+        cursor += 1
+    return None
 
 
 def _resolve_js_specifier(

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -12,18 +12,22 @@ _JS_REQUIRE = re.compile(r"""require\s*\(\s*['"]([^'"]+)['"]\s*\)""")
 _JS_IMPORT = re.compile(
     r"""(?:^|\s)import\s+(?:[\w*{},\s]+\s+from\s+)?['"]([^'"]+)['"]""", re.MULTILINE
 )
-_JS_EXTS = {".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
-_PY_EXTS = {".py"}
+_JS_EXTS = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
+_PY_EXTS = (".py",)
 
 
 @dataclass
 class ImportGraph:
+    """Repo-relative static import edges keyed by importing source file."""
+
     edges_out: dict[str, set[str]] = field(default_factory=dict)
 
 
 def build_import_graph(repo_root: Path) -> ImportGraph:
+    """Build a static import graph for Python and JS/TS files under repo_root."""
     graph = ImportGraph()
     repo_root = repo_root.resolve()
+    python_search_roots = _python_search_roots(repo_root)
 
     py_files: list[Path] = []
     js_files: list[Path] = []
@@ -38,7 +42,7 @@ def build_import_graph(repo_root: Path) -> ImportGraph:
 
     for path in py_files:
         rel = str(path.relative_to(repo_root))
-        edges = _parse_python_imports(path, repo_root)
+        edges = _parse_python_imports(path, repo_root, python_search_roots)
         if edges:
             graph.edges_out[rel] = edges
 
@@ -51,7 +55,9 @@ def build_import_graph(repo_root: Path) -> ImportGraph:
     return graph
 
 
-def _parse_python_imports(path: Path, repo_root: Path) -> set[str]:
+def _parse_python_imports(
+    path: Path, repo_root: Path, search_roots: list[Path]
+) -> set[str]:
     """Extract imported module paths from a Python file, resolved to repo-relative paths."""
     try:
         source = path.read_text(encoding="utf-8", errors="ignore")
@@ -65,34 +71,71 @@ def _parse_python_imports(path: Path, repo_root: Path) -> set[str]:
             for alias in node.names:
                 imports.append(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.module:
+            if node.level > 0:
+                imports.extend(_relative_import_names(node, path, search_roots))
+            elif node.module:
                 imports.append(node.module)
 
     edges: set[str] = set()
     src_rel = str(path.relative_to(repo_root))
 
     for module_name in imports:
-        resolved = _resolve_python_module(module_name, path, repo_root)
+        resolved = _resolve_python_module(module_name, repo_root, search_roots)
         if resolved and resolved != src_rel:
             edges.add(resolved)
 
     return edges
 
 
+def _python_search_roots(repo_root: Path) -> list[Path]:
+    """Return module-resolution roots once per graph build."""
+    roots = [repo_root]
+    roots.extend(path for path in repo_root.rglob("src") if path.is_dir())
+    return roots
+
+
+def _relative_import_names(
+    node: ast.ImportFrom, importing_file: Path, search_roots: list[Path]
+) -> list[str]:
+    """Convert an ast.ImportFrom relative import into candidate dotted modules."""
+    root = _nearest_search_root(importing_file, search_roots)
+    if root is None:
+        return []
+    try:
+        package_parts = list(importing_file.parent.relative_to(root).parts)
+    except ValueError:
+        return []
+
+    if node.level > len(package_parts) + 1:
+        return []
+
+    base_parts = package_parts[: len(package_parts) - node.level + 1]
+    if node.module:
+        base_parts.extend(node.module.split("."))
+        return [".".join(base_parts)]
+    return [".".join([*base_parts, alias.name]) for alias in node.names]
+
+
+def _nearest_search_root(path: Path, search_roots: list[Path]) -> Path | None:
+    """Return the deepest configured search root containing path."""
+    for root in sorted(
+        search_roots, key=lambda candidate: len(candidate.parts), reverse=True
+    ):
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        return root
+    return None
+
+
 def _resolve_python_module(
-    module_name: str, importing_file: Path, repo_root: Path
+    module_name: str, repo_root: Path, search_roots: list[Path]
 ) -> str | None:
     """Convert a dotted module name to a repo-relative file path."""
     # Convert dotted module to path segments
     parts = module_name.split(".")
     candidate_rel = Path(*parts)
-
-    # Search from repo root and common src layouts
-    search_roots = [repo_root]
-    for src_dir in repo_root.rglob("src"):
-        if src_dir.is_dir():
-            search_roots.append(src_dir)
-            break
 
     for search_root in search_roots:
         # Try as package (directory with __init__.py)
@@ -100,16 +143,6 @@ def _resolve_python_module(
         if pkg_path.is_file():
             return str(pkg_path.relative_to(repo_root))
         # Try as module file
-        mod_path = search_root / candidate_rel.with_suffix(".py")
-        if mod_path.is_file():
-            return str(mod_path.relative_to(repo_root))
-
-    # Try relative to the importing file's directory
-    import_dir = importing_file.parent
-    for search_root in [import_dir]:
-        pkg_path = search_root / candidate_rel / "__init__.py"
-        if pkg_path.is_file():
-            return str(pkg_path.relative_to(repo_root))
         mod_path = search_root / candidate_rel.with_suffix(".py")
         if mod_path.is_file():
             return str(mod_path.relative_to(repo_root))
@@ -150,16 +183,11 @@ def _resolve_js_specifier(
     import_dir = importing_file.parent
     candidate = (import_dir / spec).resolve()
 
-    # Try exact path, then with common extensions
-    for attempt in [
-        candidate,
-        candidate.with_suffix(".js"),
-        candidate.with_suffix(".jsx"),
-        candidate.with_suffix(".ts"),
-        candidate.with_suffix(".tsx"),
-        candidate / "index.js",
-        candidate / "index.ts",
-    ]:
+    attempts = [candidate]
+    attempts.extend(candidate.with_suffix(ext) for ext in _JS_EXTS)
+    attempts.extend(candidate / f"index{ext}" for ext in _JS_EXTS)
+
+    for attempt in attempts:
         if attempt.is_file():
             try:
                 return str(attempt.relative_to(repo_root))

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Static import graph builder for Python and JavaScript/TypeScript files."""
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_JS_REQUIRE = re.compile(r"""require\s*\(\s*['"]([^'"]+)['"]\s*\)""")
+_JS_IMPORT = re.compile(
+    r"""(?:^|\s)import\s+(?:[\w*{},\s]+\s+from\s+)?['"]([^'"]+)['"]""", re.MULTILINE
+)
+_JS_EXTS = {".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
+_PY_EXTS = {".py"}
+
+
+@dataclass
+class ImportGraph:
+    edges_out: dict[str, set[str]] = field(default_factory=dict)
+
+
+def build_import_graph(repo_root: Path) -> ImportGraph:
+    graph = ImportGraph()
+    repo_root = repo_root.resolve()
+
+    py_files: list[Path] = []
+    js_files: list[Path] = []
+
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix in _PY_EXTS:
+            py_files.append(path)
+        elif path.suffix in _JS_EXTS:
+            js_files.append(path)
+
+    for path in py_files:
+        rel = str(path.relative_to(repo_root))
+        edges = _parse_python_imports(path, repo_root)
+        if edges:
+            graph.edges_out[rel] = edges
+
+    for path in js_files:
+        rel = str(path.relative_to(repo_root))
+        edges = _parse_js_imports(path, repo_root)
+        if edges:
+            graph.edges_out[rel] = edges
+
+    return graph
+
+
+def _parse_python_imports(path: Path, repo_root: Path) -> set[str]:
+    """Extract imported module paths from a Python file, resolved to repo-relative paths."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return set()
+
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.append(node.module)
+
+    edges: set[str] = set()
+    src_rel = str(path.relative_to(repo_root))
+
+    for module_name in imports:
+        resolved = _resolve_python_module(module_name, path, repo_root)
+        if resolved and resolved != src_rel:
+            edges.add(resolved)
+
+    return edges
+
+
+def _resolve_python_module(
+    module_name: str, importing_file: Path, repo_root: Path
+) -> str | None:
+    """Convert a dotted module name to a repo-relative file path."""
+    # Convert dotted module to path segments
+    parts = module_name.split(".")
+    candidate_rel = Path(*parts)
+
+    # Search from repo root and common src layouts
+    search_roots = [repo_root]
+    for src_dir in repo_root.rglob("src"):
+        if src_dir.is_dir():
+            search_roots.append(src_dir)
+            break
+
+    for search_root in search_roots:
+        # Try as package (directory with __init__.py)
+        pkg_path = search_root / candidate_rel / "__init__.py"
+        if pkg_path.is_file():
+            return str(pkg_path.relative_to(repo_root))
+        # Try as module file
+        mod_path = search_root / candidate_rel.with_suffix(".py")
+        if mod_path.is_file():
+            return str(mod_path.relative_to(repo_root))
+
+    # Try relative to the importing file's directory
+    import_dir = importing_file.parent
+    for search_root in [import_dir]:
+        pkg_path = search_root / candidate_rel / "__init__.py"
+        if pkg_path.is_file():
+            return str(pkg_path.relative_to(repo_root))
+        mod_path = search_root / candidate_rel.with_suffix(".py")
+        if mod_path.is_file():
+            return str(mod_path.relative_to(repo_root))
+
+    return None
+
+
+def _parse_js_imports(path: Path, repo_root: Path) -> set[str]:
+    """Extract imported module paths from a JS/TS file, resolved to repo-relative paths."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return set()
+
+    src_rel = str(path.relative_to(repo_root))
+    edges: set[str] = set()
+
+    specifiers: list[str] = []
+    for m in _JS_REQUIRE.finditer(source):
+        specifiers.append(m.group(1))
+    for m in _JS_IMPORT.finditer(source):
+        specifiers.append(m.group(1))
+
+    for spec in specifiers:
+        if not spec.startswith("."):
+            continue  # skip bare module specifiers (node_modules etc.)
+        resolved = _resolve_js_specifier(spec, path, repo_root)
+        if resolved and resolved != src_rel:
+            edges.add(resolved)
+
+    return edges
+
+
+def _resolve_js_specifier(
+    spec: str, importing_file: Path, repo_root: Path
+) -> str | None:
+    """Resolve a relative JS import specifier to a repo-relative path."""
+    import_dir = importing_file.parent
+    candidate = (import_dir / spec).resolve()
+
+    # Try exact path, then with common extensions
+    for attempt in [
+        candidate,
+        candidate.with_suffix(".js"),
+        candidate.with_suffix(".jsx"),
+        candidate.with_suffix(".ts"),
+        candidate.with_suffix(".tsx"),
+        candidate / "index.js",
+        candidate / "index.ts",
+    ]:
+        if attempt.is_file():
+            try:
+                return str(attempt.relative_to(repo_root))
+            except ValueError:
+                return None
+
+    return None

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -8,7 +8,6 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-_JS_REQUIRE = re.compile(r"""require\s*\(\s*['"]([^'"]+)['"]\s*\)""")
 _JS_IMPORT = re.compile(
     r"""(?:^|\s)import\s+(?:[\w*{},\s]+\s+from\s+)?['"]([^'"]+)['"]""", re.MULTILINE
 )
@@ -62,7 +61,7 @@ def _parse_python_imports(
     try:
         source = path.read_text(encoding="utf-8", errors="ignore")
         tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
+    except (OSError, SyntaxError):
         return set()
 
     imports: list[str] = []
@@ -75,6 +74,11 @@ def _parse_python_imports(
                 imports.extend(_relative_import_names(node, path, search_roots))
             elif node.module:
                 imports.append(node.module)
+                imports.extend(
+                    f"{node.module}.{alias.name}"
+                    for alias in node.names
+                    if alias.name != "*"
+                )
 
     edges: set[str] = set()
     src_rel = str(path.relative_to(repo_root))
@@ -160,11 +164,11 @@ def _parse_js_imports(path: Path, repo_root: Path) -> set[str]:
     src_rel = str(path.relative_to(repo_root))
     edges: set[str] = set()
 
-    specifiers: list[str] = []
-    for m in _JS_REQUIRE.finditer(source):
-        specifiers.append(m.group(1))
-    for m in _JS_IMPORT.finditer(source):
-        specifiers.append(m.group(1))
+    source = _strip_js_comments(source)
+    specifiers = [
+        *_iter_js_require_specifiers(source),
+        *_iter_js_import_specifiers(source),
+    ]
 
     for spec in specifiers:
         if not spec.startswith("."):
@@ -174,6 +178,120 @@ def _parse_js_imports(path: Path, repo_root: Path) -> set[str]:
             edges.add(resolved)
 
     return edges
+
+
+def _strip_js_comments(source: str) -> str:
+    """Remove JS comments without treating comment markers inside strings as comments."""
+    output: list[str] = []
+    i = 0
+    quote: str | None = None
+    escape = False
+    while i < len(source):
+        char = source[i]
+        next_char = source[i + 1] if i + 1 < len(source) else ""
+        if quote is not None:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            i += 1
+            continue
+
+        if char in {"'", '"', "`"}:
+            quote = char
+            output.append(char)
+            i += 1
+            continue
+        if char == "/" and next_char == "/":
+            while i < len(source) and source[i] != "\n":
+                output.append(" ")
+                i += 1
+            continue
+        if char == "/" and next_char == "*":
+            output.extend((" ", " "))
+            i += 2
+            while i < len(source) - 1 and not (
+                source[i] == "*" and source[i + 1] == "/"
+            ):
+                output.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            if i < len(source) - 1:
+                output.extend((" ", " "))
+                i += 2
+            continue
+        output.append(char)
+        i += 1
+    return "".join(output)
+
+
+def _iter_js_require_specifiers(source: str) -> list[str]:
+    """Return require() specifiers that appear outside JS string literals."""
+    specifiers: list[str] = []
+    i = 0
+    quote: str | None = None
+    escape = False
+    while i < len(source):
+        char = source[i]
+        if quote is not None:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            i += 1
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            i += 1
+            continue
+        if not source.startswith("require", i):
+            i += 1
+            continue
+        before = source[i - 1] if i > 0 else ""
+        after = source[i + len("require")] if i + len("require") < len(source) else ""
+        if before.isidentifier() or after.isidentifier():
+            i += 1
+            continue
+        cursor = i + len("require")
+        while cursor < len(source) and source[cursor].isspace():
+            cursor += 1
+        if cursor >= len(source) or source[cursor] != "(":
+            i += 1
+            continue
+        cursor += 1
+        while cursor < len(source) and source[cursor].isspace():
+            cursor += 1
+        if cursor >= len(source) or source[cursor] not in {"'", '"'}:
+            i += 1
+            continue
+        spec_quote = source[cursor]
+        cursor += 1
+        start = cursor
+        while cursor < len(source):
+            if source[cursor] == "\\":
+                cursor += 2
+                continue
+            if source[cursor] == spec_quote:
+                specifiers.append(source[start:cursor])
+                break
+            cursor += 1
+        i = max(cursor + 1, i + 1)
+    return specifiers
+
+
+def _iter_js_import_specifiers(source: str) -> list[str]:
+    """Return static import specifiers from source lines that begin with import."""
+    specifiers: list[str] = []
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if not stripped.startswith(("import ", "import'", 'import"')):
+            continue
+        specifiers.extend(match.group(1) for match in _JS_IMPORT.finditer(stripped))
+    return specifiers
 
 
 def _resolve_js_specifier(

--- a/src/omnibase_core/types/typed_dict_dark_matter_pair.py
+++ b/src/omnibase_core/types/typed_dict_dark_matter_pair.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TypedDict definition for a co-change dark matter pair."""
+
+from typing import TypedDict
+
+
+class TypedDictDarkMatterPair(TypedDict):
+    """A file pair with strong co-change correlation not explained by static imports."""
+
+    a: str
+    b: str
+    npmi: float
+    co_changes: int
+
+
+__all__ = [
+    "TypedDictDarkMatterPair",
+]

--- a/tests/analysis/test_co_change_dark_matter.py
+++ b/tests/analysis/test_co_change_dark_matter.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the co-change dark matter filter pipeline."""
+
+from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
+from omnibase_core.analysis.co_change_matrix import (
+    CoChangeMatrix,
+    build_cochange_matrix,
+)
+from omnibase_core.analysis.import_graph import ImportGraph
+
+
+def _make_matrix(commits: list[list[str]]) -> CoChangeMatrix:
+    return build_cochange_matrix(commits)
+
+
+def _empty_graph() -> ImportGraph:
+    return ImportGraph()
+
+
+def _graph_with_edge(a: str, b: str) -> ImportGraph:
+    g = ImportGraph()
+    g.edges_out[a] = {b}
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: empty when fewer than 3 commits
+# ---------------------------------------------------------------------------
+
+
+class TestInsufficientCommits:
+    def test_zero_commits_returns_empty(self) -> None:
+        matrix = _make_matrix([])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_one_commit_returns_empty(self) -> None:
+        matrix = _make_matrix([["a.py", "b.py"]])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_two_commits_returns_empty(self) -> None:
+        matrix = _make_matrix([["a.py", "b.py"], ["a.py", "b.py"]])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_three_commits_passes_threshold(self) -> None:
+        commits = [["a.py", "b.py"]] * 3
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        # May or may not return results depending on other filters, but should not raise
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — < 3 co-changes
+# ---------------------------------------------------------------------------
+
+
+class TestCoChangeCountFilter:
+    def test_pair_with_two_co_changes_excluded(self) -> None:
+        commits = [["a.py", "b.py"], ["a.py", "b.py"]] + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_with_three_co_changes_not_excluded_by_count(self) -> None:
+        # Repeated 3x to pass count filter, 10 more commits for signal
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        # a.py and b.py always co-occur → NPMI = 1.0 ≥ 0.5, passes all filters
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — NPMI < 0.5
+# ---------------------------------------------------------------------------
+
+
+class TestNpmiFilter:
+    def test_low_npmi_pair_excluded(self) -> None:
+        # a.py and b.py co-change 3 times out of 100 commits each → low NPMI
+        commits = [["a.py", "b.py"]] * 3 + [["a.py"]] * 47 + [["b.py"]] * 47
+        # total_commits = 97; file_count: a.py=50, b.py=50; pair=3
+        # p_ab=3/97≈0.031, p_a=50/97≈0.515, p_b=50/97≈0.515
+        # NPMI will be negative → excluded
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — static import edge
+# ---------------------------------------------------------------------------
+
+
+class TestStaticEdgeFilter:
+    def test_pair_with_static_edge_a_imports_b_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("a.py", "b.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_with_static_edge_b_imports_a_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("b.py", "a.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_without_static_edge_not_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("c.py", "d.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — test↔impl pair
+# ---------------------------------------------------------------------------
+
+
+class TestTestImplFilter:
+    def test_test_impl_pair_excluded(self) -> None:
+        commits = [["tests/test_foo.py", "src/foo.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("src/foo.py", "tests/test_foo.py") not in pairs
+        assert ("tests/test_foo.py", "src/foo.py") not in pairs
+
+    def test_two_test_files_not_excluded_by_test_impl(self) -> None:
+        commits = [["tests/test_foo.py", "tests/test_bar.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("tests/test_bar.py", "tests/test_foo.py") in pairs
+
+    def test_two_src_files_not_excluded_by_test_impl(self) -> None:
+        commits = [["src/foo.py", "src/bar.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("src/bar.py", "src/foo.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — same-prefix pair (first 3 path segments)
+# ---------------------------------------------------------------------------
+
+
+class TestSamePrefixFilter:
+    def test_same_prefix_pair_excluded(self) -> None:
+        commits = [
+            ["src/omnibase_core/models/foo.py", "src/omnibase_core/models/bar.py"]
+        ] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert (
+            "src/omnibase_core/models/foo.py",
+            "src/omnibase_core/models/bar.py",
+        ) not in pairs
+        assert (
+            "src/omnibase_core/models/bar.py",
+            "src/omnibase_core/models/foo.py",
+        ) not in pairs
+
+    def test_different_prefix_pair_not_excluded(self) -> None:
+        commits = [
+            ["src/omnibase_core/models/foo.py", "src/omnibase_core/validation/bar.py"]
+        ] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert (
+            "src/omnibase_core/models/foo.py",
+            "src/omnibase_core/validation/bar.py",
+        ) in pairs
+
+    def test_short_paths_not_same_prefix(self) -> None:
+        # a.py and b.py have fewer than 3 segments → not same-prefix filtered
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: top 20 sorted by NPMI descending
+# ---------------------------------------------------------------------------
+
+
+class TestTopKAndSorting:
+    def test_returns_at_most_20_pairs(self) -> None:
+        # Create 30 unique pairs each co-changing 5 times
+        files = [f"module_{i}/a.py" for i in range(30)]
+        commits: list[list[str]] = []
+        # Each file pair co-changes 5 times
+        for i in range(0, 30, 2):
+            commits.extend([[files[i], files[i + 1]]] * 5)
+        # Add enough non-co-change commits
+        commits.extend([[f"solo_{i}.py"] for i in range(30)])
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        assert len(result) <= 20
+
+    def test_results_sorted_by_npmi_desc(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        npmi_values = [r["npmi"] for r in result]
+        assert npmi_values == sorted(npmi_values, reverse=True)
+
+    def test_result_contains_required_fields(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        for item in result:
+            assert {"a", "b", "npmi", "co_changes"} <= set(item.keys())
+            assert isinstance(item["npmi"], float)
+            assert isinstance(item["co_changes"], int)

--- a/tests/analysis/test_co_change_dark_matter.py
+++ b/tests/analysis/test_co_change_dark_matter.py
@@ -7,6 +7,7 @@ from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
 from omnibase_core.analysis.co_change_matrix import (
     CoChangeMatrix,
     build_cochange_matrix,
+    compute_npmi,
 )
 from omnibase_core.analysis.import_graph import ImportGraph
 
@@ -83,6 +84,9 @@ class TestCoChangeCountFilter:
 
 
 class TestNpmiFilter:
+    def test_npmi_perfect_coupling_returns_one(self) -> None:
+        assert compute_npmi(1.0, 1.0, 1.0) == 1.0
+
     def test_low_npmi_pair_excluded(self) -> None:
         # a.py and b.py co-change 3 times out of 100 commits each → low NPMI
         commits = [["a.py", "b.py"]] * 3 + [["a.py"]] * 47 + [["b.py"]] * 47

--- a/tests/analysis/test_co_change_dark_matter.py
+++ b/tests/analysis/test_co_change_dark_matter.py
@@ -3,6 +3,8 @@
 
 """Tests for the co-change dark matter filter pipeline."""
 
+import pytest
+
 from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
 from omnibase_core.analysis.co_change_matrix import (
     CoChangeMatrix,
@@ -10,6 +12,8 @@ from omnibase_core.analysis.co_change_matrix import (
     compute_npmi,
 )
 from omnibase_core.analysis.import_graph import ImportGraph
+
+pytestmark = pytest.mark.unit
 
 
 def _make_matrix(commits: list[list[str]]) -> CoChangeMatrix:

--- a/tests/analysis/test_consumer_graph.py
+++ b/tests/analysis/test_consumer_graph.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.analysis.consumer_graph import build_consumer_graph
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_counts_imports(tmp_path: Path) -> None:
+    # a.py imports b.py; c.py imports b.py — b should have count 2
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+    (tmp_path / "c.py").write_text("import b\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert "b.py" in result
+    assert result["b.py"] == 2
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_unreferenced_file_absent(tmp_path: Path) -> None:
+    (tmp_path / "standalone.py").write_text("x = 1\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert "standalone.py" not in result
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_cache_hit(tmp_path: Path) -> None:
+    (tmp_path / "x.py").write_text("import y\n", encoding="utf-8")
+    (tmp_path / "y.py").write_text("", encoding="utf-8")
+
+    # Prime cache by calling once (no git repo, sha=None)
+    build_consumer_graph(tmp_path)
+
+    cache_path = tmp_path / ".onex_state" / "consumer-graph.json"
+    assert cache_path.is_file()
+
+    cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert "y.py" in cached
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_sha_mismatch_recomputes(tmp_path: Path) -> None:
+    # Write a stale cache with a known SHA
+    cache_path = tmp_path / ".onex_state" / "consumer-graph.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale = {"sha": "deadbeef" * 5, "old_file.py": 99}
+    cache_path.write_text(json.dumps(stale), encoding="utf-8")
+
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    # old stale entry must be gone; real computation used
+    assert "old_file.py" not in result
+    assert result.get("b.py") == 1
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_returns_dict_str_int(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("import util\n", encoding="utf-8")
+    (tmp_path / "util.py").write_text("", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert isinstance(result, dict)
+    for k, v in result.items():
+        assert isinstance(k, str)
+        assert isinstance(v, int)

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -97,6 +97,27 @@ def test_python_relative_import_detected(tmp_path: Path) -> None:
     assert "pkg/b.py" in g.edges_out["pkg/a.py"]
 
 
+def test_python_relative_import_rejects_top_level_escape(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("from . import b\n")
+    b.write_text("VALUE = 1\n")
+    g = build_import_graph(tmp_path)
+    assert g.edges_out.get("a.py", set()) == set()
+
+
+def test_python_relative_import_rejects_package_escape(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    a = pkg / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("from .. import b\n")
+    b.write_text("VALUE = 1\n")
+    g = build_import_graph(tmp_path)
+    assert g.edges_out.get("pkg/a.py", set()) == set()
+
+
 def test_python_relative_from_import_submodule_detected(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     nested = pkg / "nested"

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -5,7 +5,11 @@
 
 from pathlib import Path
 
+import pytest
+
 from omnibase_core.analysis.import_graph import build_import_graph
+
+pytestmark = pytest.mark.unit
 
 
 def test_python_from_import_detected(tmp_path: Path) -> None:
@@ -81,6 +85,29 @@ def test_python_import_in_subpackage(tmp_path: Path) -> None:
     assert "pkg/b.py" in g.edges_out["pkg/a.py"]
 
 
+def test_python_relative_import_detected(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    a = pkg / "a.py"
+    b = pkg / "b.py"
+    a.write_text("from . import b\n")
+    b.write_text("VALUE = 1\n")
+    g = build_import_graph(tmp_path)
+    assert "pkg/b.py" in g.edges_out["pkg/a.py"]
+
+
+def test_python_absolute_import_does_not_resolve_sibling(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    a = pkg / "a.py"
+    b = pkg / "b.py"
+    a.write_text("import b\n")
+    b.write_text("VALUE = 1\n")
+    g = build_import_graph(tmp_path)
+    assert g.edges_out.get("pkg/a.py", set()) == set()
+
+
 def test_edges_out_keys_are_repo_relative(tmp_path: Path) -> None:
     a = tmp_path / "a.py"
     b = tmp_path / "b.py"
@@ -94,3 +121,14 @@ def test_edges_out_keys_are_repo_relative(tmp_path: Path) -> None:
 def test_empty_repo(tmp_path: Path) -> None:
     g = build_import_graph(tmp_path)
     assert g.edges_out == {}
+
+
+def test_js_index_tsx_import_detected(tmp_path: Path) -> None:
+    widget = tmp_path / "widget"
+    widget.mkdir()
+    a = tmp_path / "page.tsx"
+    b = widget / "index.tsx"
+    a.write_text("import Widget from './widget';\n")
+    b.write_text("export default function Widget() {}\n")
+    g = build_import_graph(tmp_path)
+    assert "widget/index.tsx" in g.edges_out["page.tsx"]

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -97,6 +97,20 @@ def test_python_relative_import_detected(tmp_path: Path) -> None:
     assert "pkg/b.py" in g.edges_out["pkg/a.py"]
 
 
+def test_python_from_import_submodules_detected(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "submodule.py").write_text("VALUE = 1\n")
+    (pkg / "other.py").write_text("VALUE = 2\n")
+    a = tmp_path / "a.py"
+    a.write_text("from pkg import submodule, other\n")
+    g = build_import_graph(tmp_path)
+    assert {"pkg/__init__.py", "pkg/submodule.py", "pkg/other.py"}.issubset(
+        g.edges_out["a.py"]
+    )
+
+
 def test_python_absolute_import_does_not_resolve_sibling(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     pkg.mkdir()
@@ -132,3 +146,25 @@ def test_js_index_tsx_import_detected(tmp_path: Path) -> None:
     b.write_text("export default function Widget() {}\n")
     g = build_import_graph(tmp_path)
     assert "widget/index.tsx" in g.edges_out["page.tsx"]
+
+
+def test_js_comment_and_string_imports_are_ignored(tmp_path: Path) -> None:
+    a = tmp_path / "a.js"
+    commented = tmp_path / "commented.js"
+    quoted = tmp_path / "quoted.js"
+    real = tmp_path / "real.js"
+    a.write_text(
+        "\n".join(
+            [
+                "// import './commented';",
+                "/* require('./quoted') */",
+                "const doc = \"require('./quoted')\";",
+                "import real from './real';",
+            ]
+        )
+    )
+    commented.write_text("export const value = 1;\n")
+    quoted.write_text("module.exports = 1;\n")
+    real.write_text("export const value = 2;\n")
+    g = build_import_graph(tmp_path)
+    assert g.edges_out["a.js"] == {"real.js"}

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for build_import_graph."""
+
+from pathlib import Path
+
+from omnibase_core.analysis.import_graph import build_import_graph
+
+
+def test_python_from_import_detected(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("from b import foo\n")
+    b.write_text("def foo(): ...\n")
+    g = build_import_graph(tmp_path)
+    assert "b.py" in g.edges_out["a.py"]
+
+
+def test_python_bare_import_detected(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("import b\n")
+    b.write_text("x = 1\n")
+    g = build_import_graph(tmp_path)
+    assert "b.py" in g.edges_out["a.py"]
+
+
+def test_js_require_detected(tmp_path: Path) -> None:
+    a = tmp_path / "a.js"
+    b = tmp_path / "b.js"
+    a.write_text("const x = require('./b');\n")
+    b.write_text("module.exports = 1;\n")
+    g = build_import_graph(tmp_path)
+    assert "b.js" in g.edges_out["a.js"]
+
+
+def test_js_esm_import_detected(tmp_path: Path) -> None:
+    a = tmp_path / "a.js"
+    b = tmp_path / "utils.js"
+    a.write_text("import x from './utils';\n")
+    b.write_text("export const x = 1;\n")
+    g = build_import_graph(tmp_path)
+    assert "utils.js" in g.edges_out["a.js"]
+
+
+def test_tsx_import_detected(tmp_path: Path) -> None:
+    subdir = tmp_path / "components"
+    subdir.mkdir()
+    a = tmp_path / "page.tsx"
+    b = subdir / "Widget.tsx"
+    a.write_text("import Widget from './components/Widget';\n")
+    b.write_text("export default function Widget() {}\n")
+    g = build_import_graph(tmp_path)
+    assert "components/Widget.tsx" in g.edges_out["page.tsx"]
+
+
+def test_no_self_loop(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    a.write_text("from a import something\n")
+    g = build_import_graph(tmp_path)
+    assert "a.py" not in g.edges_out.get("a.py", set())
+
+
+def test_missing_import_target_excluded(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    a.write_text("from nonexistent_module import foo\n")
+    g = build_import_graph(tmp_path)
+    assert g.edges_out.get("a.py", set()) == set()
+
+
+def test_python_import_in_subpackage(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    a = pkg / "a.py"
+    b = pkg / "b.py"
+    a.write_text("from pkg.b import bar\n")
+    b.write_text("def bar(): ...\n")
+    g = build_import_graph(tmp_path)
+    assert "pkg/b.py" in g.edges_out["pkg/a.py"]
+
+
+def test_edges_out_keys_are_repo_relative(tmp_path: Path) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("import b\n")
+    b.write_text("")
+    g = build_import_graph(tmp_path)
+    for key in g.edges_out:
+        assert not key.startswith("/"), f"Key {key!r} should be repo-relative"
+
+
+def test_empty_repo(tmp_path: Path) -> None:
+    g = build_import_graph(tmp_path)
+    assert g.edges_out == {}

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -97,6 +97,21 @@ def test_python_relative_import_detected(tmp_path: Path) -> None:
     assert "pkg/b.py" in g.edges_out["pkg/a.py"]
 
 
+def test_python_relative_from_import_submodule_detected(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    nested = pkg / "nested"
+    nested.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (nested / "__init__.py").write_text("")
+    (nested / "submodule.py").write_text("VALUE = 1\n")
+    a = pkg / "a.py"
+    a.write_text("from .nested import submodule\n")
+    g = build_import_graph(tmp_path)
+    assert {"pkg/nested/__init__.py", "pkg/nested/submodule.py"}.issubset(
+        g.edges_out["pkg/a.py"]
+    )
+
+
 def test_python_from_import_submodules_detected(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     pkg.mkdir()
@@ -168,3 +183,22 @@ def test_js_comment_and_string_imports_are_ignored(tmp_path: Path) -> None:
     real.write_text("export const value = 2;\n")
     g = build_import_graph(tmp_path)
     assert g.edges_out["a.js"] == {"real.js"}
+
+
+def test_js_multiline_esm_import_detected(tmp_path: Path) -> None:
+    a = tmp_path / "a.ts"
+    b = tmp_path / "utils.ts"
+    a.write_text(
+        "\n".join(
+            [
+                "import {",
+                "  foo,",
+                "  bar,",
+                "} from './utils';",
+                "export const value = foo + bar;",
+            ]
+        )
+    )
+    b.write_text("export const foo = 1; export const bar = 2;\n")
+    g = build_import_graph(tmp_path)
+    assert "utils.ts" in g.edges_out["a.ts"]


### PR DESCRIPTION
## Summary

- Implements `build_import_graph(repo_root: Path) -> ImportGraph` in `src/omnibase_core/analysis/import_graph.py`
- `ImportGraph.edges_out: dict[str, set[str]]` maps repo-relative source file paths to their import targets
- Supports Python `import x` / `from x import y` (via AST) and JS/TS `require('./x')` / `import x from './x'` (via regex)
- Resolves relative paths to repo-rooted file paths; excludes bare module specifiers, self-loops, and unresolvable targets
- Creates `src/omnibase_core/analysis/__init__.py` and `tests/analysis/__init__.py` package markers (defensive — also needed by Task 9/OMN-10361)

## Ticket

OMN-10363 — Task 11 [Wave 3 Co-Change] of epic OMN-10350

## Test plan

- [x] 10 unit tests cover: Python from-import, bare import, subpackage import, JS require, JS ESM import, TSX import, self-loop exclusion, missing target exclusion, repo-relative keys, empty repo
- [x] `uv run pytest tests/analysis/test_import_graph.py -v` — 10 passed
- [x] `uv run mypy src/omnibase_core/analysis/import_graph.py --strict` — Success: no issues
- [x] `uv run ruff format/check` — clean
- [x] `pre-commit run --all-files` — all hooks passed
- [x] Push hooks (mypy strict, pyright, naming conventions) — all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added import graph analysis supporting Python, JavaScript, and TypeScript to identify static file dependencies
  * Added consumer graph analysis to track which modules reference each file
  * Added co-change dark matter detection to identify hidden file dependencies not captured by static imports

* **Tests**
  * Added comprehensive test suites for import graph, consumer graph, and dark matter analysis functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->