### PR TITLE
feat(OMN-10511): fix onex run-node to publish to contract-declared topics

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -116,6 +116,14 @@ allowed_files:
     added: "2024-10-15"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/normalization/contract_validator.py"
+    reason: >-
+      Corpus validation entry point that must parse raw YAML to inspect bucket classification before selecting
+      and validating against the appropriate Pydantic model — same architectural pattern as validation/contract_validator.py
+      (excluded in hook config). Pre-existing allowlist gap.
+    added: "2026-05-12"
+    review: "2026-12-13"
+
   - file: "scripts/regenerate_fingerprints.py"
     reason: >-
       Must parse YAML to detect node_type before selecting appropriate Pydantic model class - contract

--- a/contracts/OMN-10512.yaml
+++ b/contracts/OMN-10512.yaml
@@ -26,4 +26,5 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "echo 'deploy-gate: OMN-10512 adds a pure CLI utility; no Docker image, daemon, broker topic, runtime process, docker exec, or service deploy is required'"
+        check_value: "echo 'deploy-gate: OMN-10512 adds a pure CLI utility; no Docker image, daemon, broker
+          topic, runtime process, docker exec, or service deploy is required'"

--- a/contracts/OMN-9770.yaml
+++ b/contracts/OMN-9770.yaml
@@ -3,8 +3,8 @@ schema_version: "1.0.0"
 ticket_id: OMN-9770
 title: "Policy: algorithm/io_operations optionality"
 summary: >
-  Relax compute/effect contract schema loading for migration-audit compatibility
-  while preserving runtime compute validation and recording deploy-gate evidence.
+  Relax compute/effect contract schema loading for migration-audit compatibility while preserving runtime
+  compute validation and recording deploy-gate evidence.
 is_seam_ticket: true
 interface_change: true
 interfaces_touched:
@@ -13,7 +13,8 @@ interfaces_touched:
 evidence_requirements:
   - kind: "ci"
     description: "Focused optionality regression tests pass"
-    command: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py -v"
+    command: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py
+      -v"
   - kind: "ci"
     description: "Runtime compute conversion guard tests pass"
     command: "PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py -v"
@@ -21,8 +22,10 @@ evidence_requirements:
     description: "Full mypy remains clean"
     command: "uv run mypy src/ --config-file=mypy.ini"
   - kind: "manual"
-    description: "Deploy-gate evidence: schema/model validation change only; no live runtime deploy required before merge"
-    command: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard code only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+    description: "Deploy-gate evidence: schema/model validation change only; no live runtime deploy required
+      before merge"
+    command: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard code only;
+      no Docker image, runtime service, broker topic, or live deploy is required before merge'"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -33,13 +36,15 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py -v"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/models/contracts/test_algorithm_io_operations_optionality.py
+          -v"
   - id: "dod-002"
     description: "Runtime compute conversion rejects missing algorithm before dereference"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py -v"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/nodes/test_node_compute_contract_conversion.py
+          -v"
   - id: "dod-003"
     description: "Full mypy proves optional algorithm/io_operations type surface is handled"
     source: "manual"
@@ -51,4 +56,6 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard code only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+        check_value: "echo 'deploy-gate: OMN-9770 changes contract schema validation and runtime guard
+          code only; no Docker image, runtime service, broker topic, or live deploy is required before
+          merge'"

--- a/contracts/OMN-9771.yaml
+++ b/contracts/OMN-9771.yaml
@@ -3,8 +3,8 @@ schema_version: "1.0.0"
 ticket_id: OMN-9771
 title: "Policy: family_misc_extra_fields disposition"
 summary: >
-  Add an explicit non-load-bearing annotations bag and migration-audit
-  normalization for miscellaneous legacy contract fields.
+  Add an explicit non-load-bearing annotations bag and migration-audit normalization for miscellaneous
+  legacy contract fields.
 is_seam_ticket: true
 interface_change: true
 interfaces_touched:
@@ -13,7 +13,8 @@ interfaces_touched:
 evidence_requirements:
   - kind: "ci"
     description: "Focused misc extra fields normalization tests pass"
-    command: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py -v"
+    command: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py
+      -v"
   - kind: "ci"
     description: "Normalization suite passes"
     command: "PYTHONPATH=src uv run pytest tests/unit/normalization -v"
@@ -21,8 +22,10 @@ evidence_requirements:
     description: "Full mypy remains clean"
     command: "uv run mypy src/ --config-file=mypy.ini"
   - kind: "manual"
-    description: "Deploy-gate evidence: schema/normalization change only; no live runtime deploy required before merge"
-    command: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+    description: "Deploy-gate evidence: schema/normalization change only; no live runtime deploy required
+      before merge"
+    command: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization only;
+      no Docker image, runtime service, broker topic, or live deploy is required before merge'"
 emergency_bypass:
   enabled: false
   justification: ""
@@ -33,7 +36,8 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py -v"
+        check_value: "PYTHONPATH=src uv run pytest tests/unit/normalization/test_misc_extra_fields_normalization.py
+          -v"
   - id: "dod-002"
     description: "Normalization suite passes with compose pipeline additions"
     source: "manual"
@@ -51,4 +55,5 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"
+        check_value: "echo 'deploy-gate: OMN-9771 changes contract schema and migration-audit normalization
+          only; no Docker image, runtime service, broker topic, or live deploy is required before merge'"

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -6,20 +6,107 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
+import importlib.util
 import json
 import os
 import sys
 import time
 import uuid
+from pathlib import Path
 
 import click
+from pydantic import BaseModel, ConfigDict, Field
 
-from omnibase_core.constants.constants_event_types import (
-    TOPIC_CLI_RUN_NODE_CMD,
-    TOPIC_CLI_RUN_NODE_RESPONSE,
-)
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+
+def _resolve_node_topics(node_id: str) -> tuple[str, str]:
+    """Resolve the cmd and response topics for a node from its contract.yaml.
+
+    Returns (cmd_topic, response_topic).  Looks up the node via the
+    ``onex.nodes`` entry-point group, loads the colocated contract.yaml,
+    and reads:
+      - cmd_topic:      event_bus.subscribe_topics[0]
+      - response_topic: terminal_event
+
+    Raises click.ClickException if the node is unknown, the contract is
+    missing, or the required fields are absent.
+    """
+
+    class _EventBus(BaseModel):
+        model_config = ConfigDict(extra="ignore")
+        subscribe_topics: list[str] = Field(default_factory=list)
+
+    class _ContractTopics(BaseModel):
+        model_config = ConfigDict(extra="ignore")
+        event_bus: _EventBus = Field(default_factory=_EventBus)
+        terminal_event: str = ""
+
+    matches = [
+        ep
+        for ep in importlib.metadata.entry_points(group="onex.nodes")
+        if ep.name == node_id
+    ]
+    if not matches:
+        known = sorted(
+            {ep.name for ep in importlib.metadata.entry_points(group="onex.nodes")}
+        )
+        raise click.ClickException(
+            f"Unknown node '{node_id}'. Known nodes: {', '.join(known) or '(none)'}"
+        )
+    if len(matches) > 1:
+        sources = ", ".join(str(ep.dist) for ep in matches)
+        raise click.ClickException(
+            f"Duplicate entry-point '{node_id}' registered by: {sources}"
+        )
+
+    module_path = matches[0].value.split(":", 1)[0].strip()
+    spec = importlib.util.find_spec(module_path)
+    if spec is None:
+        raise click.ClickException(
+            f"Failed to resolve module '{module_path}' for node '{node_id}'"
+        )
+
+    if spec.submodule_search_locations:
+        module_dir = Path(next(iter(spec.submodule_search_locations))).resolve()
+    elif spec.origin is not None:
+        module_dir = Path(spec.origin).resolve().parent
+    else:
+        raise click.ClickException(
+            f"Node '{node_id}' module '{module_path}' has no origin; "
+            "cannot locate contract.yaml"
+        )
+
+    contract_path = module_dir / "contract.yaml"
+    if not contract_path.exists():
+        raise click.ClickException(
+            f"Node '{node_id}' has no contract.yaml at {contract_path}"
+        )
+
+    try:
+        contract = load_and_validate_yaml_model(contract_path, _ContractTopics)
+    except ModelOnexError as exc:
+        raise click.ClickException(
+            f"Node '{node_id}' contract.yaml failed to load: {exc.message}"
+        )
+
+    if not contract.event_bus.subscribe_topics:
+        raise click.ClickException(
+            f"Node '{node_id}' contract.yaml has no event_bus.subscribe_topics; "
+            "cannot determine which Kafka topic to publish the command to"
+        )
+    cmd_topic = contract.event_bus.subscribe_topics[0]
+
+    if not contract.terminal_event:
+        raise click.ClickException(
+            f"Node '{node_id}' contract.yaml has no terminal_event; "
+            "cannot determine which Kafka topic to poll for the response"
+        )
+
+    return cmd_topic, contract.terminal_event
 
 
 def _emit_error(node_id: str, message: str, **extra: str | int) -> None:
@@ -39,8 +126,10 @@ def publish_and_poll(
     payload: dict[str, object],
     timeout: int,
     bootstrap_servers: str,
+    cmd_topic: str,
+    response_topic: str,
 ) -> dict[str, object] | None:
-    """Publish a command envelope to onex.cmd and poll for a correlated response.
+    """Publish a command envelope to cmd_topic and poll response_topic for a result.
 
     Returns the response dict, or None on timeout.
     """
@@ -93,7 +182,7 @@ def publish_and_poll(
         # Waiting here (within the caller's deadline) ensures a fast responder
         # cannot produce the reply before this consumer holds partitions
         # (auto.offset.reset="latest" would skip any pre-assignment messages).
-        consumer.subscribe([TOPIC_CLI_RUN_NODE_RESPONSE])
+        consumer.subscribe([response_topic])
         while not consumer.assignment():
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -105,7 +194,7 @@ def publish_and_poll(
 
         producer = Producer({"bootstrap.servers": bootstrap_servers})
         producer.produce(
-            topic=TOPIC_CLI_RUN_NODE_CMD,
+            topic=cmd_topic,
             value=json.dumps(envelope).encode(),
             on_delivery=_on_delivery,
         )
@@ -162,14 +251,19 @@ def publish_and_poll(
 def run_node(node_id: str, input_json: str, timeout: int) -> None:
     """Execute a remote ONEX node via Kafka.
 
-    Publishes a command envelope to the onex.cmd topic with the given NODE_ID
-    and input payload, then polls for a correlated response. Exits non-zero
+    Resolves the node's contract-declared input and terminal topics, publishes
+    a command envelope, then polls for a correlated response. Exits non-zero
     on failure or timeout, emitting a SkillRoutingError JSON envelope.
     """
     try:
         payload = json.loads(input_json)
     except json.JSONDecodeError as exc:
         _emit_error(node_id, f"Invalid JSON input: {exc}")
+
+    try:
+        cmd_topic, response_topic = _resolve_node_topics(node_id)
+    except click.ClickException as exc:
+        _emit_error(node_id, exc.format_message())
 
     bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
 
@@ -179,6 +273,8 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
             payload=payload,
             timeout=timeout,
             bootstrap_servers=bootstrap_servers,
+            cmd_topic=cmd_topic,
+            response_topic=response_topic,
         )
     except (ConnectionError, OSError, ImportError, ModelOnexError) as exc:
         _emit_error(node_id, str(exc))

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -36,11 +36,11 @@ def _resolve_node_topics(node_id: str) -> tuple[str, str]:
     missing, or the required fields are absent.
     """
 
-    class _EventBus(BaseModel):
+    class _EventBus(BaseModel):  # type: ignore[explicit-any]
         model_config = ConfigDict(extra="ignore")
         subscribe_topics: list[str] = Field(default_factory=list)
 
-    class _ContractTopics(BaseModel):
+    class _ContractTopics(BaseModel):  # type: ignore[explicit-any]
         model_config = ConfigDict(extra="ignore")
         event_bus: _EventBus = Field(default_factory=_EventBus)
         terminal_event: str = ""

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -87,6 +87,136 @@ class TestCliRunNodeNoKafkaPythonImport:
         )
 
 
+_MOCK_CMD_TOPIC = "onex.cmd.test.node-start.v1"
+_MOCK_RESPONSE_TOPIC = "onex.evt.test.node-completed.v1"
+_PATCH_RESOLVE_TOPICS = "omnibase_core.cli.cli_run_node._resolve_node_topics"
+
+
+class TestResolveNodeTopics:
+    """Test _resolve_node_topics contract lookup (OMN-10511)."""
+
+    def test_unknown_node_raises_click_exception(self) -> None:
+        import click
+
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        with patch(
+            "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
+            return_value=[],
+        ):
+            with pytest.raises(click.ClickException, match="Unknown node"):
+                _resolve_node_topics("nonexistent-node")
+
+    def test_duplicate_entry_point_raises_click_exception(self) -> None:
+        import click
+
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        ep1 = MagicMock()
+        ep1.name = "my-node"
+        ep1.value = "pkg.nodes.my_node:MyNode"
+        ep2 = MagicMock()
+        ep2.name = "my-node"
+        ep2.value = "other.nodes.my_node:MyNode"
+
+        with patch(
+            "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
+            return_value=[ep1, ep2],
+        ):
+            with pytest.raises(click.ClickException, match="Duplicate"):
+                _resolve_node_topics("my-node")
+
+    def test_resolves_topics_from_contract_yaml(self, tmp_path: Path) -> None:
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        contract = {
+            "event_bus": {"subscribe_topics": [_MOCK_CMD_TOPIC]},
+            "terminal_event": _MOCK_RESPONSE_TOPIC,
+        }
+        contract_file = tmp_path / "contract.yaml"
+        import yaml as _yaml
+
+        contract_file.write_text(_yaml.dump(contract))
+
+        ep = MagicMock()
+        ep.name = "my-node"
+        ep.value = "pkg.nodes.my_node"
+
+        mock_spec = MagicMock()
+        mock_spec.submodule_search_locations = [str(tmp_path)]
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
+                return_value=mock_spec,
+            ),
+        ):
+            cmd_topic, response_topic = _resolve_node_topics("my-node")
+
+        assert cmd_topic == _MOCK_CMD_TOPIC
+        assert response_topic == _MOCK_RESPONSE_TOPIC
+
+    def test_missing_subscribe_topics_raises(self, tmp_path: Path) -> None:
+        import click
+        import yaml as _yaml
+
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        contract = {"terminal_event": _MOCK_RESPONSE_TOPIC}
+        (tmp_path / "contract.yaml").write_text(_yaml.dump(contract))
+
+        ep = MagicMock()
+        ep.name = "my-node"
+        ep.value = "pkg.nodes.my_node"
+        mock_spec = MagicMock()
+        mock_spec.submodule_search_locations = [str(tmp_path)]
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
+                return_value=mock_spec,
+            ),
+        ):
+            with pytest.raises(click.ClickException, match="subscribe_topics"):
+                _resolve_node_topics("my-node")
+
+    def test_missing_terminal_event_raises(self, tmp_path: Path) -> None:
+        import click
+        import yaml as _yaml
+
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        contract = {"event_bus": {"subscribe_topics": [_MOCK_CMD_TOPIC]}}
+        (tmp_path / "contract.yaml").write_text(_yaml.dump(contract))
+
+        ep = MagicMock()
+        ep.name = "my-node"
+        ep.value = "pkg.nodes.my_node"
+        mock_spec = MagicMock()
+        mock_spec.submodule_search_locations = [str(tmp_path)]
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
+                return_value=mock_spec,
+            ),
+        ):
+            with pytest.raises(click.ClickException, match="terminal_event"):
+                _resolve_node_topics("my-node")
+
+
 class TestPublishAndPoll:
     """Test publish_and_poll with stubbed confluent_kafka Producer and Consumer."""
 
@@ -118,11 +248,14 @@ class TestPublishAndPoll:
                 payload={"foo": "bar"},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
+                cmd_topic=_MOCK_CMD_TOPIC,
+                response_topic=_MOCK_RESPONSE_TOPIC,
             )
 
         mock_producer.produce.assert_called_once()
         produce_kwargs = mock_producer.produce.call_args
-        assert produce_kwargs.kwargs.get("topic") or produce_kwargs.args[0]
+        assert produce_kwargs.kwargs.get("topic") == _MOCK_CMD_TOPIC
+        mock_consumer.subscribe.assert_called_once_with([_MOCK_RESPONSE_TOPIC])
         mock_producer.flush.assert_called_once_with(timeout=10.0)
 
     def test_returns_correlated_message(self) -> None:
@@ -167,6 +300,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
+                cmd_topic=_MOCK_CMD_TOPIC,
+                response_topic=_MOCK_RESPONSE_TOPIC,
             )
 
         assert result is not None
@@ -198,6 +333,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
+                cmd_topic=_MOCK_CMD_TOPIC,
+                response_topic=_MOCK_RESPONSE_TOPIC,
             )
 
         assert result is None
@@ -239,6 +376,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
+                cmd_topic=_MOCK_CMD_TOPIC,
+                response_topic=_MOCK_RESPONSE_TOPIC,
             )
 
         assert result is not None
@@ -263,6 +402,8 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
+                    cmd_topic=_MOCK_CMD_TOPIC,
+                    response_topic=_MOCK_RESPONSE_TOPIC,
                 )
         mock_consumer.close.assert_called_once()
 
@@ -277,6 +418,8 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
+                    cmd_topic=_MOCK_CMD_TOPIC,
+                    response_topic=_MOCK_RESPONSE_TOPIC,
                 )
 
     def test_delivery_failure_raises_onerror(self) -> None:
@@ -306,6 +449,8 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
+                    cmd_topic=_MOCK_CMD_TOPIC,
+                    response_topic=_MOCK_RESPONSE_TOPIC,
                 )
 
 
@@ -316,7 +461,10 @@ class TestRunNodeCommand:
         from omnibase_core.cli.cli_run_node import run_node
 
         runner = CliRunner()
-        result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
+        with patch(
+            _PATCH_RESOLVE_TOPICS, return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC)
+        ):
+            result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
         assert result.exit_code != 0
 
     def test_timeout_response_exits_nonzero(self) -> None:
@@ -332,6 +480,10 @@ class TestRunNodeCommand:
 
         with (
             patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
+            patch(
+                _PATCH_RESOLVE_TOPICS,
+                return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC),
+            ),
             patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=_monotonic_values,
@@ -350,6 +502,52 @@ class TestRunNodeCommand:
         output = json.loads(result.output)
         assert output["error_type"] == "SkillRoutingError"
         assert "Timeout" in output["message"]
+
+    def test_publishes_to_contract_declared_topics(self) -> None:
+        """run-node must use contract-declared topics, not hardcoded ones (OMN-10511)."""
+        from omnibase_core.cli.cli_run_node import run_node
+
+        runner = CliRunner()
+        mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0
+        captured_consumer: list[MagicMock] = []
+
+        def _make_consumer(config: dict[str, object]) -> MagicMock:
+            consumer = MagicMock()
+            group_id = str(config.get("group.id", ""))
+            corr = group_id.removeprefix("onex-run-node-")
+            msg = _make_mock_message(corr, extra={"result": "done"})
+            consumer.poll.return_value = msg
+            consumer.assignment.return_value = [object()]
+            captured_consumer.append(consumer)
+            return consumer
+
+        _monotonic_values = iter([1000.0, 999.0])
+
+        with (
+            patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
+            patch(
+                _PATCH_RESOLVE_TOPICS,
+                return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC),
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
+            ),
+            patch(_PATCH_CONSUMER, side_effect=_make_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            result = runner.invoke(
+                run_node, ["my-node", "--input", "{}", "--timeout", "30"]
+            )
+
+        assert result.exit_code == 0, result.output
+        produce_call = mock_producer.produce.call_args
+        assert produce_call.kwargs["topic"] == _MOCK_CMD_TOPIC
+        assert captured_consumer[0].subscribe.call_args[0][0] == [_MOCK_RESPONSE_TOPIC]
 
 
 class TestCliRunNodeNoKafkaPythonImportIsolated:

--- a/tests/unit/cli/test_cli_run_node_envelope.py
+++ b/tests/unit/cli/test_cli_run_node_envelope.py
@@ -75,6 +75,8 @@ class TestCliEnvelopeShape:
                 payload={"key": "value"},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
+                cmd_topic="onex.cmd.test.node-start.v1",
+                response_topic="onex.evt.test.node-completed.v1",
             )
 
         assert len(captured) == 1
@@ -121,6 +123,8 @@ class TestCliEnvelopeShape:
                 payload={},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
+                cmd_topic="onex.cmd.test.node-start.v1",
+                response_topic="onex.evt.test.node-completed.v1",
             )
 
         assert len(captured) == 1
@@ -352,6 +356,8 @@ class TestCliEnvelopeRoundTrip:
                 payload={"input": 42},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
+                cmd_topic="onex.cmd.test.node-start.v1",
+                response_topic="onex.evt.test.node-completed.v1",
             )
 
         assert result is not None

--- a/tests/unit/cli/test_cli_standalone.py
+++ b/tests/unit/cli/test_cli_standalone.py
@@ -100,6 +100,13 @@ class TestRunNodeCommand:
         with (
             patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
             patch(
+                "omnibase_core.cli.cli_run_node._resolve_node_topics",
+                return_value=(
+                    "onex.cmd.test.node-start.v1",
+                    "onex.evt.test.node-completed.v1",
+                ),
+            ),
+            patch(
                 "omnibase_core.cli.cli_run_node.publish_and_poll",
                 return_value=mock_response,
             ),
@@ -116,6 +123,13 @@ class TestRunNodeCommand:
         runner = CliRunner()
         with (
             patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
+            patch(
+                "omnibase_core.cli.cli_run_node._resolve_node_topics",
+                return_value=(
+                    "onex.cmd.test.node-start.v1",
+                    "onex.evt.test.node-completed.v1",
+                ),
+            ),
             patch(
                 "omnibase_core.cli.cli_run_node.publish_and_poll",
                 return_value=None,
@@ -141,6 +155,13 @@ class TestRunNodeCommand:
         runner = CliRunner()
         with (
             patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
+            patch(
+                "omnibase_core.cli.cli_run_node._resolve_node_topics",
+                return_value=(
+                    "onex.cmd.test.node-start.v1",
+                    "onex.evt.test.node-completed.v1",
+                ),
+            ),
             patch(
                 "omnibase_core.cli.cli_run_node.publish_and_poll",
                 side_effect=ConnectionError("Kafka unreachable"),


### PR DESCRIPTION
## Summary

Fixes OMN-10511: `onex run-node <node_id> --input '{...}'` was publishing to hardcoded topic constants (`onex.cmd.platform.run-node.v1` / `onex.evt.platform.run-node-response.v1`). No registered node subscribes to those topics, so every invocation timed out after 30s.

- Adds `_resolve_node_topics(node_id)` which resolves the target node via the `onex.nodes` entry-point group, loads its `contract.yaml` using `load_and_validate_yaml_model` (Pydantic, not raw `yaml.safe_load`), and extracts `event_bus.subscribe_topics[0]` (cmd topic) and `terminal_event` (response topic).
- `publish_and_poll` now accepts explicit `cmd_topic` and `response_topic` params instead of hardcoded constants.
- Adds `TestResolveNodeTopics` test class with 5 regression cases covering unknown node, duplicate entry-point, correct topic extraction, and missing-field errors.
- Backfills `normalization/contract_validator.py` into the yaml validation allowlist (pre-existing gap — same pattern as the excluded `validation/contract_validator.py`).

## Test plan

- [ ] `pytest tests/unit/cli/test_cli_run_node.py` — 18 tests including `TestResolveNodeTopics` (5 new) and `test_publishes_to_contract_declared_topics` regression
- [ ] `pytest tests/unit/cli/test_cli_standalone.py` — 24 tests, all mocking `_resolve_node_topics`
- [ ] `pytest tests/unit/cli/test_cli_run_node_envelope.py` — 8 tests
- [ ] All 570 CLI unit tests pass
- [ ] All pre-commit hooks pass (local + push hooks)
- [ ] CI green

OMN-10511

Evidence-Source: OCC#972
Evidence-Ticket: OMN-10511