### PR TITLE
ci(OMN-10419): skip TODO audit without ticket branch

### DIFF
--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -55,12 +55,12 @@ jobs:
 
           # Epic branch: epic/OMN-XXXX/OMN-YYYY/...
           if printf '%s' "$BRANCH" | grep -qiE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)"; then
-            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)" | grep -ioE "OMN-[0-9]+" | tail -1)
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)" | grep -ioE "OMN-[0-9]+" | tail -1 || true)
           fi
 
           # Standard: */omn-XXXX-* or omn-XXXX-*
           if [[ -z "$TICKET_ID" ]]; then
-            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "(OMN|omn)-[0-9]+" | head -1 | tr '[:lower:]' '[:upper:]')
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "(OMN|omn)-[0-9]+" | head -1 | tr '[:lower:]' '[:upper:]' || true)
           fi
 
           if [[ -z "$TICKET_ID" ]]; then


### PR DESCRIPTION
## Summary
- keep TODO Audit skip behavior deterministic when branch names do not contain an OMN ticket
- preserve ticket extraction for epic and standard OMN branch names while preventing grep/no-match from tripping pipefail

Evidence-Source: OCC#903
Evidence-Ticket: OMN-10419

## Verification
- local shell snippet: no-ticket branch exits through skip path
- local shell snippet: jonah/omn-10419-example resolves OMN-10419
- commit/push hooks passed
- CI: all 40 unit splits and 4 integration splits passed
- Receipt Gate rerun after adding OCC#903 evidence