### PR TITLE
feat(OMN-10365): co-change dark matter CLI script with JSON output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,7 @@ ignore = [
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/receipt_gate_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_reprobe.py" = ["T201"]  # CLI output for re-probe verification (OMN-9789)
+"scripts/analysis/co_change_dark_matter.py" = ["T201"]
 "scripts/validation/validate_pr_receipts.py" = ["T201"]
 "scripts/validation/validate_pr_deploy_required.py" = ["T201"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]

--- a/scripts/analysis/co_change_dark_matter.py
+++ b/scripts/analysis/co_change_dark_matter.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI: co-change dark matter analysis.
+
+Usage:
+    python scripts/analysis/co_change_dark_matter.py          # human-readable top 20
+    python scripts/analysis/co_change_dark_matter.py --json   # JSON to stdout
+    python scripts/analysis/co_change_dark_matter.py --write-state  # write to .onex_state/
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Insert the worktree src at position 0 so local (possibly uncommitted) modules
+# take priority over any installed version of the package. This is necessary
+# when running from a stacked worktree where analysis/ is not yet installed.
+_SCRIPT_SRC = Path(__file__).resolve().parents[2] / "src"
+if _SCRIPT_SRC.is_dir():
+    _src_str = str(_SCRIPT_SRC)
+    # Always insert at 0: PYTHONPATH may have placed a different (canonical)
+    # src earlier, which would shadow the worktree's local modules.
+    if sys.path and sys.path[0] != _src_str:
+        sys.path.insert(0, _src_str)
+
+import json
+import subprocess
+
+
+def _git_commits(repo_root: Path) -> list[list[str]]:
+    """Return per-commit file lists from git log."""
+    try:
+        out = subprocess.check_output(
+            ["git", "log", "--name-only", "--pretty=format:---COMMIT---"],
+            cwd=str(repo_root),
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    commits: list[list[str]] = []
+    current: list[str] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if line == "---COMMIT---":
+            if current:
+                commits.append(current)
+            current = []
+        elif line:
+            current.append(line)
+    if current:
+        commits.append(current)
+    return commits
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk up to find the git root, or return start if not found."""
+    current = start.resolve()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return current
+
+
+def _analyse(repo_root: Path) -> list[dict[str, object]]:
+    """Build matrix, import graph, and run dark matter filter."""
+    from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
+    from omnibase_core.analysis.co_change_matrix import build_cochange_matrix
+    from omnibase_core.analysis.import_graph import build_import_graph
+
+    commits = _git_commits(repo_root)
+    matrix = build_cochange_matrix(commits)
+    import_graph = build_import_graph(repo_root)
+    return find_dark_matter(matrix, import_graph)  # type: ignore[return-value]
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    cwd = Path.cwd()
+    repo_root = _find_repo_root(cwd)
+
+    pairs = _analyse(repo_root)
+
+    if "--json" in args:
+        print(json.dumps({"pairs": list(pairs)}, indent=2))
+        return 0
+
+    if "--write-state" in args:
+        state_dir = cwd / ".onex_state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        state_file = state_dir / "co-change-map.json"
+        state_file.write_text(json.dumps({"pairs": list(pairs)}, indent=2))
+        return 0
+
+    # Human-readable top 20
+    if not pairs:
+        print("No dark matter pairs found.")
+        return 0
+
+    print(f"{'NPMI':>6}  {'Co-changes':>10}  {'File A':<40}  {'File B'}")
+    print("-" * 90)
+    for p in pairs[:20]:
+        print(f"{p['npmi']:>6.3f}  {p['co_changes']:>10}  {p['a']!s:<40}  {p['b']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analysis/co_change_dark_matter.py
+++ b/scripts/analysis/co_change_dark_matter.py
@@ -28,6 +28,8 @@ if _SCRIPT_SRC.is_dir():
 import json
 import subprocess
 
+from omnibase_core.types.typed_dict_dark_matter_pair import TypedDictDarkMatterPair
+
 
 def _git_commits(repo_root: Path) -> list[list[str]]:
     """Return per-commit file lists from git log."""
@@ -65,7 +67,7 @@ def _find_repo_root(start: Path) -> Path:
     return current
 
 
-def _analyse(repo_root: Path) -> list[dict[str, object]]:
+def _analyse(repo_root: Path) -> list[TypedDictDarkMatterPair]:
     """Build matrix, import graph, and run dark matter filter."""
     from omnibase_core.analysis.co_change_dark_matter import find_dark_matter
     from omnibase_core.analysis.co_change_matrix import build_cochange_matrix
@@ -74,7 +76,7 @@ def _analyse(repo_root: Path) -> list[dict[str, object]]:
     commits = _git_commits(repo_root)
     matrix = build_cochange_matrix(commits)
     import_graph = build_import_graph(repo_root)
-    return find_dark_matter(matrix, import_graph)  # type: ignore[return-value]
+    return find_dark_matter(matrix, import_graph)
 
 
 def main() -> int:

--- a/scripts/analysis/co_change_dark_matter.py
+++ b/scripts/analysis/co_change_dark_matter.py
@@ -91,7 +91,7 @@ def main() -> int:
         return 0
 
     if "--write-state" in args:
-        state_dir = cwd / ".onex_state"
+        state_dir = repo_root / ".onex_state"
         state_dir.mkdir(parents=True, exist_ok=True)
         state_file = state_dir / "co-change-map.json"
         state_file.write_text(json.dumps({"pairs": list(pairs)}, indent=2))

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -117,6 +117,7 @@ def test_python_relative_import_rejects_package_escape(tmp_path: Path) -> None:
     g = build_import_graph(tmp_path)
     assert g.edges_out.get("pkg/a.py", set()) == set()
 
+
 def test_python_relative_from_import_submodule_detected(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     nested = pkg / "nested"
@@ -222,3 +223,26 @@ def test_js_multiline_esm_import_detected(tmp_path: Path) -> None:
     b.write_text("export const foo = 1; export const bar = 2;\n")
     g = build_import_graph(tmp_path)
     assert "utils.ts" in g.edges_out["a.ts"]
+
+
+@pytest.mark.parametrize(
+    ("import_spec", "target"),
+    [
+        ("./direct", "direct.mjs"),
+        ("./direct", "direct.cjs"),
+        ("./widget", "widget/index.jsx"),
+        ("./widget", "widget/index.tsx"),
+        ("./widget", "widget/index.mjs"),
+        ("./widget", "widget/index.cjs"),
+    ],
+)
+def test_js_resolution_uses_all_declared_extensions(
+    tmp_path: Path, import_spec: str, target: str
+) -> None:
+    source = tmp_path / "page.ts"
+    target_path = tmp_path / target
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(f"import value from '{import_spec}';\n")
+    target_path.write_text("export default 1;\n")
+    g = build_import_graph(tmp_path)
+    assert target in g.edges_out["page.ts"]

--- a/tests/analysis/test_import_graph.py
+++ b/tests/analysis/test_import_graph.py
@@ -117,7 +117,6 @@ def test_python_relative_import_rejects_package_escape(tmp_path: Path) -> None:
     g = build_import_graph(tmp_path)
     assert g.edges_out.get("pkg/a.py", set()) == set()
 
-
 def test_python_relative_from_import_submodule_detected(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     nested = pkg / "nested"

--- a/tests/scripts/test_co_change_dark_matter_cli.py
+++ b/tests/scripts/test_co_change_dark_matter_cli.py
@@ -92,6 +92,15 @@ class TestWriteStateFlag:
         assert result.returncode == 0
         assert state_dir.exists()
 
+    def test_write_state_uses_repo_root_from_subdirectory(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "nested"
+        subdir.mkdir()
+        result = _run("--write-state", cwd=subdir)
+        assert result.returncode == 0, result.stderr
+        assert (tmp_path / ".onex_state" / "co-change-map.json").exists()
+        assert not (subdir / ".onex_state" / "co-change-map.json").exists()
+
 
 @pytest.mark.unit
 class TestNoArgsHumanReadable:

--- a/tests/scripts/test_co_change_dark_matter_cli.py
+++ b/tests/scripts/test_co_change_dark_matter_cli.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT = (
     Path(__file__).resolve().parents[2]
     / "scripts"
@@ -22,10 +24,12 @@ def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
         cwd=str(cwd) if cwd else None,
     )
 
 
+@pytest.mark.unit
 class TestJsonFlag:
     def test_json_flag_exits_0(self, tmp_path: Path) -> None:
         result = _run("--json", cwd=tmp_path)
@@ -55,6 +59,7 @@ class TestJsonFlag:
         assert payload == {"pairs": []}
 
 
+@pytest.mark.unit
 class TestWriteStateFlag:
     def test_write_state_creates_file(self, tmp_path: Path) -> None:
         result = _run("--write-state", cwd=tmp_path)
@@ -88,6 +93,7 @@ class TestWriteStateFlag:
         assert state_dir.exists()
 
 
+@pytest.mark.unit
 class TestNoArgsHumanReadable:
     def test_no_args_exits_0(self, tmp_path: Path) -> None:
         result = _run(cwd=tmp_path)

--- a/tests/scripts/test_co_change_dark_matter_cli.py
+++ b/tests/scripts/test_co_change_dark_matter_cli.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the co-change dark matter CLI script (Task 13, OMN-10365)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "analysis"
+    / "co_change_dark_matter.py"
+)
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+class TestJsonFlag:
+    def test_json_flag_exits_0(self, tmp_path: Path) -> None:
+        result = _run("--json", cwd=tmp_path)
+        assert result.returncode == 0, result.stderr
+
+    def test_json_output_is_valid_json(self, tmp_path: Path) -> None:
+        result = _run("--json", cwd=tmp_path)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert "pairs" in payload
+
+    def test_json_schema_matches_pairs(self, tmp_path: Path) -> None:
+        result = _run("--json", cwd=tmp_path)
+        payload = json.loads(result.stdout)
+        for pair in payload["pairs"]:
+            assert {"a", "b", "npmi", "co_changes"} <= set(pair.keys()), pair
+            assert isinstance(pair["npmi"], float), pair
+            assert isinstance(pair["co_changes"], int), pair
+            assert isinstance(pair["a"], str), pair
+            assert isinstance(pair["b"], str), pair
+
+    def test_json_exits_0_on_empty_result(self, tmp_path: Path) -> None:
+        # tmp_path is a git-less directory with no git log → empty result
+        result = _run("--json", cwd=tmp_path)
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert payload == {"pairs": []}
+
+
+class TestWriteStateFlag:
+    def test_write_state_creates_file(self, tmp_path: Path) -> None:
+        result = _run("--write-state", cwd=tmp_path)
+        assert result.returncode == 0, result.stderr
+        state_file = tmp_path / ".onex_state" / "co-change-map.json"
+        assert state_file.exists(), f"Expected {state_file} to exist"
+
+    def test_write_state_content_is_valid_json(self, tmp_path: Path) -> None:
+        _run("--write-state", cwd=tmp_path)
+        state_file = tmp_path / ".onex_state" / "co-change-map.json"
+        payload = json.loads(state_file.read_text())
+        assert "pairs" in payload
+
+    def test_write_state_overwrites_existing(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".onex_state"
+        state_dir.mkdir(parents=True)
+        state_file = state_dir / "co-change-map.json"
+        state_file.write_text('{"old": true}')
+        result = _run("--write-state", cwd=tmp_path)
+        assert result.returncode == 0
+        payload = json.loads(state_file.read_text())
+        assert "pairs" in payload
+        assert "old" not in payload
+
+    def test_write_state_mkdir_p(self, tmp_path: Path) -> None:
+        # Ensure .onex_state does not exist before the call
+        state_dir = tmp_path / ".onex_state"
+        assert not state_dir.exists()
+        result = _run("--write-state", cwd=tmp_path)
+        assert result.returncode == 0
+        assert state_dir.exists()
+
+
+class TestNoArgsHumanReadable:
+    def test_no_args_exits_0(self, tmp_path: Path) -> None:
+        result = _run(cwd=tmp_path)
+        assert result.returncode == 0, result.stderr
+
+    def test_no_args_output_is_not_json(self, tmp_path: Path) -> None:
+        result = _run(cwd=tmp_path)
+        # Human-readable output should not be parseable as a JSON object
+        # (it's tabular text). On empty result it may just print a header line.
+        try:
+            parsed = json.loads(result.stdout)
+            # If it parses, it must not be the API JSON schema (a dict with "pairs")
+            assert "pairs" not in parsed
+        except json.JSONDecodeError:
+            pass  # expected for human-readable output


### PR DESCRIPTION
## OMN-10365 — [Wave 3 Co-Change] CLI script + JSON output

Implements `scripts/analysis/co_change_dark_matter.py` (Task 13 of the selective swarm patterns plan).

**Stacked on:** jonah/omn-10364-co-change-dark-matter (OMN-10364)

## Changes

- `scripts/analysis/co_change_dark_matter.py` — CLI with three modes: `--json`, `--write-state`, no-args human-readable top 20
- `src/omnibase_core/analysis/co_change_dark_matter.py` — filter pipeline with TypedDictDarkMatterPair
- `src/omnibase_core/types/typed_dict_dark_matter_pair.py` — TypedDictDarkMatterPair per ONEX convention
- `tests/scripts/test_co_change_dark_matter_cli.py` — 10 unit tests covering all 4 acceptance criteria

## Acceptance Criteria

- [x] `--json` prints valid JSON matching the required schema
- [x] `--write-state` writes to `.onex_state/co-change-map.json` (mkdir -p, overwrite)
- [x] no args prints human-readable top 20
- [x] exits 0 even on empty result

## dod_evidence

- check_type: test_pass
- ticket: OMN-10365
- test_count: 10
- command: `uv run pytest tests/scripts/test_co_change_dark_matter_cli.py -v`
- result: 10 passed
- pre_commit: all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to find file pairs that frequently change together (human table, JSON, and write-state options).
  * Added static import-graph analysis and a typed output shape to improve and standardize results.

* **Tests**
  * Added comprehensive unit and CLI tests covering analysis logic, import resolution, output formats, and state file behavior.

* **Documentation**
  * Added package docstring describing the analysis package.

* **Chores**
  * Adjusted linter settings to accommodate the new analysis scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->