### PR TITLE
feat(OMN-10356): wire path-filtered CI matrix (docs-only short-circuit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -854,6 +854,68 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Phase 1.6a - Zone Filter (OMN-10356)
+  # ---------------------------------------------------------------------------
+  # Classifies all changed files using zone_diff_filter.py.
+  # If every changed file is in the DOCS zone (exit 0), the test matrix jobs
+  # are skipped entirely to save CI minutes on docs-only PRs.
+  zone-filter:
+    name: Zone Filter (docs-only check)
+    needs: quality-gate
+    runs-on: ubuntu-latest
+    if: always() && needs.quality-gate.result == 'success'
+    outputs:
+      docs_only: ${{ steps.zone.outputs.docs_only }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Compute changed files
+        id: diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            git fetch --no-tags --depth=1 origin "$base" || true
+            FILES=$(git diff --name-only "$base"...HEAD | tr '\n' ',')
+          else
+            FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | tr '\n' ',' || echo "")
+          fi
+          echo "changed_files=$FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Run zone-diff filter
+        id: zone
+        run: |
+          ZONE_DIFF_FILTER_FAKE_DIFF="${{ steps.diff.outputs.changed_files }}" \
+            uv run python scripts/zone_diff_filter.py --check docs-only
+          RC=$?
+          if [ $RC -eq 0 ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Zone filter: DOCS-ONLY — test matrix will be skipped." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "Zone filter: production/mixed diff — full test matrix will run." >> "$GITHUB_STEP_SUMMARY"
+          fi
+        continue-on-error: true
+
+  # ---------------------------------------------------------------------------
   # Phase 1.6 - Detect Changes (shadow mode)
   # ---------------------------------------------------------------------------
   # Runs detect_test_paths and emits 5 outputs for shadow-mode comparison.
@@ -861,9 +923,9 @@ jobs:
 
   detect-changes:
     name: Detect Changes
-    needs: quality-gate
+    needs: [quality-gate, zone-filter]
     runs-on: ubuntu-latest
-    if: always() && needs.quality-gate.result == 'success'
+    if: always() && needs.quality-gate.result == 'success' && needs.zone-filter.outputs.docs_only != 'true'
     outputs:
       is_full_suite: ${{ steps.detect.outputs.is_full_suite }}
       full_suite_reason: ${{ steps.detect.outputs.full_suite_reason }}
@@ -946,7 +1008,7 @@ jobs:
   #   - This ensures quality failures are caught BEFORE spawning N test runners
   test-parallel:
     name: Tests (Split ${{ matrix.split }}/${{ needs.detect-changes.outputs.split_count }})
-    needs: [quality-gate, detect-changes]
+    needs: [quality-gate, zone-filter, detect-changes]
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
@@ -957,7 +1019,7 @@ jobs:
         && fromJSON('["self-hosted","omnibase-ci"]')
         || fromJSON('["ubuntu-latest"]')
       }}
-    if: always() && needs.quality-gate.result == 'success'
+    if: always() && needs.quality-gate.result == 'success' && needs.zone-filter.outputs.docs_only != 'true'
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -1069,7 +1131,7 @@ jobs:
   # ---------------------------------------------------------------------------
   tests-integration:
     name: Integration Tests (Split ${{ matrix.split }}/4)
-    needs: [quality-gate, detect-changes]
+    needs: [quality-gate, zone-filter, detect-changes]
     # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
     runs-on: >-
       ${{
@@ -1081,7 +1143,7 @@ jobs:
         || fromJSON('["ubuntu-latest"]')
       }}
     timeout-minutes: 30
-    if: always() && needs.quality-gate.result == 'success'
+    if: always() && needs.quality-gate.result == 'success' && needs.zone-filter.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/zone_diff_filter.py
+++ b/scripts/zone_diff_filter.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CI zone-diff filter: exit 0 for docs-only diffs, 1 otherwise (OMN-10356).
+
+Usage:
+    python scripts/zone_diff_filter.py --check docs-only
+
+Exit codes:
+    0  — all changed files are in the DOCS zone (CI matrix may be skipped)
+    1  — at least one changed file is outside the DOCS zone (run full matrix)
+    2  — bad usage / unknown mode
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _diff_files() -> list[Path]:
+    fake = os.environ.get("ZONE_DIFF_FILTER_FAKE_DIFF")
+    if fake is not None:
+        return [Path(p) for p in fake.split(",") if p.strip()]
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "origin/main...HEAD"], text=True
+    )
+    return [Path(line) for line in out.splitlines() if line]
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] != "--check" or sys.argv[2] != "docs-only":
+        sys.stderr.write("usage: zone_diff_filter --check docs-only\n")
+        return 2
+
+    # Import after arg parse so the script fails fast on bad usage without
+    # requiring omnibase_core to be installed.
+    from omnibase_core.enums.enum_file_zone import EnumFileZone
+    from omnibase_core.validation.zone_classifier import classify_path
+
+    files = _diff_files()
+    if not files:
+        return 0
+
+    zones = {classify_path(p) for p in files}
+    return 0 if zones <= {EnumFileZone.DOCS} else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/enums/enum_file_zone.py
+++ b/src/omnibase_core/enums/enum_file_zone.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""File zone enum for tiered QA gate classification (OMN-10351)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumFileZone(StrEnum):
+    """Directory-role classification for per-zone QA gating.
+
+    Distinct from EnumFileType (extension/format) — a .py file is PRODUCTION
+    under src/ but TEST under tests/.
+    """
+
+    PRODUCTION = "production"
+    TEST = "test"
+    CONFIG = "config"
+    GENERATED = "generated"
+    DOCS = "docs"
+    BUILD = "build"

--- a/src/omnibase_core/validation/zone_classifier.py
+++ b/src/omnibase_core/validation/zone_classifier.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Zone classifier: classify a file path into an EnumFileZone (OMN-10355)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+_GENERATED_MARKERS = ("__pycache__", "dist/", ".generated.", "node_modules/")
+_TEST_PREFIXES = ("tests/", "test/")
+_DOCS_PREFIXES = ("docs/", "standards/")
+_BUILD_PREFIXES = ("scripts/",)
+_BUILD_NAMES = {"Dockerfile", "docker-compose.yml", "docker-compose.yaml", "Makefile"}
+_CONFIG_SUFFIXES = (".yaml", ".yml", ".toml", ".json", ".ini")
+
+
+def classify_path(path: Path) -> EnumFileZone:
+    """Classify *path* into its EnumFileZone.
+
+    Priority order: generated > production > test > config > docs > build.
+    Symlinks are resolved before classification so the target's directory
+    structure determines the zone, not the link location.
+    """
+    resolved = path.resolve() if path.exists() else path
+    s = resolved.as_posix()
+
+    if any(m in s for m in _GENERATED_MARKERS):
+        return EnumFileZone.GENERATED
+
+    if "/src/" in f"/{s}" or s.startswith("src/"):
+        return EnumFileZone.PRODUCTION
+
+    if any(s.startswith(p) or f"/{p}" in f"/{s}" for p in _TEST_PREFIXES):
+        return EnumFileZone.TEST
+
+    if resolved.name in _BUILD_NAMES:
+        return EnumFileZone.BUILD
+
+    if any(s.startswith(p) for p in _DOCS_PREFIXES) or resolved.suffix == ".md":
+        return EnumFileZone.DOCS
+
+    if resolved.suffix in _CONFIG_SUFFIXES:
+        return EnumFileZone.CONFIG
+
+    if any(s.startswith(p) for p in _BUILD_PREFIXES):
+        return EnumFileZone.BUILD
+
+    return EnumFileZone.PRODUCTION

--- a/tests/scripts/test_zone_diff_filter.py
+++ b/tests/scripts/test_zone_diff_filter.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/zone_diff_filter.py (OMN-10356)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "zone_diff_filter.py"
+# Make the package importable in subprocess — mirrors what uv run does.
+_SRC = str(REPO_ROOT / "src")
+
+
+def _run(env_override: dict[str, str], *args: str) -> int:
+    import os
+
+    env = os.environ.copy()
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{_SRC}:{existing_pp}" if existing_pp else _SRC
+    env.update(env_override)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env,
+        check=False,
+    ).returncode
+
+
+def test_docs_only_diff_exits_0() -> None:
+    rc = _run({"ZONE_DIFF_FILTER_FAKE_DIFF": "docs/foo.md"}, "--check", "docs-only")
+    assert rc == 0
+
+
+def test_src_diff_exits_1() -> None:
+    rc = _run(
+        {"ZONE_DIFF_FILTER_FAKE_DIFF": "src/omnibase_core/foo.py"},
+        "--check",
+        "docs-only",
+    )
+    assert rc == 1
+
+
+def test_mixed_zone_exits_1() -> None:
+    rc = _run(
+        {"ZONE_DIFF_FILTER_FAKE_DIFF": "docs/foo.md,src/omnibase_core/bar.py"},
+        "--check",
+        "docs-only",
+    )
+    assert rc == 1
+
+
+def test_empty_diff_exits_0() -> None:
+    # Empty diff = no production zone touched — treat as docs-only
+    rc = _run({"ZONE_DIFF_FILTER_FAKE_DIFF": ""}, "--check", "docs-only")
+    assert rc == 0
+
+
+def test_bad_usage_exits_2() -> None:
+    rc = _run({}, "--check", "unknown-mode")
+    assert rc == 2

--- a/tests/unit/enums/test_enum_file_zone.py
+++ b/tests/unit/enums/test_enum_file_zone.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+
+
+@pytest.mark.unit
+class TestEnumFileZone:
+    def test_enum_members(self) -> None:
+        assert {z.value for z in EnumFileZone} == {
+            "production",
+            "test",
+            "config",
+            "generated",
+            "docs",
+            "build",
+        }
+
+    def test_enum_is_str_enum(self) -> None:
+        assert EnumFileZone.PRODUCTION.value == "production"
+        assert isinstance(EnumFileZone.PRODUCTION, str)
+        assert issubclass(EnumFileZone, str)
+        assert issubclass(EnumFileZone, Enum)
+
+    def test_enum_string_behavior(self) -> None:
+        assert str(EnumFileZone.TEST) == "test"
+        assert EnumFileZone.DOCS == "docs"
+
+    def test_enum_iteration(self) -> None:
+        values = list(EnumFileZone)
+        assert len(values) == 6
+
+    def test_enum_membership(self) -> None:
+        assert EnumFileZone.CONFIG in EnumFileZone
+        assert "config" in [e.value for e in EnumFileZone]
+
+    def test_enum_deserialization(self) -> None:
+        assert EnumFileZone("production") == EnumFileZone.PRODUCTION
+        assert EnumFileZone("generated") == EnumFileZone.GENERATED
+
+    def test_enum_invalid_value(self) -> None:
+        with pytest.raises(ValueError):
+            EnumFileZone("extension")  # EnumFileType domain, not zone
+
+    def test_all_members_accessible(self) -> None:
+        assert EnumFileZone.PRODUCTION == "production"
+        assert EnumFileZone.TEST == "test"
+        assert EnumFileZone.CONFIG == "config"
+        assert EnumFileZone.GENERATED == "generated"
+        assert EnumFileZone.DOCS == "docs"
+        assert EnumFileZone.BUILD == "build"

--- a/tests/validation/test_zone_classifier.py
+++ b/tests/validation/test_zone_classifier.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from omnibase_core.enums.enum_file_zone import EnumFileZone
+from omnibase_core.validation.zone_classifier import classify_path
+
+
+def test_classify_production() -> None:
+    assert classify_path(Path("src/omnibase_core/foo.py")) == EnumFileZone.PRODUCTION
+
+
+def test_classify_test() -> None:
+    assert classify_path(Path("tests/test_foo.py")) == EnumFileZone.TEST
+
+
+def test_classify_config_yaml_outside_src() -> None:
+    assert classify_path(Path("pyproject.toml")) == EnumFileZone.CONFIG
+
+
+def test_classify_yaml_inside_src_is_production() -> None:
+    # config files inside src/ are part of the package, not free config
+    assert (
+        classify_path(Path("src/omnibase_core/contracts/foo.yaml"))
+        == EnumFileZone.PRODUCTION
+    )
+
+
+def test_classify_generated_wins_over_production() -> None:
+    # priority: generated > production > test > config > docs > build
+    assert (
+        classify_path(Path("src/__pycache__/foo.cpython-312.pyc"))
+        == EnumFileZone.GENERATED
+    )
+
+
+def test_classify_docs() -> None:
+    assert classify_path(Path("docs/architecture.md")) == EnumFileZone.DOCS
+
+
+def test_classify_build() -> None:
+    assert classify_path(Path("scripts/deploy.sh")) == EnumFileZone.BUILD
+
+
+def test_symlink_resolved_before_classification(tmp_path: Path) -> None:
+    target = tmp_path / "src" / "real.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("")
+    link = tmp_path / "link.py"
+    link.symlink_to(target)
+    assert classify_path(link) == EnumFileZone.PRODUCTION


### PR DESCRIPTION
## Summary

- Adds `scripts/zone_diff_filter.py`: classifies all changed files using `zone_classifier`; exits 0 when the diff is docs-only, 1 otherwise. Supports `ZONE_DIFF_FILTER_FAKE_DIFF` env var for testing.
- Wires a new `zone-filter` CI job in `.github/workflows/ci.yml` that gates `test-parallel` and `tests-integration` — both jobs are skipped when the diff is docs-only.
- 5 unit tests in `tests/scripts/test_zone_diff_filter.py` covering all exit codes (0, 1, 2) and mixed/empty diffs.

Stacked on: jonah/omn-10355-zone-classifier (OMN-10355, Task 3). Depends on zone_classifier + EnumFileZone from that branch.

Acceptance criteria from plan (all satisfied):
1. PR touching only `docs/**.md` → `zone_diff_filter --check docs-only` exits 0, test matrix skipped
2. PR touching `src/**.py` → exits 1, full matrix runs
3. Mixed-zone PR (docs + src) → exits 1, full matrix runs
4. `zone_classifier` import only in `scripts/zone_diff_filter.py` (verified by grep)

## Test plan

- [x] `uv run pytest tests/scripts/test_zone_diff_filter.py -v` → 5 passed
- [x] `uv run ruff check scripts/zone_diff_filter.py tests/scripts/test_zone_diff_filter.py` → clean
- [x] `uv run mypy scripts/zone_diff_filter.py --strict` → 0 issues
- [x] `pre-commit run --files ...` → all hooks passed
- [x] `grep -rn "zone_classifier" scripts/ src/` → single occurrence in `scripts/zone_diff_filter.py`

## Ticket

OMN-10356