### PR TITLE
OMN-9770 Relax compute and effect audit fields

### DIFF
--- a/contracts/OMN-9770.yaml
+++ b/contracts/OMN-9770.yaml
@@ -1,0 +1,54 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9770
+title: "Policy: algorithm/io_operations optionality"
+summary: >
+  Relax compute/effect contract schema loading for migration-audit compatibility
+  while preserving runtime compute validation and recording deploy-gate evidence.
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "protocols"
+  - "events"
+evidence_requirements:
+  - kind: "ci"
+    description: "Focused optionality regression tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py -v"
+  - kind: "ci"
+    description: "Runtime compute conversion guard tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py -v"
+  - kind: "ci"
+    description: "Full mypy remains clean"
+    command: "uv run mypy src/ --config-file=mypy.ini"
+  - kind: "manual"
+    description: "Deploy-gate evidence: schema/model validation change only; no live runtime deploy required before merge"
+    command: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard code only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused optionality tests cover missing compute algorithm and effect io_operations"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py -v"
+  - id: "dod-002"
+    description: "Runtime compute conversion rejects missing algorithm before dereference"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py -v"
+  - id: "dod-003"
+    description: "Full mypy proves optional algorithm/io_operations type surface is handled"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/ --config-file=mypy.ini"
+  - id: "dod-004"
+    description: "Deploy-gate evidence records that no pre-merge live deploy is required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard code only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"

--- a/src/omnibase_core/models/contracts/model_contract_compute.py
+++ b/src/omnibase_core/models/contracts/model_contract_compute.py
@@ -15,6 +15,7 @@ Specialized contract model for NodeCompute implementations providing:
 Strict typing is enforced: No Any types allowed in implementation.
 """
 
+import logging
 from typing import ClassVar
 
 from pydantic import ConfigDict, Field, field_validator
@@ -45,6 +46,8 @@ from .model_algorithm_config import ModelAlgorithmConfig
 from .model_input_validation_config import ModelInputValidationConfig
 from .model_output_transformation_config import ModelOutputTransformationConfig
 from .model_parallel_config import ModelParallelConfig
+
+logger = logging.getLogger(__name__)
 
 
 class ModelContractCompute(MixinNodeTypeValidator, ModelContractBase):
@@ -167,10 +170,25 @@ class ModelContractCompute(MixinNodeTypeValidator, ModelContractBase):
     # These fields define the core computation behavior
 
     # Computation configuration
-    algorithm: ModelAlgorithmConfig = Field(
-        default=...,
+    algorithm: ModelAlgorithmConfig | None = Field(
+        default=None,
         description="Algorithm configuration and parameters",
+        validate_default=True,
     )
+
+    @field_validator("algorithm", mode="before")
+    @classmethod
+    def warn_missing_algorithm(
+        cls,
+        v: object,
+    ) -> object:
+        """Allow legacy compute contracts without algorithm during migration audit."""
+        if v is None:
+            logger.warning(
+                "Compute contract missing algorithm; accepted as migration debt "
+                "for legacy corpus validation (OMN-9770)."
+            )
+        return v
 
     parallel_processing: ModelParallelConfig = Field(
         default_factory=ModelParallelConfig,
@@ -253,6 +271,8 @@ class ModelContractCompute(MixinNodeTypeValidator, ModelContractBase):
 
     def _validate_compute_algorithm_config(self) -> None:
         """Validate algorithm configuration for compute nodes."""
+        if self.algorithm is None:
+            return
         if not self.algorithm.factors:
             msg = "Compute node must define at least one algorithm factor"
             raise ModelOnexError(
@@ -351,12 +371,14 @@ class ModelContractCompute(MixinNodeTypeValidator, ModelContractBase):
     def validate_algorithm_from_dict(
         cls,
         v: object,
-    ) -> ModelAlgorithmConfig:
+    ) -> ModelAlgorithmConfig | None:
         """
         Validate and convert algorithm configuration from dict if needed.
 
         Supports YAML loading by converting dict to ModelAlgorithmConfig.
         """
+        if v is None:
+            return None
         if isinstance(v, ModelAlgorithmConfig):
             return v
         if isinstance(v, dict):
@@ -399,9 +421,11 @@ class ModelContractCompute(MixinNodeTypeValidator, ModelContractBase):
     @classmethod
     def validate_algorithm_consistency(
         cls,
-        v: ModelAlgorithmConfig,
-    ) -> ModelAlgorithmConfig:
+        v: ModelAlgorithmConfig | None,
+    ) -> ModelAlgorithmConfig | None:
         """Validate algorithm configuration consistency after conversion."""
+        if v is None:
+            return None
         if v.algorithm_type == "weighted_factor_algorithm" and not v.factors:
             msg = "Weighted factor algorithm requires at least one factor"
             raise ModelOnexError(

--- a/src/omnibase_core/models/contracts/model_contract_effect.py
+++ b/src/omnibase_core/models/contracts/model_contract_effect.py
@@ -17,6 +17,7 @@ Strict typing is enforced: No Any types allowed in implementation.
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID, uuid4
@@ -77,6 +78,7 @@ if TYPE_CHECKING:
 # Lazy model rebuild flag - forward references are resolved on first use, not at import
 _models_rebuilt = False
 _rebuild_lock = threading.Lock()
+logger = logging.getLogger(__name__)
 
 
 def _ensure_models_rebuilt(contract_effect_cls: type[BaseModel] | None = None) -> None:
@@ -308,11 +310,26 @@ class ModelContractEffect(MixinNodeTypeValidator, ModelContractBase):
     # These fields define the core side-effect behavior
 
     # Side-effect configuration
-    io_operations: list[ModelIOOperationConfig] = Field(
-        default=...,
+    io_operations: list[ModelIOOperationConfig] | None = Field(
+        default=None,
         description="I/O operation specifications",
         min_length=1,
+        validate_default=True,
     )
+
+    @field_validator("io_operations", mode="before")
+    @classmethod
+    def warn_missing_io_operations(
+        cls,
+        v: object,
+    ) -> object:
+        """Allow legacy effect contracts without io_operations during migration audit."""
+        if v is None:
+            logger.warning(
+                "Effect contract missing io_operations; accepted as migration debt "
+                "for legacy corpus validation (OMN-9770)."
+            )
+        return v
 
     transaction_management: ModelTransactionConfig = Field(
         default_factory=ModelTransactionConfig,
@@ -415,6 +432,8 @@ class ModelContractEffect(MixinNodeTypeValidator, ModelContractBase):
 
     def _validate_effect_io_operations(self) -> None:
         """Validate I/O operations configuration for effect nodes."""
+        if self.io_operations is None:
+            return
         if not self.io_operations:
             msg = "Effect node must define at least one I/O operation"
             raise ModelOnexError(
@@ -433,8 +452,10 @@ class ModelContractEffect(MixinNodeTypeValidator, ModelContractBase):
     def _validate_effect_transaction_config(self) -> None:
         """Validate transaction management and retry configuration."""
         # Validate transaction configuration consistency
-        if self.transaction_management.enabled and not any(
-            op.atomic for op in self.io_operations
+        if (
+            self.io_operations is not None
+            and self.transaction_management.enabled
+            and not any(op.atomic for op in self.io_operations)
         ):
             msg = "Transaction management requires at least one atomic operation"
             raise ModelOnexError(
@@ -515,9 +536,11 @@ class ModelContractEffect(MixinNodeTypeValidator, ModelContractBase):
     @classmethod
     def validate_io_operations_consistency(
         cls,
-        v: list[ModelIOOperationConfig],
-    ) -> list[ModelIOOperationConfig]:
+        v: list[ModelIOOperationConfig] | None,
+    ) -> list[ModelIOOperationConfig] | None:
         """Validate I/O operations configuration consistency."""
+        if v is None:
+            return None
         [op.operation_type for op in v]
 
         # Check for conflicting atomic requirements

--- a/src/omnibase_core/nodes/node_compute.py
+++ b/src/omnibase_core/nodes/node_compute.py
@@ -495,8 +495,8 @@ class NodeCompute[T_Input, T_Output](NodeCoreBase, MixinHandlerRouting):
 
         Note:
             computation_type is extracted directly from algorithm.algorithm_type.
-            Both algorithm and algorithm_type are required fields in
-            ModelContractCompute and ModelAlgorithmConfig respectively.
+            Runtime compute execution requires algorithm even though legacy
+            migration-audit contract loading may accept it as absent.
         """
         # Extract input data from contract - input_state is required
         input_data: Any = None
@@ -514,8 +514,18 @@ class NodeCompute[T_Input, T_Output](NodeCoreBase, MixinHandlerRouting):
                 },
             )
 
-        # Extract computation_type directly from algorithm.algorithm_type
-        # Both fields are required in their respective models (no fallback needed)
+        if contract.algorithm is None:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message="Contract must have 'algorithm' field with valid configuration",
+                context={
+                    "node_id": str(self.node_id),
+                    "hint": "Set algorithm in compute contracts before runtime execution",
+                    "algorithm_value": str(contract.algorithm),
+                },
+            )
+
+        # Extract computation_type directly from algorithm.algorithm_type.
         computation_type: str = contract.algorithm.algorithm_type
 
         # Extract metadata (normalize None to empty dict)

--- a/tests/unit/models/contracts/test_algorithm_io_operations_optionality.py
+++ b/tests/unit/models/contracts/test_algorithm_io_operations_optionality.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Temporary legacy-corpus optionality for compute/effect contract fields."""
+
+import logging
+
+import pytest
+
+from omnibase_core.enums import EnumNodeType
+from omnibase_core.models.contracts.model_contract_compute import ModelContractCompute
+from omnibase_core.models.contracts.model_contract_effect import ModelContractEffect
+
+_BASE_CONTRACT: dict[str, object] = {
+    "name": "node_foo",
+    "contract_version": {"major": 1, "minor": 0, "patch": 0},
+    "description": "Legacy contract missing a field added after authoring.",
+    "input_model": "foo.ModelFooRequest",
+    "output_model": "foo.ModelFooResult",
+    "performance": {"single_operation_max_ms": 1000},
+}
+
+
+@pytest.mark.unit
+class TestAlgorithmIoOperationsOptionality:
+    """OMN-9770 migration-audit compatibility for legacy contracts."""
+
+    def test_effect_without_io_operations_validates(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.WARNING)
+
+        model = ModelContractEffect.model_validate(
+            {
+                **_BASE_CONTRACT,
+                "node_type": EnumNodeType.EFFECT_GENERIC,
+            }
+        )
+
+        assert model.io_operations is None
+        assert "missing io_operations" in caplog.text
+        assert "OMN-9770" in caplog.text
+
+    def test_compute_without_algorithm_validates(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.WARNING)
+
+        model = ModelContractCompute.model_validate(
+            {
+                **_BASE_CONTRACT,
+                "node_type": EnumNodeType.COMPUTE_GENERIC,
+            }
+        )
+
+        assert model.algorithm is None
+        assert "missing algorithm" in caplog.text
+        assert "OMN-9770" in caplog.text

--- a/tests/unit/nodes/test_node_compute_contract_conversion.py
+++ b/tests/unit/nodes/test_node_compute_contract_conversion.py
@@ -63,7 +63,7 @@ def valid_performance_requirements() -> ModelPerformanceRequirements:
 
 
 def create_valid_contract(
-    algorithm_config: ModelAlgorithmConfig,
+    algorithm_config: ModelAlgorithmConfig | None,
     performance_requirements: ModelPerformanceRequirements,
     input_state: dict[str, ModelSchemaValue] | None = None,
 ) -> ModelContractCompute:
@@ -180,6 +180,29 @@ class TestContractToInputMissingInputState:
 
         assert result is not None
         assert result.data is not None
+
+    def test_contract_to_input_raises_error_when_algorithm_missing(
+        self,
+        compute_node: NodeCompute[Any, Any],
+        valid_performance_requirements: ModelPerformanceRequirements,
+    ) -> None:
+        """Runtime compute conversion still requires algorithm configuration."""
+        contract = create_valid_contract(
+            algorithm_config=None,
+            performance_requirements=valid_performance_requirements,
+            input_state={"key": ModelSchemaValue.from_value("value")},
+        )
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            compute_node._contract_to_input(contract)
+
+        error = exc_info.value
+        assert error.error_code == EnumCoreErrorCode.VALIDATION_ERROR
+        assert "algorithm" in error.message.lower()
+
+        nested_context = get_nested_context(error)
+        assert "node_id" in nested_context
+        assert "hint" in nested_context
 
     def test_contract_to_input_with_empty_dict_input_state(
         self,

--- a/tests/unit/validation/test_contract_validator.py
+++ b/tests/unit/validation/test_contract_validator.py
@@ -81,10 +81,15 @@ version: [invalid yaml structure
         assert "YAML parsing error" in result.violations[0]
 
     def test_validate_missing_required_fields(self) -> None:
-        """Test validation fails when required fields are missing."""
+        """Test validation behavior when io_operations is absent from an effect contract.
+
+        OMN-9770: io_operations is now optional during migration-audit to allow legacy
+        corpus validation. Missing io_operations is accepted as migration debt, not a
+        hard violation.
+        """
         validator = ServiceContractValidator()
 
-        # Missing io_operations (required for effect contracts)
+        # Missing io_operations — accepted as migration debt since OMN-9770
         incomplete_yaml = """
 name: IncompleteEffect
 contract_version:
@@ -99,9 +104,8 @@ output_model: ModelOutput
 
         result = validator.validate_contract_yaml(incomplete_yaml, "effect")
 
-        assert not result.is_valid
-        assert result.score < 1.0
-        assert len(result.violations) > 0
+        # OMN-9770: io_operations is now optional; this contract is valid (migration debt)
+        assert result.is_valid
 
     def test_validate_contract_with_warnings(self) -> None:
         """Test validation produces warnings for non-critical issues."""


### PR DESCRIPTION
## Summary
- allow legacy compute contracts to omit algorithm during migration-audit validation while logging OMN-9770 migration debt
- allow legacy effect contracts to omit io_operations during migration-audit validation while preserving existing validation when present
- keep runtime compute execution strict by raising a validation error if algorithm is absent during contract-to-input conversion
- add focused unit coverage for optional legacy fields and runtime compute guard

## Verification
- PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py -v
- PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_model_contract_base_extensions.py -v
- PYTHONPATH=src uv run pytest tests/unit/models/contracts -m unit -v (3012 passed, 21 deselected)
- PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py -v
- uv run mypy src/ --config-file=mypy.ini
- uv run pyright src/omnibase_core/nodes/node_compute.py src/omnibase_core/models/contracts/model_contract_compute.py src/omnibase_core/models/contracts/model_contract_effect.py tests/unit/models/contracts/test_algorithm_io_operations_optionality.py tests/unit/nodes/test_node_compute_contract_conversion.py
- uv run ruff check src/omnibase_core/nodes/node_compute.py tests/unit/nodes/test_node_compute_contract_conversion.py
- uv run ruff check src/omnibase_core/models/contracts/model_contract_effect.py src/omnibase_core/models/contracts/model_contract_compute.py tests/unit/models/contracts/test_algorithm_io_operations_optionality.py
- git diff --check

## Notes
- Worktree verification used PYTHONPATH=src because plain uv run in this workspace resolved omnibase_core imports from the canonical clone instead of this ticket worktree.
- The strict-mode validator entry point from OMN-9768 is not present on current main, so this PR scopes OMN-9770 to model-level migration-audit compatibility and runtime guard preservation; strict-mode presence enforcement remains tied to the OMN-9768 validator path when it lands.

Linear: OMN-9770

Evidence-Source: 359c126a3922ae191a7699a9c6f6f3ab19dc3dd4
Evidence-Ticket: OMN-9770