### PR TITLE
feat(OMN-10691): add ADR extraction domain models to omnibase_core

### DIFF
--- a/src/omnibase_core/enums/adr/__init__.py
+++ b/src/omnibase_core/enums/adr/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ADR extraction enums."""
+
+from omnibase_core.enums.adr.enum_decision_type import EnumDecisionType
+from omnibase_core.enums.adr.enum_segment_type import EnumSegmentType
+from omnibase_core.enums.adr.enum_usage_source import EnumUsageSource
+
+__all__ = [
+    "EnumDecisionType",
+    "EnumSegmentType",
+    "EnumUsageSource",
+]

--- a/src/omnibase_core/enums/adr/enum_decision_type.py
+++ b/src/omnibase_core/enums/adr/enum_decision_type.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Decision type enum for ADR extraction (OMN-10691)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumDecisionType(StrValueHelper, str, Enum):
+    """Classifies the type of architectural decision extracted."""
+
+    ARCHITECTURE_DECISION = "architecture_decision"
+    ARCHITECTURE_PIVOT = "architecture_pivot"
+    DOCTRINE_FORMATION = "doctrine_formation"
+    OPERATIONAL_LESSON = "operational_lesson"
+    SUPERSESSION = "supersession"
+    REJECTED_APPROACH = "rejected_approach"

--- a/src/omnibase_core/enums/adr/enum_segment_type.py
+++ b/src/omnibase_core/enums/adr/enum_segment_type.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Segment type enum for ADR document segmentation (OMN-10691)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumSegmentType(StrValueHelper, str, Enum):
+    """Classifies the semantic role of a document segment."""
+
+    DECISION = "decision"
+    CRITIQUE = "critique"
+    PROPOSAL = "proposal"
+    MIGRATION = "migration"
+    INVARIANT = "invariant"
+    FAILURE_ANALYSIS = "failure_analysis"
+    OPERATIONAL_CONCERN = "operational_concern"
+    HYPOTHESIS = "hypothesis"
+    DOCTRINE_FORMATION = "doctrine_formation"
+    IMPLEMENTATION_DETAIL = "implementation_detail"
+    ARCHITECTURAL_RISK = "architectural_risk"
+    NON_DECISION = "non_decision"
+    BACKGROUND = "background"
+    UNKNOWN = "unknown"

--- a/src/omnibase_core/enums/adr/enum_usage_source.py
+++ b/src/omnibase_core/enums/adr/enum_usage_source.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Usage source enum for LLM call evidence (OMN-10691)."""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumUsageSource(StrValueHelper, str, Enum):
+    """Indicates whether token usage was measured, estimated, or unknown."""
+
+    MEASURED = "MEASURED"
+    ESTIMATED = "ESTIMATED"
+    UNKNOWN = "UNKNOWN"

--- a/src/omnibase_core/models/adr/__init__.py
+++ b/src/omnibase_core/models/adr/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ADR extraction domain models (OMN-10691)."""
+
+from omnibase_core.models.adr.model_adr_draft import ModelADRDraft
+from omnibase_core.models.adr.model_adr_extraction_metadata import (
+    ModelADRExtractionMetadata,
+)
+from omnibase_core.models.adr.model_canary_result import ModelCanaryResult
+from omnibase_core.models.adr.model_decision_extraction import ModelDecisionExtraction
+from omnibase_core.models.adr.model_document_segment import ModelDocumentSegment
+from omnibase_core.models.adr.model_extraction_score import ModelExtractionScore
+from omnibase_core.models.adr.model_llm_call_evidence import ModelLLMCallEvidence
+
+__all__ = [
+    "ModelADRDraft",
+    "ModelADRExtractionMetadata",
+    "ModelCanaryResult",
+    "ModelDecisionExtraction",
+    "ModelDocumentSegment",
+    "ModelExtractionScore",
+    "ModelLLMCallEvidence",
+]

--- a/src/omnibase_core/models/adr/model_adr_draft.py
+++ b/src/omnibase_core/models/adr/model_adr_draft.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ADR draft model produced by the extraction pipeline (OMN-10691)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.adr.model_adr_extraction_metadata import (
+    ModelADRExtractionMetadata,
+)
+
+
+class ModelADRDraft(BaseModel):
+    """A proposed ADR in Proposed state, ready for human review."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    status: Literal["Proposed"] = Field(
+        default="Proposed", description="Always 'Proposed'"
+    )
+    date: datetime = Field(description="Date the draft was generated")
+    title: str = Field(description="ADR title")
+    context: str = Field(description="Context and problem statement")
+    decision: str = Field(description="The decision that was made")
+    consequences: str = Field(description="Consequences of the decision")
+    alternatives_considered: list[str] = Field(
+        default_factory=list, description="Alternatives that were evaluated"
+    )
+    supersedes: list[str] = Field(
+        default_factory=list, description="IDs of superseded ADRs"
+    )
+    source_evidence: list[str] = Field(
+        default_factory=list, description="Segment IDs providing evidence"
+    )
+    extraction_metadata: ModelADRExtractionMetadata = Field(
+        description="Provenance metadata from the extraction pipeline"
+    )
+
+
+__all__ = ["ModelADRDraft"]

--- a/src/omnibase_core/models/adr/model_adr_extraction_metadata.py
+++ b/src/omnibase_core/models/adr/model_adr_extraction_metadata.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ADR extraction metadata model capturing LLM provenance (OMN-10691)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelADRExtractionMetadata(BaseModel):
+    """Metadata capturing the provenance of an ADR draft."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    model_id: str = Field(  # string-id-ok: LLM model name identifier, not a UUID
+        description="LLM model ID used for extraction"
+    )
+    confidence: float = Field(ge=0.0, le=1.0, description="Extraction confidence score")
+    pipeline_version: str = Field(  # string-version-ok: pipeline semver string
+        description="ADR extraction pipeline version"
+    )
+    # string-id-ok: template name identifier, not a UUID
+    prompt_template_id: str = Field(description="Prompt template identifier")
+    prompt_template_version: str = Field(  # string-version-ok: template semver string
+        description="Prompt template version"
+    )
+    canary_run_id: str = Field(  # string-id-ok: canary run name/slug, not a UUID
+        description="Canary run identifier"
+    )
+    extracted_at: datetime = Field(description="Timestamp of extraction")
+
+
+__all__ = ["ModelADRExtractionMetadata"]

--- a/src/omnibase_core/models/adr/model_canary_result.py
+++ b/src/omnibase_core/models/adr/model_canary_result.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canary run result aggregating per-model scores (OMN-10691)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.adr.model_extraction_score import ModelExtractionScore
+
+
+class ModelCanaryResult(BaseModel):
+    """Aggregated result from a canary extraction run over one ground-truth ADR."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ground_truth_adr_path: str = Field(
+        description="Path to the ground-truth ADR document"
+    )
+    source_doc_paths: list[str] = Field(
+        default_factory=list, description="Source documents used as input"
+    )
+    model_scores: dict[str, ModelExtractionScore] = Field(
+        default_factory=dict,
+        description="Per-model extraction scores keyed by model_id",
+    )
+    best_model_id: str | None = Field(  # string-id-ok: LLM model name, not a UUID
+        default=None, description="Model ID with the highest overall_score"
+    )
+    cost_summary: dict[str, object] = Field(
+        default_factory=dict, description="Cost breakdown by model and total"
+    )
+
+
+__all__ = ["ModelCanaryResult"]

--- a/src/omnibase_core/models/adr/model_decision_extraction.py
+++ b/src/omnibase_core/models/adr/model_decision_extraction.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Decision extraction model for ADR extraction pipeline (OMN-10691)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.adr.enum_decision_type import EnumDecisionType
+
+
+class ModelDecisionExtraction(BaseModel):
+    """An architectural decision extracted from one or more document segments.
+
+    extraction_id is deterministic: sha256(extraction_version + model_id
+    + sorted(source_segment_ids) + sorted(segment_content_hashes)).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # string-id-ok: deterministic sha256 hex digest, not a UUID
+    extraction_id: str = Field(
+        default="", description="Deterministic sha256 extraction identifier"
+    )
+    decision_type: EnumDecisionType = Field(
+        description="Classification of the decision"
+    )
+    title: str = Field(description="Short human-readable decision title")
+    confidence: float = Field(ge=0.0, le=1.0, description="Extraction confidence score")
+    rationale: list[str] = Field(
+        default_factory=list, description="Supporting rationale statements"
+    )
+    subsystems: list[str] = Field(
+        default_factory=list, description="Affected subsystems"
+    )
+    supersedes: list[str] = Field(
+        default_factory=list, description="IDs of superseded decisions"
+    )
+    alternatives_considered: list[str] = Field(
+        default_factory=list, description="Alternatives that were evaluated"
+    )
+    source_segment_ids: list[str] = Field(description="Segment IDs used as evidence")
+    segment_content_hashes: list[str] = Field(
+        description="Content hashes of source segments"
+    )
+    extraction_model_id: str = Field(  # string-id-ok: LLM model name, not a UUID
+        description="LLM model ID used for extraction"
+    )
+    extraction_version: str = Field(  # string-version-ok: pipeline semver string
+        description="Extraction pipeline version"
+    )
+    # string-id-ok: template name identifier, not a UUID
+    prompt_template_id: str = Field(description="Prompt template identifier")
+    prompt_template_version: str = Field(  # string-version-ok: template semver string
+        description="Prompt template version"
+    )
+    extracted_at: datetime = Field(description="Timestamp of extraction")
+
+    @model_validator(mode="after")
+    def _compute_extraction_id(self) -> ModelDecisionExtraction:
+        if not self.extraction_id:
+            sorted_ids = sorted(self.source_segment_ids)
+            sorted_hashes = sorted(self.segment_content_hashes)
+            raw = (
+                f"{self.extraction_version}"
+                f"{self.extraction_model_id}"
+                f"{''.join(sorted_ids)}"
+                f"{''.join(sorted_hashes)}"
+            )
+            computed = hashlib.sha256(raw.encode()).hexdigest()
+            object.__setattr__(self, "extraction_id", computed)
+        return self
+
+
+__all__ = ["ModelDecisionExtraction"]

--- a/src/omnibase_core/models/adr/model_document_segment.py
+++ b/src/omnibase_core/models/adr/model_document_segment.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Document segment model for ADR extraction pipeline (OMN-10691)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.adr.enum_segment_type import EnumSegmentType
+
+
+class ModelDocumentSegment(BaseModel):
+    """A bounded region of source text with a classified semantic role.
+
+    segment_id is deterministic: sha256(source_path + source_content_sha256
+    + start_line + end_line + segment_type).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # string-id-ok: deterministic sha256 hex digest, not a UUID
+    segment_id: str = Field(
+        default="", description="Deterministic sha256 segment identifier"
+    )
+    source_path: str = Field(description="Repo-relative path to the source document")
+    segment_type: EnumSegmentType = Field(
+        description="Semantic classification of this segment"
+    )
+    content: str = Field(description="Raw text content of the segment")
+    source_content_sha256: str = Field(
+        description="SHA256 of the entire source document"
+    )
+    segment_content_sha256: str = Field(description="SHA256 of this segment's content")
+    start_line: int = Field(ge=1, description="1-based start line in source document")
+    end_line: int = Field(ge=1, description="1-based end line in source document")
+    git_sha: str = Field(description="Git commit SHA at extraction time")
+    created_at: datetime = Field(description="Timestamp when segment was first created")
+    updated_at: datetime = Field(description="Timestamp when segment was last updated")
+    subsystems: list[str] = Field(default_factory=list, description="Subsystem tags")
+    tags: list[str] = Field(default_factory=list, description="Freeform tags")
+
+    @model_validator(mode="after")
+    def _compute_segment_id(self) -> ModelDocumentSegment:
+        if not self.segment_id:
+            raw = (
+                f"{self.source_path}"
+                f"{self.source_content_sha256}"
+                f"{self.start_line}"
+                f"{self.end_line}"
+                f"{self.segment_type.value}"
+            )
+            computed = hashlib.sha256(raw.encode()).hexdigest()
+            object.__setattr__(self, "segment_id", computed)
+        return self
+
+
+__all__ = ["ModelDocumentSegment"]

--- a/src/omnibase_core/models/adr/model_extraction_score.py
+++ b/src/omnibase_core/models/adr/model_extraction_score.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Extraction quality score for a single model run (OMN-10691)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelExtractionScore(BaseModel):
+    """Quality scores for one model's ADR extraction attempt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # string-id-ok: LLM model name, not a UUID
+    model_id: str = Field(description="LLM model identifier")
+    recall: float = Field(
+        ge=0.0, le=1.0, description="Fraction of ground-truth decisions found"
+    )
+    precision: float = Field(
+        ge=0.0, le=1.0, description="Fraction of extractions that are correct"
+    )
+    fidelity: float = Field(ge=0.0, le=1.0, description="Faithfulness to source text")
+    format_compliance: float = Field(
+        ge=0.0, le=1.0, description="ADR format compliance score"
+    )
+    consensus_agreement: float = Field(
+        ge=0.0, le=1.0, description="Agreement with other model outputs"
+    )
+    overall_score: float = Field(ge=0.0, le=1.0, description="Weighted composite score")
+    success: bool = Field(
+        description="Whether extraction completed without fatal error"
+    )
+    error_code: str | None = Field(
+        default=None, description="Error code if not successful"
+    )
+    error_message: str | None = Field(
+        default=None, description="Error message if not successful"
+    )
+
+
+__all__ = ["ModelExtractionScore"]

--- a/src/omnibase_core/models/adr/model_llm_call_evidence.py
+++ b/src/omnibase_core/models/adr/model_llm_call_evidence.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""LLM call evidence model for audit and cost tracking (OMN-10691)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.adr.enum_usage_source import EnumUsageSource
+
+
+class ModelLLMCallEvidence(BaseModel):
+    """Durable record of a single LLM inference call with cost and provenance."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    model_id: str = Field(  # string-id-ok: LLM model name, not a UUID
+        description="LLM model identifier"
+    )
+    provider: str = Field(
+        description="Inference provider (e.g., vllm_local, openrouter)"
+    )
+    # string-id-ok: template name identifier, not a UUID
+    prompt_template_id: str = Field(description="Prompt template identifier")
+    prompt_template_version: str = Field(  # string-version-ok: template semver string
+        description="Prompt template version"
+    )
+    prompt_hash: str = Field(description="SHA256 of the rendered prompt")
+    input_hash: str = Field(description="SHA256 of the full input payload")
+    request_timestamp: datetime = Field(
+        description="UTC timestamp when request was sent"
+    )
+    response_hash: str = Field(description="SHA256 of the raw response body")
+    raw_response_path: str | None = Field(
+        default=None, description="Optional path to persisted raw response file"
+    )
+    usage_source: EnumUsageSource = Field(
+        description="Whether token counts were measured, estimated, or unknown"
+    )
+    prompt_tokens: int | None = Field(default=None, description="Prompt token count")
+    completion_tokens: int | None = Field(
+        default=None, description="Completion token count"
+    )
+    total_tokens: int | None = Field(default=None, description="Total token count")
+    estimated_cost_usd: float | None = Field(
+        default=None, description="Estimated cost in USD"
+    )
+    # string-version-ok: manifest semver string
+    pricing_manifest_version: str | None = Field(
+        default=None, description="Version of the pricing manifest used"
+    )
+    error_state: str | None = Field(
+        default=None, description="Error code if call failed"
+    )
+    success: bool = Field(description="Whether the call completed successfully")
+
+
+__all__ = ["ModelLLMCallEvidence"]

--- a/tests/models/adr/__init__.py
+++ b/tests/models/adr/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/models/adr/test_adr_models.py
+++ b/tests/models/adr/test_adr_models.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for ADR extraction domain models (OMN-10691)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.enums.adr.enum_decision_type import EnumDecisionType
+from omnibase_core.enums.adr.enum_segment_type import EnumSegmentType
+from omnibase_core.enums.adr.enum_usage_source import EnumUsageSource
+from omnibase_core.models.adr.model_adr_draft import ModelADRDraft
+from omnibase_core.models.adr.model_canary_result import ModelCanaryResult
+from omnibase_core.models.adr.model_decision_extraction import ModelDecisionExtraction
+from omnibase_core.models.adr.model_document_segment import ModelDocumentSegment
+from omnibase_core.models.adr.model_extraction_score import ModelExtractionScore
+from omnibase_core.models.adr.model_llm_call_evidence import ModelLLMCallEvidence
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+
+# --- EnumSegmentType ---
+
+
+def test_enum_segment_type_members() -> None:
+    expected = {
+        "decision",
+        "critique",
+        "proposal",
+        "migration",
+        "invariant",
+        "failure_analysis",
+        "operational_concern",
+        "hypothesis",
+        "doctrine_formation",
+        "implementation_detail",
+        "architectural_risk",
+        "non_decision",
+        "background",
+        "unknown",
+    }
+    assert {v.value for v in EnumSegmentType} == expected
+
+
+def test_enum_segment_type_is_str() -> None:
+    assert isinstance(EnumSegmentType.DECISION, str)
+    assert EnumSegmentType.DECISION.value == "decision"
+
+
+# --- EnumDecisionType ---
+
+
+def test_enum_decision_type_members() -> None:
+    expected = {
+        "architecture_decision",
+        "architecture_pivot",
+        "doctrine_formation",
+        "operational_lesson",
+        "supersession",
+        "rejected_approach",
+    }
+    assert {v.value for v in EnumDecisionType} == expected
+
+
+# --- EnumUsageSource ---
+
+
+def test_enum_usage_source_members() -> None:
+    expected = {"MEASURED", "ESTIMATED", "UNKNOWN"}
+    assert {v.value for v in EnumUsageSource} == expected
+
+
+# --- ModelDocumentSegment ---
+
+
+def _make_segment(**overrides: object) -> ModelDocumentSegment:
+    defaults: dict[str, object] = {
+        "source_path": "docs/adr/001.md",
+        "segment_type": EnumSegmentType.DECISION,
+        "content": "We decided to use Pydantic for models.",
+        "source_content_sha256": "a" * 64,
+        "segment_content_sha256": "b" * 64,
+        "start_line": 1,
+        "end_line": 10,
+        "git_sha": "abc123",
+        "created_at": NOW,
+        "updated_at": NOW,
+        "subsystems": ["core"],
+        "tags": ["pydantic"],
+    }
+    defaults.update(overrides)
+    return ModelDocumentSegment(**defaults)  # type: ignore[arg-type]
+
+
+def test_document_segment_deterministic_id() -> None:
+    seg = _make_segment()
+    raw = f"{seg.source_path}{seg.source_content_sha256}{seg.start_line}{seg.end_line}{seg.segment_type.value}"
+    expected = hashlib.sha256(raw.encode()).hexdigest()
+    assert seg.segment_id == expected
+
+
+def test_document_segment_frozen() -> None:
+    seg = _make_segment()
+    with pytest.raises(Exception):
+        seg.content = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+def test_document_segment_extra_forbid() -> None:
+    with pytest.raises(Exception):
+        _make_segment(unknown_field="bad")  # type: ignore[call-overload]
+
+
+def test_document_segment_default_lists() -> None:
+    seg = _make_segment(subsystems=[], tags=[])
+    assert seg.subsystems == []
+    assert seg.tags == []
+
+
+# --- ModelDecisionExtraction ---
+
+
+def _make_extraction(**overrides: object) -> ModelDecisionExtraction:
+    defaults: dict[str, object] = {
+        "decision_type": EnumDecisionType.ARCHITECTURE_DECISION,
+        "title": "Use Pydantic for models",
+        "confidence": 0.9,
+        "rationale": ["Type safety", "Validation"],
+        "subsystems": ["core"],
+        "supersedes": [],
+        "alternatives_considered": ["dataclass", "attrs"],
+        "source_segment_ids": ["seg1", "seg2"],
+        "segment_content_hashes": ["hash1", "hash2"],
+        "extraction_model_id": "qwen3-30b",
+        "extraction_version": "1.0.0",
+        "prompt_template_id": "extract_v1",
+        "prompt_template_version": "1",
+        "extracted_at": NOW,
+    }
+    defaults.update(overrides)
+    return ModelDecisionExtraction(**defaults)  # type: ignore[arg-type]
+
+
+def test_decision_extraction_deterministic_id() -> None:
+    ext = _make_extraction()
+    sorted_ids = sorted(ext.source_segment_ids)
+    sorted_hashes = sorted(ext.segment_content_hashes)
+    raw = f"{ext.extraction_version}{ext.extraction_model_id}{''.join(sorted_ids)}{''.join(sorted_hashes)}"
+    expected = hashlib.sha256(raw.encode()).hexdigest()
+    assert ext.extraction_id == expected
+
+
+def test_decision_extraction_confidence_bounds() -> None:
+    with pytest.raises(Exception):
+        _make_extraction(confidence=1.1)
+    with pytest.raises(Exception):
+        _make_extraction(confidence=-0.1)
+
+
+def test_decision_extraction_frozen() -> None:
+    ext = _make_extraction()
+    with pytest.raises(Exception):
+        ext.title = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+# --- ModelADRDraft ---
+
+
+def _make_adr_draft(**overrides: object) -> ModelADRDraft:
+    defaults: dict[str, object] = {
+        "date": NOW,
+        "title": "Use Pydantic for models",
+        "context": "We need a validation library.",
+        "decision": "We will use Pydantic.",
+        "consequences": "Strong typing throughout.",
+        "alternatives_considered": ["dataclass"],
+        "supersedes": [],
+        "source_evidence": ["seg1"],
+        "extraction_metadata": {
+            "model_id": "qwen3-30b",
+            "confidence": 0.9,
+            "pipeline_version": "1.0.0",
+            "prompt_template_id": "extract_v1",
+            "prompt_template_version": "1",
+            "canary_run_id": "run-001",
+            "extracted_at": NOW,
+        },
+    }
+    defaults.update(overrides)
+    return ModelADRDraft(**defaults)  # type: ignore[arg-type]
+
+
+def test_adr_draft_status_always_proposed() -> None:
+    draft = _make_adr_draft()
+    assert draft.status == "Proposed"
+
+
+def test_adr_draft_frozen() -> None:
+    draft = _make_adr_draft()
+    with pytest.raises(Exception):
+        draft.title = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+def test_adr_draft_date_is_datetime() -> None:
+    draft = _make_adr_draft()
+    assert isinstance(draft.date, datetime)
+
+
+# --- ModelExtractionScore ---
+
+
+def _make_score(**overrides: object) -> ModelExtractionScore:
+    defaults: dict[str, object] = {
+        "model_id": "qwen3-30b",
+        "recall": 0.8,
+        "precision": 0.9,
+        "fidelity": 0.85,
+        "format_compliance": 1.0,
+        "consensus_agreement": 0.75,
+        "overall_score": 0.86,
+        "success": True,
+        "error_code": None,
+        "error_message": None,
+    }
+    defaults.update(overrides)
+    return ModelExtractionScore(**defaults)  # type: ignore[arg-type]
+
+
+def test_extraction_score_frozen() -> None:
+    score = _make_score()
+    with pytest.raises(Exception):
+        score.model_id = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+def test_extraction_score_float_bounds() -> None:
+    with pytest.raises(Exception):
+        _make_score(recall=1.1)
+    with pytest.raises(Exception):
+        _make_score(overall_score=-0.1)
+
+
+def test_extraction_score_error_fields_nullable() -> None:
+    score = _make_score(
+        success=False, error_code="LLM_TIMEOUT", error_message="timed out"
+    )
+    assert score.error_code == "LLM_TIMEOUT"
+    assert score.success is False
+
+
+# --- ModelCanaryResult ---
+
+
+def test_canary_result_frozen() -> None:
+    score = _make_score()
+    result = ModelCanaryResult(
+        ground_truth_adr_path="docs/adr/001.md",
+        source_doc_paths=["docs/decisions.md"],
+        model_scores={"qwen3-30b": score},
+        best_model_id="qwen3-30b",
+        cost_summary={"total_usd": 0.42},
+    )
+    with pytest.raises(Exception):
+        result.best_model_id = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+def test_canary_result_empty_scores() -> None:
+    result = ModelCanaryResult(
+        ground_truth_adr_path="docs/adr/001.md",
+        source_doc_paths=[],
+        model_scores={},
+        best_model_id=None,
+        cost_summary={},
+    )
+    assert result.model_scores == {}
+    assert result.best_model_id is None
+
+
+# --- ModelLLMCallEvidence ---
+
+
+def _make_llm_evidence(**overrides: object) -> ModelLLMCallEvidence:
+    defaults: dict[str, object] = {
+        "model_id": "qwen3-30b",
+        "provider": "vllm_local",
+        "prompt_template_id": "extract_v1",
+        "prompt_template_version": "1",
+        "prompt_hash": "p" * 64,
+        "input_hash": "i" * 64,
+        "request_timestamp": NOW,
+        "response_hash": "r" * 64,
+        "raw_response_path": None,
+        "usage_source": EnumUsageSource.MEASURED,
+        "prompt_tokens": 512,
+        "completion_tokens": 256,
+        "total_tokens": 768,
+        "estimated_cost_usd": 0.001,
+        "pricing_manifest_version": "v1",
+        "error_state": None,
+        "success": True,
+    }
+    defaults.update(overrides)
+    return ModelLLMCallEvidence(**defaults)  # type: ignore[arg-type]
+
+
+def test_llm_call_evidence_frozen() -> None:
+    ev = _make_llm_evidence()
+    with pytest.raises(Exception):
+        ev.model_id = "mutated"  # type: ignore[misc,unused-ignore]
+
+
+def test_llm_call_evidence_nullable_fields() -> None:
+    ev = _make_llm_evidence(
+        prompt_tokens=None,
+        completion_tokens=None,
+        total_tokens=None,
+        estimated_cost_usd=None,
+        pricing_manifest_version=None,
+        raw_response_path=None,
+        error_state="LLM_TIMEOUT",
+        success=False,
+    )
+    assert ev.prompt_tokens is None
+    assert ev.success is False
+    assert ev.error_state == "LLM_TIMEOUT"
+
+
+def test_llm_call_evidence_usage_source_estimated() -> None:
+    ev = _make_llm_evidence(usage_source=EnumUsageSource.ESTIMATED)
+    assert ev.usage_source == EnumUsageSource.ESTIMATED
+
+
+def test_llm_call_evidence_request_timestamp_is_datetime() -> None:
+    ev = _make_llm_evidence()
+    assert isinstance(ev.request_timestamp, datetime)


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_core/models/adr/` with 6 frozen Pydantic models for the ADR canary extraction pipeline
- Adds `src/omnibase_core/enums/adr/` with 3 enums (EnumSegmentType×14, EnumDecisionType×6, EnumUsageSource×3)
- 23 unit tests covering frozen invariants, deterministic ID computation, confidence bounds, and nullable field behavior

## Models

| Model | Key invariant |
|---|---|
| `ModelDocumentSegment` | `segment_id` = sha256(source_path+source_content_sha256+start_line+end_line+segment_type) |
| `ModelDecisionExtraction` | `extraction_id` = sha256(extraction_version+model_id+sorted(segment_ids)+sorted(hashes)) |
| `ModelADRDraft` | `status` always `"Proposed"` |
| `ModelADRExtractionMetadata` | LLM provenance (model_id, confidence, pipeline_version, prompt_template) |
| `ModelExtractionScore` | recall/precision/fidelity/consensus all `float[0,1]` |
| `ModelCanaryResult` | per-model score dict keyed by model_id |
| `ModelLLMCallEvidence` | usage_source: MEASURED/ESTIMATED/UNKNOWN, full token/cost accounting |

All models: `ConfigDict(frozen=True, extra="forbid", from_attributes=True)`. All timestamps: `datetime` not `str`.

## Test plan

- [x] `uv run pytest tests/models/adr/ -v` — 23/23 passing
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Remote push hooks: mypy --strict, pyright — pass
- [x] `gh pr checks` to watch CI

## OMN-10691

dod_evidence:
  - type: test_pass
    description: 23 unit tests covering all 6 models and 3 enums
  - type: pre_commit_pass
    description: All pre-commit hooks pass including ONEX validators

Evidence-Source: OCC#822
Evidence-Ticket: OMN-10691