### PR TITLE
fix(OMN-10079): accept runtime target on dispatch bus commands

### DIFF
--- a/src/omnibase_core/models/dispatch/model_dispatch_bus_command.py
+++ b/src/omnibase_core/models/dispatch/model_dispatch_bus_command.py
@@ -47,6 +47,10 @@ class ModelDispatchBusCommand(BaseModel):
         le=600,
         description="Requested timeout for the broker round-trip.",
     )
+    target_runtime_address: str | None = Field(
+        default=None,
+        description="Optional runtime:// address selector for routed dispatch.",
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="UTC timestamp when the broker request was created.",

--- a/tests/unit/dispatch/test_dispatch_bus_client.py
+++ b/tests/unit/dispatch/test_dispatch_bus_client.py
@@ -49,6 +49,19 @@ def test_load_dispatch_bus_route_uses_contract_topics(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_dispatch_bus_command_accepts_target_runtime_address() -> None:
+    command = ModelDispatchBusCommand(
+        command_name="session_bootstrap",
+        requester="codex",
+        payload={"dry_run": True},
+        response_topic="onex.evt.omnimarket.pattern-b-dispatch-completed.v1",
+        target_runtime_address="runtime://omninode-pc/main",
+    )
+
+    assert command.target_runtime_address == "runtime://omninode-pc/main"
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_dispatch_bus_client_request_round_trips_on_inmemory_bus(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add optional target_runtime_address to ModelDispatchBusCommand
- keep the dispatch bus command compatible with Codex/market runtime requests that include runtime:// targeting

## Live proof
- On .201, the previous broker parse failure on target_runtime_address was cleared after applying the model field
- session_bootstrap then completed through the brokered Codex runtime adapter path

## Verification
- uv run pytest tests/unit/dispatch/test_dispatch_bus_client.py -q
- uv run ruff format src/omnibase_core/models/dispatch/model_dispatch_bus_command.py tests/unit/dispatch/test_dispatch_bus_client.py
- uv run ruff check --fix src/omnibase_core/models/dispatch/model_dispatch_bus_command.py tests/unit/dispatch/test_dispatch_bus_client.py
- git push hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch commands now support an optional target runtime address parameter, allowing commands to be selectively routed to and executed on specific runtime environments.

* **Tests**
  * Added unit test verifying the target runtime address field is correctly accepted and preserved on dispatch command instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->