### PR TITLE
feat(OMN-10420): add ticket-identity binding to receipt_gate

### DIFF
--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -13,6 +13,11 @@ Canonical receipt path:
 
 Decision matrix:
     - No tickets in PR body              → FAIL ("no ticket ref")
+    - Evidence-Ticket missing            → FAIL ("missing Evidence-Ticket")
+    - PR title ↔ Evidence-Ticket mismatch → FAIL ("PR title mismatch")
+    - Branch ↔ Evidence-Ticket mismatch  → FAIL ("branch mismatch")
+    - Contract ticket_id ↔ Evidence-Ticket mismatch → FAIL ("contract ticket_id mismatch")
+    - Receipt ticket_id ↔ Evidence-Ticket mismatch  → FAIL ("receipt ticket_id mismatch")
     - Ticket has no contract file        → FAIL ("no contract")
     - Contract has no dod_evidence       → FAIL ("no dod_evidence")
     - Receipt missing for any check      → FAIL ("no receipt")
@@ -119,6 +124,16 @@ OVERRIDE_PATTERN = re.compile(
 # Inline marker pattern used only to reject the superseded approval syntax.
 # Receipt-gate bypass requires the central allowlist checked by _validate_skip_token.
 ALLOWLIST_PATTERN = re.compile(r"#\s*skip-token-allowed:\s*(\S+)", re.IGNORECASE)
+# Matches "Evidence-Ticket: OMN-XXXX" line in PR body (OMN-10420 identity binding).
+EVIDENCE_TICKET_PATTERN = re.compile(
+    r"^Evidence-Ticket:\s*(OMN-\d+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Matches "Evidence-Source: ..." line — presence triggers identity binding (OMN-10420).
+EVIDENCE_SOURCE_PATTERN = re.compile(
+    r"^Evidence-Source:\s*\S",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 # Matches "Evidence-Source: OCC#1234" or "Evidence-Source: <40-char-sha>" lines.
 # OCC#NNN form references an open PR by number; SHA form references a merged commit.
@@ -580,6 +595,95 @@ def _validate_skip_token(
     return (True, audit_msg)
 
 
+def _verify_ticket_identity(
+    evidence_ticket: str,
+    pr_title: str | None,
+    branch_name: str | None,
+    contracts_dir: Path,
+    receipts_dir: Path,
+) -> str | None:
+    """Verify that the Evidence-Ticket is consistent across all four identity axes.
+
+    This enforces invariant I3 (OMN-10420): evidence must correspond to the same
+    ticket as the PR.  Checks (in order):
+
+    1. PR title contains Evidence-Ticket (case-insensitive).
+    2. Branch name contains Evidence-Ticket (case-insensitive).
+    3. ``contracts/<ticket-id>.yaml`` exists and its ``ticket_id`` field matches.
+    4. Every receipt under ``drift/dod_receipts/<ticket-id>/`` has a ``ticket_id``
+       field that matches.
+
+    Args:
+        evidence_ticket: Normalised ticket id (e.g. "OMN-10420") from the ``Evidence-Ticket:`` line.
+        pr_title: PR title; checked for case-insensitive ticket reference.
+        branch_name: Git branch name; checked for case-insensitive ticket reference.
+        contracts_dir: Directory containing contract YAML files.
+        receipts_dir: Root of the receipt tree.
+
+    Returns:
+        ``None`` when all axes are consistent.  Otherwise an operator-facing failure
+        reason identifying exactly which axis mismatched.
+    """
+    ticket_upper = evidence_ticket.upper()
+
+    # Axis 1: PR title.
+    if pr_title is not None:
+        if ticket_upper not in pr_title.upper():
+            return (
+                f"IDENTITY BINDING FAILED: PR title does not reference {evidence_ticket}. "
+                f"PR title={pr_title!r}, Evidence-Ticket={evidence_ticket!r}. "
+                "The PR title must contain the same ticket cited in Evidence-Ticket."
+            )
+
+    # Axis 2: Branch name.
+    if branch_name is not None:
+        if ticket_upper not in branch_name.upper():
+            return (
+                f"IDENTITY BINDING FAILED: branch name does not reference {evidence_ticket}. "
+                f"branch={branch_name!r}, Evidence-Ticket={evidence_ticket!r}. "
+                "The branch must be named for the same ticket cited in Evidence-Ticket."
+            )
+
+    # Axis 3: Contract ticket_id field.
+    contract_path = contracts_dir / f"{evidence_ticket}.yaml"
+    if contract_path.exists():
+        try:
+            with contract_path.open(encoding="utf-8") as fh:
+                contract_data = yaml.safe_load(fh)
+        except (yaml.YAMLError, OSError) as e:
+            return f"IDENTITY BINDING FAILED: cannot read contract {contract_path}: {e}"
+        if isinstance(contract_data, dict):
+            contract_ticket_id = contract_data.get("ticket_id")
+            if contract_ticket_id is not None:
+                if str(contract_ticket_id).upper() != ticket_upper:
+                    return (
+                        f"IDENTITY BINDING FAILED: contract {contract_path} declares "
+                        f"ticket_id={contract_ticket_id!r} but Evidence-Ticket is "
+                        f"{evidence_ticket!r}. The contract ticket_id must match."
+                    )
+
+    # Axis 4: Receipt ticket_id fields.
+    receipt_ticket_dir = receipts_dir / evidence_ticket
+    if receipt_ticket_dir.exists():
+        for receipt_path in receipt_ticket_dir.rglob("*.yaml"):
+            try:
+                with receipt_path.open(encoding="utf-8") as fh:
+                    raw = yaml.safe_load(fh)
+            except (yaml.YAMLError, OSError):
+                continue  # corrupt receipts caught by _check_one_receipt
+            if not isinstance(raw, dict):
+                continue
+            receipt_tid = raw.get("ticket_id")
+            if receipt_tid is not None and str(receipt_tid).upper() != ticket_upper:
+                return (
+                    f"IDENTITY BINDING FAILED: receipt {receipt_path} declares "
+                    f"ticket_id={receipt_tid!r} but Evidence-Ticket is "
+                    f"{evidence_ticket!r}. All receipts must belong to the same ticket."
+                )
+
+    return None
+
+
 def validate_pr_receipts(
     pr_body: str,
     contracts_dir: Path,
@@ -590,6 +694,8 @@ def validate_pr_receipts(
     current_repo: str | None = None,
     current_pr_number: int | None = None,
     pr_opened_at: datetime | None = None,
+    evidence_ticket: str | None = None,
+    branch_name: str | None = None,
 ) -> ModelReceiptGateResult:
     """Run the receipt-gate against a PR's body + the repo's contracts + receipts.
 
@@ -608,6 +714,14 @@ def validate_pr_receipts(
             missing ``contract_sha256`` is a hard FAIL (post-cutoff) or ADVISORY
             (within the 7-day legacy migration window). When None, the hash-binding
             check is skipped because no PR-open timestamp is available.
+        evidence_ticket: Ticket id (e.g. "OMN-10420") from the ``Evidence-Ticket:``
+            PR body line.  When provided (or auto-detected from the PR body), identity
+            binding is enforced across all four axes: PR title, branch name, contract
+            ticket_id, receipt ticket_id.  When ``None``, auto-detected from the
+            ``Evidence-Ticket:`` line in ``pr_body``; if that line is present and this
+            arg is also ``None`` the detected value is used.  If neither source yields
+            a value and ``Evidence-Source`` is present, the gate fails.
+        branch_name: Git branch name for axis-2 identity binding.
     """
     override = OVERRIDE_PATTERN.search(pr_body)
     skip_match = SKIP_TOKEN_PATTERN.search(pr_body)
@@ -665,6 +779,40 @@ def validate_pr_receipts(
             friction_logged=True,
             message=message,
         )
+
+    # Identity binding (OMN-10420 / I3): enforced when Evidence-Source is present in the
+    # PR body (T6a pairing) OR when evidence_ticket is explicitly passed to the gate.
+    # Without Evidence-Source the caller has not opted into OCC pinning yet, so identity
+    # binding is skipped (backward-compatible with pre-T6a PRs).
+    has_evidence_source = bool(EVIDENCE_SOURCE_PATTERN.search(pr_body))
+    if has_evidence_source or evidence_ticket is not None:
+        resolved_evidence_ticket = evidence_ticket
+        if resolved_evidence_ticket is None:
+            et_match = EVIDENCE_TICKET_PATTERN.search(pr_body)
+            if et_match:
+                resolved_evidence_ticket = et_match.group(1).upper()
+
+        if resolved_evidence_ticket is None:
+            return ModelReceiptGateResult(
+                passed=False,
+                message=(
+                    "RECEIPT GATE FAILED: PR body contains 'Evidence-Source' but is "
+                    "missing an 'Evidence-Ticket: OMN-XXXX' line. Every PR with "
+                    "Evidence-Source must also declare Evidence-Ticket so the gate can "
+                    "verify the evidence is for the same ticket as the PR. "
+                    "Add 'Evidence-Ticket: OMN-XXXX' to the PR body."
+                ),
+            )
+
+        identity_failure = _verify_ticket_identity(
+            evidence_ticket=resolved_evidence_ticket,
+            pr_title=pr_title,
+            branch_name=branch_name,
+            contracts_dir=contracts_dir,
+            receipts_dir=receipts_dir,
+        )
+        if identity_failure is not None:
+            return ModelReceiptGateResult(passed=False, message=identity_failure)
 
     ticket_ids = _extract_ticket_ids(pr_body, pr_title)
     if not ticket_ids:
@@ -773,7 +921,9 @@ __all__ = [
     "EVIDENCE_SOURCE_ANY_PATTERN",
     "EVIDENCE_SOURCE_CUTOFF_SHA",
     "EVIDENCE_SOURCE_OCC_PR_PATTERN",
+    "EVIDENCE_SOURCE_PATTERN",
     "EVIDENCE_SOURCE_SHA_PATTERN",
+    "EVIDENCE_TICKET_PATTERN",
     "OVERRIDE_PATTERN",
     "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -625,10 +625,13 @@ def _verify_ticket_identity(
         reason identifying exactly which axis mismatched.
     """
     ticket_upper = evidence_ticket.upper()
+    exact_ticket_pattern = re.compile(
+        rf"(?<![A-Z0-9]){re.escape(ticket_upper)}(?![A-Z0-9])"
+    )
 
     # Axis 1: PR title.
     if pr_title is not None:
-        if ticket_upper not in pr_title.upper():
+        if exact_ticket_pattern.search(pr_title.upper()) is None:
             return (
                 f"IDENTITY BINDING FAILED: PR title does not reference {evidence_ticket}. "
                 f"PR title={pr_title!r}, Evidence-Ticket={evidence_ticket!r}. "
@@ -637,7 +640,7 @@ def _verify_ticket_identity(
 
     # Axis 2: Branch name.
     if branch_name is not None:
-        if ticket_upper not in branch_name.upper():
+        if exact_ticket_pattern.search(branch_name.upper()) is None:
             return (
                 f"IDENTITY BINDING FAILED: branch name does not reference {evidence_ticket}. "
                 f"branch={branch_name!r}, Evidence-Ticket={evidence_ticket!r}. "
@@ -654,13 +657,21 @@ def _verify_ticket_identity(
             return f"IDENTITY BINDING FAILED: cannot read contract {contract_path}: {e}"
         if isinstance(contract_data, dict):
             contract_ticket_id = contract_data.get("ticket_id")
-            if contract_ticket_id is not None:
-                if str(contract_ticket_id).upper() != ticket_upper:
-                    return (
-                        f"IDENTITY BINDING FAILED: contract {contract_path} declares "
-                        f"ticket_id={contract_ticket_id!r} but Evidence-Ticket is "
-                        f"{evidence_ticket!r}. The contract ticket_id must match."
-                    )
+            if (
+                not isinstance(contract_ticket_id, str)
+                or not contract_ticket_id.strip()
+            ):
+                return (
+                    f"IDENTITY BINDING FAILED: contract {contract_path} is missing "
+                    "a non-empty ticket_id. The contract ticket_id must match "
+                    f"{evidence_ticket!r}."
+                )
+            if contract_ticket_id.strip().upper() != ticket_upper:
+                return (
+                    f"IDENTITY BINDING FAILED: contract {contract_path} declares "
+                    f"ticket_id={contract_ticket_id!r} but Evidence-Ticket is "
+                    f"{evidence_ticket!r}. The contract ticket_id must match."
+                )
 
     # Axis 4: Receipt ticket_id fields.
     receipt_ticket_dir = receipts_dir / evidence_ticket
@@ -786,7 +797,11 @@ def validate_pr_receipts(
     # binding is skipped (backward-compatible with pre-T6a PRs).
     has_evidence_source = bool(EVIDENCE_SOURCE_PATTERN.search(pr_body))
     if has_evidence_source or evidence_ticket is not None:
-        resolved_evidence_ticket = evidence_ticket
+        resolved_evidence_ticket = (
+            evidence_ticket.strip().upper()
+            if isinstance(evidence_ticket, str) and evidence_ticket.strip()
+            else None
+        )
         if resolved_evidence_ticket is None:
             et_match = EVIDENCE_TICKET_PATTERN.search(pr_body)
             if et_match:

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -94,6 +94,24 @@ def main(argv: list[str] | None = None) -> int:
         help="OMN-10417: PR number. Used for skip-token scope check.",
     )
     parser.add_argument(
+        "--evidence-ticket",
+        default=None,
+        help=(
+            "OMN-10420: OMN-XXXX ticket id from 'Evidence-Ticket:' PR body line. "
+            "When provided, identity binding is enforced across PR title, branch name, "
+            "contract ticket_id, and receipt ticket_id. When omitted, auto-detected "
+            "from the PR body; if absent there too, the gate fails."
+        ),
+    )
+    parser.add_argument(
+        "--branch-name",
+        default=None,
+        help=(
+            "OMN-10420: Git branch name of the PR head. Used for axis-2 identity "
+            "binding (branch must reference the same ticket as Evidence-Ticket)."
+        ),
+    )
+    parser.add_argument(
         "--reexecute-probes",
         action="store_true",
         default=False,
@@ -115,6 +133,8 @@ def main(argv: list[str] | None = None) -> int:
         pr_author=args.pr_author,
         current_repo=args.current_repo,
         current_pr_number=args.current_pr_number,
+        evidence_ticket=args.evidence_ticket,
+        branch_name=args.branch_name,
     )
 
     if result.friction_logged:

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -99,8 +99,9 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "OMN-10420: OMN-XXXX ticket id from 'Evidence-Ticket:' PR body line. "
             "When provided, identity binding is enforced across PR title, branch name, "
-            "contract ticket_id, and receipt ticket_id. When omitted, auto-detected "
-            "from the PR body; if absent there too, the gate fails."
+            "contract ticket_id, and receipt ticket_id. When omitted, it is "
+            "auto-detected from the PR body while identity binding is active; "
+            "if no ticket is available when Evidence-Source is present, the gate fails."
         ),
     )
     parser.add_argument(

--- a/tests/unit/validation/test_receipt_gate_evidence_source.py
+++ b/tests/unit/validation/test_receipt_gate_evidence_source.py
@@ -195,6 +195,7 @@ class TestReceiptGateEvidenceSourceIntegration:
 
         pr_body = (
             "Closes OMN-10419\n\n"
+            "Evidence-Ticket: OMN-10419\n"
             "Evidence-Source: OCC#588\n\n"
             "Implements the Evidence-Source pinning requirement."
         )
@@ -252,7 +253,9 @@ class TestReceiptGateEvidenceSourceIntegration:
         # Receipts directory exists but is empty — no receipt files.
         receipts_dir.mkdir(parents=True, exist_ok=True)
 
-        pr_body = "Closes OMN-10419\n\nEvidence-Source: OCC#588"
+        pr_body = (
+            "Closes OMN-10419\n\nEvidence-Ticket: OMN-10419\nEvidence-Source: OCC#588"
+        )
         result = validate_pr_receipts(
             pr_body=pr_body,
             contracts_dir=contracts_dir,
@@ -279,7 +282,11 @@ class TestReceiptGateEvidenceSourceIntegration:
         contracts_dir.mkdir(parents=True, exist_ok=True)
         receipts_dir.mkdir(parents=True, exist_ok=True)
 
-        pr_body = "Closes OMN-10419\n\nEvidence-Source: abc1234def5678901234567890abcdef12345678"
+        pr_body = (
+            "Closes OMN-10419\n\n"
+            "Evidence-Ticket: OMN-10419\n"
+            "Evidence-Source: abc1234def5678901234567890abcdef12345678"
+        )
         result = validate_pr_receipts(
             pr_body=pr_body,
             contracts_dir=contracts_dir,

--- a/tests/unit/validation/test_receipt_gate_identity_binding.py
+++ b/tests/unit/validation/test_receipt_gate_identity_binding.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Ticket-identity binding tests for receipt-gate (OMN-10420).
+
+Five cases as required by the plan (T6b):
+    1. missing_evidence_ticket   — no Evidence-Ticket line → FAIL
+    2. pr_title_mismatch         — PR title references different ticket → FAIL
+    3. branch_mismatch           — branch name references different ticket → FAIL
+    4. contract_ticket_id_mismatch — contract ticket_id field ≠ Evidence-Ticket → FAIL
+    5. receipt_ticket_id_mismatch  — receipt ticket_id field ≠ Evidence-Ticket → FAIL
+
+Each failure message must identify the specific axis that mismatched.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation.receipt_gate import validate_pr_receipts
+
+
+def _write_contract(
+    contracts_dir: Path,
+    ticket_id: str,
+    *,
+    contract_ticket_id: str | None = None,
+) -> None:
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "ticket_id": contract_ticket_id
+        if contract_ticket_id is not None
+        else ticket_id,
+        "schema_version": "1.0.0",
+        "summary": "test contract for identity binding",
+        "dod_evidence": [
+            {
+                "id": "dod-001",
+                "description": "identity check",
+                "checks": [{"check_type": "command", "check_value": "echo ok"}],
+            }
+        ],
+    }
+    (contracts_dir / f"{ticket_id}.yaml").write_text(yaml.safe_dump(body))
+
+
+def _write_receipt(
+    receipts_dir: Path,
+    ticket_id: str,
+    *,
+    receipt_ticket_id: str | None = None,
+) -> None:
+    p = receipts_dir / ticket_id / "dod-001" / "command.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "schema_version": "1.0.0",
+        "ticket_id": receipt_ticket_id if receipt_ticket_id is not None else ticket_id,
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "echo ok",
+        "status": "PASS",
+        "run_timestamp": datetime.now(tz=UTC).isoformat(),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "worker-A",
+        "verifier": "foreground-claude-X",
+        "probe_command": "echo ok",
+        "probe_stdout": "ok\n",
+    }
+    p.write_text(yaml.safe_dump(data))
+
+
+@pytest.mark.unit
+class TestTicketIdentityBinding:
+    """Five required identity-binding failure cases (OMN-10420 / T6b)."""
+
+    # Identity binding is triggered when Evidence-Source is present in the PR body
+    # (T6a pairing) OR when evidence_ticket is explicitly passed to the gate.
+    # All tests below use Evidence-Source in the PR body to activate binding.
+
+    def test_missing_evidence_ticket_fails(self, tmp_path: Path) -> None:
+        """Case 1: Evidence-Source present but no Evidence-Ticket line → FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n\n"
+                "This PR implements the feature."
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "evidence-ticket" in msg_lower, (
+            f"message must mention 'Evidence-Ticket'; got: {result.message!r}"
+        )
+
+    def test_pr_title_mismatch_fails(self, tmp_path: Path) -> None:
+        """Case 2: PR title references OMN-1234 but Evidence-Ticket is OMN-10420 → FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-1234): some other ticket entirely",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "pr title" in msg_lower or "title" in msg_lower, (
+            f"message must mention 'PR title'; got: {result.message!r}"
+        )
+        assert "omn-10420" in msg_lower or "omn-1234" in msg_lower
+
+    def test_branch_mismatch_fails(self, tmp_path: Path) -> None:
+        """Case 3: branch references OMN-9999 but Evidence-Ticket is OMN-10420 → FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-9999-completely-different-ticket",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "branch" in msg_lower, (
+            f"message must mention 'branch'; got: {result.message!r}"
+        )
+        assert "omn-9999" in msg_lower or "omn-10420" in msg_lower
+
+    def test_contract_ticket_id_mismatch_fails(self, tmp_path: Path) -> None:
+        """Case 4: contract ticket_id=OMN-5678 but Evidence-Ticket=OMN-10420 → FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        # Contract file is named OMN-10420.yaml but its ticket_id field says OMN-5678
+        _write_contract(contracts, "OMN-10420", contract_ticket_id="OMN-5678")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "contract" in msg_lower, (
+            f"message must mention 'contract'; got: {result.message!r}"
+        )
+        assert "ticket_id" in msg_lower or "omn-5678" in msg_lower
+
+    def test_receipt_ticket_id_mismatch_fails(self, tmp_path: Path) -> None:
+        """Case 5: receipt ticket_id=OMN-9999 but Evidence-Ticket=OMN-10420 → FAIL."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        # Receipt lives under OMN-10420/ dir but its ticket_id field says OMN-9999
+        _write_receipt(receipts, "OMN-10420", receipt_ticket_id="OMN-9999")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "receipt" in msg_lower, (
+            f"message must mention 'receipt'; got: {result.message!r}"
+        )
+        assert "ticket_id" in msg_lower or "omn-9999" in msg_lower
+
+    def test_valid_identity_passes_gate(self, tmp_path: Path) -> None:
+        """Sanity: all axes consistent → gate passes normally."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert result.passed, result.message
+
+    def test_evidence_ticket_auto_detected_from_pr_body(self, tmp_path: Path) -> None:
+        """Evidence-Ticket line is auto-detected when Evidence-Source is also present."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420\n\n"
+                "Some body text."
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+            # evidence_ticket not passed — must be auto-detected from pr_body
+        )
+
+        assert result.passed, result.message
+
+    def test_evidence_ticket_arg_overrides_body_detection(self, tmp_path: Path) -> None:
+        """Explicit evidence_ticket= arg takes precedence over PR body detection."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\nEvidence-Source: abc123\nEvidence-Ticket: OMN-9999"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+            evidence_ticket="OMN-10420",  # explicit arg wins; body says OMN-9999
+        )
+
+        assert result.passed, result.message
+
+    def test_no_evidence_source_skips_identity_binding(self, tmp_path: Path) -> None:
+        """Without Evidence-Source, identity binding is not triggered (pre-T6a compat)."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-10420\n\nNo Evidence-Source here.",
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        # Gate should proceed to receipt verification, not fail on missing Evidence-Ticket
+        assert result.passed, result.message

--- a/tests/unit/validation/test_receipt_gate_identity_binding.py
+++ b/tests/unit/validation/test_receipt_gate_identity_binding.py
@@ -29,12 +29,10 @@ def _write_contract(
     ticket_id: str,
     *,
     contract_ticket_id: str | None = None,
+    include_ticket_id: bool = True,
 ) -> None:
     contracts_dir.mkdir(parents=True, exist_ok=True)
     body = {
-        "ticket_id": contract_ticket_id
-        if contract_ticket_id is not None
-        else ticket_id,
         "schema_version": "1.0.0",
         "summary": "test contract for identity binding",
         "dod_evidence": [
@@ -45,6 +43,10 @@ def _write_contract(
             }
         ],
     }
+    if include_ticket_id:
+        body["ticket_id"] = (
+            contract_ticket_id if contract_ticket_id is not None else ticket_id
+        )
     (contracts_dir / f"{ticket_id}.yaml").write_text(yaml.safe_dump(body))
 
 
@@ -132,6 +134,28 @@ class TestTicketIdentityBinding:
         )
         assert "omn-10420" in msg_lower or "omn-1234" in msg_lower
 
+    def test_pr_title_partial_ticket_match_fails(self, tmp_path: Path) -> None:
+        """PR title must contain the exact Evidence-Ticket token, not a prefix."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-104201): wrong ticket prefix",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        assert "pr title" in result.message.lower()
+
     def test_branch_mismatch_fails(self, tmp_path: Path) -> None:
         """Case 3: branch references OMN-9999 but Evidence-Ticket is OMN-10420 → FAIL."""
         contracts = tmp_path / "contracts"
@@ -157,6 +181,28 @@ class TestTicketIdentityBinding:
             f"message must mention 'branch'; got: {result.message!r}"
         )
         assert "omn-9999" in msg_lower or "omn-10420" in msg_lower
+
+    def test_branch_partial_ticket_match_fails(self, tmp_path: Path) -> None:
+        """Branch name must contain the exact Evidence-Ticket token, not a prefix."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-104201-wrong-ticket-prefix",
+        )
+
+        assert not result.passed
+        assert "branch" in result.message.lower()
 
     def test_contract_ticket_id_mismatch_fails(self, tmp_path: Path) -> None:
         """Case 4: contract ticket_id=OMN-5678 but Evidence-Ticket=OMN-10420 → FAIL."""
@@ -184,6 +230,30 @@ class TestTicketIdentityBinding:
             f"message must mention 'contract'; got: {result.message!r}"
         )
         assert "ticket_id" in msg_lower or "omn-5678" in msg_lower
+
+    def test_contract_missing_ticket_id_fails(self, tmp_path: Path) -> None:
+        """Case 4b: contract without ticket_id fails closed."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420", include_ticket_id=False)
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-10420\n\n"
+                "Evidence-Source: abc123\n"
+                "Evidence-Ticket: OMN-10420"
+            ),
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+        )
+
+        assert not result.passed
+        msg_lower = result.message.lower()
+        assert "contract" in msg_lower
+        assert "ticket_id" in msg_lower
 
     def test_receipt_ticket_id_mismatch_fails(self, tmp_path: Path) -> None:
         """Case 5: receipt ticket_id=OMN-9999 but Evidence-Ticket=OMN-10420 → FAIL."""
@@ -272,6 +342,24 @@ class TestTicketIdentityBinding:
             receipts_dir=receipts,
             branch_name="jonah/omn-10420-ticket-identity-binding",
             evidence_ticket="OMN-10420",  # explicit arg wins; body says OMN-9999
+        )
+
+        assert result.passed, result.message
+
+    def test_explicit_evidence_ticket_is_normalized(self, tmp_path: Path) -> None:
+        """Explicit evidence_ticket arguments use canonical case for path lookups."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-10420")
+        _write_receipt(receipts, "OMN-10420")
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-10420\n\nEvidence-Source: abc123",
+            pr_title="feat(OMN-10420): ticket identity binding",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-10420-ticket-identity-binding",
+            evidence_ticket=" omn-10420 ",
         )
 
         assert result.passed, result.message


### PR DESCRIPTION
## Summary
- Add ticket-identity binding to receipt gate validation
- Wire receipt_gate_cli.py for identity verification

## Ticket
OMN-10420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces Evidence-Ticket identity binding across PR title, branch, contract and receipt references with axis-specific failure messages.
  * Auto-detects and normalizes Evidence-Ticket from PR body; fails immediately if Evidence-Source is present but no ticket found.
  * Adds CLI options to explicitly supply evidence-ticket and branch-name.

* **Tests**
  * Added comprehensive tests covering detection, normalization, precedence, matching/mismatches, and skipped-identity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->