### PR TITLE
feat(OMN-9906): add WORKTREE_GUARD bit to EnumHookBit (bit 59)

### DIFF
--- a/src/omnibase_core/enums/enum_hook_bit.py
+++ b/src/omnibase_core/enums/enum_hook_bit.py
@@ -91,6 +91,7 @@ class EnumHookBit(IntEnum):
     SESSION_START_ONEX_CLI_PIN_CHECK = 1 << 56
     HANDOFF_NUDGE = 1 << 57
     TASK_BOUNDARY_TESTS = 1 << 58
+    WORKTREE_GUARD = 1 << 59
 
 
 # Default mask ORs all actual member values — correct even after tombstones are

--- a/tests/unit/test_enum_hook_bit.py
+++ b/tests/unit/test_enum_hook_bit.py
@@ -13,7 +13,7 @@ from omnibase_core.enums.enum_hook_bit import EnumHookBit, hook_enabled
 pytestmark = pytest.mark.unit
 
 # Frozen GATE count from Task 1 inventory. Update only when the inventory doc changes.
-_N_GATE = 59
+_N_GATE = 60
 
 
 class TestEnumHookBit:


### PR DESCRIPTION
## Summary

- Adds `WORKTREE_GUARD = 1 << 59` to `EnumHookBit` in `enum_hook_bit.py`
- This bit is the canonical bitmask entry for the git-worktree path enforcement hook, replacing the legacy `ONEX_WORKTREE_GUARD` env-var toggle
- Append-only per bit governance policy (bit 59 follows `TASK_BOUNDARY_TESTS` at bit 58)

## Motivation

OMN-9906: `ONEX_WORKTREE_GUARD=off` was an interim env-var toggle outside the contract+overlay system. The companion omniclaude PR migrates the shell hook to use `onex_hook_gate WORKTREE_GUARD` via `ONEX_HOOKS_MASK`, which requires this bit to be defined.

## Dependency

Must land before the omniclaude OMN-9906 PR bumps its `omnibase-core` pin to pick up this bit.

## Test plan

- [ ] `uv run pytest tests/ -m unit -v` passes (no test changes needed — enum is append-only)
- [ ] Pre-commit hook `hook_bits.sh drift check` passes (regenerates from updated enum)
- [ ] CI green

Evidence-Source: OCC#972
Evidence-Ticket: OMN-9906