### PR TITLE
feat(OMN-9904): define EnumScope + ModelEnforcementScope contract schema

### DIFF
--- a/src/omnibase_core/enums/enum_diagnostics_mode.py
+++ b/src/omnibase_core/enums/enum_diagnostics_mode.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumDiagnosticsMode — opt-in diagnostics behavior for unavailable skills."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumDiagnosticsMode(StrValueHelper, str, Enum):
+    """
+    Opt-in diagnostics behavior for unavailable skills.
+
+    When diagnostics are enabled, discovery commands (/onex:doctor or
+    equivalent) list hidden/suppressed skills with structured reasons,
+    giving alpha testers visibility into the scope system.
+
+    Attributes:
+        EXPLAIN: List unavailable skills with structured reasons on request.
+        SILENT:  No diagnostics. Hidden skills stay invisible in all contexts.
+
+    Example:
+        >>> EnumDiagnosticsMode.EXPLAIN.value
+        'explain'
+    """
+
+    EXPLAIN = "explain"
+    """Emit structured reason on discovery command. Enables /onex:doctor listing."""
+
+    SILENT = "silent"
+    """No diagnostics. Suppressed skills remain invisible in all contexts."""
+
+
+__all__ = ["EnumDiagnosticsMode"]

--- a/src/omnibase_core/enums/enum_enforcement.py
+++ b/src/omnibase_core/enums/enum_enforcement.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+EnumEnforcement — operational outcome tiers for ONEX hook/skill enforcement.
+
+Used by ModelEnforcementScope to declare how strictly a hook or skill enforces
+its scope contract. The four tiers compose with the overlay loader (OMN-9905):
+overlays may downgrade but never upgrade (e.g. block -> warn is legal; warn ->
+block requires explicit operator intent).
+
+Failure posture rules (from OMN-9895 epic):
+- observe: log-only — never surface to user, never fail CI.
+- warn:    emit a user-visible warning, return success (exit 0).
+- block:   raise / exit 2 on violation. Default for security hooks.
+- fail-fast: abort the session entirely. Reserved for security-critical
+             contracts where continuing would produce unsafe state.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumEnforcement(StrValueHelper, str, Enum):
+    """
+    Operational outcome tiers for enforcement-scope contracts.
+
+    Hooks and skills declare an ``enforcement`` field using these values to
+    control what happens when a scope predicate fires. The tiers are ordered
+    by severity: observe < warn < block < fail-fast.
+
+    Overlay composition semantics (OMN-9905):
+        Overlays may *downgrade* enforcement (block -> warn, warn -> observe)
+        to support tester/external-contributor profiles. Upgrades require
+        explicit operator-level intent and are not auto-composed.
+
+    Attributes:
+        OBSERVE:    Log the event; never surface to user or fail CI.
+        WARN:       Emit a user-visible warning; return success (exit 0).
+        BLOCK:      Raise / exit 2 on violation. Default for security hooks.
+        FAIL_FAST:  Abort the session entirely. Reserved for security-critical
+                    contracts where continuation would produce unsafe state.
+
+    Example:
+        >>> EnumEnforcement.BLOCK.value
+        'block'
+        >>> EnumEnforcement.WARN < EnumEnforcement.BLOCK
+        True
+    """
+
+    OBSERVE = "observe"
+    """Log only. Never surfaces to user; never fails CI. For telemetry hooks."""
+
+    WARN = "warn"
+    """Emit a warning, return success. Suitable for advisory checks."""
+
+    BLOCK = "block"
+    """Raise / exit 2. Default enforcement for hard-block hooks."""
+
+    FAIL_FAST = "fail-fast"
+    """Abort session. Reserved for security-critical contract violations."""
+
+    def severity(self) -> int:
+        """Return numeric severity (higher = stricter) for overlay comparison."""
+        _order = {
+            EnumEnforcement.OBSERVE: 0,
+            EnumEnforcement.WARN: 1,
+            EnumEnforcement.BLOCK: 2,
+            EnumEnforcement.FAIL_FAST: 3,
+        }
+        return _order[self]
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, EnumEnforcement):
+            return NotImplemented
+        return self.severity() < other.severity()
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, EnumEnforcement):
+            return NotImplemented
+        return self.severity() <= other.severity()
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, EnumEnforcement):
+            return NotImplemented
+        return self.severity() > other.severity()
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, EnumEnforcement):
+            return NotImplemented
+        return self.severity() >= other.severity()
+
+    @classmethod
+    def can_downgrade_to(
+        cls, source: "EnumEnforcement", target: "EnumEnforcement"
+    ) -> bool:
+        """Return True if target is a legal overlay downgrade of source."""
+        return target.severity() <= source.severity()
+
+
+__all__ = ["EnumEnforcement"]

--- a/src/omnibase_core/enums/enum_scope_token.py
+++ b/src/omnibase_core/enums/enum_scope_token.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+EnumScopeToken — named topology classes for cwd_in predicate resolution.
+
+A scope token is a symbolic label that the scope registry resolves from the
+current working directory (and related runtime state) during predicate
+evaluation. The registry is the ONLY authoritative source of machine-specific
+path knowledge; tokens are stable cross-machine identifiers.
+
+Token resolution order: cwd → git remote → OMNI_HOME env → registry lookup.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumScopeToken(StrValueHelper, str, Enum):
+    """
+    Named topology classes used in ``cwd_in`` scope predicates.
+
+    These tokens let scope predicates stay machine-independent. The scope
+    registry (introduced in OMN-9905) maps runtime cwd to the matching token
+    via ``is_omninode_repo`` and its successor matchers.
+
+    ``cwd_in: [omninode_repo]`` matches any clone or worktree of an OmniNode
+    repository regardless of its absolute path on disk.
+
+    Attributes:
+        OMNINODE_REPO:   Any OmniNode-managed git repository.
+        OMNINODE_WORKTREE: A git worktree under $OMNI_HOME/omni_worktrees/.
+        OMNINODE_HOME:   The canonical omni_home registry root.
+        EXTERNAL_REPO:   Any non-OmniNode repository.
+        UNKNOWN:         Could not resolve cwd to a known topology class.
+
+    Example:
+        >>> EnumScopeToken.OMNINODE_REPO.value
+        'omninode_repo'
+    """
+
+    OMNINODE_REPO = "omninode_repo"
+    """Any OmniNode-managed git repository (clone or worktree)."""
+
+    OMNINODE_WORKTREE = "omninode_worktree"
+    """A git worktree under $OMNI_HOME/omni_worktrees/."""
+
+    OMNINODE_HOME = "omninode_home"
+    """The canonical omni_home registry root ($OMNI_HOME)."""
+
+    EXTERNAL_REPO = "external_repo"
+    """Any repository not managed by OmniNode tooling."""
+
+    UNKNOWN = "unknown"
+    """Could not resolve cwd to a known topology class."""
+
+    def is_omninode_context(self) -> bool:
+        """Return True if this token indicates an OmniNode-managed context."""
+        return self in (
+            EnumScopeToken.OMNINODE_REPO,
+            EnumScopeToken.OMNINODE_WORKTREE,
+            EnumScopeToken.OMNINODE_HOME,
+        )
+
+
+__all__ = ["EnumScopeToken"]

--- a/src/omnibase_core/enums/enum_unavailable_mode.py
+++ b/src/omnibase_core/enums/enum_unavailable_mode.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumUnavailableMode — skill unavailability presentation modes."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumUnavailableMode(StrValueHelper, str, Enum):
+    """
+    How a skill presents itself when its scope is not satisfied.
+
+    Attributes:
+        HIDDEN: Skill not registered; not visible in autocomplete.
+        NOOP:   Registered; invocation returns immediately with no output.
+        WARN:   Registered; invocation prints a one-line "skill unavailable" notice.
+        BLOCK:  Registered; invocation prints a structured error with reasons.
+
+    Example:
+        >>> EnumUnavailableMode.HIDDEN.value
+        'hidden'
+    """
+
+    HIDDEN = "hidden"
+    """Skill not registered. Not visible in autocomplete or /help output."""
+
+    NOOP = "noop"
+    """Registered but silent. Invocation returns immediately with no output."""
+
+    WARN = "warn"
+    """Registered. Invocation prints one-line 'skill unavailable' notice."""
+
+    BLOCK = "block"
+    """Registered. Invocation prints structured error explaining unavailability."""
+
+
+__all__ = ["EnumUnavailableMode"]

--- a/src/omnibase_core/models/scope/__init__.py
+++ b/src/omnibase_core/models/scope/__init__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Scope contract schema for ONEX hooks and skills (OMN-9904).
+
+Defines the activation / applicability / enforcement triad that makes
+per-artifact scope declarations first-class in the contract system.
+
+Enums live in omnibase_core.enums.*; models live here.
+
+Public surface:
+    ModelActivationScope      — manifest-level plugin load gate
+    ModelApplicabilityScope   — per-artifact applies_when / disabled_when
+    ModelArtifactEnforcement  — per-artifact enforcement tier config
+    ModelEnforcementScope     — top-level scope contract (triad)
+    ModelIntegrationFilter    — integration predicate filter
+    ModelRepoFilter           — repo-kind predicate filter
+    ModelScopePredicate       — full predicate vocabulary
+    ModelStateFilter          — state marker predicate filter
+    ModelTicketFilter         — ticket namespace predicate filter
+    ModelUnavailableBehavior  — skill unavailability presentation contract
+"""
+
+from omnibase_core.models.scope.model_activation_scope import ModelActivationScope
+from omnibase_core.models.scope.model_applicability_scope import ModelApplicabilityScope
+from omnibase_core.models.scope.model_artifact_enforcement import (
+    ModelArtifactEnforcement,
+)
+from omnibase_core.models.scope.model_enforcement_scope import ModelEnforcementScope
+from omnibase_core.models.scope.model_integration_filter import ModelIntegrationFilter
+from omnibase_core.models.scope.model_repo_filter import ModelRepoFilter
+from omnibase_core.models.scope.model_scope_predicate import ModelScopePredicate
+from omnibase_core.models.scope.model_state_filter import ModelStateFilter
+from omnibase_core.models.scope.model_ticket_filter import ModelTicketFilter
+from omnibase_core.models.scope.model_unavailable_behavior import (
+    ModelUnavailableBehavior,
+)
+
+__all__ = [
+    "ModelActivationScope",
+    "ModelApplicabilityScope",
+    "ModelArtifactEnforcement",
+    "ModelEnforcementScope",
+    "ModelIntegrationFilter",
+    "ModelRepoFilter",
+    "ModelScopePredicate",
+    "ModelStateFilter",
+    "ModelTicketFilter",
+    "ModelUnavailableBehavior",
+]

--- a/src/omnibase_core/models/scope/model_activation_scope.py
+++ b/src/omnibase_core/models/scope/model_activation_scope.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelActivationScope — manifest-level plugin load decision.
+
+Activation is the outermost gate: it decides whether a plugin (hook package
+or skill collection) is loaded at all for the current session. This is
+distinct from applicability (per-artifact does-this-apply) and enforcement
+(what-happens-when-it-applies).
+
+A plugin whose activation scope is not satisfied is never loaded. Its hooks
+and skills are not registered. No further scope evaluation occurs.
+
+Plugin manifest example:
+
+.. code-block:: yaml
+
+    activation_scope:
+      requires_tokens: [omninode_repo]
+      requires_env: [OMNI_HOME]
+      requires_integrations:
+        linear:
+          workspace: omninode
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_scope_token import EnumScopeToken
+
+
+class ModelActivationScope(BaseModel):
+    """
+    Manifest-level gate controlling whether a plugin loads for this session.
+
+    Evaluated once at session start by the overlay loader (OMN-9905) and by
+    the plugin activation gate (OMN-10044). A plugin is loaded only when all
+    declared requirements are satisfied simultaneously.
+
+    Semantics:
+        - ``requires_tokens``: ALL listed tokens must match the resolved cwd
+          token for the session. Empty list means "always load."
+        - ``requires_env``: ALL listed env var names must be set (non-empty)
+          in the session environment. Empty list means "no env requirement."
+        - ``requires_integrations``: ALL declared integrations must be
+          available and match the given key/value filters.
+
+    Activation vs Applicability:
+        Activation is manifest-level and coarse-grained — it applies to the
+        entire plugin. Applicability (see :class:`~omnibase_core.models.scope.model_applicability_scope.ModelApplicabilityScope`)
+        is per-artifact and fine-grained. A hook can be activated (plugin
+        loaded) but still be non-applicable (predicate fails for this tool
+        event).
+
+    Attributes:
+        requires_tokens:       Topology class tokens that must match cwd.
+        requires_env:          Env var names that must be set.
+        requires_integrations: Named integrations that must be available.
+
+    Example YAML surface:
+
+    .. code-block:: yaml
+
+        activation_scope:
+          requires_tokens: [omninode_repo]
+          requires_env: [OMNI_HOME, ONEX_STATE_DIR]
+          requires_integrations:
+            linear:
+              workspace: omninode
+
+    See Also:
+        - :class:`~omnibase_core.enums.enum_scope_token.EnumScopeToken`:
+          Named topology classes for token matching.
+        - :class:`~omnibase_core.models.scope.model_enforcement_scope.ModelEnforcementScope`:
+          Parent scope model that nests activation, applicability, and enforcement.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    requires_tokens: list[EnumScopeToken] = Field(
+        default_factory=list,
+        description=(
+            "All listed topology tokens must match the resolved cwd token. "
+            "Empty list means the plugin loads in any context."
+        ),
+    )
+    requires_env: list[str] = Field(
+        default_factory=list,
+        description=(
+            "All listed environment variable names must be set (non-empty). "
+            "Empty list means no environment requirement."
+        ),
+    )
+    requires_integrations: dict[str, dict[str, str]] = Field(
+        default_factory=dict,
+        description=(
+            "Named integrations that must be available. Keys are integration "
+            "names ('linear', 'kafka'); values are key/value filter maps."
+        ),
+    )
+
+    def is_unrestricted(self) -> bool:
+        """Return True if the plugin loads in any context (no requirements)."""
+        return (
+            not self.requires_tokens
+            and not self.requires_env
+            and not self.requires_integrations
+        )
+
+
+__all__ = ["ModelActivationScope"]

--- a/src/omnibase_core/models/scope/model_applicability_scope.py
+++ b/src/omnibase_core/models/scope/model_applicability_scope.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelApplicabilityScope — per-artifact applies_when / disabled_when gate.
+
+Determines whether a hook or skill applies to the current repo, session,
+or tool event. Evaluated per-invocation, after the plugin has been activated.
+
+Conflict resolution: disabled_when always wins over applies_when when both
+predicates match simultaneously.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.scope.model_scope_predicate import ModelScopePredicate
+
+
+class ModelApplicabilityScope(BaseModel):
+    """
+    Per-artifact applicability gate (applies_when / disabled_when).
+
+    Determines whether a hook or skill applies to the current repo, session,
+    or tool event. Evaluated per-invocation, after the plugin has been
+    activated.
+
+    Conflict resolution:
+        ``disabled_when`` **always wins** over ``applies_when`` when both
+        predicates match simultaneously. An explicit opt-out always takes
+        precedence over an opt-in.
+
+    Overlay semantics (OMN-9905):
+        Overlay applicability scopes are merged by predicate key union.
+        ``applies_when`` keys from the overlay extend the base; conflicting
+        keys take the overlay value. ``disabled_when`` follows the same rule.
+        The disabled-wins conflict rule applies to the merged result.
+
+    Attributes:
+        applies_when:  Predicate that must match for this artifact to apply.
+                       Empty predicate (default) matches universally.
+        disabled_when: Predicate that, when matching, suppresses this artifact.
+                       Takes precedence over applies_when on conflict.
+
+    See Also:
+        - :class:`~omnibase_core.models.scope.model_scope_predicate.ModelScopePredicate`:
+          Predicate vocabulary (cwd_in, repo, ticket, state, integrations).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    applies_when: ModelScopePredicate = Field(
+        default_factory=ModelScopePredicate,
+        description=(
+            "Predicate that must match for this artifact to apply. "
+            "An empty predicate matches universally (default behaviour)."
+        ),
+    )
+    disabled_when: ModelScopePredicate = Field(
+        default_factory=ModelScopePredicate,
+        description=(
+            "Predicate that, when matching, suppresses this artifact. "
+            "disabled_when wins over applies_when on any conflict."
+        ),
+    )
+
+
+__all__ = ["ModelApplicabilityScope"]

--- a/src/omnibase_core/models/scope/model_artifact_enforcement.py
+++ b/src/omnibase_core/models/scope/model_artifact_enforcement.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelArtifactEnforcement — per-artifact enforcement tier configuration.
+
+Declares what outcome occurs when a scope predicate fires. Supports different
+tiers for the default path vs. specific failure modes, allowing fine-grained
+control without requiring separate hook variants.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_enforcement import EnumEnforcement
+
+
+class ModelArtifactEnforcement(BaseModel):
+    """
+    Per-artifact enforcement tier configuration.
+
+    Declares what outcome occurs when a scope predicate fires. Supports
+    different tiers for the default path vs. specific failure modes, allowing
+    fine-grained control without requiring separate hook variants.
+
+    Overlay composition (OMN-9905):
+        Overlays may downgrade enforcement (block -> warn, warn -> observe)
+        to support tester or external-contributor profiles. Upgrades require
+        explicit operator intent and are not auto-composed by the loader.
+        See :meth:`~omnibase_core.enums.enum_enforcement.EnumEnforcement.can_downgrade_to`.
+
+    Attributes:
+        default:            Enforcement tier for the default (matching) path.
+        non_matching_scope: Tier when the scope predicate does not match.
+                            Defaults to 'observe' (skip silently).
+        missing_dependency: Tier when a declared dependency is unavailable.
+                            Defaults to 'observe' (skip silently).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    default: EnumEnforcement = Field(
+        default=EnumEnforcement.BLOCK,
+        description=(
+            "Enforcement tier for the matching (default) path. "
+            "'block' is the default for security-relevant hooks."
+        ),
+    )
+    non_matching_scope: EnumEnforcement = Field(
+        default=EnumEnforcement.OBSERVE,
+        description=(
+            "Enforcement tier when the scope predicate does not match. "
+            "Defaults to 'observe' (log only; do not interrupt non-OmniNode sessions)."
+        ),
+    )
+    missing_dependency: EnumEnforcement = Field(
+        default=EnumEnforcement.OBSERVE,
+        description=(
+            "Enforcement tier when a declared dependency is unavailable. "
+            "Defaults to 'observe' (skip silently if dep is missing)."
+        ),
+    )
+
+
+__all__ = ["ModelArtifactEnforcement"]

--- a/src/omnibase_core/models/scope/model_enforcement_scope.py
+++ b/src/omnibase_core/models/scope/model_enforcement_scope.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelEnforcementScope — top-level scope contract for hooks and skills.
+
+This is the primary model that hooks and skills declare in their YAML
+contracts to describe their scope. It makes the activation / applicability /
+enforcement triad first-class: each is a separate sub-model with its own
+semantics, rather than a collapsed "is the plugin installed?" boolean.
+
+Triad semantics:
+    Activation  — manifest-level. Should the plugin load at all this session?
+                  Evaluated once at session start. (ModelActivationScope)
+    Applicability — per-artifact. Does this hook/skill apply to this
+                  repo/session/tool-event? (ModelApplicabilityScope)
+    Enforcement — per-artifact. What happens when the artifact is applicable
+                  and a scope condition fires? (ModelArtifactEnforcement)
+
+Today the three collapse into "is the plugin installed?" — this schema
+corrects that by making each independently contract-addressable.
+
+Hook YAML example:
+
+.. code-block:: yaml
+
+    hook:
+      id: pre_tool_use_dispatch_guard_ticket_evidence
+      event: PreToolUse
+      scope:
+        activation:
+          requires_tokens: [omninode_repo]
+        applicability:
+          applies_when:
+            repo:
+              kind: omninode
+            ticket:
+              namespace: OMN
+            state:
+              requires: [ONEX_STATE_DIR, evidence_dir]
+          disabled_when:
+            repo:
+              kind: external
+        enforcement:
+          default: block
+          non_matching_scope: observe
+          missing_dependency: observe
+      unavailable_behavior:
+        default: hidden
+        diagnostics: explain
+
+Skill YAML example:
+
+.. code-block:: yaml
+
+    skill:
+      id: create_ticket
+      scope:
+        activation:
+          requires_tokens: [omninode_repo]
+        applicability:
+          applies_when:
+            integrations:
+              linear:
+                workspace: omninode
+                ticket_prefix: OMN
+        enforcement:
+          default: warn
+      unavailable_behavior:
+        default: hidden
+        diagnostics: explain
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.scope.model_activation_scope import ModelActivationScope
+from omnibase_core.models.scope.model_applicability_scope import ModelApplicabilityScope
+from omnibase_core.models.scope.model_artifact_enforcement import (
+    ModelArtifactEnforcement,
+)
+from omnibase_core.models.scope.model_unavailable_behavior import (
+    ModelUnavailableBehavior,
+)
+
+
+class ModelEnforcementScope(BaseModel):
+    """
+    Top-level scope contract for ONEX hooks and skills.
+
+    Embeds the full activation / applicability / enforcement triad as
+    first-class sub-models. This is the model that hook and skill YAML
+    contracts reference in their ``scope:`` block.
+
+    Triad semantics:
+        **Activation** (:class:`~omnibase_core.models.scope.model_activation_scope.ModelActivationScope`):
+            Should the plugin load at all for this session? Manifest-level,
+            coarse-grained. Evaluated once by the overlay loader at session
+            start. A plugin that fails activation is not registered at all.
+
+        **Applicability** (:class:`~omnibase_core.models.scope.model_applicability_scope.ModelApplicabilityScope`):
+            Does this specific hook or skill apply to the current invocation
+            context? Per-artifact, fine-grained. Evaluated per-tool-use or
+            per-invocation. ``disabled_when`` wins over ``applies_when`` on
+            conflict.
+
+        **Enforcement** (:class:`~omnibase_core.models.scope.model_artifact_enforcement.ModelArtifactEnforcement`):
+            What outcome occurs when the artifact is applicable and a scope
+            condition fires? Per-artifact. Supports differentiated tiers for
+            matching vs. non-matching vs. missing-dependency paths.
+
+    Skills additionally declare ``unavailable_behavior`` to control what
+    users see when the skill's scope is not satisfied (OMN-9895).
+
+    Overlay loader composition (OMN-9905):
+        Base scope + overlay scope -> merged scope. Overlays may narrow
+        applicability predicates, downgrade enforcement tiers, and change
+        unavailable_behavior. They cannot introduce new activation requirements
+        that were absent from the base without a coordinated base update.
+
+    Attributes:
+        activation:          Manifest-level plugin load gate.
+        applicability:       Per-artifact applies_when / disabled_when predicates.
+        enforcement:         Per-artifact enforcement tier configuration.
+        unavailable_behavior: How skills present when scope is not satisfied.
+                              Not applicable to hooks (hooks are simply skipped).
+
+    See Also:
+        - :class:`~omnibase_core.models.scope.model_activation_scope.ModelActivationScope`
+        - :class:`~omnibase_core.models.scope.model_applicability_scope.ModelApplicabilityScope`
+        - :class:`~omnibase_core.models.scope.model_artifact_enforcement.ModelArtifactEnforcement`
+        - :class:`~omnibase_core.models.scope.model_unavailable_behavior.ModelUnavailableBehavior`
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    activation: ModelActivationScope = Field(
+        default_factory=ModelActivationScope,
+        description=(
+            "Manifest-level plugin load gate. Evaluated once at session start. "
+            "A plugin that fails activation is not registered."
+        ),
+    )
+    applicability: ModelApplicabilityScope = Field(
+        default_factory=ModelApplicabilityScope,
+        description=(
+            "Per-artifact applies_when / disabled_when predicates. "
+            "disabled_when wins over applies_when on conflict."
+        ),
+    )
+    enforcement: ModelArtifactEnforcement = Field(
+        default_factory=ModelArtifactEnforcement,
+        description=(
+            "Per-artifact enforcement tier. Overlays may downgrade (never upgrade) "
+            "enforcement tiers without operator-level intent."
+        ),
+    )
+    unavailable_behavior: ModelUnavailableBehavior = Field(
+        default_factory=ModelUnavailableBehavior,
+        description=(
+            "How skills present when scope is not satisfied. "
+            "Not applicable to hooks (hooks are simply skipped when not applicable)."
+        ),
+    )
+
+
+__all__ = ["ModelEnforcementScope"]

--- a/src/omnibase_core/models/scope/model_integration_filter.py
+++ b/src/omnibase_core/models/scope/model_integration_filter.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelIntegrationFilter — scope predicate filter targeting availability of named integrations."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelIntegrationFilter(BaseModel):
+    """Predicate filter targeting availability of named integrations."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    linear: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Linear integration requirements. Keys: 'workspace', 'ticket_prefix'."
+        ),
+    )
+    kafka: dict[str, str] | None = Field(
+        default=None,
+        description="Kafka/Redpanda integration requirements.",
+    )
+
+
+__all__ = ["ModelIntegrationFilter"]

--- a/src/omnibase_core/models/scope/model_repo_filter.py
+++ b/src/omnibase_core/models/scope/model_repo_filter.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRepoFilter — scope predicate filter targeting repository kind."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRepoFilter(BaseModel):
+    """Predicate filter targeting repository kind."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: str = Field(
+        description=(
+            "Repository kind identifier. Common values: 'omninode', 'external'. "
+            "Matched against the resolved EnumScopeToken for the current cwd."
+        )
+    )
+
+
+__all__ = ["ModelRepoFilter"]

--- a/src/omnibase_core/models/scope/model_scope_predicate.py
+++ b/src/omnibase_core/models/scope/model_scope_predicate.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelScopePredicate — per-artifact applicability predicate vocabulary.
+
+Used in ModelApplicabilityScope.applies_when and disabled_when fields.
+Conflict resolution: disabled_when always wins over applies_when when both
+match for the same predicate key.
+
+Predicate vocabulary is intentionally extensible: all fields are Optional so
+that new predicates can be added to the schema without breaking existing YAML
+files. The overlay loader (OMN-9905) merges predicates by union of keys; a
+key present in both base and overlay takes the overlay value.
+
+Predicate semantics:
+    cwd_in:       Match cwd against named EnumScopeToken topology classes.
+                  Evaluated by the scope registry, not by string comparison.
+    repo:         Match repository kind (omninode, external, etc.).
+    ticket:       Match the current Linear ticket namespace.
+    state:        Match required runtime state markers (env vars, dirs).
+    integrations: Match availability of named integrations (linear, kafka).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_scope_token import EnumScopeToken
+from omnibase_core.models.scope.model_integration_filter import ModelIntegrationFilter
+from omnibase_core.models.scope.model_repo_filter import ModelRepoFilter
+from omnibase_core.models.scope.model_state_filter import ModelStateFilter
+from omnibase_core.models.scope.model_ticket_filter import ModelTicketFilter
+
+
+class ModelScopePredicate(BaseModel):
+    """
+    Applicability predicate for a hook or skill scope declaration.
+
+    Used in ``applies_when`` and ``disabled_when`` within
+    :class:`~omnibase_core.models.scope.model_applicability_scope.ModelApplicabilityScope`.
+    All fields are optional — an empty predicate matches universally.
+
+    Conflict resolution:
+        When ``disabled_when`` and ``applies_when`` both produce a match for
+        the same artifact invocation, ``disabled_when`` wins unconditionally.
+        This ensures explicit opt-outs always take precedence.
+
+    Overlay semantics (OMN-9905):
+        Predicates from an overlay are merged by key union. A key present in
+        both base and overlay takes the overlay value. New keys introduced by
+        an overlay extend (not replace) the base predicate.
+
+    Attributes:
+        cwd_in:       Match cwd against named topology class tokens.
+        repo:         Match repository kind.
+        ticket:       Match the current Linear ticket namespace.
+        state:        Match required runtime state markers.
+        integrations: Match availability of named integrations.
+
+    Example YAML surface (illustrative):
+
+    .. code-block:: yaml
+
+        applies_when:
+          cwd_in: [omninode_repo]
+          repo:
+            kind: omninode
+          ticket:
+            namespace: OMN
+          state:
+            requires: [ONEX_STATE_DIR, evidence_dir]
+          integrations:
+            linear:
+              workspace: omninode
+              ticket_prefix: OMN
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    cwd_in: list[EnumScopeToken] = Field(
+        default_factory=list,
+        description=(
+            "Match cwd against these named topology class tokens. "
+            "Empty list matches universally. Evaluated by the scope registry."
+        ),
+    )
+    repo: ModelRepoFilter | None = Field(
+        default=None,
+        description="Match repository kind. None matches universally.",
+    )
+    ticket: ModelTicketFilter | None = Field(
+        default=None,
+        description="Match the current Linear ticket namespace. None matches universally.",
+    )
+    state: ModelStateFilter | None = Field(
+        default=None,
+        description="Match required runtime state markers. None matches universally.",
+    )
+    integrations: ModelIntegrationFilter | None = Field(
+        default=None,
+        description="Match availability of named integrations. None matches universally.",
+    )
+
+    def is_universal(self) -> bool:
+        """Return True if all predicate fields are empty/None (matches everything)."""
+        return (
+            not self.cwd_in
+            and self.repo is None
+            and self.ticket is None
+            and self.state is None
+            and self.integrations is None
+        )
+
+
+__all__ = ["ModelScopePredicate"]

--- a/src/omnibase_core/models/scope/model_state_filter.py
+++ b/src/omnibase_core/models/scope/model_state_filter.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelStateFilter — scope predicate filter targeting required runtime state markers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelStateFilter(BaseModel):
+    """Predicate filter targeting required runtime state markers."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    requires: list[str] = Field(
+        default_factory=list,
+        description=(
+            "List of required state markers: env var names or directory paths. "
+            "All must be present for the predicate to match."
+        ),
+    )
+
+
+__all__ = ["ModelStateFilter"]

--- a/src/omnibase_core/models/scope/model_ticket_filter.py
+++ b/src/omnibase_core/models/scope/model_ticket_filter.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelTicketFilter — scope predicate filter targeting the current Linear ticket namespace."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelTicketFilter(BaseModel):
+    """Predicate filter targeting the current Linear ticket namespace."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    namespace: str = Field(
+        description=(
+            "Linear ticket namespace prefix (e.g. 'OMN'). "
+            "Matched against the active ticket context when available."
+        )
+    )
+
+
+__all__ = ["ModelTicketFilter"]

--- a/src/omnibase_core/models/scope/model_unavailable_behavior.py
+++ b/src/omnibase_core/models/scope/model_unavailable_behavior.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ModelUnavailableBehavior — skill unavailability presentation contract.
+
+Skills declare this block to control what a user experiences when the skill's
+activation or applicability scope is not satisfied. This prevents the silent
+disappearance of skills in non-OmniNode contexts and gives alpha testers a
+path to understand why a skill is missing.
+
+The four modes (hidden | noop | warn | block) mirror the enforcement tier
+vocabulary intentionally: they describe user-visible outcome, not enforcement
+severity.
+
+diagnostics: explain (opt-in):
+    When set, a separate discovery command (e.g. /onex:doctor) lists hidden
+    skills with structured reasons. Without this, users in external contexts
+    cannot discover that skills exist but are suppressed.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_diagnostics_mode import EnumDiagnosticsMode
+from omnibase_core.enums.enum_unavailable_mode import EnumUnavailableMode
+
+
+class ModelUnavailableBehavior(BaseModel):
+    """
+    Skill unavailability presentation contract.
+
+    Controls what a user experiences when a skill's activation or applicability
+    scope is not satisfied for the current session or invocation context.
+
+    Skills that omit this block default to ``hidden`` with ``silent``
+    diagnostics — the safe default that avoids confusing non-OmniNode users
+    with unfamiliar skill names.
+
+    Attributes:
+        default:     Presentation mode when scope is not satisfied.
+        diagnostics: Whether to emit structured reasons via discovery commands.
+
+    Example YAML surface:
+
+    .. code-block:: yaml
+
+        unavailable_behavior:
+          default: hidden
+          diagnostics: explain
+
+    See Also:
+        - :class:`~omnibase_core.enums.enum_unavailable_mode.EnumUnavailableMode`:
+          Available presentation modes.
+        - :class:`~omnibase_core.enums.enum_diagnostics_mode.EnumDiagnosticsMode`:
+          Diagnostics opt-in.
+        - :class:`~omnibase_core.models.scope.model_enforcement_scope.ModelEnforcementScope`:
+          Parent scope model for skills.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    default: EnumUnavailableMode = Field(
+        default=EnumUnavailableMode.HIDDEN,
+        description=(
+            "Presentation mode when the skill's scope is not satisfied. "
+            "Defaults to 'hidden' to avoid confusing non-OmniNode users."
+        ),
+    )
+    diagnostics: EnumDiagnosticsMode = Field(
+        default=EnumDiagnosticsMode.SILENT,
+        description=(
+            "Whether to emit structured unavailability reasons via /onex:doctor "
+            "or equivalent discovery commands. Set 'explain' for alpha-tester profiles."
+        ),
+    )
+
+
+__all__ = ["ModelUnavailableBehavior"]

--- a/tests/unit/models/scope/__init__.py
+++ b/tests/unit/models/scope/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for omnibase_core.models.scope (OMN-9904)."""
+
+__all__: list[str] = []

--- a/tests/unit/models/scope/test_scope_models.py
+++ b/tests/unit/models/scope/test_scope_models.py
@@ -41,6 +41,19 @@ from omnibase_core.models.scope import (
     ModelUnavailableBehavior,
 )
 
+ENFORCEMENT_VALUES: tuple[EnumEnforcement, ...] = tuple(
+    EnumEnforcement.__members__.values()
+)
+SCOPE_TOKEN_VALUES: tuple[EnumScopeToken, ...] = tuple(
+    EnumScopeToken.__members__.values()
+)
+UNAVAILABLE_MODE_VALUES: tuple[EnumUnavailableMode, ...] = tuple(
+    EnumUnavailableMode.__members__.values()
+)
+DIAGNOSTICS_MODE_VALUES: tuple[EnumDiagnosticsMode, ...] = tuple(
+    EnumDiagnosticsMode.__members__.values()
+)
+
 # ---------------------------------------------------------------------------
 # EnumEnforcement
 # ---------------------------------------------------------------------------
@@ -50,7 +63,7 @@ from omnibase_core.models.scope import (
 class TestEnumEnforcement:
     def test_all_values_round_trip_yaml(self) -> None:
         """Each enforcement value survives yaml.safe_load -> Pydantic round-trip."""
-        for member in EnumEnforcement:
+        for member in ENFORCEMENT_VALUES:
             raw = yaml.safe_dump({"enforcement": member.value})
             loaded = yaml.safe_load(raw)
             assert EnumEnforcement(loaded["enforcement"]) == member
@@ -120,7 +133,7 @@ class TestEnumScopeToken:
         assert not EnumScopeToken.UNKNOWN.is_omninode_context()
 
     def test_yaml_round_trip(self) -> None:
-        for token in EnumScopeToken:
+        for token in SCOPE_TOKEN_VALUES:
             raw = yaml.safe_dump({"token": token.value})
             loaded = yaml.safe_load(raw)
             assert EnumScopeToken(loaded["token"]) == token
@@ -294,7 +307,7 @@ class TestModelArtifactEnforcement:
 
     def test_yaml_round_trip_all_enforcement_values(self) -> None:
         """Each enforcement enum value round-trips through YAML for each field."""
-        for value in EnumEnforcement:
+        for value in ENFORCEMENT_VALUES:
             data = {
                 "default": value.value,
                 "non_matching_scope": value.value,
@@ -321,7 +334,7 @@ class TestModelUnavailableBehavior:
         assert ub.diagnostics == EnumDiagnosticsMode.SILENT
 
     def test_yaml_round_trip_all_unavailable_modes(self) -> None:
-        for mode in EnumUnavailableMode:
+        for mode in UNAVAILABLE_MODE_VALUES:
             data = {"default": mode.value, "diagnostics": "silent"}
             raw = yaml.safe_dump(data)
             loaded = yaml.safe_load(raw)
@@ -336,9 +349,9 @@ class TestModelUnavailableBehavior:
         assert ub.diagnostics == EnumDiagnosticsMode.EXPLAIN
 
     def test_all_enum_values_valid(self) -> None:
-        for mode in EnumUnavailableMode:
+        for mode in UNAVAILABLE_MODE_VALUES:
             assert mode.value in ("hidden", "noop", "warn", "block")
-        for diag in EnumDiagnosticsMode:
+        for diag in DIAGNOSTICS_MODE_VALUES:
             assert diag.value in ("explain", "silent")
 
     def test_extra_fields_forbidden(self) -> None:

--- a/tests/unit/models/scope/test_scope_models.py
+++ b/tests/unit/models/scope/test_scope_models.py
@@ -1,0 +1,487 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+YAML round-trip and unit tests for OMN-9904 scope schema models.
+
+Covers:
+- EnumEnforcement: all four values, severity ordering, downgrade guard
+- EnumScopeToken: all five values, is_omninode_context()
+- ModelScopePredicate: construction, is_universal(), predicate vocabulary
+- ModelActivationScope: construction, is_unrestricted()
+- ModelApplicabilityScope: applies_when / disabled_when
+- ModelArtifactEnforcement: all three tier fields
+- ModelEnforcementScope: full triad round-trip from YAML
+- ModelUnavailableBehavior: all modes + diagnostics
+- YAML round-trips for each enforcement enum value
+- YAML round-trips for each unavailable_behavior mode
+- disabled_when conflict semantics (documentation test)
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_diagnostics_mode import EnumDiagnosticsMode
+from omnibase_core.enums.enum_enforcement import EnumEnforcement
+from omnibase_core.enums.enum_scope_token import EnumScopeToken
+from omnibase_core.enums.enum_unavailable_mode import EnumUnavailableMode
+from omnibase_core.models.scope import (
+    ModelActivationScope,
+    ModelApplicabilityScope,
+    ModelArtifactEnforcement,
+    ModelEnforcementScope,
+    ModelIntegrationFilter,
+    ModelRepoFilter,
+    ModelScopePredicate,
+    ModelStateFilter,
+    ModelTicketFilter,
+    ModelUnavailableBehavior,
+)
+
+# ---------------------------------------------------------------------------
+# EnumEnforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnumEnforcement:
+    def test_all_values_round_trip_yaml(self) -> None:
+        """Each enforcement value survives yaml.safe_load -> Pydantic round-trip."""
+        for member in EnumEnforcement:
+            raw = yaml.safe_dump({"enforcement": member.value})
+            loaded = yaml.safe_load(raw)
+            assert EnumEnforcement(loaded["enforcement"]) == member
+
+    def test_value_strings(self) -> None:
+        assert EnumEnforcement.OBSERVE.value == "observe"
+        assert EnumEnforcement.WARN.value == "warn"
+        assert EnumEnforcement.BLOCK.value == "block"
+        assert EnumEnforcement.FAIL_FAST.value == "fail-fast"
+
+    def test_severity_ordering(self) -> None:
+        assert EnumEnforcement.OBSERVE < EnumEnforcement.WARN
+        assert EnumEnforcement.WARN < EnumEnforcement.BLOCK
+        assert EnumEnforcement.BLOCK < EnumEnforcement.FAIL_FAST
+
+    def test_str_representation(self) -> None:
+        assert str(EnumEnforcement.BLOCK) == "block"
+        assert str(EnumEnforcement.FAIL_FAST) == "fail-fast"
+
+    def test_can_downgrade_to_legal(self) -> None:
+        assert EnumEnforcement.can_downgrade_to(
+            EnumEnforcement.BLOCK, EnumEnforcement.WARN
+        )
+        assert EnumEnforcement.can_downgrade_to(
+            EnumEnforcement.WARN, EnumEnforcement.OBSERVE
+        )
+        assert EnumEnforcement.can_downgrade_to(
+            EnumEnforcement.BLOCK, EnumEnforcement.BLOCK
+        )
+
+    def test_can_downgrade_to_illegal(self) -> None:
+        assert not EnumEnforcement.can_downgrade_to(
+            EnumEnforcement.WARN, EnumEnforcement.BLOCK
+        )
+        assert not EnumEnforcement.can_downgrade_to(
+            EnumEnforcement.OBSERVE, EnumEnforcement.FAIL_FAST
+        )
+
+    def test_ge_le(self) -> None:
+        assert EnumEnforcement.BLOCK >= EnumEnforcement.WARN
+        assert EnumEnforcement.WARN <= EnumEnforcement.BLOCK
+
+    def test_comparison_type_error(self) -> None:
+        result = EnumEnforcement.BLOCK.__lt__("not_an_enforcement")
+        assert result is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# EnumScopeToken
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnumScopeToken:
+    def test_all_values(self) -> None:
+        assert EnumScopeToken.OMNINODE_REPO.value == "omninode_repo"
+        assert EnumScopeToken.OMNINODE_WORKTREE.value == "omninode_worktree"
+        assert EnumScopeToken.OMNINODE_HOME.value == "omninode_home"
+        assert EnumScopeToken.EXTERNAL_REPO.value == "external_repo"
+        assert EnumScopeToken.UNKNOWN.value == "unknown"
+
+    def test_is_omninode_context(self) -> None:
+        assert EnumScopeToken.OMNINODE_REPO.is_omninode_context()
+        assert EnumScopeToken.OMNINODE_WORKTREE.is_omninode_context()
+        assert EnumScopeToken.OMNINODE_HOME.is_omninode_context()
+        assert not EnumScopeToken.EXTERNAL_REPO.is_omninode_context()
+        assert not EnumScopeToken.UNKNOWN.is_omninode_context()
+
+    def test_yaml_round_trip(self) -> None:
+        for token in EnumScopeToken:
+            raw = yaml.safe_dump({"token": token.value})
+            loaded = yaml.safe_load(raw)
+            assert EnumScopeToken(loaded["token"]) == token
+
+
+# ---------------------------------------------------------------------------
+# ModelScopePredicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelScopePredicate:
+    def test_default_is_universal(self) -> None:
+        pred = ModelScopePredicate()
+        assert pred.is_universal()
+
+    def test_with_cwd_in_not_universal(self) -> None:
+        pred = ModelScopePredicate(cwd_in=[EnumScopeToken.OMNINODE_REPO])
+        assert not pred.is_universal()
+
+    def test_with_repo_filter(self) -> None:
+        pred = ModelScopePredicate(repo=ModelRepoFilter(kind="omninode"))
+        assert pred.repo is not None
+        assert pred.repo.kind == "omninode"
+        assert not pred.is_universal()
+
+    def test_with_ticket_filter(self) -> None:
+        pred = ModelScopePredicate(ticket=ModelTicketFilter(namespace="OMN"))
+        assert pred.ticket is not None
+        assert pred.ticket.namespace == "OMN"
+
+    def test_with_state_filter(self) -> None:
+        pred = ModelScopePredicate(
+            state=ModelStateFilter(requires=["ONEX_STATE_DIR", "evidence_dir"])
+        )
+        assert pred.state is not None
+        assert "ONEX_STATE_DIR" in pred.state.requires
+
+    def test_with_integrations_filter(self) -> None:
+        pred = ModelScopePredicate(
+            integrations=ModelIntegrationFilter(
+                linear={"workspace": "omninode", "ticket_prefix": "OMN"}
+            )
+        )
+        assert pred.integrations is not None
+        assert pred.integrations.linear is not None
+
+    def test_yaml_round_trip_full_predicate(self) -> None:
+        data = {
+            "cwd_in": ["omninode_repo"],
+            "repo": {"kind": "omninode"},
+            "ticket": {"namespace": "OMN"},
+            "state": {"requires": ["ONEX_STATE_DIR"]},
+            "integrations": {"linear": {"workspace": "omninode"}},
+        }
+        raw = yaml.safe_dump(data)
+        loaded = yaml.safe_load(raw)
+        pred = ModelScopePredicate.model_validate(loaded)
+        assert pred.cwd_in == [EnumScopeToken.OMNINODE_REPO]
+        assert pred.repo is not None
+        assert pred.ticket is not None
+        assert not pred.is_universal()
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelScopePredicate.model_validate({"unknown_field": "value"})
+
+    def test_frozen(self) -> None:
+        pred = ModelScopePredicate()
+        with pytest.raises(ValidationError, match="frozen_instance"):
+            pred.cwd_in = [EnumScopeToken.OMNINODE_REPO]  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ModelActivationScope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelActivationScope:
+    def test_default_is_unrestricted(self) -> None:
+        scope = ModelActivationScope()
+        assert scope.is_unrestricted()
+
+    def test_with_tokens_not_unrestricted(self) -> None:
+        scope = ModelActivationScope(requires_tokens=[EnumScopeToken.OMNINODE_REPO])
+        assert not scope.is_unrestricted()
+
+    def test_with_env_not_unrestricted(self) -> None:
+        scope = ModelActivationScope(requires_env=["OMNI_HOME"])
+        assert not scope.is_unrestricted()
+
+    def test_yaml_round_trip(self) -> None:
+        data = {
+            "requires_tokens": ["omninode_repo", "omninode_worktree"],
+            "requires_env": ["OMNI_HOME", "ONEX_STATE_DIR"],
+            "requires_integrations": {"linear": {"workspace": "omninode"}},
+        }
+        raw = yaml.safe_dump(data)
+        loaded = yaml.safe_load(raw)
+        scope = ModelActivationScope.model_validate(loaded)
+        assert EnumScopeToken.OMNINODE_REPO in scope.requires_tokens
+        assert "OMNI_HOME" in scope.requires_env
+        assert "linear" in scope.requires_integrations
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActivationScope.model_validate({"bad_field": True})
+
+
+# ---------------------------------------------------------------------------
+# ModelApplicabilityScope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelApplicabilityScope:
+    def test_defaults(self) -> None:
+        scope = ModelApplicabilityScope()
+        assert scope.applies_when.is_universal()
+        assert scope.disabled_when.is_universal()
+
+    def test_applies_when_set(self) -> None:
+        scope = ModelApplicabilityScope(
+            applies_when=ModelScopePredicate(repo=ModelRepoFilter(kind="omninode"))
+        )
+        assert scope.applies_when.repo is not None
+
+    def test_disabled_when_set(self) -> None:
+        scope = ModelApplicabilityScope(
+            disabled_when=ModelScopePredicate(repo=ModelRepoFilter(kind="external"))
+        )
+        assert scope.disabled_when.repo is not None
+
+    def test_yaml_round_trip(self) -> None:
+        data = {
+            "applies_when": {"repo": {"kind": "omninode"}},
+            "disabled_when": {"repo": {"kind": "external"}},
+        }
+        raw = yaml.safe_dump(data)
+        loaded = yaml.safe_load(raw)
+        scope = ModelApplicabilityScope.model_validate(loaded)
+        assert scope.applies_when.repo is not None
+        assert scope.disabled_when.repo is not None
+        assert scope.applies_when.repo.kind == "omninode"
+        assert scope.disabled_when.repo.kind == "external"
+
+
+# ---------------------------------------------------------------------------
+# ModelArtifactEnforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelArtifactEnforcement:
+    def test_defaults(self) -> None:
+        enf = ModelArtifactEnforcement()
+        assert enf.default == EnumEnforcement.BLOCK
+        assert enf.non_matching_scope == EnumEnforcement.OBSERVE
+        assert enf.missing_dependency == EnumEnforcement.OBSERVE
+
+    def test_all_fields_configurable(self) -> None:
+        enf = ModelArtifactEnforcement(
+            default=EnumEnforcement.WARN,
+            non_matching_scope=EnumEnforcement.WARN,
+            missing_dependency=EnumEnforcement.BLOCK,
+        )
+        assert enf.default == EnumEnforcement.WARN
+        assert enf.non_matching_scope == EnumEnforcement.WARN
+        assert enf.missing_dependency == EnumEnforcement.BLOCK
+
+    def test_yaml_round_trip_all_enforcement_values(self) -> None:
+        """Each enforcement enum value round-trips through YAML for each field."""
+        for value in EnumEnforcement:
+            data = {
+                "default": value.value,
+                "non_matching_scope": value.value,
+                "missing_dependency": value.value,
+            }
+            raw = yaml.safe_dump(data)
+            loaded = yaml.safe_load(raw)
+            enf = ModelArtifactEnforcement.model_validate(loaded)
+            assert enf.default == value
+            assert enf.non_matching_scope == value
+            assert enf.missing_dependency == value
+
+
+# ---------------------------------------------------------------------------
+# ModelUnavailableBehavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelUnavailableBehavior:
+    def test_defaults(self) -> None:
+        ub = ModelUnavailableBehavior()
+        assert ub.default == EnumUnavailableMode.HIDDEN
+        assert ub.diagnostics == EnumDiagnosticsMode.SILENT
+
+    def test_yaml_round_trip_all_unavailable_modes(self) -> None:
+        for mode in EnumUnavailableMode:
+            data = {"default": mode.value, "diagnostics": "silent"}
+            raw = yaml.safe_dump(data)
+            loaded = yaml.safe_load(raw)
+            ub = ModelUnavailableBehavior.model_validate(loaded)
+            assert ub.default == mode
+
+    def test_yaml_round_trip_diagnostics_explain(self) -> None:
+        data = {"default": "hidden", "diagnostics": "explain"}
+        raw = yaml.safe_dump(data)
+        loaded = yaml.safe_load(raw)
+        ub = ModelUnavailableBehavior.model_validate(loaded)
+        assert ub.diagnostics == EnumDiagnosticsMode.EXPLAIN
+
+    def test_all_enum_values_valid(self) -> None:
+        for mode in EnumUnavailableMode:
+            assert mode.value in ("hidden", "noop", "warn", "block")
+        for diag in EnumDiagnosticsMode:
+            assert diag.value in ("explain", "silent")
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelUnavailableBehavior.model_validate({"unexpected": True})
+
+
+# ---------------------------------------------------------------------------
+# ModelEnforcementScope (top-level full triad)
+# ---------------------------------------------------------------------------
+
+
+HOOK_YAML = """
+activation:
+  requires_tokens: [omninode_repo]
+  requires_env: [OMNI_HOME]
+applicability:
+  applies_when:
+    repo:
+      kind: omninode
+    ticket:
+      namespace: OMN
+    state:
+      requires: [ONEX_STATE_DIR, evidence_dir]
+  disabled_when:
+    repo:
+      kind: external
+enforcement:
+  default: block
+  non_matching_scope: observe
+  missing_dependency: observe
+unavailable_behavior:
+  default: hidden
+  diagnostics: explain
+"""
+
+SKILL_YAML = """
+activation:
+  requires_tokens: [omninode_repo]
+applicability:
+  applies_when:
+    integrations:
+      linear:
+        workspace: omninode
+        ticket_prefix: OMN
+enforcement:
+  default: warn
+unavailable_behavior:
+  default: hidden
+  diagnostics: explain
+"""
+
+
+@pytest.mark.unit
+class TestModelEnforcementScope:
+    def test_default_construction(self) -> None:
+        scope = ModelEnforcementScope()
+        assert scope.activation.is_unrestricted()
+        assert scope.applicability.applies_when.is_universal()
+        assert scope.enforcement.default == EnumEnforcement.BLOCK
+        assert scope.unavailable_behavior.default == EnumUnavailableMode.HIDDEN
+
+    def test_hook_yaml_round_trip(self) -> None:
+        data = yaml.safe_load(HOOK_YAML)
+        scope = ModelEnforcementScope.model_validate(data)
+
+        # Activation
+        assert EnumScopeToken.OMNINODE_REPO in scope.activation.requires_tokens
+        assert "OMNI_HOME" in scope.activation.requires_env
+
+        # Applicability
+        assert scope.applicability.applies_when.repo is not None
+        assert scope.applicability.applies_when.repo.kind == "omninode"
+        assert scope.applicability.applies_when.ticket is not None
+        assert scope.applicability.applies_when.ticket.namespace == "OMN"
+        assert scope.applicability.applies_when.state is not None
+        assert "ONEX_STATE_DIR" in scope.applicability.applies_when.state.requires
+        assert scope.applicability.disabled_when.repo is not None
+        assert scope.applicability.disabled_when.repo.kind == "external"
+
+        # Enforcement — HOOK_YAML sets observe for non_matching_scope and missing_dependency
+        assert scope.enforcement.default == EnumEnforcement.BLOCK
+        assert scope.enforcement.non_matching_scope == EnumEnforcement.OBSERVE
+        assert scope.enforcement.missing_dependency == EnumEnforcement.OBSERVE
+
+        # Unavailable behavior
+        assert scope.unavailable_behavior.default == EnumUnavailableMode.HIDDEN
+        assert scope.unavailable_behavior.diagnostics == EnumDiagnosticsMode.EXPLAIN
+
+    def test_skill_yaml_round_trip(self) -> None:
+        data = yaml.safe_load(SKILL_YAML)
+        scope = ModelEnforcementScope.model_validate(data)
+
+        assert EnumScopeToken.OMNINODE_REPO in scope.activation.requires_tokens
+        assert scope.applicability.applies_when.integrations is not None
+        assert scope.applicability.applies_when.integrations.linear is not None
+        assert scope.enforcement.default == EnumEnforcement.WARN
+        assert scope.unavailable_behavior.diagnostics == EnumDiagnosticsMode.EXPLAIN
+
+    def test_pydantic_serialization_round_trip(self) -> None:
+        data = yaml.safe_load(HOOK_YAML)
+        scope = ModelEnforcementScope.model_validate(data)
+        serialized = scope.model_dump()
+        restored = ModelEnforcementScope.model_validate(serialized)
+        assert restored == scope
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEnforcementScope.model_validate({"unknown_top_level": True})
+
+    def test_triad_independence(self) -> None:
+        """Activation, applicability, and enforcement are independently configurable."""
+        scope = ModelEnforcementScope(
+            activation=ModelActivationScope(
+                requires_tokens=[EnumScopeToken.OMNINODE_REPO]
+            ),
+            applicability=ModelApplicabilityScope(
+                applies_when=ModelScopePredicate(repo=ModelRepoFilter(kind="omninode"))
+            ),
+            enforcement=ModelArtifactEnforcement(default=EnumEnforcement.FAIL_FAST),
+        )
+        assert not scope.activation.is_unrestricted()
+        assert not scope.applicability.applies_when.is_universal()
+        assert scope.enforcement.default == EnumEnforcement.FAIL_FAST
+
+    def test_disabled_when_wins_documentation(self) -> None:
+        """
+        Conflict resolution: disabled_when always wins over applies_when.
+
+        This is a documentation test. The scope schema declares the contract;
+        the scope evaluator (OMN-9905) enforces it at runtime. The test
+        validates that the schema correctly represents both predicates
+        simultaneously — a schema that only allowed one or the other would
+        prevent declaring the conflict resolution policy.
+        """
+        scope = ModelEnforcementScope.model_validate(yaml.safe_load(HOOK_YAML))
+        # Both predicates are representable in the schema simultaneously.
+        # disabled_when.repo.kind == "external" would suppress even if
+        # applies_when.repo.kind == "omninode" also matched.
+        assert scope.applicability.applies_when.repo is not None
+        assert scope.applicability.disabled_when.repo is not None
+        # They represent different conditions — schema supports both.
+        assert (
+            scope.applicability.applies_when.repo.kind
+            != scope.applicability.disabled_when.repo.kind
+        )


### PR DESCRIPTION
## Summary

Defines the EnumScope and ModelEnforcementScope contract schema foundation.

Linear: OMN-9904
Evidence-Ticket: OMN-9904
Evidence-Source: OCC#716
