### PR TITLE
chore(release, OMN-10530): omnibase-core 0.40.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.40.0"
+version = "0.40.1"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.40.0"
+version = "0.40.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- bump omnibase-core package version to 0.40.1
- refresh uv.lock package metadata

## Release intent
Rollback checkpoint patch release for the post-merge-sweep infrastructure baseline. This is not a production GA marker.

Ticket: OMN-10530

## Verification
- uv lock
- uv build
- version-smoke: importlib.metadata and omnibase_core.__version__ report 0.40.1
- git diff --check

Note: full local pytest was intentionally stopped after startup because this is a version-only patch and the suite contains 40k tests; CI will run the required gates.