### PR TITLE
fix(OMN-11000): remove concrete Redis DSNs from cache examples

### DIFF
--- a/src/omnibase_core/backends/cache/__init__.py
+++ b/src/omnibase_core/backends/cache/__init__.py
@@ -30,8 +30,8 @@ Usage:
 
         # Check if Redis is available
         if REDIS_AVAILABLE:
-            # Create Redis backend
-            backend = BackendCacheRedis(url="redis://localhost:16379/0")
+            # Create Redis backend from contract/config-owned connection material
+            backend = BackendCacheRedis(url=redis_url)
             await backend.connect()
 
             # Use with MixinCaching
@@ -40,7 +40,7 @@ Usage:
                     super().__init__(container, backend=backend)
 
         # Sanitize URLs for safe logging
-        safe_url = sanitize_redis_url("redis://user:pass@host:6379")
+        safe_url = sanitize_redis_url(redis_url)
         # Returns: "redis://***:***@host:6379"
 
 Requirements:

--- a/src/omnibase_core/backends/cache/backend_cache_redis.py
+++ b/src/omnibase_core/backends/cache/backend_cache_redis.py
@@ -21,8 +21,8 @@ Usage:
 
         from omnibase_core.backends.cache import BackendCacheRedis
 
-        # Create and connect
-        backend = BackendCacheRedis(url="redis://localhost:16379/0")
+        # Create and connect from contract/config-owned connection material
+        backend = BackendCacheRedis(url=redis_url)
         await backend.connect()
 
         # Use for caching
@@ -40,7 +40,7 @@ Usage:
         from omnibase_core.mixins import MixinCaching
         from omnibase_core.nodes import NodeCompute
 
-        backend = BackendCacheRedis(url="redis://localhost:16379/0")
+        backend = BackendCacheRedis(url=redis_url)
         await backend.connect()
 
         class MyNode(NodeCompute, MixinCaching):
@@ -281,7 +281,7 @@ class BackendCacheRedis:
         Connection pooling handles concurrent access safely.
 
     Attributes:
-        url: Redis connection URL (e.g., "redis://localhost:16379/0")
+        url: Redis connection URL provided by the caller.
         prefix: Optional key prefix for namespacing
         default_ttl: Default TTL in seconds (None = no expiration)
 
@@ -293,7 +293,7 @@ class BackendCacheRedis:
             async def main():
                 # Create backend with connection pool
                 backend = BackendCacheRedis(
-                    url="redis://localhost:16379/0",
+                    url=redis_url,
                     prefix="myapp:",
                     default_ttl=3600,
                 )
@@ -390,7 +390,7 @@ class BackendCacheRedis:
         Example:
             .. code-block:: python
 
-                async with BackendCacheRedis(url="redis://localhost:16379") as cache:
+                async with BackendCacheRedis(url=redis_url) as cache:
                     await cache.set("key", "value")
                 # Connection automatically closed on exit
 
@@ -495,7 +495,9 @@ class BackendCacheRedis:
             logger.warning(
                 "Error during connection cleanup: %s", sanitize_error_message(str(e))
             )
-        except Exception as e:  # noqa: BLE001
+        except (
+            Exception  # noqa: BLE001
+        ) as e:  # fallback-ok: cleanup must not mask connect failure
             # cleanup-resilience-ok: catch-all ensures cleanup never fails unexpectedly
             logger.warning(
                 "Unexpected error during connection cleanup: %s",
@@ -524,7 +526,9 @@ class BackendCacheRedis:
             logger.warning(
                 "Error closing Redis client: %s", sanitize_error_message(str(e))
             )
-        except Exception as e:  # noqa: BLE001
+        except (
+            Exception  # noqa: BLE001
+        ) as e:  # fallback-ok: close should continue to pool cleanup
             # cleanup-resilience-ok: catch-all ensures pool cleanup always runs
             logger.warning(
                 "Unexpected error closing Redis client: %s",
@@ -541,7 +545,9 @@ class BackendCacheRedis:
             logger.warning(
                 "Error disconnecting Redis pool: %s", sanitize_error_message(str(e))
             )
-        except Exception as e:  # noqa: BLE001
+        except (
+            Exception  # noqa: BLE001
+        ) as e:  # fallback-ok: close must reset pool state
             # cleanup-resilience-ok: catch-all ensures state is always reset
             logger.warning(
                 "Unexpected error disconnecting Redis pool: %s",

--- a/src/omnibase_core/mixins/mixin_caching.py
+++ b/src/omnibase_core/mixins/mixin_caching.py
@@ -42,8 +42,8 @@ Usage:
         from omnibase_core.mixins import MixinCaching
         from omnibase_core.nodes import NodeCompute
 
-        # With L2 Redis backend
-        backend = BackendCacheRedis(url="redis://localhost:16379/0")
+        # With L2 Redis backend from contract/config-owned connection material
+        backend = BackendCacheRedis(url=redis_url)
         await backend.connect()
 
         class MyComputeNode(NodeCompute, MixinCaching):
@@ -142,8 +142,8 @@ class MixinCaching:
             from omnibase_core.mixins import MixinCaching
             from omnibase_core.nodes import NodeCompute
 
-            # Create Redis backend for L2
-            backend = BackendCacheRedis(url="redis://localhost:16379/0")
+            # Create Redis backend for L2 from contract/config-owned connection material
+            backend = BackendCacheRedis(url=redis_url)
             await backend.connect()
 
             class MyNode(NodeCompute, MixinCaching):
@@ -357,6 +357,7 @@ class MixinCaching:
             except (
                 Exception  # noqa: BLE001
             ) as e:  # cleanup-resilience-ok: cleanup must complete even on error
+                # fallback-ok: L2 cleanup failures must not break L1 cache operation.
                 error = self._wrap_cache_error(e, "cleanup")
                 logger.warning(
                     "L2 cache backend cleanup failed: %s (exception type: %s)",

--- a/tests/unit/backends/cache/test_cache_backend_dsn_examples.py
+++ b/tests/unit/backends/cache/test_cache_backend_dsn_examples.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for source examples that should not embed local DSNs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FLAGGED_SOURCE_MODULES = (
+    "src/omnibase_core/backends/cache/__init__.py",
+    "src/omnibase_core/backends/cache/backend_cache_redis.py",
+    "src/omnibase_core/mixins/mixin_caching.py",
+)
+CONCRETE_LOCAL_REDIS_DSNS = (
+    "redis://localhost:16379",
+    "redis://localhost:16379/0",
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_path", FLAGGED_SOURCE_MODULES)
+def test_flagged_cache_modules_do_not_embed_concrete_local_redis_dsn(
+    module_path: str,
+) -> None:
+    """Cache examples should rely on caller-owned config, not local DSNs."""
+    source = (REPO_ROOT / module_path).read_text(encoding="utf-8")
+
+    for dsn in CONCRETE_LOCAL_REDIS_DSNS:
+        assert dsn not in source


### PR DESCRIPTION
## Summary
- classify OMN-10994 critical omnibase_core cache DSN findings as source examples/docstrings, not runtime production defaults
- replace concrete local Redis DSNs in cache examples with caller-supplied `redis_url` material owned by contract/config
- add a focused regression test covering the flagged cache modules
- add explicit fallback annotations required by repo hooks for existing cleanup/degradation paths in touched files

## Verification
- `uv run ruff format src/omnibase_core/backends/cache/__init__.py src/omnibase_core/backends/cache/backend_cache_redis.py src/omnibase_core/mixins/mixin_caching.py tests/unit/backends/cache/test_cache_backend_dsn_examples.py`
- `uv run ruff check src/omnibase_core/backends/cache/__init__.py src/omnibase_core/backends/cache/backend_cache_redis.py src/omnibase_core/mixins/mixin_caching.py tests/unit/backends/cache/test_cache_backend_dsn_examples.py`
- `uv run pytest tests/unit/backends/cache/test_cache_backend_dsn_examples.py tests/unit/backends/cache/test_sanitize_redis_url.py -q`
- commit hooks passed
- push hooks passed: mypy, pyright, ONEX naming/file naming/protocol UUID/enum governance/node purity

## Ticket closeout
Worktree retained for PR review: `/Volumes/PRO-G40/Code/omni_home/omni_worktrees/OMN-11000/omnibase_core`. Cleanup is pending PR merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Redis configuration examples to demonstrate best practices using configurable variables instead of hardcoded connection strings.

* **Tests**
  * Added test to verify cache modules do not contain embedded local Redis connection strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1076)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-11000
Evidence-Source: OCC#1012