### PR TITLE
feat(OMN-10859): add SEMANTIC_GRADING to EnumDodCheckType

### DIFF
--- a/src/omnibase_core/enums/ticket/enum_dod_check_type.py
+++ b/src/omnibase_core/enums/ticket/enum_dod_check_type.py
@@ -35,6 +35,10 @@ class EnumDodCheckType(StrEnum):
         Assert that a deployed binary SHA matches the expected contract SHA.
     COMMAND_EXIT_0
         Assert that a shell command exits with code 0 (explicit exit-code variant).
+    SEMANTIC_GRADING
+        Assert that a semantic grading receipt exists at the canonical path, produced
+        by node_pr_semantic_grader_llm_effect. Phase 1: ADVISORY status passes.
+        Phase 2 (after calibration): hard fail when anti_pattern_present >= 0.7.
     """
 
     TEST_EXISTS = "test_exists"
@@ -47,6 +51,7 @@ class EnumDodCheckType(StrEnum):
     RENDERED_OUTPUT = "rendered_output"
     RUNTIME_SHA_MATCH = "runtime_sha_match"
     COMMAND_EXIT_0 = "command_exit_0"
+    SEMANTIC_GRADING = "semantic_grading"
 
 
 __all__ = ["EnumDodCheckType"]

--- a/tests/unit/models/ticket/test_model_contract_dod_item.py
+++ b/tests/unit/models/ticket/test_model_contract_dod_item.py
@@ -160,3 +160,18 @@ class TestModelContractDodItemExtendedChecks:
             checks=[check],
         )
         assert item.checks[0].cwd is None
+
+    def test_semantic_grading_check_type_accepted(self) -> None:
+        """OMN-10859: SEMANTIC_GRADING check type accepted by ModelDodEvidenceCheck."""
+        check = ModelDodEvidenceCheck(
+            check_type=EnumDodCheckType.SEMANTIC_GRADING,
+            check_value="drift/dod_receipts/OMN-10859/dod-001/semantic_grading.yaml",
+        )
+        item = ModelContractDodItem(
+            id="dod-013",
+            description="Acceptance criteria semantically satisfied (advisory Phase 1)",
+            source="generated",
+            checks=[check],
+        )
+        assert item.checks[0].check_type == EnumDodCheckType.SEMANTIC_GRADING
+        assert item.checks[0].check_type == "semantic_grading"


### PR DESCRIPTION
## Summary

- Adds `SEMANTIC_GRADING = "semantic_grading"` to `EnumDodCheckType` in `omnibase_core`
- `ModelDodEvidenceCheck` (which uses this enum) can now declare semantic grading receipts as DoD evidence
- Phase 1: advisory-only — receipt gate treats ADVISORY status as passing; Phase 2 adds hard-fail after calibration

Evidence-Ticket: OMN-10859
Evidence-Source: OCC#954

## OMN-10859

This is Task 1 of 4 for OMN-10859 (semantic ticket verification gate, Phase 1 advisory).

## Test plan

- [x] `uv run pytest tests/unit/models/ticket/test_model_contract_dod_item.py -v` — 15 tests including new `test_semantic_grading_check_type_accepted`
- [x] `uv run mypy src/omnibase_core/enums/ticket/enum_dod_check_type.py --strict` — clean
- [x] `pre-commit run --all-files` — all hooks pass