### PR TITLE
feat(OMN-10375): AST semantic diff CLI + PR risk labeler

### DIFF
--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -1,0 +1,86 @@
+name: Semantic Diff Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    name: AST Risk Labeler
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run semantic diff
+        id: diff
+        run: |
+          uv run python scripts/analysis/semantic_diff.py \
+            --base origin/${{ github.base_ref }} \
+            --head HEAD \
+            --json > /tmp/semantic_diff_report.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Apply risk labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('/tmp/semantic_diff_report.json', 'utf8'));
+            const changes = report.changes || [];
+
+            const severities = new Set(changes.map(c => c.severity));
+            const existingLabels = context.payload.pull_request.labels.map(l => l.name);
+
+            const riskLabels = ['risk:critical', 'risk:high'];
+
+            // Remove stale risk labels before applying fresh ones
+            for (const label of existingLabels) {
+              if (riskLabels.includes(label)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label,
+                }).catch(() => {});
+              }
+            }
+
+            // Apply new labels based on highest severity found
+            if (severities.has('critical')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['risk:critical'],
+              });
+              core.summary.addRaw('Applied label: **risk:critical**');
+            } else if (severities.has('high')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['risk:high'],
+              });
+              core.summary.addRaw('Applied label: **risk:high**');
+            } else {
+              core.summary.addRaw('No risk label applied (medium/low changes only).');
+            }
+
+            await core.summary.write();

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CLI: compute AST-level semantic diff between two git refs (OMN-10375).
+
+Usage:
+    python scripts/analysis/semantic_diff.py --base origin/main --head HEAD --json
+
+Exits 0 always — changes are advisory. Gating is opt-in via separate workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from omnibase_core.analysis.consumer_graph import build_consumer_graph
+from omnibase_core.analysis.semantic_diff import compute_diff
+from omnibase_core.models.analysis.model_semantic_diff_report import (
+    ModelSemanticDiffReport,
+)
+from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
+
+
+def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACM",
+            f"{base}...{head}",
+            "--",
+            "*.py",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def _git_file_at(ref: str, rel_path: str, repo_root: Path) -> str:
+    """Return file content at given ref, empty string if not present."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{rel_path}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _compute_report(base: str, head: str, repo_root: Path) -> ModelSemanticDiffReport:
+    consumer_graph = build_consumer_graph(repo_root)
+    changed_files = _git_changed_py_files(base, head, repo_root)
+
+    all_changes: list[ModelSymbolChange] = []
+    total_consumers = 0
+
+    for file_path in changed_files:
+        rel = file_path.relative_to(repo_root).as_posix()
+        old_source = _git_file_at(base, rel, repo_root)
+        new_source = _git_file_at(head, rel, repo_root)
+        consumers = consumer_graph.get(rel, 0)
+        report = compute_diff(old_source, new_source, rel, consumers)
+        all_changes.extend(report.changes)
+        total_consumers += consumers
+
+    return ModelSemanticDiffReport(
+        changes=tuple(all_changes),
+        total_consumers_affected=total_consumers,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="AST semantic diff between two git refs"
+    )
+    parser.add_argument("--base", required=True, help="Base git ref (e.g. origin/main)")
+    parser.add_argument("--head", required=True, help="Head git ref (e.g. HEAD)")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit JSON report to stdout"
+    )
+    args = parser.parse_args()
+
+    report = _compute_report(args.base, args.head, _REPO_ROOT)
+
+    if args.json:
+        print(json.dumps(report.model_dump(), indent=2))  # noqa: T201
+    elif not report.changes:
+        print("No semantic changes detected.")  # noqa: T201
+    else:
+        for change in report.changes:
+            print(  # noqa: T201
+                f"[{change.severity.upper()}] {change.kind}: {change.symbol_name} ({change.file_path})"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -29,7 +29,56 @@ from omnibase_core.models.analysis.model_semantic_diff_report import (
 from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
 
 
+def _git_ref_exists(ref: str, repo_root: Path) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _ensure_ref_available(ref: str, repo_root: Path) -> bool:
+    if _git_ref_exists(ref, repo_root):
+        return True
+
+    if ref.startswith("origin/"):
+        branch = ref.removeprefix("origin/")
+        subprocess.run(
+            [
+                "git",
+                "fetch",
+                "--depth=1",
+                "origin",
+                f"refs/heads/{branch}:refs/remotes/origin/{branch}",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    return _git_ref_exists(ref, repo_root)
+
+
 def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
+    if not _ensure_ref_available(base, repo_root):
+        print(  # noqa: T201
+            f"warning: base ref {base!r} is unavailable; emitting empty advisory report",
+            file=sys.stderr,
+        )
+        return []
+    if not _ensure_ref_available(head, repo_root):
+        print(  # noqa: T201
+            f"warning: head ref {head!r} is unavailable; emitting empty advisory report",
+            file=sys.stderr,
+        )
+        return []
+
     result = subprocess.run(
         [
             "git",
@@ -43,8 +92,15 @@ def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    if result.returncode != 0:
+        print(  # noqa: T201
+            "warning: git diff failed for "
+            f"{base!r}...{head!r}: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return []
     return [repo_root / line for line in result.stdout.splitlines() if line]
 
 

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -6,7 +6,8 @@
 Usage:
     python scripts/analysis/semantic_diff.py --base origin/main --head HEAD --json
 
-Exits 0 always — changes are advisory. Gating is opt-in via separate workflows.
+Exits 0 on completed analysis; argparse usage errors still exit non-zero.
+Detected changes are advisory. Gating is opt-in via separate workflows.
 """
 
 from __future__ import annotations
@@ -84,7 +85,7 @@ def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
             "git",
             "diff",
             "--name-only",
-            "--diff-filter=ACM",
+            "--diff-filter=ACMDR",
             f"{base}...{head}",
             "--",
             "*.py",
@@ -133,7 +134,8 @@ def _compute_report(base: str, head: str, repo_root: Path) -> ModelSemanticDiffR
         consumers = consumer_graph.get(rel, 0)
         report = compute_diff(old_source, new_source, rel, consumers)
         all_changes.extend(report.changes)
-        total_consumers += consumers
+        if report.changes:
+            total_consumers += consumers
 
     return ModelSemanticDiffReport(
         changes=tuple(all_changes),

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -39,6 +39,8 @@ test_infrastructure_paths:
 # Note: shared_modules entries here are not consulted at runtime
 # (they trigger full suite first), but kept for completeness/documentation.
 adjacency:
+  analysis:
+    reverse_deps: []
   models:
     reverse_deps: [analysis, nodes, contracts, runtime, validation, services, factories, container]
   contracts:

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -18,6 +18,10 @@ class ImportGraph:
     edges_out: dict[str, set[str]] = field(default_factory=dict)
 
 
+def _to_repo_rel(path: Path, repo_root: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
 def build_import_graph(repo_root: Path) -> ImportGraph:
     """Build a static import graph for Python and JS/TS files under repo_root."""
     graph = ImportGraph()
@@ -36,13 +40,13 @@ def build_import_graph(repo_root: Path) -> ImportGraph:
             js_files.append(path)
 
     for path in py_files:
-        rel = str(path.relative_to(repo_root))
+        rel = _to_repo_rel(path, repo_root)
         edges = _parse_python_imports(path, repo_root, python_search_roots)
         if edges:
             graph.edges_out[rel] = edges
 
     for path in js_files:
-        rel = str(path.relative_to(repo_root))
+        rel = _to_repo_rel(path, repo_root)
         edges = _parse_js_imports(path, repo_root)
         if edges:
             graph.edges_out[rel] = edges
@@ -77,7 +81,7 @@ def _parse_python_imports(
                 )
 
     edges: set[str] = set()
-    src_rel = str(path.relative_to(repo_root))
+    src_rel = _to_repo_rel(path, repo_root)
 
     for module_name in imports:
         resolved = _resolve_python_module(module_name, repo_root, search_roots)
@@ -149,11 +153,11 @@ def _resolve_python_module(
         # Try as package (directory with __init__.py)
         pkg_path = search_root / candidate_rel / "__init__.py"
         if pkg_path.is_file():
-            return str(pkg_path.relative_to(repo_root))
+            return _to_repo_rel(pkg_path, repo_root)
         # Try as module file
         mod_path = search_root / candidate_rel.with_suffix(".py")
         if mod_path.is_file():
-            return str(mod_path.relative_to(repo_root))
+            return _to_repo_rel(mod_path, repo_root)
 
     return None
 
@@ -165,7 +169,7 @@ def _parse_js_imports(path: Path, repo_root: Path) -> set[str]:
     except OSError:
         return set()
 
-    src_rel = str(path.relative_to(repo_root))
+    src_rel = _to_repo_rel(path, repo_root)
     edges: set[str] = set()
 
     source = _strip_js_comments(source)
@@ -408,7 +412,7 @@ def _resolve_js_specifier(
     for attempt in attempts:
         if attempt.is_file():
             try:
-                return str(attempt.relative_to(repo_root))
+                return _to_repo_rel(attempt, repo_root)
             except ValueError:
                 return None
 

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import re
+from difflib import SequenceMatcher
 
 from omnibase_core.analysis.symbol_extractor import extract_symbols
 from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
@@ -46,10 +47,14 @@ def _rename_tolerance(
     new_sym: TypedDictSymbolMetadata,
     new_name: str,
 ) -> bool:
-    """True if name-normalized signatures match AND line counts are within 20%."""
+    """True when a delete/add pair is similar enough to classify as a refactor."""
     old_sig = _strip_name(old_sym["signature"], old_name)
     new_sig = _strip_name(new_sym["signature"], new_name)
     if old_sig != new_sig:
+        return False
+    if old_sym["kind"] != new_sym["kind"]:
+        return False
+    if SequenceMatcher(None, old_name, new_name).ratio() < 0.6:
         return False
     old_lines = _line_count(old_sym)
     new_lines = _line_count(new_sym)
@@ -124,8 +129,8 @@ def compute_diff(
     # Rename detection: pair removed R with added A if signatures match + line tolerance
     renamed_removed: set[str] = set()
     renamed_added: set[str] = set()
-    for r_name, r_sym in removed.items():
-        for a_name, a_sym in added.items():
+    for r_name, r_sym in sorted(removed.items()):
+        for a_name, a_sym in sorted(added.items()):
             if a_name in renamed_added:
                 continue
             if _rename_tolerance(r_sym, r_name, a_sym, a_name):
@@ -159,5 +164,5 @@ def compute_diff(
 
     return ModelSemanticDiffReport(
         changes=tuple(changes),
-        total_consumers_affected=consumers_count,
+        total_consumers_affected=consumers_count if changes else 0,
     )

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -3,6 +3,7 @@
 
 import re
 from difflib import SequenceMatcher
+from typing import cast
 
 from omnibase_core.analysis.symbol_extractor import extract_symbols
 from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
@@ -10,7 +11,7 @@ from omnibase_core.models.analysis.model_semantic_diff_report import (
     ModelSemanticDiffReport,
 )
 from omnibase_core.models.analysis.model_symbol_change import ModelSymbolChange
-from omnibase_core.types.typed_dict_symbol_metadata import TypedDictSymbolMetadata
+from omnibase_core.types.typed_dict_extracted_symbol import TypedDictExtractedSymbol
 
 _GUARD_PATTERN = re.compile(
     r"(?i)(guard|check|validate|verify|ensure|assert|require)",
@@ -28,7 +29,7 @@ _KIND_SEVERITY: dict[EnumChangeKind, EnumDiffSeverity] = {
 }
 
 
-def _line_count(sym: TypedDictSymbolMetadata) -> int:
+def _line_count(sym: TypedDictExtractedSymbol) -> int:
     return sym["end_line"] - sym["start_line"] + 1
 
 
@@ -42,12 +43,11 @@ def _strip_name(signature: str, name: str) -> str:
 
 
 def _rename_tolerance(
-    old_sym: TypedDictSymbolMetadata,
-    old_name: str,
-    new_sym: TypedDictSymbolMetadata,
-    new_name: str,
+    old_sym: TypedDictExtractedSymbol, new_sym: TypedDictExtractedSymbol
 ) -> bool:
     """True when a delete/add pair is similar enough to classify as a refactor."""
+    old_name = old_sym.get("name", "")
+    new_name = new_sym.get("name", "")
     old_sig = _strip_name(old_sym["signature"], old_name)
     new_sig = _strip_name(new_sym["signature"], new_name)
     if old_sig != new_sig:
@@ -62,6 +62,19 @@ def _rename_tolerance(
     if max_lines == 0:
         return True
     return abs(old_lines - new_lines) / max_lines <= 0.20
+
+
+def _symbol_with_name(
+    sym: TypedDictExtractedSymbol, name: str
+) -> TypedDictExtractedSymbol:
+    return {
+        "kind": sym["kind"],
+        "signature": sym["signature"],
+        "body_hash": sym["body_hash"],
+        "start_line": sym["start_line"],
+        "end_line": sym["end_line"],
+        "name": name,
+    }
 
 
 def _make_change(
@@ -95,8 +108,14 @@ def compute_diff(
             "consumers_count must be greater than or equal to 0",
         )
 
-    old_symbols = extract_symbols(old_source)
-    new_symbols = extract_symbols(new_source)
+    old_symbols = {
+        name: cast(TypedDictExtractedSymbol, symbol)
+        for name, symbol in extract_symbols(old_source).items()
+    }
+    new_symbols = {
+        name: cast(TypedDictExtractedSymbol, symbol)
+        for name, symbol in extract_symbols(new_source).items()
+    }
 
     old_names = set(old_symbols)
     new_names = set(new_symbols)
@@ -104,7 +123,7 @@ def compute_diff(
     changes: list[ModelSymbolChange] = []
 
     # Same-name symbols: classify by what changed
-    for name in old_names & new_names:
+    for name in sorted(old_names & new_names):
         old_sym = old_symbols[name]
         new_sym = new_symbols[name]
         if old_sym["signature"] != new_sym["signature"]:
@@ -130,10 +149,12 @@ def compute_diff(
     renamed_removed: set[str] = set()
     renamed_added: set[str] = set()
     for r_name, r_sym in sorted(removed.items()):
+        r_sym = _symbol_with_name(r_sym, r_name)
         for a_name, a_sym in sorted(added.items()):
             if a_name in renamed_added:
                 continue
-            if _rename_tolerance(r_sym, r_name, a_sym, a_name):
+            a_sym = _symbol_with_name(a_sym, a_name)
+            if _rename_tolerance(r_sym, a_sym):
                 changes.append(
                     _make_change(
                         EnumChangeKind.REFACTOR, a_name, file_path, consumers_count
@@ -144,7 +165,7 @@ def compute_diff(
                 break
 
     # Remaining removed symbols
-    for name in removed:
+    for name in sorted(removed):
         if name in renamed_removed:
             continue
         kind = (
@@ -155,7 +176,7 @@ def compute_diff(
         changes.append(_make_change(kind, name, file_path, consumers_count))
 
     # Remaining added symbols
-    for name in added:
+    for name in sorted(added):
         if name in renamed_added:
             continue
         changes.append(

--- a/src/omnibase_core/analysis/semantic_diff.py
+++ b/src/omnibase_core/analysis/semantic_diff.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import re
-from difflib import SequenceMatcher
 from typing import cast
 
 from omnibase_core.analysis.symbol_extractor import extract_symbols
@@ -16,6 +15,7 @@ from omnibase_core.types.typed_dict_extracted_symbol import TypedDictExtractedSy
 _GUARD_PATTERN = re.compile(
     r"(?i)(guard|check|validate|verify|ensure|assert|require)",
 )
+_NAME_TOKEN_PATTERN = re.compile(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)|\d+")
 
 _KIND_SEVERITY: dict[EnumChangeKind, EnumDiffSeverity] = {
     EnumChangeKind.GUARD_REMOVED: EnumDiffSeverity.CRITICAL,
@@ -42,19 +42,35 @@ def _strip_name(signature: str, name: str) -> str:
     return signature.replace(name, "__sym__", 1)
 
 
+def _name_tokens(name: str) -> set[str]:
+    return {
+        token.lower()
+        for part in name.replace(".", "_").split("_")
+        for token in _NAME_TOKEN_PATTERN.findall(part)
+        if len(token) >= 3
+    }
+
+
+def _has_shared_name_context(old_name: str, new_name: str) -> bool:
+    return bool(_name_tokens(old_name) & _name_tokens(new_name))
+
+
 def _rename_tolerance(
     old_sym: TypedDictExtractedSymbol, new_sym: TypedDictExtractedSymbol
 ) -> bool:
-    """True when a delete/add pair is similar enough to classify as a refactor."""
+    """True if symbols look like the same implementation renamed in place."""
     old_name = old_sym.get("name", "")
     new_name = new_sym.get("name", "")
+    if old_sym["kind"] != new_sym["kind"]:
+        return False
+    if not _has_shared_name_context(old_name, new_name):
+        return False
+
     old_sig = _strip_name(old_sym["signature"], old_name)
     new_sig = _strip_name(new_sym["signature"], new_name)
     if old_sig != new_sig:
         return False
-    if old_sym["kind"] != new_sym["kind"]:
-        return False
-    if SequenceMatcher(None, old_name, new_name).ratio() < 0.6:
+    if old_sym["body_hash"] != new_sym["body_hash"]:
         return False
     old_lines = _line_count(old_sym)
     new_lines = _line_count(new_sym)

--- a/src/omnibase_core/analysis/symbol_extractor.py
+++ b/src/omnibase_core/analysis/symbol_extractor.py
@@ -43,7 +43,7 @@ def _extract_signature_and_body(node: Node, source_lines: list[str]) -> tuple[st
             signature_source = sig_line[: block.start_point[1]]
             body_source = sig_line[block.start_point[1] :]
     else:
-        signature_source = sig_line.rstrip("\n")
+        signature_source = "".join(source_lines[node.start_point[0] : body_start])
         body_source = "".join(source_lines[body_start : body_end + 1])
 
     signature = _collapse_whitespace(signature_source.rstrip("\n"))
@@ -54,12 +54,14 @@ def _node_text(node: Node) -> str:
     return node.text.decode() if node.text else ""
 
 
-def _definition_node(node: Node) -> Node:
+def _unwrap_decorated_definition(node: Node) -> Node:
     if node.type != "decorated_definition":
         return node
-
-    for child in node.children:
-        if child.type in {"class_definition", "function_definition"}:
+    definition = node.child_by_field_name("definition")
+    if definition is not None:
+        return definition
+    for child in reversed(node.children):
+        if child.type in {"function_definition", "class_definition"}:
             return child
     return node
 
@@ -113,9 +115,9 @@ def _process_class(
         return
     block = block_nodes[0]
     for child in block.children:
-        definition = _definition_node(child)
-        if definition.type == "function_definition":
-            _process_function(definition, source_lines, result, class_name=class_name)
+        child = _unwrap_decorated_definition(child)
+        if child.type == "function_definition":
+            _process_function(child, source_lines, result, class_name=class_name)
 
 
 def extract_symbols(content: str) -> SymbolTable:
@@ -130,10 +132,10 @@ def extract_symbols(content: str) -> SymbolTable:
 
     result: SymbolTable = {}
     for node in root.children:
-        definition = _definition_node(node)
-        if definition.type == "function_definition":
-            _process_function(definition, source_lines, result)
-        elif definition.type == "class_definition":
-            _process_class(definition, source_lines, result)
+        node = _unwrap_decorated_definition(node)
+        if node.type == "function_definition":
+            _process_function(node, source_lines, result)
+        elif node.type == "class_definition":
+            _process_class(node, source_lines, result)
 
     return result

--- a/src/omnibase_core/types/typed_dict_extracted_symbol.py
+++ b/src/omnibase_core/types/typed_dict_extracted_symbol.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from typing import NotRequired, TypedDict
+
+
+class TypedDictExtractedSymbol(TypedDict):
+    kind: str
+    signature: str
+    body_hash: str
+    start_line: int
+    end_line: int
+    name: NotRequired[str]

--- a/tests/analysis/test_semantic_diff_classifier.py
+++ b/tests/analysis/test_semantic_diff_classifier.py
@@ -139,12 +139,11 @@ def test_non_guard_delete_is_deleted_function_not_guard():
 
 
 def test_rename_detected_same_signature_similar_line_count():
-    # Same signature and body (just name changes) — should pair as rename
-    old = "def foo(x):\n    return x\n"
-    new = "def bar(x):\n    return x\n"
+    # Same signature, body, and symbol context should pair as rename.
+    old = "def fetch_user(x):\n    return x\n"
+    new = "def load_user(x):\n    return x\n"
     report = compute_diff(old, new, file_path="x.py", consumers_count=0)
-    # foo is removed, bar is added — should be merged as a rename (refactor)
-    change = _by_name(report, "bar")
+    change = _by_name(report, "load_user")
     assert change is not None
     assert change.kind == EnumChangeKind.REFACTOR
 

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = pytest.mark.unit
-
 from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
 from omnibase_core.models.analysis.model_semantic_diff_report import (
     ModelSemanticDiffReport,

--- a/tests/models/analysis/test_semantic_diff_models.py
+++ b/tests/models/analysis/test_semantic_diff_models.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from omnibase_core.enums.enum_diff_severity import EnumChangeKind, EnumDiffSeverity
 from omnibase_core.models.analysis.model_semantic_diff_report import (
     ModelSemanticDiffReport,

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -97,6 +97,18 @@ def test_cli_missing_required_args_exits_nonzero() -> None:
 
 
 @pytest.mark.unit
+def test_cli_unavailable_base_ref_emits_empty_advisory_report() -> None:
+    """CLI stays advisory when a shallow checkout lacks the requested base ref."""
+    result = _run_cli(
+        "--base", "refs/heads/omn-missing-base", "--head", "HEAD", "--json"
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "base ref" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {"changes": [], "total_consumers_affected": 0}
+
+
+@pytest.mark.unit
 def test_cli_json_change_fields() -> None:
     """Each change entry has the required fields."""
     result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/analysis/semantic_diff.py CLI (OMN-10375)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "scripts" / "analysis" / "semantic_diff.py"
+
+# Ensure the worktree src takes precedence when running subprocess CLI calls.
+# The editable .pth install may resolve to the canonical clone if it appears
+# earlier on sys.path, which lacks not-yet-merged subpackages from stacked branches.
+_WORKTREE_SRC = str(REPO_ROOT / "src")
+_SUBPROCESS_ENV = {
+    **os.environ,
+    "PYTHONPATH": _WORKTREE_SRC + os.pathsep + os.environ.get("PYTHONPATH", ""),
+}
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: PLW1510
+        [sys.executable, str(CLI), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=_SUBPROCESS_ENV,
+    )
+
+
+@pytest.mark.unit
+def test_cli_exits_0_with_json_flag() -> None:
+    """CLI exits 0 even when critical changes are detected (advisory mode)."""
+    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+
+@pytest.mark.unit
+def test_cli_json_output_validates_against_model() -> None:
+    """JSON output validates against ModelSemanticDiffReport via a subprocess round-trip."""
+    # Validate via subprocess so the worktree src path takes precedence cleanly.
+    # In-process import resolves to the editable-installed canonical clone which
+    # lacks not-yet-merged subpackages from stacked branches.
+    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
+        f.write(result.stdout)
+        tmp_path = f.name
+
+    validate_script = (
+        "import sys, json;"
+        f"sys.path.insert(0, {_WORKTREE_SRC!r});"
+        "from omnibase_core.models.analysis.model_semantic_diff_report import ModelSemanticDiffReport;"
+        f"data = json.load(open({tmp_path!r}));"
+        "r = ModelSemanticDiffReport.model_validate(data);"
+        "assert isinstance(r.changes, tuple);"
+        "assert isinstance(r.total_consumers_affected, int);"
+        "print('ok')"
+    )
+    val_result = subprocess.run(  # noqa: PLW1510
+        [sys.executable, "-c", validate_script],
+        capture_output=True,
+        text=True,
+        env=_SUBPROCESS_ENV,
+    )
+    Path(tmp_path).unlink(missing_ok=True)
+    assert val_result.returncode == 0, f"Validation failed: {val_result.stderr}"
+    assert val_result.stdout.strip() == "ok"
+
+
+@pytest.mark.unit
+def test_cli_json_has_required_fields() -> None:
+    """JSON output has changes list and total_consumers_affected."""
+    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    payload = json.loads(result.stdout)
+    assert "changes" in payload
+    assert "total_consumers_affected" in payload
+    assert isinstance(payload["changes"], list)
+    assert isinstance(payload["total_consumers_affected"], int)
+
+
+@pytest.mark.unit
+def test_cli_missing_required_args_exits_nonzero() -> None:
+    """CLI exits non-zero when required --base / --head args are absent."""
+    result = _run_cli("--json")
+    assert result.returncode != 0
+
+
+@pytest.mark.unit
+def test_cli_json_change_fields() -> None:
+    """Each change entry has the required fields."""
+    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    for change in payload["changes"]:
+        assert "kind" in change
+        assert "severity" in change
+        assert "symbol_name" in change
+        assert "file_path" in change
+        assert "consumers_count" in change

--- a/tests/unit/analysis/test_import_graph.py
+++ b/tests/unit/analysis/test_import_graph.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.analysis.import_graph import build_import_graph
+
+
+@pytest.mark.unit
+def test_build_import_graph_resolves_relative_imports(tmp_path):
+    package = tmp_path / "src" / "pkg"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (package / "sub.py").write_text("from . import helpers\n", encoding="utf-8")
+
+    graph = build_import_graph(tmp_path)
+
+    assert graph.edges_out["src/pkg/sub.py"] == {"src/pkg/helpers.py"}
+
+
+@pytest.mark.unit
+def test_build_import_graph_resolves_parent_relative_imports(tmp_path):
+    package = tmp_path / "src" / "pkg"
+    child = package / "child"
+    child.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (child / "__init__.py").write_text("", encoding="utf-8")
+    (child / "sub.py").write_text("from .. import helpers\n", encoding="utf-8")
+
+    graph = build_import_graph(tmp_path)
+
+    assert graph.edges_out["src/pkg/child/sub.py"] == {"src/pkg/helpers.py"}

--- a/tests/unit/analysis/test_semantic_diff.py
+++ b/tests/unit/analysis/test_semantic_diff.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.analysis.semantic_diff import compute_diff
+from omnibase_core.enums.enum_diff_severity import EnumChangeKind
+
+
+@pytest.mark.unit
+def test_compute_diff_zeroes_consumers_without_symbol_changes() -> None:
+    source = "def unchanged() -> int:\n    return 1\n"
+    report = compute_diff(source, source, "src/example.py", consumers_count=7)
+
+    assert report.changes == ()
+    assert report.total_consumers_affected == 0
+
+
+@pytest.mark.unit
+def test_compute_diff_does_not_refactor_unrelated_same_signature_symbols() -> None:
+    old_source = "def alpha(value: int) -> int:\n    return value + 1\n"
+    new_source = "def omega(value: int) -> int:\n    return value + 1\n"
+
+    report = compute_diff(old_source, new_source, "src/example.py", consumers_count=3)
+
+    kinds = {change.kind for change in report.changes}
+    assert EnumChangeKind.REFACTOR not in kinds
+    assert EnumChangeKind.DELETED_FUNCTION in kinds
+    assert EnumChangeKind.NEW_FUNCTION in kinds
+    assert report.total_consumers_affected == 3

--- a/tests/unit/analysis/test_symbol_extractor.py
+++ b/tests/unit/analysis/test_symbol_extractor.py
@@ -72,6 +72,38 @@ def test_signature_whitespace_collapsed():
 
 
 @pytest.mark.unit
+def test_multiline_signature_is_fully_extracted():
+    source = """\
+def foo(
+    x: int,
+    y: str,
+) -> str:
+    return y * x
+"""
+    result = extract_symbols(source)
+    assert result["foo"]["signature"] == "def foo( x: int, y: str, ) -> str:"
+
+
+@pytest.mark.unit
+def test_decorated_symbols_are_extracted():
+    source = """\
+@top_level
+def decorated_func() -> None:
+    pass
+
+@decorate_class
+class Decorated:
+    @staticmethod
+    def helper() -> int:
+        return 1
+"""
+    result = extract_symbols(source)
+    assert "decorated_func" in result
+    assert "Decorated" in result
+    assert "Decorated.helper" in result
+
+
+@pytest.mark.unit
 def test_body_hash_is_sha256_hex():
     result = extract_symbols(SIMPLE_FUNCTION)
     body_hash = result["foo"]["body_hash"]


### PR DESCRIPTION
## OMN-10375 — Task 23: [Wave 5 AST Diff] CLI + PR risk labeler integration

**Plan:** docs/plans/2026-04-30-selective-swarm-patterns.md, Task 23
**Epic:** OMN-10350

## Changes

- `scripts/analysis/semantic_diff.py` — CLI that computes AST-level semantic diff between two git refs and emits JSON matching `ModelSemanticDiffReport`. Exits 0 always (advisory mode).
- `.github/workflows/semantic-diff-labeler.yml` — GHA workflow that applies `risk:critical` or `risk:high` labels to PRs based on diff severity; no label for medium/low only.
- `tests/scripts/test_semantic_diff_cli.py` — 5 unit tests covering all 4 acceptance criteria.
- Forward-ports `semantic_diff.py` (Task 21/OMN-10373), `consumer_graph.py` (Task 22/OMN-10374), and `import_graph.py` (Task 11/OMN-10363) into this stacked branch for complete wiring.

**Note:** Stacked on jonah/omn-10373-change-classifier (Task 21) locally; PR targets main pending that branch's merge.

## Acceptance Criteria

1. CLI: `python scripts/analysis/semantic_diff.py --base origin/main --head HEAD --json` — verified by test_cli_exits_0_with_json_flag
2. JSON validates against `ModelSemanticDiffReport` via `model_validate` — verified by test_cli_json_output_validates_against_model
3. GHA labels `risk:critical` for any CRITICAL change, `risk:high` for HIGH, none for medium/low only — implemented in semantic-diff-labeler.yml
4. CLI exits 0 even with critical changes (advisory) — verified by test_cli_exits_0_with_json_flag

## dod_evidence

```json
{
  "ticket": "OMN-10375",
  "tests_passed": "5/5 (tests/scripts/test_semantic_diff_cli.py)",
  "mypy_strict": "passed (scripts/analysis/semantic_diff.py)",
  "ruff_clean": "passed",
  "pre_commit": "all hooks passed",
  "acceptance_criteria": "4/4"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated PR risk labeling based on semantic code analysis—pull requests are now automatically labeled with `risk:critical` or `risk:high` severity based on the scope and impact of changes.
  * Semantic diff analysis engine that tracks code dependencies and evaluates how changes affect consuming code.

* **Tests**
  * New test coverage for semantic diff analysis, import graph resolution, symbol extraction, and CLI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->