### PR TITLE
feat(OMN-9043): add check-local-paths pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -729,6 +729,31 @@ repos:
         exclude: ^(tests/|archived/|archive/|scripts/validation/).*\.py$
         stages: [pre-commit]
 
+      # Portability: No machine-specific absolute paths (OMN-9043)
+      # Catches /Volumes/..., /Users/..., /home/..., C:\... hardcoded paths. # local-path-ok
+      # Fails loud if validator_local_paths is not importable (not a silent skip).
+      # Suppress legitimate lines with: # local-path-ok
+      - id: check-local-paths
+        name: No hardcoded local/machine-specific paths (OMN-9043)
+        entry: uv run python -m omnibase_core.validation.validator_local_paths
+        language: system
+        types: [text]
+        exclude: >-
+          (?x)^(
+            \.secrets\.baseline$|
+            archived/|
+            archive/|
+            tests/fixtures/|
+            tests/unit/validation/test_validator_local_paths\.py$|
+            tests/unit/validation/test_checker_enum_member_casing\.py$|
+            tests/unit/validation/test_checker_literal_duplication\.py$|
+            tests/unit/validation/test_checker_naming_convention\.py$|
+            tests/unit/validation/test_validation_utils\.py$|
+            tests/unit/validation/test_validation_utils_edge_cases\.py$
+          )
+        pass_filenames: true
+        stages: [pre-commit]
+
       - id: validate-exception-handling
         name: ONEX Exception Handling Validation
         entry: uv run python scripts/validation/validate-exception-handling.py

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -35,9 +35,6 @@
   validator: hardcoded-local-paths
   kind: MISSING_CI_WORKFLOW
 - repo: omnibase_core
-  validator: hardcoded-local-paths
-  kind: MISSING_PRE_COMMIT
-- repo: omnibase_core
   validator: naming-conventions
   kind: SILENT_SKIP_WRAPPER
 - repo: omnibase_core

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -235,11 +235,10 @@ class ModelContractBase(BaseModel, ABC):
         description="Contract classification tags",
     )
 
-    annotations: dict[str, Any] | None = (
-        Field(  # ONEX_EXCLUDE: dict_str_any - explicit non-load-bearing migration annotations bag
-            default=None,
-            description="Non-load-bearing operational annotations preserved from legacy contract corpus.",
-        )
+    # ONEX_EXCLUDE: dict_str_any - non-load-bearing migration annotations bag
+    annotations: dict[str, Any] | None = Field(
+        default=None,
+        description="Non-load-bearing operational annotations preserved from legacy contract corpus.",
     )
 
     feature_flags: list[ModelContractFeatureFlag] = Field(

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -336,7 +336,7 @@ A: Create a new file `fixture_<name>.py`, inherit from `TestFixtureBase`, and ad
 
 ## Related Documentation
 
-- **ONEX Patterns:** `/Volumes/PRO-G40/Code/Archon/docs/ONEX_ARCHITECTURE_PATTERNS_COMPLETE.md`
+- **ONEX Patterns:** `docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md`
 - **PR #59 Follow-up Plan:** `docs/PR59_FOLLOWUP_PLAN.md` (Section 5)
 - **Pre-commit Hooks:** `.pre-commit-config.yaml`
 - **Validation Script:** `scripts/validation/validate_no_pydantic_bypass.py`

--- a/tests/unit/models/contracts/test_model_dod_receipt.py
+++ b/tests/unit/models/contracts/test_model_dod_receipt.py
@@ -438,9 +438,9 @@ class TestModelDodReceiptConsolidationFields:
 
     def test_working_dir_field_accepts_string(self) -> None:
         fields = _base_fields()
-        fields["working_dir"] = "/home/runner/work/omnibase_core"
+        fields["working_dir"] = "/home/runner/work/omnibase_core"  # local-path-ok
         receipt = ModelDodReceipt(**fields)
-        assert receipt.working_dir == "/home/runner/work/omnibase_core"
+        assert receipt.working_dir == "/home/runner/work/omnibase_core"  # local-path-ok
 
     def test_both_branch_and_working_dir_together(self) -> None:
         fields = _base_fields()

--- a/tests/unit/models/handlers/test_model_handler_packaging.py
+++ b/tests/unit/models/handlers/test_model_handler_packaging.py
@@ -267,7 +267,7 @@ class TestModelHandlerPackagingURLStructureValidation:
             "oci://docker.io/library/python:3.12",
             "registry://internal.corp/handlers/validator",
             "file:///opt/handlers/handler.whl",
-            "file:///home/user/handlers/handler.whl",
+            "file:///home/user/handlers/handler.whl",  # local-path-ok
         ]
         for url in valid_urls:
             packaging = ModelHandlerPackaging(

--- a/tests/unit/models/intelligence/test_model_tool_execution.py
+++ b/tests/unit/models/intelligence/test_model_tool_execution.py
@@ -374,9 +374,9 @@ class TestModelToolExecutionDirectoryProperty:
             tool_name="Read",
             index=0,
             success=True,
-            file_path="/home/user/project/src/main.py",
+            file_path="/home/user/project/src/main.py",  # local-path-ok
         )
-        assert execution.directory == "/home/user/project/src"
+        assert execution.directory == "/home/user/project/src"  # local-path-ok
 
     def test_directory_from_relative_path(self) -> None:
         """Test directory extracts parent from relative path."""

--- a/tests/unit/models/intelligence/test_model_tool_execution_content.py
+++ b/tests/unit/models/intelligence/test_model_tool_execution_content.py
@@ -229,7 +229,7 @@ class TestModelToolExecutionContentOptionalFields:
         content = ModelToolExecutionContent(
             tool_name_raw="Write",
             tool_name=EnumClaudeCodeToolName.WRITE,
-            file_path="/home/user/test.py",
+            file_path="/home/user/test.py",  # local-path-ok
             language="python",
             content_preview="def main(): pass",
             content_length=16,
@@ -247,7 +247,7 @@ class TestModelToolExecutionContentOptionalFields:
 
         assert content.tool_name_raw == "Write"
         assert content.tool_name == EnumClaudeCodeToolName.WRITE
-        assert content.file_path == "/home/user/test.py"
+        assert content.file_path == "/home/user/test.py"  # local-path-ok
         assert content.language == "python"
         assert content.content_preview == "def main(): pass"
         assert content.content_length == 16
@@ -514,7 +514,7 @@ class TestModelToolExecutionContentSerialization:
         original = ModelToolExecutionContent(
             tool_name_raw="Write",
             tool_name=EnumClaudeCodeToolName.WRITE,
-            file_path="/home/user/test.py",
+            file_path="/home/user/test.py",  # local-path-ok
             language="python",
             content_preview="def main(): pass",
             content_length=16,
@@ -669,7 +669,7 @@ class TestModelToolExecutionContentFromToolName:
         timestamp = datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC)
         content = ModelToolExecutionContent.from_tool_name(
             "Write",
-            file_path="/home/user/test.py",
+            file_path="/home/user/test.py",  # local-path-ok
             language="python",
             content_preview="def main(): pass",
             content_length=16,
@@ -687,7 +687,7 @@ class TestModelToolExecutionContentFromToolName:
         assert content.tool_name == EnumClaudeCodeToolName.WRITE
 
         # Optional fields passed through
-        assert content.file_path == "/home/user/test.py"
+        assert content.file_path == "/home/user/test.py"  # local-path-ok
         assert content.language == "python"
         assert content.content_preview == "def main(): pass"
         assert content.content_length == 16


### PR DESCRIPTION
## Summary

- OMN-9043 — Gap 2: omnibase_core had no check-local-paths pre-commit hook, meaning hardcoded /Volumes/, /Users/, /home/ paths in this repo's source were never caught at commit time
- Adds check-local-paths hook directly invoking omnibase_core.validation.validator_local_paths (no wrapper needed since the module lives here)
- Excludes tests/fixtures/ and validator test files that intentionally contain hardcoded paths for testing the validator itself
- Annotates 10 legitimate test data paths with # local-path-ok
- Removes stale MISSING_PRE_COMMIT baseline entry from validator-requirements-baseline.yaml
- Fixes pre-existing ONEX_EXCLUDE comment misplacement in model_contract_base.py (comment was on closing paren, not the line with dict[str, Any], so it never suppressed the dict-any gate)

## Test plan

- pre-commit run --all-files passes (verified locally — all 70+ hooks green)
- uv run pytest tests/unit/models/contracts/test_model_dod_receipt.py tests/unit/models/handlers/test_model_handler_packaging.py tests/unit/models/intelligence/ -- 234 passed
- CI green

Evidence-Ticket: OMN-9043
Evidence-Source: OCC#952