### PR TITLE
feat(OMN-10614): draft task-class contract schema

### DIFF
--- a/src/omnibase_core/enums/enum_cloud_routing_policy.py
+++ b/src/omnibase_core/enums/enum_cloud_routing_policy.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""EnumCloudRoutingPolicy: controls when a task class may route to cloud LLM endpoints (OMN-10614)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumCloudRoutingPolicy(str, Enum):
+    """Controls when a task class may be routed to cloud LLM endpoints."""
+
+    OPT_IN = "opt_in"
+    ALLOWED = "allowed"
+    BLOCKED = "blocked"
+
+
+__all__ = ["EnumCloudRoutingPolicy"]

--- a/src/omnibase_core/models/delegation/model_definition_of_done.py
+++ b/src/omnibase_core/models/delegation/model_definition_of_done.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelDefinitionOfDone: split-by-semantics DoD checks for task-class contracts (OMN-10614)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDefinitionOfDone(BaseModel):
+    """DoD checks split by enforcement semantics.
+
+    Deterministic checks BLOCK delegation result injection on failure.
+    Heuristic checks MAY escalate or warn per escalation_policy — a heuristic
+    pass is not proof of correctness and must not be represented as such.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    deterministic: list[str] = Field(default_factory=list)
+    heuristic: list[str] = Field(default_factory=list)
+
+
+__all__ = ["ModelDefinitionOfDone"]

--- a/src/omnibase_core/models/delegation/model_escalation_policy.py
+++ b/src/omnibase_core/models/delegation/model_escalation_policy.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelEscalationPolicy: routing tier escalation policy for task-class contracts (OMN-10614)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelEscalationPolicy(BaseModel):
+    """Escalation policy for a task class.
+
+    tier_order defines the sequence of routing tiers tried on escalation.
+    max_escalations caps how many times the result can be escalated before
+    the delegation is treated as failed.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    max_escalations: int = Field(..., ge=0)
+    tier_order: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_escalation_bounds(self) -> ModelEscalationPolicy:
+        if len(self.tier_order) < self.max_escalations:
+            msg = (
+                f"tier_order has {len(self.tier_order)} entries but max_escalations is "
+                f"{self.max_escalations}; tier_order must have at least max_escalations entries"
+            )
+            raise ValueError(msg)
+        return self
+
+
+__all__ = ["ModelEscalationPolicy"]

--- a/src/omnibase_core/models/delegation/model_task_class_contract.py
+++ b/src/omnibase_core/models/delegation/model_task_class_contract.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTaskClassContract: root model for task_class_contract.yaml (OMN-10614)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.delegation.model_task_class_entry import ModelTaskClassEntry
+
+
+class ModelTaskClassContract(BaseModel):
+    """Root model for task_class_contract.yaml.
+
+    Parsed directly from YAML via model_validate(yaml.safe_load(...)). The
+    version field is a string to allow future semver expansion without a
+    breaking schema change.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    version: str
+    task_classes: dict[str, ModelTaskClassEntry] = Field(default_factory=dict)
+
+
+__all__ = ["ModelTaskClassContract"]

--- a/src/omnibase_core/models/delegation/model_task_class_entry.py
+++ b/src/omnibase_core/models/delegation/model_task_class_entry.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelTaskClassEntry: declaration for a single task class in the task-class contract (OMN-10614)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_cloud_routing_policy import EnumCloudRoutingPolicy
+from omnibase_core.models.delegation.model_definition_of_done import (
+    ModelDefinitionOfDone,
+)
+from omnibase_core.models.delegation.model_escalation_policy import (
+    ModelEscalationPolicy,
+)
+
+
+class ModelTaskClassEntry(BaseModel):
+    """Declaration for a single task class."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    required_capabilities: list[str] = Field(default_factory=list)
+    pricing_ceiling_per_1k_tokens: float = Field(..., ge=0.0)
+    latency_sla_p99_ms: int = Field(..., gt=0)
+    cloud_routing_policy: EnumCloudRoutingPolicy
+    definition_of_done: ModelDefinitionOfDone
+    escalation_policy: ModelEscalationPolicy
+
+
+__all__ = ["ModelTaskClassEntry"]

--- a/tests/unit/models/delegation/test_model_task_class_contract.py
+++ b/tests/unit/models/delegation/test_model_task_class_contract.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelTaskClassContract and sub-models (OMN-10614)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_cloud_routing_policy import EnumCloudRoutingPolicy
+from omnibase_core.models.delegation.model_definition_of_done import (
+    ModelDefinitionOfDone,
+)
+from omnibase_core.models.delegation.model_escalation_policy import (
+    ModelEscalationPolicy,
+)
+from omnibase_core.models.delegation.model_task_class_contract import (
+    ModelTaskClassContract,
+)
+from omnibase_core.models.delegation.model_task_class_entry import ModelTaskClassEntry
+
+_VALID_ENTRY_DATA: dict = {
+    "required_capabilities": ["code", "tool_use"],
+    "pricing_ceiling_per_1k_tokens": 0.01,
+    "latency_sla_p99_ms": 5000,
+    "cloud_routing_policy": "opt_in",
+    "definition_of_done": {
+        "deterministic": ["output_parses", "signature_preserved"],
+        "heuristic": ["no_refusal", "min_length_chars_50"],
+    },
+    "escalation_policy": {
+        "max_escalations": 2,
+        "tier_order": ["local_mlx", "cheap_cloud", "claude_sonnet"],
+    },
+}
+
+_VALID_CONTRACT_DATA: dict = {
+    "version": "1",
+    "task_classes": {
+        "code_generation": _VALID_ENTRY_DATA,
+        "documentation": {
+            "required_capabilities": ["text"],
+            "pricing_ceiling_per_1k_tokens": 0.005,
+            "latency_sla_p99_ms": 10000,
+            "cloud_routing_policy": "allowed",
+            "definition_of_done": {
+                "deterministic": ["output_parses"],
+                "heuristic": ["no_refusal", "min_length_chars_100"],
+            },
+            "escalation_policy": {
+                "max_escalations": 1,
+                "tier_order": ["local_mlx", "cheap_cloud"],
+            },
+        },
+        "research": {
+            "required_capabilities": ["text", "reasoning"],
+            "pricing_ceiling_per_1k_tokens": 0.008,
+            "latency_sla_p99_ms": 15000,
+            "cloud_routing_policy": "allowed",
+            "definition_of_done": {
+                "deterministic": ["output_parses"],
+                "heuristic": ["no_refusal", "min_length_chars_200"],
+            },
+            "escalation_policy": {
+                "max_escalations": 2,
+                "tier_order": ["local_mlx", "cheap_cloud", "claude_sonnet"],
+            },
+        },
+    },
+}
+
+
+@pytest.mark.unit
+class TestModelDefinitionOfDone:
+    def test_valid_with_both_lists(self) -> None:
+        dod = ModelDefinitionOfDone(
+            deterministic=["output_parses"],
+            heuristic=["no_refusal"],
+        )
+        assert dod.deterministic == ["output_parses"]
+        assert dod.heuristic == ["no_refusal"]
+
+    def test_defaults_to_empty_lists(self) -> None:
+        dod = ModelDefinitionOfDone()
+        assert dod.deterministic == []
+        assert dod.heuristic == []
+
+    def test_frozen(self) -> None:
+        dod = ModelDefinitionOfDone(deterministic=["output_parses"])
+        with pytest.raises(Exception):
+            dod.deterministic = ["changed"]  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDefinitionOfDone.model_validate({"unknown_field": True})
+
+
+@pytest.mark.unit
+class TestModelEscalationPolicy:
+    def test_valid_policy(self) -> None:
+        policy = ModelEscalationPolicy(
+            max_escalations=2,
+            tier_order=["local_mlx", "cheap_cloud", "claude_sonnet"],
+        )
+        assert policy.max_escalations == 2
+        assert len(policy.tier_order) == 3
+
+    def test_zero_escalations_with_empty_tier_order(self) -> None:
+        policy = ModelEscalationPolicy(max_escalations=0, tier_order=[])
+        assert policy.max_escalations == 0
+
+    def test_tier_order_shorter_than_max_escalations_raises(self) -> None:
+        with pytest.raises(ValidationError, match="tier_order must have at least"):
+            ModelEscalationPolicy(
+                max_escalations=3,
+                tier_order=["local_mlx", "cheap_cloud"],
+            )
+
+    def test_negative_max_escalations_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEscalationPolicy(max_escalations=-1, tier_order=[])
+
+    def test_frozen(self) -> None:
+        policy = ModelEscalationPolicy(
+            max_escalations=1, tier_order=["local_mlx", "cheap_cloud"]
+        )
+        with pytest.raises(Exception):
+            policy.max_escalations = 5  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestEnumCloudRoutingPolicy:
+    def test_all_values_parse(self) -> None:
+        assert EnumCloudRoutingPolicy("opt_in") is EnumCloudRoutingPolicy.OPT_IN
+        assert EnumCloudRoutingPolicy("allowed") is EnumCloudRoutingPolicy.ALLOWED
+        assert EnumCloudRoutingPolicy("blocked") is EnumCloudRoutingPolicy.BLOCKED
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EnumCloudRoutingPolicy("mandatory")
+
+
+@pytest.mark.unit
+class TestModelTaskClassEntry:
+    def test_valid_entry(self) -> None:
+        entry = ModelTaskClassEntry.model_validate(_VALID_ENTRY_DATA)
+        assert entry.cloud_routing_policy is EnumCloudRoutingPolicy.OPT_IN
+        assert entry.pricing_ceiling_per_1k_tokens == 0.01
+        assert entry.latency_sla_p99_ms == 5000
+        assert "output_parses" in entry.definition_of_done.deterministic
+
+    def test_missing_pricing_ceiling_raises(self) -> None:
+        data = {**_VALID_ENTRY_DATA}
+        del data["pricing_ceiling_per_1k_tokens"]
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+    def test_missing_latency_sla_raises(self) -> None:
+        data = {**_VALID_ENTRY_DATA}
+        del data["latency_sla_p99_ms"]
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+    def test_invalid_cloud_routing_policy_raises(self) -> None:
+        data = {**_VALID_ENTRY_DATA, "cloud_routing_policy": "mandatory"}
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+    def test_negative_pricing_ceiling_raises(self) -> None:
+        data = {**_VALID_ENTRY_DATA, "pricing_ceiling_per_1k_tokens": -0.001}
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+    def test_zero_latency_sla_raises(self) -> None:
+        data = {**_VALID_ENTRY_DATA, "latency_sla_p99_ms": 0}
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+    def test_extra_fields_forbidden(self) -> None:
+        data = {**_VALID_ENTRY_DATA, "surprise_field": "whoops"}
+        with pytest.raises(ValidationError):
+            ModelTaskClassEntry.model_validate(data)
+
+
+@pytest.mark.unit
+class TestModelTaskClassContract:
+    def test_valid_contract_validates(self) -> None:
+        contract = ModelTaskClassContract.model_validate(_VALID_CONTRACT_DATA)
+        assert contract.version == "1"
+        assert "code_generation" in contract.task_classes
+        assert "documentation" in contract.task_classes
+        assert "research" in contract.task_classes
+
+    def test_missing_version_raises(self) -> None:
+        data = {k: v for k, v in _VALID_CONTRACT_DATA.items() if k != "version"}
+        with pytest.raises(ValidationError):
+            ModelTaskClassContract.model_validate(data)
+
+    def test_empty_task_classes_allowed(self) -> None:
+        contract = ModelTaskClassContract(version="1")
+        assert contract.task_classes == {}
+
+    def test_serialization_round_trip(self) -> None:
+        contract = ModelTaskClassContract.model_validate(_VALID_CONTRACT_DATA)
+        dumped = contract.model_dump()
+        restored = ModelTaskClassContract.model_validate(dumped)
+        assert restored.version == contract.version
+        assert set(restored.task_classes.keys()) == set(contract.task_classes.keys())
+
+    def test_code_generation_class_entry(self) -> None:
+        contract = ModelTaskClassContract.model_validate(_VALID_CONTRACT_DATA)
+        cg = contract.task_classes["code_generation"]
+        assert cg.cloud_routing_policy is EnumCloudRoutingPolicy.OPT_IN
+        assert cg.escalation_policy.max_escalations == 2
+        assert cg.escalation_policy.tier_order[0] == "local_mlx"
+
+    def test_research_class_uses_allowed_policy(self) -> None:
+        contract = ModelTaskClassContract.model_validate(_VALID_CONTRACT_DATA)
+        research = contract.task_classes["research"]
+        assert research.cloud_routing_policy is EnumCloudRoutingPolicy.ALLOWED
+
+    def test_extra_fields_forbidden(self) -> None:
+        data = {**_VALID_CONTRACT_DATA, "not_a_field": "extra"}
+        with pytest.raises(ValidationError):
+            ModelTaskClassContract.model_validate(data)
+
+    def test_frozen(self) -> None:
+        contract = ModelTaskClassContract.model_validate(_VALID_CONTRACT_DATA)
+        with pytest.raises(Exception):
+            contract.version = "2"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `EnumCloudRoutingPolicy` (opt_in | allowed | blocked) in `enums/enum_cloud_routing_policy.py`
- Adds `ModelDefinitionOfDone`, `ModelEscalationPolicy`, `ModelTaskClassEntry`, `ModelTaskClassContract` — one class per file per ONEX single-class-per-file rule
- `ModelEscalationPolicy` enforces `len(tier_order) >= max_escalations` at construction time
- Deterministic DoD failures block delegation result injection; heuristic failures escalate per policy (semantics documented in model docstrings)
- 26 unit tests: valid round-trips, invalid enum values, missing required fields, negative pricing/latency, frozen invariant, tier_order length constraint

## Test plan

- [x] `uv run pytest tests/unit/models/delegation/test_model_task_class_contract.py -v` → 26/26 passed
- [x] `uv run mypy src/omnibase_core/models/delegation/model_task_class_contract.py --strict` → 0 errors
- [x] `pre-commit run --all-files` → all hooks passed including `onex-single-class-per-file`
- [x] Push pre-commit hook (mypy strict + pyright) → passed

OMN-10614