### PR TITLE
feat(OMN-10278): extend resolver Step 4 to multi-param known injection

### DIFF
--- a/contracts/OMN-10278.yaml
+++ b/contracts/OMN-10278.yaml
@@ -1,0 +1,38 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-10278"
+title: "Mandatory DI params resolver multi-param injection"
+summary: "Extend ServiceHandlerResolver Step 4 to inject known dependency params beyond event_bus while
+  preserving deterministic handler construction."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Resolver and enum tests pass on omnibase_core PR #1057"
+    command: "uv run pytest tests/unit/enums/test_enum_handler_resolution_outcome.py tests/unit/services/test_service_handler_resolver.py
+      tests/unit/services/test_service_handler_resolver_multi_param.py -v"
+  - kind: "ci"
+    description: "omnibase_core PR #1057 CI checks pass"
+    command: "gh pr checks 1057 --repo OmniNode-ai/omnibase_core"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-core-tests"
+    description: "Focused resolver and enum coverage proves multi-param known injection behavior"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/enums/test_enum_handler_resolution_outcome.py tests/unit/services/test_service_handler_resolver.py
+          tests/unit/services/test_service_handler_resolver_multi_param.py -v"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: resolver-only service construction change; no pre-merge runtime
+      deploy is required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-10278 changes ServiceHandlerResolver dependency injection
+          semantics only; no Docker image, daemon, broker topic, runtime process, docker exec, or service
+          deploy is required before merge'"

--- a/src/omnibase_core/enums/enum_handler_resolution_outcome.py
+++ b/src/omnibase_core/enums/enum_handler_resolution_outcome.py
@@ -3,19 +3,20 @@
 
 """EnumHandlerResolutionOutcome - terminal outcomes of HandlerResolver.resolve().
 
-Represents the six terminal branches of the `HandlerResolver` precedence chain
-introduced by OMN-9195 (HandlerResolver Architecture Phase 1).
+Represents the seven terminal branches of the `HandlerResolver` precedence chain
+introduced by OMN-9195 (HandlerResolver Architecture Phase 1) and extended
+by OMN-10278 (mandatory DI params — multi-param known injection).
 
-Five values correspond to successful resolution paths (including the
+Six values correspond to successful resolution paths (including the
 deliberate LOCAL_OWNERSHIP_SKIP non-error path, where the handler's parent
-node is not hosted in this runtime). The sixth value (`UNRESOLVABLE`) is a
+node is not hosted in this runtime). The seventh value (`UNRESOLVABLE`) is a
 reserved terminal label; the resolver does NOT return it — it raises
 `TypeError` when the precedence chain is exhausted so that OMN-8735's
 fail-fast invariant is preserved.
 
 Justification for introducing this enum rather than reusing
 `EnumCoreErrorCode`: the outcomes are successful branches of a decision
-chain, not error codes. Five of six values are success states. See
+chain, not error codes. Six of seven values are success states. See
 `docs/plans/2026-04-18-handler-resolver-architecture.md` §"Known Types
 Inventory".
 """
@@ -33,5 +34,6 @@ class EnumHandlerResolutionOutcome(StrEnum):
     RESOLVED_VIA_NODE_REGISTRY = "resolved_via_node_registry"
     RESOLVED_VIA_CONTAINER = "resolved_via_container"
     RESOLVED_VIA_EVENT_BUS = "resolved_via_event_bus"
+    RESOLVED_VIA_KNOWN_PARAMS = "resolved_via_known_params"
     RESOLVED_VIA_ZERO_ARG = "resolved_via_zero_arg"
     UNRESOLVABLE = "unresolvable"

--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -6,7 +6,7 @@ Precedence (first match wins):
     1. Local ownership skip — node not hosted here -> skip cleanly
     2. Node registry        — materialized explicit dep map from create_registry
     3. Container DI         — container.get_service(handler_cls)
-    4. Event-bus injection  — __init__(self, event_bus) single param
+    4. Known-param injection — any combination of event_bus/container/ownership_query
     5. Zero-arg             — handler_cls()
     6. TypeError            — unresolvable (never returns UNRESOLVABLE)
 
@@ -157,13 +157,26 @@ class ServiceHandlerResolver:
             and v.default is inspect.Parameter.empty
         }
 
-        # Step 4 - event_bus injection.
-        if context.event_bus is not None and set(non_self_required_params) == {
-            "event_bus"
-        }:
-            instance = context.handler_cls(event_bus=context.event_bus)
+        # Step 4 - known-param injection (event_bus, container, ownership_query).
+        # Builds a provider map from the context, filters to params the handler
+        # actually requires, and instantiates only when every required param is
+        # satisfiable and no provider value is None. RESOLVED_VIA_KNOWN_PARAMS
+        # subsumes the old single-param RESOLVED_VIA_EVENT_BUS path (OMN-10278).
+        _known_providers: dict[str, object] = {
+            k: v
+            for k, v in (
+                ("event_bus", context.event_bus),
+                ("container", context.container),
+                ("ownership_query", context.ownership_query),
+            )
+            if k in non_self_required_params and v is not None
+        }
+        if non_self_required_params and set(non_self_required_params) <= set(
+            _known_providers
+        ):
+            instance = context.handler_cls(**_known_providers)
             return ModelHandlerResolution(
-                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+                outcome=EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS,
                 handler_instance=instance,
             )
 
@@ -187,7 +200,7 @@ class ServiceHandlerResolver:
             f"Handler {context.handler_module}.{context.handler_name} "
             f"requires constructor parameters {dep_names!r} but no "
             f"ownership_query, node registry explicit deps, container, or "
-            f"event_bus could satisfy them."
+            f"known injectable params could satisfy them."
         )
 
 

--- a/tests/unit/enums/test_enum_handler_resolution_outcome.py
+++ b/tests/unit/enums/test_enum_handler_resolution_outcome.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for EnumHandlerResolutionOutcome (OMN-9195/OMN-9196).
+"""Unit tests for EnumHandlerResolutionOutcome (OMN-9195/OMN-9196/OMN-10278).
 
 Verifies the enum contract for the HandlerResolver precedence chain:
-exactly six terminal outcomes with lowercase-snake wire-stable values.
+seven terminal outcomes with lowercase-snake wire-stable values.
 """
 
 from __future__ import annotations
@@ -29,17 +29,18 @@ class TestEnumHandlerResolutionOutcomeMembership:
         assert issubclass(EnumHandlerResolutionOutcome, str)
         assert issubclass(EnumHandlerResolutionOutcome, Enum)
 
-    def test_enum_has_six_members(self) -> None:
-        """Plan §Task 1 Step 1: exactly six members with fixed names."""
+    def test_enum_has_seven_members(self) -> None:
+        """Plan §Task 1 (OMN-10278): seven members — added RESOLVED_VIA_KNOWN_PARAMS."""
         assert {m.name for m in EnumHandlerResolutionOutcome} == {
             "RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP",
             "RESOLVED_VIA_NODE_REGISTRY",
             "RESOLVED_VIA_CONTAINER",
             "RESOLVED_VIA_EVENT_BUS",
+            "RESOLVED_VIA_KNOWN_PARAMS",
             "RESOLVED_VIA_ZERO_ARG",
             "UNRESOLVABLE",
         }
-        assert len(list(EnumHandlerResolutionOutcome)) == 6
+        assert len(list(EnumHandlerResolutionOutcome)) == 7
 
 
 @pytest.mark.unit
@@ -63,6 +64,10 @@ class TestEnumHandlerResolutionOutcomeValues:
         assert (
             EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS.value
             == "resolved_via_event_bus"
+        )
+        assert (
+            EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS.value
+            == "resolved_via_known_params"
         )
         assert (
             EnumHandlerResolutionOutcome.RESOLVED_VIA_ZERO_ARG.value

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -244,7 +244,11 @@ def test_step_4_event_bus_injection() -> None:
 
     result = ServiceHandlerResolver().resolve(ctx)
 
-    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS
+    # OMN-10278: RESOLVED_VIA_KNOWN_PARAMS subsumes RESOLVED_VIA_EVENT_BUS.
+    assert result.outcome in {
+        EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS,
+        EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+    }
     assert isinstance(result.handler_instance, _HandlerEventBusOnly)
     assert result.handler_instance.event_bus is event_bus
 

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -245,10 +245,7 @@ def test_step_4_event_bus_injection() -> None:
     result = ServiceHandlerResolver().resolve(ctx)
 
     # OMN-10278: RESOLVED_VIA_KNOWN_PARAMS subsumes RESOLVED_VIA_EVENT_BUS.
-    assert result.outcome in {
-        EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS,
-        EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
-    }
+    assert result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS
     assert isinstance(result.handler_instance, _HandlerEventBusOnly)
     assert result.handler_instance.event_bus is event_bus
 

--- a/tests/unit/services/test_service_handler_resolver_multi_param.py
+++ b/tests/unit/services/test_service_handler_resolver_multi_param.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for multi-param known injection in ServiceHandlerResolver (OMN-10278).
+
+Verifies the extended Step 4 that resolves handlers requiring any combination
+of the known injectable params: event_bus, container, ownership_query.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_handler_resolution_outcome import (
+    EnumHandlerResolutionOutcome,
+)
+from omnibase_core.models.resolver.model_handler_resolver_context import (
+    ModelHandlerResolverContext,
+)
+from omnibase_core.services.service_handler_resolver import ServiceHandlerResolver
+
+
+class _FakeEventBus:
+    pass
+
+
+class _FakeContainer:
+    pass
+
+
+@pytest.mark.unit
+def test_resolves_handler_with_event_bus_and_container() -> None:
+    """Handler requiring both event_bus and container is resolved via known params."""
+
+    class HandlerMultiParam:
+        def __init__(self, event_bus: _FakeEventBus, container: _FakeContainer) -> None:
+            self.event_bus = event_bus
+            self.container = container
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=HandlerMultiParam,
+        handler_module="test",
+        handler_name="HandlerMultiParam",
+        contract_name="test_contract",
+        node_name="test_node",
+        event_bus=_FakeEventBus(),
+        container=_FakeContainer(),
+    )
+    resolution = ServiceHandlerResolver().resolve(ctx)
+    assert resolution.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS
+    assert isinstance(resolution.handler_instance, HandlerMultiParam)
+
+
+@pytest.mark.unit
+def test_resolves_handler_with_single_container_param() -> None:
+    """Handler requiring only container is resolved via known params."""
+
+    class HandlerContainerOnly:
+        def __init__(self, container: _FakeContainer) -> None:
+            self.container = container
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=HandlerContainerOnly,
+        handler_module="test",
+        handler_name="HandlerContainerOnly",
+        contract_name="test_contract",
+        node_name="test_node",
+        container=_FakeContainer(),
+    )
+    resolution = ServiceHandlerResolver().resolve(ctx)
+    assert resolution.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS
+    assert isinstance(resolution.handler_instance, HandlerContainerOnly)
+
+
+@pytest.mark.unit
+def test_raises_when_required_known_param_is_none_in_context() -> None:
+    """Handler requires container but context.container is None — must fail at Step 6."""
+
+    class HandlerContainerOnly:
+        def __init__(self, container: object) -> None:
+            self.container = container
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=HandlerContainerOnly,
+        handler_module="test",
+        handler_name="HandlerContainerOnly",
+        contract_name="test_contract",
+        node_name="test_node",
+        event_bus=_FakeEventBus(),
+        container=None,
+    )
+    with pytest.raises(TypeError, match="HandlerContainerOnly"):
+        ServiceHandlerResolver().resolve(ctx)
+
+
+@pytest.mark.unit
+def test_existing_single_event_bus_still_resolves() -> None:
+    """Existing single-event_bus handlers still resolve (regression test)."""
+
+    class HandlerSingleBus:
+        def __init__(self, event_bus: _FakeEventBus) -> None:
+            self.event_bus = event_bus
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=HandlerSingleBus,
+        handler_module="test",
+        handler_name="HandlerSingleBus",
+        contract_name="test_contract",
+        node_name="test_node",
+        event_bus=_FakeEventBus(),
+    )
+    resolution = ServiceHandlerResolver().resolve(ctx)
+    # RESOLVED_VIA_KNOWN_PARAMS subsumes the old RESOLVED_VIA_EVENT_BUS path.
+    assert resolution.outcome in {
+        EnumHandlerResolutionOutcome.RESOLVED_VIA_KNOWN_PARAMS,
+        EnumHandlerResolutionOutcome.RESOLVED_VIA_EVENT_BUS,
+    }
+    assert resolution.handler_instance is not None
+
+
+@pytest.mark.unit
+def test_known_param_missing_from_context_falls_through_to_type_error() -> None:
+    """Handler has unknown required param — not satisfiable, raises TypeError."""
+
+    class HandlerUnknownDep:
+        def __init__(self, unknown_service: object) -> None:
+            self.unknown_service = unknown_service
+
+    ctx = ModelHandlerResolverContext(
+        handler_cls=HandlerUnknownDep,
+        handler_module="test",
+        handler_name="HandlerUnknownDep",
+        contract_name="test_contract",
+        node_name="test_node",
+        event_bus=_FakeEventBus(),
+        container=_FakeContainer(),
+    )
+    with pytest.raises(TypeError, match="HandlerUnknownDep"):
+        ServiceHandlerResolver().resolve(ctx)


### PR DESCRIPTION
## Summary

- Adds RESOLVED_VIA_KNOWN_PARAMS to EnumHandlerResolutionOutcome (Task 1 of OMN-10278)
- Replaces the single-event_bus Step 4 with a general known-param provider map (event_bus, container, ownership_query)
- RESOLVED_VIA_EVENT_BUS retained in enum for wire stability but no longer emitted

## Test plan

- 5 new TDD tests in test_service_handler_resolver_multi_param.py
- 69 tests pass (enum + resolver + model/resolver tests)
- mypy --strict 0 errors, ruff clean, all pre-commit hooks pass

## Ticket

OMN-10278 Track 1 (Tasks 1+2).

Evidence-Source: OCC#913

Evidence-Ticket: OMN-10278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handler resolution now supports flexible multi-parameter injection, allowing handlers to receive combinations of known context dependencies rather than a single special-case injection.

* **Tests**
  * Added and updated unit tests covering multi-parameter resolution, success and failure cases, and backward compatibility for single-parameter handlers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1057)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->