### PR TITLE
feat(OMN-10611): add model health status contract for delegation routing

### DIFF
--- a/src/omnibase_core/enums/enum_model_health_state.py
+++ b/src/omnibase_core/enums/enum_model_health_state.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Enum for model health states used by the delegation routing system (OMN-10611)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumModelHealthState(StrValueHelper, str, Enum):
+    """Observable health state of a model endpoint for delegation routing.
+
+    States:
+        AVAILABLE: Model responds within its declared latency SLA.
+        DEGRADED: Model responds but latency exceeds latency_threshold_ms.
+        UNAVAILABLE: Model does not respond or returns errors.
+    """
+
+    AVAILABLE = "available"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+
+
+__all__ = ["EnumModelHealthState"]

--- a/src/omnibase_core/models/delegation/__init__.py
+++ b/src/omnibase_core/models/delegation/__init__.py
@@ -1,2 +1,29 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+from omnibase_core.enums.enum_model_health_state import EnumModelHealthState
+from omnibase_core.models.delegation.model_a2a_task_request import ModelA2ATaskRequest
+from omnibase_core.models.delegation.model_a2a_task_response import ModelA2ATaskResponse
+from omnibase_core.models.delegation.model_agent_task_lifecycle_event import (
+    ModelAgentTaskLifecycleEvent,
+)
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_model_health_status import (
+    ModelModelHealthStatus,
+)
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_core.models.delegation.model_routing_rule import ModelRoutingRule
+from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
+
+__all__ = [
+    "EnumModelHealthState",
+    "ModelA2ATaskRequest",
+    "ModelA2ATaskResponse",
+    "ModelAgentTaskLifecycleEvent",
+    "ModelInvocationCommand",
+    "ModelModelHealthStatus",
+    "ModelRemoteTaskState",
+    "ModelRoutingRule",
+    "ModelTargetAgent",
+]

--- a/src/omnibase_core/models/delegation/model_model_health_status.py
+++ b/src/omnibase_core/models/delegation/model_model_health_status.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelModelHealthStatus: health snapshot for a model endpoint (OMN-10611)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_model_health_state import EnumModelHealthState
+
+
+class ModelModelHealthStatus(BaseModel):
+    """Point-in-time health snapshot for a model endpoint.
+
+    Used by the delegation routing reducer to skip unavailable models.
+    If all models are unavailable, the original Claude Code tool call proceeds.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    model_key: str
+    endpoint_url: str
+    state: EnumModelHealthState
+    latency_ms: float | None = None
+    latency_threshold_ms: float = 5000.0
+    last_checked_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+    )
+    error_message: str | None = None
+    consecutive_failures: int = 0
+
+
+__all__ = ["ModelModelHealthStatus"]

--- a/src/omnibase_core/models/delegation/model_model_health_status.py
+++ b/src/omnibase_core/models/delegation/model_model_health_status.py
@@ -23,13 +23,13 @@ class ModelModelHealthStatus(BaseModel):
     model_key: str
     endpoint_url: str
     state: EnumModelHealthState
-    latency_ms: float | None = None
-    latency_threshold_ms: float = 5000.0
+    latency_ms: float | None = Field(default=None, ge=0)
+    latency_threshold_ms: float = Field(default=5000.0, ge=0)
     last_checked_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
     )
     error_message: str | None = None
-    consecutive_failures: int = 0
+    consecutive_failures: int = Field(default=0, ge=0)
 
 
 __all__ = ["ModelModelHealthStatus"]

--- a/tests/unit/models/delegation/test_model_health_status.py
+++ b/tests/unit/models/delegation/test_model_health_status.py
@@ -92,7 +92,7 @@ class TestModelModelHealthStatus:
             last_checked_at=_NOW,
         )
         with pytest.raises(Exception):
-            status.state = EnumModelHealthState.UNAVAILABLE  # type: ignore[misc]
+            status.state = EnumModelHealthState.UNAVAILABLE  # NOTE(OMN-10611): intentional mutation attempt to verify frozen model behavior.  # type: ignore[misc]
 
     def test_extra_fields_forbidden(self) -> None:
         with pytest.raises(ValidationError):
@@ -111,9 +111,32 @@ class TestModelModelHealthStatus:
             ModelModelHealthStatus(
                 model_key="qwen3-coder",
                 endpoint_url=_ENDPOINT,
-                state="flying",  # type: ignore[arg-type]
+                state="flying",  # NOTE(OMN-10611): intentional invalid enum value for validation-path testing.  # type: ignore[arg-type]
                 last_checked_at=_NOW,
             )
+
+    @pytest.mark.parametrize(
+        ("field_name", "value"),
+        [
+            ("latency_ms", -1.0),
+            ("latency_threshold_ms", -1.0),
+            ("consecutive_failures", -1),
+        ],
+    )
+    def test_negative_health_metrics_raise(
+        self,
+        field_name: str,
+        value: float | int,
+    ) -> None:
+        payload = {
+            "model_key": "qwen3-coder",
+            "endpoint_url": _ENDPOINT,
+            "state": EnumModelHealthState.AVAILABLE,
+            "last_checked_at": _NOW,
+            field_name: value,
+        }
+        with pytest.raises(ValidationError):
+            ModelModelHealthStatus(**payload)
 
     def test_serialization_round_trip(self) -> None:
         status = ModelModelHealthStatus(

--- a/tests/unit/models/delegation/test_model_health_status.py
+++ b/tests/unit/models/delegation/test_model_health_status.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelModelHealthStatus and EnumModelHealthState (OMN-10611)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_model_health_state import EnumModelHealthState
+from omnibase_core.models.delegation.model_model_health_status import (
+    ModelModelHealthStatus,
+)
+
+_ENDPOINT = "http://192.168.86.201:8000"
+_NOW = datetime(2026, 5, 6, 10, 0, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+class TestEnumModelHealthState:
+    def test_all_values_present(self) -> None:
+        assert EnumModelHealthState.AVAILABLE == "available"
+        assert EnumModelHealthState.DEGRADED == "degraded"
+        assert EnumModelHealthState.UNAVAILABLE == "unavailable"
+
+    def test_exactly_three_members(self) -> None:
+        assert len(EnumModelHealthState) == 3
+
+    def test_str_coercible(self) -> None:
+        assert str(EnumModelHealthState.AVAILABLE) == "available"
+
+
+@pytest.mark.unit
+class TestModelModelHealthStatus:
+    def test_available_state(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.AVAILABLE,
+            latency_ms=120.5,
+            last_checked_at=_NOW,
+        )
+        assert status.state is EnumModelHealthState.AVAILABLE
+        assert status.latency_ms == 120.5
+        assert status.consecutive_failures == 0
+        assert status.error_message is None
+
+    def test_degraded_state(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.DEGRADED,
+            latency_ms=6000.0,
+            last_checked_at=_NOW,
+        )
+        assert status.state is EnumModelHealthState.DEGRADED
+        assert (
+            status.latency_ms is not None
+            and status.latency_ms > status.latency_threshold_ms
+        )
+
+    def test_unavailable_state(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.UNAVAILABLE,
+            error_message="connection refused",
+            consecutive_failures=3,
+            last_checked_at=_NOW,
+        )
+        assert status.state is EnumModelHealthState.UNAVAILABLE
+        assert status.error_message == "connection refused"
+        assert status.consecutive_failures == 3
+
+    def test_default_latency_threshold(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.AVAILABLE,
+            last_checked_at=_NOW,
+        )
+        assert status.latency_threshold_ms == 5000.0
+
+    def test_frozen(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.AVAILABLE,
+            last_checked_at=_NOW,
+        )
+        with pytest.raises(Exception):
+            status.state = EnumModelHealthState.UNAVAILABLE  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelModelHealthStatus.model_validate(
+                {
+                    "model_key": "qwen3-coder",
+                    "endpoint_url": _ENDPOINT,
+                    "state": "available",
+                    "unknown_field": "bad",
+                    "last_checked_at": _NOW,
+                }
+            )
+
+    def test_invalid_state_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelModelHealthStatus(
+                model_key="qwen3-coder",
+                endpoint_url=_ENDPOINT,
+                state="flying",  # type: ignore[arg-type]
+                last_checked_at=_NOW,
+            )
+
+    def test_serialization_round_trip(self) -> None:
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.DEGRADED,
+            latency_ms=7500.0,
+            consecutive_failures=1,
+            error_message=None,
+            last_checked_at=_NOW,
+        )
+        raw = json.loads(status.model_dump_json())
+        restored = ModelModelHealthStatus.model_validate(raw)
+        assert restored.state is EnumModelHealthState.DEGRADED
+        assert restored.latency_ms == status.latency_ms
+        assert restored.consecutive_failures == status.consecutive_failures
+
+    def test_last_checked_at_defaults_to_now(self) -> None:
+        before = datetime.now(UTC)
+        status = ModelModelHealthStatus(
+            model_key="qwen3-coder",
+            endpoint_url=_ENDPOINT,
+            state=EnumModelHealthState.AVAILABLE,
+        )
+        after = datetime.now(UTC)
+        assert before <= status.last_checked_at <= after


### PR DESCRIPTION
## Summary
- Adds `EnumModelHealthState` (available/degraded/unavailable) to `omnibase_core/enums/`
- Adds `ModelModelHealthStatus` to `omnibase_core/models/delegation/` — frozen, extra-forbidden, with default 5000ms latency threshold
- Exports both from `models/delegation/__init__.py`
- 12 unit tests covering all three states, frozen enforcement, extra-field rejection, invalid state rejection, serialization round-trip, and default timestamp generation

## Ticket
OMN-10611 (epic OMN-10604)

## Test plan
- [x] 12 unit tests pass
- [x] mypy --strict clean (pre-push hook confirmed)
- [x] pyright basic clean (pre-push hook confirmed)
- [x] All pre-commit hooks pass (55 checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model health monitoring system for tracking endpoint status with three distinct health states: available, degraded, and unavailable
  * Point-in-time health status snapshots capturing endpoint health metrics including response latency, error messages, and consecutive failure counts
  * Enhanced package exports to expose new health monitoring capabilities

* **Tests**
  * Added comprehensive test coverage for health monitoring including state validation, latency threshold testing, immutability verification, and serialization round-trips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->