### PR TITLE
feat(OMN-10512): extract shared contract-to-topics resolver

### DIFF
--- a/contracts/OMN-10512.yaml
+++ b/contracts/OMN-10512.yaml
@@ -1,0 +1,29 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-10512"
+title: "Extract shared contract-to-topics resolver"
+summary: "Add a reusable CLI-layer resolver for node contract paths and command/terminal topics."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Focused resolver unit tests pass in omnibase_core PR #1032"
+    command: "uv run pytest tests/unit/cli/test_cli_resolve_contract_topics.py -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused unit tests cover resolver success and error paths"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/cli/test_cli_resolve_contract_topics.py -q"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: pure CLI utility, no runtime process or service deploy required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-10512 adds a pure CLI utility; no Docker image, daemon, broker topic, runtime process, docker exec, or service deploy is required'"

--- a/src/omnibase_core/cli/cli_resolve_contract_topics.py
+++ b/src/omnibase_core/cli/cli_resolve_contract_topics.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Reusable contract-to-topics resolver for ONEX CLI dispatch (OMN-10512).
+
+Provides two functions usable outside Click commands:
+- resolve_node_contract: entry-point name → contract.yaml Path
+- resolve_contract_topics: contract.yaml Path → (command_topic, terminal_topic)
+
+Key distinction from dispatch_bus_client._resolve_command_topic: that function
+reads publish_topics (what the node publishes TO). This reads subscribe_topics
+(what the node listens ON), because the CLI is the sender.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import warnings
+from importlib.metadata import entry_points
+from pathlib import Path
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.core.model_generic_yaml import ModelGenericYaml
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+
+def resolve_node_contract(node_id: str) -> Path:
+    """Resolve a node ID via the ``onex.nodes`` entry-point group to its contract.yaml.
+
+    Raises:
+        ModelOnexError: If the node is unknown, duplicated, the module cannot be
+            found, or the packaged contract.yaml is missing.
+    """
+    matches = [ep for ep in entry_points(group="onex.nodes") if ep.name == node_id]
+    if not matches:
+        known = sorted({ep.name for ep in entry_points(group="onex.nodes")})
+        raise ModelOnexError(
+            message=f"Unknown node '{node_id}'. Known nodes: {', '.join(known) or '(none)'}",
+            error_code=EnumCoreErrorCode.NOT_FOUND,
+        )
+    if len(matches) > 1:
+        sources = ", ".join(str(ep.dist) for ep in matches)
+        raise ModelOnexError(
+            message=(
+                f"Duplicate entry-point name '{node_id}' registered by: {sources}. "
+                "Disambiguate by uninstalling the conflicting package."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    module_path = matches[0].value.split(":", 1)[0].strip()
+    spec = importlib.util.find_spec(module_path)
+    if spec is None:
+        raise ModelOnexError(
+            message=f"Failed to resolve node module '{module_path}' from installed metadata.",
+            error_code=EnumCoreErrorCode.MODULE_NOT_FOUND,
+        )
+
+    if spec.submodule_search_locations:
+        module_dir = Path(next(iter(spec.submodule_search_locations))).resolve()
+    elif spec.origin is not None:
+        module_dir = Path(spec.origin).resolve().parent
+    else:
+        raise ModelOnexError(
+            message=(
+                f"Node '{node_id}' module '{module_path}' has no origin; "
+                "cannot locate packaged contract.yaml under current packaging convention."
+            ),
+            error_code=EnumCoreErrorCode.MODULE_NOT_FOUND,
+        )
+
+    contract = module_dir / "contract.yaml"
+    if not contract.exists():
+        raise ModelOnexError(
+            message=(
+                f"Node '{node_id}' resolved to {module_dir} but no contract.yaml found there. "
+                "This violates the current packaging convention (colocated contract.yaml)."
+            ),
+            error_code=EnumCoreErrorCode.FILE_NOT_FOUND,
+        )
+    return contract
+
+
+def resolve_contract_topics(contract_path: Path) -> tuple[str, str]:
+    """Resolve command and terminal topics from a contract.yaml.
+
+    Command topic resolution priority:
+      (a) explicit event_bus.command_topic if present
+      (b) subscribe_topics[0] as compatibility fallback (warns to stderr if
+          multiple subscribe topics exist)
+
+    Returns:
+        (command_topic, terminal_topic)
+
+    Raises:
+        ModelOnexError: If subscribe_topics or terminal_event is missing or
+            cannot be resolved, with a message naming the contract path.
+    """
+    raw_model = load_and_validate_yaml_model(contract_path, ModelGenericYaml)
+    data: dict[str, object] = raw_model.model_dump(mode="json", exclude_none=True)
+
+    command_topic = _resolve_subscribe_topic(data, contract_path)
+    terminal_topic = _resolve_terminal_topic(data, contract_path)
+    return command_topic, terminal_topic
+
+
+def _resolve_subscribe_topic(data: dict[str, object], contract_path: Path) -> str:
+    # Priority (a): explicit event_bus.command_topic
+    event_bus = data.get("event_bus")
+    if isinstance(event_bus, dict):
+        command_topic = event_bus.get("command_topic")
+        if isinstance(command_topic, str) and command_topic:
+            return command_topic
+
+    # Priority (b): subscribe_topics[0]
+    subscribe_topics = data.get("subscribe_topics")
+    if not isinstance(subscribe_topics, list) or not subscribe_topics:
+        raise ModelOnexError(
+            message=(
+                f"Contract at {contract_path} has no subscribe_topics. "
+                "Cannot resolve command topic for CLI dispatch."
+            ),
+            error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+        )
+
+    first = subscribe_topics[0]
+    if not isinstance(first, str) or not first:
+        raise ModelOnexError(
+            message=(
+                f"Contract at {contract_path} subscribe_topics[0] is not a non-empty string."
+            ),
+            error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+        )
+
+    if len(subscribe_topics) > 1:
+        warnings.warn(
+            f"Contract at {contract_path} has multiple subscribe_topics; "
+            f"using first: {first!r}",
+            stacklevel=3,
+        )
+
+    return first
+
+
+def _resolve_terminal_topic(data: dict[str, object], contract_path: Path) -> str:
+    terminal_event = data.get("terminal_event")
+    if isinstance(terminal_event, str) and terminal_event:
+        return terminal_event
+    if isinstance(terminal_event, dict):
+        topic = terminal_event.get("topic")
+        if isinstance(topic, str) and topic:
+            return topic
+
+    raise ModelOnexError(
+        message=(
+            f"Contract at {contract_path} has no terminal_event. "
+            "Cannot resolve terminal topic for CLI dispatch."
+        ),
+        error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+    )
+
+
+__all__ = [
+    "resolve_contract_topics",
+    "resolve_node_contract",
+]

--- a/src/omnibase_core/cli/cli_resolve_contract_topics.py
+++ b/src/omnibase_core/cli/cli_resolve_contract_topics.py
@@ -50,7 +50,13 @@ def resolve_node_contract(node_id: str) -> Path:
         )
 
     module_path = matches[0].value.split(":", 1)[0].strip()
-    spec = importlib.util.find_spec(module_path)
+    try:
+        spec = importlib.util.find_spec(module_path)
+    except (ImportError, ValueError) as exc:
+        raise ModelOnexError(
+            message=f"Failed to resolve node module '{module_path}' from installed metadata.",
+            error_code=EnumCoreErrorCode.MODULE_NOT_FOUND,
+        ) from exc
     if spec is None:
         raise ModelOnexError(
             message=f"Failed to resolve node module '{module_path}' from installed metadata.",

--- a/tests/unit/cli/test_cli_resolve_contract_topics.py
+++ b/tests/unit/cli/test_cli_resolve_contract_topics.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for cli_resolve_contract_topics (OMN-10512).
+
+Covers:
+    - unknown node_id raises ModelOnexError listing known nodes
+    - resolve_node_contract returns a valid Path ending in contract.yaml
+    - resolve_contract_topics returns (command_topic, terminal_topic) from subscribe_topics
+    - resolve_contract_topics returns command_topic from event_bus.command_topic (priority a)
+    - missing subscribe_topics raises ModelOnexError
+    - missing terminal_event raises ModelOnexError
+    - terminal_event as dict with .topic field is resolved correctly
+    - multiple subscribe_topics warns to stderr and uses first
+"""
+
+from __future__ import annotations
+
+import warnings
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from omnibase_core.cli.cli_resolve_contract_topics import (
+    resolve_contract_topics,
+    resolve_node_contract,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_contract(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "contract.yaml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _fake_ep(name: str, value: str) -> object:
+    class _EP:
+        pass
+
+    ep = _EP()
+    ep.name = name  # type: ignore[attr-defined]
+    ep.value = value  # type: ignore[attr-defined]
+    ep.dist = "local-fake"  # type: ignore[attr-defined]
+    return ep
+
+
+# ---------------------------------------------------------------------------
+# resolve_node_contract
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_node_id_raises_model_onex_error_with_known_list() -> None:
+    with patch(
+        "omnibase_core.cli.cli_resolve_contract_topics.entry_points",
+        return_value=[_fake_ep("node_real", "some.module:Node")],
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            resolve_node_contract("node_does_not_exist")
+    msg = str(exc_info.value)
+    assert "node_does_not_exist" in msg
+    assert "node_real" in msg
+
+
+def test_resolve_node_contract_returns_contract_path(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "fake_node_pkg"
+    pkg_dir.mkdir()
+    contract = pkg_dir / "contract.yaml"
+    contract.write_text("name: fake\n", encoding="utf-8")
+
+    spec = ModuleSpec("fake_node_pkg", loader=None, is_package=True)
+    spec.submodule_search_locations = [str(pkg_dir)]
+
+    with (
+        patch(
+            "omnibase_core.cli.cli_resolve_contract_topics.entry_points",
+            return_value=[_fake_ep("node_fake", "fake_node_pkg:Node")],
+        ),
+        patch(
+            "omnibase_core.cli.cli_resolve_contract_topics.importlib.util.find_spec",
+            return_value=spec,
+        ),
+    ):
+        result = resolve_node_contract("node_fake")
+
+    assert result.name == "contract.yaml"
+    assert result.exists()
+
+
+def test_missing_packaged_contract_raises_file_not_found(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "fake_node_pkg_nocontract"
+    pkg_dir.mkdir()
+
+    spec = ModuleSpec("fake_node_pkg_nocontract", loader=None, is_package=True)
+    spec.submodule_search_locations = [str(pkg_dir)]
+
+    with (
+        patch(
+            "omnibase_core.cli.cli_resolve_contract_topics.entry_points",
+            return_value=[_fake_ep("node_nocontract", "fake_node_pkg_nocontract:Node")],
+        ),
+        patch(
+            "omnibase_core.cli.cli_resolve_contract_topics.importlib.util.find_spec",
+            return_value=spec,
+        ),
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            resolve_node_contract("node_nocontract")
+    assert "contract.yaml" in str(exc_info.value)
+
+
+def test_duplicate_entry_point_raises_model_onex_error() -> None:
+    ep1 = _fake_ep("node_dup", "pkg_a:Node")
+    ep2 = _fake_ep("node_dup", "pkg_b:Node")
+
+    with patch(
+        "omnibase_core.cli.cli_resolve_contract_topics.entry_points",
+        return_value=[ep1, ep2],
+    ):
+        with pytest.raises(ModelOnexError) as exc_info:
+            resolve_node_contract("node_dup")
+    assert "Duplicate" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# resolve_contract_topics — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_contract_topics_from_subscribe_topics(tmp_path: Path) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics:\n"
+        "  - onex.cmd.omnimarket.duplication-sweep-start.v1\n"
+        "terminal_event: onex.evt.omnimarket.duplication-sweep-completed.v1\n",
+    )
+    cmd, terminal = resolve_contract_topics(contract)
+    assert cmd == "onex.cmd.omnimarket.duplication-sweep-start.v1"
+    assert terminal == "onex.evt.omnimarket.duplication-sweep-completed.v1"
+
+
+def test_resolve_contract_topics_event_bus_command_topic_takes_priority(
+    tmp_path: Path,
+) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics:\n"
+        "  - onex.cmd.omnimarket.ignored-topic.v1\n"
+        "event_bus:\n"
+        "  command_topic: onex.cmd.omnimarket.explicit-command.v1\n"
+        "terminal_event: onex.evt.omnimarket.done.v1\n",
+    )
+    cmd, terminal = resolve_contract_topics(contract)
+    assert cmd == "onex.cmd.omnimarket.explicit-command.v1"
+    assert terminal == "onex.evt.omnimarket.done.v1"
+
+
+def test_resolve_contract_topics_terminal_event_as_dict(tmp_path: Path) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics:\n"
+        "  - onex.cmd.svc.start.v1\n"
+        "terminal_event:\n"
+        "  topic: onex.evt.svc.completed.v1\n",
+    )
+    cmd, terminal = resolve_contract_topics(contract)
+    assert cmd == "onex.cmd.svc.start.v1"
+    assert terminal == "onex.evt.svc.completed.v1"
+
+
+def test_resolve_contract_topics_multiple_subscribe_topics_warns(
+    tmp_path: Path,
+) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics:\n"
+        "  - onex.cmd.svc.first.v1\n"
+        "  - onex.cmd.svc.second.v1\n"
+        "terminal_event: onex.evt.svc.done.v1\n",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cmd, _ = resolve_contract_topics(contract)
+    assert cmd == "onex.cmd.svc.first.v1"
+    assert any("multiple subscribe_topics" in str(w.message) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# resolve_contract_topics — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_subscribe_topics_raises_model_onex_error(tmp_path: Path) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "name: no_subscribe\nterminal_event: onex.evt.svc.done.v1\n",
+    )
+    with pytest.raises(ModelOnexError) as exc_info:
+        resolve_contract_topics(contract)
+    assert "subscribe_topics" in str(exc_info.value)
+    assert str(contract) in str(exc_info.value)
+
+
+def test_missing_terminal_event_raises_model_onex_error(tmp_path: Path) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics:\n  - onex.cmd.svc.start.v1\n",
+    )
+    with pytest.raises(ModelOnexError) as exc_info:
+        resolve_contract_topics(contract)
+    assert "terminal_event" in str(exc_info.value)
+    assert str(contract) in str(exc_info.value)
+
+
+def test_empty_subscribe_topics_list_raises_model_onex_error(tmp_path: Path) -> None:
+    contract = _write_contract(
+        tmp_path,
+        "subscribe_topics: []\nterminal_event: onex.evt.svc.done.v1\n",
+    )
+    with pytest.raises(ModelOnexError) as exc_info:
+        resolve_contract_topics(contract)
+    assert "subscribe_topics" in str(exc_info.value)

--- a/tests/unit/cli/test_cli_resolve_contract_topics.py
+++ b/tests/unit/cli/test_cli_resolve_contract_topics.py
@@ -23,6 +23,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from omnibase_core.cli.cli_resolve_contract_topics import (
     resolve_contract_topics,
     resolve_node_contract,
@@ -45,6 +47,7 @@ def _fake_ep(name: str, value: str) -> object:
         pass
 
     ep = _EP()
+    # NOTE(OMN-10512): dynamic attr assignment on a bare class for entry-point test stub.
     ep.name = name  # type: ignore[attr-defined]
     ep.value = value  # type: ignore[attr-defined]
     ep.dist = "local-fake"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_core/cli/cli_resolve_contract_topics.py` with two public functions:
  - `resolve_node_contract(node_id)` resolves an `onex.nodes` entry-point name to its packaged `contract.yaml` path, raising `ModelOnexError` so it is reusable outside Click commands.
  - `resolve_contract_topics(contract_path)` loads the contract YAML and returns `(command_topic, terminal_topic)`, reading `subscribe_topics` because the CLI is the sender.
- Adds `tests/unit/cli/test_cli_resolve_contract_topics.py` with 11 unit tests covering the resolver acceptance criteria.
- Adds repo-local `contracts/OMN-10512.yaml` so deploy-gate can prove no runtime deploy is required for this pure CLI utility.

## Ticket

OMN-10512

## DoD Evidence

- `env -u PYTHONPATH uv run pytest tests/unit/cli/test_cli_resolve_contract_topics.py -q` -> 11 passed locally.
- `uv run validate-yaml contracts/OMN-10512.yaml` passed locally.
- Local deploy-gate reproduction passed against `contracts/OMN-10512.yaml`.
- Central OCC contract and receipts: https://github.com/OmniNode-ai/onex_change_control/pull/706

Evidence-Source: 659460cd044318eb1ad6973872cbc0f0c6efdf01
Evidence-Ticket: OMN-10512

## Test plan

- [ ] CI passes (Quality Gate + Tests Gate)
- [x] Unknown node raises `ModelOnexError` with known-nodes list
- [x] Missing `subscribe_topics` raises `ModelOnexError`
- [x] Missing `terminal_event` raises `ModelOnexError`