### PR TITLE
feat(OMN-10371): add EnumDiffSeverity, EnumChangeKind, and AST diff result models

### DIFF
--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -59,6 +59,7 @@ adjacency:
     reverse_deps: [models, runtime, nodes, services]
   # Leaf modules with no reverse_deps still appear so the loader can validate
   # that every src/omnibase_core/<dir> has an entry.
+  analysis: {reverse_deps: []}
   backends: {reverse_deps: []}
   cli: {reverse_deps: []}
   constants: {reverse_deps: []}

--- a/src/omnibase_core/analysis/__init__.py
+++ b/src/omnibase_core/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/enums/enum_diff_severity.py
+++ b/src/omnibase_core/enums/enum_diff_severity.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""AST diff severity and change-kind enums (OMN-10371)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDiffSeverity(StrEnum):
+    """Risk severity for a code-symbol change detected by AST diff."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class EnumChangeKind(StrEnum):
+    """Classifier for the kind of change made to a symbol."""
+
+    SIGNATURE_CHANGE = "signature_change"
+    API_CHANGE = "api_change"
+    GUARD_REMOVED = "guard_removed"
+    DELETED_FUNCTION = "deleted_function"
+    LOGIC_CHANGE = "logic_change"
+    NEW_FUNCTION = "new_function"
+    REFACTOR = "refactor"
+    COSMETIC = "cosmetic"

--- a/src/omnibase_core/models/analysis/__init__.py
+++ b/src/omnibase_core/models/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/models/analysis/model_semantic_diff_report.py
+++ b/src/omnibase_core/models/analysis/model_semantic_diff_report.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelSemanticDiffReport — aggregate result of an AST semantic diff (OMN-10371)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+
+class ModelSemanticDiffReport(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    changes: tuple[ModelSymbolChange, ...]
+    total_consumers_affected: int

--- a/src/omnibase_core/models/analysis/model_symbol_change.py
+++ b/src/omnibase_core/models/analysis/model_symbol_change.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelSymbolChange — a single symbol-level change in an AST diff (OMN-10371)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+
+
+class ModelSymbolChange(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: EnumChangeKind
+    severity: EnumDiffSeverity
+    symbol_name: str
+    file_path: str
+    consumers_count: int

--- a/tests/analysis/__init__.py
+++ b/tests/analysis/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for omnibase_core.analysis modules."""
+
+__all__: list[str] = []

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for omnibase_core.models modules."""
+
+__all__: list[str] = []

--- a/tests/models/analysis/__init__.py
+++ b/tests/models/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -49,7 +49,7 @@ def test_model_symbol_change_frozen() -> None:
         consumers_count=3,
     )
     with pytest.raises(Exception):
-        sc.symbol_name = "other"  # type: ignore[misc]
+        sc.symbol_name = "other"  # type: ignore[misc]  # NOTE(OMN-10371): intentional frozen-model mutation check
 
 
 def test_model_symbol_change_fields() -> None:
@@ -77,7 +77,7 @@ def test_model_semantic_diff_report_frozen() -> None:
     )
     report = ModelSemanticDiffReport(changes=(sc,), total_consumers_affected=0)
     with pytest.raises(Exception):
-        report.total_consumers_affected = 5  # type: ignore[misc]
+        report.total_consumers_affected = 5  # type: ignore[misc]  # NOTE(OMN-10371): intentional frozen-model mutation check
 
 
 def test_model_semantic_diff_report_fields() -> None:

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for EnumDiffSeverity, EnumChangeKind, ModelSymbolChange, ModelSemanticDiffReport."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+
+def test_enum_diff_severity_members() -> None:
+    assert {v.value for v in EnumDiffSeverity} == {"critical", "high", "medium", "low"}
+
+
+def test_enum_diff_severity_is_str() -> None:
+    assert isinstance(EnumDiffSeverity.CRITICAL, str)
+    assert EnumDiffSeverity.CRITICAL.value == "critical"
+
+
+def test_enum_change_kind_members() -> None:
+    expected = {
+        "signature_change",
+        "api_change",
+        "guard_removed",
+        "deleted_function",
+        "logic_change",
+        "new_function",
+        "refactor",
+        "cosmetic",
+    }
+    assert {v.value for v in EnumChangeKind} == expected
+
+
+def test_enum_change_kind_is_str() -> None:
+    assert isinstance(EnumChangeKind.SIGNATURE_CHANGE, str)
+
+
+def test_model_symbol_change_frozen() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.SIGNATURE_CHANGE,
+        severity=EnumDiffSeverity.HIGH,
+        symbol_name="my_func",
+        file_path="src/foo.py",
+        consumers_count=3,
+    )
+    with pytest.raises(Exception):
+        sc.symbol_name = "other"  # type: ignore[misc]
+
+
+def test_model_symbol_change_fields() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.GUARD_REMOVED,
+        severity=EnumDiffSeverity.CRITICAL,
+        symbol_name="validate_token",
+        file_path="src/auth.py",
+        consumers_count=10,
+    )
+    assert sc.kind == EnumChangeKind.GUARD_REMOVED
+    assert sc.severity == EnumDiffSeverity.CRITICAL
+    assert sc.symbol_name == "validate_token"
+    assert sc.file_path == "src/auth.py"
+    assert sc.consumers_count == 10
+
+
+def test_model_semantic_diff_report_frozen() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.NEW_FUNCTION,
+        severity=EnumDiffSeverity.LOW,
+        symbol_name="helper",
+        file_path="src/utils.py",
+        consumers_count=0,
+    )
+    report = ModelSemanticDiffReport(changes=(sc,), total_consumers_affected=0)
+    with pytest.raises(Exception):
+        report.total_consumers_affected = 5  # type: ignore[misc]
+
+
+def test_model_semantic_diff_report_fields() -> None:
+    sc1 = ModelSymbolChange(
+        kind=EnumChangeKind.LOGIC_CHANGE,
+        severity=EnumDiffSeverity.MEDIUM,
+        symbol_name="process",
+        file_path="src/core.py",
+        consumers_count=2,
+    )
+    sc2 = ModelSymbolChange(
+        kind=EnumChangeKind.DELETED_FUNCTION,
+        severity=EnumDiffSeverity.HIGH,
+        symbol_name="old_handler",
+        file_path="src/core.py",
+        consumers_count=5,
+    )
+    report = ModelSemanticDiffReport(changes=(sc1, sc2), total_consumers_affected=7)
+    assert len(report.changes) == 2
+    assert report.total_consumers_affected == 7
+    assert report.changes[0].symbol_name == "process"
+
+
+def test_model_semantic_diff_report_empty_changes() -> None:
+    report = ModelSemanticDiffReport(changes=(), total_consumers_affected=0)
+    assert report.changes == ()
+    assert report.total_consumers_affected == 0


### PR DESCRIPTION
## Summary

- Adds `EnumDiffSeverity` (StrEnum: critical/high/medium/low) for AST diff risk classification
- Adds `EnumChangeKind` (StrEnum: 8 change classifiers) for symbol-level change typing
- Adds `ModelSymbolChange` (frozen Pydantic): per-symbol change result with kind, severity, symbol_name, file_path, consumers_count
- Adds `ModelSemanticDiffReport` (frozen Pydantic): aggregate diff result with `changes: tuple[ModelSymbolChange, ...]` and `total_consumers_affected`
- Seeds `src/omnibase_core/analysis/` and `src/omnibase_core/models/analysis/` package roots for Wave 5 (Tasks 20-23)

Ticket: OMN-10371
Epic: OMN-10350

## Why not reuse EnumTriageSeverity

`EnumTriageSeverity` has values CRITICAL/HIGH/MEDIUM/LOW/INFO (uppercase, operational urgency). `EnumDiffSeverity` uses lowercase values and represents code-review risk, not operational urgency. Different semantics and value sets.

## Test plan

- [x] 9 unit tests covering all enum members, frozen model invariants, field correctness, empty report
- [x] `uv run pytest tests/models/analysis/ -v` — 9 passed
- [x] `uv run mypy src/omnibase_core/enums/enum_diff_severity.py src/omnibase_core/models/analysis/ --strict` — no issues
- [x] `uv run ruff format` + `ruff check` — clean
- [x] `pre-commit run --all-files` — all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic change analysis: severity levels (critical → low), change-type categories, and immutable models summarizing symbol-level diffs and consumer impact.

* **Tests**
  * Added tests validating enum values, string behavior, model immutability, and report/changes structure.

* **Chores**
  * Updated CI adjacency data and added SPDX license headers across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->