### PR TITLE
fix(OMN-11007): exclude generated and evidence dirs from local-path scan

### DIFF
--- a/src/omnibase_core/validation/validator_local_paths.py
+++ b/src/omnibase_core/validation/validator_local_paths.py
@@ -75,9 +75,38 @@ _TEXT_EXTENSIONS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Directories to skip during recursive scan
+# Directories to skip during recursive scan.
+#
+# Three groups:
+#   1. Standard generated/cache trees (.git, __pycache__, node_modules, venvs).
+#   2. Frontend and graph generation output (.next, dist, build, graphify-out).
+#      These mirror source strings into compiled output and would inflate
+#      source-owner triage counts if scanned. See OMN-11007.
+#   3. Immutable evidence and local runtime state. OCC receipts under
+#      dod_receipts/ and evidence/, plus historical .evidence/ command
+#      records and .onex_state/ runtime captures, preserve real cwds and so
+#      look like source violations even though they are not source-owner
+#      actionable.
 _SKIP_DIRS: Final[frozenset[str]] = frozenset(
-    {".git", "__pycache__", "node_modules", ".tox", ".venv", "venv"}
+    {
+        # Standard
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".tox",
+        ".venv",
+        "venv",
+        # Generated frontend / graph output (OMN-11007)
+        ".next",
+        "dist",
+        "build",
+        "graphify-out",
+        # Evidence and local runtime state (OMN-11007)
+        "dod_receipts",
+        "evidence",
+        ".evidence",
+        ".onex_state",
+    }
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/validation/test_validator_local_paths.py
+++ b/tests/unit/validation/test_validator_local_paths.py
@@ -235,6 +235,106 @@ class TestCheckPathsDirectory:
 
 
 @pytest.mark.unit
+class TestGeneratedAndEvidenceExclusions:
+    """OMN-11007: generated frontend, graph caches, OCC receipts, and evidence
+    artifacts must not inflate source-owner triage counts.
+    """
+
+    def test_dot_next_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Compiled Next.js output under '.next/' must be excluded."""
+        next_dir = tmp_path / ".next" / "server" / "app"
+        next_dir.mkdir(parents=True)
+        (next_dir / "page.js").write_text(
+            'var p = "/Users/jonah/projects"\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_graphify_out_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Generated graphify caches under 'graphify-out/' must be excluded."""
+        cache_dir = tmp_path / "src" / "pkg" / "graphify-out" / "cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "node.json").write_text(
+            '{"path": "/Volumes/PRO-G40/Code/x"}\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_dod_receipts_directory_is_skipped(self, tmp_path: Path) -> None:
+        """OCC immutable receipts under 'dod_receipts/' must be excluded."""
+        receipt_dir = tmp_path / "drift" / "dod_receipts" / "OMN-1" / "x"
+        receipt_dir.mkdir(parents=True)
+        (receipt_dir / "command.yaml").write_text(
+            "cwd: /Users/jonah/work\n", encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_evidence_directory_is_skipped(self, tmp_path: Path) -> None:
+        """OCC evidence artifacts under 'evidence/' must be excluded."""
+        evidence_dir = tmp_path / "evidence" / "OMN-1"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "dod_report.json").write_text(
+            '{"cwd": "/Users/jonah/x"}\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_dot_evidence_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Historical command evidence under '.evidence/' must be excluded."""
+        evidence_dir = tmp_path / ".evidence" / "run-1"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "transcript.txt").write_text(
+            "ran cd /Users/jonah/x\n", encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_dot_onex_state_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Local state under '.onex_state/' must be excluded."""
+        state_dir = tmp_path / ".onex_state" / "overnight-x"
+        state_dir.mkdir(parents=True)
+        (state_dir / "log.txt").write_text(
+            "cwd: /Volumes/PRO-G40/Code\n", encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_source_violations_still_detected_alongside_excluded_dirs(
+        self, tmp_path: Path
+    ) -> None:
+        """Excluding generated/evidence dirs must not hide real source violations."""
+        src = tmp_path / "src" / "pkg"
+        src.mkdir(parents=True)
+        (src / "real.py").write_text(
+            'ROOT = "/Volumes/PRO-G40/Code"\n', encoding="utf-8"
+        )
+
+        generated = tmp_path / ".next"
+        generated.mkdir()
+        (generated / "noise.js").write_text(
+            'var p = "/Users/jonah/noise"\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert len(violations) == 1
+        assert "real.py" in str(violations[0].file)
+
+
+@pytest.mark.unit
 class TestModelLocalPathViolation:
     """ModelLocalPathViolation Pydantic model properties."""
 

--- a/tests/unit/validation/test_validator_local_paths.py
+++ b/tests/unit/validation/test_validator_local_paths.py
@@ -264,6 +264,30 @@ class TestGeneratedAndEvidenceExclusions:
         violations = validator.check_paths([tmp_path])
         assert violations == []
 
+    def test_dist_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Generated frontend output under 'dist/' must be excluded."""
+        dist_dir = tmp_path / "frontend" / "dist" / "assets"
+        dist_dir.mkdir(parents=True)
+        (dist_dir / "bundle.js").write_text(
+            'var p = "/Users/jonah/projects"\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
+    def test_build_directory_is_skipped(self, tmp_path: Path) -> None:
+        """Generated frontend output under 'build/' must be excluded."""
+        build_dir = tmp_path / "frontend" / "build" / "static"
+        build_dir.mkdir(parents=True)
+        (build_dir / "main.js").write_text(
+            'var p = "/Users/jonah/projects"\n', encoding="utf-8"
+        )
+
+        validator = ValidatorLocalPaths()
+        violations = validator.check_paths([tmp_path])
+        assert violations == []
+
     def test_dod_receipts_directory_is_skipped(self, tmp_path: Path) -> None:
         """OCC immutable receipts under 'dod_receipts/' must be excluded."""
         receipt_dir = tmp_path / "drift" / "dod_receipts" / "OMN-1" / "x"


### PR DESCRIPTION
## Summary

`ValidatorLocalPaths` now skips compiled frontend output, graph generation caches, OCC immutable receipts, historical command evidence, and local runtime state when scanning a directory recursively. Added to `_SKIP_DIRS`:

- Frontend / graph output: `.next`, `dist`, `build`, `graphify-out`
- Evidence & local runtime state: `dod_receipts`, `evidence`, `.evidence`, `.onex_state`

The OMN-11004 env/local-path classification attributed 1,631 of 3,273 rows to these directories. Excluding them collapses noise so source owners only see source-owner-actionable violations.

## Why

`OMN-11007` follow-up from `OMN-11004` env/local-path classification. The largest noisy bucket (1,631 rows) was generated/evidence content. These trees mirror source strings — `.next` page bundles, graphify cache JSON, OCC receipts capturing real cwds — but are not source-owner actionable.

## Test plan

- [x] New `TestGeneratedAndEvidenceExclusions` class (7 tests): each excluded directory verified to produce zero violations when seeded with a clear local-path
- [x] Mixed-content regression test (`test_source_violations_still_detected_alongside_excluded_dirs`) proves the excludes do not hide real source violations
- [x] Full file suite: 30/30 pass (23 baseline + 7 new)
- [x] Targeted related suites: `test_validator_local_paths.py` + `test_architecture.py` + `test_validate_hardcoded_env_vars.py` — 123/123 pass
- [x] `uv run ruff format` + `uv run ruff check --fix`
- [x] `pre-commit run --files <changed>` — all hooks pass

Linear: OMN-11007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Path validation now skips additional generated build output and local evidence/state artifact directories, reducing false-positive local-path violations from build/runtime artifacts.

* **Tests**
  * Added tests ensuring these directories are excluded from scans while real source-file violations are still detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1077)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: 9e9cf1edac47bd65e1a083aedc0635bc2fe27a56
Evidence-Ticket: OMN-11007