### PR TITLE
feat(enums): add TASK_BOUNDARY_TESTS bit to EnumHookBit [OMN-7261]

### DIFF
--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -90,6 +90,7 @@ class EnumHookBit(IntEnum):
     SESSION_START = 1 << 55
     SESSION_START_ONEX_CLI_PIN_CHECK = 1 << 56
     HANDOFF_NUDGE = 1 << 57
+    TASK_BOUNDARY_TESTS = 1 << 58
 
 
 # Default mask ORs all actual member values — correct even after tombstones are

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -13,7 +13,7 @@ from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
 pytestmark = pytest.mark.unit
 
 # Frozen GATE count from Task 1 inventory. Update only when the inventory doc changes.
-_N_GATE = 58
+_N_GATE = 59
 
 
 class TestEnumHookBit:


### PR DESCRIPTION
## Summary
- Appends `TASK_BOUNDARY_TESTS = 1 << 58` to `EnumHookBit` (bit 58, after `HANDOFF_NUDGE`)
- Required by omniclaude PR for the task-boundary test discovery hook (OMN-7261 Workstream E Phase 1)

## Linked
- OMN-7261
- Cross-repo: OmniNode-ai/omniclaude (task-boundary hook implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new hook configuration option to extend event handling and monitoring; it is included in the default hook mask so behavior reflects the expanded set of hooks.
* **Tests**
  * Updated unit tests to account for the additional hook option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->