### PR TITLE
feat(OMN-10422): add call-reject-skip.yml caller for merge_group skip-token re-scan

### DIFF
--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-10422 (Wave 5): Caller — re-scan skip-gate bypass tokens at merge_group entry.
+#
+# Invokes the omniclaude-hosted reusable workflow on pull_request and merge_group.
+# On merge_group, the reusable workflow resolves the PR via head SHA and asserts
+# exactly-one-PR (invariant I10). Cache is not reused across events (invariant I9).
+#
+# Required-status-check name: `scan / reject-skip-gate-token`
+# Wire via: Settings → Branches → main → Require status checks → add the check name above.
+
+name: Reject skip-gate bypass tokens
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  call-reject-skip-token:
+    uses: OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- OMN-10422 (Wave 5, T9): add `call-reject-skip.yml` invoking `omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main` on both `pull_request` and `merge_group`
- On `merge_group`, the reusable workflow resolves the PR via head SHA and asserts exactly-one-PR (invariant I10)
- Gate re-evaluates fully without cached state (invariant I9)

## Required status check

After this PR merges, add `scan / reject-skip-gate-token` as a required status check on `main` via branch protection settings (admin action required).

## Sequencing note

This caller references `@main` of the omniclaude reusable workflow. The omniclaude PR (OmniNode-ai/omniclaude#1493) must merge first. This PR is opened in parallel but depends on that merge.

## Test plan

- [ ] CI passes on this PR
- [ ] After omniclaude PR merges: verify `scan / reject-skip-gate-token` runs on PRs in this repo
- [ ] Verify gate fires at merge_group entry on a test PR with skip token

## Evidence

OMN-10422 — Wave 5 gate-collapse-fix plan (`docs/plans/2026-04-30-gate-collapse-fix.md` Task 12)