### PR TITLE
fix(OMN-10836): validate-exception-handling exits non-zero on violation by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,7 @@ ignore = [
 "scripts/validation/validate_no_none_guard_publish.py" = ["T201"]
 "scripts/validation/validate_no_import_none_fallback.py" = ["T201"]
 "scripts/validation/validate-stubbed-functionality.py" = ["T201", "BLE001"]
+"scripts/validation/validate-exception-handling.py" = ["T201", "BLE001"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]
 "src/omnibase_core/validation/validator_local_paths.py" = ["T201"]
 "src/omnibase_core/validation/validator_patterns.py" = ["T201"]

--- a/scripts/validation/validate-exception-handling.py
+++ b/scripts/validation/validate-exception-handling.py
@@ -12,7 +12,7 @@ Validates that exception handling follows ONEX standards:
 
 Exit codes:
   0 - All validations passed
-  1 - Validation failures found
+  1 - Validation failures found (always enforced; use # fallback-ok to suppress)
 """
 
 import argparse
@@ -152,12 +152,6 @@ def main() -> int:
         nargs="+",
         help="Python files to validate",
     )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Fail on any issues (default: warn only)",
-    )
-
     args = parser.parse_args()
 
     validator = ExceptionHandlingValidator()
@@ -171,7 +165,7 @@ def main() -> int:
 
     if not all_valid:
         validator.print_report()
-        return 1 if args.strict else 0
+        return 1
 
     return 0
 

--- a/tests/unit/scripts/validation/test_validate_exception_handling.py
+++ b/tests/unit/scripts/validation/test_validate_exception_handling.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for validate-exception-handling.py — exit-code enforcement (OMN-10836)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).parent.parent.parent.parent.parent / "scripts" / "validation"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+spec = importlib.util.spec_from_file_location(
+    "validate_exception_handling",
+    SCRIPTS_DIR / "validate-exception-handling.py",
+)
+if spec is None or spec.loader is None:
+    raise ImportError(f"Cannot find validate-exception-handling.py at {SCRIPTS_DIR}")
+_mod = importlib.util.module_from_spec(spec)
+sys.modules["validate_exception_handling"] = _mod
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+ExceptionHandlingValidator = _mod.ExceptionHandlingValidator
+main = _mod.main
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+
+@pytest.mark.unit
+class TestExceptionHandlingValidatorExitCode:
+    """Verify that main() exits non-zero on violations without --strict."""
+
+    def test_bare_except_exits_nonzero_by_default(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.py"
+        f.write_text("try:\n    pass\nexcept:\n    pass\n")
+        with patch.object(sys, "argv", ["validate-exception-handling.py", str(f)]):
+            result = main()
+        assert result == 1
+
+    def test_clean_file_exits_zero(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("def foo() -> None:\n    pass\n")
+        with patch.object(sys, "argv", ["validate-exception-handling.py", str(f)]):
+            result = main()
+        assert result == 0
+
+    def test_fallback_ok_suppresses_bare_except(self, tmp_path: Path) -> None:
+        f = tmp_path / "ok.py"
+        f.write_text("try:\n    pass\nexcept:  # fallback-ok: intentional\n    pass\n")
+        with patch.object(sys, "argv", ["validate-exception-handling.py", str(f)]):
+            result = main()
+        assert result == 0
+
+    def test_base_exception_exits_nonzero_by_default(self, tmp_path: Path) -> None:
+        f = tmp_path / "base.py"
+        f.write_text("try:\n    pass\nexcept BaseException:\n    pass\n")
+        with patch.object(sys, "argv", ["validate-exception-handling.py", str(f)]):
+            result = main()
+        assert result == 1
+
+    def test_non_python_file_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "readme.txt"
+        f.write_text("except:\n    pass\n")
+        with patch.object(sys, "argv", ["validate-exception-handling.py", str(f)]):
+            result = main()
+        assert result == 0
+
+
+@pytest.mark.unit
+class TestExceptionHandlingValidatorLogic:
+    """Unit tests for the validator's detection logic."""
+
+    def test_bare_except_detected(self, tmp_path: Path) -> None:
+        f = tmp_path / "bare.py"
+        f.write_text("try:\n    pass\nexcept:\n    pass\n")
+        v = ExceptionHandlingValidator()
+        assert not v.validate_file(f)
+        assert len(v.errors) == 1
+        assert "Bare except:" in v.errors[0][2]
+
+    def test_base_exception_detected(self, tmp_path: Path) -> None:
+        f = tmp_path / "base.py"
+        f.write_text("try:\n    pass\nexcept BaseException:\n    pass\n")
+        v = ExceptionHandlingValidator()
+        assert not v.validate_file(f)
+        assert len(v.errors) == 1
+
+    def test_clean_file_passes(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("try:\n    pass\nexcept ValueError:\n    raise\n")
+        v = ExceptionHandlingValidator()
+        assert v.validate_file(f)
+        assert v.errors == []

--- a/tests/unit/scripts/validation/test_validate_exception_handling.py
+++ b/tests/unit/scripts/validation/test_validate_exception_handling.py
@@ -26,6 +26,7 @@ if spec is None or spec.loader is None:
     raise ImportError(f"Cannot find validate-exception-handling.py at {SCRIPTS_DIR}")
 _mod = importlib.util.module_from_spec(spec)
 sys.modules["validate_exception_handling"] = _mod
+# NOTE(OMN-10836): spec.loader is validated as non-None two lines above.
 spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 
 ExceptionHandlingValidator = _mod.ExceptionHandlingValidator


### PR DESCRIPTION
## Summary

- Removes the `--strict` conditional in `validate-exception-handling.py` so violations always produce exit code 1 (previously the script silently returned 0 unless `--strict` was passed, making the hook advisory-only)
- Adds `scripts/validation/validate-exception-handling.py` to `pyproject.toml` per-file-ignores for `T201`/`BLE001` — matching the pattern used by all other CLI validation scripts in this repo
- Adds 8 unit tests in `tests/unit/scripts/validation/test_validate_exception_handling.py` covering: non-zero exit on bare except, non-zero exit on BaseException, zero exit on clean files, fallback-ok suppression, and non-Python file skipping

Closes OMN-10836

Evidence-Source: OCC#922

Evidence-Ticket: OMN-10836

## Test plan

- [x] `uv run pytest tests/unit/scripts/validation/test_validate_exception_handling.py -v` — 8 passed
- [x] `uv run pytest tests/unit/scripts/validation/ -v` — 293 passed
- [x] `pre-commit run --files scripts/validation/validate-exception-handling.py tests/unit/scripts/validation/test_validate_exception_handling.py pyproject.toml` — all passed
- [x] `git push` pre-push hooks passed