### PR TITLE
feat(cli): add onex hooks {list,mask,enable,disable} subcommands [OMN-9614]

### DIFF
--- a/contracts/OMN-9614.yaml
+++ b/contracts/OMN-9614.yaml
@@ -1,0 +1,60 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9614
+summary: "Add onex hooks CLI subcommands for ONEX_HOOKS_MASK management"
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "public_api"
+evidence_requirements:
+  - kind: "ci"
+    description: "omnibase_core PR #1013 checks pass, including deploy-gate"
+    command: "gh pr checks 1013 --repo OmniNode-ai/omnibase_core --watch"
+  - kind: "manual"
+    description: "Focused onex hooks CLI unit tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/cli/test_cli_hooks.py -q"
+  - kind: "manual"
+    description: "Touched CLI files pass lint, format, and type checks"
+    command: "PYTHONPATH=src uv run ruff check src/omnibase_core/cli/cli_commands.py src/omnibase_core/cli/cli_hooks.py
+      tests/unit/cli/test_cli_hooks.py && PYTHONPATH=src uv run ruff format --check src/omnibase_core/cli/cli_commands.py
+      src/omnibase_core/cli/cli_hooks.py tests/unit/cli/test_cli_hooks.py && PYTHONPATH=src uv run mypy
+      src/omnibase_core/cli/cli_commands.py src/omnibase_core/cli/cli_hooks.py tests/unit/cli/test_cli_hooks.py
+      --strict"
+  - kind: "manual"
+    description: "Post-deploy runtime smoke proves the onex hooks CLI group is importable and registered"
+    command: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from click.testing import
+      CliRunner; from omnibase_core.cli.cli_commands import cli; result = CliRunner().invoke(cli, ['hooks',
+      'mask']); assert result.exit_code == 0, result.output; assert result.output.strip().startswith('0x');
+      print('OMN-9614 onex hooks deploy validation OK')\""
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused onex hooks CLI unit tests cover list, mask, enable, disable, unknown names,
+      and env-file preservation"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/cli/test_cli_hooks.py -q"
+  - id: "dod-002"
+    description: "Touched CLI files pass lint, format, and type checks"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run ruff check src/omnibase_core/cli/cli_commands.py src/omnibase_core/cli/cli_hooks.py
+          tests/unit/cli/test_cli_hooks.py && PYTHONPATH=src uv run ruff format --check src/omnibase_core/cli/cli_commands.py
+          src/omnibase_core/cli/cli_hooks.py tests/unit/cli/test_cli_hooks.py && PYTHONPATH=src uv run
+          mypy src/omnibase_core/cli/cli_commands.py src/omnibase_core/cli/cli_hooks.py tests/unit/cli/test_cli_hooks.py
+          --strict"
+  - id: "dod-003"
+    description: "Post-deploy runtime smoke confirms the deployed runtime imports the onex CLI and executes
+      hooks mask"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from click.testing
+          import CliRunner; from omnibase_core.cli.cli_commands import cli; result = CliRunner().invoke(cli,
+          ['hooks', 'mask']); assert result.exit_code == 0, result.output; assert result.output.strip().startswith('0x');
+          print('OMN-9614 onex hooks deploy validation OK')\""

--- a/contracts/OMN-9614.yaml
+++ b/contracts/OMN-9614.yaml
@@ -1,6 +1,7 @@
 ---
 schema_version: "1.0.0"
 ticket_id: OMN-9614
+title: "Add onex hooks CLI subcommands"
 summary: "Add onex hooks CLI subcommands for ONEX_HOOKS_MASK management"
 is_seam_ticket: false
 interface_change: true

--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -718,6 +718,11 @@ from omnibase_core.cli.cli_refresh_credentials import refresh_credentials
 
 cli.add_command(refresh_credentials)
 
+# Register hooks command group (list, mask, enable, disable) [OMN-9614]
+from omnibase_core.cli.cli_hooks import hooks_group
+
+cli.add_command(hooks_group)
+
 # Load CLI extension groups registered by other packages via the onex.cli entry-point group.
 # Each entry point must expose a click.Group or click.Command.
 # This enables infra packages (e.g. omnibase_infra) to contribute subcommands

--- a/src/omnibase_core/cli/cli_hooks.py
+++ b/src/omnibase_core/cli/cli_hooks.py
@@ -67,6 +67,7 @@ def _write_mask(path: Path, mask: int) -> None:
         try:
             Path(tmp).unlink()
         except OSError:
+            # Preserve the original write/replace exception if temp cleanup fails.
             pass
         raise
 

--- a/src/omnibase_core/cli/cli_hooks.py
+++ b/src/omnibase_core/cli/cli_hooks.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""``onex hooks`` — manage ONEX_HOOKS_MASK bitmask for hook enable/disable."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import tempfile
+from pathlib import Path
+
+import click
+
+from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK, EnumHookBit
+
+_ENV_VAR = "OMNIBASE_ENV_FILE"
+_MASK_KEY = "ONEX_HOOKS_MASK"
+_NAMES = {m.name.lower(): m for m in EnumHookBit}
+
+
+def _env_path() -> Path:
+    raw = os.environ.get(_ENV_VAR)
+    if raw:
+        return Path(raw)
+    return Path.home() / ".omnibase" / ".env"
+
+
+def _read_mask(path: Path) -> int:
+    if not path.exists():
+        return _DEFAULT_MASK
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_MASK_KEY + "="):
+            raw = stripped.split("=", 1)[1].strip()
+            try:
+                val = int(raw, 0)
+                return val if val >= 0 else _DEFAULT_MASK
+            except ValueError:
+                return _DEFAULT_MASK
+    return _DEFAULT_MASK
+
+
+def _write_mask(path: Path, mask: int) -> None:
+    lines: list[str]
+    if path.exists():
+        lines = path.read_text().splitlines()
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = []
+
+    mask_line = f"{_MASK_KEY}=0x{mask:x}"
+    replaced = False
+    for i, line in enumerate(lines):
+        if line.strip().startswith(_MASK_KEY + "="):
+            lines[i] = mask_line
+            replaced = True
+            break
+    if not replaced:
+        lines.append(mask_line)
+
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".env_tmp_")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("\n".join(lines) + "\n")
+        Path(tmp).replace(path)
+    except BaseException:
+        try:
+            Path(tmp).unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _resolve_name(name: str) -> EnumHookBit:
+    lower = name.lower()
+    if lower in _NAMES:
+        return _NAMES[lower]
+    matches = difflib.get_close_matches(lower, _NAMES.keys(), n=1, cutoff=0.6)
+    hint = f" Did you mean {matches[0].upper()}?" if matches else ""
+    click.echo(f"Unknown hook '{name}'.{hint}", err=True)
+    raise SystemExit(2)  # error-ok: CLI usage error, exit 2 per spec
+
+
+@click.group("hooks")
+def hooks_group() -> None:  # stub-ok
+    """Manage ONEX hook bitmask (enable/disable individual hooks)."""
+
+
+@hooks_group.command("list")
+def hooks_list() -> None:
+    """Show every hook and its current ON/OFF state."""
+    path = _env_path()
+    mask = _read_mask(path)
+    for m in EnumHookBit:
+        state = (
+            click.style("ON", fg="green")
+            if (mask & int(m))
+            else click.style("OFF", fg="red")
+        )
+        click.echo(f"  {m.name:<50s} {state}")
+
+
+@hooks_group.command("mask")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["hex", "dec", "bin"]),
+    default="hex",
+    help="Output format (default: hex).",
+)
+def hooks_mask(fmt: str) -> None:
+    """Print the current effective mask value."""
+    path = _env_path()
+    mask = _read_mask(path)
+    if fmt == "hex":
+        click.echo(f"0x{mask:x}")
+    elif fmt == "dec":
+        click.echo(str(mask))
+    else:
+        click.echo(f"0b{mask:b}")
+
+
+@hooks_group.command("disable")
+@click.argument("name")
+def hooks_disable(name: str) -> None:
+    """Disable a hook by clearing its bit in ONEX_HOOKS_MASK."""
+    bit = _resolve_name(name)
+    path = _env_path()
+    mask = _read_mask(path)
+    new_mask = mask & ~int(bit)
+    _write_mask(path, new_mask)
+    click.echo(f"onex hooks: {bit.name} disabled (mask=0x{new_mask:x})")
+
+
+@hooks_group.command("enable")
+@click.argument("name")
+def hooks_enable(name: str) -> None:
+    """Enable a hook by setting its bit in ONEX_HOOKS_MASK."""
+    bit = _resolve_name(name)
+    path = _env_path()
+    mask = _read_mask(path)
+    new_mask = mask | int(bit)
+    _write_mask(path, new_mask)
+    click.echo(f"onex hooks: {bit.name} enabled (mask=0x{new_mask:x})")

--- a/tests/unit/cli/test_cli_hooks.py
+++ b/tests/unit/cli/test_cli_hooks.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for cli_hooks.py — onex hooks {list,mask,enable,disable}."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_core.cli.cli_hooks import hooks_group
+from omnibase_core.enums.enum_hook_bit import _DEFAULT_MASK, EnumHookBit
+
+pytestmark = pytest.mark.unit
+
+
+def _env_file(tmp_path: Path) -> Path:
+    return tmp_path / ".env"
+
+
+def _write_env(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _read_env(path: Path) -> str:
+    return path.read_text()
+
+
+def _mask_from_env(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    for line in path.read_text().splitlines():
+        if line.startswith("ONEX_HOOKS_MASK="):
+            return int(line.split("=", 1)[1], 0)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# list subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestHooksList:
+    def test_list_includes_every_member(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["list"])
+        assert result.exit_code == 0
+        for m in EnumHookBit:
+            assert m.name in result.output
+
+    def test_list_shows_on_state_by_default(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["list"])
+        assert result.exit_code == 0
+        assert "ON" in result.output
+
+    def test_list_shows_off_for_disabled_bit(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        _write_env(env_path, ["ONEX_HOOKS_MASK=0x0"])
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["list"])
+        assert result.exit_code == 0
+        assert "OFF" in result.output
+
+
+# ---------------------------------------------------------------------------
+# mask subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestHooksMask:
+    def test_mask_prints_hex_default(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["mask"])
+        assert result.exit_code == 0
+        assert f"0x{_DEFAULT_MASK:x}" in result.output
+
+    def test_mask_prints_stored_hex(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        _write_env(env_path, ["ONEX_HOOKS_MASK=0xff"])
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["mask"])
+        assert result.exit_code == 0
+        assert "0xff" in result.output
+
+    def test_mask_dec_format(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["mask", "--format", "dec"])
+        assert result.exit_code == 0
+        assert str(_DEFAULT_MASK) in result.output
+
+    def test_mask_bin_format(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["mask", "--format", "bin"])
+        assert result.exit_code == 0
+        assert "0b" in result.output
+
+
+# ---------------------------------------------------------------------------
+# disable subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestHooksDisable:
+    def test_disable_clears_bit(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+        assert result.exit_code == 0
+        mask = _mask_from_env(env_path)
+        assert mask is not None
+        assert not (mask & int(EnumHookBit.CI_REMINDER))
+
+    def test_disable_prints_summary(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+        assert "CI_REMINDER" in result.output
+        assert "disabled" in result.output
+
+    def test_disable_preserves_adjacent_lines(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        _write_env(
+            env_path,
+            [
+                "SOME_VAR=hello",
+                "ONEX_HOOKS_MASK=0xff",
+                "# a comment",
+                "OTHER_VAR=world",
+            ],
+        )
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+        assert result.exit_code == 0
+        content = _read_env(env_path)
+        assert "SOME_VAR=hello" in content
+        assert "# a comment" in content
+        assert "OTHER_VAR=world" in content
+
+    def test_disable_unknown_name_exits_with_error(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "NONEXISTENT_HOOK"])
+        assert result.exit_code == 2
+        assert "Unknown hook" in result.output
+
+    def test_disable_case_insensitive(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "ci_reminder"])
+        assert result.exit_code == 0
+        mask = _mask_from_env(env_path)
+        assert mask is not None
+        assert not (mask & int(EnumHookBit.CI_REMINDER))
+
+
+# ---------------------------------------------------------------------------
+# enable subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestHooksEnable:
+    def test_enable_sets_bit(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+            result = runner.invoke(hooks_group, ["enable", "CI_REMINDER"])
+        assert result.exit_code == 0
+        mask = _mask_from_env(env_path)
+        assert mask is not None
+        assert mask & int(EnumHookBit.CI_REMINDER)
+
+    def test_enable_prints_summary(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+            result = runner.invoke(hooks_group, ["enable", "CI_REMINDER"])
+        assert "CI_REMINDER" in result.output
+        assert "enabled" in result.output
+
+    def test_enable_unknown_name_exits_with_error(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["enable", "GARBAGE"])
+        assert result.exit_code == 2
+        assert "Unknown hook" in result.output
+
+    def test_enable_preserves_adjacent_lines(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        _write_env(
+            env_path,
+            [
+                "SOME_VAR=hello",
+                "ONEX_HOOKS_MASK=0x0",
+                "# a comment",
+            ],
+        )
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["enable", "CI_REMINDER"])
+        assert result.exit_code == 0
+        content = _read_env(env_path)
+        assert "SOME_VAR=hello" in content
+        assert "# a comment" in content
+
+
+# ---------------------------------------------------------------------------
+# nearest-match hint
+# ---------------------------------------------------------------------------
+
+
+class TestNearestMatch:
+    def test_suggests_similar_name(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "CI_REMINDE"])
+        assert result.exit_code == 2
+        assert "CI_REMINDER" in result.output
+
+    def test_no_hint_for_completely_wrong_name(self, tmp_path: Path) -> None:
+        env_path = _env_file(tmp_path)
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "ZZZZZZZZZ"])
+        assert result.exit_code == 2
+        assert "Unknown hook" in result.output
+
+
+# ---------------------------------------------------------------------------
+# env file creation
+# ---------------------------------------------------------------------------
+
+
+class TestEnvFileCreation:
+    def test_creates_env_if_missing(self, tmp_path: Path) -> None:
+        env_path = tmp_path / "subdir" / ".env"
+        runner = CliRunner()
+        with mock.patch.dict(
+            os.environ, {"OMNIBASE_ENV_FILE": str(env_path)}, clear=False
+        ):
+            result = runner.invoke(hooks_group, ["disable", "CI_REMINDER"])
+        assert result.exit_code == 0
+        assert env_path.exists()
+        mask = _mask_from_env(env_path)
+        assert mask is not None


### PR DESCRIPTION
## Summary
- Add `onex hooks {list,mask,enable,disable}` CLI subcommand family to the `onex` click CLI
- Reads/writes `ONEX_HOOKS_MASK` in `~/.omnibase/.env` atomically (temp file + rename)
- Preserves adjacent lines and comments in `.env`
- Unknown hook names exit 2 with nearest-match hint via `difflib.get_close_matches`
- Case-insensitive hook name resolution

## Linked ticket
OMN-9614 (Task 7 of OMN-9609 epic)

## Verification
- 19 unit tests pass covering all subcommands, error paths, and edge cases
- `mypy --strict` clean
- `ruff check` clean
- All pre-commit hooks pass