### PR TITLE
ci(OMN-10602): stop auto-merge workflow fanout

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@
 # by jonahgabriel. Ensures PRs do not sit idle in the merge queue waiting
 # for manual enrollment.
 #
-# OMN-7786: Re-trigger on review and workflow_run events so the workflow
+# OMN-7786: Re-trigger on review and check_suite events so the workflow
 # re-attempts auto-merge after CodeRabbit review finishes and branch
 # protection gates clear. Silent continue-on-error removed; "already
 # enqueued" races are tolerated but real failures surface.
@@ -21,8 +21,7 @@ on:
     types: [opened, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
-  workflow_run:
-    workflows: ["*"]
+  check_suite:
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -63,6 +62,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_FROM_PAYLOAD: ${{ github.event.pull_request.number }}
           PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
+          CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
           PR_AUTHOR_FROM_PAYLOAD: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
@@ -75,11 +75,14 @@ jobs:
               PR="$PR_FROM_DISPATCH"
               ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
               ;;
-            workflow_run)
-              # workflow_run does not carry PR context directly; skip gracefully
-              echo "workflow_run event — no direct PR context; skipping"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
+            check_suite)
+              PR="$(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" and length > 0 then .[0].number else empty end')"
+              if [ -z "$PR" ]; then
+                echo "check_suite had no associated PRs; nothing to do"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
               ;;
             *)
               echo "unsupported event: $EVENT_NAME"
@@ -87,6 +90,15 @@ jobs:
               exit 0
               ;;
           esac
+          BASE_REF="$(gh pr view "$PR" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
+          DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "PR #$PR targets '$BASE_REF', not default '$DEFAULT_BRANCH'; skipping auto-merge enrollment for stacked PR"
+            echo "pr=$PR" >> "$GITHUB_OUTPUT"
+            echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
           echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -76,9 +76,18 @@ jobs:
               ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
               ;;
             check_suite)
-              PR="$(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" and length > 0 then .[0].number else empty end')"
+              DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+              PR=""
+              while IFS= read -r candidate_pr; do
+                [ -z "$candidate_pr" ] && continue
+                candidate_base="$(gh pr view "$candidate_pr" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
+                if [ "$candidate_base" = "$DEFAULT_BRANCH" ]; then
+                  PR="$candidate_pr"
+                  break
+                fi
+              done < <(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" then .[]?.number else empty end')
               if [ -z "$PR" ]; then
-                echo "check_suite had no associated PRs; nothing to do"
+                echo "check_suite had no associated PR targeting '$DEFAULT_BRANCH'; nothing to do"
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
@@ -91,7 +100,7 @@ jobs:
               ;;
           esac
           BASE_REF="$(gh pr view "$PR" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
-          DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+          DEFAULT_BRANCH="${DEFAULT_BRANCH:-$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')}"
           if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
             echo "PR #$PR targets '$BASE_REF', not default '$DEFAULT_BRANCH'; skipping auto-merge enrollment for stacked PR"
             echo "pr=$PR" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 # Prevent auto-cancellation for normal PR/push workflows, but cancel superseded
 # merge_group runs so stale merge-queue attempts do not accumulate.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ on:
   schedule:
     - cron: "13 7 * * *"   # 07:13 UTC nightly
 
-# Prevent auto-cancellation of running workflows when new commits are pushed
-# This ensures test splits actually run to completion instead of being skipped
+# Prevent auto-cancellation for normal PR/push workflows, but cancel superseded
+# merge_group runs so stale merge-queue attempts do not accumulate.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 env:
   UV_VERSION: "0.8.3"


### PR DESCRIPTION
## Summary
- replace wildcard workflow_run Auto-Merge retrigger with check_suite completed
- resolve PR context from check_suite pull_requests instead of spawning no-op workflow_run jobs
- skip stacked PRs targeting non-default branches before enqueue attempts
- cancel superseded merge_group CI runs so queue rotations do not accumulate stale CI jobs

## Evidence
- `workflow_run: workflows: ["*"]` was introduced by core PR #796 / commit 3f65727b on 2026-04-11.
- Before this change, omnibase_core had a large queued Auto-Merge workflow_run backlog and dozens of stale merge_group CI runs.
- Branch protection only requires CI Summary, verify / verify, and CodeRabbit Thread Gate; Auto-Merge is not required.
- Local YAML parse passed for auto-merge.yml and ci.yml.

## Verification
- python yaml.safe_load(.github/workflows/auto-merge.yml)
- python yaml.safe_load(.github/workflows/ci.yml)
- git diff --check

Linear: OMN-10602


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved auto-merge workflow to handle additional GitHub event types, enabling merges triggered from alternative event sources and better PR resolution.
  * Updated CI concurrency behavior to more selectively cancel in-progress runs during merge operations, reducing unnecessary work and improving pipeline efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->