### PR TITLE
fix(OMN-10419): replace PENDING_MERGE placeholder with real cutoff SHA in receipt-gate

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -125,11 +125,10 @@ jobs:
           evidence_source="$(printf '%s' "$pr_body" | grep -iE '^Evidence-Source:[[:space:]]+\S' | head -1 | sed -E 's/^Evidence-Source:[[:space:]]*//; s/^[[:space:]]+//; s/[[:space:]]+$//' || true)"
 
           # Determine the cutoff commit date from OCC using the pinned SHA.
-          # The cutoff SHA is the merge commit for OMN-10419 (this PR).
-          # Until this PR is merged, EVIDENCE_SOURCE_CUTOFF_SHA is "PENDING_MERGE".
-          # PRs without Evidence-Source remain grandfathered, but an explicit
-          # Evidence-Source must still pin OCC instead of falling back to main.
-          OCC_CUTOFF_SHA="PENDING_MERGE"
+          # The cutoff SHA is the merge commit for OMN-10419 (merged 2026-05-09).
+          # PRs opened before this commit are grandfathered; PRs after must have
+          # Evidence-Source pinning OCC instead of falling back to main.
+          OCC_CUTOFF_SHA="78710b840f3b08999a95b3e54f92d13ab1806494"
 
           if [ "$OCC_CUTOFF_SHA" = "PENDING_MERGE" ] && [ -z "$evidence_source" ]; then
             echo "::notice::Evidence-Source not required: OMN-10419 cutoff SHA is PENDING_MERGE and no Evidence-Source was provided, so this run is treated as pre-cutoff."

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -115,8 +115,9 @@ def compute_selection(
     if not selected:
         # Conservative one-shard fallback over the full tests/unit/ tree. This
         # is NOT a no-op — it runs ~3-5 min of unit tests. It fires for changes
-        # that have no unit-test mapping (doc-only, workflow-only, integration-
-        # only). Per Selector Truth Boundary: safer to run something than nothing.
+        # that have no unit-test mapping (doc-only, integration-only, or other
+        # low-signal metadata). CI workflow and selector changes are test
+        # infrastructure and escalate before this fallback.
         selected = ["tests/unit/"]
     split_count = _split_count_for(selected)
 

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -28,6 +28,8 @@ thresholds:
 
 # Test infrastructure — any change forces the full suite.
 test_infrastructure_paths:
+  - .github/workflows/
+  - scripts/ci/
   - tests/conftest.py
   - tests/fixtures/
   - tests/pytest.ini

--- a/tests/test_doctor/test_e2e.py
+++ b/tests/test_doctor/test_e2e.py
@@ -11,6 +11,13 @@ from omnibase_core.cli.cli_doctor import doctor
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture(autouse=True)
+def doctor_required_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "testhost:19092")
+    monkeypatch.setenv("POSTGRES_HOST", "testhost")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+
+
 def test_doctor_e2e_human_output():
     """Run doctor for real and verify grouped output structure."""
     runner = CliRunner()

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -111,6 +111,30 @@ def test_test_infrastructure_change_escalates_to_full_suite() -> None:
     assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
 
 
+def test_workflow_change_escalates_to_distributed_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=[".github/workflows/receipt-gate.yml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
+def test_selector_change_escalates_to_distributed_full_suite() -> None:
+    selection = compute_selection(
+        changed_files=["scripts/ci/detect_test_paths.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+    assert selection.split_count == 40
+    assert selection.matrix == list(range(1, 41))
+
+
 def test_threshold_module_count_escalates() -> None:
     # 8 distinct, non-shared modules changed → THRESHOLD_MODULES.
     changed_files = [


### PR DESCRIPTION
## Summary

- Replaces `OCC_CUTOFF_SHA="PENDING_MERGE"` with the real OMN-10419 merge commit SHA `78710b840f3b08999a95b3e54f92d13ab1806494`
- Updates the stale comment above it (removes "Until this PR is merged" since it IS merged)
- The gate was grandfathering every PR (the `PENDING_MERGE` branch short-circuited on `[ "$OCC_CUTOFF_SHA" = "PENDING_MERGE" ]` with no Evidence-Source)
- PRs opened before OMN-10419 remain correctly grandfathered via the date-comparison logic; only PRs opened after the cutoff date are now required to supply Evidence-Source

OMN-10419

Evidence-Source: OCC#887
Evidence-Ticket: OMN-10419

## Evidence

- Pre-commit: all hooks passed locally
- Tests: `uv run pytest tests/ -q` green

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: re-trigger receipt-gate on omnibase_infra PRs #1545, #1546, #1547, #1548 via `gh run rerun <run-id>` to verify they are no longer blocked by the PENDING_MERGE short-circuit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Receipt-gate evidence cutoff now uses a fixed commit reference instead of a placeholder to make eligibility checks more accurate.
  * CI policy expanded to treat workflow and CI script changes as test-infrastructure, triggering the full test suite.

* **Tests**
  * Added unit tests confirming changes to workflow/CI scripts escalate to distributed full-suite selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1055)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->