### PR TITLE
feat(enums): add HANDOFF_NUDGE bit to EnumHookBit [OMN-9617]

### DIFF
--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -89,6 +89,7 @@ class EnumHookBit(IntEnum):
     WORKFLOW_GUARD = 1 << 54
     SESSION_START = 1 << 55
     SESSION_START_ONEX_CLI_PIN_CHECK = 1 << 56
+    HANDOFF_NUDGE = 1 << 57
 
 
 # Default mask ORs all actual member values — correct even after tombstones are

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -13,7 +13,7 @@ from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
 pytestmark = pytest.mark.unit
 
 # Frozen GATE count from Task 1 inventory. Update only when the inventory doc changes.
-_N_GATE = 57
+_N_GATE = 58
 
 
 class TestEnumHookBit:


### PR DESCRIPTION
## Summary
- Append `HANDOFF_NUDGE = 1 << 57` to `EnumHookBit` for `user_prompt_structured_handoff_nudge.sh` which had a legacy env var but no enum member
- Regenerate `hook_bits.sh` with the new bit

## Linked ticket
OMN-9617 (Task 5 of OMN-9609 epic) — pairs with omniclaude PR

## Merge order
This PR must merge before the omniclaude PR (which references the new bit in `hook_bits.sh`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new hook-gating option (`HANDOFF_NUDGE`) to extend available hook management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->