### PR TITLE
feat: remove API key requirements from frontier model auth (OMN-7835)

### DIFF
--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -26,8 +26,8 @@ jobs:
     name: Stale TODO Gate
     runs-on: >-
       ${{
-        vars.USE_SELF_HOSTED_RUNNERS == 'true'
-        && 'self-hosted, omnibase-ci'
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true'
+          && fromJSON('["self-hosted","omnibase-ci"]'))
         || 'ubuntu-latest'
       }}
 

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -24,12 +24,7 @@ on:
 jobs:
   stale-todo-gate:
     name: Stale TODO Gate
-    runs-on: >-
-      ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true'
-          && fromJSON('["self-hosted","omnibase-ci"]'))
-        || 'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/src/omnibase_core/enums/enum_llm_provider.py
+++ b/src/omnibase_core/enums/enum_llm_provider.py
@@ -28,8 +28,13 @@ class EnumLlmProvider(StrValueHelper, str, Enum):
         return self in {self.LOCAL, self.LITELLM}
 
     def requires_api_key(self) -> bool:
-        """Check if this provider requires an API key."""
-        return self in {self.CLAUDE, self.OPENAI, self.GEMINI, self.ANTHROPIC}
+        """Check if this provider requires an API key.
+
+        Per OMN-7467/OMN-7835, all frontier providers use SSO/OAuth.
+        Only GLM (Zhipu AI) requires an explicit API key, but GLM is
+        not represented in this enum. All members here use SSO/OAuth.
+        """
+        return False
 
 
 __all__ = ["EnumLlmProvider"]

--- a/src/omnibase_core/models/configuration/model_agent_config.py
+++ b/src/omnibase_core/models/configuration/model_agent_config.py
@@ -30,7 +30,10 @@ class ModelAgentConfig(BaseModel):
         default="claude-3-sonnet-20240229",
         description="Claude model to use for the agent",
     )
-    api_key: str = Field(description="Anthropic API key for authentication")
+    api_key: str | None = Field(
+        default=None,
+        description="API key for authentication (optional — SSO/OAuth used when absent, per OMN-7835)",
+    )
     permissions: ModelAgentPermissions = Field(
         description="Agent permission configuration",
     )

--- a/tests/unit/enums/test_enum_llm_provider.py
+++ b/tests/unit/enums/test_enum_llm_provider.py
@@ -113,16 +113,9 @@ class TestEnumLlmProvider:
         assert EnumLlmProvider.ANTHROPIC.is_local() is False
 
     def test_requires_api_key_method(self):
-        """Test the requires_api_key method"""
-        # Providers that require API keys
-        assert EnumLlmProvider.CLAUDE.requires_api_key() is True
-        assert EnumLlmProvider.OPENAI.requires_api_key() is True
-        assert EnumLlmProvider.GEMINI.requires_api_key() is True
-        assert EnumLlmProvider.ANTHROPIC.requires_api_key() is True
-
-        # Providers that don't require API keys
-        assert EnumLlmProvider.LOCAL.requires_api_key() is False
-        assert EnumLlmProvider.LITELLM.requires_api_key() is False
+        """Test the requires_api_key method — all use SSO/OAuth (OMN-7835)."""
+        for provider in EnumLlmProvider:
+            assert provider.requires_api_key() is False
 
     def test_enum_provider_types(self):
         """Test provider type categorization"""
@@ -143,10 +136,6 @@ class TestEnumLlmProvider:
         all_providers = set(EnumLlmProvider)
         assert commercial_providers.union(local_providers) == all_providers
 
-        # Verify all commercial providers require API keys
-        for provider in commercial_providers:
-            assert provider.requires_api_key() is True
-
-        # Verify all local providers don't require API keys
-        for provider in local_providers:
+        # Verify no providers require API keys (SSO/OAuth, OMN-7835)
+        for provider in all_providers:
             assert provider.requires_api_key() is False

--- a/tests/unit/enums/test_enum_llm_provider.py
+++ b/tests/unit/enums/test_enum_llm_provider.py
@@ -114,7 +114,7 @@ class TestEnumLlmProvider:
 
     def test_requires_api_key_method(self):
         """Test the requires_api_key method — all use SSO/OAuth (OMN-7835)."""
-        for provider in EnumLlmProvider:
+        for provider in EnumLlmProvider.__members__.values():
             assert provider.requires_api_key() is False
 
     def test_enum_provider_types(self):
@@ -133,7 +133,7 @@ class TestEnumLlmProvider:
             EnumLlmProvider.LITELLM,
         }
 
-        all_providers = set(EnumLlmProvider)
+        all_providers = set(EnumLlmProvider.__members__.values())
         assert commercial_providers.union(local_providers) == all_providers
 
         # Verify no providers require API keys (SSO/OAuth, OMN-7835)


### PR DESCRIPTION
## Summary
- Remove hard API key requirements for frontier model providers (Anthropic, OpenAI, Google) per OMN-7835 / OMN-7467
- `EnumLlmProvider.requires_api_key()` now returns `False` for all members (SSO/OAuth is the primary auth path)
- `ModelAgentConfig.api_key` changed from required `str` to optional `str | None = Field(default=None)`
- Updated test assertions to match new SSO/OAuth auth model

## Acceptance Criteria (OMN-7835)
- [x] No code path requires `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`
- [x] GLM auth uses `LLM_GLM_API_KEY` from env (unchanged, not in this enum)
- [x] Delegation router starts without any API key preflight failures

## Test Results
- 15/15 enum tests pass
- mypy strict: 0 errors
- All pre-commit hooks pass

## Evidence-Source

Evidence-Source: OCC#613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent API key is now optional; users can authenticate via SSO/OAuth when no explicit API key is provided.

* **Behavior Change**
  * Providers are consistently treated as not requiring an explicit API key.

* **Tests**
  * Authentication tests updated to reflect the unified API-key behavior across all providers.

* **Chores**
  * CI workflow runner selection logic improved for self-hosted runner usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Evidence-Ticket: OMN-7835