### PR TITLE
fix(OMN-10650): remove lab paths from core checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,8 +143,7 @@ repos:
         name: Block planning docs (belong in omni_home/docs/plans/)
         entry: bash -c 'PLAN_FILES=$(git diff --cached --name-only -- "docs/plans/"); if [ -n "$PLAN_FILES"
           ]; then echo "ERROR - Planning docs must live in omni_home/docs/plans/, not in this repo"; echo
-          "$PLAN_FILES"; echo ""; echo "Move your file to /Volumes/PRO-G40/Code/omni_home/docs/plans/";
-          exit 1; fi'
+          "$PLAN_FILES"; echo ""; echo "Move your file to \$OMNI_HOME/docs/plans/"; exit 1; fi'
         language: system
         pass_filenames: false
         always_run: true

--- a/architecture-handshakes/install.sh
+++ b/architecture-handshakes/install.sh
@@ -67,7 +67,7 @@ usage() {
     echo ""
     echo "Examples:"
     echo "  $0 omnibase_core"
-    echo "  $0 omniclaude /Volumes/PRO-G40/Code/omniclaude"
+    echo "  $0 omniclaude /path/to/omniclaude"
 }
 
 log_success() { echo -e "${GREEN}✓${NC} $1"; }

--- a/tests/integration/models/agents/test_agent_yaml_validation.py
+++ b/tests/integration/models/agents/test_agent_yaml_validation.py
@@ -65,6 +65,7 @@ def agent_yaml_files() -> list[Path]:
     return get_agent_yaml_files()
 
 
+@pytest.mark.integration
 class TestAgentYAMLValidation:
     """Test that real agent YAML files validate against our models."""
 

--- a/tests/integration/models/agents/test_agent_yaml_validation.py
+++ b/tests/integration/models/agents/test_agent_yaml_validation.py
@@ -17,6 +17,7 @@ See OMN-1914 for the follow-up ticket to standardize all agent YAML files.
 The parametrized tests are marked as xfail until standardization is complete.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -24,10 +25,26 @@ import yaml
 
 from omnibase_core.models.agents import ModelAgentDefinition
 
-# Path to omniclaude agent configs (cross-repo reference)
-OMNICLAUDE_AGENTS_PATH = Path(
-    "/Volumes/PRO-G40/Code/omniclaude/plugins/onex/agents/configs"
-)
+
+def _resolve_omniclaude_agents_path() -> Path | None:
+    """Resolve the optional cross-repo omniclaude agents path from env."""
+    explicit_path = os.environ.get("OMNICLAUDE_AGENTS_PATH")
+    if explicit_path:
+        return Path(explicit_path)
+
+    omni_home = os.environ.get("OMNI_HOME")
+    if omni_home:
+        return Path(omni_home) / "omniclaude/plugins/onex/agents/configs"
+
+    return None
+
+
+# Optional cross-repo reference; tests skip when the path is not configured.
+OMNICLAUDE_AGENTS_PATH = _resolve_omniclaude_agents_path()
+
+
+def _omniclaude_agents_path_available() -> bool:
+    return OMNICLAUDE_AGENTS_PATH is not None and OMNICLAUDE_AGENTS_PATH.exists()
 
 
 def get_agent_yaml_files() -> list[Path]:
@@ -36,8 +53,9 @@ def get_agent_yaml_files() -> list[Path]:
     Returns:
         Sorted list of YAML file paths, empty if path doesn't exist.
     """
-    if not OMNICLAUDE_AGENTS_PATH.exists():
+    if not _omniclaude_agents_path_available():
         return []
+    assert OMNICLAUDE_AGENTS_PATH is not None
     return sorted(OMNICLAUDE_AGENTS_PATH.glob("*.yaml"))
 
 
@@ -51,17 +69,18 @@ class TestAgentYAMLValidation:
     """Test that real agent YAML files validate against our models."""
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     def test_omniclaude_agents_path_exists(self) -> None:
         """Verify omniclaude agents directory exists."""
+        assert OMNICLAUDE_AGENTS_PATH is not None
         assert OMNICLAUDE_AGENTS_PATH.exists()
         assert OMNICLAUDE_AGENTS_PATH.is_dir()
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     def test_agent_yaml_files_found(self, agent_yaml_files: list[Path]) -> None:
         """Verify we found agent YAML files."""
@@ -72,8 +91,8 @@ class TestAgentYAMLValidation:
         )
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     @pytest.mark.xfail(
         reason="OMN-1914: Agent YAMLs need standardization to match schema",
@@ -107,8 +126,8 @@ class TestAgentYAMLValidation:
         assert agent.agent_identity.description is not None
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     def test_validate_compliant_agents(self) -> None:
         """Test validation against agents known to be schema-compliant.
@@ -121,6 +140,7 @@ class TestAgentYAMLValidation:
             # Add more agents here as they become compliant (OMN-1914)
         ]
 
+        assert OMNICLAUDE_AGENTS_PATH is not None
         for agent_name in compliant_agents:
             yaml_path = OMNICLAUDE_AGENTS_PATH / agent_name
             if not yaml_path.exists():
@@ -133,11 +153,12 @@ class TestAgentYAMLValidation:
             assert agent.agent_identity.name is not None
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     def test_pr_review_agent_has_expected_structure(self) -> None:
         """Test that pr-review.yaml has expected structure."""
+        assert OMNICLAUDE_AGENTS_PATH is not None
         yaml_path = OMNICLAUDE_AGENTS_PATH / "pr-review.yaml"
         if not yaml_path.exists():
             pytest.skip("pr-review.yaml not found")
@@ -156,8 +177,8 @@ class TestAgentYAMLValidation:
         assert len(agent.capabilities.primary) > 0
 
     @pytest.mark.skipif(
-        not OMNICLAUDE_AGENTS_PATH.exists(),
-        reason="omniclaude agents path not available",
+        not _omniclaude_agents_path_available(),
+        reason="omniclaude agents path not configured or not available",
     )
     def test_all_agents_summary(self, agent_yaml_files: list[Path]) -> None:
         """Generate summary of all agent validations."""


### PR DESCRIPTION
## Summary
- remove lab-machine absolute paths from core validation checks and examples
- make the omniclaude agent config integration test resolve from `OMNICLAUDE_AGENTS_PATH` or `OMNI_HOME` instead of Jonah's local volume path
- keep the test skipped when the external config repo is not available

## Evidence
- Evidence-Source: OCC#797
- Evidence-Commit: a4b1518d163a3347d2eb931580697899bf9524a9

## Verification
- `rg -n "/Volumes/PRO-G40/Code/omniclaude|/Volumes/PRO-G40/Code/omni_home" tests/integration/models/agents/test_agent_yaml_validation.py .pre-commit-config.yaml architecture-handshakes/install.sh`
- `uv run pytest tests/integration/models/agents/test_agent_yaml_validation.py -q`
- `pre-commit run --files .pre-commit-config.yaml architecture-handshakes/install.sh tests/integration/models/agents/test_agent_yaml_validation.py`
- `git diff --check`
- `uv run validate-yaml contracts/OMN-10650.yaml` in onex_change_control#797
- `pre-commit run --files contracts/OMN-10650.yaml drift/dod_receipts/OMN-10650/dod-agent-yaml-tests/command.yaml drift/dod_receipts/OMN-10650/dod-precommit/command.yaml drift/dod_receipts/OMN-10650/dod-pr-1047-head/command.yaml drift/dod_receipts/OMN-10650/dod-occ-pr/command.yaml` in onex_change_control#797