### PR TITLE
feat(OMN-10417): harden receipt-gate skip-token to require allowlist approval

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -226,6 +226,9 @@ jobs:
         #
         # merge_group events do not carry pull_request.body. Derive the PR number
         # from merge_group.head_ref (format: pr-<num>-<sha>) and fetch via API.
+        #
+        # OMN-10417: also capture PR author login and resolved PR number for
+        # skip-token self-approval and scope checks.
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -237,35 +240,71 @@ jobs:
           if [ -n "$PR_NUMBER" ]; then
             # pull_request event: always fetch live body so re-runs see edits.
             # Single API call fetches both fields to minimise rate-limit consumption.
-            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title 2>/dev/null)"; then
+            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title,author 2>/dev/null)"; then
               printf '%s' "$pr_json" | jq -r '.body' > /tmp/pr_body.txt
               printf '%s' "$pr_json" | jq -r '.title' > /tmp/pr_title.txt
+              printf '%s' "$pr_json" | jq -r '.author.login' > /tmp/pr_author.txt
+              printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             else
               # API unavailable — fall back to event payload with a warning.
               echo "::warning::gh pr view failed for PR #${PR_NUMBER}; using event payload (may be stale)"
               printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
               printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
+              : > /tmp/pr_author.txt
+              printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             fi
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then
             pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
             if [ -n "$pr_num" ] && [ "$pr_num" != "$MERGE_GROUP_HEAD_REF" ]; then
-              gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title --jq '.body' > /tmp/pr_body.txt
-              gh pr view "$pr_num" --repo "${{ github.repository }}" --json title --jq '.title' > /tmp/pr_title.txt
+              pr_json="$(gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title,author)"
+              printf '%s' "$pr_json" | jq -r '.body' > /tmp/pr_body.txt
+              printf '%s' "$pr_json" | jq -r '.title' > /tmp/pr_title.txt
+              printf '%s' "$pr_json" | jq -r '.author.login' > /tmp/pr_author.txt
+              printf '%s' "$pr_num" > /tmp/pr_number.txt
             else
               : > /tmp/pr_body.txt
               : > /tmp/pr_title.txt
+              : > /tmp/pr_author.txt
+              : > /tmp/pr_number.txt
             fi
           else
             : > /tmp/pr_body.txt
             : > /tmp/pr_title.txt
+            : > /tmp/pr_author.txt
+            : > /tmp/pr_number.txt
           fi
 
       - name: Run Receipt-Gate
         run: |
           PR_BODY="$(cat /tmp/pr_body.txt)"
           PR_TITLE="$(cat /tmp/pr_title.txt)"
+          PR_AUTHOR="$(cat /tmp/pr_author.txt 2>/dev/null || true)"
+          PR_NUMBER_RESOLVED="$(cat /tmp/pr_number.txt 2>/dev/null || true)"
+          REPO_NAME="${{ github.repository }}"
+          REPO_SHORT="${REPO_NAME##*/}"
+
+          ALLOWLIST_ARG=""
+          if [ -f ".onex_change_control/allowlists/skip_token_approvals.yaml" ]; then
+            ALLOWLIST_ARG="--allowlist-path .onex_change_control/allowlists/skip_token_approvals.yaml"
+          fi
+
+          PR_AUTHOR_ARG=""
+          if [ -n "$PR_AUTHOR" ]; then
+            PR_AUTHOR_ARG="--pr-author $PR_AUTHOR"
+          fi
+
+          PR_NUMBER_ARG=""
+          if [ -n "$PR_NUMBER_RESOLVED" ]; then
+            PR_NUMBER_ARG="--current-pr-number $PR_NUMBER_RESOLVED"
+          fi
+
+          # shellcheck disable=SC2086
           python -m omnibase_core.validation.receipt_gate_cli \
             --pr-body "$PR_BODY" \
             --pr-title "$PR_TITLE" \
             --contracts-dir ".onex_change_control/${{ inputs.contracts-dir }}" \
-            --receipts-dir ".onex_change_control/${{ inputs.receipts-dir }}"
+            --receipts-dir ".onex_change_control/${{ inputs.receipts-dir }}" \
+            --current-repo "$REPO_SHORT" \
+            $ALLOWLIST_ARG \
+            $PR_AUTHOR_ARG \
+            $PR_NUMBER_ARG

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -234,6 +234,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_EVENT_BODY: ${{ github.event.pull_request.body }}
           PR_EVENT_TITLE: ${{ github.event.pull_request.title }}
+          PR_EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -e
@@ -250,7 +251,7 @@ jobs:
               echo "::warning::gh pr view failed for PR #${PR_NUMBER}; using event payload (may be stale)"
               printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
               printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
-              : > /tmp/pr_author.txt
+              printf '%s' "$PR_EVENT_AUTHOR" > /tmp/pr_author.txt
               printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             fi
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then

--- a/scripts/grant-skip-approval.sh
+++ b/scripts/grant-skip-approval.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# grant-skip-approval.sh — OMN-10417
+#
+# Manual approval flow for [skip-receipt-gate: <id>] tokens.
+#
+# USAGE
+#   bash scripts/grant-skip-approval.sh \
+#     --id        appr-20260430-001 \
+#     --granted-by jonahgabriel \
+#     --repo      omnibase_core \
+#     --pr-number 1234 \
+#     --occ-path  /path/to/onex_change_control
+#
+# WHAT THIS DOES
+#   1. Validates that the approver is NOT the PR author (call this script from
+#      a shell authenticated as the approver, not the PR author).
+#   2. Appends a new entry to onex_change_control/allowlists/skip_token_approvals.yaml
+#      with a 7-day expiry.
+#   3. Prints the token to add to the PR body.
+#   4. Reminds you to open a PR to OCC with CODEOWNERS review from @OmniNode-ai/platform-leads.
+#
+# RULES
+#   - The approver MUST be a member of @OmniNode-ai/platform-leads.
+#   - The approver MUST NOT be the PR author (self-approval is rejected by receipt_gate.py).
+#   - scope_pr_numbers is REQUIRED — every approval is scoped to specific PRs.
+#   - Approvals expire after 7 days by default (pass --days N to override).
+#   - You MUST open a PR to OCC and get CODEOWNERS review before the approval is live.
+#
+# EXAMPLE WORKFLOW
+#   # 1. Platform lead runs this script for a worker's PR:
+#   bash scripts/grant-skip-approval.sh \
+#     --id appr-20260430-001 \
+#     --granted-by platform-lead-login \
+#     --repo omnibase_core \
+#     --pr-number 1234 \
+#     --occ-path $OMNI_HOME/omni_home/onex_change_control
+#
+#   # 2. Platform lead opens a PR to OCC with the modified allowlists/skip_token_approvals.yaml.
+#   # 3. CODEOWNERS review from @OmniNode-ai/platform-leads.
+#   # 4. Once the OCC PR merges, the worker adds to their PR body:
+#   #      [skip-receipt-gate: appr-20260430-001]
+#   # 5. Receipt gate validates the token against the live allowlist.
+
+set -euo pipefail
+
+ID=""
+GRANTED_BY=""
+REPO=""
+PR_NUMBER=""
+OCC_PATH=""
+DAYS=7
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --id)           ID="$2"; shift 2 ;;
+    --granted-by)   GRANTED_BY="$2"; shift 2 ;;
+    --repo)         REPO="$2"; shift 2 ;;
+    --pr-number)    PR_NUMBER="$2"; shift 2 ;;
+    --occ-path)     OCC_PATH="$2"; shift 2 ;;
+    --days)         DAYS="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ID" || -z "$GRANTED_BY" || -z "$REPO" || -z "$PR_NUMBER" || -z "$OCC_PATH" ]]; then
+  echo "ERROR: --id, --granted-by, --repo, --pr-number, and --occ-path are all required." >&2
+  exit 1
+fi
+
+ALLOWLIST="$OCC_PATH/allowlists/skip_token_approvals.yaml"
+if [[ ! -f "$ALLOWLIST" ]]; then
+  echo "ERROR: allowlist not found at $ALLOWLIST" >&2
+  exit 1
+fi
+
+NOW_UTC=$(python3 -c "from datetime import UTC, datetime; print(datetime.now(tz=UTC).isoformat())")
+EXPIRES_UTC=$(python3 -c "from datetime import UTC, datetime, timedelta; print((datetime.now(tz=UTC) + timedelta(days=${DAYS})).isoformat())")
+
+# Append the new entry via Python to keep YAML valid.
+python3 - << PYEOF
+import yaml
+from pathlib import Path
+
+path = Path("$ALLOWLIST")
+data = yaml.safe_load(path.read_text()) or {}
+approvals = data.get("approvals") or []
+
+new_entry = {
+    "id": "$ID",
+    "granted_by": "$GRANTED_BY",
+    "granted_at": "$NOW_UTC",
+    "expires_at": "$EXPIRES_UTC",
+    "scope_repos": ["$REPO"],
+    "scope_pr_numbers": [int("$PR_NUMBER")],
+}
+
+# Reject duplicate ids.
+if any(a.get("id") == "$ID" for a in approvals):
+    raise SystemExit(f"ERROR: id '$ID' already exists in allowlist.")
+
+approvals.append(new_entry)
+data["approvals"] = approvals
+path.write_text(yaml.safe_dump(data, default_flow_style=False, sort_keys=False))
+print(f"Added entry {new_entry['id']!r} to {path}")
+PYEOF
+
+echo ""
+echo "========================================"
+echo "  NEXT STEPS"
+echo "========================================"
+echo ""
+echo "1. Open a PR to onex_change_control with the modified allowlist:"
+echo "   git -C $OCC_PATH add allowlists/skip_token_approvals.yaml"
+echo "   git -C $OCC_PATH commit -m 'feat(OMN-10417): grant skip-receipt-gate approval $ID'"
+echo "   gh pr create --repo OmniNode-ai/onex_change_control --title 'feat(OMN-10417): grant skip-receipt-gate approval $ID'"
+echo ""
+echo "2. Get CODEOWNERS review from @OmniNode-ai/platform-leads."
+echo ""
+echo "3. Once merged, add to the PR body:"
+echo "   [skip-receipt-gate: $ID]"
+echo ""
+echo "4. Approval expires: $EXPIRES_UTC"
+echo "========================================"

--- a/scripts/grant-skip-approval.sh
+++ b/scripts/grant-skip-approval.sh
@@ -70,6 +70,21 @@ if [[ -z "$ID" || -z "$GRANTED_BY" || -z "$REPO" || -z "$PR_NUMBER" || -z "$OCC_
   exit 1
 fi
 
+if [[ ! "$ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: --id must contain only letters, digits, dot, underscore, and hyphen." >&2
+  exit 1
+fi
+
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ || "$PR_NUMBER" -le 0 ]]; then
+  echo "ERROR: --pr-number must be a positive integer." >&2
+  exit 1
+fi
+
+if [[ ! "$DAYS" =~ ^[0-9]+$ || "$DAYS" -lt 1 || "$DAYS" -gt 365 ]]; then
+  echo "ERROR: --days must be an integer between 1 and 365." >&2
+  exit 1
+fi
+
 ALLOWLIST="$OCC_PATH/allowlists/skip_token_approvals.yaml"
 if [[ ! -f "$ALLOWLIST" ]]; then
   echo "ERROR: allowlist not found at $ALLOWLIST" >&2

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -355,16 +355,22 @@ def _validate_skip_token(
             "[skip-receipt-gate] REJECTED: allowlist 'approvals' key is not a list",
         )
 
-    entry = next(
-        (a for a in approvals if isinstance(a, dict) and a.get("id") == approval_id),
-        None,
-    )
-    if entry is None:
+    matches = [
+        a for a in approvals if isinstance(a, dict) and a.get("id") == approval_id
+    ]
+    if not matches:
         return (
             False,
             f"[skip-receipt-gate] REJECTED: approval id {approval_id!r} not found in allowlist. "
             "Use scripts/grant-skip-approval.sh to create an approved entry.",
         )
+    if len(matches) > 1:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: approval id {approval_id!r} appears "
+            f"{len(matches)} times in the allowlist. Approval ids must be unique.",
+        )
+    entry = matches[0]
 
     # scope_pr_numbers is REQUIRED — missing or empty means the entry is invalid.
     scope_prs = entry.get("scope_pr_numbers")
@@ -376,12 +382,15 @@ def _validate_skip_token(
         )
 
     # Self-approval: granted_by must not equal the PR author.
-    granted_by = entry.get("granted_by", "")
-    if (
-        pr_author
-        and isinstance(granted_by, str)
-        and granted_by.strip().casefold() == pr_author.strip().casefold()
-    ):
+    granted_by_raw = entry.get("granted_by")
+    if not isinstance(granted_by_raw, str) or not granted_by_raw.strip():
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist entry {approval_id!r} missing or empty "
+            "'granted_by' — every approval must record the approver login.",
+        )
+    granted_by = granted_by_raw.strip()
+    if pr_author and granted_by.casefold() == pr_author.strip().casefold():
         return (
             False,
             f"[skip-receipt-gate] REJECTED: self-approval — approval {approval_id!r} was "

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -317,9 +317,9 @@ def _validate_skip_token(
 
     Args:
         approval_id: The bare identifier from ``[skip-receipt-gate: <id>]``.
-        pr_author: GitHub login of the PR author. None disables self-approval check.
-        current_repo: Repo name (e.g. ``omnibase_core``) to scope check. None disables.
-        current_pr_number: PR number to scope check. None disables.
+        pr_author: GitHub login of the PR author for self-approval checks.
+        current_repo: Repo name (e.g. ``omnibase_core``) to scope check.
+        current_pr_number: PR number to scope check.
         allowlist_path: Path to ``skip_token_approvals.yaml``.
 
     Returns:
@@ -467,9 +467,9 @@ def validate_pr_receipts(
         allowlist_path: Path to ``onex_change_control/allowlists/skip_token_approvals.yaml``.
             When None, any ``[skip-receipt-gate: <id>]`` token is rejected because
             there is no allowlist to verify against.
-        pr_author: GitHub login of the PR author. Used for self-approval check.
-        current_repo: Repository name (e.g. ``omnibase_core``). Used for scope check.
-        current_pr_number: PR number. Used for scope check.
+        pr_author: GitHub login of the PR author. Required for skip tokens.
+        current_repo: Repository name (e.g. ``omnibase_core``). Required for skip tokens.
+        current_pr_number: PR number. Required for skip tokens.
     """
     override = OVERRIDE_PATTERN.search(pr_body)
     if override:
@@ -482,6 +482,25 @@ def validate_pr_receipts(
                     "no allowlist_path provided to the gate. "
                     "Pass --allowlist-path pointing to "
                     "onex_change_control/allowlists/skip_token_approvals.yaml."
+                ),
+            )
+        if pr_author is None or current_repo is None or current_pr_number is None:
+            missing_context = [
+                name
+                for name, value in (
+                    ("pr_author", pr_author),
+                    ("current_repo", current_repo),
+                    ("current_pr_number", current_pr_number),
+                )
+                if value is None
+            ]
+            return ModelReceiptGateResult(
+                passed=False,
+                message=(
+                    f"[skip-receipt-gate] REJECTED: token {approval_id!r} present but "
+                    f"required PR context is missing: {', '.join(missing_context)}. "
+                    "Pass --pr-author, --current-repo, and --current-pr-number so "
+                    "self-approval and repo/PR scope checks cannot be bypassed."
                 ),
             )
         accepted, message = _validate_skip_token(

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -23,8 +23,13 @@ Decision matrix:
     - Receipt missing probe_command/stdout → FAIL ("missing probe_command|probe_stdout")
     - Receipt verifier == runner          → FAIL ("self-attestation: ... ADVISORY")
     - Receipt status != PASS              → FAIL ("failing receipt (ADVISORY|FAIL|PENDING)")
-    - Override token in PR body           → PASS with friction ("override accepted")
-    - All checks have PASS receipts       → PASS
+    - Override token: free-text reason   → FAIL (must use approved allowlist id)
+    - Override token: unknown id         → FAIL ("unknown approval id")
+    - Override token: expired            → FAIL ("approval expired")
+    - Override token: scope mismatch     → FAIL ("approval not scoped to this repo/PR")
+    - Override token: self-approved      → FAIL ("self-approval rejected")
+    - Override token: valid allowlist id → PASS with friction ("override accepted")
+    - All checks have PASS receipts      → PASS
 
 Adversarial invariants (OMN-9788)
 ---------------------------------
@@ -43,11 +48,37 @@ exactly which adversarial guarantee was missed:
 Invariants 1-3 are enforced as pre-schema lookups so missing-field
 errors mention the field name even when other validation errors would
 otherwise mask the problem.
+
+Skip-token allowlist (OMN-10417)
+---------------------------------
+``[skip-receipt-gate: <approval-id>]`` requires ``<approval-id>`` to exist
+in ``onex_change_control/allowlists/skip_token_approvals.yaml``.  Free-text
+reasons are rejected.  Allowlist schema:
+
+    approvals:
+      - id: <str>
+        granted_by: <github-login>
+        granted_at: <ISO-8601>
+        expires_at: <ISO-8601>
+        scope_repos: [<repo>, ...]
+        scope_pr_numbers: [<int>, ...]   # REQUIRED
+
+Rejection criteria (all hard FAIL, no bypass):
+    - ``approval-id`` not found in allowlist
+    - ``expires_at`` in the past
+    - current repo not in ``scope_repos``
+    - current PR not in ``scope_pr_numbers``
+    - ``granted_by == pr_author`` (self-approval)
+    - ``scope_pr_numbers`` missing or empty in the allowlist entry
+
+Every accepted bypass logs to CI output with the allowlist entry id, granted_by,
+and scope for audit traceability.
 """
 
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
@@ -67,7 +98,9 @@ CLOSING_KEYWORD_PATTERN = re.compile(
     r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
 )
-OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(.+?)\]", re.IGNORECASE)
+# Matches [skip-receipt-gate: <token>] — token must be a non-whitespace identifier
+# to reject free-text reasons. UUID-style, slug, or alphanumeric IDs are all accepted.
+OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(\S+)\s*\]", re.IGNORECASE)
 
 
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
@@ -270,26 +303,198 @@ def _check_one_receipt(
     )
 
 
+def _validate_skip_token(
+    approval_id: str,
+    pr_author: str | None,
+    current_repo: str | None,
+    current_pr_number: int | None,
+    allowlist_path: Path,
+) -> tuple[bool, str]:
+    """Validate a skip-receipt-gate approval ID against the allowlist.
+
+    Args:
+        approval_id: The bare identifier from ``[skip-receipt-gate: <id>]``.
+        pr_author: GitHub login of the PR author. None disables self-approval check.
+        current_repo: Repo name (e.g. ``omnibase_core``) to scope check. None disables.
+        current_pr_number: PR number to scope check. None disables.
+        allowlist_path: Path to ``skip_token_approvals.yaml``.
+
+    Returns:
+        ``(True, audit_message)`` when the token is valid and accepted.
+        ``(False, rejection_reason)`` for every rejection case.
+    """
+    if not allowlist_path.exists():
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist not found at {allowlist_path}. "
+            "Use scripts/grant-skip-approval.sh to create an approved entry.",
+        )
+
+    try:
+        with allowlist_path.open(encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError) as e:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist corrupt at {allowlist_path}: {e}",
+        )
+
+    if not isinstance(raw, dict):
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist at {allowlist_path} is not a YAML mapping",
+        )
+
+    approvals = raw.get("approvals", [])
+    if not isinstance(approvals, list):
+        return (
+            False,
+            "[skip-receipt-gate] REJECTED: allowlist 'approvals' key is not a list",
+        )
+
+    entry = next(
+        (a for a in approvals if isinstance(a, dict) and a.get("id") == approval_id),
+        None,
+    )
+    if entry is None:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: approval id {approval_id!r} not found in allowlist. "
+            "Use scripts/grant-skip-approval.sh to create an approved entry.",
+        )
+
+    # scope_pr_numbers is REQUIRED — missing or empty means the entry is invalid.
+    scope_prs = entry.get("scope_pr_numbers")
+    if not scope_prs or not isinstance(scope_prs, list) or len(scope_prs) == 0:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist entry {approval_id!r} missing or empty "
+            "'scope_pr_numbers' — every approval must be scoped to specific PR numbers.",
+        )
+
+    # Self-approval: granted_by must not equal the PR author.
+    granted_by = entry.get("granted_by", "")
+    if (
+        pr_author
+        and isinstance(granted_by, str)
+        and granted_by.strip() == pr_author.strip()
+    ):
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: self-approval — approval {approval_id!r} was "
+            f"granted by {granted_by!r} who is also the PR author. "
+            "A different team member must grant the approval.",
+        )
+
+    # Expiry check — deterministic: compare against current UTC time.
+    expires_at_raw = entry.get("expires_at")
+    if expires_at_raw is not None:
+        try:
+            if isinstance(expires_at_raw, str):
+                expires_at = datetime.fromisoformat(expires_at_raw)
+            elif isinstance(expires_at_raw, datetime):
+                expires_at = expires_at_raw
+            else:
+                # error-ok: internal sentinel immediately re-caught by enclosing except (ValueError, TypeError)
+                raise ValueError(f"unexpected type: {type(expires_at_raw)}")
+            # Make timezone-aware if naive (assume UTC).
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+            now_utc = datetime.now(tz=UTC)
+            if now_utc > expires_at:
+                return (
+                    False,
+                    f"[skip-receipt-gate] REJECTED: approval {approval_id!r} expired at "
+                    f"{expires_at.isoformat()} (now={now_utc.isoformat()}). "
+                    "Use scripts/grant-skip-approval.sh to create a new entry.",
+                )
+        except (ValueError, TypeError) as e:
+            return (
+                False,
+                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} has unparseable "
+                f"expires_at {expires_at_raw!r}: {e}",
+            )
+
+    # Repo scope check.
+    scope_repos = entry.get("scope_repos", [])
+    if current_repo is not None and isinstance(scope_repos, list) and scope_repos:
+        if current_repo not in scope_repos:
+            return (
+                False,
+                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} is scoped to repos "
+                f"{scope_repos!r} but current repo is {current_repo!r}.",
+            )
+
+    # PR number scope check.
+    if current_pr_number is not None and isinstance(scope_prs, list):
+        if current_pr_number not in scope_prs:
+            return (
+                False,
+                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} is scoped to PR numbers "
+                f"{scope_prs!r} but current PR is #{current_pr_number}.",
+            )
+
+    audit_msg = (
+        f"[skip-receipt-gate] BYPASS ACCEPTED: approval={approval_id!r} "
+        f"granted_by={granted_by!r} "
+        f"scope_repos={scope_repos!r} scope_pr_numbers={scope_prs!r}. "
+        "FRICTION LOGGED: receipt gate bypassed — every override must be "
+        "tracked and closed within 7 days."
+    )
+    return (True, audit_msg)
+
+
 def validate_pr_receipts(
     pr_body: str,
     contracts_dir: Path,
     receipts_dir: Path,
     pr_title: str | None = None,
+    allowlist_path: Path | None = None,
+    pr_author: str | None = None,
+    current_repo: str | None = None,
+    current_pr_number: int | None = None,
 ) -> ModelReceiptGateResult:
-    """Run the receipt-gate against a PR's body + the repo's contracts + receipts."""
+    """Run the receipt-gate against a PR's body + the repo's contracts + receipts.
+
+    Args:
+        pr_body: Full PR description text.
+        contracts_dir: Directory containing OMN-<ticket-id>.yaml ticket contracts.
+        receipts_dir: Directory tree containing ModelDodReceipt YAML files.
+        pr_title: Optional PR title; used as fallback ticket extraction source.
+        allowlist_path: Path to ``onex_change_control/allowlists/skip_token_approvals.yaml``.
+            When None, any ``[skip-receipt-gate: <id>]`` token is rejected because
+            there is no allowlist to verify against.
+        pr_author: GitHub login of the PR author. Used for self-approval check.
+        current_repo: Repository name (e.g. ``omnibase_core``). Used for scope check.
+        current_pr_number: PR number. Used for scope check.
+    """
     override = OVERRIDE_PATTERN.search(pr_body)
     if override:
-        reason = override.group(1).strip()
-        if reason:
+        approval_id = override.group(1).strip()
+        if allowlist_path is None:
             return ModelReceiptGateResult(
-                passed=True,
-                friction_logged=True,
+                passed=False,
                 message=(
-                    f"[skip-receipt-gate] override accepted: {reason!r}. "
-                    "FRICTION LOGGED: receipt gate bypassed — every override must be "
-                    "tracked and closed within 7 days."
+                    f"[skip-receipt-gate] REJECTED: token {approval_id!r} present but "
+                    "no allowlist_path provided to the gate. "
+                    "Pass --allowlist-path pointing to "
+                    "onex_change_control/allowlists/skip_token_approvals.yaml."
                 ),
             )
+        accepted, message = _validate_skip_token(
+            approval_id=approval_id,
+            pr_author=pr_author,
+            current_repo=current_repo,
+            current_pr_number=current_pr_number,
+            allowlist_path=allowlist_path,
+        )
+        if not accepted:
+            return ModelReceiptGateResult(passed=False, message=message)
+        return ModelReceiptGateResult(
+            passed=True,
+            friction_logged=True,
+            message=message,
+        )
 
     ticket_ids = _extract_ticket_ids(pr_body, pr_title)
     if not ticket_ids:
@@ -298,7 +503,7 @@ def validate_pr_receipts(
             message=(
                 "RECEIPT GATE FAILED: PR body cites no OMN-XXXX ticket. "
                 "Every PR must cite a ticket whose dod_evidence proves the work. "
-                "Use [skip-receipt-gate: <reason>] if this is a truly ticket-less "
+                "Use [skip-receipt-gate: <approval-id>] if this is a truly ticket-less "
                 "change (rare — chore/docs/emergency hotfix)."
             ),
         )
@@ -384,5 +589,6 @@ __all__ = [
     "CLOSING_KEYWORD_PATTERN",
     "OVERRIDE_PATTERN",
     "TICKET_PATTERN",
+    "_validate_skip_token",
     "validate_pr_receipts",
 ]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -98,8 +98,10 @@ CLOSING_KEYWORD_PATTERN = re.compile(
     r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
 )
-# Matches any [skip-*: ...] bypass token (OMN-10347: Rule #10 enforcement).
-SKIP_TOKEN_PATTERN = re.compile(r"\[skip-[a-zA-Z][^]]*\]", re.IGNORECASE)
+# Matches any real [skip-*: ...] bypass token (OMN-10347: Rule #10 enforcement).
+# Angle-bracket placeholders such as [skip-receipt-gate: <token>] are docs
+# examples, not executable bypass tokens.
+SKIP_TOKEN_PATTERN = re.compile(r"\[skip-[a-zA-Z][^\]<>]*\]", re.IGNORECASE)
 # Matches [skip-receipt-gate: <token>] — token must be a safe identifier to
 # reject free-text reasons and placeholder examples such as "<token>".
 OVERRIDE_PATTERN = re.compile(
@@ -405,32 +407,37 @@ def _validate_skip_token(
 
     # Expiry check — deterministic: compare against current UTC time.
     expires_at_raw = entry.get("expires_at")
-    if expires_at_raw is not None:
-        try:
-            if isinstance(expires_at_raw, str):
-                expires_at = datetime.fromisoformat(expires_at_raw)
-            elif isinstance(expires_at_raw, datetime):
-                expires_at = expires_at_raw
-            else:
-                # error-ok: internal sentinel immediately re-caught by enclosing except (ValueError, TypeError)
-                raise ValueError(f"unexpected type: {type(expires_at_raw)}")
-            # Make timezone-aware if naive (assume UTC).
-            if expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=UTC)
-            now_utc = datetime.now(tz=UTC)
-            if now_utc > expires_at:
-                return (
-                    False,
-                    f"[skip-receipt-gate] REJECTED: approval {approval_id!r} expired at "
-                    f"{expires_at.isoformat()} (now={now_utc.isoformat()}). "
-                    "Use scripts/grant-skip-approval.sh to create a new entry.",
-                )
-        except (ValueError, TypeError) as e:
+    if expires_at_raw is None:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist entry {approval_id!r} missing "
+            "'expires_at' — every approval must expire.",
+        )
+    try:
+        if isinstance(expires_at_raw, str):
+            expires_at = datetime.fromisoformat(expires_at_raw)
+        elif isinstance(expires_at_raw, datetime):
+            expires_at = expires_at_raw
+        else:
+            # error-ok: internal sentinel immediately re-caught by enclosing except (ValueError, TypeError)
+            raise ValueError(f"unexpected type: {type(expires_at_raw)}")
+        # Make timezone-aware if naive (assume UTC).
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        now_utc = datetime.now(tz=UTC)
+        if now_utc > expires_at:
             return (
                 False,
-                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} has unparseable "
-                f"expires_at {expires_at_raw!r}: {e}",
+                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} expired at "
+                f"{expires_at.isoformat()} (now={now_utc.isoformat()}). "
+                "Use scripts/grant-skip-approval.sh to create a new entry.",
             )
+    except (ValueError, TypeError) as e:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: approval {approval_id!r} has unparseable "
+            f"expires_at {expires_at_raw!r}: {e}",
+        )
 
     # Repo scope check.
     scope_repos = entry.get("scope_repos")
@@ -642,6 +649,5 @@ __all__ = [
     "OVERRIDE_PATTERN",
     "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",
-    "_validate_skip_token",
     "validate_pr_receipts",
 ]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -419,14 +419,19 @@ def _validate_skip_token(
             )
 
     # Repo scope check.
-    scope_repos = entry.get("scope_repos", [])
-    if current_repo is not None and isinstance(scope_repos, list) and scope_repos:
-        if current_repo not in scope_repos:
-            return (
-                False,
-                f"[skip-receipt-gate] REJECTED: approval {approval_id!r} is scoped to repos "
-                f"{scope_repos!r} but current repo is {current_repo!r}.",
-            )
+    scope_repos = entry.get("scope_repos")
+    if not isinstance(scope_repos, list) or len(scope_repos) == 0:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: allowlist entry {approval_id!r} missing or empty "
+            "'scope_repos' — every approval must be scoped to specific repos.",
+        )
+    if current_repo is not None and current_repo not in scope_repos:
+        return (
+            False,
+            f"[skip-receipt-gate] REJECTED: approval {approval_id!r} is scoped to repos "
+            f"{scope_repos!r} but current repo is {current_repo!r}.",
+        )
 
     # PR number scope check.
     if current_pr_number is not None and isinstance(scope_prs, list):
@@ -484,16 +489,14 @@ def validate_pr_receipts(
                     "onex_change_control/allowlists/skip_token_approvals.yaml."
                 ),
             )
-        if pr_author is None or current_repo is None or current_pr_number is None:
-            missing_context = [
-                name
-                for name, value in (
-                    ("pr_author", pr_author),
-                    ("current_repo", current_repo),
-                    ("current_pr_number", current_pr_number),
-                )
-                if value is None
-            ]
+        missing_context: list[str] = []
+        if not isinstance(pr_author, str) or not pr_author.strip():
+            missing_context.append("pr_author")
+        if not isinstance(current_repo, str) or not current_repo.strip():
+            missing_context.append("current_repo")
+        if current_pr_number is None:
+            missing_context.append("current_pr_number")
+        if missing_context:
             return ModelReceiptGateResult(
                 passed=False,
                 message=(

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -98,9 +98,12 @@ CLOSING_KEYWORD_PATTERN = re.compile(
     r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
 )
-# Matches [skip-receipt-gate: <token>] — token must be a non-whitespace identifier
-# to reject free-text reasons. UUID-style, slug, or alphanumeric IDs are all accepted.
-OVERRIDE_PATTERN = re.compile(r"\[skip-receipt-gate:\s*(\S+)\s*\]", re.IGNORECASE)
+# Matches [skip-receipt-gate: <token>] — token must be a safe identifier to
+# reject free-text reasons and placeholder examples such as "<token>".
+OVERRIDE_PATTERN = re.compile(
+    r"\[skip-receipt-gate:\s*([A-Za-z0-9._-]+)\s*\]",
+    re.IGNORECASE,
+)
 
 
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
@@ -377,7 +380,7 @@ def _validate_skip_token(
     if (
         pr_author
         and isinstance(granted_by, str)
-        and granted_by.strip() == pr_author.strip()
+        and granted_by.strip().casefold() == pr_author.strip().casefold()
     ):
         return (
             False,

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -66,6 +66,34 @@ def main(argv: list[str] | None = None) -> int:
         help="Directory tree containing ModelDodReceipt YAML files.",
     )
     parser.add_argument(
+        "--allowlist-path",
+        default=None,
+        help=(
+            "OMN-10417: path to onex_change_control/allowlists/skip_token_approvals.yaml. "
+            "Required when the PR body contains a [skip-receipt-gate: <id>] token. "
+            "Without this flag, any skip token is rejected."
+        ),
+    )
+    parser.add_argument(
+        "--pr-author",
+        default=None,
+        help="OMN-10417: GitHub login of the PR author. Used for self-approval rejection.",
+    )
+    parser.add_argument(
+        "--current-repo",
+        default=None,
+        help=(
+            "OMN-10417: repository name (e.g. omnibase_core). "
+            "Used for skip-token scope check."
+        ),
+    )
+    parser.add_argument(
+        "--current-pr-number",
+        type=int,
+        default=None,
+        help="OMN-10417: PR number. Used for skip-token scope check.",
+    )
+    parser.add_argument(
         "--reexecute-probes",
         action="store_true",
         default=False,
@@ -83,6 +111,10 @@ def main(argv: list[str] | None = None) -> int:
         contracts_dir=Path(args.contracts_dir),
         receipts_dir=Path(args.receipts_dir),
         pr_title=args.pr_title,
+        allowlist_path=Path(args.allowlist_path) if args.allowlist_path else None,
+        pr_author=args.pr_author,
+        current_repo=args.current_repo,
+        current_pr_number=args.current_pr_number,
     )
 
     if result.friction_logged:

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -9,7 +9,7 @@ failing-receipt, corrupt-receipt, receipt-path-mismatch, all-PASS, override.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -75,6 +75,33 @@ def _write_receipt(
         data.update(overrides)
     p.write_text(yaml.safe_dump(data))
     return p
+
+
+def _write_skip_approval_allowlist(
+    allowlist_path: Path,
+    *,
+    approval_id: str = "appr-script-test",
+    scope_pr_numbers: list[int] | None = None,
+) -> None:
+    allowlist_path.parent.mkdir(parents=True, exist_ok=True)
+    allowlist_path.write_text(
+        yaml.safe_dump(
+            {
+                "approvals": [
+                    {
+                        "id": approval_id,
+                        "granted_by": "platform-lead",
+                        "granted_at": datetime.now(tz=UTC).isoformat(),
+                        "expires_at": (
+                            datetime.now(tz=UTC) + timedelta(days=1)
+                        ).isoformat(),
+                        "scope_repos": ["omnibase_core"],
+                        "scope_pr_numbers": scope_pr_numbers or [1015],
+                    }
+                ]
+            }
+        )
+    )
 
 
 @pytest.mark.unit
@@ -360,14 +387,36 @@ class TestReceiptGateMultiTicket:
 @pytest.mark.unit
 class TestReceiptGateOverride:
     def test_override_passes_with_friction(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_skip_approval_allowlist(
+            allowlist,
+            approval_id="appr-override-001",
+            scope_pr_numbers=[1015],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="fix: emergency hotfix [skip-receipt-gate: appr-override-001]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-author",
+            current_repo="omnibase_core",
+            current_pr_number=1015,
+        )
+        assert result.passed
+        assert result.friction_logged
+        assert "BYPASS ACCEPTED" in result.message
+        assert "appr-override-001" in result.message
+
+    def test_free_text_reason_does_not_override(self, tmp_path: Path) -> None:
         result = validate_pr_receipts(
             pr_body="fix: emergency hotfix [skip-receipt-gate: prod down OMN-1]",
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
         )
-        assert result.passed
-        assert result.friction_logged
-        assert "prod down OMN-1" in result.message
+        assert not result.passed
+        assert not result.friction_logged
+        assert "cites no" in result.message.lower()
 
     def test_empty_reason_does_not_override(self, tmp_path: Path) -> None:
         """Override must include a non-empty reason — empty falls through to FAIL."""
@@ -377,7 +426,8 @@ class TestReceiptGateOverride:
             receipts_dir=tmp_path / "receipts",
         )
         # Empty/whitespace reason doesn't count as a legitimate override
-        assert not result.passed or result.friction_logged
+        assert not result.passed
+        assert not result.friction_logged
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -16,6 +16,7 @@ Also tests:
     - placeholder token (<token>) → falls through to ticket extraction
     - missing scope_pr_numbers → FAIL
     - no allowlist_path provided → FAIL
+    - missing PR context for allowlist skip → FAIL
 """
 
 from __future__ import annotations
@@ -73,6 +74,7 @@ class TestSkipTokenAllowlist:
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
             allowlist_path=allowlist,
+            pr_author="worker-A",
             current_repo="omnibase_core",
             current_pr_number=999,
         )
@@ -93,6 +95,7 @@ class TestSkipTokenAllowlist:
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
             allowlist_path=allowlist,
+            pr_author="worker-A",
             current_repo="omnibase_core",
             current_pr_number=999,
         )
@@ -113,6 +116,7 @@ class TestSkipTokenAllowlist:
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
             allowlist_path=allowlist,
+            pr_author="worker-A",
             current_repo="omnibase_core",
             current_pr_number=999,
         )
@@ -133,6 +137,7 @@ class TestSkipTokenAllowlist:
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
             allowlist_path=allowlist,
+            pr_author="worker-A",
             current_repo="omnibase_core",
             current_pr_number=999,
         )
@@ -260,6 +265,7 @@ class TestSkipTokenEdgeCases:
             contracts_dir=tmp_path / "contracts",
             receipts_dir=tmp_path / "receipts",
             allowlist_path=allowlist,
+            pr_author="worker-A",
             current_repo="omnibase_core",
             current_pr_number=999,
         )
@@ -281,3 +287,37 @@ class TestSkipTokenEdgeCases:
             "allowlist" in result.message.lower()
             or "no allowlist" in result.message.lower()
         )
+
+    @pytest.mark.parametrize(
+        "missing_name", ["pr_author", "current_repo", "current_pr_number"]
+    )
+    def test_allowlist_skip_requires_full_pr_context(
+        self,
+        tmp_path: Path,
+        missing_name: str,
+    ) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(allowlist, [_valid_entry(entry_id="appr-valid")])
+        pr_author: str | None = "worker-A"
+        current_repo: str | None = "omnibase_core"
+        current_pr_number: int | None = 999
+        if missing_name == "pr_author":
+            pr_author = None
+        elif missing_name == "current_repo":
+            current_repo = None
+        else:
+            current_pr_number = None
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-valid]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author=pr_author,
+            current_repo=current_repo,
+            current_pr_number=current_pr_number,
+        )
+
+        assert not result.passed
+        assert missing_name in result.message
+        assert "required PR context is missing" in result.message

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Skip-token allowlist tests for receipt-gate (OMN-10417).
+
+Six cases as required by the plan:
+    1. unknown_id       — id not found in allowlist → FAIL
+    2. expired          — expires_at in the past → FAIL
+    3. scope_mismatch_repo — current repo not in scope_repos → FAIL
+    4. scope_mismatch_pr   — current PR not in scope_pr_numbers → FAIL
+    5. self_approved    — granted_by == pr_author → FAIL
+    6. valid            — all checks pass → PASS with friction_logged=True
+
+Also tests:
+    - free-text token (space in id) → FAIL (OVERRIDE_PATTERN rejects)
+    - missing scope_pr_numbers → FAIL
+    - no allowlist_path provided → FAIL
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation.receipt_gate import validate_pr_receipts
+
+
+def _write_allowlist(path: Path, entries: list[dict[object, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({"approvals": entries}))
+
+
+def _future(days: int = 7) -> str:
+    return (datetime.now(tz=UTC) + timedelta(days=days)).isoformat()
+
+
+def _past(days: int = 1) -> str:
+    return (datetime.now(tz=UTC) - timedelta(days=days)).isoformat()
+
+
+def _valid_entry(
+    *,
+    entry_id: str = "appr-001",
+    granted_by: str = "platform-lead",
+    scope_repos: list[str] | None = None,
+    scope_pr_numbers: list[int] | None = None,
+    expires_at: str | None = None,
+) -> dict[object, object]:
+    return {
+        "id": entry_id,
+        "granted_by": granted_by,
+        "granted_at": "2026-04-30T00:00:00+00:00",
+        "expires_at": expires_at or _future(),
+        "scope_repos": scope_repos or ["omnibase_core"],
+        "scope_pr_numbers": scope_pr_numbers if scope_pr_numbers is not None else [999],
+    }
+
+
+@pytest.mark.unit
+class TestSkipTokenAllowlist:
+    """Six required cases for allowlist-authenticated skip token."""
+
+    def test_unknown_id_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(allowlist, [_valid_entry(entry_id="appr-001")])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-999]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "appr-999" in result.message
+        assert "not found" in result.message.lower()
+
+    def test_expired_entry_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [_valid_entry(entry_id="appr-expired", expires_at=_past(1))],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-expired]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "expired" in result.message.lower()
+        assert "appr-expired" in result.message
+
+    def test_scope_mismatch_repo_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [_valid_entry(entry_id="appr-scoped", scope_repos=["omniclaude"])],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-scoped]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        msg = result.message.lower()
+        assert "scope" in msg or "repo" in msg
+
+    def test_scope_mismatch_pr_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [_valid_entry(entry_id="appr-pr-scoped", scope_pr_numbers=[111, 222])],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-pr-scoped]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "999" in result.message or "scope" in result.message.lower()
+
+    def test_self_approved_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [_valid_entry(entry_id="appr-self", granted_by="jonahgabriel")],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-self]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="jonahgabriel",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        msg = result.message.lower()
+        assert "self" in msg or "self-approval" in msg or "jonahgabriel" in msg
+
+    def test_valid_entry_passes_with_friction(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [
+                _valid_entry(
+                    entry_id="appr-valid",
+                    granted_by="platform-lead",
+                    scope_repos=["omnibase_core"],
+                    scope_pr_numbers=[999],
+                )
+            ],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-valid]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-A",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert result.passed, result.message
+        assert result.friction_logged
+        assert "appr-valid" in result.message
+        assert "platform-lead" in result.message
+
+
+@pytest.mark.unit
+class TestSkipTokenEdgeCases:
+    """Additional edge cases: free-text, missing scope_pr_numbers, no allowlist_path."""
+
+    def test_free_text_reason_not_matched_by_override_pattern(
+        self, tmp_path: Path
+    ) -> None:
+        """A token with spaces is not a bare identifier — OVERRIDE_PATTERN won't match it
+        and the gate proceeds to ticket extraction (which finds no ticket → FAIL)."""
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: this is a free text reason]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+        )
+        # OVERRIDE_PATTERN requires \S+ (no whitespace), so this doesn't match.
+        # Falls through to ticket extraction → no ticket → FAIL.
+        assert not result.passed
+        assert "no omn" in result.message.lower() or "ticket" in result.message.lower()
+
+    def test_missing_scope_pr_numbers_in_entry_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        entry: dict[object, object] = {
+            "id": "appr-no-pr-scope",
+            "granted_by": "platform-lead",
+            "granted_at": "2026-04-30T00:00:00+00:00",
+            "expires_at": _future(),
+            "scope_repos": ["omnibase_core"],
+            # scope_pr_numbers intentionally omitted
+        }
+        _write_allowlist(allowlist, [entry])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-no-pr-scope]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "scope_pr_numbers" in result.message
+
+    def test_no_allowlist_path_provided_fails(self, tmp_path: Path) -> None:
+        """Skip token present but no allowlist_path → hard FAIL."""
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-001]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=None,
+        )
+
+        assert not result.passed
+        assert (
+            "allowlist" in result.message.lower()
+            or "no allowlist" in result.message.lower()
+        )

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -13,6 +13,7 @@ Six cases as required by the plan:
 
 Also tests:
     - free-text token (space in id) → FAIL (OVERRIDE_PATTERN rejects)
+    - placeholder token (<token>) → falls through to ticket extraction
     - missing scope_pr_numbers → FAIL
     - no allowlist_path provided → FAIL
 """
@@ -160,6 +161,26 @@ class TestSkipTokenAllowlist:
         msg = result.message.lower()
         assert "self" in msg or "self-approval" in msg or "jonahgabriel" in msg
 
+    def test_self_approved_fails_case_insensitively(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [_valid_entry(entry_id="appr-self-case", granted_by="JonahGabriel")],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-self-case]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="jonahgabriel",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "self" in result.message.lower()
+
     def test_valid_entry_passes_with_friction(self, tmp_path: Path) -> None:
         allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
         _write_allowlist(
@@ -208,6 +229,19 @@ class TestSkipTokenEdgeCases:
         # Falls through to ticket extraction → no ticket → FAIL.
         assert not result.passed
         assert "no omn" in result.message.lower() or "ticket" in result.message.lower()
+
+    def test_placeholder_token_not_matched_by_override_pattern(
+        self, tmp_path: Path
+    ) -> None:
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10417. Documents the [skip-receipt-gate: <token>] syntax."
+            ),
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+        )
+
+        assert not result.message.startswith("[skip-receipt-gate]")
 
     def test_missing_scope_pr_numbers_in_entry_fails(self, tmp_path: Path) -> None:
         allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -273,6 +273,61 @@ class TestSkipTokenEdgeCases:
         assert not result.passed
         assert "scope_pr_numbers" in result.message
 
+    def test_duplicate_approval_ids_fail_closed(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(
+            allowlist,
+            [
+                _valid_entry(entry_id="appr-duplicate", scope_pr_numbers=[999]),
+                _valid_entry(entry_id="appr-duplicate", scope_pr_numbers=[1000]),
+            ],
+        )
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-duplicate]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-A",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "duplicate" in result.message.lower()
+        assert "unique" in result.message.lower()
+
+    @pytest.mark.parametrize("granted_by", [None, "", "   "])
+    def test_missing_or_blank_granted_by_fails(
+        self,
+        tmp_path: Path,
+        granted_by: object,
+    ) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        entry: dict[object, object] = {
+            "id": "appr-no-grantor",
+            "granted_at": "2026-04-30T00:00:00+00:00",
+            "expires_at": _future(),
+            "scope_repos": ["omnibase_core"],
+            "scope_pr_numbers": [999],
+        }
+        if granted_by is not None:
+            entry["granted_by"] = granted_by
+        _write_allowlist(allowlist, [entry])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-no-grantor]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-A",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "granted_by" in result.message
+
     @pytest.mark.parametrize("scope_repos", [None, [], "omnibase_core"])
     def test_missing_or_invalid_scope_repos_in_entry_fails(
         self,

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -273,6 +273,30 @@ class TestSkipTokenEdgeCases:
         assert not result.passed
         assert "scope_pr_numbers" in result.message
 
+    def test_missing_expires_at_in_entry_fails(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        entry: dict[object, object] = {
+            "id": "appr-no-expiry",
+            "granted_by": "platform-lead",
+            "granted_at": "2026-04-30T00:00:00+00:00",
+            "scope_repos": ["omnibase_core"],
+            "scope_pr_numbers": [999],
+        }
+        _write_allowlist(allowlist, [entry])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-no-expiry]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-A",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "expires_at" in result.message
+
     def test_duplicate_approval_ids_fail_closed(self, tmp_path: Path) -> None:
         allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
         _write_allowlist(

--- a/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_allowlist.py
@@ -273,6 +273,37 @@ class TestSkipTokenEdgeCases:
         assert not result.passed
         assert "scope_pr_numbers" in result.message
 
+    @pytest.mark.parametrize("scope_repos", [None, [], "omnibase_core"])
+    def test_missing_or_invalid_scope_repos_in_entry_fails(
+        self,
+        tmp_path: Path,
+        scope_repos: object,
+    ) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        entry: dict[object, object] = {
+            "id": "appr-no-repo-scope",
+            "granted_by": "platform-lead",
+            "granted_at": "2026-04-30T00:00:00+00:00",
+            "expires_at": _future(),
+            "scope_pr_numbers": [999],
+        }
+        if scope_repos is not None:
+            entry["scope_repos"] = scope_repos
+        _write_allowlist(allowlist, [entry])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-no-repo-scope]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author="worker-A",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+        )
+
+        assert not result.passed
+        assert "scope_repos" in result.message
+
     def test_no_allowlist_path_provided_fails(self, tmp_path: Path) -> None:
         """Skip token present but no allowlist_path → hard FAIL."""
         result = validate_pr_receipts(
@@ -316,6 +347,39 @@ class TestSkipTokenEdgeCases:
             pr_author=pr_author,
             current_repo=current_repo,
             current_pr_number=current_pr_number,
+        )
+
+        assert not result.passed
+        assert missing_name in result.message
+        assert "required PR context is missing" in result.message
+
+    @pytest.mark.parametrize(
+        ("pr_author", "current_repo", "missing_name"),
+        [
+            ("", "omnibase_core", "pr_author"),
+            ("   ", "omnibase_core", "pr_author"),
+            ("worker-A", "", "current_repo"),
+            ("worker-A", "   ", "current_repo"),
+        ],
+    )
+    def test_allowlist_skip_rejects_blank_pr_context(
+        self,
+        tmp_path: Path,
+        pr_author: str,
+        current_repo: str,
+        missing_name: str,
+    ) -> None:
+        allowlist = tmp_path / "allowlists" / "skip_token_approvals.yaml"
+        _write_allowlist(allowlist, [_valid_entry(entry_id="appr-valid")])
+
+        result = validate_pr_receipts(
+            pr_body="[skip-receipt-gate: appr-valid]",
+            contracts_dir=tmp_path / "contracts",
+            receipts_dir=tmp_path / "receipts",
+            allowlist_path=allowlist,
+            pr_author=pr_author,
+            current_repo=current_repo,
+            current_pr_number=999,
         )
 
         assert not result.passed

--- a/tests/unit/validation/test_receipt_gate_skip_token_hardening.py
+++ b/tests/unit/validation/test_receipt_gate_skip_token_hardening.py
@@ -54,6 +54,9 @@ class TestSkipTokenPattern:
     def test_no_match_on_clean_body(self) -> None:
         assert not SKIP_TOKEN_PATTERN.search("Closes OMN-9999\nNormal PR body.")
 
+    def test_no_match_on_placeholder_example(self) -> None:
+        assert not SKIP_TOKEN_PATTERN.search("[skip-receipt-gate: <token>]")
+
     def test_case_insensitive_skip_receipt_gate(self) -> None:
         assert SKIP_TOKEN_PATTERN.search("[Skip-Receipt-Gate: reason]")
 


### PR DESCRIPTION
## Summary

Closes OMN-10417. Hardens the [skip-receipt-gate: <token>] override surface from yesterday's receipt-gate cascade incident (2026-04-30) that allowed workers to self-authorize bypasses with free-text reasons.

- OVERRIDE_PATTERN now requires a bare identifier (no spaces), rejecting free-text reasons structurally
- _validate_skip_token() looks up the ID in onex_change_control/allowlists/skip_token_approvals.yaml
- Allowlist schema: {id, granted_by, granted_at, expires_at, scope_repos[], scope_pr_numbers[]} — scope_pr_numbers REQUIRED
- Hard FAIL on: unknown id, expired, repo scope mismatch, PR scope mismatch, self-approval (granted_by == pr_author), missing scope_pr_numbers
- Every accepted bypass logs id + granted_by + scope to CI output for audit
- CLI gains --allowlist-path, --pr-author, --current-repo, --current-pr-number
- receipt-gate.yml passes all four new params; fetches PR author via gh pr view --json author
- scripts/grant-skip-approval.sh documents the manual approval flow

## Tests

9 unit tests in tests/unit/validation/test_receipt_gate_skip_token_allowlist.py — all 6 required cases plus 3 edge cases (free-text, missing scope_pr_numbers, no allowlist_path). All pass.

## Paired OCC PR

OMN-10417 contract, dod_evidence receipt, and allowlists/skip_token_approvals.yaml seed file shipped in OmniNode-ai/onex_change_control (branch jonah/omn-10417-skip-token-allowlist).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured skip-approval system with expiry, repo/PR scoping, and audit logging.
  * CLI to grant skip approvals and print next-step instructions.
  * CI/gate now captures and supplies PR author and PR number to the validator.

* **Refactor**
  * Skip tokens validated against an allowlist; free-text/implicit bypasses rejected; self-approval, scope, and expiry checks enforced.

* **Tests**
  * New unit tests covering allowlist validation, scoping, expiry, self-approval, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->