### PR TITLE
feat(OMN-10617): add ModelEscalationEvent and EnumQualityGateResult to delegation models

### DIFF
--- a/src/omnibase_core/enums/enum_quality_gate_result.py
+++ b/src/omnibase_core/enums/enum_quality_gate_result.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""EnumQualityGateResult: quality gate verdict enum for delegation escalation (OMN-10617)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumQualityGateResult(str, Enum):
+    """Quality gate verdict that triggered a model escalation."""
+
+    PASS = "pass"
+    FAIL_DETERMINISTIC = "fail_deterministic"
+    FAIL_HEURISTIC = "fail_heuristic"
+
+
+__all__ = ["EnumQualityGateResult"]

--- a/src/omnibase_core/models/delegation/__init__.py
+++ b/src/omnibase_core/models/delegation/__init__.py
@@ -1,2 +1,10 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
+from omnibase_core.enums.enum_quality_gate_result import (
+    EnumQualityGateResult,
+)
+from omnibase_core.models.delegation.model_escalation_event import (
+    ModelEscalationEvent,
+)
+
+__all__ = ["EnumQualityGateResult", "ModelEscalationEvent"]

--- a/src/omnibase_core/models/delegation/model_escalation_event.py
+++ b/src/omnibase_core/models/delegation/model_escalation_event.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelEscalationEvent: structured event emitted on model escalation (OMN-10617)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_quality_gate_result import (
+    EnumQualityGateResult,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+class ModelEscalationEvent(BaseModel):
+    """Emitted by the delegation orchestrator FSM when a model escalation occurs.
+
+    Escalation happens when the current model fails a quality gate and the
+    orchestrator selects the next model in the escalation chain. The stopping
+    rule (max_attempts) is enforced by the orchestrator; this model carries the
+    audit trail for a single escalation step.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(
+        ...,
+        description="Ties this event to the originating delegation request.",
+    )
+    prior_model: str = Field(
+        ...,
+        description="Identifier of the model that failed the quality gate.",
+    )
+    next_model: str = Field(
+        ...,
+        description="Identifier of the model selected for the next attempt.",
+    )
+    reason: str = Field(
+        ...,
+        description="Human-readable explanation of why escalation occurred.",
+    )
+    quality_gate_result: EnumQualityGateResult = Field(
+        ...,
+        description="Gate verdict that triggered this escalation.",
+    )
+    attempt_number: int = Field(
+        ...,
+        ge=1,
+        description="Current attempt number (1-indexed); must be >= 1.",
+    )
+    max_attempts: int = Field(
+        ...,
+        ge=1,
+        description="Maximum number of attempts allowed by the orchestrator contract.",
+    )
+    contract_version: ModelSemVer = Field(
+        ...,
+        description="Delegation orchestrator contract version at time of escalation.",
+    )
+
+    @model_validator(mode="after")
+    def _attempt_within_bounds(self) -> ModelEscalationEvent:
+        if self.attempt_number > self.max_attempts:
+            msg = (
+                f"attempt_number ({self.attempt_number}) must not exceed "
+                f"max_attempts ({self.max_attempts})"
+            )
+            raise ValueError(msg)
+        return self
+
+
+__all__ = ["ModelEscalationEvent"]

--- a/tests/unit/models/delegation/test_model_escalation_event.py
+++ b/tests/unit/models/delegation/test_model_escalation_event.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ModelEscalationEvent and EnumQualityGateResult (OMN-10617)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_quality_gate_result import (
+    EnumQualityGateResult,
+)
+from omnibase_core.models.delegation.model_escalation_event import ModelEscalationEvent
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+_CORR_ID = uuid.UUID("cccccccc-0000-0000-0000-000000000003")
+_SEMVER = ModelSemVer(major=1, minor=0, patch=0)
+
+_VALID_KWARGS: dict = {
+    "correlation_id": _CORR_ID,
+    "prior_model": "qwen3-30b",
+    "next_model": "claude-sonnet",
+    "reason": "quality_score below threshold",
+    "quality_gate_result": EnumQualityGateResult.FAIL_HEURISTIC,
+    "attempt_number": 1,
+    "max_attempts": 3,
+    "contract_version": _SEMVER,
+}
+
+
+@pytest.mark.unit
+class TestEnumQualityGateResult:
+    def test_all_values_distinct(self) -> None:
+        values = [e.value for e in EnumQualityGateResult]
+        assert len(values) == len(set(values))
+
+    def test_pass_value(self) -> None:
+        assert EnumQualityGateResult.PASS.value == "pass"
+
+    def test_fail_deterministic_value(self) -> None:
+        assert EnumQualityGateResult.FAIL_DETERMINISTIC.value == "fail_deterministic"
+
+    def test_fail_heuristic_value(self) -> None:
+        assert EnumQualityGateResult.FAIL_HEURISTIC.value == "fail_heuristic"
+
+
+@pytest.mark.unit
+class TestModelEscalationEvent:
+    def test_minimal_valid(self) -> None:
+        event = ModelEscalationEvent(**_VALID_KWARGS)
+        assert event.correlation_id == _CORR_ID
+        assert event.prior_model == "qwen3-30b"
+        assert event.next_model == "claude-sonnet"
+        assert event.quality_gate_result is EnumQualityGateResult.FAIL_HEURISTIC
+        assert event.attempt_number == 1
+        assert event.max_attempts == 3
+        assert event.contract_version == _SEMVER
+
+    def test_frozen(self) -> None:
+        event = ModelEscalationEvent(**_VALID_KWARGS)
+        with pytest.raises(Exception):
+            event.prior_model = "changed"  # type: ignore[misc]
+
+    def test_attempt_number_ge_1(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEscalationEvent(**{**_VALID_KWARGS, "attempt_number": 0})
+
+    def test_max_attempts_ge_1(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEscalationEvent(**{**_VALID_KWARGS, "max_attempts": 0})
+
+    def test_attempt_number_exceeds_max_attempts_raises(self) -> None:
+        with pytest.raises(ValidationError, match="must not exceed max_attempts"):
+            ModelEscalationEvent(
+                **{**_VALID_KWARGS, "attempt_number": 4, "max_attempts": 3}
+            )
+
+    def test_attempt_number_equals_max_attempts_is_valid(self) -> None:
+        event = ModelEscalationEvent(
+            **{**_VALID_KWARGS, "attempt_number": 3, "max_attempts": 3}
+        )
+        assert event.attempt_number == event.max_attempts
+
+    def test_serialization_round_trip(self) -> None:
+        event = ModelEscalationEvent(**_VALID_KWARGS)
+        data = event.model_dump()
+        restored = ModelEscalationEvent.model_validate(data)
+        assert restored == event
+
+    def test_json_round_trip(self) -> None:
+        event = ModelEscalationEvent(**_VALID_KWARGS)
+        json_str = event.model_dump_json()
+        restored = ModelEscalationEvent.model_validate_json(json_str)
+        assert restored == event
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEscalationEvent(**{**_VALID_KWARGS, "unknown_field": "value"})
+
+    def test_enum_coercion_from_string(self) -> None:
+        data = {**_VALID_KWARGS, "quality_gate_result": "fail_deterministic"}
+        event = ModelEscalationEvent.model_validate(data)
+        assert event.quality_gate_result is EnumQualityGateResult.FAIL_DETERMINISTIC
+
+    def test_pass_verdict_is_valid(self) -> None:
+        event = ModelEscalationEvent(
+            **{**_VALID_KWARGS, "quality_gate_result": EnumQualityGateResult.PASS}
+        )
+        assert event.quality_gate_result is EnumQualityGateResult.PASS

--- a/tests/unit/models/delegation/test_model_escalation_event.py
+++ b/tests/unit/models/delegation/test_model_escalation_event.py
@@ -61,7 +61,7 @@ class TestModelEscalationEvent:
     def test_frozen(self) -> None:
         event = ModelEscalationEvent(**_VALID_KWARGS)
         with pytest.raises(Exception):
-            event.prior_model = "changed"  # type: ignore[misc]
+            event.prior_model = "changed"  # type: ignore[misc]  # NOTE(OMN-10617): Intentional mutation to assert frozen-model enforcement.
 
     def test_attempt_number_ge_1(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary

- Adds `EnumQualityGateResult` (`pass`, `fail_deterministic`, `fail_heuristic`) to `src/omnibase_core/enums/enum_quality_gate_result.py`
- Adds `ModelEscalationEvent` to `src/omnibase_core/models/delegation/model_escalation_event.py` — structured audit event emitted by the delegation orchestrator FSM on each model escalation
- `contract_version` uses `ModelSemVer`; `model_validator` enforces `attempt_number <= max_attempts`; frozen + `extra="forbid"` per repo standards
- Exports wired through `models/delegation/__init__.py`
- 15 unit tests covering validation, bounds enforcement, enum coercion, serialization round-trips

## Test plan

- [x] `uv run pytest tests/unit/models/delegation/test_model_escalation_event.py -v` — 15/15 passed
- [x] `uv run mypy src/omnibase_core/models/delegation/model_escalation_event.py --strict` — no issues
- [x] `uv run ruff format && ruff check --fix` — clean
- [x] `pre-commit run --all-files` — all hooks passed
- [x] Remote push hooks (mypy strict, pyright) — passed

OMN-10617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quality gate result tracking: New enum to classify quality gate verdicts as pass or fail (deterministic/heuristic).
  * Escalation event model: New data model to represent delegation escalation events with correlation IDs, model transitions, quality gate results, and attempt tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->