### PR TITLE
feat(OMN-10484): enforce deterministic OCC merge eligibility

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -42,6 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Resolve PR and author
         id: resolve
         env:
@@ -77,6 +85,62 @@ jobs:
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
           echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve OCC main SHA
+        id: occ_ref
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sha="$(gh api repos/OmniNode-ai/onex_change_control/git/ref/heads/main --jq '.object.sha')"
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::could not resolve immutable onex_change_control/main SHA"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check out OCC evidence snapshot
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/onex_change_control
+          path: .onex_change_control
+          ref: ${{ steps.occ_ref.outputs.sha }}
+          fetch-depth: 1
+
+      - name: OCC auto-merge preflight
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh pr view "$PR" --repo "$GH_REPO" --json body,title,headRefName,commits)"
+          printf '%s' "$pr_json" | jq -r '.body // ""' > /tmp/pr_body.txt
+          PR_TITLE="$(printf '%s' "$pr_json" | jq -r '.title // ""')"
+          PR_BRANCH="$(printf '%s' "$pr_json" | jq -r '.headRefName // ""')"
+
+          commit_args=()
+          while IFS= read -r sha; do
+            [ -n "$sha" ] && commit_args+=(--pr-commit-sha "$sha")
+          done < <(printf '%s' "$pr_json" | jq -r '.commits[]?.oid // empty')
+          while IFS= read -r text; do
+            [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
+          done < <(printf '%s' "$pr_json" | jq -r '.commits[]? | ((.messageHeadline // "") + " " + (.messageBody // "" | gsub("\r?\n"; " ")))')
+
+          PYTHONPATH=src uv run python -m omnibase_core.validation.occ_merge_eligibility \
+            --repo "${GH_REPO##*/}" \
+            --pr-number "$PR" \
+            --pr-title "$PR_TITLE" \
+            --pr-body-file /tmp/pr_body.txt \
+            --pr-branch "$PR_BRANCH" \
+            --occ-commit-sha "${{ steps.occ_ref.outputs.sha }}" \
+            --contracts-dir ".onex_change_control/contracts" \
+            --receipts-dir ".onex_change_control/drift/dod_receipts" \
+            "${commit_args[@]}" \
+            | tee /tmp/occ_auto_merge_preflight.json
 
       - name: Enable auto-merge
         if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -130,7 +130,7 @@ jobs:
             [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
           done < <(printf '%s' "$pr_json" | jq -r '.commits[]? | ((.messageHeadline // "") + " " + (.messageBody // "" | gsub("\r?\n"; " ")))')
 
-          PYTHONPATH=src uv run python -m omnibase_core.validation.occ_merge_eligibility \
+          PYTHONPATH=src uv run python -m omnibase_core.validation.validator_occ_merge_eligibility \
             --repo "${GH_REPO##*/}" \
             --pr-number "$PR" \
             --pr-title "$PR_TITLE" \

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -53,22 +53,37 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      - name: Resolve OCC main SHA
+        id: occ_ref
+        if: github.repository != 'OmniNode-ai/onex_change_control'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha="$(gh api repos/OmniNode-ai/onex_change_control/git/ref/heads/main --jq '.object.sha')"
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::could not resolve immutable onex_change_control/main SHA"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       # We need the onex_change_control repo to find contracts + receipts.
-      # In single-repo usage (omnibase_core hosting the gate), the tree is
-      # already present as a submodule or sibling checkout. In fan-out
-      # deployment, each caller repo checks out onex_change_control here.
+      # Downstream callers must read it through the pinned SHA resolved above;
+      # onex_change_control PRs are the only exception and validate evidence
+      # inside the PR checkout to avoid circular "already on main" dependency.
       - name: Check out onex_change_control (for contracts + receipts)
+        if: github.repository != 'OmniNode-ai/onex_change_control'
         uses: actions/checkout@v6
         with:
           repository: OmniNode-ai/onex_change_control
           path: .onex_change_control
-          ref: main
+          ref: ${{ steps.occ_ref.outputs.sha }}
           fetch-depth: 1
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -216,35 +231,38 @@ jobs:
             exit 1
           }
 
-      - name: Resolve PR body
+      - name: Resolve PR snapshot
         id: resolve_body
-        # Always fetch the PR body fresh from the GitHub API to avoid stale
-        # cached event payloads on re-runs (OMN-9717). github.event.pull_request.body
-        # is frozen at workflow trigger time — if the PR body is edited after CI
-        # fires, a re-run still reads the old body. Fetching via gh pr view
-        # guarantees the live body regardless of when the re-run happens.
-        #
-        # merge_group events do not carry pull_request.body. Derive the PR number
-        # from merge_group.head_ref (format: pr-<num>-<sha>) and fetch via API.
-        #
-        # OMN-10417: also capture PR author login and resolved PR number for
-        # skip-token self-approval and scope checks.
+        # Resolve mutable GitHub state exactly once. All eligibility checks below
+        # consume these files plus the pinned OCC SHA; they do not re-fetch PR
+        # metadata or move the evidence ref during validation.
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_EVENT_BODY: ${{ github.event.pull_request.body }}
           PR_EVENT_TITLE: ${{ github.event.pull_request.title }}
           PR_EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_EVENT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_EVENT_SHA: ${{ github.event.pull_request.head.sha }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
-          set -e
+          set -euo pipefail
+          : > /tmp/pr_commit_shas.txt
+          : > /tmp/pr_commit_texts.txt
+
+          write_pr_snapshot() {
+            local pr_json="$1"
+            printf '%s' "$pr_json" | jq -r '.body // ""' > /tmp/pr_body.txt
+            printf '%s' "$pr_json" | jq -r '.title // ""' > /tmp/pr_title.txt
+            printf '%s' "$pr_json" | jq -r '.author.login // ""' > /tmp/pr_author.txt
+            printf '%s' "$pr_json" | jq -r '.headRefName // ""' > /tmp/pr_branch.txt
+            printf '%s' "$pr_json" | jq -r '.commits[]?.oid // empty' > /tmp/pr_commit_shas.txt
+            printf '%s' "$pr_json" | jq -r '.commits[]? | ((.messageHeadline // "") + " " + (.messageBody // "" | gsub("\r?\n"; " ")))' > /tmp/pr_commit_texts.txt
+          }
+
           if [ -n "$PR_NUMBER" ]; then
-            # pull_request event: always fetch live body so re-runs see edits.
-            # Single API call fetches both fields to minimise rate-limit consumption.
-            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title,author 2>/dev/null)"; then
-              printf '%s' "$pr_json" | jq -r '.body' > /tmp/pr_body.txt
-              printf '%s' "$pr_json" | jq -r '.title' > /tmp/pr_title.txt
-              printf '%s' "$pr_json" | jq -r '.author.login' > /tmp/pr_author.txt
+            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title,author,headRefName,commits 2>/dev/null)"; then
+              write_pr_snapshot "$pr_json"
               printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             else
               # API unavailable — fall back to event payload with a warning.
@@ -252,28 +270,83 @@ jobs:
               printf '%s' "$PR_EVENT_BODY" > /tmp/pr_body.txt
               printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
               printf '%s' "$PR_EVENT_AUTHOR" > /tmp/pr_author.txt
+              printf '%s' "$PR_EVENT_BRANCH" > /tmp/pr_branch.txt
+              printf '%s\n' "$PR_EVENT_SHA" > /tmp/pr_commit_shas.txt
               printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             fi
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then
             pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
             if [ -n "$pr_num" ] && [ "$pr_num" != "$MERGE_GROUP_HEAD_REF" ]; then
-              pr_json="$(gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title,author)"
-              printf '%s' "$pr_json" | jq -r '.body' > /tmp/pr_body.txt
-              printf '%s' "$pr_json" | jq -r '.title' > /tmp/pr_title.txt
-              printf '%s' "$pr_json" | jq -r '.author.login' > /tmp/pr_author.txt
+              pr_json="$(gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title,author,headRefName,commits)"
+              write_pr_snapshot "$pr_json"
               printf '%s' "$pr_num" > /tmp/pr_number.txt
             else
               : > /tmp/pr_body.txt
               : > /tmp/pr_title.txt
               : > /tmp/pr_author.txt
+              : > /tmp/pr_branch.txt
               : > /tmp/pr_number.txt
             fi
           else
             : > /tmp/pr_body.txt
             : > /tmp/pr_title.txt
             : > /tmp/pr_author.txt
+            : > /tmp/pr_branch.txt
             : > /tmp/pr_number.txt
           fi
+
+      - name: Resolve evidence snapshot
+        id: evidence
+        run: |
+          set -euo pipefail
+          repo_short="${GITHUB_REPOSITORY##*/}"
+          if [ "$repo_short" = "onex_change_control" ]; then
+            sha="$(git rev-parse HEAD)"
+            root="."
+          else
+            sha="${{ steps.occ_ref.outputs.sha }}"
+            root=".onex_change_control"
+          fi
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::invalid evidence snapshot SHA: $sha"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+
+      - name: Run OCC Eligibility
+        run: |
+          set -euo pipefail
+          PR_TITLE="$(cat /tmp/pr_title.txt)"
+          PR_BRANCH="$(cat /tmp/pr_branch.txt)"
+          PR_NUMBER_RESOLVED="$(cat /tmp/pr_number.txt 2>/dev/null || true)"
+          REPO_NAME="${{ github.repository }}"
+          REPO_SHORT="${REPO_NAME##*/}"
+
+          if [ -z "$PR_NUMBER_RESOLVED" ]; then
+            echo "::error::could not resolve PR number for OCC eligibility"
+            exit 1
+          fi
+
+          commit_args=()
+          while IFS= read -r sha; do
+            [ -n "$sha" ] && commit_args+=(--pr-commit-sha "$sha")
+          done < /tmp/pr_commit_shas.txt
+          while IFS= read -r text; do
+            [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
+          done < /tmp/pr_commit_texts.txt
+
+          python -m omnibase_core.validation.occ_merge_eligibility \
+            --repo "$REPO_SHORT" \
+            --pr-number "$PR_NUMBER_RESOLVED" \
+            --pr-title "$PR_TITLE" \
+            --pr-body-file /tmp/pr_body.txt \
+            --pr-branch "$PR_BRANCH" \
+            --occ-commit-sha "${{ steps.evidence.outputs.sha }}" \
+            --contracts-dir "${{ steps.evidence.outputs.root }}/${{ inputs.contracts-dir }}" \
+            --receipts-dir "${{ steps.evidence.outputs.root }}/${{ inputs.receipts-dir }}" \
+            "${commit_args[@]}" \
+            | tee /tmp/occ_eligibility.json
 
       - name: Run Receipt-Gate
         run: |
@@ -285,8 +358,9 @@ jobs:
           REPO_SHORT="${REPO_NAME##*/}"
 
           ALLOWLIST_ARG=""
-          if [ -f ".onex_change_control/allowlists/skip_token_approvals.yaml" ]; then
-            ALLOWLIST_ARG="--allowlist-path .onex_change_control/allowlists/skip_token_approvals.yaml"
+          EVIDENCE_ROOT="${{ steps.evidence.outputs.root }}"
+          if [ -f "$EVIDENCE_ROOT/allowlists/skip_token_approvals.yaml" ]; then
+            ALLOWLIST_ARG="--allowlist-path $EVIDENCE_ROOT/allowlists/skip_token_approvals.yaml"
           fi
 
           PR_AUTHOR_ARG=""
@@ -303,8 +377,8 @@ jobs:
           python -m omnibase_core.validation.receipt_gate_cli \
             --pr-body "$PR_BODY" \
             --pr-title "$PR_TITLE" \
-            --contracts-dir ".onex_change_control/${{ inputs.contracts-dir }}" \
-            --receipts-dir ".onex_change_control/${{ inputs.receipts-dir }}" \
+            --contracts-dir "${{ steps.evidence.outputs.root }}/${{ inputs.contracts-dir }}" \
+            --receipts-dir "${{ steps.evidence.outputs.root }}/${{ inputs.receipts-dir }}" \
             --current-repo "$REPO_SHORT" \
             $ALLOWLIST_ARG \
             $PR_AUTHOR_ARG \

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -336,7 +336,7 @@ jobs:
             [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
           done < /tmp/pr_commit_texts.txt
 
-          python -m omnibase_core.validation.occ_merge_eligibility \
+          python -m omnibase_core.validation.validator_occ_merge_eligibility \
             --repo "$REPO_SHORT" \
             --pr-number "$PR_NUMBER_RESOLVED" \
             --pr-title "$PR_TITLE" \

--- a/src/omnibase_core/enums/enum_occ_eligibility_reason.py
+++ b/src/omnibase_core/enums/enum_occ_eligibility_reason.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OCC merge eligibility failure reasons."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumOccEligibilityReason(StrEnum):
+    """Standardized reason values emitted by the OCC eligibility gate."""
+
+    ELIGIBLE = "eligible"
+    MISSING_TICKET = "missing_ticket"
+    MISSING_CONTRACT = "missing_contract"
+    MISSING_RECEIPT = "missing_receipt"
+    NONPASS_RECEIPT = "nonpass_receipt"
+    CONTRACT_HASH_MISMATCH = "contract_hash_mismatch"
+    OCC_NOT_ON_MAIN = "occ_not_on_main"
+    PR_TICKET_MISMATCH = "pr_ticket_mismatch"
+
+
+__all__ = ["EnumOccEligibilityReason"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -58,8 +58,7 @@ from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 
 _TICKET_ID_RE = re.compile(r"^OMN-\d+$")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
-# SHA-256 hex digest — exactly 64 lowercase hex chars.
-_CONTRACT_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
 # SemVer 2.0.0 — official regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 # Rejects leading zeros in numeric core (e.g. "01.0.0"), allows pre-release
 # identifiers with dot-separated alphanumerics and hyphens (e.g. "1.0.0-rc.1"),
@@ -215,6 +214,16 @@ class ModelDodReceipt(BaseModel):
             "to merge gate invocations. None for receipts not tied to a PR."
         ),
     )
+    contract_sha256: str | None = Field(
+        default=None,
+        description=(
+            "SHA-256 digest of contracts/<ticket_id>.yaml used when producing "
+            "this receipt. The OCC-first eligibility gate requires this field "
+            "and rejects receipts whose digest does not match the pinned OCC "
+            "contract. Optional here only for staged migration of historical "
+            "Receipt Gate fixtures."
+        ),
+    )
     branch: str | None = Field(
         default=None,
         description=(
@@ -229,18 +238,6 @@ class ModelDodReceipt(BaseModel):
             "from EvidenceReceipt (OMN-9792). None when not applicable."
         ),
     )
-    contract_sha256: str | None = Field(
-        default=None,
-        description=(
-            "SHA-256 hex digest of the contract YAML file at the time this receipt "
-            "was produced (OMN-10421, invariant I4). None for legacy receipts "
-            "produced before this field was introduced. When present, the receipt-gate "
-            "recomputes sha256(contracts/<ticket-id>.yaml) at the checked-out OCC SHA "
-            "and fails if the digest does not match — proving the contract has not "
-            "mutated since the probes ran. Must be exactly 64 lowercase hex chars."
-        ),
-    )
-
     @field_validator("branch")
     @classmethod
     def _validate_branch(cls, v: str | None) -> str | None:
@@ -255,15 +252,6 @@ class ModelDodReceipt(BaseModel):
     def _validate_working_dir(cls, v: str | None) -> str | None:
         if v is not None and not v.startswith("/"):
             raise ValueError("working_dir must be an absolute path (start with '/')")
-        return v
-
-    @field_validator("contract_sha256")
-    @classmethod
-    def _validate_contract_sha256(cls, v: str | None) -> str | None:
-        if v is not None and not _CONTRACT_SHA256_RE.match(v):
-            raise ValueError(
-                f"contract_sha256 must be exactly 64 lowercase hex chars (SHA-256), got: {v!r}"
-            )
         return v
 
     @field_validator("runner", "verifier")
@@ -301,6 +289,21 @@ class ModelDodReceipt(BaseModel):
         if not _SHA_RE.match(v):
             raise ValueError(f"commit_sha must be 7-40 hex chars (git SHA), got: {v!r}")
         return v
+
+    @field_validator("contract_sha256")
+    @classmethod
+    def _validate_contract_sha256(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        normalized = v.strip().lower()
+        if not _SHA256_RE.match(normalized):
+            raise ValueError(
+                "contract_sha256 must be a sha256:<64 lowercase hex> digest "
+                "or a bare 64-character lowercase hex digest"
+            )
+        if not normalized.startswith("sha256:"):
+            normalized = f"sha256:{normalized}"
+        return normalized
 
     @field_validator("run_timestamp")
     @classmethod
@@ -378,5 +381,4 @@ __all__ = [
     "EXECUTABLE_CHECK_TYPES",
     "ModelDodReceipt",
     "WEAK_PROOF_CHECK_TYPES",
-    "_CONTRACT_SHA256_RE",
 ]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -238,6 +238,7 @@ class ModelDodReceipt(BaseModel):
             "from EvidenceReceipt (OMN-9792). None when not applicable."
         ),
     )
+
     @field_validator("branch")
     @classmethod
     def _validate_branch(cls, v: str | None) -> str | None:

--- a/src/omnibase_core/models/validation/model_occ_eligibility_input.py
+++ b/src/omnibase_core/models/validation/model_occ_eligibility_input.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input snapshot for deterministic OCC merge eligibility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelOccEligibilityInput(BaseModel):
+    """Immutable PR/OCC snapshot used for deterministic eligibility."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(..., min_length=1)
+    pr_number: int = Field(..., ge=1)
+    pr_title: str = Field(default="")
+    pr_body: str = Field(default="")
+    pr_branch: str = Field(default="")
+    pr_commit_shas: tuple[str, ...] = Field(default_factory=tuple)
+    pr_commit_texts: tuple[str, ...] = Field(default_factory=tuple)
+    occ_commit_sha: str = Field(..., pattern=r"^[0-9a-f]{40}$")
+    contracts_dir: Path
+    receipts_dir: Path
+
+
+__all__ = ["ModelOccEligibilityInput"]

--- a/src/omnibase_core/models/validation/model_occ_eligibility_result.py
+++ b/src/omnibase_core/models/validation/model_occ_eligibility_result.py
@@ -32,13 +32,13 @@ class ModelOccEligibilityResult(BaseModel):
         return {
             "eligible": self.eligible,
             "reason": self.reason.value,
-            "ticket_ids": list(self.ticket_ids),
+            "ticket_ids": sorted(self.ticket_ids),
             "occ_commit_sha": self.occ_commit_sha,
             "contract_hashes": dict(sorted(self.contract_hashes.items())),
-            "receipt_ids": list(self.receipt_ids),
-            "missing_contracts": list(self.missing_contracts),
-            "missing_or_nonpass_receipts": list(self.missing_or_nonpass_receipts),
-            "dependency_prs": list(self.dependency_prs),
+            "receipt_ids": sorted(self.receipt_ids),
+            "missing_contracts": sorted(self.missing_contracts),
+            "missing_or_nonpass_receipts": sorted(self.missing_or_nonpass_receipts),
+            "dependency_prs": sorted(self.dependency_prs, key=str),
             "detail": self.detail,
         }
 

--- a/src/omnibase_core/models/validation/model_occ_eligibility_result.py
+++ b/src/omnibase_core/models/validation/model_occ_eligibility_result.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Result model for deterministic OCC merge eligibility."""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_occ_eligibility_reason import EnumOccEligibilityReason
+
+
+class ModelOccEligibilityResult(BaseModel):
+    """Replayable OCC eligibility decision."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    eligible: bool
+    reason: EnumOccEligibilityReason
+    ticket_ids: tuple[str, ...] = Field(default_factory=tuple)
+    occ_commit_sha: str = Field(default="")
+    contract_hashes: dict[str, str] = Field(default_factory=dict)
+    receipt_ids: tuple[str, ...] = Field(default_factory=tuple)
+    missing_contracts: tuple[str, ...] = Field(default_factory=tuple)
+    missing_or_nonpass_receipts: tuple[str, ...] = Field(default_factory=tuple)
+    dependency_prs: tuple[str, ...] = Field(default_factory=tuple)
+    detail: str = Field(default="")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "eligible": self.eligible,
+            "reason": self.reason.value,
+            "ticket_ids": list(self.ticket_ids),
+            "occ_commit_sha": self.occ_commit_sha,
+            "contract_hashes": dict(sorted(self.contract_hashes.items())),
+            "receipt_ids": list(self.receipt_ids),
+            "missing_contracts": list(self.missing_contracts),
+            "missing_or_nonpass_receipts": list(self.missing_or_nonpass_receipts),
+            "dependency_prs": list(self.dependency_prs),
+            "detail": self.detail,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["ModelOccEligibilityResult"]

--- a/src/omnibase_core/validation/occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/occ_merge_eligibility.py
@@ -178,16 +178,8 @@ def validate_occ_merge_eligibility(
                     ),
                 )
             if receipt.contract_sha256 is None:
-                return ModelOccEligibilityResult(
-                    eligible=False,
-                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
-                    ticket_ids=ticket_ids,
-                    occ_commit_sha=snapshot.occ_commit_sha,
-                    contract_hashes=contract_hashes,
-                    receipt_ids=tuple(sorted(receipt_ids)),
-                    detail=f"receipt {receipt_path} missing contract_sha256",
-                )
-            if receipt.contract_sha256 != contract_hash:
+                pass
+            elif receipt.contract_sha256 != contract_hash:
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,

--- a/src/omnibase_core/validation/occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/occ_merge_eligibility.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deterministic OCC-first merge eligibility checks.
+
+This module is intentionally pure after the caller supplies a PR metadata
+snapshot and a pinned OCC commit SHA. It does not fetch GitHub or mutate state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_occ_eligibility_reason import EnumOccEligibilityReason
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.models.validation.model_occ_eligibility_input import (
+    ModelOccEligibilityInput,
+)
+from omnibase_core.models.validation.model_occ_eligibility_result import (
+    ModelOccEligibilityResult,
+)
+from omnibase_core.validation.receipt_gate import (
+    _extract_ticket_ids,
+    _iter_dod_evidence,
+)
+
+EVIDENCE_TICKET_PATTERN = re.compile(
+    r"^\s*Evidence-Ticket\s*:\s*(OMN-\d+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _load_yaml(path: Path) -> object:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=yaml.SafeLoader)
+
+
+def _normalize_sha_set(values: tuple[str, ...]) -> set[str]:
+    return {v.strip().lower() for v in values if v.strip()}
+
+
+def _ticket_bound_to_pr(ticket_id: str, snapshot: ModelOccEligibilityInput) -> bool:
+    needle = ticket_id.casefold()
+    if needle in snapshot.pr_title.casefold():
+        return True
+    if needle in snapshot.pr_branch.casefold():
+        return True
+    if any(needle in text.casefold() for text in snapshot.pr_commit_texts):
+        return True
+    evidence_tickets = {
+        match.group(1).upper()
+        for match in EVIDENCE_TICKET_PATTERN.finditer(snapshot.pr_body)
+    }
+    return ticket_id in evidence_tickets
+
+
+def _receipt_bound_to_pr(
+    receipt: ModelDodReceipt,
+    snapshot: ModelOccEligibilityInput,
+) -> bool:
+    if receipt.pr_number == snapshot.pr_number:
+        return True
+    shas = _normalize_sha_set(snapshot.pr_commit_shas)
+    return receipt.commit_sha.lower() in shas
+
+
+def validate_occ_merge_eligibility(
+    snapshot: ModelOccEligibilityInput,
+) -> ModelOccEligibilityResult:
+    """Validate PR merge eligibility against a pinned OCC evidence snapshot."""
+
+    ticket_ids = tuple(_extract_ticket_ids(snapshot.pr_body, snapshot.pr_title))
+    if not ticket_ids:
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.MISSING_TICKET,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            detail="PR title/body does not cite an OMN ticket",
+        )
+
+    for ticket_id in ticket_ids:
+        if not _ticket_bound_to_pr(ticket_id, snapshot):
+            return ModelOccEligibilityResult(
+                eligible=False,
+                reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,
+                ticket_ids=ticket_ids,
+                occ_commit_sha=snapshot.occ_commit_sha,
+                detail=(
+                    f"{ticket_id} is cited but not bound through PR title, branch, "
+                    "commit text, or Evidence-Ticket metadata"
+                ),
+            )
+
+    contract_hashes: dict[str, str] = {}
+    receipt_ids: list[str] = []
+    missing_contracts: list[str] = []
+    missing_receipts: list[str] = []
+    nonpass_receipts: list[str] = []
+    tickets_with_pr_bound_receipt: set[str] = set()
+
+    for ticket_id in ticket_ids:
+        contract_path = snapshot.contracts_dir / f"{ticket_id}.yaml"
+        if not contract_path.exists():
+            missing_contracts.append(ticket_id)
+            continue
+        contract_hash = _sha256_file(contract_path)
+        contract_hashes[ticket_id] = contract_hash
+        try:
+            contract_data = _load_yaml(contract_path)
+        except (OSError, yaml.YAMLError) as exc:
+            missing_contracts.append(ticket_id)
+            return ModelOccEligibilityResult(
+                eligible=False,
+                reason=EnumOccEligibilityReason.MISSING_CONTRACT,
+                ticket_ids=ticket_ids,
+                occ_commit_sha=snapshot.occ_commit_sha,
+                contract_hashes=contract_hashes,
+                missing_contracts=tuple(sorted(missing_contracts)),
+                detail=f"contract {contract_path} is unreadable: {exc}",
+            )
+        triples = _iter_dod_evidence(contract_data)
+        if not triples:
+            missing_receipts.append(f"{ticket_id}:*:*")
+            continue
+        for evidence_item_id, check_type, _check_value in triples:
+            receipt_path = (
+                snapshot.receipts_dir
+                / ticket_id
+                / evidence_item_id
+                / f"{check_type}.yaml"
+            )
+            receipt_key = f"{ticket_id}:{evidence_item_id}:{check_type}"
+            if not receipt_path.exists():
+                missing_receipts.append(receipt_key)
+                continue
+            try:
+                receipt_raw = _load_yaml(receipt_path)
+                receipt = ModelDodReceipt.model_validate(receipt_raw)
+            except (OSError, yaml.YAMLError, ValidationError) as exc:
+                nonpass_receipts.append(receipt_key)
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    missing_or_nonpass_receipts=tuple(sorted(nonpass_receipts)),
+                    detail=f"receipt {receipt_path} is invalid: {exc}",
+                )
+            if receipt.ticket_id != ticket_id:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    detail=(
+                        f"receipt {receipt_path} declares ticket_id={receipt.ticket_id}, "
+                        f"expected {ticket_id}"
+                    ),
+                )
+            if receipt.contract_sha256 is None:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    detail=f"receipt {receipt_path} missing contract_sha256",
+                )
+            if receipt.contract_sha256 != contract_hash:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    detail=(
+                        f"receipt {receipt_path} contract_sha256={receipt.contract_sha256} "
+                        f"does not match pinned contract hash {contract_hash}"
+                    ),
+                )
+            if _receipt_bound_to_pr(receipt, snapshot):
+                tickets_with_pr_bound_receipt.add(ticket_id)
+            if receipt.status is not EnumReceiptStatus.PASS:
+                nonpass_receipts.append(receipt_key)
+                continue
+            receipt_ids.append(receipt_key)
+
+    if missing_contracts:
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.MISSING_CONTRACT,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            missing_contracts=tuple(sorted(missing_contracts)),
+            detail="one or more ticket contracts are missing from pinned OCC evidence",
+        )
+    if missing_receipts or nonpass_receipts:
+        reason = (
+            EnumOccEligibilityReason.MISSING_RECEIPT
+            if missing_receipts
+            else EnumOccEligibilityReason.NONPASS_RECEIPT
+        )
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=reason,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            missing_or_nonpass_receipts=tuple(
+                sorted([*missing_receipts, *nonpass_receipts])
+            ),
+            detail="one or more receipts are missing or non-PASS",
+        )
+    unbound_tickets = tuple(
+        ticket_id
+        for ticket_id in ticket_ids
+        if ticket_id not in tickets_with_pr_bound_receipt
+    )
+    if unbound_tickets:
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            detail=(
+                "no PASS receipt for one or more tickets binds to PR "
+                f"#{snapshot.pr_number} or one of its commit SHAs: "
+                f"{', '.join(unbound_tickets)}"
+            ),
+        )
+
+    return ModelOccEligibilityResult(
+        eligible=True,
+        reason=EnumOccEligibilityReason.ELIGIBLE,
+        ticket_ids=ticket_ids,
+        occ_commit_sha=snapshot.occ_commit_sha,
+        contract_hashes=contract_hashes,
+        receipt_ids=tuple(sorted(receipt_ids)),
+        detail="OCC evidence is present, PASS, hash-bound, and PR-bound",
+    )
+
+
+def _read_file(path: str | None) -> str:
+    if not path:
+        return ""
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="OCC-first merge eligibility gate")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--pr-title", required=True)
+    parser.add_argument("--pr-body", default=None)
+    parser.add_argument("--pr-body-file", default=None)
+    parser.add_argument("--pr-branch", required=True)
+    parser.add_argument("--pr-commit-sha", action="append", default=[])
+    parser.add_argument("--pr-commit-text", action="append", default=[])
+    parser.add_argument("--occ-commit-sha", required=True)
+    parser.add_argument("--contracts-dir", required=True)
+    parser.add_argument("--receipts-dir", required=True)
+    args = parser.parse_args(argv)
+
+    body = args.pr_body if args.pr_body is not None else _read_file(args.pr_body_file)
+    snapshot = ModelOccEligibilityInput(
+        repo=args.repo,
+        pr_number=args.pr_number,
+        pr_title=args.pr_title,
+        pr_body=body,
+        pr_branch=args.pr_branch,
+        pr_commit_shas=tuple(args.pr_commit_sha),
+        pr_commit_texts=tuple(args.pr_commit_text),
+        occ_commit_sha=args.occ_commit_sha,
+        contracts_dir=Path(args.contracts_dir),
+        receipts_dir=Path(args.receipts_dir),
+    )
+    result = validate_occ_merge_eligibility(snapshot)
+    sys.stdout.write(f"{result.to_json()}\n")
+    return 0 if result.eligible else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "EnumOccEligibilityReason",
+    "ModelOccEligibilityInput",
+    "ModelOccEligibilityResult",
+    "validate_occ_merge_eligibility",
+]

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -126,6 +126,11 @@ def compute_contract_sha256(contract_path: Path) -> str:
     return hashlib.sha256(contract_path.read_bytes()).hexdigest()
 
 
+def _prefixed_contract_sha256(contract_path: Path) -> str:
+    """Return the canonical contract hash value used by DoD receipts."""
+    return f"sha256:{compute_contract_sha256(contract_path)}"
+
+
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
     """Return sorted unique ticket IDs cited by this PR.
 
@@ -328,7 +333,7 @@ def _check_one_receipt(
         and contract_path.exists()
         and pr_opened_at is not None
     ):
-        actual_sha = compute_contract_sha256(contract_path)
+        actual_sha = _prefixed_contract_sha256(contract_path)
         if receipt.contract_sha256 is None:
             is_post_cutoff = pr_opened_at >= _CONTRACT_SHA256_REQUIRED_AFTER
             if is_post_cutoff:

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -36,6 +36,7 @@ EVIDENCE_TICKET_PATTERN = re.compile(
     r"^\s*Evidence-Ticket\s*:\s*(OMN-\d+)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+TICKET_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9])OMN-(\d+)(?![A-Z0-9])", re.IGNORECASE)
 
 
 def _sha256_file(path: Path) -> str:
@@ -56,18 +57,21 @@ def _normalize_sha_set(values: tuple[str, ...]) -> set[str]:
 
 
 def _ticket_bound_to_pr(ticket_id: str, snapshot: ModelOccEligibilityInput) -> bool:
-    needle = ticket_id.casefold()
-    if needle in snapshot.pr_title.casefold():
-        return True
-    if needle in snapshot.pr_branch.casefold():
-        return True
-    if any(needle in text.casefold() for text in snapshot.pr_commit_texts):
-        return True
+    searchable_texts = (
+        snapshot.pr_title,
+        snapshot.pr_branch,
+        *snapshot.pr_commit_texts,
+    )
+    bound_tickets = {
+        f"OMN-{match.group(1)}".upper()
+        for text in searchable_texts
+        for match in TICKET_TOKEN_PATTERN.finditer(text)
+    }
     evidence_tickets = {
         match.group(1).upper()
         for match in EVIDENCE_TICKET_PATTERN.finditer(snapshot.pr_body)
     }
-    return ticket_id in evidence_tickets
+    return ticket_id in bound_tickets or ticket_id in evidence_tickets
 
 
 def _receipt_bound_to_pr(
@@ -116,13 +120,12 @@ def validate_occ_merge_eligibility(
 
     for ticket_id in ticket_ids:
         contract_path = snapshot.contracts_dir / f"{ticket_id}.yaml"
-        if not contract_path.exists():
+        if not contract_path.is_file():
             missing_contracts.append(ticket_id)
             continue
-        contract_hash = _sha256_file(contract_path)
-        contract_hashes[ticket_id] = contract_hash
         try:
             contract_data = _load_yaml(contract_path)
+            contract_hash = _sha256_file(contract_path)
         except (OSError, yaml.YAMLError) as exc:
             missing_contracts.append(ticket_id)
             return ModelOccEligibilityResult(
@@ -134,6 +137,7 @@ def validate_occ_merge_eligibility(
                 missing_contracts=tuple(sorted(missing_contracts)),
                 detail=f"contract {contract_path} is unreadable: {exc}",
             )
+        contract_hashes[ticket_id] = contract_hash
         triples = _iter_dod_evidence(contract_data)
         if not triples:
             missing_receipts.append(f"{ticket_id}:*:*")

--- a/tests/unit/validation/test_auto_merge_workflow_shape.py
+++ b/tests/unit/validation/test_auto_merge_workflow_shape.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "auto-merge.yml"
+)
+
+
+def _steps() -> list[dict[str, object]]:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    return data["jobs"]["auto-merge"]["steps"]
+
+
+def _step(name: str) -> dict[str, object]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{name!r} step not found in auto-merge.yml")
+
+
+def test_auto_merge_uses_python_313() -> None:
+    step = _step("Set up Python 3.13")
+    assert step["with"]["python-version"] == "3.13"
+
+
+def test_auto_merge_pins_occ_before_preflight() -> None:
+    resolve_step = _step("Resolve OCC main SHA")
+    checkout_step = _step("Check out OCC evidence snapshot")
+
+    assert "git/ref/heads/main" in resolve_step["run"]
+    assert checkout_step["with"]["ref"] == "${{ steps.occ_ref.outputs.sha }}"
+
+
+def test_auto_merge_runs_occ_preflight_before_mutating_pr() -> None:
+    names = [step.get("name") for step in _steps()]
+
+    assert names.index("OCC auto-merge preflight") < names.index("Enable auto-merge")
+    assert names.index("OCC auto-merge preflight") < names.index(
+        "Force enqueue to merge queue"
+    )
+
+
+def test_auto_merge_preflight_uses_single_pr_snapshot() -> None:
+    script = _step("OCC auto-merge preflight")["run"]
+
+    assert "gh pr view" in script
+    assert "--json body,title,headRefName,commits" in script
+    assert "omnibase_core.validation.occ_merge_eligibility" in script
+    assert "--occ-commit-sha" in script
+    assert "--pr-body-file /tmp/pr_body.txt" in script

--- a/tests/unit/validation/test_auto_merge_workflow_shape.py
+++ b/tests/unit/validation/test_auto_merge_workflow_shape.py
@@ -54,6 +54,6 @@ def test_auto_merge_preflight_uses_single_pr_snapshot() -> None:
 
     assert "gh pr view" in script
     assert "--json body,title,headRefName,commits" in script
-    assert "omnibase_core.validation.occ_merge_eligibility" in script
+    assert "omnibase_core.validation.validator_occ_merge_eligibility" in script
     assert "--occ-commit-sha" in script
     assert "--pr-body-file /tmp/pr_body.txt" in script

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -293,6 +293,18 @@ def test_missing_contract_hash_is_migration_compatible(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_bare_contract_hash_is_migration_compatible(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=contract_hash.removeprefix("sha256:"))
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+    assert result.contract_hashes == {TICKET: contract_hash}
+
+
+@pytest.mark.unit
 def test_eligible_output_is_replay_stable(tmp_path: Path) -> None:
     contract_hash = _write_contract(tmp_path)
     _write_receipt(tmp_path, contract_sha256=contract_hash)

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -11,14 +11,14 @@ import pytest
 import yaml
 
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
-from omnibase_core.validation.occ_merge_eligibility import (
+from omnibase_core.validation.validator_occ_merge_eligibility import (
     EnumOccEligibilityReason,
     ModelOccEligibilityInput,
     validate_occ_merge_eligibility,
 )
 
 TICKET = "OMN-10484"
-PR_SHA = "a1b2c3d4e5f678901234567890abcdef12345678"
+PR_SHA = "1" * 40
 
 
 def _contract_text(ticket_id: str = TICKET) -> str:
@@ -141,7 +141,41 @@ def test_ticket_not_bound_to_pr_is_ineligible(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_ticket_binding_uses_full_ticket_tokens(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path, ticket_id="OMN-1")
+    _write_receipt(tmp_path, ticket_id="OMN-1", contract_sha256=contract_hash)
+    snapshot = ModelOccEligibilityInput(
+        repo="omnibase_core",
+        pr_number=123,
+        pr_title="feat(OMN-10484): harden OCC eligibility",
+        pr_body="Closes: OMN-1",
+        pr_branch="jonah/omn-10484-occ-eligibility",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=("feat(OMN-10484): add eligibility",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+
+
+@pytest.mark.unit
 def test_missing_contract_is_ineligible(tmp_path: Path) -> None:
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_CONTRACT
+    assert result.missing_contracts == (TICKET,)
+
+
+@pytest.mark.unit
+def test_contract_directory_is_reported_as_missing_contract(tmp_path: Path) -> None:
+    (tmp_path / "contracts" / f"{TICKET}.yaml").mkdir(parents=True)
+
     result = validate_occ_merge_eligibility(_snapshot(tmp_path))
 
     assert result.eligible is False

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.validation.occ_merge_eligibility import (
+    EnumOccEligibilityReason,
+    ModelOccEligibilityInput,
+    validate_occ_merge_eligibility,
+)
+
+TICKET = "OMN-10484"
+PR_SHA = "a1b2c3d4e5f678901234567890abcdef12345678"
+
+
+def _contract_text(ticket_id: str = TICKET) -> str:
+    return yaml.safe_dump(
+        {
+            "ticket_id": ticket_id,
+            "title": "OCC eligibility",
+            "dod_evidence": [
+                {
+                    "id": "dod-001",
+                    "description": "focused tests pass",
+                    "checks": [
+                        {
+                            "check_type": "command",
+                            "check_value": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
+                        }
+                    ],
+                }
+            ],
+        },
+        sort_keys=True,
+    )
+
+
+def _contract_hash(text: str) -> str:
+    return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
+
+
+def _write_contract(root: Path, ticket_id: str = TICKET) -> str:
+    text = _contract_text(ticket_id)
+    (root / "contracts").mkdir(parents=True, exist_ok=True)
+    (root / "contracts" / f"{ticket_id}.yaml").write_text(text, encoding="utf-8")
+    return _contract_hash(text)
+
+
+def _write_receipt(
+    root: Path,
+    *,
+    ticket_id: str = TICKET,
+    evidence_item_id: str = "dod-001",
+    status: EnumReceiptStatus = EnumReceiptStatus.PASS,
+    pr_number: int | None = 123,
+    commit_sha: str = PR_SHA,
+    contract_sha256: str,
+) -> None:
+    path = root / "receipts" / ticket_id / evidence_item_id / "command.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "1.0.0",
+                "ticket_id": ticket_id,
+                "evidence_item_id": evidence_item_id,
+                "check_type": "command",
+                "check_value": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
+                "status": status.value,
+                "run_timestamp": datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+                "commit_sha": commit_sha,
+                "runner": "worker",
+                "verifier": "foreground",
+                "probe_command": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
+                "probe_stdout": "1 passed\n",
+                "exit_code": 0,
+                "pr_number": pr_number,
+                "contract_sha256": contract_sha256,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _snapshot(
+    root: Path, *, body: str | None = None, title: str | None = None
+) -> ModelOccEligibilityInput:
+    return ModelOccEligibilityInput(
+        repo="omnibase_core",
+        pr_number=123,
+        pr_title=title or f"feat({TICKET}): harden OCC eligibility",
+        pr_body=body or f"Closes: {TICKET}",
+        pr_branch=f"jonah/{TICKET.lower()}-occ-eligibility",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(f"feat({TICKET}): add eligibility",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=root / "contracts",
+        receipts_dir=root / "receipts",
+    )
+
+
+@pytest.mark.unit
+def test_missing_ticket_is_ineligible(tmp_path: Path) -> None:
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, body="No ticket here", title="docs: no ticket")
+    )
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_TICKET
+
+
+@pytest.mark.unit
+def test_ticket_not_bound_to_pr_is_ineligible(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=contract_hash)
+    snapshot = ModelOccEligibilityInput(
+        repo="omnibase_core",
+        pr_number=123,
+        pr_title="feat: unrelated title",
+        pr_body=f"Closes: {TICKET}",
+        pr_branch="jonah/no-ticket-here",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=("feat: unrelated commit",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+
+
+@pytest.mark.unit
+def test_missing_contract_is_ineligible(tmp_path: Path) -> None:
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_CONTRACT
+    assert result.missing_contracts == (TICKET,)
+
+
+@pytest.mark.unit
+def test_missing_receipt_is_ineligible(tmp_path: Path) -> None:
+    _write_contract(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
+    assert result.missing_or_nonpass_receipts == (f"{TICKET}:dod-001:command",)
+
+
+@pytest.mark.unit
+def test_nonpass_receipt_is_ineligible(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path, status=EnumReceiptStatus.FAIL, contract_sha256=contract_hash
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.NONPASS_RECEIPT
+
+
+@pytest.mark.unit
+def test_receipt_without_pr_or_commit_binding_is_ineligible(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+
+
+@pytest.mark.unit
+def test_at_least_one_ticket_receipt_must_bind_to_pr(tmp_path: Path) -> None:
+    contract = {
+        "ticket_id": TICKET,
+        "title": "multi PR ticket",
+        "dod_evidence": [
+            {
+                "id": "dod-001",
+                "checks": [{"check_type": "command", "check_value": "a"}],
+            },
+            {
+                "id": "dod-002",
+                "checks": [{"check_type": "command", "check_value": "b"}],
+            },
+        ],
+    }
+    contract_text = yaml.safe_dump(contract, sort_keys=True)
+    (tmp_path / "contracts").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "contracts" / f"{TICKET}.yaml").write_text(
+        contract_text, encoding="utf-8"
+    )
+    contract_hash = _contract_hash(contract_text)
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="dod-001",
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="dod-002",
+        pr_number=123,
+        commit_sha=PR_SHA,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.receipt_ids == (
+        f"{TICKET}:dod-001:command",
+        f"{TICKET}:dod-002:command",
+    )
+
+
+@pytest.mark.unit
+def test_contract_hash_mismatch_is_ineligible(tmp_path: Path) -> None:
+    _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=f"sha256:{'0' * 64}")
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+@pytest.mark.unit
+def test_eligible_output_is_replay_stable(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=contract_hash)
+    snapshot = _snapshot(tmp_path)
+
+    first = validate_occ_merge_eligibility(snapshot)
+    second = validate_occ_merge_eligibility(snapshot)
+
+    assert first.eligible is True
+    assert first.reason is EnumOccEligibilityReason.ELIGIBLE
+    assert first.to_json() == second.to_json()
+    assert first.occ_commit_sha == "b" * 40
+    assert first.contract_hashes == {TICKET: contract_hash}
+    assert first.receipt_ids == (f"{TICKET}:dod-001:command",)

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -62,31 +62,30 @@ def _write_receipt(
     status: EnumReceiptStatus = EnumReceiptStatus.PASS,
     pr_number: int | None = 123,
     commit_sha: str = PR_SHA,
-    contract_sha256: str,
+    contract_sha256: str | None,
 ) -> None:
+    receipt = {
+        "schema_version": "1.0.0",
+        "ticket_id": ticket_id,
+        "evidence_item_id": evidence_item_id,
+        "check_type": "command",
+        "check_value": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
+        "status": status.value,
+        "run_timestamp": datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        "commit_sha": commit_sha,
+        "runner": "worker",
+        "verifier": "foreground",
+        "probe_command": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
+        "probe_stdout": "1 passed\n",
+        "exit_code": 0,
+        "pr_number": pr_number,
+    }
+    if contract_sha256 is not None:
+        receipt["contract_sha256"] = contract_sha256
     path = root / "receipts" / ticket_id / evidence_item_id / "command.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        yaml.safe_dump(
-            {
-                "schema_version": "1.0.0",
-                "ticket_id": ticket_id,
-                "evidence_item_id": evidence_item_id,
-                "check_type": "command",
-                "check_value": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
-                "status": status.value,
-                "run_timestamp": datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
-                "commit_sha": commit_sha,
-                "runner": "worker",
-                "verifier": "foreground",
-                "probe_command": "uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q",
-                "probe_stdout": "1 passed\n",
-                "exit_code": 0,
-                "pr_number": pr_number,
-                "contract_sha256": contract_sha256,
-            },
-            sort_keys=True,
-        ),
+        yaml.safe_dump(receipt, sort_keys=True),
         encoding="utf-8",
     )
 
@@ -245,6 +244,18 @@ def test_contract_hash_mismatch_is_ineligible(tmp_path: Path) -> None:
 
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+@pytest.mark.unit
+def test_missing_contract_hash_is_migration_compatible(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=None)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+    assert result.contract_hashes == {TICKET: contract_hash}
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -38,6 +38,15 @@ def _install_step_script() -> str:
     raise AssertionError("Install omnibase_core step not found in receipt-gate.yml")
 
 
+def _workflow_step(name: str) -> dict[str, object]:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"]["verify"]["steps"]
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{name!r} step not found in receipt-gate.yml")
+
+
 def test_install_step_builds_wheel_from_source() -> None:
     """Core install must build a wheel, not install from PyPI."""
     script = _install_step_script()
@@ -117,3 +126,54 @@ def test_workflow_checks_out_omnibase_core_when_missing() -> None:
         "receipt-gate must check out omnibase_core source for downstream callers "
         "that don't already have it in-tree"
     )
+
+
+def test_workflow_uses_python_313() -> None:
+    """Receipt gate runtime must stay on the requested Python 3.13 line."""
+    step = _workflow_step("Set up Python 3.13")
+    assert step["with"]["python-version"] == "3.13"
+
+
+def test_workflow_pins_occ_main_before_checkout() -> None:
+    """Downstream validation must read OCC evidence from an immutable commit."""
+    resolve_step = _workflow_step("Resolve OCC main SHA")
+    checkout_step = _workflow_step(
+        "Check out onex_change_control (for contracts + receipts)"
+    )
+
+    assert "git/ref/heads/main" in resolve_step["run"]
+    assert checkout_step["with"]["ref"] == "${{ steps.occ_ref.outputs.sha }}"
+
+
+def test_workflow_validates_occ_pr_diff_without_main_dependency() -> None:
+    """onex_change_control PRs validate same-PR evidence to avoid a circular gate."""
+    evidence_step = _workflow_step("Resolve evidence snapshot")
+    script = evidence_step["run"]
+
+    assert 'repo_short" = "onex_change_control"' in script
+    assert 'root="."' in script
+    assert "git rev-parse HEAD" in script
+
+
+def test_workflow_captures_pr_snapshot_once_for_eligibility() -> None:
+    """The eligibility gate must consume a PR metadata snapshot, not live state."""
+    step = _workflow_step("Resolve PR snapshot")
+    script = step["run"]
+
+    assert "--json body,title,author,headRefName,commits" in script
+    assert "/tmp/pr_commit_shas.txt" in script
+    assert "/tmp/pr_commit_texts.txt" in script
+    assert "MERGE_GROUP_HEAD_REF" in script
+
+
+def test_workflow_runs_occ_eligibility_before_legacy_receipt_gate() -> None:
+    """Receipt Gate now has a deterministic PR/ticket/receipt binding preflight."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"]["verify"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert names.index("Run OCC Eligibility") < names.index("Run Receipt-Gate")
+    script = _workflow_step("Run OCC Eligibility")["run"]
+    assert "omnibase_core.validation.occ_merge_eligibility" in script
+    assert "--occ-commit-sha" in script
+    assert "--pr-body-file /tmp/pr_body.txt" in script

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -174,6 +174,6 @@ def test_workflow_runs_occ_eligibility_before_legacy_receipt_gate() -> None:
 
     assert names.index("Run OCC Eligibility") < names.index("Run Receipt-Gate")
     script = _workflow_step("Run OCC Eligibility")["run"]
-    assert "omnibase_core.validation.occ_merge_eligibility" in script
+    assert "omnibase_core.validation.validator_occ_merge_eligibility" in script
     assert "--occ-commit-sha" in script
     assert "--pr-body-file /tmp/pr_body.txt" in script


### PR DESCRIPTION
Closes OMN-10484.\n\nImplements deterministic OCC-first merge eligibility with PR-ticket-receipt binding, contract hash checks, pinned OCC evidence snapshots, merge_group revalidation wiring, and auto-merge preflight.\n\nVerification:\n- PYTHONPATH=src uv run pytest tests/unit/validation/test_occ_merge_eligibility.py tests/unit/validation/test_receipt_gate_workflow_shape.py tests/unit/validation/test_auto_merge_workflow_shape.py tests/unit/models/contracts/test_model_dod_receipt.py -q\n- pre-commit hooks during commit\n- proof-of-life: before missing_receipt, after eligible, repeat stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic OCC merge-eligibility checks with structured results and standardized failure reasons
  * Receipt contract-hash acceptance/normalization for migration-friendly compatibility

* **Tests**
  * New unit tests validating eligibility behavior and CI workflow shape and ordering

* **Chores**
  * CI workflows updated to pin OCC evidence, use Python 3.13, and run OCC preflight before auto-merge and receipt gating
<!-- end of auto-generated comment: release notes by coderabbit.ai -->