### PR TITLE
fix(OMN-10520): honor explicit receipt evidence source

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -121,12 +121,13 @@ jobs:
 
           # Determine the cutoff commit date from OCC using the pinned SHA.
           # The cutoff SHA is the merge commit for OMN-10419 (this PR).
-          # Until this PR is merged, EVIDENCE_SOURCE_CUTOFF_SHA is "PENDING_MERGE"
-          # and the cutoff check is skipped (all PRs are pre-cutoff).
+          # Until this PR is merged, EVIDENCE_SOURCE_CUTOFF_SHA is "PENDING_MERGE".
+          # PRs without Evidence-Source remain grandfathered, but an explicit
+          # Evidence-Source must still pin OCC instead of falling back to main.
           OCC_CUTOFF_SHA="PENDING_MERGE"
 
-          if [ "$OCC_CUTOFF_SHA" = "PENDING_MERGE" ]; then
-            echo "::notice::Evidence-Source not required: OMN-10419 cutoff SHA is PENDING_MERGE, so this run is treated as pre-cutoff."
+          if [ "$OCC_CUTOFF_SHA" = "PENDING_MERGE" ] && [ -z "$evidence_source" ]; then
+            echo "::notice::Evidence-Source not required: OMN-10419 cutoff SHA is PENDING_MERGE and no Evidence-Source was provided, so this run is treated as pre-cutoff."
             echo "PENDING_MERGE" > /tmp/occ_sha.txt
             echo "occ_sha=PENDING_MERGE" >> "$GITHUB_OUTPUT"
             exit 0

--- a/tests/unit/validation/test_receipt_gate_evidence_source.py
+++ b/tests/unit/validation/test_receipt_gate_evidence_source.py
@@ -433,8 +433,12 @@ class TestReceiptGateWorkflowShapeOMN10419:
                     "(backwards compatibility — OMN-10419)"
                 )
                 assert 'OCC_CUTOFF_SHA" = "PENDING_MERGE"' in script, (
-                    "Resolve Evidence-Source must short-circuit while the OMN-10419 cutoff "
-                    "SHA is PENDING_MERGE"
+                    "Resolve Evidence-Source must retain cutoff handling while the "
+                    "OMN-10419 cutoff SHA is PENDING_MERGE"
+                )
+                assert '[ -z "$evidence_source" ]' in script, (
+                    "Resolve Evidence-Source must only short-circuit pending-cutoff "
+                    "PRs when no Evidence-Source was provided"
                 )
                 return
         pytest.fail("Resolve Evidence-Source step not found")


### PR DESCRIPTION
Evidence-Ticket: OMN-10520
Evidence-Source: OCC#689
Ticket: OMN-10520

Fixes the reusable Receipt Gate resolver so explicit Evidence-Source lines still pin onex_change_control while the OMN-10419 cutoff marker is pending. PRs with no Evidence-Source remain grandfathered.

Verification:
- uv run pytest tests/unit/validation/test_receipt_gate_evidence_source.py tests/unit/validation/test_receipt_gate_workflow_shape.py -q
- uv run ruff check tests/unit/validation/test_receipt_gate_evidence_source.py tests/unit/validation/test_receipt_gate_workflow_shape.py
- git diff --check