### PR TITLE
feat(OMN-10421): hash-bind contract to receipt via contract_sha256

### DIFF
--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -58,6 +58,8 @@ from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 
 _TICKET_ID_RE = re.compile(r"^OMN-\d+$")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+# SHA-256 hex digest — exactly 64 lowercase hex chars.
+_CONTRACT_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 # SemVer 2.0.0 — official regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 # Rejects leading zeros in numeric core (e.g. "01.0.0"), allows pre-release
 # identifiers with dot-separated alphanumerics and hyphens (e.g. "1.0.0-rc.1"),
@@ -227,6 +229,17 @@ class ModelDodReceipt(BaseModel):
             "from EvidenceReceipt (OMN-9792). None when not applicable."
         ),
     )
+    contract_sha256: str | None = Field(
+        default=None,
+        description=(
+            "SHA-256 hex digest of the contract YAML file at the time this receipt "
+            "was produced (OMN-10421, invariant I4). None for legacy receipts "
+            "produced before this field was introduced. When present, the receipt-gate "
+            "recomputes sha256(contracts/<ticket-id>.yaml) at the checked-out OCC SHA "
+            "and fails if the digest does not match — proving the contract has not "
+            "mutated since the probes ran. Must be exactly 64 lowercase hex chars."
+        ),
+    )
 
     @field_validator("branch")
     @classmethod
@@ -242,6 +255,15 @@ class ModelDodReceipt(BaseModel):
     def _validate_working_dir(cls, v: str | None) -> str | None:
         if v is not None and not v.startswith("/"):
             raise ValueError("working_dir must be an absolute path (start with '/')")
+        return v
+
+    @field_validator("contract_sha256")
+    @classmethod
+    def _validate_contract_sha256(cls, v: str | None) -> str | None:
+        if v is not None and not _CONTRACT_SHA256_RE.match(v):
+            raise ValueError(
+                f"contract_sha256 must be exactly 64 lowercase hex chars (SHA-256), got: {v!r}"
+            )
         return v
 
     @field_validator("runner", "verifier")
@@ -356,4 +378,5 @@ __all__ = [
     "EXECUTABLE_CHECK_TYPES",
     "ModelDodReceipt",
     "WEAK_PROOF_CHECK_TYPES",
+    "_CONTRACT_SHA256_RE",
 ]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -77,6 +77,7 @@ and scope for audit traceability.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -92,6 +93,10 @@ from omnibase_core.models.contracts.ticket.model_receipt_check_result import (
 from omnibase_core.models.contracts.ticket.model_receipt_gate_result import (
     ModelReceiptGateResult,
 )
+
+# PRs opened after this UTC datetime must include contract_sha256 in receipts;
+# earlier PRs get ADVISORY downgrade for the 7-day legacy window (OMN-10421).
+_CONTRACT_SHA256_REQUIRED_AFTER = datetime(2026, 4, 30, 0, 0, 0, tzinfo=UTC)
 
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
 CLOSING_KEYWORD_PATTERN = re.compile(
@@ -111,6 +116,11 @@ OVERRIDE_PATTERN = re.compile(
 # Inline marker pattern used only to reject the superseded approval syntax.
 # Receipt-gate bypass requires the central allowlist checked by _validate_skip_token.
 ALLOWLIST_PATTERN = re.compile(r"#\s*skip-token-allowed:\s*(\S+)", re.IGNORECASE)
+
+
+def compute_contract_sha256(contract_path: Path) -> str:
+    """Return the SHA-256 hex digest of a contract YAML file's raw bytes."""
+    return hashlib.sha256(contract_path.read_bytes()).hexdigest()
 
 
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
@@ -246,6 +256,8 @@ def _check_one_receipt(
     evidence_item_id: str,
     check_type: str,
     receipts_dir: Path,
+    contract_path: Path | None = None,
+    pr_opened_at: datetime | None = None,
 ) -> ModelReceiptCheckResult:
     """Verify exactly one (ticket, evidence, check) has a PASS receipt on disk."""
     receipt_path = receipts_dir / ticket_id / evidence_item_id / f"{check_type}.yaml"
@@ -303,6 +315,43 @@ def _check_one_receipt(
     )
     if adversarial_validated_failure is not None:
         return fail(adversarial_validated_failure)
+
+    # Hash-binding check (OMN-10421, invariant I4): verify the contract has
+    # not mutated since this receipt was produced. Only active when the caller
+    # supplies pr_opened_at — callers that omit it get no hash enforcement
+    # (backward-compatible with pre-OMN-10421 call sites).
+    if (
+        contract_path is not None
+        and contract_path.exists()
+        and pr_opened_at is not None
+    ):
+        actual_sha = compute_contract_sha256(contract_path)
+        if receipt.contract_sha256 is None:
+            is_post_cutoff = pr_opened_at >= _CONTRACT_SHA256_REQUIRED_AFTER
+            if is_post_cutoff:
+                return fail(
+                    f"receipt at {receipt_path} missing required contract_sha256 field "
+                    f"(OMN-10421): receipts produced after {_CONTRACT_SHA256_REQUIRED_AFTER.date()} "
+                    "must record the contract hash. Rerun probes to produce a new receipt."
+                )
+            # Pre-cutoff PR: ADVISORY downgrade — field expected soon but not yet required.
+            return ModelReceiptCheckResult(
+                ticket_id=ticket_id,
+                evidence_item_id=evidence_item_id,
+                check_type=check_type,
+                passed=False,
+                reason=(
+                    f"receipt at {receipt_path} missing contract_sha256 (ADVISORY — "
+                    "legacy receipt within 7-day migration window; rerun probes to bind "
+                    "the receipt to the current contract hash)"
+                ),
+            )
+        if receipt.contract_sha256 != actual_sha:
+            return fail(
+                f"contract mutated post-receipt; rerun probes. "
+                f"receipt contract_sha256={receipt.contract_sha256!r} but "
+                f"sha256({contract_path})={actual_sha!r}"
+            )
 
     return ModelReceiptCheckResult(
         ticket_id=ticket_id,
@@ -482,6 +531,7 @@ def validate_pr_receipts(
     pr_author: str | None = None,
     current_repo: str | None = None,
     current_pr_number: int | None = None,
+    pr_opened_at: datetime | None = None,
 ) -> ModelReceiptGateResult:
     """Run the receipt-gate against a PR's body + the repo's contracts + receipts.
 
@@ -496,6 +546,9 @@ def validate_pr_receipts(
         pr_author: GitHub login of the PR author. Required for skip tokens.
         current_repo: Repository name (e.g. ``omnibase_core``). Required for skip tokens.
         current_pr_number: PR number. Required for skip tokens.
+        pr_opened_at: UTC datetime when the PR was opened. Used to determine whether
+            missing ``contract_sha256`` is a hard FAIL (post-cutoff) or ADVISORY
+            (within the 7-day legacy migration window). When None, treated as post-cutoff.
     """
     override = OVERRIDE_PATTERN.search(pr_body)
     skip_match = SKIP_TOKEN_PATTERN.search(pr_body)
@@ -611,7 +664,14 @@ def validate_pr_receipts(
 
         for item_id, check_type, _check_value in triples:
             all_checks.append(
-                _check_one_receipt(ticket_id, item_id, check_type, receipts_dir)
+                _check_one_receipt(
+                    ticket_id,
+                    item_id,
+                    check_type,
+                    receipts_dir,
+                    contract_path=contract_path,
+                    pr_opened_at=pr_opened_at,
+                )
             )
 
     failures = [c for c in all_checks if not c.passed]
@@ -649,5 +709,7 @@ __all__ = [
     "OVERRIDE_PATTERN",
     "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",
+    "_CONTRACT_SHA256_REQUIRED_AFTER",
+    "compute_contract_sha256",
     "validate_pr_receipts",
 ]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -548,7 +548,8 @@ def validate_pr_receipts(
         current_pr_number: PR number. Required for skip tokens.
         pr_opened_at: UTC datetime when the PR was opened. Used to determine whether
             missing ``contract_sha256`` is a hard FAIL (post-cutoff) or ADVISORY
-            (within the 7-day legacy migration window). When None, treated as post-cutoff.
+            (within the 7-day legacy migration window). When None, the hash-binding
+            check is skipped because no PR-open timestamp is available.
     """
     override = OVERRIDE_PATTERN.search(pr_body)
     skip_match = SKIP_TOKEN_PATTERN.search(pr_body)

--- a/tests/unit/validation/test_receipt_gate_contract_sha256.py
+++ b/tests/unit/validation/test_receipt_gate_contract_sha256.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for contract_sha256 hash-binding in the receipt-gate (OMN-10421).
+
+Four cases per the plan (T11):
+1. Receipt with matching contract_sha256 → PASS.
+2. Receipt with mismatched contract_sha256 → FAIL ("contract mutated post-receipt").
+3. Receipt missing contract_sha256 on a legacy PR (pre-cutoff) → ADVISORY/FAIL with
+   migration-window message.
+4. Receipt missing contract_sha256 on a post-cutoff PR → hard FAIL.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation.receipt_gate import (
+    _CONTRACT_SHA256_REQUIRED_AFTER,
+    compute_contract_sha256,
+    validate_pr_receipts,
+)
+
+_TICKET_ID = "OMN-10421"
+_EVIDENCE_ID = "dod-001"
+_CHECK_TYPE = "command"
+
+# A PR opened 8 days before the cutoff — within the legacy window.
+_PRE_CUTOFF_OPENED_AT = _CONTRACT_SHA256_REQUIRED_AFTER - timedelta(days=8)
+# A PR opened at the cutoff or after — must hard-fail without contract_sha256.
+_POST_CUTOFF_OPENED_AT = _CONTRACT_SHA256_REQUIRED_AFTER
+
+
+def _write_contract(contracts_dir: Path) -> Path:
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "ticket_id": _TICKET_ID,
+        "schema_version": "1.0.0",
+        "summary": "hash-binding test",
+        "dod_evidence": [
+            {
+                "id": _EVIDENCE_ID,
+                "description": "test check",
+                "checks": [{"check_type": _CHECK_TYPE, "check_value": "echo ok"}],
+            }
+        ],
+    }
+    path = contracts_dir / f"{_TICKET_ID}.yaml"
+    path.write_text(yaml.safe_dump(body))
+    return path
+
+
+def _sha256_of(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _receipt_dict(
+    *,
+    contract_sha256: str | None,
+    ticket_id: str = _TICKET_ID,
+) -> dict[str, object]:
+    d: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": ticket_id,
+        "evidence_item_id": _EVIDENCE_ID,
+        "check_type": _CHECK_TYPE,
+        "check_value": "echo ok",
+        "status": "PASS",
+        "run_timestamp": datetime.now(tz=UTC).isoformat(),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "ci-receipt-gate",
+        "verifier": "foreground-receipt-gate-2026-04-30",
+        "probe_command": "echo ok",
+        "probe_stdout": "ok\n",
+    }
+    if contract_sha256 is not None:
+        d["contract_sha256"] = contract_sha256
+    return d
+
+
+def _write_receipt(receipts_dir: Path, data: dict[str, object]) -> None:
+    p = receipts_dir / _TICKET_ID / _EVIDENCE_ID / f"{_CHECK_TYPE}.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data))
+
+
+@pytest.mark.unit
+class TestContractSha256HashBinding:
+    def test_matching_contract_sha256_passes(self, tmp_path: Path) -> None:
+        """Receipt with correct contract_sha256 must PASS the gate."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        contract_path = _write_contract(contracts)
+        correct_sha = _sha256_of(contract_path)
+
+        _write_receipt(receipts, _receipt_dict(contract_sha256=correct_sha))
+        result = validate_pr_receipts(
+            pr_body=f"Closes {_TICKET_ID}",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_opened_at=_POST_CUTOFF_OPENED_AT,
+        )
+        assert result.passed, result.message
+
+    def test_mismatched_contract_sha256_fails(self, tmp_path: Path) -> None:
+        """Receipt with wrong contract_sha256 must FAIL with 'contract mutated' message."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts)
+        wrong_sha = "a" * 64  # valid format but wrong digest
+
+        _write_receipt(receipts, _receipt_dict(contract_sha256=wrong_sha))
+        result = validate_pr_receipts(
+            pr_body=f"Closes {_TICKET_ID}",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_opened_at=_POST_CUTOFF_OPENED_AT,
+        )
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "contract mutated" in msg_lower or "rerun probes" in msg_lower, (
+            f"expected 'contract mutated' or 'rerun probes' in message; got: {result.message!r}"
+        )
+
+    def test_missing_contract_sha256_pre_cutoff_is_advisory_fail(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy receipt without contract_sha256 on a pre-cutoff PR → ADVISORY downgrade, not hard FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts)
+        _write_receipt(receipts, _receipt_dict(contract_sha256=None))
+
+        result = validate_pr_receipts(
+            pr_body=f"Closes {_TICKET_ID}",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_opened_at=_PRE_CUTOFF_OPENED_AT,
+        )
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert (
+            "advisory" in msg_lower
+            or "migration window" in msg_lower
+            or "legacy" in msg_lower
+        ), (
+            f"expected advisory/migration/legacy in message for pre-cutoff legacy receipt; "
+            f"got: {result.message!r}"
+        )
+
+    def test_missing_contract_sha256_post_cutoff_hard_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Receipt without contract_sha256 on a post-cutoff PR → hard FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts)
+        _write_receipt(receipts, _receipt_dict(contract_sha256=None))
+
+        result = validate_pr_receipts(
+            pr_body=f"Closes {_TICKET_ID}",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_opened_at=_POST_CUTOFF_OPENED_AT,
+        )
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "contract_sha256" in msg_lower or "rerun probes" in msg_lower, (
+            f"expected 'contract_sha256' or 'rerun probes' in post-cutoff failure; "
+            f"got: {result.message!r}"
+        )
+
+    def test_missing_pr_opened_at_skips_hash_check(self, tmp_path: Path) -> None:
+        """When pr_opened_at is None, the hash check is skipped entirely — backward-compatible."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts)
+        _write_receipt(receipts, _receipt_dict(contract_sha256=None))
+
+        result = validate_pr_receipts(
+            pr_body=f"Closes {_TICKET_ID}",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_opened_at=None,
+        )
+        assert result.passed, result.message
+
+
+@pytest.mark.unit
+class TestComputeContractSha256:
+    def test_sha256_matches_hashlib(self, tmp_path: Path) -> None:
+        """compute_contract_sha256 must return the same digest as hashlib directly."""
+        f = tmp_path / "OMN-10421.yaml"
+        f.write_bytes(b"ticket_id: OMN-10421\n")
+        expected = hashlib.sha256(b"ticket_id: OMN-10421\n").hexdigest()
+        assert compute_contract_sha256(f) == expected
+
+    def test_sha256_is_64_lowercase_hex(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.yaml"
+        f.write_bytes(b"x: 1\n")
+        digest = compute_contract_sha256(f)
+        assert len(digest) == 64
+        assert digest == digest.lower()
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_sha256_changes_when_content_changes(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.yaml"
+        f.write_bytes(b"original: true\n")
+        sha1 = compute_contract_sha256(f)
+        f.write_bytes(b"mutated: true\n")
+        sha2 = compute_contract_sha256(f)
+        assert sha1 != sha2


### PR DESCRIPTION
## Summary

Implements OMN-10421 (Task 11 / Plan T11) — hash-binding of contract YAML to receipt (invariant I4 from the gate-collapse-fix plan).

- Extends `ModelDodReceipt` with `contract_sha256: str | None` field (64-char SHA-256 hex digest, validated by `_CONTRACT_SHA256_RE`)
- Adds `compute_contract_sha256(contract_path)` helper in `receipt_gate.py`
- Enforces hash check in `_check_one_receipt` when `pr_opened_at` is provided: mismatch → FAIL "contract mutated post-receipt; rerun probes"
- Migration policy: post-cutoff PRs (opened ≥ 2026-04-30) without the field → hard FAIL; pre-cutoff → ADVISORY downgrade for 7-day window; callers omitting `pr_opened_at` skip check entirely (backward compatible)
- 8 new unit tests covering all 4 plan-required cases plus `compute_contract_sha256` correctness

**ADDITIVE ONLY**: does not touch OCC checkout logic (T6a) or ticket-identity checks (T6b).

## Evidence

- `OMN-10421` — this ticket
- All 145 receipt-gate unit tests pass (no regressions)
- mypy --strict clean on changed files
- All pre-commit hooks pass

## Test plan

- [x] `test_matching_contract_sha256_passes` — PASS with correct hash
- [x] `test_mismatched_contract_sha256_fails` — FAIL with "contract mutated" message
- [x] `test_missing_contract_sha256_pre_cutoff_is_advisory_fail` — ADVISORY downgrade for legacy receipts
- [x] `test_missing_contract_sha256_post_cutoff_hard_fails` — hard FAIL post-cutoff
- [x] `test_missing_pr_opened_at_skips_hash_check` — backward-compatible when no pr_opened_at
- [x] `TestComputeContractSha256` — hash correctness, format, mutation detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt validation now includes contract integrity verification to detect if contracts have been modified after receipt generation.

* **Tests**
  * Added comprehensive test coverage for contract hash validation scenarios, including matching hashes, mismatched hashes, and legacy receipt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->