### PR TITLE
feat(OMN-10364): co-change dark matter filter pipeline

### DIFF
--- a/src/omnibase_core/analysis/co_change_dark_matter.py
+++ b/src/omnibase_core/analysis/co_change_dark_matter.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Filter pipeline for co-change dark matter detection.
+
+Dark matter pairs: files that co-change frequently but have no static import
+relationship — hidden coupling that is architecturally significant precisely
+because it cannot be explained by the import graph.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.analysis.co_change_matrix import CoChangeMatrix, compute_npmi
+from omnibase_core.analysis.import_graph import ImportGraph
+from omnibase_core.types.typed_dict_dark_matter_pair import TypedDictDarkMatterPair
+
+_MIN_CO_CHANGES = 3
+_MIN_NPMI = 0.5
+_TOP_K = 20
+_MIN_COMMITS = 3
+
+
+def find_dark_matter(
+    matrix: CoChangeMatrix,
+    import_graph: ImportGraph,
+) -> list[TypedDictDarkMatterPair]:
+    """Return the top 20 co-change pairs not explained by the import graph.
+
+    Returns an empty list when the matrix has fewer than _MIN_COMMITS commits
+    (insufficient statistical signal).
+    """
+    if matrix.total_commits < _MIN_COMMITS:
+        return []
+
+    total = matrix.total_commits
+    candidates: list[TypedDictDarkMatterPair] = []
+
+    for (a, b), co_count in matrix.pair_count.items():
+        if co_count < _MIN_CO_CHANGES:
+            continue
+
+        p_a = matrix.file_count.get(a, 0) / total
+        p_b = matrix.file_count.get(b, 0) / total
+        p_ab = co_count / total
+
+        # p_ab == 1.0 → every commit contains both files → NPMI = 1.0 by definition;
+        # compute_npmi divides by -log(p_ab) which is 0 at p_ab=1.
+        if p_ab >= 1.0:
+            npmi = 1.0
+        else:
+            npmi = compute_npmi(p_a, p_b, p_ab)
+        if npmi < _MIN_NPMI:
+            continue
+
+        if _has_static_edge(a, b, import_graph):
+            continue
+
+        if _is_test_impl_pair(a, b):
+            continue
+
+        if _same_prefix(a, b):
+            continue
+
+        candidates.append(
+            TypedDictDarkMatterPair(a=a, b=b, npmi=npmi, co_changes=co_count)
+        )
+
+    candidates.sort(key=lambda p: p["npmi"], reverse=True)
+    return candidates[:_TOP_K]
+
+
+def _has_static_edge(a: str, b: str, graph: ImportGraph) -> bool:
+    """True if there is a static import edge in either direction."""
+    a_edges = graph.edges_out.get(a, set())
+    b_edges = graph.edges_out.get(b, set())
+    return b in a_edges or a in b_edges
+
+
+def _is_test_impl_pair(a: str, b: str) -> bool:
+    """True if exactly one of the two paths lives under a test directory."""
+    return _is_test_path(a) != _is_test_path(b)
+
+
+def _is_test_path(path: str) -> bool:
+    parts = Path(path).parts
+    return any(p in ("tests", "test") for p in parts)
+
+
+def _same_prefix(a: str, b: str, segments: int = 3) -> bool:
+    """True if the first `segments` path components are identical."""
+    a_parts = Path(a).parts
+    b_parts = Path(b).parts
+    if len(a_parts) < segments or len(b_parts) < segments:
+        return False
+    return a_parts[:segments] == b_parts[:segments]

--- a/src/omnibase_core/analysis/co_change_matrix.py
+++ b/src/omnibase_core/analysis/co_change_matrix.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+import math
+from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CoChangeMatrix:
+    pair_count: dict[tuple[str, str], int]
+    file_count: dict[str, int]
+    total_commits: int
+
+
+def build_cochange_matrix(commits: list[list[str]]) -> CoChangeMatrix:
+    pair_count: Counter[tuple[str, str]] = Counter()
+    file_count: Counter[str] = Counter()
+    for files in commits:
+        unique = sorted(set(files))
+        for f in unique:
+            file_count[f] += 1
+        for i in range(len(unique)):
+            for j in range(i + 1, len(unique)):
+                pair_count[(unique[i], unique[j])] += 1
+    return CoChangeMatrix(dict(pair_count), dict(file_count), len(commits))
+
+
+def compute_npmi(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_ab <= 0:
+        return -1.0
+    pmi = math.log(p_ab) - math.log(p_a * p_b)
+    npmi = pmi / -math.log(p_ab)
+    return max(-1.0, min(1.0, npmi))
+
+
+def compute_lift(p_a: float, p_b: float, p_ab: float) -> float:
+    if p_a == 0 or p_b == 0:
+        return 0.0
+    return p_ab / (p_a * p_b)

--- a/src/omnibase_core/types/typed_dict_dark_matter_pair.py
+++ b/src/omnibase_core/types/typed_dict_dark_matter_pair.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TypedDict definition for a co-change dark matter pair."""
+
+from typing import TypedDict
+
+
+class TypedDictDarkMatterPair(TypedDict):
+    """A file pair with strong co-change correlation not explained by static imports."""
+
+    a: str
+    b: str
+    npmi: float
+    co_changes: int
+
+
+__all__ = [
+    "TypedDictDarkMatterPair",
+]

--- a/tests/analysis/test_co_change_dark_matter.py
+++ b/tests/analysis/test_co_change_dark_matter.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the co-change dark matter filter pipeline."""
+
+from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
+from omnibase_core.analysis.co_change_matrix import (
+    CoChangeMatrix,
+    build_cochange_matrix,
+)
+from omnibase_core.analysis.import_graph import ImportGraph
+
+
+def _make_matrix(commits: list[list[str]]) -> CoChangeMatrix:
+    return build_cochange_matrix(commits)
+
+
+def _empty_graph() -> ImportGraph:
+    return ImportGraph()
+
+
+def _graph_with_edge(a: str, b: str) -> ImportGraph:
+    g = ImportGraph()
+    g.edges_out[a] = {b}
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: empty when fewer than 3 commits
+# ---------------------------------------------------------------------------
+
+
+class TestInsufficientCommits:
+    def test_zero_commits_returns_empty(self) -> None:
+        matrix = _make_matrix([])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_one_commit_returns_empty(self) -> None:
+        matrix = _make_matrix([["a.py", "b.py"]])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_two_commits_returns_empty(self) -> None:
+        matrix = _make_matrix([["a.py", "b.py"], ["a.py", "b.py"]])
+        result = find_dark_matter(matrix, _empty_graph())
+        assert result == []
+
+    def test_three_commits_passes_threshold(self) -> None:
+        commits = [["a.py", "b.py"]] * 3
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        # May or may not return results depending on other filters, but should not raise
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — < 3 co-changes
+# ---------------------------------------------------------------------------
+
+
+class TestCoChangeCountFilter:
+    def test_pair_with_two_co_changes_excluded(self) -> None:
+        commits = [["a.py", "b.py"], ["a.py", "b.py"]] + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_with_three_co_changes_not_excluded_by_count(self) -> None:
+        # Repeated 3x to pass count filter, 10 more commits for signal
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        # a.py and b.py always co-occur → NPMI = 1.0 ≥ 0.5, passes all filters
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — NPMI < 0.5
+# ---------------------------------------------------------------------------
+
+
+class TestNpmiFilter:
+    def test_low_npmi_pair_excluded(self) -> None:
+        # a.py and b.py co-change 3 times out of 100 commits each → low NPMI
+        commits = [["a.py", "b.py"]] * 3 + [["a.py"]] * 47 + [["b.py"]] * 47
+        # total_commits = 97; file_count: a.py=50, b.py=50; pair=3
+        # p_ab=3/97≈0.031, p_a=50/97≈0.515, p_b=50/97≈0.515
+        # NPMI will be negative → excluded
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — static import edge
+# ---------------------------------------------------------------------------
+
+
+class TestStaticEdgeFilter:
+    def test_pair_with_static_edge_a_imports_b_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("a.py", "b.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_with_static_edge_b_imports_a_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("b.py", "a.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") not in pairs
+
+    def test_pair_without_static_edge_not_excluded(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        graph = _graph_with_edge("c.py", "d.py")
+        result = find_dark_matter(matrix, graph)
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — test↔impl pair
+# ---------------------------------------------------------------------------
+
+
+class TestTestImplFilter:
+    def test_test_impl_pair_excluded(self) -> None:
+        commits = [["tests/test_foo.py", "src/foo.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("src/foo.py", "tests/test_foo.py") not in pairs
+        assert ("tests/test_foo.py", "src/foo.py") not in pairs
+
+    def test_two_test_files_not_excluded_by_test_impl(self) -> None:
+        commits = [["tests/test_foo.py", "tests/test_bar.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("tests/test_bar.py", "tests/test_foo.py") in pairs
+
+    def test_two_src_files_not_excluded_by_test_impl(self) -> None:
+        commits = [["src/foo.py", "src/bar.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("src/bar.py", "src/foo.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: filter — same-prefix pair (first 3 path segments)
+# ---------------------------------------------------------------------------
+
+
+class TestSamePrefixFilter:
+    def test_same_prefix_pair_excluded(self) -> None:
+        commits = [
+            ["src/omnibase_core/models/foo.py", "src/omnibase_core/models/bar.py"]
+        ] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert (
+            "src/omnibase_core/models/foo.py",
+            "src/omnibase_core/models/bar.py",
+        ) not in pairs
+        assert (
+            "src/omnibase_core/models/bar.py",
+            "src/omnibase_core/models/foo.py",
+        ) not in pairs
+
+    def test_different_prefix_pair_not_excluded(self) -> None:
+        commits = [
+            ["src/omnibase_core/models/foo.py", "src/omnibase_core/validation/bar.py"]
+        ] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert (
+            "src/omnibase_core/models/foo.py",
+            "src/omnibase_core/validation/bar.py",
+        ) in pairs
+
+    def test_short_paths_not_same_prefix(self) -> None:
+        # a.py and b.py have fewer than 3 segments → not same-prefix filtered
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        pairs = [(r["a"], r["b"]) for r in result]
+        assert ("a.py", "b.py") in pairs
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: top 20 sorted by NPMI descending
+# ---------------------------------------------------------------------------
+
+
+class TestTopKAndSorting:
+    def test_returns_at_most_20_pairs(self) -> None:
+        # Create 30 unique pairs each co-changing 5 times
+        files = [f"module_{i}/a.py" for i in range(30)]
+        commits: list[list[str]] = []
+        # Each file pair co-changes 5 times
+        for i in range(0, 30, 2):
+            commits.extend([[files[i], files[i + 1]]] * 5)
+        # Add enough non-co-change commits
+        commits.extend([[f"solo_{i}.py"] for i in range(30)])
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        assert len(result) <= 20
+
+    def test_results_sorted_by_npmi_desc(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        npmi_values = [r["npmi"] for r in result]
+        assert npmi_values == sorted(npmi_values, reverse=True)
+
+    def test_result_contains_required_fields(self) -> None:
+        commits = [["a.py", "b.py"]] * 3 + [["c.py"]] * 10
+        matrix = _make_matrix(commits)
+        result = find_dark_matter(matrix, _empty_graph())
+        for item in result:
+            assert {"a", "b", "npmi", "co_changes"} <= set(item.keys())
+            assert isinstance(item["npmi"], float)
+            assert isinstance(item["co_changes"], int)


### PR DESCRIPTION
## Summary

Implements Task 12 of the Selective Swarm Pattern Adoption plan (OMN-10350 epic).

- Adds `find_dark_matter()` in `src/omnibase_core/analysis/co_change_dark_matter.py` with a 5-stage filter pipeline: ≥3 co-changes, NPMI ≥0.5, no static import edge, no test↔impl pair, no same-prefix pair (first 3 path segments)
- Returns top 20 pairs by NPMI descending; empty list when fewer than 3 commits (insufficient signal)
- `TypedDictDarkMatterPair` placed in `types/` per ONEX TypedDict convention
- Also ports `co_change_matrix.py` (Tasks 9+10 from OMN-10362) as a dependency since the NPMI-lift branch is not yet merged into this stack

## Acceptance Criteria

- [x] Returns at most 20 pairs sorted by NPMI descending
- [x] All 5 filters applied: ≥3 co-changes, NPMI ≥0.5, no static edge, no test↔impl, no same-prefix
- [x] Empty when < 3 commits in history

## Test plan

- 19 unit tests covering every filter path (positive + negative), NPMI boundary, insufficient-commit guard, top-K cap, sort order, and field presence
- All pre-commit hooks pass (mypy strict, ruff, ONEX TypedDict convention, pyright)

## Ticket

OMN-10364

## dod_evidence

- check_type: test_pass
- test_count: 19
- command: `PYTHONPATH=src uv run pytest tests/analysis/test_co_change_dark_matter.py -v`
- result: 19 passed