### PR TITLE
feat(OMN-10688): AST-based contract-config compliance validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,52 @@ jobs:
           echo "- ENUM_003: Detect duplicate enum values across files (warn-only)" >> $GITHUB_STEP_SUMMARY
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Contract-config compliance validator (OMN-10688)
+  contract-config-compliance:
+    name: Contract-Config Compliance (OMN-10688)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run contract-config compliance validator
+        run: uv run python -m omnibase_core.validators.contract_config_compliance src/omnibase_core/
+        # CI runners don't have ambient PYTHONPATH; runs cleanly without env -u PYTHONPATH
+
+      - name: Contract-config compliance summary
+        if: always()
+        run: |
+          echo "## Contract-Config Compliance (OMN-10688)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Validates three anti-patterns in handler and script files:" >> $GITHUB_STEP_SUMMARY
+          echo "- bare_env_read: handler reads env vars not in INFRA_ALLOWLIST without contract declaration" >> $GITHUB_STEP_SUMMARY
+          echo "- bus_bypass_import: scripts import directly from nodes/*/handlers/ (bypasses event bus)" >> $GITHUB_STEP_SUMMARY
+          echo "- missing_contract_config: handler env reads with no matching contract.yaml entry" >> $GITHUB_STEP_SUMMARY
+
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Baseline security scan using detect-secrets (OMN-2226)
   # Uses detect-secrets-hook for proper baseline comparison (handles type+hash equality)
   detect-secrets:
@@ -779,7 +825,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance]
     if: always()
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,7 +618,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run contract-config compliance validator
-        run: uv run python -m omnibase_core.validators.contract_config_compliance src/omnibase_core/
+        run: uv run python -m omnibase_core.validators.contract_config_compliance src/omnibase_core/ scripts/
         # CI runners don't have ambient PYTHONPATH; runs cleanly without env -u PYTHONPATH
 
       - name: Contract-config compliance summary
@@ -845,6 +845,7 @@ jobs:
           enum_gov="${{ needs.enum-governance.result }}"
           secrets="${{ needs.detect-secrets.result }}"
           sdk_boundary="${{ needs.sdk-boundary-check.result }}"
+          contract_config="${{ needs.contract-config-compliance.result }}"
 
           # Report each check
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
@@ -860,6 +861,7 @@ jobs:
           echo "| Enum Governance | $enum_gov |" >> $GITHUB_STEP_SUMMARY
           echo "| Detect Secrets | $secrets |" >> $GITHUB_STEP_SUMMARY
           echo "| SDK Boundary Guard | $sdk_boundary |" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract-Config Compliance | $contract_config |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
           # node-purity-check is NOT evaluated by this gate (continue-on-error until tech debt resolved)
@@ -872,7 +874,8 @@ jobs:
              [[ "$docs" == "success" ]] && \
              [[ "$enum_gov" == "success" ]] && \
              [[ "$secrets" == "success" ]] && \
-             [[ "$sdk_boundary" == "success" ]]; then
+             [[ "$sdk_boundary" == "success" ]] && \
+             [[ "$contract_config" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY
             echo "All quality checks passed."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -299,7 +299,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 
@@ -427,6 +427,17 @@ repos:
         pass_filenames: true
         files: ^src/.*\.py$
         exclude: ^(tests/|archived/|archive/|scripts/validation/).*\.py$
+        stages: [pre-commit]
+
+      # Contract-config compliance (OMN-10688)
+      # Blocks bare env reads, bus-bypass imports, and undeclared env vars in handlers.
+      # Suppress a line with: # contract-config-ok: <reason>
+      - id: contract-config-compliance
+        name: Contract-Config Compliance (OMN-10688)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.validators.contract_config_compliance
+        language: system
+        pass_filenames: false
+        always_run: true
         stages: [pre-commit]
 
       # SPDX Header Requirement

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -94,4 +94,5 @@ adjacency:
   tools: {reverse_deps: []}
   types: {reverse_deps: [models]}
   utils: {reverse_deps: []}
+  validators: {reverse_deps: []}
   workflows: {reverse_deps: [nodes]}

--- a/src/omnibase_core/models/validation/model_contract_config_compliance_finding.py
+++ b/src/omnibase_core/models/validation/model_contract_config_compliance_finding.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""ContractConfigFinding — single finding from the contract-config compliance validator."""
+"""ModelContractConfigComplianceFinding — finding from the contract-config compliance validator."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 @dataclass(frozen=True, slots=True)
-class ContractConfigFinding:
+class ModelContractConfigComplianceFinding:
     """A single finding from the contract-config compliance validator."""
 
     path: Path

--- a/src/omnibase_core/models/validation/model_contract_config_finding.py
+++ b/src/omnibase_core/models/validation/model_contract_config_finding.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractConfigFinding — single finding from the contract-config compliance validator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ContractConfigFinding:
+    """A single finding from the contract-config compliance validator."""
+
+    path: Path
+    line: int
+    column: int
+    rule: str
+    message: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column + 1}: [{self.rule}] {self.message}"
+        )

--- a/src/omnibase_core/validators/__init__.py
+++ b/src/omnibase_core/validators/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/validators/contract_config_compliance.py
+++ b/src/omnibase_core/validators/contract_config_compliance.py
@@ -90,7 +90,7 @@ _EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
     }
 )
 
-_DEFAULT_SCAN_ROOT = Path("src")
+_DEFAULT_SCAN_ROOTS = (Path("src"), Path("scripts"))
 
 # ---------------------------------------------------------------------------
 # AST helpers
@@ -488,7 +488,7 @@ def main(argv: list[str] | None = None) -> int:
         "paths",
         nargs="*",
         type=Path,
-        default=[_DEFAULT_SCAN_ROOT],
+        default=list(_DEFAULT_SCAN_ROOTS),
         help="Python files or directories to scan.",
     )
     parser.add_argument(

--- a/src/omnibase_core/validators/contract_config_compliance.py
+++ b/src/omnibase_core/validators/contract_config_compliance.py
@@ -1,0 +1,529 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract-config compliance validator (OMN-10688).
+
+Catches three anti-patterns in handler and script files:
+
+1. **bare_env_read** — handler files calling os.environ.get() / os.environ[] /
+   os.getenv() for variables NOT in INFRA_ALLOWLIST.  Config vars must be
+   declared in the node's contract.yaml and resolved via the config layer.
+
+2. **bus_bypass_import** — script files importing directly from
+   nodes/*/handlers/  (bypasses the event bus; scripts must use the public
+   node API).
+
+3. **missing_contract_config** — handler files reading an env var that has no
+   matching entry in the adjacent contract.yaml ``config`` or ``dependencies``
+   section.
+
+Usage::
+
+    # Check src tree (returns non-zero on findings)
+    python -m omnibase_core.validators.contract_config_compliance src/
+
+    # Generate YAML allowlist of existing violations
+    python -m omnibase_core.validators.contract_config_compliance \\
+        --generate-allowlist src/ > allowlist.yaml
+
+Suppression::
+
+    Add  # contract-config-ok: <reason>  anywhere on a violating line to
+    silence that specific finding.
+
+INFRA_ALLOWLIST keys are connection bootstrap vars that intentionally live in
+env rather than contract config (Kafka, Postgres, API credentials, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent contract.yaml files
+
+from omnibase_core.models.validation.model_contract_config_finding import (
+    ContractConfigFinding,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+INFRA_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "OMNI_HOME",
+        "ONEX_STATE_DIR",
+        "ONEX_STATE_ROOT",
+        "OPENROUTER_API_KEY",
+        "LINEAR_API_KEY",
+        "GITHUB_TOKEN",
+        "GH_PAT",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "LLM_GLM_API_KEY",
+        "POSTGRES_PASSWORD",
+        "MEMGRAPH_USER",
+        "MEMGRAPH_PASSWORD",
+        "GOOGLE_API_KEY",
+    }
+)
+
+SUPPRESSION_MARKER = "contract-config-ok:"
+
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".git",
+        "archived",
+        "archive",
+    }
+)
+
+_DEFAULT_SCAN_ROOT = Path("src")
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    """Return dotted name of the called function, or None."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        parts: list[str] = []
+        cur: ast.expr = func
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _str_arg(node: ast.Call) -> str | None:
+    """Return the first string literal argument of a call, or None."""
+    if node.args:
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+    return None
+
+
+def _subscript_str_key(node: ast.Subscript) -> str | None:
+    """Return the string key of a subscript, or None."""
+    sl = node.slice
+    if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+        return sl.value
+    return None
+
+
+def _module_of_import(node: ast.ImportFrom) -> str:
+    return node.module or ""
+
+
+# ---------------------------------------------------------------------------
+# Rule checkers
+# ---------------------------------------------------------------------------
+
+
+def _check_bare_env_reads(
+    path: Path,
+    tree: ast.Module,
+    lines: list[str],
+) -> list[ContractConfigFinding]:
+    """Rule bare_env_read: env reads outside INFRA_ALLOWLIST in handler files."""
+    findings: list[ContractConfigFinding] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            fname = _call_func_name(node)
+            if fname in ("os.getenv", "os.environ.get"):
+                key = _str_arg(node)
+                if key and key not in INFRA_ALLOWLIST:
+                    line_text = (
+                        lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+                    )
+                    if SUPPRESSION_MARKER not in line_text:
+                        findings.append(
+                            ContractConfigFinding(
+                                path=path,
+                                line=node.lineno,
+                                column=node.col_offset,
+                                rule="bare_env_read",
+                                message=(
+                                    f"bare env read of {key!r} — "
+                                    "declare in contract.yaml config/dependencies instead"
+                                ),
+                            )
+                        )
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if isinstance(node.value, ast.Attribute):
+                if (
+                    node.value.attr == "environ"
+                    and isinstance(node.value.value, ast.Name)
+                    and node.value.value.id == "os"
+                ):
+                    key = _subscript_str_key(node)
+                    if key and key not in INFRA_ALLOWLIST:
+                        line_text = (
+                            lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+                        )
+                        if SUPPRESSION_MARKER not in line_text:
+                            findings.append(
+                                ContractConfigFinding(
+                                    path=path,
+                                    line=node.lineno,
+                                    column=node.col_offset,
+                                    rule="bare_env_read",
+                                    message=(
+                                        f"bare env read of {key!r} — "
+                                        "declare in contract.yaml config/dependencies instead"
+                                    ),
+                                )
+                            )
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return findings
+
+
+def _check_bus_bypass_imports(
+    path: Path,
+    tree: ast.Module,
+    lines: list[str],
+) -> list[ContractConfigFinding]:
+    """Rule bus_bypass_import: scripts importing directly from nodes/*/handlers/."""
+    findings: list[ContractConfigFinding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = _module_of_import(node)
+            if "nodes" in mod and "handlers" in mod:
+                line_text = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+                if SUPPRESSION_MARKER not in line_text:
+                    findings.append(
+                        ContractConfigFinding(
+                            path=path,
+                            line=node.lineno,
+                            column=node.col_offset,
+                            rule="bus_bypass_import",
+                            message=(
+                                f"direct handler import {mod!r} bypasses event bus — "
+                                "use the node public API or contract topic instead"
+                            ),
+                        )
+                    )
+    return findings
+
+
+def _extract_env_keys_from_tree(tree: ast.Module) -> set[str]:
+    """Collect all string keys read from os.environ / os.getenv in this file."""
+    keys: set[str] = set()
+
+    class _KeyVisitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            fname = _call_func_name(node)
+            if fname in ("os.getenv", "os.environ.get"):
+                key = _str_arg(node)
+                if key:
+                    keys.add(key)
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if isinstance(node.value, ast.Attribute):
+                if (
+                    node.value.attr == "environ"
+                    and isinstance(node.value.value, ast.Name)
+                    and node.value.value.id == "os"
+                ):
+                    key = _subscript_str_key(node)
+                    if key:
+                        keys.add(key)
+            self.generic_visit(node)
+
+    _KeyVisitor().visit(tree)
+    return keys
+
+
+def _load_contract_env_keys(contract_path: Path) -> set[str]:
+    """Extract declared env var names from a contract.yaml."""
+    if not contract_path.exists():
+        return set()
+    try:
+        # ONEX_EXCLUDE: manual_yaml - reading adjacent node contract for validation
+        data = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001  # fallback-ok: malformed contract treated as empty
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    keys: set[str] = set()
+    # config section: flat key=value or env_var fields
+    config = data.get("config", {})
+    if isinstance(config, dict):
+        for k, v in config.items():
+            if k.endswith("_env_var") or k == "env_var":
+                if isinstance(v, str):
+                    keys.add(v)
+            if isinstance(k, str) and k.isupper():
+                keys.add(k)
+    # dependencies section: type == "environment" entries
+    deps = data.get("dependencies", [])
+    if isinstance(deps, list):
+        for dep in deps:
+            if isinstance(dep, dict) and dep.get("type") == "environment":
+                ev = dep.get("env_var")
+                if isinstance(ev, str):
+                    keys.add(ev)
+    return keys
+
+
+def _find_contract_yaml(handler_path: Path) -> Path | None:
+    """Walk up from a handler file to find the nearest contract.yaml."""
+    current = handler_path.parent
+    for _ in range(6):
+        candidate = current / "contract.yaml"
+        if candidate.exists():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            break
+        # Stop searching once we've left the node tree
+        if current.name in ("src", "nodes"):
+            break
+        current = parent
+    return None
+
+
+def _check_missing_contract_config(
+    path: Path,
+    tree: ast.Module,
+    lines: list[str],
+) -> list[ContractConfigFinding]:
+    """Rule missing_contract_config: env reads in handlers not in contract.yaml."""
+    env_keys = _extract_env_keys_from_tree(tree)
+    uncovered = {k for k in env_keys if k not in INFRA_ALLOWLIST}
+    if not uncovered:
+        return []
+
+    contract_path = _find_contract_yaml(path)
+    contract_keys = _load_contract_env_keys(contract_path) if contract_path else set()
+
+    missing = uncovered - contract_keys
+    if not missing:
+        return []
+
+    findings: list[ContractConfigFinding] = []
+
+    class _LineVisitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            fname = _call_func_name(node)
+            if fname in ("os.getenv", "os.environ.get"):
+                key = _str_arg(node)
+                if key and key in missing:
+                    line_text = (
+                        lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+                    )
+                    if SUPPRESSION_MARKER not in line_text:
+                        findings.append(
+                            ContractConfigFinding(
+                                path=path,
+                                line=node.lineno,
+                                column=node.col_offset,
+                                rule="missing_contract_config",
+                                message=(
+                                    f"env var {key!r} read in handler but not declared "
+                                    f"in contract.yaml "
+                                    f"(nearest: {contract_path or 'not found'})"
+                                ),
+                            )
+                        )
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if isinstance(node.value, ast.Attribute):
+                if (
+                    node.value.attr == "environ"
+                    and isinstance(node.value.value, ast.Name)
+                    and node.value.value.id == "os"
+                ):
+                    key = _subscript_str_key(node)
+                    if key and key in missing:
+                        line_text = (
+                            lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+                        )
+                        if SUPPRESSION_MARKER not in line_text:
+                            findings.append(
+                                ContractConfigFinding(
+                                    path=path,
+                                    line=node.lineno,
+                                    column=node.col_offset,
+                                    rule="missing_contract_config",
+                                    message=(
+                                        f"env var {key!r} read in handler but not declared "
+                                        f"in contract.yaml "
+                                        f"(nearest: {contract_path or 'not found'})"
+                                    ),
+                                )
+                            )
+            self.generic_visit(node)
+
+    _LineVisitor().visit(tree)
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# File-level dispatch
+# ---------------------------------------------------------------------------
+
+
+def _is_handler_file(path: Path) -> bool:
+    """True if this file is inside a handlers/ directory."""
+    return "handlers" in path.parts
+
+
+def _is_script_file(path: Path) -> bool:
+    """True if this file looks like a script (not inside src/, or in scripts/)."""
+    parts = path.parts
+    return "scripts" in parts or (
+        "src" not in parts and "handlers" not in parts and "nodes" not in parts
+    )
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
+
+
+def validate_file(
+    path: Path, rules: frozenset[str] | None = None
+) -> list[ContractConfigFinding]:
+    """Validate one Python file; return findings list."""
+    if _is_excluded(path):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    active = rules or frozenset(
+        {"bare_env_read", "bus_bypass_import", "missing_contract_config"}
+    )
+    findings: list[ContractConfigFinding] = []
+
+    if "bare_env_read" in active and _is_handler_file(path):
+        findings.extend(_check_bare_env_reads(path, tree, lines))
+
+    if "bus_bypass_import" in active and _is_script_file(path):
+        findings.extend(_check_bus_bypass_imports(path, tree, lines))
+
+    if "missing_contract_config" in active and _is_handler_file(path):
+        findings.extend(_check_missing_contract_config(path, tree, lines))
+
+    return findings
+
+
+def validate_paths(
+    paths: list[Path], rules: frozenset[str] | None = None
+) -> list[ContractConfigFinding]:
+    """Validate all Python files under the given paths."""
+    findings: list[ContractConfigFinding] = []
+    for path in paths:
+        if path.is_file() and path.suffix == ".py":
+            findings.extend(validate_file(path, rules))
+        elif path.is_dir():
+            for py_file in sorted(path.rglob("*.py")):
+                if "__pycache__" not in py_file.parts:
+                    findings.extend(validate_file(py_file, rules))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# --generate-allowlist
+# ---------------------------------------------------------------------------
+
+
+def generate_allowlist(findings: list[ContractConfigFinding]) -> str:
+    """Render findings as a YAML allowlist for bootstrapping suppressions."""
+    by_rule: dict[str, list[dict[str, object]]] = {}
+    for f in findings:
+        by_rule.setdefault(f.rule, []).append(
+            {"path": str(f.path), "line": f.line, "message": f.message}
+        )
+    # ONEX_EXCLUDE: manual_yaml - generating allowlist YAML output
+    return yaml.dump({"allowlist": by_rule}, default_flow_style=False, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+_VALIDATOR_NAME = "contract_config_compliance"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for contract-config compliance validator."""
+    parser = argparse.ArgumentParser(
+        description="Contract-config compliance validator (OMN-10688).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[_DEFAULT_SCAN_ROOT],
+        help="Python files or directories to scan.",
+    )
+    parser.add_argument(
+        "--generate-allowlist",
+        action="store_true",
+        help="Output existing violations as YAML allowlist (stdout).",
+    )
+    parser.add_argument(
+        "--rule",
+        action="append",
+        dest="rules",
+        choices=["bare_env_read", "bus_bypass_import", "missing_contract_config"],
+        help="Enable only specific rules (repeatable; default: all rules).",
+    )
+    args = parser.parse_args(argv)
+
+    active_rules = frozenset(args.rules) if args.rules else None
+    findings = validate_paths(args.paths, active_rules)
+
+    if args.generate_allowlist:
+        sys.stdout.write(generate_allowlist(findings))
+        return 0
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"{_VALIDATOR_NAME}: {len(findings)} finding(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    sys.stderr.write(
+        "\nDeclare config vars in contract.yaml and resolve via the config layer.\n"
+        "Suppress individual lines with:  # contract-config-ok: <reason>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/src/omnibase_core/validators/contract_config_compliance.py
+++ b/src/omnibase_core/validators/contract_config_compliance.py
@@ -44,8 +44,8 @@ from pathlib import Path
 
 import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent contract.yaml files
 
-from omnibase_core.models.validation.model_contract_config_finding import (
-    ContractConfigFinding,
+from omnibase_core.models.validation.model_contract_config_compliance_finding import (
+    ModelContractConfigComplianceFinding,
 )
 
 # ---------------------------------------------------------------------------
@@ -144,9 +144,9 @@ def _check_bare_env_reads(
     path: Path,
     tree: ast.Module,
     lines: list[str],
-) -> list[ContractConfigFinding]:
+) -> list[ModelContractConfigComplianceFinding]:
     """Rule bare_env_read: env reads outside INFRA_ALLOWLIST in handler files."""
-    findings: list[ContractConfigFinding] = []
+    findings: list[ModelContractConfigComplianceFinding] = []
 
     class _Visitor(ast.NodeVisitor):
         def visit_Call(self, node: ast.Call) -> None:
@@ -159,7 +159,7 @@ def _check_bare_env_reads(
                     )
                     if SUPPRESSION_MARKER not in line_text:
                         findings.append(
-                            ContractConfigFinding(
+                            ModelContractConfigComplianceFinding(
                                 path=path,
                                 line=node.lineno,
                                 column=node.col_offset,
@@ -186,7 +186,7 @@ def _check_bare_env_reads(
                         )
                         if SUPPRESSION_MARKER not in line_text:
                             findings.append(
-                                ContractConfigFinding(
+                                ModelContractConfigComplianceFinding(
                                     path=path,
                                     line=node.lineno,
                                     column=node.col_offset,
@@ -207,9 +207,9 @@ def _check_bus_bypass_imports(
     path: Path,
     tree: ast.Module,
     lines: list[str],
-) -> list[ContractConfigFinding]:
+) -> list[ModelContractConfigComplianceFinding]:
     """Rule bus_bypass_import: scripts importing directly from nodes/*/handlers/."""
-    findings: list[ContractConfigFinding] = []
+    findings: list[ModelContractConfigComplianceFinding] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             mod = _module_of_import(node)
@@ -217,7 +217,7 @@ def _check_bus_bypass_imports(
                 line_text = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
                 if SUPPRESSION_MARKER not in line_text:
                     findings.append(
-                        ContractConfigFinding(
+                        ModelContractConfigComplianceFinding(
                             path=path,
                             line=node.lineno,
                             column=node.col_offset,
@@ -313,7 +313,7 @@ def _check_missing_contract_config(
     path: Path,
     tree: ast.Module,
     lines: list[str],
-) -> list[ContractConfigFinding]:
+) -> list[ModelContractConfigComplianceFinding]:
     """Rule missing_contract_config: env reads in handlers not in contract.yaml."""
     env_keys = _extract_env_keys_from_tree(tree)
     uncovered = {k for k in env_keys if k not in INFRA_ALLOWLIST}
@@ -327,7 +327,7 @@ def _check_missing_contract_config(
     if not missing:
         return []
 
-    findings: list[ContractConfigFinding] = []
+    findings: list[ModelContractConfigComplianceFinding] = []
 
     class _LineVisitor(ast.NodeVisitor):
         def visit_Call(self, node: ast.Call) -> None:
@@ -340,7 +340,7 @@ def _check_missing_contract_config(
                     )
                     if SUPPRESSION_MARKER not in line_text:
                         findings.append(
-                            ContractConfigFinding(
+                            ModelContractConfigComplianceFinding(
                                 path=path,
                                 line=node.lineno,
                                 column=node.col_offset,
@@ -368,7 +368,7 @@ def _check_missing_contract_config(
                         )
                         if SUPPRESSION_MARKER not in line_text:
                             findings.append(
-                                ContractConfigFinding(
+                                ModelContractConfigComplianceFinding(
                                     path=path,
                                     line=node.lineno,
                                     column=node.col_offset,
@@ -410,7 +410,7 @@ def _is_excluded(path: Path) -> bool:
 
 def validate_file(
     path: Path, rules: frozenset[str] | None = None
-) -> list[ContractConfigFinding]:
+) -> list[ModelContractConfigComplianceFinding]:
     """Validate one Python file; return findings list."""
     if _is_excluded(path):
         return []
@@ -427,7 +427,7 @@ def validate_file(
     active = rules or frozenset(
         {"bare_env_read", "bus_bypass_import", "missing_contract_config"}
     )
-    findings: list[ContractConfigFinding] = []
+    findings: list[ModelContractConfigComplianceFinding] = []
 
     if "bare_env_read" in active and _is_handler_file(path):
         findings.extend(_check_bare_env_reads(path, tree, lines))
@@ -443,9 +443,9 @@ def validate_file(
 
 def validate_paths(
     paths: list[Path], rules: frozenset[str] | None = None
-) -> list[ContractConfigFinding]:
+) -> list[ModelContractConfigComplianceFinding]:
     """Validate all Python files under the given paths."""
-    findings: list[ContractConfigFinding] = []
+    findings: list[ModelContractConfigComplianceFinding] = []
     for path in paths:
         if path.is_file() and path.suffix == ".py":
             findings.extend(validate_file(path, rules))
@@ -461,7 +461,7 @@ def validate_paths(
 # ---------------------------------------------------------------------------
 
 
-def generate_allowlist(findings: list[ContractConfigFinding]) -> str:
+def generate_allowlist(findings: list[ModelContractConfigComplianceFinding]) -> str:
     """Render findings as a YAML allowlist for bootstrapping suppressions."""
     by_rule: dict[str, list[dict[str, object]]] = {}
     for f in findings:

--- a/src/omnibase_core/validators/contracts/__init__.py
+++ b/src/omnibase_core/validators/contracts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/validators/__init__.py
+++ b/tests/unit/validators/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/validators/test_contract_config_compliance.py
+++ b/tests/unit/validators/test_contract_config_compliance.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for contract_config_compliance validator (OMN-10688)."""
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.models.validation.model_contract_config_finding import (
+    ContractConfigFinding,
+)
+from omnibase_core.validators.contract_config_compliance import (
+    INFRA_ALLOWLIST,
+    generate_allowlist,
+    validate_file,
+    validate_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> Path:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _handler(tmp_path: Path, name: str, content: str) -> Path:
+    return _write(tmp_path, f"nodes/my_node/handlers/{name}", content)
+
+
+def _script(tmp_path: Path, name: str, content: str) -> Path:
+    return _write(tmp_path, f"scripts/{name}", content)
+
+
+# ---------------------------------------------------------------------------
+# Rule: bare_env_read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBareEnvRead:
+    def test_getenv_not_in_allowlist_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_SERVICE_URL')\n",
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "bare_env_read"
+        assert "MY_SERVICE_URL" in findings[0].message
+
+    def test_environ_get_not_in_allowlist_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.environ.get('MY_DB_HOST')\n",
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        assert len(findings) == 1
+        assert "MY_DB_HOST" in findings[0].message
+
+    def test_environ_subscript_not_in_allowlist_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.environ['MY_SECRET']\n",
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        assert len(findings) == 1
+        assert "MY_SECRET" in findings[0].message
+
+    def test_allowlist_key_not_flagged(self, tmp_path: Path) -> None:
+        for key in list(INFRA_ALLOWLIST)[:3]:
+            p = _handler(
+                tmp_path,
+                f"handler_{key.lower()}.py",
+                f"import os\nval = os.getenv('{key}')\n",
+            )
+            findings = validate_file(p, frozenset({"bare_env_read"}))
+            assert findings == [], f"{key} should be in allowlist"
+
+    def test_non_handler_file_not_checked(self, tmp_path: Path) -> None:
+        # A file not inside handlers/ should NOT trigger bare_env_read
+        p = _write(
+            tmp_path, "services/service_foo.py", "import os\nx = os.getenv('MY_KEY')\n"
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        assert findings == []
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_KEY')  # contract-config-ok: legacy compat\n",
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        assert findings == []
+
+    def test_unknown_var_name_no_string_arg_not_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nkey = 'MY_KEY'\nval = os.getenv(key)\n",
+        )
+        findings = validate_file(p, frozenset({"bare_env_read"}))
+        # Non-literal key can't be statically determined — not flagged
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule: bus_bypass_import
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBusBypassImport:
+    def test_script_importing_handler_flagged(self, tmp_path: Path) -> None:
+        p = _script(
+            tmp_path,
+            "run_something.py",
+            "from omnibase_infra.nodes.node_foo.handlers.handler_bar import HandlerBar\n",
+        )
+        findings = validate_file(p, frozenset({"bus_bypass_import"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "bus_bypass_import"
+        assert "handlers" in findings[0].message
+
+    def test_script_not_importing_handler_clean(self, tmp_path: Path) -> None:
+        p = _script(
+            tmp_path,
+            "run_something.py",
+            "from omnibase_infra.nodes.node_foo import NodeFoo\n",
+        )
+        findings = validate_file(p, frozenset({"bus_bypass_import"}))
+        assert findings == []
+
+    def test_handler_importing_sibling_handler_clean(self, tmp_path: Path) -> None:
+        # handlers/ importing handlers/ — rule only fires on script files
+        p = _handler(
+            tmp_path,
+            "handler_a.py",
+            "from omnibase_infra.nodes.node_foo.handlers.handler_b import HandlerB\n",
+        )
+        findings = validate_file(p, frozenset({"bus_bypass_import"}))
+        assert findings == []
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        p = _script(
+            tmp_path,
+            "run_something.py",
+            "from omnibase_infra.nodes.node_foo.handlers.handler_bar import HandlerBar  # contract-config-ok: test helper\n",
+        )
+        findings = validate_file(p, frozenset({"bus_bypass_import"}))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule: missing_contract_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMissingContractConfig:
+    def test_env_read_with_no_contract_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_SERVICE_URL')\n",
+        )
+        findings = validate_file(p, frozenset({"missing_contract_config"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "missing_contract_config"
+        assert "MY_SERVICE_URL" in findings[0].message
+
+    def test_env_read_declared_in_contract_clean(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "nodes/my_node/contract.yaml",
+            "dependencies:\n  - name: svc\n    type: environment\n    env_var: MY_SERVICE_URL\n    required: true\n",
+        )
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_SERVICE_URL')\n",
+        )
+        findings = validate_file(p, frozenset({"missing_contract_config"}))
+        assert findings == []
+
+    def test_allowlist_key_not_checked(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('KAFKA_BOOTSTRAP_SERVERS')\n",
+        )
+        findings = validate_file(p, frozenset({"missing_contract_config"}))
+        assert findings == []
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_KEY')  # contract-config-ok: bootstrapped externally\n",
+        )
+        findings = validate_file(p, frozenset({"missing_contract_config"}))
+        assert findings == []
+
+    def test_contract_with_config_section_key(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "nodes/my_node/contract.yaml",
+            "config:\n  poll_interval: 60\n  token_env_var: MY_SERVICE_TOKEN\n",
+        )
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            "import os\nval = os.getenv('MY_SERVICE_TOKEN')\n",
+        )
+        findings = validate_file(p, frozenset({"missing_contract_config"}))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Finding model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContractConfigFinding:
+    def test_format_output(self, tmp_path: Path) -> None:
+        f = ContractConfigFinding(
+            path=Path("src/nodes/n/handlers/h.py"),
+            line=42,
+            column=4,
+            rule="bare_env_read",
+            message="bare env read of 'X'",
+        )
+        formatted = f.format()
+        assert "src/nodes/n/handlers/h.py:42:5" in formatted
+        assert "bare_env_read" in formatted
+        assert "bare env read of 'X'" in formatted
+
+    def test_finding_is_frozen(self) -> None:
+        f = ContractConfigFinding(
+            path=Path("a.py"),
+            line=1,
+            column=0,
+            rule="bare_env_read",
+            message="msg",
+        )
+        with pytest.raises(Exception):
+            f.rule = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# validate_paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatePaths:
+    def test_directory_scan_finds_violations(self, tmp_path: Path) -> None:
+        _handler(tmp_path, "handler_a.py", "import os\nval = os.getenv('FOO_URL')\n")
+        _handler(tmp_path, "handler_b.py", "import os\nval = os.getenv('BAR_URL')\n")
+        findings = validate_paths([tmp_path])
+        assert len(findings) >= 2
+
+    def test_empty_directory_returns_empty(self, tmp_path: Path) -> None:
+        findings = validate_paths([tmp_path])
+        assert findings == []
+
+    def test_non_python_files_ignored(self, tmp_path: Path) -> None:
+        p = tmp_path / "nodes" / "my_node" / "handlers"
+        p.mkdir(parents=True)
+        (p / "readme.md").write_text("some text", encoding="utf-8")
+        findings = validate_paths([tmp_path])
+        assert findings == []
+
+    def test_syntax_error_file_skipped(self, tmp_path: Path) -> None:
+        p = _handler(tmp_path, "broken.py", "def bad(\n")
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_excluded_pycache_ignored(self, tmp_path: Path) -> None:
+        p = _write(
+            tmp_path,
+            "nodes/my_node/handlers/__pycache__/handler_foo.cpython-312.pyc",
+            "import os\nval = os.getenv('SECRET')\n",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# generate_allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateAllowlist:
+    def test_empty_findings_produces_empty_allowlist(self) -> None:
+        output = generate_allowlist([])
+        assert "allowlist" in output
+
+    def test_findings_grouped_by_rule(self, tmp_path: Path) -> None:
+        findings = [
+            ContractConfigFinding(
+                path=Path("a/handlers/h.py"),
+                line=1,
+                column=0,
+                rule="bare_env_read",
+                message="bare env read of 'X'",
+            ),
+            ContractConfigFinding(
+                path=Path("scripts/s.py"),
+                line=5,
+                column=0,
+                rule="bus_bypass_import",
+                message="direct handler import",
+            ),
+        ]
+        output = generate_allowlist(findings)
+        assert "bare_env_read" in output
+        assert "bus_bypass_import" in output
+        assert "a/handlers/h.py" in output

--- a/tests/unit/validators/test_contract_config_compliance.py
+++ b/tests/unit/validators/test_contract_config_compliance.py
@@ -254,6 +254,8 @@ class TestModelContractConfigComplianceFinding:
             message="msg",
         )
         with pytest.raises(Exception):
+            # NOTE(OMN-10688): frozen dataclass assignment raises FrozenInstanceError at runtime;
+            # mypy[misc] suppressed because the static type-checker correctly rejects this line.
             f.rule = "other"  # type: ignore[misc]
 
 
@@ -305,7 +307,7 @@ class TestValidatePaths:
 class TestGenerateAllowlist:
     def test_empty_findings_produces_empty_allowlist(self) -> None:
         output = generate_allowlist([])
-        assert "allowlist" in output
+        assert output.strip() == "allowlist: {}"
 
     def test_findings_grouped_by_rule(self, tmp_path: Path) -> None:
         findings = [

--- a/tests/unit/validators/test_contract_config_compliance.py
+++ b/tests/unit/validators/test_contract_config_compliance.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from omnibase_core.models.validation.model_contract_config_finding import (
-    ContractConfigFinding,
+from omnibase_core.models.validation.model_contract_config_compliance_finding import (
+    ModelContractConfigComplianceFinding,
 )
 from omnibase_core.validators.contract_config_compliance import (
     INFRA_ALLOWLIST,
@@ -231,9 +231,9 @@ class TestMissingContractConfig:
 
 
 @pytest.mark.unit
-class TestContractConfigFinding:
+class TestModelContractConfigComplianceFinding:
     def test_format_output(self, tmp_path: Path) -> None:
-        f = ContractConfigFinding(
+        f = ModelContractConfigComplianceFinding(
             path=Path("src/nodes/n/handlers/h.py"),
             line=42,
             column=4,
@@ -246,7 +246,7 @@ class TestContractConfigFinding:
         assert "bare env read of 'X'" in formatted
 
     def test_finding_is_frozen(self) -> None:
-        f = ContractConfigFinding(
+        f = ModelContractConfigComplianceFinding(
             path=Path("a.py"),
             line=1,
             column=0,
@@ -309,14 +309,14 @@ class TestGenerateAllowlist:
 
     def test_findings_grouped_by_rule(self, tmp_path: Path) -> None:
         findings = [
-            ContractConfigFinding(
+            ModelContractConfigComplianceFinding(
                 path=Path("a/handlers/h.py"),
                 line=1,
                 column=0,
                 rule="bare_env_read",
                 message="bare env read of 'X'",
             ),
-            ContractConfigFinding(
+            ModelContractConfigComplianceFinding(
                 path=Path("scripts/s.py"),
                 line=5,
                 column=0,


### PR DESCRIPTION
Evidence-Source: OCC#813
Evidence-Ticket: OMN-10688

## Summary

- Adds `omnibase_core.validators.contract_config_compliance`: an AST-based static validator that catches three contract-config anti-patterns in handler and script files
- Adds `omnibase_core.models.validation.model_contract_config_compliance_finding.ModelContractConfigComplianceFinding` frozen dataclass for findings
- Wires validator as pre-commit hook and CI gate (`contract-config-compliance` job in Phase 1, feeds `quality-gate`)

## Rules enforced

| Rule | Trigger | File scope |
|---|---|---|
| `bare_env_read` | `os.getenv` / `os.environ.get` / `os.environ[...]` with literal key not in `INFRA_ALLOWLIST` | `handlers/` only |
| `bus_bypass_import` | `from ... .handlers. ...` import in a script file | `scripts/` only |
| `missing_contract_config` | env var read not declared in `contract.yaml` `dependencies` or `config` section | `handlers/` only |

Suppression: `# contract-config-ok: <reason>` silences any line.

`--generate-allowlist` mode emits a starter YAML block from existing violations.

## Tests

25 unit tests under `tests/unit/validators/` — all pass locally.

## Ticket

OMN-10688

## dod_evidence

- 25 unit tests passing (25/25)
- pre-commit run --all-files clean on staged files
- pre-push hooks clean (mypy strict, pyright, naming conventions)
- CI gate wired as required status check in `quality-gate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contract-config compliance validator to detect uncontracted env reads, bus-bypass imports, and missing contract config; includes a CLI mode and allowlist generation.

* **Chores**
  * Integrated the validator into CI quality gates and added a pre-commit hook to run it automatically.

* **Tests**
  * Added comprehensive unit tests covering rules, suppression, allowlist behavior, and output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->