### PR TITLE
feat(OMN-10726): AST-based DI-only handler constructor gate

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -55,6 +55,19 @@
   require_serial: true
   stages: [pre-commit]
 
+- id: handler-di-gate
+  name: Handler DI Gate (OMN-10726)
+  description: >
+    AST-based gate that enforces handlers and nodes acquire all resources via DI container. Rejects __init__
+    signatures with extra parameters beyond (self, container) and rejects direct infrastructure construction
+    (EventBusInmemory(), sqlite3.connect(), etc.) inside __init__. Suppression: # handler-di-ok: <reason>
+  language: python
+  entry: python -m omnibase_core.validators.handler_di_gate
+  types: [python]
+  files: (handlers/handler_.*\.py|nodes/node\.py)$
+  pass_filenames: true
+  stages: [pre-commit]
+
 - id: check-hardcoded-topics-v2
   name: Hardcoded ONEX Topic Strings (contract-driven)
   description: >

--- a/src/omnibase_core/models/validation/model_handler_di_gate_finding.py
+++ b/src/omnibase_core/models/validation/model_handler_di_gate_finding.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelHandlerDiGateFinding — finding from the handler DI gate validator (OMN-10726)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ModelHandlerDiGateFinding:
+    """A single finding from the handler DI gate validator."""
+
+    path: Path
+    line: int
+    column: int
+    rule: str
+    message: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column + 1}: [{self.rule}] {self.message}"
+        )

--- a/src/omnibase_core/validators/handler_di_gate.py
+++ b/src/omnibase_core/validators/handler_di_gate.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Handler DI gate validator (OMN-10726).
+
+Enforces: handler/node constructors must accept exactly `__init__(self, container)`
+and must only acquire resources via container resolution — no direct infrastructure
+construction in handlers.
+
+Two rules:
+
+1. **constructor_signature** — `__init__` must have signature `(self, container)`
+   or `(self, container: SomeType)`. No extra parameters beyond `self` and one
+   `container` positional-or-keyword param.
+
+2. **direct_construction** — assignments inside `__init__` must not construct
+   infrastructure objects directly. Flags `self._x = Anything(...)` patterns where
+   the called constructor is NOT a container resolution call
+   (`container.resolve(...)` / `container.get_service(...)`).
+
+Scanned targets:
+  - ``**/handlers/handler_*.py``
+  - ``**/nodes/node.py``
+
+Usage::
+
+    python -m omnibase_core.validators.handler_di_gate src/
+
+Suppression::
+
+    Add  # handler-di-ok: <reason>  on a violating line to silence that finding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+from omnibase_core.models.validation.model_handler_di_gate_finding import (
+    ModelHandlerDiGateFinding,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPRESSION_MARKER = "handler-di-ok:"
+
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".git",
+        "archived",
+        "archive",
+    }
+)
+
+# Names that indicate a container resolution call — not infrastructure construction.
+_CONTAINER_RESOLUTION_ATTRS: frozenset[str] = frozenset(
+    {"resolve", "get_service", "get", "get_or_none"}
+)
+
+_DEFAULT_SCAN_ROOTS = (Path("src"),)
+
+# ---------------------------------------------------------------------------
+# Path matchers
+# ---------------------------------------------------------------------------
+
+
+def _is_handler_file(path: Path) -> bool:
+    """True if the file is a handler_*.py inside a handlers/ directory."""
+    parts = path.parts
+    return (
+        "handlers" in parts
+        and path.name.startswith("handler_")
+        and path.suffix == ".py"
+    )
+
+
+def _is_node_file(path: Path) -> bool:
+    """True if the file is node.py inside a nodes/ directory."""
+    parts = path.parts
+    return "nodes" in parts and path.name == "node.py"
+
+
+def _is_target_file(path: Path) -> bool:
+    return _is_handler_file(path) or _is_node_file(path)
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_call_dotted_name(node: ast.expr) -> str | None:
+    """Return dotted name of a Call's func, e.g. 'container.resolve'."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parts: list[str] = []
+        cur: ast.expr = node
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _is_container_resolution(call_node: ast.Call) -> bool:
+    """True if call is container.resolve(...) / container.get_service(...) etc."""
+    func = call_node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in _CONTAINER_RESOLUTION_ATTRS:
+        return False
+    # The receiver must be a simple name (container, self._container, etc.)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Rule: constructor_signature
+# ---------------------------------------------------------------------------
+
+
+def _check_constructor_signature(
+    path: Path,
+    cls: ast.ClassDef,
+    lines: list[str],
+) -> list[ModelHandlerDiGateFinding]:
+    """Fail if __init__ does not have exactly (self, container[: T]) params."""
+    findings: list[ModelHandlerDiGateFinding] = []
+
+    for item in cls.body:
+        if not (isinstance(item, ast.FunctionDef) and item.name == "__init__"):
+            continue
+        args = item.args
+        # Collect all param names excluding 'self'
+        all_params = [a.arg for a in args.args]
+        if all_params and all_params[0] == "self":
+            all_params = all_params[1:]
+
+        # PASS: no params after self (container acquired via other means — skip)
+        # PASS: exactly one param named 'container'
+        # FAIL: zero params after self but body has direct constructions (handled separately)
+        # FAIL: param not named 'container'
+        # FAIL: more than one param after self
+
+        if len(all_params) == 0:
+            # No container param — no signature violation, direct_construction rule
+            # will catch any bad assignments
+            continue
+
+        if len(all_params) == 1 and all_params[0] == "container":
+            continue  # PASS
+
+        # Violation
+        param_str = ", ".join(all_params)
+        line_text = lines[item.lineno - 1] if item.lineno <= len(lines) else ""
+        if SUPPRESSION_MARKER in line_text:
+            continue
+        findings.append(
+            ModelHandlerDiGateFinding(
+                path=path,
+                line=item.lineno,
+                column=item.col_offset,
+                rule="constructor_signature",
+                message=(
+                    f"class {cls.name!r} __init__ params ({param_str}) — "
+                    "must be exactly (self, container) with no additional parameters"
+                ),
+            )
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Rule: direct_construction
+# ---------------------------------------------------------------------------
+
+
+def _check_direct_construction(
+    path: Path,
+    cls: ast.ClassDef,
+    lines: list[str],
+) -> list[ModelHandlerDiGateFinding]:
+    """Fail if __init__ assigns self._ = SomeClass() not via container."""
+    findings: list[ModelHandlerDiGateFinding] = []
+
+    for item in cls.body:
+        if not (isinstance(item, ast.FunctionDef) and item.name == "__init__"):
+            continue
+
+        for stmt in ast.walk(item):
+            if not isinstance(stmt, ast.Assign):
+                continue
+            # Only flag `self.xxx = <Call>(...)` patterns
+            for target in stmt.targets:
+                if not (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    continue
+                # RHS must be a Call
+                if not isinstance(stmt.value, ast.Call):
+                    continue
+                call = stmt.value
+                if _is_container_resolution(call):
+                    continue
+                # It's a direct construction — flag it
+                line_text = lines[stmt.lineno - 1] if stmt.lineno <= len(lines) else ""
+                if SUPPRESSION_MARKER in line_text:
+                    continue
+                called_name = _get_call_dotted_name(call.func) or "<unknown>"
+                findings.append(
+                    ModelHandlerDiGateFinding(
+                        path=path,
+                        line=stmt.lineno,
+                        column=stmt.col_offset,
+                        rule="direct_construction",
+                        message=(
+                            f"class {cls.name!r} directly constructs {called_name!r} "
+                            "in __init__ — acquire resources via container.resolve() "
+                            "or container.get_service() instead"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# File-level dispatch
+# ---------------------------------------------------------------------------
+
+
+def _class_name_looks_like_handler(cls_name: str) -> bool:
+    """True if the class name pattern matches a handler or node class."""
+    lower = cls_name.lower()
+    return (
+        "handler" in lower
+        or "node" in lower
+        or "reducer" in lower
+        or "orchestrator" in lower
+        or "effect" in lower
+    )
+
+
+def validate_file(
+    path: Path, rules: frozenset[str] | None = None
+) -> list[ModelHandlerDiGateFinding]:
+    """Validate one Python file; return findings list."""
+    if _is_excluded(path) or not _is_target_file(path):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    active = rules or frozenset({"constructor_signature", "direct_construction"})
+    findings: list[ModelHandlerDiGateFinding] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not _class_name_looks_like_handler(node.name):
+            continue
+        if "constructor_signature" in active:
+            findings.extend(_check_constructor_signature(path, node, lines))
+        if "direct_construction" in active:
+            findings.extend(_check_direct_construction(path, node, lines))
+
+    return findings
+
+
+def validate_paths(
+    paths: list[Path], rules: frozenset[str] | None = None
+) -> list[ModelHandlerDiGateFinding]:
+    """Validate all Python files under the given paths."""
+    findings: list[ModelHandlerDiGateFinding] = []
+    for path in paths:
+        if path.is_file() and path.suffix == ".py":
+            findings.extend(validate_file(path, rules))
+        elif path.is_dir():
+            for py_file in sorted(path.rglob("*.py")):
+                if not _is_excluded(py_file):
+                    findings.extend(validate_file(py_file, rules))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+_VALIDATOR_NAME = "handler_di_gate"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for handler DI gate validator."""
+    parser = argparse.ArgumentParser(
+        description="Handler DI gate validator (OMN-10726).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=list(_DEFAULT_SCAN_ROOTS),
+        help="Python files or directories to scan.",
+    )
+    parser.add_argument(
+        "--rule",
+        action="append",
+        dest="rules",
+        choices=["constructor_signature", "direct_construction"],
+        help="Enable only specific rules (repeatable; default: all rules).",
+    )
+    args = parser.parse_args(argv)
+
+    active_rules = frozenset(args.rules) if args.rules else None
+    findings = validate_paths(args.paths, active_rules)
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"{_VALIDATOR_NAME}: {len(findings)} finding(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    sys.stderr.write(
+        "\nHandlers must accept only (self, container) and resolve deps via container.\n"
+        "Suppress individual lines with:  # handler-di-ok: <reason>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validators/test_handler_di_gate.py
+++ b/tests/unit/validators/test_handler_di_gate.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for handler_di_gate validator (OMN-10726)."""
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.handler_di_gate import validate_file, validate_paths
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _handler(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / f"nodes/my_node/handlers/{name}"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _node_file(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "nodes/my_node/node.py"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _non_handler(tmp_path: Path, name: str, content: str) -> Path:
+    """A Python file NOT in a handlers/ directory."""
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Rule: constructor_signature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConstructorSignature:
+    def test_good_handler_container_only_passes(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, container):
+        self._bus = container.get_service("ProtocolEventBus")
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert findings == []
+
+    def test_good_handler_container_annotated_passes(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, container: ModelONEXContainer) -> None:
+        self._bus = container.get_service("ProtocolEventBus")
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert findings == []
+
+    def test_extra_param_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, container, event_bus):
+        self._bus = event_bus
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "constructor_signature"
+        assert "HandlerBad" in findings[0].message
+        assert "event_bus" in findings[0].message
+
+    def test_wrong_param_name_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, event_bus):
+        self._bus = event_bus
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "constructor_signature"
+
+    def test_no_params_after_self_passes(self, tmp_path: Path) -> None:
+        """Parameterless __init__ has no signature violation (direct_construction rule covers it)."""
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self):
+        pass
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert findings == []
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, container, extra):  # handler-di-ok: legacy param
+        pass
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule: direct_construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDirectConstruction:
+    def test_container_resolve_passes(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, container):
+        self._bus = container.resolve("ProtocolEventBus")
+        self._store = container.get_service("ProtocolStore")
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert findings == []
+
+    def test_direct_event_bus_construction_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+from omnibase_infra.event_bus import EventBusInmemory
+
+class HandlerBad:
+    def __init__(self, container):
+        self._bus = EventBusInmemory()
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "direct_construction"
+        assert "EventBusInmemory" in findings[0].message
+
+    def test_direct_db_connection_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+import sqlite3
+
+class HandlerBad:
+    def __init__(self, container):
+        self._conn = sqlite3.connect(":memory:")
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "direct_construction"
+        assert "sqlite3.connect" in findings[0].message
+
+    def test_direct_adapter_construction_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, container):
+        self._adapter = SomeAdapter()
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert len(findings) == 1
+        assert findings[0].rule == "direct_construction"
+        assert "SomeAdapter" in findings[0].message
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, container):
+        self._bus = EventBusInmemory()  # handler-di-ok: test-only shim
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert findings == []
+
+    def test_non_self_assignment_not_flagged(self, tmp_path: Path) -> None:
+        """Local variable assignments are not flagged."""
+        p = _handler(
+            tmp_path,
+            "handler_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, container):
+        local = SomeHelper()
+        self._bus = container.get_service("ProtocolEventBus")
+""",
+        )
+        findings = validate_file(p, frozenset({"direct_construction"}))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# File targeting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFileTargeting:
+    def test_non_handler_class_in_non_handler_dir_skipped(self, tmp_path: Path) -> None:
+        """Classes outside handlers/ and nodes/ directories are not scanned."""
+        p = _non_handler(
+            tmp_path,
+            "services/service_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, container, extra):
+        self._bus = EventBusInmemory()
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_handler_file_not_named_handler_prefix_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Files in handlers/ but not named handler_*.py are not scanned."""
+        p = tmp_path / "nodes/my_node/handlers/base.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            """\
+class HandlerBase:
+    def __init__(self, container, extra):
+        self._bus = EventBusInmemory()
+""",
+            encoding="utf-8",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_node_py_file_is_scanned(self, tmp_path: Path) -> None:
+        p = _node_file(
+            tmp_path,
+            """\
+class NodeFoo:
+    def __init__(self, container, extra_dep):
+        pass
+""",
+        )
+        findings = validate_file(p, frozenset({"constructor_signature"}))
+        assert len(findings) == 1
+
+    def test_validate_paths_scans_directory(self, tmp_path: Path) -> None:
+        _handler(
+            tmp_path,
+            "handler_a.py",
+            """\
+class HandlerA:
+    def __init__(self, container, event_bus):
+        pass
+""",
+        )
+        _handler(
+            tmp_path,
+            "handler_b.py",
+            """\
+class HandlerB:
+    def __init__(self, container):
+        self._bus = container.get_service("ProtocolEventBus")
+""",
+        )
+        findings = validate_paths([tmp_path], frozenset({"constructor_signature"}))
+        assert len(findings) == 1
+        assert "HandlerA" in findings[0].message


### PR DESCRIPTION
## Summary

- Adds \`src/omnibase_core/validators/handler_di_gate.py\`: AST scanner enforcing two rules on \`handlers/handler_*.py\` and \`nodes/node.py\` files
  - \`constructor_signature\`: \`__init__\` must be exactly \`(self, container)\` — no extra params
  - \`direct_construction\`: \`self._x = SomeClass()\` inside \`__init__\` is rejected unless it is a \`container.resolve()\` / \`container.get_service()\` call
- Adds \`ModelHandlerDiGateFinding\` dataclass (mirrors \`ModelContractConfigComplianceFinding\` pattern)
- Wired as \`handler-di-gate\` pre-commit hook in \`.pre-commit-hooks.yaml\`
- 16 unit tests covering both rules, suppression marker, file targeting, and \`validate_paths\` directory scan

## Test plan

- [x] \`uv run pytest tests/unit/validators/test_handler_di_gate.py -v\` → 16 passed
- [x] \`uv run mypy src/omnibase_core/validators/handler_di_gate.py src/omnibase_core/models/validation/model_handler_di_gate_finding.py --strict\` → 0 errors
- [x] \`pre-commit run --all-files\` on staged files → all hooks passed
- [ ] CI green via \`gh pr checks\`

Evidence-Source: OCC#928
Evidence-Ticket: OMN-10726