### PR TITLE
feat(OMN-9743): add ModelPackageHookActivations envelope for hook_activations.yaml

### DIFF
--- a/src/omnibase_core/models/contracts/subcontracts/__init__.py
+++ b/src/omnibase_core/models/contracts/subcontracts/__init__.py
@@ -118,6 +118,7 @@ from .model_node_progress import ModelNodeProgress
 from .model_observability_subcontract import ModelObservabilitySubcontract
 from .model_operation_bindings import ModelOperationBindings
 from .model_operation_mapping import ModelOperationMapping
+from .model_package_hook_activations import ModelPackageHookActivations
 from .model_progress_status import ModelProgressStatus
 from .model_protocol_dependency import ModelProtocolDependency
 from .model_reply_topics import ModelReplyTopics
@@ -253,6 +254,7 @@ __all__ = [
     "ModelHealthCheckResult",
     "ModelHealthCheckSubcontract",
     "ModelHookActivation",
+    "ModelPackageHookActivations",
     "ModelNodeHealthStatus",
     # Introspection subcontracts
     "ModelIntrospectionSubcontract",

--- a/src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_hook_activation.py
@@ -21,7 +21,13 @@ class ModelHookActivation(BaseModel):
         if isinstance(v, EnumHookBit):
             return v
         if isinstance(v, str):
-            return EnumHookBit[v]
+            try:
+                return EnumHookBit[v]
+            except KeyError as exc:
+                raise ValueError(f"Cannot coerce {v!r} to EnumHookBit") from exc
         if isinstance(v, int):
-            return EnumHookBit(v)
+            try:
+                return EnumHookBit(v)
+            except ValueError as exc:
+                raise ValueError(f"Cannot coerce {v!r} to EnumHookBit") from exc
         raise ValueError(f"Cannot coerce {v!r} to EnumHookBit")

--- a/src/omnibase_core/models/contracts/subcontracts/model_package_hook_activations.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_package_hook_activations.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.subcontracts.model_hook_activation import (
+    ModelHookActivation,
+)
+
+
+class ModelPackageHookActivations(BaseModel):
+    """Envelope that <package>/contracts/hook_activations.yaml validates against."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    hook_activations: list[ModelHookActivation] = Field(default_factory=list)

--- a/tests/unit/models/contracts/test_model_package_hook_activations.py
+++ b/tests/unit/models/contracts/test_model_package_hook_activations.py
@@ -30,7 +30,7 @@ def test_package_hook_activations_defaults_to_empty() -> None:
 
 @pytest.mark.unit
 def test_package_hook_activations_rejects_unknown_bit() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="hook_bit"):
         ModelPackageHookActivations.model_validate(
             {
                 "hook_activations": [

--- a/tests/unit/models/contracts/test_model_package_hook_activations.py
+++ b/tests/unit/models/contracts/test_model_package_hook_activations.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from omnibase_core.enums.enum_hook_bit import EnumHookBit
+from omnibase_core.models.contracts.subcontracts.model_package_hook_activations import (
+    ModelPackageHookActivations,
+)
+
+
+@pytest.mark.unit
+def test_package_hook_activations_round_trips() -> None:
+    raw = {
+        "hook_activations": [
+            {"hook_bit": "CI_REMINDER", "enabled_by_default": True},
+            {"hook_bit": "AUTO_HOSTILE_REVIEW", "enabled_by_default": False},
+        ]
+    }
+    m = ModelPackageHookActivations.model_validate(raw)
+    assert len(m.hook_activations) == 2
+    assert m.hook_activations[0].hook_bit == EnumHookBit.CI_REMINDER
+
+
+@pytest.mark.unit
+def test_package_hook_activations_defaults_to_empty() -> None:
+    m = ModelPackageHookActivations.model_validate({})
+    assert m.hook_activations == []
+
+
+@pytest.mark.unit
+def test_package_hook_activations_rejects_unknown_bit() -> None:
+    with pytest.raises(Exception):
+        ModelPackageHookActivations.model_validate(
+            {
+                "hook_activations": [
+                    {"hook_bit": "DOES_NOT_EXIST", "enabled_by_default": True}
+                ]
+            }
+        )


### PR DESCRIPTION
## Summary

Adds `ModelPackageHookActivations` to `omnibase_core` as the envelope model for validating `<package>/contracts/hook_activations.yaml` via `model_validate()`.

- Creates `src/omnibase_core/models/contracts/subcontracts/model_package_hook_activations.py` — frozen Pydantic model wrapping `list[ModelHookActivation]` with `extra="forbid"` and `from_attributes=True`
- Wires the new model into `subcontracts/__init__.py` (import + `__all__`)
- Ships 3 unit tests: round-trip, empty-defaults, unknown-bit rejection

## Context

This is the Task 3 prerequisite for OMN-9743 (Track 1 Task 4 of parent epic OMN-9737: omniclaude restructure + contract-driven hook activation). `ModelPackageHookActivations` is the typed envelope that package-level `hook_activations.yaml` files validate against. It was absent from the codebase despite being referenced by the plan.

## Test plan

- [ ] `uv run pytest tests/unit/models/contracts/test_model_package_hook_activations.py -v` — 3 passed
- [ ] `uv run mypy src/omnibase_core/models/contracts/subcontracts/model_package_hook_activations.py --strict` — no issues
- [ ] `pre-commit run --all-files` — all hooks passed
- [ ] `ModelPackageHookActivations.model_validate({})` → `hook_activations == []`
- [ ] `ModelPackageHookActivations.model_validate({"hook_activations": [{"hook_bit": "CI_REMINDER", "enabled_by_default": True}]})` → `hook_activations[0].hook_bit == EnumHookBit.CI_REMINDER`
- [ ] Unknown `hook_bit` raises `ValidationError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating hook activation configurations in package contracts.

* **Tests**
  * Added unit tests for hook activation validation, covering default behavior and input validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Evidence

Evidence-Source: OCC#828
Evidence-Ticket: OMN-9743