### PR TITLE
feat(OMN-10720): wire 5 substrate gates + stubbed-functionality as blocking pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,89 @@ repos:
         files: ^(src/omnibase_core/enums/enum_hook_bit\.py|scripts/gen_hook_bits\.py|scripts/check_hook_bits_drift\.py)$
         stages: [pre-commit]
 
+      # Substrate Gate: silent except-pass (OMN-wire-validators)
+      # Baseline: 102 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Annotate justified cases with: # substrate-allow: <reason>
+      - id: substrate-silent-except-pass
+        name: No silent except-pass (substrate gate)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.cli.substrate_gates.silent_except_pass
+          --max-violations 102
+        language: system
+        types: [python]
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/)
+        stages: [pre-commit]
+
+      # Substrate Gate: env silent fallback (OMN-wire-validators)
+      # Baseline: 38 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Annotate justified bootstrap cases with: # substrate-allow: bootstrap-fallback
+      - id: substrate-env-silent-fallback
+        name: No env silent fallback (substrate gate)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.cli.substrate_gates.env_silent_fallback
+          --max-violations 38
+        language: system
+        types: [python]
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/)
+        stages: [pre-commit]
+
+      # Substrate Gate: identity field optionality (OMN-wire-validators)
+      # Baseline: 122 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Annotate justified cases with: # substrate-allow: <reason>
+      - id: substrate-identity-field-optionality
+        name: No optional identity fields (substrate gate)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.cli.substrate_gates.identity_field_optionality
+          --max-violations 122
+        language: system
+        types: [python]
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/)
+        stages: [pre-commit]
+
+      # Substrate Gate: loose typing in internal (OMN-wire-validators)
+      # Baseline: 345 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Annotate justified cases with: # substrate-allow: <reason>
+      - id: substrate-loose-typing-internal
+        name: No loose typing in internal (substrate gate)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.cli.substrate_gates.loose_typing_in_internal
+          --max-violations 345
+        language: system
+        types: [python]
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/)
+        stages: [pre-commit]
+
+      # Substrate Gate: protocol kwargs object (OMN-wire-validators)
+      # Baseline: 6 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Protocol methods must use explicit typed parameters, not *args/**kwargs: object/Any.
+      # Annotate justified cases with: # substrate-allow: <reason>
+      - id: substrate-protocol-kwargs-object
+        name: No protocol *args/**kwargs loose typing (substrate gate)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.cli.substrate_gates.protocol_kwargs_object
+          --max-violations 6
+        language: system
+        types: [python]
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/)
+        stages: [pre-commit]
+
+      # validate-stubbed-functionality (OMN-wire-validators)
+      # Baseline: 124 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
+      # Detects NotImplementedError stubs, pass-only methods, TODO/FIXME in prod code.
+      - id: validate-stubbed-functionality
+        name: ONEX Stubbed Functionality Detection
+        entry: uv run python scripts/validation/validate-stubbed-functionality.py --max-violations 124
+        language: system
+        pass_filenames: true
+        files: ^src/.*\.py$
+        exclude: ^(tests/|archived/|archive/|examples/prototypes/).*\.py$
+        stages: [pre-commit]
+
   # ONEX Framework Validation (from shared templates)
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -249,7 +249,8 @@ repos:
       # Detects NotImplementedError stubs, pass-only methods, TODO/FIXME in prod code.
       - id: validate-stubbed-functionality
         name: ONEX Stubbed Functionality Detection
-        entry: uv run python scripts/validation/validate-stubbed-functionality.py --max-violations 124
+        entry: env -u PYTHONPATH uv run python scripts/validation/validate-stubbed-functionality.py --max-violations
+          124
         language: system
         pass_filenames: true
         files: ^src/.*\.py$

--- a/contracts/OMN-10720.yaml
+++ b/contracts/OMN-10720.yaml
@@ -1,0 +1,33 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-10720"
+title: "Wire 5 substrate gates + stubbed-functionality as blocking pre-commit hooks"
+summary: "Wire previously unwired substrate validators as blocking pre-commit hooks with --max-violations
+  ratchet flags. Fixes audit_optional.py advisory exit code. All 6 validators now block on violations."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Unit tests for --max-violations ratchet semantics pass"
+    command: "uv run pytest tests/unit/cli/substrate_gates/test_base.py -v"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "22 unit tests in test_base.py pass covering max-violations boundary semantics"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/cli/substrate_gates/test_base.py -v"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: pure pre-commit hook wiring changes and CLI flag additions; no
+      runtime process or service deploy required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-10720 wires substrate_gates validators as pre-commit hooks
+          and adds --max-violations CLI flag; no Docker image, daemon, broker topic, runtime process,
+          docker exec, or service deploy is required'"

--- a/contracts/OMN-10720.yaml
+++ b/contracts/OMN-10720.yaml
@@ -17,7 +17,8 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-001"
-    description: "22 unit tests in test_base.py pass covering max-violations boundary semantics"
+    description: "23 unit tests in test_base.py pass covering max-violations boundary semantics and negative
+      threshold rejection"
     source: "manual"
     checks:
       - check_type: "command"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ ignore = [
 "scripts/validation/validate_no_except_swallow.py" = ["T201"]
 "scripts/validation/validate_no_none_guard_publish.py" = ["T201"]
 "scripts/validation/validate_no_import_none_fallback.py" = ["T201"]
+"scripts/validation/validate-stubbed-functionality.py" = ["T201", "BLE001"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]
 "src/omnibase_core/validation/validator_local_paths.py" = ["T201"]
 "src/omnibase_core/validation/validator_patterns.py" = ["T201"]

--- a/scripts/validation/audit_optional.py
+++ b/scripts/validation/audit_optional.py
@@ -465,8 +465,8 @@ Examples:
         sys.exit(0)
     else:
         errors = len([v for v in auditor.violations if v.justification_needed])
-        print(f"\n[WARNING] {errors} Optional usages need business justification!")
-        sys.exit(0)  # Don't fail the build for this, just warn
+        print(f"\n[FAIL] {errors} Optional usages need business justification!")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/validation/validate-stubbed-functionality.py
+++ b/scripts/validation/validate-stubbed-functionality.py
@@ -288,8 +288,14 @@ def main() -> int:
     """Main entry point for the validation script."""
     import argparse
 
+    def _non_negative_int(value: str) -> int:
+        n = int(value)
+        if n < 0:
+            raise argparse.ArgumentTypeError(f"--max-violations must be >= 0, got {n}")
+        return n
+
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--max-violations", type=int, default=None)
+    parser.add_argument("--max-violations", type=_non_negative_int, default=None)
     known, remaining = parser.parse_known_args()
 
     if not remaining:

--- a/scripts/validation/validate-stubbed-functionality.py
+++ b/scripts/validation/validate-stubbed-functionality.py
@@ -286,7 +286,13 @@ class ONEXStubbedFunctionalityValidator:
 
 def main() -> int:
     """Main entry point for the validation script."""
-    if len(sys.argv) < 2:
+    import argparse
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--max-violations", type=int, default=None)
+    known, remaining = parser.parse_known_args()
+
+    if not remaining:
         print("Usage: validate-stubbed-functionality.py <file1.py> [file2.py] ...")
         print(
             "Validates that code doesn't contain stubbed or incomplete functionality."
@@ -295,12 +301,20 @@ def main() -> int:
 
     validator = ONEXStubbedFunctionalityValidator()
 
-    # Process all provided files
-    file_paths = [Path(arg) for arg in sys.argv[1:]]
-    success = validator.check_files(file_paths)
+    file_paths = [Path(arg) for arg in remaining]
+    validator.check_files(file_paths)
 
     validator.print_results()
-    return 0 if success else 1
+
+    if known.max_violations is not None:
+        if len(validator.errors) > known.max_violations:
+            print(
+                f"[gate] {len(validator.errors)} violations exceed threshold {known.max_violations}"
+            )
+            return 1
+        return 0
+
+    return 0 if not validator.errors else 1
 
 
 if __name__ == "__main__":

--- a/src/omnibase_core/cli/substrate_gates/_base.py
+++ b/src/omnibase_core/cli/substrate_gates/_base.py
@@ -102,8 +102,14 @@ def main_for_gate(gate: BaseGateCheck, argv: list[str] | None = None) -> int:
     """
     import argparse
 
+    def _non_negative_int(value: str) -> int:
+        n = int(value)
+        if n < 0:
+            raise argparse.ArgumentTypeError(f"--max-violations must be >= 0, got {n}")
+        return n
+
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--max-violations", type=int, default=None)
+    parser.add_argument("--max-violations", type=_non_negative_int, default=None)
     known, remaining = parser.parse_known_args(
         argv if argv is not None else sys.argv[1:]
     )

--- a/src/omnibase_core/cli/substrate_gates/_base.py
+++ b/src/omnibase_core/cli/substrate_gates/_base.py
@@ -96,12 +96,30 @@ class BaseGateCheck(ABC):
 def main_for_gate(gate: BaseGateCheck, argv: list[str] | None = None) -> int:
     """CLI entry point for a single gate.
 
-    Accepts a list of file paths as positional arguments.
-    Exits 0 when no violations are found, 1 otherwise.
+    Accepts a list of file paths as positional arguments.  When ``--max-violations N``
+    is supplied (ratchet mode), exits 0 if violation count <= N and 1 otherwise.
+    Without the flag, exits 0 only when there are zero violations.
     """
-    args = argv if argv is not None else sys.argv[1:]
-    paths = [Path(a) for a in args]
+    import argparse
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--max-violations", type=int, default=None)
+    known, remaining = parser.parse_known_args(
+        argv if argv is not None else sys.argv[1:]
+    )
+
+    paths = [Path(a) for a in remaining]
     violations = gate.run(paths)
     for v in violations:
         print(v, file=sys.stderr)  # print-ok: CLI violation reporting to stderr
+
+    if known.max_violations is not None:
+        if len(violations) > known.max_violations:
+            print(  # print-ok: CLI violation reporting to stderr
+                f"[gate] {len(violations)} violations exceed threshold {known.max_violations}",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
     return 1 if violations else 0

--- a/tests/unit/cli/substrate_gates/test_base.py
+++ b/tests/unit/cli/substrate_gates/test_base.py
@@ -171,3 +171,50 @@ class TestMainForGate:
     def test_no_args_exits_zero(self) -> None:
         gate = _AlwaysViolatingGate()
         assert main_for_gate(gate, []) == 0
+
+    def test_max_violations_below_threshold_exits_zero(self, tmp_path: Path) -> None:
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.py"
+            f.write_text("x = 1\n")
+            files.append(f)
+        gate = _AlwaysViolatingGate()
+        # 3 violations ≤ threshold 5 → exit 0
+        assert (
+            main_for_gate(gate, ["--max-violations", "5"] + [str(f) for f in files])
+            == 0
+        )
+
+    def test_max_violations_at_threshold_exits_zero(self, tmp_path: Path) -> None:
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.py"
+            f.write_text("x = 1\n")
+            files.append(f)
+        gate = _AlwaysViolatingGate()
+        # 3 violations == threshold 3 → exit 0
+        assert (
+            main_for_gate(gate, ["--max-violations", "3"] + [str(f) for f in files])
+            == 0
+        )
+
+    def test_max_violations_exceeds_threshold_exits_one(self, tmp_path: Path) -> None:
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.py"
+            f.write_text("x = 1\n")
+            files.append(f)
+        gate = _AlwaysViolatingGate()
+        # 3 violations > threshold 2 → exit 1
+        assert (
+            main_for_gate(gate, ["--max-violations", "2"] + [str(f) for f in files])
+            == 1
+        )
+
+    def test_max_violations_zero_with_no_violations_exits_zero(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "ok.py"
+        f.write_text("x = 1\n")
+        gate = _AlwaysCleanGate()
+        assert main_for_gate(gate, ["--max-violations", "0", str(f)]) == 0

--- a/tests/unit/cli/substrate_gates/test_base.py
+++ b/tests/unit/cli/substrate_gates/test_base.py
@@ -52,11 +52,13 @@ class _AlwaysViolatingGate(BaseGateCheck):
 
 
 class TestGateViolation:
+    @pytest.mark.unit
     def test_str_format(self, tmp_path: Path) -> None:
         p = tmp_path / "foo.py"
         v = GateViolation(path=p, line=42, message="something wrong")
         assert str(v) == f"{p}:42: something wrong"
 
+    @pytest.mark.unit
     def test_frozen(self) -> None:
         p = Path("x.py")
         v = GateViolation(path=p, line=1, message="msg")
@@ -70,29 +72,36 @@ class TestGateViolation:
 
 
 class TestHasAllowAnnotation:
+    @pytest.mark.unit
     def test_substrate_allow(self) -> None:
         lines = ["x: int | None = None  # substrate-allow: pending-fix"]
         assert has_allow_annotation(lines, 1) is True
 
+    @pytest.mark.unit
     def test_onex_exclude(self) -> None:
         lines = ["y: Any  # ONEX_EXCLUDE: any_type"]
         assert has_allow_annotation(lines, 1) is True
 
+    @pytest.mark.unit
     def test_ai_slop_ok(self) -> None:
         lines = ["z: dict[str, Any]  # ai-slop-ok"]
         assert has_allow_annotation(lines, 1) is True
 
+    @pytest.mark.unit
     def test_no_annotation(self) -> None:
         lines = ["x: int | None = None"]
         assert has_allow_annotation(lines, 1) is False
 
+    @pytest.mark.unit
     def test_out_of_range_low(self) -> None:
         assert has_allow_annotation([], 0) is False
 
+    @pytest.mark.unit
     def test_out_of_range_high(self) -> None:
         lines = ["x = 1"]
         assert has_allow_annotation(lines, 99) is False
 
+    @pytest.mark.unit
     def test_case_insensitive_onex_exclude(self) -> None:
         lines = ["y: Any  # onex_exclude: something"]
         assert has_allow_annotation(lines, 1) is True
@@ -104,16 +113,19 @@ class TestHasAllowAnnotation:
 
 
 class TestBaseGateCheckRun:
+    @pytest.mark.unit
     def test_empty_input_returns_empty_list(self) -> None:
         gate = _AlwaysViolatingGate()
         assert gate.run([]) == []
 
+    @pytest.mark.unit
     def test_clean_file_returns_no_violations(self, tmp_path: Path) -> None:
         f = tmp_path / "clean.py"
         f.write_text("x = 1\n")
         gate = _AlwaysCleanGate()
         assert gate.run([f]) == []
 
+    @pytest.mark.unit
     def test_violating_file_returns_violation(self, tmp_path: Path) -> None:
         f = tmp_path / "bad.py"
         f.write_text("x = 1\n")
@@ -123,6 +135,7 @@ class TestBaseGateCheckRun:
         assert violations[0].path == f
         assert violations[0].line == 1
 
+    @pytest.mark.unit
     def test_syntax_error_reported_as_violation(self, tmp_path: Path) -> None:
         f = tmp_path / "broken.py"
         f.write_text("def foo(\n")  # unclosed paren → SyntaxError
@@ -131,6 +144,7 @@ class TestBaseGateCheckRun:
         assert len(violations) == 1
         assert "syntax error" in violations[0].message.lower()
 
+    @pytest.mark.unit
     def test_unreadable_file_reported_as_violation(self, tmp_path: Path) -> None:
         f = tmp_path / "ghost.py"
         # File never created — OSError on read
@@ -139,6 +153,7 @@ class TestBaseGateCheckRun:
         assert len(violations) == 1
         assert "cannot read file" in violations[0].message.lower()
 
+    @pytest.mark.unit
     def test_multiple_files_aggregated(self, tmp_path: Path) -> None:
         files = []
         for i in range(3):
@@ -156,22 +171,26 @@ class TestBaseGateCheckRun:
 
 
 class TestMainForGate:
+    @pytest.mark.unit
     def test_clean_exits_zero(self, tmp_path: Path) -> None:
         f = tmp_path / "ok.py"
         f.write_text("x = 1\n")
         gate = _AlwaysCleanGate()
         assert main_for_gate(gate, [str(f)]) == 0
 
+    @pytest.mark.unit
     def test_violation_exits_one(self, tmp_path: Path) -> None:
         f = tmp_path / "bad.py"
         f.write_text("x = 1\n")
         gate = _AlwaysViolatingGate()
         assert main_for_gate(gate, [str(f)]) == 1
 
+    @pytest.mark.unit
     def test_no_args_exits_zero(self) -> None:
         gate = _AlwaysViolatingGate()
         assert main_for_gate(gate, []) == 0
 
+    @pytest.mark.unit
     def test_max_violations_below_threshold_exits_zero(self, tmp_path: Path) -> None:
         files = []
         for i in range(3):
@@ -185,6 +204,7 @@ class TestMainForGate:
             == 0
         )
 
+    @pytest.mark.unit
     def test_max_violations_at_threshold_exits_zero(self, tmp_path: Path) -> None:
         files = []
         for i in range(3):
@@ -198,6 +218,7 @@ class TestMainForGate:
             == 0
         )
 
+    @pytest.mark.unit
     def test_max_violations_exceeds_threshold_exits_one(self, tmp_path: Path) -> None:
         files = []
         for i in range(3):
@@ -211,6 +232,7 @@ class TestMainForGate:
             == 1
         )
 
+    @pytest.mark.unit
     def test_max_violations_zero_with_no_violations_exits_zero(
         self, tmp_path: Path
     ) -> None:
@@ -218,3 +240,11 @@ class TestMainForGate:
         f.write_text("x = 1\n")
         gate = _AlwaysCleanGate()
         assert main_for_gate(gate, ["--max-violations", "0", str(f)]) == 0
+
+    @pytest.mark.unit
+    def test_negative_max_violations_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "ok.py"
+        f.write_text("x = 1\n")
+        gate = _AlwaysCleanGate()
+        with pytest.raises(SystemExit):
+            main_for_gate(gate, ["--max-violations", "-1", str(f)])


### PR DESCRIPTION
## Summary

- Adds `--max-violations N` ratchet flag to `main_for_gate()` in `_base.py` so gates can be wired at baseline violation counts and tightened over time without blocking day-1 commits
- Wires all 6 previously unwired validators as blocking pre-commit hooks (all using `pass_filenames=true` for per-file incremental enforcement)
- Fixes `audit_optional.py` advisory exit code (was `sys.exit(0)` on violations — now `sys.exit(1)`)

## Gates wired

| Hook ID | Baseline violations | Mode |
|---|---|---|
| `substrate-silent-except-pass` | 102 | ratchet (`--max-violations 102`) |
| `substrate-env-silent-fallback` | 38 | ratchet (`--max-violations 38`) |
| `substrate-identity-field-optionality` | 122 | ratchet (`--max-violations 122`) |
| `substrate-loose-typing-internal` | 345 | ratchet (`--max-violations 345`) |
| `substrate-protocol-kwargs-object` | 6 | ratchet (`--max-violations 6`) |
| `validate-stubbed-functionality` | 124 | ratchet (`--max-violations 124`) |

All hooks use `env -u PYTHONPATH` to avoid ambient `PYTHONPATH` shadowing the worktree's editable install.

## Fixes

- `audit-optional-usage` hook was already wired but exited 0 on violations — now exits 1 (blocking)
- `validate-stubbed-functionality.py` now accepts `--max-violations` flag for consistent ratchet behaviour

## Test plan

- [x] 4 new unit tests in `test_base.py` for `--max-violations` boundary semantics (below, at, exceeds threshold; zero threshold with clean gate)
- [x] All 22 tests in `tests/unit/cli/substrate_gates/test_base.py` pass
- [x] All 66 pre-commit hooks pass on this PR's staged files
- [x] Pre-push hooks pass (mypy, pyright, naming, protocol UUID, node purity)

Evidence-Source: OCC#921

Evidence-Ticket: OMN-10720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extra commit-time validation hooks and a ratcheting "--max-violations" mode to enforce thresholds
  * Integrated stubbed-functionality detection into the validation pipeline

* **Bug Fixes**
  * Optional-type audit now fails instead of emitting a warning

* **Tests**
  * Expanded unit tests to cover threshold behavior, CLI flag parsing, and validation failure cases

* **Chores**
  * Added a contract entry describing validation requirements, evidence, and deploy notes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1060)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->