### PR TITLE
feat(OMN-10374): consumer graph builder + SHA-keyed cache

### DIFF
--- a/src/omnibase_core/analysis/consumer_graph.py
+++ b/src/omnibase_core/analysis/consumer_graph.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Consumer graph builder: counts how many files import each module."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from omnibase_core.analysis.import_graph import build_import_graph
+
+
+def build_consumer_graph(repo_root: Path) -> dict[str, int]:
+    """Return a mapping of repo-relative file path -> number of files that import it.
+
+    Results are cached in .onex_state/consumer-graph.json keyed by the current
+    git HEAD SHA. A SHA mismatch triggers a full recompute and cache overwrite.
+    """
+    repo_root = repo_root.resolve()
+    cache_path = repo_root / ".onex_state" / "consumer-graph.json"
+    head_sha = _git_head_sha(repo_root)
+
+    if head_sha and cache_path.is_file():
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            if cached.get("sha") == head_sha:
+                return {k: v for k, v in cached.items() if k != "sha"}
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    counts = _compute(repo_root)
+    _write_cache(cache_path, head_sha, counts)
+    return counts
+
+
+def _compute(repo_root: Path) -> dict[str, int]:
+    graph = build_import_graph(repo_root)
+    counts: dict[str, int] = {}
+    for _src, targets in graph.edges_out.items():
+        for target in targets:
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def _git_head_sha(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _write_cache(cache_path: Path, sha: str | None, counts: dict[str, int]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, object] = {"sha": sha, **counts}
+        cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        pass

--- a/tests/analysis/test_consumer_graph.py
+++ b/tests/analysis/test_consumer_graph.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.analysis.consumer_graph import build_consumer_graph
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_counts_imports(tmp_path: Path) -> None:
+    # a.py imports b.py; c.py imports b.py — b should have count 2
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+    (tmp_path / "c.py").write_text("import b\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert "b.py" in result
+    assert result["b.py"] == 2
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_unreferenced_file_absent(tmp_path: Path) -> None:
+    (tmp_path / "standalone.py").write_text("x = 1\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert "standalone.py" not in result
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_cache_hit(tmp_path: Path) -> None:
+    (tmp_path / "x.py").write_text("import y\n", encoding="utf-8")
+    (tmp_path / "y.py").write_text("", encoding="utf-8")
+
+    # Prime cache by calling once (no git repo, sha=None)
+    build_consumer_graph(tmp_path)
+
+    cache_path = tmp_path / ".onex_state" / "consumer-graph.json"
+    assert cache_path.is_file()
+
+    cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert "y.py" in cached
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_sha_mismatch_recomputes(tmp_path: Path) -> None:
+    # Write a stale cache with a known SHA
+    cache_path = tmp_path / ".onex_state" / "consumer-graph.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale = {"sha": "deadbeef" * 5, "old_file.py": 99}
+    cache_path.write_text(json.dumps(stale), encoding="utf-8")
+
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    # old stale entry must be gone; real computation used
+    assert "old_file.py" not in result
+    assert result.get("b.py") == 1
+
+
+@pytest.mark.unit
+def test_build_consumer_graph_returns_dict_str_int(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("import util\n", encoding="utf-8")
+    (tmp_path / "util.py").write_text("", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert isinstance(result, dict)
+    for k, v in result.items():
+        assert isinstance(k, str)
+        assert isinstance(v, int)


### PR DESCRIPTION
## OMN-10374 — Consumer Graph Builder + Cache

Implements Task 22 of the Wave 5 AST Diff plan.

### Changes

- `src/omnibase_core/analysis/consumer_graph.py` — `build_consumer_graph(repo_root: Path) -> dict[str, int]`
- `tests/analysis/test_consumer_graph.py` — 5 unit tests

### Acceptance criteria

1. `build_consumer_graph(repo_root: Path) -> dict[str, int]` ✅
2. Reuses `omnibase_core.analysis.import_graph.build_import_graph` ✅
3. Caches to `.onex_state/consumer-graph.json` keyed by `git rev-parse HEAD` ✅
4. SHA mismatch → recompute + rewrite ✅

### dod_evidence

- type: test_pass
  check_type: pytest
  result: 5/5 unit tests PASS (`tests/analysis/test_consumer_graph.py`)
  verifier: pre-commit + CI

- type: lint_pass
  check_type: ruff + mypy --strict
  result: 0 errors

- type: hook_pass
  check_type: pre-commit
  result: all hooks PASS on commit