### PR TITLE
OMN-9771 Normalize misc legacy annotations

### DIFF
--- a/contracts/OMN-9771.yaml
+++ b/contracts/OMN-9771.yaml
@@ -1,0 +1,54 @@
+---
+schema_version: "1.0.0"
+ticket_id: OMN-9771
+title: "Policy: family_misc_extra_fields disposition"
+summary: >
+  Add an explicit non-load-bearing annotations bag and migration-audit
+  normalization for miscellaneous legacy contract fields.
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "protocols"
+  - "events"
+evidence_requirements:
+  - kind: "ci"
+    description: "Focused misc extra fields normalization tests pass"
+    command: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py -v"
+  - kind: "ci"
+    description: "Normalization suite passes"
+    command: "PYTHONPATH=src uv run pytest tests/unit/normalization -v"
+  - kind: "ci"
+    description: "Full mypy remains clean"
+    command: "uv run mypy src/ --config-file=mypy.ini"
+  - kind: "manual"
+    description: "Deploy-gate evidence: schema/normalization change only; no live runtime deploy required before merge"
+    command: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Focused misc extra fields normalization tests cover annotations and governance"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py -v"
+  - id: "dod-002"
+    description: "Normalization suite passes with compose pipeline additions"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/normalization -v"
+  - id: "dod-003"
+    description: "Full mypy proves typed normalization and base-model surface remain clean"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/ --config-file=mypy.ini"
+  - id: "dod-004"
+    description: "Deploy-gate evidence records that no pre-merge live deploy is required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -16,7 +16,7 @@ This implementation does not use Any types.
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -233,6 +233,13 @@ class ModelContractBase(BaseModel, ABC):
     tags: list[str] = Field(
         default_factory=list,
         description="Contract classification tags",
+    )
+
+    annotations: dict[str, Any] | None = (
+        Field(  # ONEX_EXCLUDE: dict_str_any - explicit non-load-bearing migration annotations bag
+            default=None,
+            description="Non-load-bearing operational annotations preserved from legacy contract corpus.",
+        )
     )
 
     feature_flags: list[ModelContractFeatureFlag] = Field(

--- a/src/omnibase_core/normalization/__init__.py
+++ b/src/omnibase_core/normalization/__init__.py
@@ -15,21 +15,27 @@ preservation of dropped/rewritten content is the caller's responsibility.
 from __future__ import annotations
 
 from omnibase_core.normalization.contract_normalizer import (
+    compose_normalization_pipeline,
     is_omnimarket_v0,
+    normalize_dod_evidence,
     normalize_event_bus,
     normalize_handler_routing,
     normalize_io_model_ref,
     normalize_omnimarket_v0_contract,
     strip_legacy_metadata,
 )
+from omnibase_core.normalization.contract_validator import validate_contract_file
 from omnibase_core.normalization.corpus_classifier import classify_contract_path
 
 __all__ = [
     "classify_contract_path",
+    "compose_normalization_pipeline",
     "is_omnimarket_v0",
+    "normalize_dod_evidence",
     "normalize_event_bus",
     "normalize_handler_routing",
     "normalize_io_model_ref",
     "normalize_omnimarket_v0_contract",
     "strip_legacy_metadata",
+    "validate_contract_file",
 ]

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -272,6 +272,8 @@ def normalize_dod_evidence(raw: dict[str, object]) -> dict[str, object]:
             kind_value = normalized.pop("kind")
             if isinstance(kind_value, str):
                 normalized["type"] = _DOD_KIND_TO_TYPE.get(kind_value, kind_value)
+            else:
+                normalized["type"] = kind_value
             new_items.append(normalized)
         else:
             new_items.append(item)

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -30,6 +30,10 @@ Functions in this module:
     - normalize_omnimarket_v0_contract (OMN-9765): strips legacy omnimarket
       v0 handler, descriptor, and terminal_event blocks while hoisting
       handler.input_model when needed.
+    - normalize_dod_evidence (OMN-9766): maps legacy ``kind`` → ``type``
+      on dod_evidence entries.
+    - compose_normalization_pipeline (OMN-9766): composes the six
+      normalizers in the documented order.
 """
 
 from __future__ import annotations
@@ -37,6 +41,7 @@ from __future__ import annotations
 import copy
 import re
 from collections.abc import Mapping
+from typing import cast
 
 from omnibase_core.types.type_json import JsonType
 
@@ -226,8 +231,96 @@ def normalize_omnimarket_v0_contract(raw: dict[str, object]) -> dict[str, object
     return result
 
 
+_DOD_KIND_TO_TYPE: dict[str, str] = {
+    "test": "unit_test",
+    "unit_test": "unit_test",
+    "integration_test": "integration_test",
+    "pr_merged": "pr_merged",
+    "file_exists": "file_exists",
+}
+
+
+def normalize_dod_evidence(raw: dict[str, object]) -> dict[str, object]:
+    """Map legacy ``kind`` → ``type`` on dod_evidence entries.
+
+    Legacy contracts spelled the discriminator on each dod_evidence entry
+    as ``kind``; the canonical schema names it ``type``. Per-entry rules:
+
+    - String entries (``"test_passes"``) pass through unchanged.
+    - Dict entries with ``kind`` and no ``type`` are rewritten:
+      ``kind`` is removed, ``type`` is set via :data:`_DOD_KIND_TO_TYPE`
+      (or copied verbatim if no mapping is registered).
+    - Dict entries that already carry ``type`` are left alone (no double
+      mapping; pre-canonical entries win).
+
+    The input dict is not mutated; a new dict is returned. Idempotent:
+    running twice yields the same result. No-op when ``dod_evidence`` is
+    absent.
+
+    Corpus context: 8 files in the audited corpus carry legacy ``kind``.
+    """
+    if "dod_evidence" not in raw:
+        return raw
+    result = dict(raw)
+    items_raw = result.get("dod_evidence")
+    if not isinstance(items_raw, list):
+        return result
+    new_items: list[object] = []
+    for item in items_raw:
+        if isinstance(item, dict) and "kind" in item and "type" not in item:
+            normalized: dict[str, object] = dict(item)
+            kind_value = normalized.pop("kind")
+            if isinstance(kind_value, str):
+                normalized["type"] = _DOD_KIND_TO_TYPE.get(kind_value, kind_value)
+            new_items.append(normalized)
+        else:
+            new_items.append(item)
+    result["dod_evidence"] = new_items
+    return result
+
+
+def compose_normalization_pipeline(raw: dict[str, object]) -> dict[str, object]:
+    """Apply all per-family normalizers in canonical order.
+
+    Step order is fixed and documented:
+
+    1. :func:`strip_legacy_metadata` — drop ``metadata`` /
+       ``contract_name`` / ``node_name``.
+    2. :func:`normalize_event_bus` — strip the legacy event_bus block
+       and top-level topic keys.
+    3. :func:`normalize_io_model_ref` — convert ``{name, module}`` dict
+       refs to dotted strings.
+    4. :func:`normalize_handler_routing` — derive routing_key /
+       handler_key / version on the routing block.
+    5. :func:`normalize_omnimarket_v0_contract` — conditional on
+       :func:`is_omnimarket_v0`; rewrites the omnimarket v0 shape.
+    6. :func:`normalize_dod_evidence` — map legacy ``kind`` → ``type``.
+
+    Pure: no I/O, no logging, no mutation of the caller's dict. Note
+    that :func:`normalize_event_bus` is typed against ``dict[str,
+    JsonType]``; we cast at the boundary because the pipeline carries
+    unconstrained ``dict[str, object]``.
+
+    Task 14 will append ``normalize_misc_extra_fields`` as the final
+    step; that step is intentionally deferred per OMN-9757 plan.
+    """
+    out: dict[str, object] = strip_legacy_metadata(raw)
+    out = cast(
+        "dict[str, object]",
+        normalize_event_bus(cast("dict[str, JsonType]", out)),
+    )
+    out = normalize_io_model_ref(out)
+    out = normalize_handler_routing(out)
+    if is_omnimarket_v0(out):
+        out = normalize_omnimarket_v0_contract(out)
+    out = normalize_dod_evidence(out)
+    return out
+
+
 __all__ = [
+    "compose_normalization_pipeline",
     "is_omnimarket_v0",
+    "normalize_dod_evidence",
     "normalize_event_bus",
     "normalize_handler_routing",
     "normalize_io_model_ref",

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -37,8 +37,7 @@ from __future__ import annotations
 import copy
 import re
 from collections.abc import Mapping
-
-from omnibase_core.types.type_json import JsonType
+from functools import lru_cache
 
 _LEGACY_METADATA_KEYS: frozenset[str] = frozenset(
     {"metadata", "contract_name", "node_name"}
@@ -53,6 +52,20 @@ _MULTI_OP_FLAG: str = "multi_operation_requires_human_review"
 
 _PASCAL_TO_SNAKE_BOUNDARY_1 = re.compile(r"(.)([A-Z][a-z]+)")
 _PASCAL_TO_SNAKE_BOUNDARY_2 = re.compile(r"([a-z0-9])([A-Z])")
+_ANNOTATIONS_FORBIDDEN_KEYS: frozenset[str] = frozenset(
+    {
+        "topic",
+        "topics",
+        "handler",
+        "routes",
+        "routing",
+        "validate",
+        "validator",
+        "consumer_group",
+        "subscriber",
+        "producer",
+    }
+)
 
 
 def strip_legacy_metadata(raw: Mapping[str, object]) -> dict[str, object]:
@@ -90,7 +103,7 @@ def _normalize_single_io_ref(value: dict[str, object] | str | None) -> str | Non
     return None
 
 
-def normalize_event_bus(raw: dict[str, JsonType]) -> dict[str, JsonType]:
+def normalize_event_bus(raw: Mapping[str, object]) -> dict[str, object]:
     """Strip the legacy event_bus block and top-level topic list keys.
 
     Drops `event_bus`, `subscribe_topics`, `publish_topics`, and `topics` keys
@@ -226,11 +239,88 @@ def normalize_omnimarket_v0_contract(raw: dict[str, object]) -> dict[str, object
     return result
 
 
+@lru_cache(maxsize=1)
+def _derive_known_contract_keys() -> frozenset[str]:
+    """Derive canonical contract keys from the typed contract models."""
+    from omnibase_core.models.contracts.model_contract_base import ModelContractBase
+    from omnibase_core.models.contracts.model_contract_compute import (
+        ModelContractCompute,
+    )
+    from omnibase_core.models.contracts.model_contract_effect import ModelContractEffect
+    from omnibase_core.models.contracts.model_contract_orchestrator import (
+        ModelContractOrchestrator,
+    )
+    from omnibase_core.models.contracts.model_contract_reducer import (
+        ModelContractReducer,
+    )
+
+    keys: set[str] = set()
+    for model in (
+        ModelContractBase,
+        ModelContractEffect,
+        ModelContractCompute,
+        ModelContractReducer,
+        ModelContractOrchestrator,
+    ):
+        keys.update(model.model_fields.keys())
+    return frozenset(keys)
+
+
+def normalize_misc_extra_fields(
+    raw: Mapping[str, object],
+    *,
+    known_keys: frozenset[str] | set[str] | None = None,
+) -> dict[str, object]:
+    """Move non-canonical legacy fields into the explicit annotations bag.
+
+    ``extra="forbid"`` remains canonical model policy. This audit-mode
+    normalizer preserves legacy operational annotation fields under the typed
+    ``annotations`` field instead of letting arbitrary top-level keys through.
+    """
+    contract_keys = (
+        known_keys if known_keys is not None else _derive_known_contract_keys()
+    )
+    extra = {k: v for k, v in raw.items() if k not in contract_keys}
+    if not extra:
+        return dict(raw)
+
+    result = {k: v for k, v in raw.items() if k in contract_keys}
+    existing_annotations = raw.get("annotations")
+    annotations: dict[str, object] = (
+        dict(existing_annotations) if isinstance(existing_annotations, Mapping) else {}
+    )
+    annotations.update(extra)
+    result["annotations"] = annotations
+    return result
+
+
+def validate_annotations_governance(annotations: Mapping[str, object]) -> list[str]:
+    """Return strict-mode governance violations for annotation keys."""
+    return [
+        f"Forbidden annotation key: {key!r} -- must be a typed field, not in annotations"
+        for key in annotations
+        if key in _ANNOTATIONS_FORBIDDEN_KEYS
+    ]
+
+
+def compose_normalization_pipeline(raw: Mapping[str, object]) -> dict[str, object]:
+    """Apply the migration-audit normalization pipeline in canonical order."""
+    normalized: dict[str, object] = strip_legacy_metadata(raw)
+    normalized = normalize_event_bus(normalized)
+    normalized = normalize_io_model_ref(normalized)
+    normalized = normalize_handler_routing(normalized)
+    normalized = normalize_omnimarket_v0_contract(normalized)
+    return normalize_misc_extra_fields(normalized)
+
+
 __all__ = [
+    "compose_normalization_pipeline",
     "is_omnimarket_v0",
     "normalize_event_bus",
     "normalize_handler_routing",
     "normalize_io_model_ref",
+    "normalize_misc_extra_fields",
     "normalize_omnimarket_v0_contract",
     "strip_legacy_metadata",
+    "validate_annotations_governance",
 ]

--- a/src/omnibase_core/normalization/contract_validator.py
+++ b/src/omnibase_core/normalization/contract_validator.py
@@ -143,9 +143,20 @@ def validate_contract_file(
     aggregate sweeps; this function is the single entry point so both paths
     apply identical classification / normalization / validation logic.
     """
-    raw_text = path.read_text()
-    loaded = yaml.safe_load(raw_text)
-    raw: dict[str, object] = loaded if isinstance(loaded, dict) else {}
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+        loaded = yaml.safe_load(raw_text)
+        raw: dict[str, object] = loaded if isinstance(loaded, dict) else {}
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        classification = classify_contract_path(path, raw={})
+        return ModelCorpusValidationReport(
+            path=path,
+            bucket=classification.bucket,
+            mode=mode,
+            passed=False,
+            errors=[f"Failed to read/parse contract YAML: {exc}"],
+            normalized=False,
+        )
 
     classification = classify_contract_path(path, raw=raw)
 

--- a/src/omnibase_core/normalization/contract_validator.py
+++ b/src/omnibase_core/normalization/contract_validator.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-file contract validator with mode selection (OMN-9768, parent OMN-9757).
+
+Phase 3 — central seam tying corpus classification + per-family
+normalization to strict Pydantic validation. Replaces ad-hoc per-call
+validation paths so both the strict CI gate and the migration_audit
+batch sweep funnel through one entry point.
+
+Two modes (:class:`omnibase_core.enums.enum_validator_mode.EnumValidatorMode`):
+
+- ``STRICT`` — no normalization; node-root contracts validate against
+  the canonical typed contract model (``extra="forbid"``). Fails
+  immediately on legacy shapes. Used by CI for new/edited contracts.
+- ``MIGRATION_AUDIT`` — runs :func:`compose_normalization_pipeline`
+  first, then validates; ``normalized=True`` on the report. Used for
+  batch sweeps over the legacy corpus to inventory substantive
+  validation failures separate from pre-existing schema debt.
+
+Non-node-root buckets (handler / package / integration / etc.) skip
+validation entirely and return a passed report with the bucket
+recorded for downstream aggregation. Unknown ``node_type`` returns a
+failed report.
+
+Strict-mode pre-check: this validator asserts presence of
+``algorithm`` (COMPUTE) / ``io_operations`` (EFFECT, non-empty list)
+*before* calling ``model_validate``. Today the canonical models
+already require those fields, so the pre-check is redundant. After
+Task 13 (OMN-9770) makes them optional in the model, this pre-check
+preserves the strict-mode invariant that those fields are mandatory
+for new/edited contracts. The pre-check is intentionally NOT applied
+in ``MIGRATION_AUDIT`` mode — that mode is for inventorying corpus
+debt, not enforcing schema rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+from omnibase_core.models.contracts.model_corpus_validation_report import (
+    ModelCorpusValidationReport,
+)
+from omnibase_core.normalization.contract_normalizer import (
+    compose_normalization_pipeline,
+)
+from omnibase_core.normalization.corpus_classifier import classify_contract_path
+
+# Lazy-loaded mapping of canonical node_type values → canonical contract
+# model class. Built once on first call to keep the module import-light
+# and to avoid forcing the full contract model graph at module load time
+# (the contract models pull in a non-trivial dependency closure).
+_NODE_TYPE_TO_MODEL_CACHE: dict[str, type[BaseModel]] = {}
+
+
+def _get_model_registry() -> dict[str, type[BaseModel]]:
+    if not _NODE_TYPE_TO_MODEL_CACHE:
+        from omnibase_core.models.contracts.model_contract_compute import (
+            ModelContractCompute,
+        )
+        from omnibase_core.models.contracts.model_contract_effect import (
+            ModelContractEffect,
+        )
+        from omnibase_core.models.contracts.model_contract_orchestrator import (
+            ModelContractOrchestrator,
+        )
+        from omnibase_core.models.contracts.model_contract_reducer import (
+            ModelContractReducer,
+        )
+
+        _NODE_TYPE_TO_MODEL_CACHE.update(
+            {
+                "EFFECT_GENERIC": ModelContractEffect,
+                "COMPUTE_GENERIC": ModelContractCompute,
+                "REDUCER_GENERIC": ModelContractReducer,
+                "ORCHESTRATOR_GENERIC": ModelContractOrchestrator,
+            }
+        )
+    return _NODE_TYPE_TO_MODEL_CACHE
+
+
+# Short aliases written by older tooling resolved to canonical
+# EnumNodeType wire values. Resolution is one-way (alias → canonical)
+# and does not mutate the caller's dict.
+_NODE_TYPE_ALIASES: dict[str, str] = {
+    "EFFECT": "EFFECT_GENERIC",
+    "COMPUTE": "COMPUTE_GENERIC",
+    "REDUCER": "REDUCER_GENERIC",
+    "ORCHESTRATOR": "ORCHESTRATOR_GENERIC",
+}
+
+
+def _strict_field_precheck_errors(
+    canonical_node_type: str, raw: dict[str, object]
+) -> list[str]:
+    """Return strict-mode pre-check errors for ``algorithm`` / ``io_operations``.
+
+    Empty list means the pre-check passed. Only invoked in STRICT mode.
+    """
+    errors: list[str] = []
+    if canonical_node_type == "COMPUTE_GENERIC":
+        if "algorithm" not in raw:
+            errors.append(
+                "strict-mode pre-check: COMPUTE_GENERIC contract is missing required "
+                "'algorithm' field"
+            )
+    elif canonical_node_type == "EFFECT_GENERIC":
+        io_ops = raw.get("io_operations")
+        if "io_operations" not in raw:
+            errors.append(
+                "strict-mode pre-check: EFFECT_GENERIC contract is missing required "
+                "'io_operations' field"
+            )
+        elif not isinstance(io_ops, list) or len(io_ops) == 0:
+            errors.append(
+                "strict-mode pre-check: EFFECT_GENERIC contract requires non-empty "
+                "'io_operations' list"
+            )
+    return errors
+
+
+def validate_contract_file(
+    path: Path,
+    mode: EnumValidatorMode = EnumValidatorMode.STRICT,
+) -> ModelCorpusValidationReport:
+    """Validate a single contract YAML file under the chosen mode.
+
+    Args:
+        path: Filesystem path to the contract YAML. Must exist and be readable.
+        mode: ``STRICT`` (default) or ``MIGRATION_AUDIT``. See module docstring
+            for the contract of each mode.
+
+    Returns:
+        :class:`ModelCorpusValidationReport` recording the bucket, mode, pass /
+        fail outcome, error strings, and whether normalization was applied.
+
+    The report is the unit of evidence the batch validator (Task 12) and the
+    Track 2 ``runtime_contract_config_loader`` (OMN-9747) collect into
+    aggregate sweeps; this function is the single entry point so both paths
+    apply identical classification / normalization / validation logic.
+    """
+    raw_text = path.read_text()
+    loaded = yaml.safe_load(raw_text)
+    raw: dict[str, object] = loaded if isinstance(loaded, dict) else {}
+
+    classification = classify_contract_path(path, raw=raw)
+
+    # Non-node-root buckets are out of scope for typed model validation.
+    # Record the bucket and pass through; aggregators downstream still need
+    # the row so they can count files-by-bucket.
+    if not classification.requires_validation:
+        return ModelCorpusValidationReport(
+            path=path,
+            bucket=classification.bucket,
+            mode=mode,
+            passed=True,
+            errors=[],
+            normalized=False,
+        )
+
+    normalized = False
+    if mode is EnumValidatorMode.MIGRATION_AUDIT:
+        raw = compose_normalization_pipeline(raw)
+        normalized = True
+
+    raw_node_type = raw.get("node_type", "")
+    raw_node_type_str = raw_node_type if isinstance(raw_node_type, str) else ""
+    canonical_node_type = _NODE_TYPE_ALIASES.get(raw_node_type_str, raw_node_type_str)
+    model_cls = _get_model_registry().get(canonical_node_type)
+
+    if model_cls is None:
+        return ModelCorpusValidationReport(
+            path=path,
+            bucket=classification.bucket,
+            mode=mode,
+            passed=False,
+            errors=[
+                f"Unknown or unmapped node_type: {raw_node_type_str!r}"
+                if raw_node_type_str
+                else "Missing required 'node_type' field"
+            ],
+            normalized=normalized,
+        )
+
+    # Strict-mode pre-check enforces algorithm / io_operations even after
+    # Task 13 makes them optional in the model. Migration-audit mode skips
+    # the pre-check; surfacing only what the model itself rejects is the
+    # whole point of the audit pass.
+    if mode is EnumValidatorMode.STRICT:
+        precheck_errors = _strict_field_precheck_errors(canonical_node_type, raw)
+        if precheck_errors:
+            return ModelCorpusValidationReport(
+                path=path,
+                bucket=classification.bucket,
+                mode=mode,
+                passed=False,
+                errors=precheck_errors,
+                normalized=normalized,
+            )
+
+    try:
+        model_cls.model_validate(raw)
+        return ModelCorpusValidationReport(
+            path=path,
+            bucket=classification.bucket,
+            mode=mode,
+            passed=True,
+            errors=[],
+            normalized=normalized,
+        )
+    except ValidationError as exc:
+        return ModelCorpusValidationReport(
+            path=path,
+            bucket=classification.bucket,
+            mode=mode,
+            passed=False,
+            errors=[str(e) for e in exc.errors()],
+            normalized=normalized,
+        )
+
+
+__all__ = ["validate_contract_file"]

--- a/tests/unit/normalization/test_contract_normalizer.py
+++ b/tests/unit/normalization/test_contract_normalizer.py
@@ -29,7 +29,9 @@ import copy
 import pytest
 
 from omnibase_core.normalization.contract_normalizer import (
+    compose_normalization_pipeline,
     is_omnimarket_v0,
+    normalize_dod_evidence,
     normalize_event_bus,
     normalize_handler_routing,
     normalize_io_model_ref,
@@ -400,3 +402,165 @@ def test_handler_routing_does_not_mutate_input() -> None:
     raw_copy = copy.deepcopy(raw)
     normalize_handler_routing(raw)
     assert raw == raw_copy
+
+
+@pytest.mark.unit
+class TestNormalizeDodEvidence:
+    """Tests for normalize_dod_evidence (OMN-9766, family_dod_evidence_kind).
+
+    Maps the legacy ``kind`` discriminator on dod_evidence entries to the
+    canonical ``type`` discriminator. String entries pass through; entries
+    that already declare ``type`` are not double-mapped.
+    """
+
+    def test_no_op_when_dod_evidence_absent(self) -> None:
+        raw = {"name": "n", "node_type": "EFFECT_GENERIC"}
+        result = normalize_dod_evidence(raw)
+        assert result == raw
+
+    def test_string_list_passthrough(self) -> None:
+        raw = {"dod_evidence": ["test_passes", "pr_merged"]}
+        result = normalize_dod_evidence(raw)
+        assert result["dod_evidence"] == ["test_passes", "pr_merged"]
+
+    def test_kind_test_maps_to_type_unit_test(self) -> None:
+        raw = {"dod_evidence": [{"kind": "test", "command": "uv run pytest"}]}
+        result = normalize_dod_evidence(raw)
+        item = result["dod_evidence"][0]
+        assert item == {"type": "unit_test", "command": "uv run pytest"}
+        assert "kind" not in item
+
+    def test_kind_unit_test_passthrough_value(self) -> None:
+        raw = {"dod_evidence": [{"kind": "unit_test", "command": "x"}]}
+        result = normalize_dod_evidence(raw)
+        assert result["dod_evidence"][0]["type"] == "unit_test"
+
+    def test_kind_unmapped_falls_back_to_kind_value(self) -> None:
+        raw = {"dod_evidence": [{"kind": "novel_kind", "command": "x"}]}
+        result = normalize_dod_evidence(raw)
+        assert result["dod_evidence"][0]["type"] == "novel_kind"
+
+    def test_existing_type_not_overwritten(self) -> None:
+        """Entries with both kind and type keep type and drop kind quietly.
+
+        The function does not overwrite a pre-existing ``type`` value with
+        the mapping derived from ``kind``; the canonical ``type`` wins.
+        """
+        raw = {
+            "dod_evidence": [
+                {"kind": "test", "type": "integration_test", "command": "x"}
+            ]
+        }
+        result = normalize_dod_evidence(raw)
+        # Pre-canonical entries are left alone — kind is not stripped here.
+        item = result["dod_evidence"][0]
+        assert item["type"] == "integration_test"
+
+    def test_does_not_mutate_input(self) -> None:
+        raw = {"dod_evidence": [{"kind": "test", "command": "x"}]}
+        snapshot = copy.deepcopy(raw)
+        normalize_dod_evidence(raw)
+        assert raw == snapshot
+
+    def test_idempotent(self) -> None:
+        raw = {"dod_evidence": [{"kind": "test", "command": "x"}]}
+        once = normalize_dod_evidence(raw)
+        twice = normalize_dod_evidence(once)
+        assert once == twice
+
+    def test_non_list_dod_evidence_passthrough(self) -> None:
+        """Garbage shapes (non-list) are not transformed; we don't fabricate."""
+        raw = {"dod_evidence": "not_a_list"}
+        result = normalize_dod_evidence(raw)
+        assert result == raw
+
+
+@pytest.mark.unit
+class TestComposeNormalizationPipeline:
+    """Tests for compose_normalization_pipeline (OMN-9766).
+
+    The pipeline is the migration_audit entry point that funnels every
+    per-family normalizer into a single dict→dict transform. Step order
+    is fixed; each step is documented in the function docstring.
+    """
+
+    def test_full_pipeline_compose(self) -> None:
+        raw: dict[str, object] = {
+            "name": "node_foo_effect",
+            "node_type": "EFFECT_GENERIC",
+            "metadata": {"author": "Team"},
+            "contract_name": "node_foo_effect",
+            "event_bus": {"subscribe_topics": ["t"]},
+            "input_model": {"name": "ModelFooRequest", "module": "foo.bar"},
+            "handler_routing": {
+                "routing_strategy": "operation_match",
+                "handlers": [
+                    {
+                        "handler_type": "foo",
+                        "supported_operations": ["foo.run"],
+                        "handler": {"name": "HandlerFoo", "module": "bar"},
+                    }
+                ],
+            },
+        }
+        result = compose_normalization_pipeline(raw)
+        assert "metadata" not in result
+        assert "contract_name" not in result
+        assert "event_bus" not in result
+        assert result["input_model"] == "foo.bar.ModelFooRequest"
+        hr = result["handler_routing"]
+        assert isinstance(hr, dict)
+        assert hr["version"] == {"major": 1, "minor": 0, "patch": 0}
+        handlers = hr["handlers"]
+        assert isinstance(handlers, list)
+        first = handlers[0]
+        assert isinstance(first, dict)
+        assert first["routing_key"] == "foo.run"
+
+    def test_pipeline_does_not_mutate_input(self) -> None:
+        raw: dict[str, object] = {
+            "name": "n",
+            "metadata": {"author": "x"},
+            "input_model": {"name": "M", "module": "m"},
+        }
+        snapshot = copy.deepcopy(raw)
+        compose_normalization_pipeline(raw)
+        assert raw == snapshot
+
+    def test_pipeline_idempotent_on_canonical_input(self) -> None:
+        """Running the pipeline on already-canonical input is a near-no-op
+        (modulo dict-copy semantics)."""
+        raw: dict[str, object] = {
+            "name": "n",
+            "node_type": "EFFECT_GENERIC",
+            "input_model": "x.y.Z",
+            "output_model": "x.y.W",
+        }
+        once = compose_normalization_pipeline(raw)
+        twice = compose_normalization_pipeline(once)
+        assert once == twice
+
+    def test_pipeline_runs_dod_evidence_step(self) -> None:
+        """The dod_evidence step is wired into the composed pipeline."""
+        raw: dict[str, object] = {
+            "name": "n",
+            "node_type": "EFFECT_GENERIC",
+            "dod_evidence": [{"kind": "test", "command": "uv run pytest"}],
+        }
+        result = compose_normalization_pipeline(raw)
+        evidence = result["dod_evidence"]
+        assert isinstance(evidence, list)
+        first = evidence[0]
+        assert isinstance(first, dict)
+        assert first["type"] == "unit_test"
+        assert "kind" not in first
+
+    def test_pipeline_runs_omnimarket_v0_only_when_detected(self) -> None:
+        """Non-omnimarket-v0 contracts are not rewritten by that step."""
+        raw: dict[str, object] = {
+            "name": "n",
+            "node_type": "EFFECT_GENERIC",
+            "input_model": "x.y.Z",
+        }
+        result = compose_normalization_pipeline(raw)
+        assert result["input_model"] == "x.y.Z"  # unchanged

--- a/tests/unit/normalization/test_contract_validator.py
+++ b/tests/unit/normalization/test_contract_validator.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for validate_contract_file (OMN-9768, parent OMN-9757).
+
+Phase 3 — central seam tying corpus classification + per-family
+normalization to strict Pydantic validation. Two modes:
+
+- ``STRICT``: no normalization; node-root contracts validate against the
+  canonical typed contract model (extra="forbid"); fails immediately on
+  legacy fields.
+- ``MIGRATION_AUDIT``: runs the full normalization pipeline first, then
+  validates; ``normalized=True`` on the result record. Used for batch
+  sweeps over the legacy corpus.
+
+Non-node-root buckets (handler/package/integration/etc.) skip validation
+and pass with the bucket recorded for downstream aggregation. Unknown
+node_type returns a failed report with a descriptive error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_core.enums.enum_contract_bucket import EnumContractBucket
+from omnibase_core.enums.enum_validator_mode import EnumValidatorMode
+from omnibase_core.normalization.contract_validator import validate_contract_file
+
+
+def _clean_effect_contract() -> dict[str, Any]:
+    return {
+        "name": "node_foo_effect",
+        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+        "description": "Foo effect node test fixture.",
+        "node_type": "EFFECT_GENERIC",
+        "input_model": "foo.bar.models.ModelFooRequest",
+        "output_model": "foo.bar.models.ModelFooResult",
+        "handler_routing": {
+            "version": {"major": 1, "minor": 0, "patch": 0},
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "routing_key": "foo.run",
+                    "handler_key": "handle_foo_run",
+                    "priority": 0,
+                }
+            ],
+        },
+        "io_operations": [
+            {
+                "operation_type": "read",
+                "resource_type": "external_api",
+                "resource_identifier": "foo.api/run",
+            }
+        ],
+    }
+
+
+def _legacy_effect_contract() -> dict[str, Any]:
+    """Legacy shape: dict-form input/output_model, event_bus block,
+    metadata, no handler_routing version, supported_operations form."""
+    return {
+        "name": "node_bar_effect",
+        "contract_version": {"major": 1, "minor": 0, "patch": 0},
+        "description": "Bar legacy effect contract test fixture.",
+        "node_type": "EFFECT_GENERIC",
+        "metadata": {"author": "Team"},
+        "contract_name": "node_bar_effect",
+        "event_bus": {"subscribe_topics": ["onex.evt.foo.v1"]},
+        "input_model": {"name": "ModelBarRequest", "module": "bar.models"},
+        "output_model": {"name": "ModelBarResult", "module": "bar.models"},
+        "handler_routing": {
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "handler_type": "bar",
+                    "supported_operations": ["bar.run"],
+                    "handler": {"name": "HandlerBar", "module": "bar"},
+                }
+            ],
+        },
+        "io_operations": [
+            {
+                "operation_type": "write",
+                "resource_type": "database",
+                "resource_identifier": "bar_db.bar_table",
+            }
+        ],
+    }
+
+
+def _write_contract(tmp_path: Path, body: dict[str, Any]) -> Path:
+    p = tmp_path / "nodes" / body["name"] / "contract.yaml"
+    p.parent.mkdir(parents=True)
+    p.write_text(yaml.safe_dump(body))
+    return p
+
+
+@pytest.mark.unit
+class TestStrictMode:
+    """Strict mode: no normalization, fail on any legacy shape."""
+
+    def test_strict_mode_passes_clean_contract(self, tmp_path: Path) -> None:
+        path = _write_contract(tmp_path, _clean_effect_contract())
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is True, f"unexpected errors: {result.errors}"
+        assert result.errors == []
+        assert result.normalized is False
+        assert result.bucket is EnumContractBucket.NODE_ROOT_CONTRACT
+        assert result.mode is EnumValidatorMode.STRICT
+
+    def test_strict_mode_fails_legacy_contract(self, tmp_path: Path) -> None:
+        path = _write_contract(tmp_path, _legacy_effect_contract())
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is False
+        assert len(result.errors) > 0
+        assert result.normalized is False
+
+    def test_strict_mode_default(self, tmp_path: Path) -> None:
+        """STRICT is the default mode."""
+        path = _write_contract(tmp_path, _clean_effect_contract())
+        default = validate_contract_file(path)
+        explicit = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert default.mode is EnumValidatorMode.STRICT
+        assert default.passed is explicit.passed
+
+
+@pytest.mark.unit
+class TestMigrationAuditMode:
+    """Migration-audit mode: normalize, then validate; mark normalized=True."""
+
+    def test_migration_audit_passes_legacy_contract(self, tmp_path: Path) -> None:
+        path = _write_contract(tmp_path, _legacy_effect_contract())
+        result = validate_contract_file(path, mode=EnumValidatorMode.MIGRATION_AUDIT)
+        assert result.passed is True, f"unexpected errors: {result.errors}"
+        assert result.normalized is True
+        assert result.mode is EnumValidatorMode.MIGRATION_AUDIT
+
+    def test_migration_audit_passes_clean_contract(self, tmp_path: Path) -> None:
+        """A clean contract still passes under migration_audit; pipeline is a no-op."""
+        path = _write_contract(tmp_path, _clean_effect_contract())
+        result = validate_contract_file(path, mode=EnumValidatorMode.MIGRATION_AUDIT)
+        assert result.passed is True, f"unexpected errors: {result.errors}"
+        assert result.normalized is True
+
+
+@pytest.mark.unit
+class TestBucketSkipping:
+    """Non-node-root buckets pass without invoking model_validate()."""
+
+    def test_integration_contract_bucket_skips_validation(self, tmp_path: Path) -> None:
+        path = tmp_path / "integrations" / "github_webhook" / "contract.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"name": "github_webhook"}))
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is True
+        assert result.bucket is EnumContractBucket.INTEGRATION_CONTRACT
+        assert result.errors == []
+        assert result.normalized is False
+
+    def test_package_contract_bucket_skips_validation(self, tmp_path: Path) -> None:
+        path = tmp_path / "some_package" / "contract.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"name": "pkg"}))
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is True
+        assert result.bucket is EnumContractBucket.PACKAGE_CONTRACT
+
+
+@pytest.mark.unit
+class TestUnknownNodeType:
+    """Unknown / unmapped node_type returns failed with descriptive error."""
+
+    def test_unknown_node_type_fails(self, tmp_path: Path) -> None:
+        body = _clean_effect_contract()
+        body["node_type"] = "MYSTERY_NODE_TYPE"
+        path = _write_contract(tmp_path, body)
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is False
+        assert any("node_type" in e for e in result.errors), result.errors
+
+
+@pytest.mark.unit
+class TestNodeTypeAliases:
+    """Short aliases (EFFECT, COMPUTE, REDUCER, ORCHESTRATOR) resolve to GENERIC."""
+
+    def test_effect_alias_resolves(self, tmp_path: Path) -> None:
+        body = _clean_effect_contract()
+        body["node_type"] = "EFFECT"
+        path = _write_contract(tmp_path, body)
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is True, f"unexpected errors: {result.errors}"
+
+
+@pytest.mark.unit
+class TestStrictModeRequiresAlgorithmAndIo:
+    """Strict mode pre-checks algorithm (COMPUTE) and io_operations (EFFECT)
+    before model_validate, preserving enforcement after Task 13 makes those
+    fields optional in the model."""
+
+    def test_strict_mode_fails_effect_missing_io_operations(
+        self, tmp_path: Path
+    ) -> None:
+        body = _clean_effect_contract()
+        del body["io_operations"]
+        path = _write_contract(tmp_path, body)
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is False
+        assert any("io_operations" in e for e in result.errors), result.errors
+
+    def test_strict_mode_fails_effect_empty_io_operations(self, tmp_path: Path) -> None:
+        body = _clean_effect_contract()
+        body["io_operations"] = []
+        path = _write_contract(tmp_path, body)
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is False
+        assert any("io_operations" in e for e in result.errors), result.errors
+
+    def test_migration_audit_does_not_require_algorithm_or_io(
+        self, tmp_path: Path
+    ) -> None:
+        """Migration_audit mode does NOT pre-enforce algorithm/io_operations;
+        it surfaces only what the (post-normalization) model itself rejects."""
+        body = _clean_effect_contract()
+        del body["io_operations"]
+        path = _write_contract(tmp_path, body)
+        result = validate_contract_file(path, mode=EnumValidatorMode.MIGRATION_AUDIT)
+        # Result is whatever the model says; we just want to confirm we did
+        # NOT short-circuit on the strict-mode pre-check (no "io_operations
+        # required" pre-check error). The model's own min_length=1 may still
+        # fail today; what matters is normalized=True and the error came from
+        # model_validate, not the pre-check.
+        assert result.normalized is True
+
+
+@pytest.mark.unit
+class TestEmptyOrInvalidYaml:
+    """Edge cases on YAML parsing."""
+
+    def test_empty_yaml_skips_when_bucket_does_not_require_validation(
+        self, tmp_path: Path
+    ) -> None:
+        # empty yaml under a non-node-root path: passes (skipped).
+        path = tmp_path / "other" / "contract.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text("")
+        result = validate_contract_file(path, mode=EnumValidatorMode.STRICT)
+        assert result.passed is True
+        assert result.bucket is not EnumContractBucket.NODE_ROOT_CONTRACT

--- a/tests/unit/normalization/test_contract_validator.py
+++ b/tests/unit/normalization/test_contract_validator.py
@@ -235,6 +235,9 @@ class TestStrictModeRequiresAlgorithmAndIo:
         # fail today; what matters is normalized=True and the error came from
         # model_validate, not the pre-check.
         assert result.normalized is True
+        assert all("strict-mode pre-check" not in e for e in result.errors), (
+            result.errors
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/normalization/test_misc_extra_fields_normalization.py
+++ b/tests/unit/normalization/test_misc_extra_fields_normalization.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-9771 normalization for miscellaneous legacy contract fields."""
+
+import pytest
+
+from omnibase_core.models.contracts.model_contract_base import ModelContractBase
+from omnibase_core.normalization.contract_normalizer import (
+    compose_normalization_pipeline,
+    normalize_misc_extra_fields,
+    validate_annotations_governance,
+)
+
+_KNOWN_KEYS = {
+    "name",
+    "node_type",
+    "contract_version",
+    "input_model",
+    "output_model",
+    "handler_routing",
+    "io_operations",
+    "algorithm",
+    "state_machine",
+    "dod_evidence",
+    "yaml_consumed_events",
+    "yaml_published_events",
+    "published_events",
+    "annotations",
+    "dependencies",
+    "lifecycle",
+}
+
+
+@pytest.mark.unit
+class TestMiscExtraFieldsNormalization:
+    """Migration-audit compatibility for one-off legacy annotation keys."""
+
+    def test_unknown_keys_moved_to_annotations(self) -> None:
+        raw: dict[str, object] = {
+            "name": "node_foo",
+            "node_type": "EFFECT_GENERIC",
+            "capabilities": ["read", "write"],
+            "health_check": {"endpoint": "/health"},
+        }
+
+        result = normalize_misc_extra_fields(raw, known_keys=_KNOWN_KEYS)
+
+        assert "capabilities" not in result
+        assert "health_check" not in result
+        assert result["annotations"] == {
+            "capabilities": ["read", "write"],
+            "health_check": {"endpoint": "/health"},
+        }
+
+    def test_known_keys_not_moved(self) -> None:
+        raw: dict[str, object] = {
+            "name": "node_foo",
+            "node_type": "EFFECT_GENERIC",
+        }
+
+        result = normalize_misc_extra_fields(raw, known_keys=_KNOWN_KEYS)
+
+        assert result == raw
+
+    def test_existing_annotations_are_preserved(self) -> None:
+        raw: dict[str, object] = {
+            "name": "node_foo",
+            "annotations": {"owner": "platform"},
+            "rate_limiting": {"per_minute": 60},
+        }
+
+        result = normalize_misc_extra_fields(raw, known_keys=_KNOWN_KEYS)
+
+        assert result["annotations"] == {
+            "owner": "platform",
+            "rate_limiting": {"per_minute": 60},
+        }
+
+    def test_annotations_field_accepted_by_model_contract_base(self) -> None:
+        assert "annotations" in ModelContractBase.model_fields
+
+    def test_validate_annotations_governance_clean(self) -> None:
+        assert (
+            validate_annotations_governance(
+                {"owner": "platform", "migrated_from_v0": True}
+            )
+            == []
+        )
+
+    def test_validate_annotations_governance_forbidden_key(self) -> None:
+        violations = validate_annotations_governance({"topics": ["legacy.topic.v1"]})
+
+        assert len(violations) == 1
+        assert "topics" in violations[0]
+        assert "typed field" in violations[0]
+
+    def test_compose_pipeline_moves_misc_fields_after_legacy_strips(self) -> None:
+        raw: dict[str, object] = {
+            "name": "node_foo",
+            "node_type": "EFFECT_GENERIC",
+            "metadata": {"author": "legacy"},
+            "capabilities": ["read"],
+        }
+
+        result = compose_normalization_pipeline(raw)
+
+        assert "metadata" not in result
+        assert result["annotations"] == {"capabilities": ["read"]}


### PR DESCRIPTION
## Summary
- add explicit `annotations` field to `ModelContractBase` for non-load-bearing legacy metadata
- add `normalize_misc_extra_fields()` and `validate_annotations_governance()` to the migration-audit normalizer
- add `compose_normalization_pipeline()` with misc-field normalization as the final step
- add focused tests for misc-field hoisting, annotation preservation, governance violations, and composed pipeline behavior
- add repo-local OMN-9771 deploy-gate contract

## Verification
- PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py -v
- PYTHONPATH=src uv run pytest tests/unit/normalization -v (82 passed)
- PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_model_contract_base_extensions.py -v (35 passed)
- uv run mypy src/ --config-file=mypy.ini
- uv run pyright src/omnibase_core/normalization/contract_normalizer.py src/omnibase_core/models/contracts/model_contract_base.py tests/unit/normalization/test_misc_extra_fields_normalization.py
- uv run ruff check src/omnibase_core/models/contracts/model_contract_base.py src/omnibase_core/normalization/contract_normalizer.py tests/unit/normalization/test_misc_extra_fields_normalization.py
- ModelTicketContract parses contracts/OMN-9771.yaml
- git diff --check

Linear: OMN-9771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized annotations field to capture miscellaneous legacy contract fields.
  * Ship a canonical normalization pipeline that cleans legacy fields, normalizes evidence entries, and enforces annotation governance.
  * Added a per-contract validator mode that can run normalization and strict typed validation.

* **Tests**
  * Added unit tests covering migration normalization, evidence mapping, annotation governance, and validator behaviors.

* **Chores**
  * Added policy contract for miscellaneous fields disposition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#708
Evidence-Ticket: OMN-9771

