### PR TITLE
feat(OMN-10609): add delegation request envelope contract

### DIFF
--- a/src/omnibase_core/enums/enum_redaction_policy.py
+++ b/src/omnibase_core/enums/enum_redaction_policy.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""EnumRedactionPolicy: controls how tool-input content is captured in delegation envelopes."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumRedactionPolicy(str, Enum):
+    """Controls how tool-input content is captured in the delegation envelope."""
+
+    REDACT = "redact"
+    HASH_ONLY = "hash_only"
+    FULL_CAPTURE = "full_capture"
+
+
+__all__ = ["EnumRedactionPolicy"]

--- a/src/omnibase_core/models/delegation/__init__.py
+++ b/src/omnibase_core/models/delegation/__init__.py
@@ -1,2 +1,30 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+
+from omnibase_core.enums.enum_redaction_policy import EnumRedactionPolicy
+from omnibase_core.models.delegation.model_a2a_task_request import ModelA2ATaskRequest
+from omnibase_core.models.delegation.model_a2a_task_response import ModelA2ATaskResponse
+from omnibase_core.models.delegation.model_agent_task_lifecycle_event import (
+    ModelAgentTaskLifecycleEvent,
+)
+from omnibase_core.models.delegation.model_delegation_request import (
+    ModelDelegationRequest,
+)
+from omnibase_core.models.delegation.model_invocation_command import (
+    ModelInvocationCommand,
+)
+from omnibase_core.models.delegation.model_remote_task_state import ModelRemoteTaskState
+from omnibase_core.models.delegation.model_routing_rule import ModelRoutingRule
+from omnibase_core.models.delegation.model_target_agent import ModelTargetAgent
+
+__all__ = [
+    "EnumRedactionPolicy",
+    "ModelA2ATaskRequest",
+    "ModelA2ATaskResponse",
+    "ModelAgentTaskLifecycleEvent",
+    "ModelDelegationRequest",
+    "ModelInvocationCommand",
+    "ModelRemoteTaskState",
+    "ModelRoutingRule",
+    "ModelTargetAgent",
+]

--- a/src/omnibase_core/models/delegation/model_delegation_request.py
+++ b/src/omnibase_core/models/delegation/model_delegation_request.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelDelegationRequest: wire envelope for Claude Code hook delegation (OMN-10609)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_redaction_policy import EnumRedactionPolicy
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+class ModelDelegationRequest(BaseModel):
+    """Envelope emitted by a Claude Code hook when delegating tool execution.
+
+    Carries enough context for the delegation pipeline to route, audit, and
+    replay the request without re-reading the original hook payload.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    envelope_id: UUID = Field(default_factory=uuid4)
+    correlation_id: UUID = Field(default_factory=uuid4)
+    causation_id: UUID
+    # string-id-ok: Claude Code session IDs are opaque strings, not UUIDs
+    session_id: str
+    # string-id-ok: Claude Code tool_use_id is "toolu_01..." not a UUID
+    tool_use_id: str
+    hook_name: str
+    tool_name: str
+    # String rather than EnumTaskType to avoid a cross-repo import into omnibase_core.
+    task_type: str
+    input_hash: str
+    input_redaction_policy: EnumRedactionPolicy = EnumRedactionPolicy.HASH_ONLY
+    requested_at: datetime = Field(
+        default_factory=lambda: datetime.now(tz=UTC),
+    )
+    contract_version: ModelSemVer = Field(
+        default_factory=lambda: ModelSemVer(major=1, minor=0, patch=0),
+    )
+
+
+__all__ = ["ModelDelegationRequest"]

--- a/tests/unit/models/delegation/test_model_delegation_request.py
+++ b/tests/unit/models/delegation/test_model_delegation_request.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelDelegationRequest and EnumRedactionPolicy (OMN-10609)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_redaction_policy import EnumRedactionPolicy
+from omnibase_core.models.delegation.model_delegation_request import (
+    ModelDelegationRequest,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+_CAUSATION_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
+_MINIMAL_KWARGS: dict[str, object] = {
+    "causation_id": _CAUSATION_ID,
+    "session_id": "sess-abc123",
+    "tool_use_id": "tu-xyz789",
+    "hook_name": "PreToolUse",
+    "tool_name": "Bash",
+    "task_type": "compute",
+    "input_hash": "sha256:deadbeef",
+}
+
+
+@pytest.mark.unit
+class TestEnumRedactionPolicy:
+    def test_values(self) -> None:
+        assert EnumRedactionPolicy.REDACT.value == "redact"
+        assert EnumRedactionPolicy.HASH_ONLY.value == "hash_only"
+        assert EnumRedactionPolicy.FULL_CAPTURE.value == "full_capture"
+
+    def test_is_str_subclass(self) -> None:
+        assert isinstance(EnumRedactionPolicy.REDACT, str)
+
+
+@pytest.mark.unit
+class TestModelDelegationRequest:
+    def test_minimal_instantiation(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        assert req.causation_id == _CAUSATION_ID
+        assert req.session_id == "sess-abc123"
+        assert req.tool_name == "Bash"
+        assert req.input_hash == "sha256:deadbeef"
+
+    def test_envelope_id_auto_generated(self) -> None:
+        r1 = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        r2 = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        assert r1.envelope_id != r2.envelope_id
+
+    def test_correlation_id_auto_generated(self) -> None:
+        r1 = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        r2 = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        assert r1.correlation_id != r2.correlation_id
+
+    def test_default_redaction_policy(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        assert req.input_redaction_policy is EnumRedactionPolicy.HASH_ONLY
+
+    def test_explicit_redaction_policy(self) -> None:
+        req = ModelDelegationRequest(
+            **_MINIMAL_KWARGS,  # type: ignore[arg-type]
+            input_redaction_policy=EnumRedactionPolicy.FULL_CAPTURE,
+        )
+        assert req.input_redaction_policy is EnumRedactionPolicy.FULL_CAPTURE
+
+    def test_requested_at_default_is_utc(self) -> None:
+        before = datetime.now(tz=UTC)
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        after = datetime.now(tz=UTC)
+        assert before <= req.requested_at <= after
+
+    def test_contract_version_default(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        assert req.contract_version == ModelSemVer(major=1, minor=0, patch=0)
+
+    def test_explicit_envelope_id(self) -> None:
+        fixed_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        req = ModelDelegationRequest(
+            **_MINIMAL_KWARGS,  # type: ignore[arg-type]
+            envelope_id=fixed_id,
+        )
+        assert req.envelope_id == fixed_id
+
+    def test_frozen(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        with pytest.raises((TypeError, ValidationError)):
+            req.tool_name = "Edit"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDelegationRequest(
+                **_MINIMAL_KWARGS,  # type: ignore[arg-type]
+                unknown_field="boom",
+            )
+
+    def test_causation_id_required(self) -> None:
+        kwargs = {k: v for k, v in _MINIMAL_KWARGS.items() if k != "causation_id"}
+        with pytest.raises(ValidationError):
+            ModelDelegationRequest(**kwargs)  # type: ignore[arg-type]
+
+    def test_round_trip_serialization(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        data = req.model_dump(mode="json")
+        restored = ModelDelegationRequest.model_validate(data)
+        assert restored == req
+
+    def test_json_string_round_trip(self) -> None:
+        req = ModelDelegationRequest(**_MINIMAL_KWARGS)  # type: ignore[arg-type]
+        json_str = req.model_dump_json()
+        restored = ModelDelegationRequest.model_validate_json(json_str)
+        assert restored == req


### PR DESCRIPTION
## Summary

- Adds `EnumRedactionPolicy` to `omnibase_core/enums/` (redact / hash_only / full_capture)
- Adds `ModelDelegationRequest` to `omnibase_core/models/delegation/` with fields: `envelope_id`, `correlation_id`, `causation_id`, `session_id`, `tool_use_id`, `hook_name`, `tool_name`, `task_type`, `input_hash`, `input_redaction_policy`, `requested_at`, `contract_version`
- Updates `models/delegation/__init__.py` to export both new symbols
- 15 unit tests: instantiation, auto-generated defaults, redaction policy, UTC timestamp, frozen/extra-fields enforcement, JSON round-trip

## Ticket

OMN-10609 (epic OMN-10604)

## dod_evidence

- type: unit_tests
  description: 15 unit tests pass (pytest tests/unit/models/delegation/test_model_delegation_request.py)
- type: static_analysis
  description: mypy --strict clean, ruff clean, all pre-commit hooks pass

## Test plan

- [x] Unit tests pass
- [x] mypy --strict clean
- [x] Pre-commit clean (all 50+ hooks)