### PR TITLE
fix(OMN-10835): env_silent_fallback validator catches os.environ.get with default

### DIFF
--- a/contracts/OMN-10835.yaml
+++ b/contracts/OMN-10835.yaml
@@ -1,0 +1,33 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-10835"
+title: "Fix env_silent_fallback validator to exempt os.environ.get(KEY, None)"
+summary: "Adds _default_arg_is_none() helper to EnvSilentFallbackGate so that os.environ.get(KEY, None)
+  and os.getenv(KEY, None) are no longer flagged as silent fallbacks. Explicit None is semantically identical
+  to no default."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "env_silent_fallback gate unit tests pass"
+    command: "uv run pytest tests/unit/cli/substrate_gates/test_env_silent_fallback.py -v"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "20 unit tests for env_silent_fallback gate pass, including 5 new None-default tests"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/cli/substrate_gates/test_env_silent_fallback.py -v"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: pure AST validator fix to existing pre-commit hook, no runtime
+      process or service deploy required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-10835 fixes env_silent_fallback AST gate; no Docker image,
+          daemon, broker topic, runtime process, docker exec, or service deploy is required'"

--- a/src/omnibase_core/cli/substrate_gates/env_silent_fallback.py
+++ b/src/omnibase_core/cli/substrate_gates/env_silent_fallback.py
@@ -4,14 +4,16 @@
 """Gate 3 — banned os.environ.get / os.getenv silent fallback with a default value.
 
 Banned forms:
-  os.environ.get("KEY", "default")   — explicit second arg
-  os.getenv("KEY", "default")        — explicit second arg
+  os.environ.get("KEY", "default")   — explicit non-None second arg
+  os.getenv("KEY", "default")        — explicit non-None second arg
   os.environ.get("KEY") or "default" — BoolOp Or with a constant right side
 
 Allowed:
   os.environ["KEY"]                  — fail-fast KeyError
   os.environ.get("KEY")              — no default, returns None
   os.getenv("KEY")                   — no default, returns None
+  os.environ.get("KEY", None)        — explicit None is equivalent to no default
+  os.getenv("KEY", None)             — explicit None is equivalent to no default
   ... # substrate-allow: bootstrap-fallback  (line-level suppression)
 """
 
@@ -69,6 +71,20 @@ def _is_getenv_call(node: ast.AST) -> bool:
     )
 
 
+def _default_arg_is_none(call: ast.Call) -> bool:
+    """Return True if the default argument is the literal None constant.
+
+    os.environ.get("KEY", None) is semantically identical to os.environ.get("KEY")
+    and must not be flagged as a silent fallback.
+    """
+    if len(call.args) >= 2:
+        return isinstance(call.args[1], ast.Constant) and call.args[1].value is None
+    for kw in call.keywords:
+        if kw.arg == "default":
+            return isinstance(kw.value, ast.Constant) and kw.value.value is None
+    return False
+
+
 class EnvSilentFallbackGate(BaseGateCheck):
     """Detect os.environ.get / os.getenv calls that silently supply a default value."""
 
@@ -99,9 +115,10 @@ class EnvSilentFallbackGate(BaseGateCheck):
 
             # --- Variant 1: os.environ.get(KEY, default) ---
             if isinstance(node, ast.Call) and _is_environ_get_call(node):
-                if len(node.args) >= 2 or any(
+                has_default = len(node.args) >= 2 or any(
                     kw.arg == "default" for kw in node.keywords
-                ):
+                )
+                if has_default and not _default_arg_is_none(node):
                     lineno = node.lineno
                     if not has_allow_annotation(source_lines, lineno):
                         violations.append(
@@ -112,9 +129,10 @@ class EnvSilentFallbackGate(BaseGateCheck):
 
             # --- Variant 2: os.getenv(KEY, default) ---
             if isinstance(node, ast.Call) and _is_getenv_call(node):
-                if len(node.args) >= 2 or any(
+                has_default = len(node.args) >= 2 or any(
                     kw.arg == "default" for kw in node.keywords
-                ):
+                )
+                if has_default and not _default_arg_is_none(node):
                     lineno = node.lineno
                     if not has_allow_annotation(source_lines, lineno):
                         violations.append(

--- a/tests/unit/cli/substrate_gates/test_env_silent_fallback.py
+++ b/tests/unit/cli/substrate_gates/test_env_silent_fallback.py
@@ -154,6 +154,52 @@ class TestAllowAnnotation:
 # ---------------------------------------------------------------------------
 
 
+class TestNoneDefaultAllowed:
+    """os.environ.get(KEY, None) and os.getenv(KEY, None) must NOT be flagged.
+
+    Explicit None is semantically identical to no default — the caller still
+    receives None and must handle the missing-key case explicitly.  Flagging it
+    would produce false positives and push callers toward the uglier
+    os.environ.get(KEY) form with no benefit.
+    """
+
+    def test_environ_get_none_positional_allowed(
+        self, gate: EnvSilentFallbackGate, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "none_pos.py"
+        f.write_text('import os\nHOST = os.environ.get("HOST", None)\n')
+        assert gate.run([f]) == [], "explicit None default must not be flagged"
+
+    def test_environ_get_none_keyword_allowed(
+        self, gate: EnvSilentFallbackGate, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "none_kw.py"
+        f.write_text('import os\nHOST = os.environ.get("HOST", default=None)\n')
+        assert gate.run([f]) == [], "explicit None keyword default must not be flagged"
+
+    def test_getenv_none_positional_allowed(
+        self, gate: EnvSilentFallbackGate, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "none_getenv.py"
+        f.write_text('import os\nPORT = os.getenv("PORT", None)\n')
+        assert gate.run([f]) == [], "os.getenv with None default must not be flagged"
+
+    def test_non_none_default_still_flagged(
+        self, gate: EnvSilentFallbackGate, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "non_none.py"
+        f.write_text('import os\nHOST = os.environ.get("HOST", "/default/path")\n')
+        violations = gate.run([f])
+        assert len(violations) == 1, "non-None string default must still be flagged"
+
+    def test_environ_get_no_default_allowed(
+        self, gate: EnvSilentFallbackGate, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "no_default.py"
+        f.write_text('import os\nHOST = os.environ.get("HOST")\n')
+        assert gate.run([f]) == []
+
+
 class TestAllowedPatterns:
     def test_environ_key_access_allowed(
         self, gate: EnvSilentFallbackGate, tmp_path: Path

--- a/tests/unit/cli/substrate_gates/test_env_silent_fallback.py
+++ b/tests/unit/cli/substrate_gates/test_env_silent_fallback.py
@@ -11,6 +11,8 @@ import pytest
 
 from omnibase_core.cli.substrate_gates.env_silent_fallback import EnvSilentFallbackGate
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def gate() -> EnvSilentFallbackGate:


### PR DESCRIPTION
## Summary

Adds _default_arg_is_none() helper to EnvSilentFallbackGate.check_tree so that os.environ.get(KEY, None) and os.getenv(KEY, None) are no longer flagged as silent fallbacks. Explicit None is semantically identical to os.environ.get(KEY) — the caller still receives None and must handle the missing-key case.

All other non-None defaults (strings, paths, integers, etc.) continue to be flagged.

## Changes

- src/omnibase_core/cli/substrate_gates/env_silent_fallback.py: add _default_arg_is_none(), update docstring, update Variant 1 and Variant 2 check logic
- tests/unit/cli/substrate_gates/test_env_silent_fallback.py: add TestNoneDefaultAllowed class with 5 targeted tests; add module-level pytestmark = pytest.mark.unit
- contracts/OMN-10835.yaml: ticket contract with dod-deploy evidence

## Test plan

- [x] uv run pytest tests/unit/cli/substrate_gates/test_env_silent_fallback.py -v - 20/20 pass
- [x] ruff format + ruff check - clean
- [x] pre-commit run --files ... - all hooks pass

Evidence-Source: OCC#923
Evidence-Ticket: OMN-10835

Fixes OMN-10835