### PR TITLE
feat(OMN-10373): AST diff change classifier with rename detection

### DIFF
--- a/src/omnibase_core/analysis/__init__.py
+++ b/src/omnibase_core/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import re
+
+from omnibase_core.analysis.symbol_extractor import extract_symbols
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+_GUARD_PATTERN = re.compile(
+    r"(?i)(guard|check|validate|verify|ensure|assert|require)",
+)
+
+_KIND_SEVERITY: dict[EnumChangeKind, EnumDiffSeverity] = {
+    EnumChangeKind.GUARD_REMOVED: EnumDiffSeverity.CRITICAL,
+    EnumChangeKind.SIGNATURE_CHANGE: EnumDiffSeverity.HIGH,
+    EnumChangeKind.API_CHANGE: EnumDiffSeverity.HIGH,
+    EnumChangeKind.DELETED_FUNCTION: EnumDiffSeverity.HIGH,
+    EnumChangeKind.LOGIC_CHANGE: EnumDiffSeverity.MEDIUM,
+    EnumChangeKind.REFACTOR: EnumDiffSeverity.MEDIUM,
+    EnumChangeKind.NEW_FUNCTION: EnumDiffSeverity.LOW,
+    EnumChangeKind.COSMETIC: EnumDiffSeverity.LOW,
+}
+
+
+def _line_count(sym: dict) -> int:  # type: ignore[type-arg]
+    return int(sym["end_line"]) - int(sym["start_line"]) + 1
+
+
+def _is_guard(name: str) -> bool:
+    return bool(_GUARD_PATTERN.search(name))
+
+
+def _strip_name(signature: str, name: str) -> str:
+    """Replace the first occurrence of the symbol name in the signature."""
+    return signature.replace(name, "__sym__", 1)
+
+
+def _rename_tolerance(
+    old_sym: dict,  # type: ignore[type-arg]
+    old_name: str,
+    new_sym: dict,  # type: ignore[type-arg]
+    new_name: str,
+) -> bool:
+    """True if name-normalized signatures match AND line counts are within 20%."""
+    old_sig = _strip_name(old_sym["signature"], old_name)
+    new_sig = _strip_name(new_sym["signature"], new_name)
+    if old_sig != new_sig:
+        return False
+    old_lines = _line_count(old_sym)
+    new_lines = _line_count(new_sym)
+    max_lines = max(old_lines, new_lines)
+    if max_lines == 0:
+        return True
+    return abs(old_lines - new_lines) / max_lines <= 0.20
+
+
+def _make_change(
+    kind: EnumChangeKind,
+    name: str,
+    file_path: str,
+    consumers_count: int,
+) -> ModelSymbolChange:
+    return ModelSymbolChange(
+        kind=kind,
+        severity=_KIND_SEVERITY[kind],
+        symbol_name=name,
+        file_path=file_path,
+        consumers_count=consumers_count,
+    )
+
+
+def compute_diff(
+    old_source: str,
+    new_source: str,
+    file_path: str,
+    consumers_count: int,
+) -> ModelSemanticDiffReport:
+    old_symbols = extract_symbols(old_source)
+    new_symbols = extract_symbols(new_source)
+
+    old_names = set(old_symbols)
+    new_names = set(new_symbols)
+
+    changes: list[ModelSymbolChange] = []
+
+    # Same-name symbols: classify by what changed
+    for name in old_names & new_names:
+        old_sym = old_symbols[name]
+        new_sym = new_symbols[name]
+        if old_sym["signature"] != new_sym["signature"]:
+            changes.append(
+                _make_change(
+                    EnumChangeKind.SIGNATURE_CHANGE, name, file_path, consumers_count
+                )
+            )
+        elif old_sym["body_hash"] != new_sym["body_hash"]:
+            changes.append(
+                _make_change(
+                    EnumChangeKind.LOGIC_CHANGE, name, file_path, consumers_count
+                )
+            )
+        # else: unchanged — no entry
+
+    # Removed symbols
+    removed = {name: old_symbols[name] for name in old_names - new_names}
+    # Added symbols
+    added = {name: new_symbols[name] for name in new_names - old_names}
+
+    # Rename detection: pair removed R with added A if signatures match + line tolerance
+    renamed_removed: set[str] = set()
+    renamed_added: set[str] = set()
+    for r_name, r_sym in removed.items():
+        for a_name, a_sym in added.items():
+            if a_name in renamed_added:
+                continue
+            if _rename_tolerance(r_sym, r_name, a_sym, a_name):
+                changes.append(
+                    _make_change(
+                        EnumChangeKind.REFACTOR, a_name, file_path, consumers_count
+                    )
+                )
+                renamed_removed.add(r_name)
+                renamed_added.add(a_name)
+                break
+
+    # Remaining removed symbols
+    for name in removed:
+        if name in renamed_removed:
+            continue
+        kind = (
+            EnumChangeKind.GUARD_REMOVED
+            if _is_guard(name)
+            else EnumChangeKind.DELETED_FUNCTION
+        )
+        changes.append(_make_change(kind, name, file_path, consumers_count))
+
+    # Remaining added symbols
+    for name in added:
+        if name in renamed_added:
+            continue
+        changes.append(
+            _make_change(EnumChangeKind.NEW_FUNCTION, name, file_path, consumers_count)
+        )
+
+    return ModelSemanticDiffReport(
+        changes=tuple(changes),
+        total_consumers_affected=consumers_count,
+    )

--- a/src/omnibase_core/enums/enum_diff_severity.py
+++ b/src/omnibase_core/enums/enum_diff_severity.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""AST diff severity and change-kind enums (OMN-10371)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDiffSeverity(StrEnum):
+    """Risk severity for a code-symbol change detected by AST diff."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class EnumChangeKind(StrEnum):
+    """Classifier for the kind of change made to a symbol."""
+
+    SIGNATURE_CHANGE = "signature_change"
+    API_CHANGE = "api_change"
+    GUARD_REMOVED = "guard_removed"
+    DELETED_FUNCTION = "deleted_function"
+    LOGIC_CHANGE = "logic_change"
+    NEW_FUNCTION = "new_function"
+    REFACTOR = "refactor"
+    COSMETIC = "cosmetic"

--- a/src/omnibase_core/models/analysis/__init__.py
+++ b/src/omnibase_core/models/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/models/analysis/model_semantic_diff_report.py
+++ b/src/omnibase_core/models/analysis/model_semantic_diff_report.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelSemanticDiffReport — aggregate result of an AST semantic diff (OMN-10371)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+
+class ModelSemanticDiffReport(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    changes: tuple[ModelSymbolChange, ...]
+    total_consumers_affected: int

--- a/src/omnibase_core/models/analysis/model_symbol_change.py
+++ b/src/omnibase_core/models/analysis/model_symbol_change.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelSymbolChange — a single symbol-level change in an AST diff (OMN-10371)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+
+
+class ModelSymbolChange(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: EnumChangeKind
+    severity: EnumDiffSeverity
+    symbol_name: str
+    file_path: str
+    consumers_count: int

--- a/tests/analysis/__init__.py
+++ b/tests/analysis/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for omnibase_core.analysis modules."""
+
+__all__: list[str] = []

--- a/tests/analysis/test_semantic_diff_classifier.py
+++ b/tests/analysis/test_semantic_diff_classifier.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from omnibase_core.analysis.semantic_diff import compute_diff
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+
+
+def _kinds(report: ModelSemanticDiffReport) -> list[str]:
+    return [c.kind for c in report.changes]
+
+
+def _by_name(report: ModelSemanticDiffReport, name: str):
+    return next((c for c in report.changes if c.symbol_name == name), None)
+
+
+# --- new function ---
+
+
+def test_new_function_detected():
+    old = ""
+    new = "def foo(x): return x\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.NEW_FUNCTION in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.LOW
+
+
+# --- deleted function ---
+
+
+def test_deleted_function_detected():
+    old = "def foo(x): return x\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.DELETED_FUNCTION in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.HIGH
+
+
+# --- signature change ---
+
+
+def test_signature_change_detected():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.SIGNATURE_CHANGE in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.HIGH
+
+
+# --- logic change (body differs, signature same) ---
+
+
+def test_logic_change_detected():
+    old = "def foo(x):\n    return x\n"
+    new = "def foo(x):\n    return x * 2\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert EnumChangeKind.LOGIC_CHANGE in _kinds(report)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.severity == EnumDiffSeverity.MEDIUM
+
+
+# --- no change (same body + signature) ---
+
+
+def test_no_change_produces_no_entry():
+    src = "def foo(x):\n    return x\n"
+    report = compute_diff(src, src, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "foo") is None
+
+
+# --- guard_removed: name matches guard pattern ---
+
+
+def test_guard_removed_on_guard_name():
+    old = "def validate_token(token):\n    if not token: raise ValueError\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "validate_token")
+    assert change is not None
+    assert change.kind == EnumChangeKind.GUARD_REMOVED
+    assert change.severity == EnumDiffSeverity.CRITICAL
+
+
+def test_guard_removed_check_prefix():
+    old = "def check_permissions(user):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "check_permissions")
+    assert change is not None
+    assert change.kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_guard_removed_ensure_prefix():
+    old = "def ensure_authenticated(req):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "ensure_authenticated").kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_guard_removed_assert_prefix():
+    old = "def assert_invariant(x):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert _by_name(report, "assert_invariant").kind == EnumChangeKind.GUARD_REMOVED
+
+
+def test_non_guard_delete_is_deleted_function_not_guard():
+    old = "def process_data(x):\n    pass\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    change = _by_name(report, "process_data")
+    assert change.kind == EnumChangeKind.DELETED_FUNCTION
+
+
+# --- rename detection ---
+
+
+def test_rename_detected_same_signature_similar_line_count():
+    # Same signature and body (just name changes) — should pair as rename
+    old = "def foo(x):\n    return x\n"
+    new = "def bar(x):\n    return x\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    # foo is removed, bar is added — should be merged as a rename (refactor)
+    change = _by_name(report, "bar")
+    assert change is not None
+    assert change.kind == EnumChangeKind.REFACTOR
+
+
+def test_rename_not_detected_when_line_count_diverges_too_much():
+    # bar has very different body size — no rename, should be separate add/delete
+    old = "def foo(x):\n    return x\n"
+    new = (
+        "def bar(x):\n"
+        "    y = x * 2\n"
+        "    z = y + 1\n"
+        "    w = z - 3\n"
+        "    v = w / 2\n"
+        "    return v\n"
+    )
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    # foo should be a delete, bar should be a new function (not rename)
+    foo_change = _by_name(report, "foo")
+    bar_change = _by_name(report, "bar")
+    assert foo_change is not None
+    assert bar_change is not None
+    assert bar_change.kind == EnumChangeKind.NEW_FUNCTION
+
+
+# --- consumers_count is carried through ---
+
+
+def test_consumers_count_on_deleted():
+    old = "def foo(x): return x\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=5)
+    change = _by_name(report, "foo")
+    assert change is not None
+    assert change.consumers_count == 5
+
+
+def test_total_consumers_affected():
+    old = "def foo(x): return x\ndef bar(y): return y\n"
+    new = ""
+    report = compute_diff(old, new, file_path="x.py", consumers_count=3)
+    assert report.total_consumers_affected == 3
+
+
+# --- return type is correct ---
+
+
+def test_returns_model_semantic_diff_report():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="x.py", consumers_count=0)
+    assert isinstance(report, ModelSemanticDiffReport)
+    assert isinstance(report.changes, tuple)
+
+
+# --- file_path is propagated ---
+
+
+def test_file_path_in_changes():
+    old = "def foo(x): return x\n"
+    new = "def foo(x, y): return x + y\n"
+    report = compute_diff(old, new, file_path="src/foo.py", consumers_count=0)
+    for change in report.changes:
+        assert change.file_path == "src/foo.py"

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for omnibase_core.models modules."""
+
+__all__: list[str] = []

--- a/tests/models/analysis/__init__.py
+++ b/tests/models/analysis/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for EnumDiffSeverity, EnumChangeKind, ModelSymbolChange, ModelSemanticDiffReport."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+
+def test_enum_diff_severity_members() -> None:
+    assert {v.value for v in EnumDiffSeverity} == {"critical", "high", "medium", "low"}
+
+
+def test_enum_diff_severity_is_str() -> None:
+    assert isinstance(EnumDiffSeverity.CRITICAL, str)
+    assert EnumDiffSeverity.CRITICAL.value == "critical"
+
+
+def test_enum_change_kind_members() -> None:
+    expected = {
+        "signature_change",
+        "api_change",
+        "guard_removed",
+        "deleted_function",
+        "logic_change",
+        "new_function",
+        "refactor",
+        "cosmetic",
+    }
+    assert {v.value for v in EnumChangeKind} == expected
+
+
+def test_enum_change_kind_is_str() -> None:
+    assert isinstance(EnumChangeKind.SIGNATURE_CHANGE, str)
+
+
+def test_model_symbol_change_frozen() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.SIGNATURE_CHANGE,
+        severity=EnumDiffSeverity.HIGH,
+        symbol_name="my_func",
+        file_path="src/foo.py",
+        consumers_count=3,
+    )
+    with pytest.raises(Exception):
+        sc.symbol_name = "other"  # type: ignore[misc]
+
+
+def test_model_symbol_change_fields() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.GUARD_REMOVED,
+        severity=EnumDiffSeverity.CRITICAL,
+        symbol_name="validate_token",
+        file_path="src/auth.py",
+        consumers_count=10,
+    )
+    assert sc.kind == EnumChangeKind.GUARD_REMOVED
+    assert sc.severity == EnumDiffSeverity.CRITICAL
+    assert sc.symbol_name == "validate_token"
+    assert sc.file_path == "src/auth.py"
+    assert sc.consumers_count == 10
+
+
+def test_model_semantic_diff_report_frozen() -> None:
+    sc = ModelSymbolChange(
+        kind=EnumChangeKind.NEW_FUNCTION,
+        severity=EnumDiffSeverity.LOW,
+        symbol_name="helper",
+        file_path="src/utils.py",
+        consumers_count=0,
+    )
+    report = ModelSemanticDiffReport(changes=(sc,), total_consumers_affected=0)
+    with pytest.raises(Exception):
+        report.total_consumers_affected = 5  # type: ignore[misc]
+
+
+def test_model_semantic_diff_report_fields() -> None:
+    sc1 = ModelSymbolChange(
+        kind=EnumChangeKind.LOGIC_CHANGE,
+        severity=EnumDiffSeverity.MEDIUM,
+        symbol_name="process",
+        file_path="src/core.py",
+        consumers_count=2,
+    )
+    sc2 = ModelSymbolChange(
+        kind=EnumChangeKind.DELETED_FUNCTION,
+        severity=EnumDiffSeverity.HIGH,
+        symbol_name="old_handler",
+        file_path="src/core.py",
+        consumers_count=5,
+    )
+    report = ModelSemanticDiffReport(changes=(sc1, sc2), total_consumers_affected=7)
+    assert len(report.changes) == 2
+    assert report.total_consumers_affected == 7
+    assert report.changes[0].symbol_name == "process"
+
+
+def test_model_semantic_diff_report_empty_changes() -> None:
+    report = ModelSemanticDiffReport(changes=(), total_consumers_affected=0)
+    assert report.changes == ()
+    assert report.total_consumers_affected == 0


### PR DESCRIPTION
## Summary

- Implements `compute_diff()` in `src/omnibase_core/analysis/semantic_diff.py` (Task 21 of OMN-10350 epic)
- Classifies same-name symbol changes as `signature_change` (HIGH) or `logic_change` (MEDIUM)
- Rename detection: pairs removed/added symbols when name-normalized signatures match and line-count ratio ≤ 20% (emits `refactor`)
- `guard_removed` (CRITICAL) fires when a deleted symbol name matches `guard|check|validate|verify|ensure|assert|require`
- New functions → LOW; deleted non-guard → HIGH
- 16 unit tests covering all classification paths, guard patterns, rename detection, and boundary conditions

## Ticket

OMN-10373

## dod_evidence

- type: test_pass
- command: `PYTHONPATH=src uv run pytest tests/analysis/test_semantic_diff_classifier.py -v`
- result: 16 passed, 0 failed
- type: lint_pass
- command: `uv run ruff check src/omnibase_core/analysis/semantic_diff.py tests/analysis/test_semantic_diff_classifier.py`
- result: All checks passed
- type: type_check_pass
- command: `PYTHONPATH=src uv run mypy src/omnibase_core/analysis/semantic_diff.py --strict`
- result: Success, no issues found
- type: precommit_pass
- result: All hooks passed on commit

## Base branch

Stacked on `jonah/omn-10372-ast-diff-symbol-extractor` (Task 20 — tree-sitter symbol extractor) and merges in `jonah/omn-10371-enum-diff-severity` (Task 19 — EnumDiffSeverity models).