### PR TITLE
fix(OMN-10602): guard check_suite fanout in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -56,26 +56,34 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr: ${{ steps.resolve.outputs.pr }}
+      actor: ${{ steps.resolve.outputs.actor }}
       skip: ${{ steps.resolve.outputs.skip }}
     steps:
-      - name: Resolve PR number without checkout
+      - name: Resolve PR number and author without checkout
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           PR_FROM_PAYLOAD: ${{ github.event.pull_request.number }}
+          PR_AUTHOR_FROM_PAYLOAD: ${{ github.event.pull_request.user.login }}
           PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
           CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
         run: |
           set -euo pipefail
           case "$EVENT_NAME" in
             pull_request|pull_request_review)
-              echo "pr=$PR_FROM_PAYLOAD" >> "$GITHUB_OUTPUT"
+              PR="$PR_FROM_PAYLOAD"
+              ACTOR="${PR_AUTHOR_FROM_PAYLOAD:-$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')}"
+              echo "pr=$PR" >> "$GITHUB_OUTPUT"
+              echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
               echo "skip=false" >> "$GITHUB_OUTPUT"
               ;;
             workflow_dispatch)
-              echo "pr=$PR_FROM_DISPATCH" >> "$GITHUB_OUTPUT"
+              PR="$PR_FROM_DISPATCH"
+              ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
+              echo "pr=$PR" >> "$GITHUB_OUTPUT"
+              echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
               echo "skip=false" >> "$GITHUB_OUTPUT"
               ;;
             check_suite)
@@ -93,8 +101,11 @@ jobs:
                 echo "check_suite has no PR targeting '$DEFAULT_BRANCH'; skipping"
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 echo "pr=" >> "$GITHUB_OUTPUT"
+                echo "actor=" >> "$GITHUB_OUTPUT"
               else
+                ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
                 echo "pr=$PR" >> "$GITHUB_OUTPUT"
+                echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
                 echo "skip=false" >> "$GITHUB_OUTPUT"
               fi
               ;;
@@ -102,13 +113,14 @@ jobs:
               echo "unsupported event: $EVENT_NAME; skipping"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "pr=" >> "$GITHUB_OUTPUT"
+              echo "actor=" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
   auto-merge:
     name: Enable Auto-Merge
     needs: pre-check
-    if: needs.pre-check.outputs.skip != 'true'
+    if: needs.pre-check.outputs.skip != 'true' && needs.pre-check.outputs.actor == 'jonahgabriel'
     runs-on: >-
       ${{
         github.event_name != 'pull_request'
@@ -126,28 +138,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Resolve PR author
-        id: resolve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ needs.pre-check.outputs.pr }}
-          PR_AUTHOR_FROM_PAYLOAD: ${{ github.event.pull_request.user.login }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-          # PR number already validated by pre-check; just resolve the author.
-          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_AUTHOR_FROM_PAYLOAD" ]; then
-            ACTOR="$PR_AUTHOR_FROM_PAYLOAD"
-          else
-            ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
-          fi
-          echo "pr=$PR" >> "$GITHUB_OUTPUT"
-          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
-
       - name: Resolve OCC main SHA
         id: occ_ref
-        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -160,7 +152,6 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Check out OCC evidence snapshot
-        if: steps.resolve.outputs.actor == 'jonahgabriel'
         uses: actions/checkout@v6
         with:
           repository: OmniNode-ai/onex_change_control
@@ -169,11 +160,10 @@ jobs:
           fetch-depth: 1
 
       - name: OCC auto-merge preflight
-        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR: ${{ steps.resolve.outputs.pr }}
+          PR: ${{ needs.pre-check.outputs.pr }}
         run: |
           set -euo pipefail
           pr_json="$(gh pr view "$PR" --repo "$GH_REPO" --json body,title,headRefName,commits)"
@@ -202,11 +192,10 @@ jobs:
             | tee /tmp/occ_auto_merge_preflight.json
 
       - name: Enable auto-merge
-        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR: ${{ steps.resolve.outputs.pr }}
+          PR: ${{ needs.pre-check.outputs.pr }}
         run: |
           set -euo pipefail
           # "already enqueued" race is benign — treat as success.
@@ -223,11 +212,10 @@ jobs:
           exit 1
 
       - name: Force enqueue to merge queue
-        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR: ${{ steps.resolve.outputs.pr }}
+          PR: ${{ needs.pre-check.outputs.pr }}
         run: |
           set -euo pipefail
           OWNER="${GH_REPO%/*}"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,15 @@
 # Arming auto-merge (gh pr merge --auto) is not the same as enqueuing —
 # the PR sits armed but idle until enqueuePullRequest is called. This was
 # the root cause of the #869 incident (1hr idle → ejected → manual rescue).
+#
+# OMN-10602: Guard check_suite fanout. check_suite fires on every CI run
+# completion (all workflows, all branches), flooding the Actions queue with
+# runs that immediately no-op because there is no PR context. The pre-check
+# job resolves the PR number cheaply (no checkout, no Python setup) and
+# outputs skip=true for suites with no associated PR or for non-default-branch
+# targets. The main job depends on pre-check and is skipped entirely when
+# skip=true. A concurrency group per PR cancels redundant queued runs so
+# only the most-recent check_suite completion for a given PR actually runs.
 name: Auto-Merge
 
 on:
@@ -34,9 +43,72 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  # One active run per PR (or per dispatch invocation). Cancels the queued
+  # run when a newer check_suite completion arrives for the same PR, keeping
+  # only the latest attempt in flight.
+  group: auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.check_suite.id }}
+  cancel-in-progress: true
+
 jobs:
+  pre-check:
+    name: Resolve PR (fanout guard)
+    runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.resolve.outputs.pr }}
+      skip: ${{ steps.resolve.outputs.skip }}
+    steps:
+      - name: Resolve PR number without checkout
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_FROM_PAYLOAD: ${{ github.event.pull_request.number }}
+          PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
+          CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request|pull_request_review)
+              echo "pr=$PR_FROM_PAYLOAD" >> "$GITHUB_OUTPUT"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_dispatch)
+              echo "pr=$PR_FROM_DISPATCH" >> "$GITHUB_OUTPUT"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+            check_suite)
+              DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+              PR=""
+              while IFS= read -r candidate_pr; do
+                [ -z "$candidate_pr" ] && continue
+                candidate_base="$(gh pr view "$candidate_pr" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
+                if [ "$candidate_base" = "$DEFAULT_BRANCH" ]; then
+                  PR="$candidate_pr"
+                  break
+                fi
+              done < <(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" then .[]?.number else empty end')
+              if [ -z "$PR" ]; then
+                echo "check_suite has no PR targeting '$DEFAULT_BRANCH'; skipping"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                echo "pr=" >> "$GITHUB_OUTPUT"
+              else
+                echo "pr=$PR" >> "$GITHUB_OUTPUT"
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "unsupported event: $EVENT_NAME; skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "pr=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   auto-merge:
     name: Enable Auto-Merge
+    needs: pre-check
+    if: needs.pre-check.outputs.skip != 'true'
     runs-on: >-
       ${{
         github.event_name != 'pull_request'
@@ -54,67 +126,28 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Resolve PR and author
+      - name: Resolve PR author
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_FROM_PAYLOAD: ${{ github.event.pull_request.number }}
-          PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
-          CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
+          PR: ${{ needs.pre-check.outputs.pr }}
           PR_AUTHOR_FROM_PAYLOAD: ${{ github.event.pull_request.user.login }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          case "$EVENT_NAME" in
-            pull_request|pull_request_review)
-              PR="$PR_FROM_PAYLOAD"
-              ACTOR="$PR_AUTHOR_FROM_PAYLOAD"
-              ;;
-            workflow_dispatch)
-              PR="$PR_FROM_DISPATCH"
-              ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
-              ;;
-            check_suite)
-              DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
-              PR=""
-              while IFS= read -r candidate_pr; do
-                [ -z "$candidate_pr" ] && continue
-                candidate_base="$(gh pr view "$candidate_pr" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
-                if [ "$candidate_base" = "$DEFAULT_BRANCH" ]; then
-                  PR="$candidate_pr"
-                  break
-                fi
-              done < <(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" then .[]?.number else empty end')
-              if [ -z "$PR" ]; then
-                echo "check_suite had no associated PR targeting '$DEFAULT_BRANCH'; nothing to do"
-                echo "skip=true" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
-              ;;
-            *)
-              echo "unsupported event: $EVENT_NAME"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-          BASE_REF="$(gh pr view "$PR" --repo "$GH_REPO" --json baseRefName --jq '.baseRefName')"
-          DEFAULT_BRANCH="${DEFAULT_BRANCH:-$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')}"
-          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
-            echo "PR #$PR targets '$BASE_REF', not default '$DEFAULT_BRANCH'; skipping auto-merge enrollment for stacked PR"
-            echo "pr=$PR" >> "$GITHUB_OUTPUT"
-            echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          # PR number already validated by pre-check; just resolve the author.
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_AUTHOR_FROM_PAYLOAD" ]; then
+            ACTOR="$PR_AUTHOR_FROM_PAYLOAD"
+          else
+            ACTOR="$(gh pr view "$PR" --repo "$GH_REPO" --json author --jq '.author.login')"
           fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
           echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Resolve OCC main SHA
         id: occ_ref
-        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -127,7 +160,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Check out OCC evidence snapshot
-        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        if: steps.resolve.outputs.actor == 'jonahgabriel'
         uses: actions/checkout@v6
         with:
           repository: OmniNode-ai/onex_change_control
@@ -136,7 +169,7 @@ jobs:
           fetch-depth: 1
 
       - name: OCC auto-merge preflight
-        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -169,7 +202,7 @@ jobs:
             | tee /tmp/occ_auto_merge_preflight.json
 
       - name: Enable auto-merge
-        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -190,7 +223,7 @@ jobs:
           exit 1
 
       - name: Force enqueue to merge queue
-        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        if: steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -47,7 +47,7 @@ concurrency:
   # One active run per PR (or per dispatch invocation). Cancels the queued
   # run when a newer check_suite completion arrives for the same PR, keeping
   # only the latest attempt in flight.
-  group: auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.check_suite.id }}
+  group: auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Evidence-Source: OCC#765
Evidence-Ticket: OMN-10602

## Summary

- OMN-10602: check_suite fires on every CI workflow completion, flooding the Actions queue
- Added lightweight pre-check job (no checkout, no Python/uv setup) that emits skip=true for suites with no PR context
- Added concurrency group per PR to cancel redundant queued runs

## What changed

.github/workflows/auto-merge.yml:
- New pre-check job: resolves PR number cheaply via gh CLI, emits skip output
- auto-merge job: depends on pre-check, guarded by if: needs.pre-check.outputs.skip != 'true'
- Simplified resolve step: PR number from pre-check, author-only lookup
- Added concurrency group: auto-merge per PR number or check_suite.id

## Other repos

This same check_suite pattern exists in omniclaude, omnibase_infra, and omnibase_spi — those repos should receive the same fix via separate tickets.

## Test plan

- Open a new PR → pre-check skip=false, auto-merge runs
- CI workflow completes with no PR context → pre-check skips, auto-merge job skipped entirely
- Multiple rapid check_suite completions → concurrency cancels all but latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved auto-merge workflow efficiency with enhanced pull request validation logic
  * Added concurrency controls to cancel redundant workflow runs
  * Refined merge queue error handling for increased reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->