### PR TITLE
feat(OMN-10920): delegation runtime profile contract validators

### DIFF
--- a/src/omnibase_core/validation/delegation/__init__.py
+++ b/src/omnibase_core/validation/delegation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/validation/delegation/validator_delegation_profile.py
+++ b/src/omnibase_core/validation/delegation/validator_delegation_profile.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Delegation runtime profile validator.
+
+Rejects malformed profiles at parse time via two passes:
+1. Pydantic schema validation (type errors, required fields, min_length)
+2. Custom semantic rules (no raw URLs/IPs in ref fields, token limit consistency)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.model_delegation_runtime_profile import (
+    ModelDelegationRuntimeProfile,
+)
+
+__all__ = ["ValidationResult", "validate_delegation_profile"]
+
+_URL_PATTERN = re.compile(r"^https?://", re.IGNORECASE)
+_IP_PATTERN = re.compile(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
+
+
+@dataclass
+class ValidationResult:
+    is_valid: bool
+    errors: list[str] = field(default_factory=list)
+
+
+def _looks_like_endpoint(value: str) -> bool:
+    return bool(_URL_PATTERN.search(value) or _IP_PATTERN.search(value))
+
+
+def _check_llm_backends(
+    profile: ModelDelegationRuntimeProfile,
+    errors: list[str],
+) -> None:
+    for backend_name, backend in profile.llm_backends.items():
+        if _looks_like_endpoint(backend.bifrost_endpoint_ref):
+            errors.append(
+                f"llm_backends[{backend_name!r}].bifrost_endpoint_ref must be a "
+                f"symbolic ref, not a raw URL or IP address: "
+                f"{backend.bifrost_endpoint_ref!r}"
+            )
+        if backend.max_tokens_hard_limit < backend.max_tokens_default:
+            errors.append(
+                f"llm_backends[{backend_name!r}].max_tokens_hard_limit "
+                f"({backend.max_tokens_hard_limit}) must be >= max_tokens_default "
+                f"({backend.max_tokens_default})"
+            )
+
+
+def _check_event_bus(
+    profile: ModelDelegationRuntimeProfile,
+    errors: list[str],
+) -> None:
+    for server in profile.event_bus.bootstrap_servers:
+        if _URL_PATTERN.search(server):
+            errors.append(
+                f"event_bus.bootstrap_servers entry must not be a URL "
+                f"(use host:port form): {server!r}"
+            )
+
+
+def validate_delegation_profile(data: Any) -> ValidationResult:
+    """Validate a delegation runtime profile dict.
+
+    Returns a ValidationResult with is_valid=False and populated errors on any
+    schema or semantic violation. Never raises.
+    """
+    try:
+        profile = ModelDelegationRuntimeProfile.model_validate(data)
+    except ValidationError as exc:
+        return ValidationResult(
+            is_valid=False,
+            errors=[str(e["msg"]) for e in exc.errors()],
+        )
+    except Exception as exc:  # noqa: BLE001  # fallback-ok: validator contract — never raises, captures all errors into result
+        return ValidationResult(is_valid=False, errors=[str(exc)])
+
+    errors: list[str] = []
+    _check_llm_backends(profile, errors)
+    _check_event_bus(profile, errors)
+
+    return ValidationResult(is_valid=not errors, errors=errors)

--- a/src/omnibase_core/validation/delegation/validator_delegation_profile.py
+++ b/src/omnibase_core/validation/delegation/validator_delegation_profile.py
@@ -14,11 +14,10 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import ValidationError
-
-from omnibase_core.models.contracts.model_delegation_runtime_profile import (
+from omnibase_compat.contracts.delegation.model_delegation_runtime_profile import (
     ModelDelegationRuntimeProfile,
 )
+from pydantic import ValidationError
 
 __all__ = ["ValidationResult", "validate_delegation_profile"]
 

--- a/tests/unit/validation/delegation/__init__.py
+++ b/tests/unit/validation/delegation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/validation/delegation/test_validator_delegation_profile.py
+++ b/tests/unit/validation/delegation/test_validator_delegation_profile.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import yaml
+
+from omnibase_core.validation.delegation.validator_delegation_profile import (
+    validate_delegation_profile,
+)
+
+VALID_YAML = """
+name: delegation-runtime-profile
+version: 1
+runtime_profile: main
+event_bus:
+  provider: kafka
+  bootstrap_servers:
+    - redpanda:9092
+  topic_policy_ref: default-topics
+llm_backends:
+  default:
+    bifrost_endpoint_ref: local-bifrost
+    default_task_model_ref: qwen3-coder
+    max_tokens_default: 2048
+    max_tokens_hard_limit: 8192
+    timeout_ms: 120000
+"""
+
+
+def test_valid_profile_passes() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    result = validate_delegation_profile(data)
+    assert result.is_valid
+    assert result.errors == []
+
+
+def test_rejects_endpoint_url_in_bifrost_ref() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["llm_backends"]["default"]["bifrost_endpoint_ref"] = (
+        "http://192.168.86.201:8000"
+    )
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+    assert any("bifrost_endpoint_ref" in e for e in result.errors)
+
+
+def test_rejects_ip_in_bifrost_ref() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["llm_backends"]["default"]["bifrost_endpoint_ref"] = "192.168.86.201:8000"
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+    assert any("bifrost_endpoint_ref" in e for e in result.errors)
+
+
+def test_rejects_missing_bootstrap_servers() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["event_bus"]["bootstrap_servers"] = []
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+
+
+def test_rejects_max_tokens_hard_limit_below_default() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["llm_backends"]["default"]["max_tokens_hard_limit"] = 512
+    data["llm_backends"]["default"]["max_tokens_default"] = 2048
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+    assert any("max_tokens" in e for e in result.errors)
+
+
+def test_rejects_raw_value_in_secret_ref() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["security"] = {
+        "broker_allowlist_ref": "broker-list",
+        "endpoint_cidr_allowlist_ref": "cidr-list",
+        "shared_secret_ref": {
+            "ref_name": "MY_SECRET",
+            "raw_value": "super-secret-value",
+        },
+    }
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+
+
+def test_rejects_url_in_bootstrap_server() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["event_bus"]["bootstrap_servers"] = ["http://redpanda:9092"]
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+    assert any("bootstrap_servers" in e for e in result.errors)
+
+
+def test_multiple_llm_backends_all_validated() -> None:
+    data = yaml.safe_load(VALID_YAML)
+    data["llm_backends"]["fast"] = {
+        "bifrost_endpoint_ref": "https://bad-url.example.com/api",
+        "default_task_model_ref": "haiku",
+        "max_tokens_default": 1024,
+        "max_tokens_hard_limit": 4096,
+        "timeout_ms": 30000,
+    }
+    result = validate_delegation_profile(data)
+    assert not result.is_valid
+    assert any("fast" in e for e in result.errors)
+
+
+def test_invalid_yaml_structure_rejected() -> None:
+    result = validate_delegation_profile({"not": "a valid profile"})
+    assert not result.is_valid

--- a/tests/unit/validation/delegation/test_validator_delegation_profile.py
+++ b/tests/unit/validation/delegation/test_validator_delegation_profile.py
@@ -36,7 +36,7 @@ def test_valid_profile_passes() -> None:
 def test_rejects_endpoint_url_in_bifrost_ref() -> None:
     data = yaml.safe_load(VALID_YAML)
     data["llm_backends"]["default"]["bifrost_endpoint_ref"] = (
-        "http://192.168.86.201:8000"
+        "https://192.168.86.201:8000"
     )
     result = validate_delegation_profile(data)
     assert not result.is_valid
@@ -83,7 +83,7 @@ def test_rejects_raw_value_in_secret_ref() -> None:
 
 def test_rejects_url_in_bootstrap_server() -> None:
     data = yaml.safe_load(VALID_YAML)
-    data["event_bus"]["bootstrap_servers"] = ["http://redpanda:9092"]
+    data["event_bus"]["bootstrap_servers"] = ["https://redpanda:9092"]
     result = validate_delegation_profile(data)
     assert not result.is_valid
     assert any("bootstrap_servers" in e for e in result.errors)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -650,7 +650,7 @@ wheels = [
 [[package]]
 name = "omnibase-compat"
 version = "0.3.1"
-source = { git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main#64897d1b15d6d8502a46518ddf3e126382645150" }
+source = { git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main#d86ee00a8b585f9bf32b1ec7c8e785843e4957b0" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },


### PR DESCRIPTION
## Summary
- Adds `validate_delegation_profile()` with `ValidationResult` dataclass — two-pass validation (Pydantic schema + custom semantic rules)
- Rejects raw URLs/IPs in `bifrost_endpoint_ref` fields (must be symbolic refs, not hardcoded endpoints)
- Rejects `max_tokens_hard_limit < max_tokens_default` (token limit consistency)
- Rejects URL schemes in `bootstrap_servers` entries (must be `host:port` form)
- Pydantic pass catches schema violations: missing required fields, empty `bootstrap_servers` list, raw `shared_secret_ref.raw_value`

## Test plan
- [x] Valid profile passes validation
- [x] Endpoint URL in `bifrost_endpoint_ref` rejected
- [x] Raw IP in `bifrost_endpoint_ref` rejected
- [x] Empty `bootstrap_servers` rejected (Pydantic `min_length=1`)
- [x] `max_tokens_hard_limit < max_tokens_default` rejected
- [x] Raw value in `shared_secret_ref` rejected (Pydantic model validator on `ModelDelegationSecretRef`)
- [x] URL scheme in `bootstrap_servers` entry rejected
- [x] All backends in multi-backend profile validated
- [x] Invalid YAML structure (missing required fields) rejected
- [x] All pre-commit hooks pass on new files

OMN-10920

Evidence-Source: OCC#990
Evidence-Ticket: OMN-10920