### PR TITLE
fix(OMN-11026): volume-aware CI test split count

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -22,6 +23,17 @@ TEST_UNIT_PREFIX = "tests/unit/"
 TEST_INTEGRATION_PREFIX = "tests/integration/"
 
 FULL_SUITE_BRANCHES = {"main"}
+
+# Volume-aware split sizing (OMN-11026).
+# Main-branch full-suite uses 40 splits over the whole tree (~1,500 test files,
+# ~40K test items) and finishes within the 35-min job timeout. We match that
+# density — roughly 40 test files per split — when smart-selection expands to
+# large test directories. The path-count floor still keeps small PRs cheap.
+VOLUME_TARGET_FILES_PER_SPLIT = 40
+VOLUME_THRESHOLD_FILES = 80
+VOLUME_MAX_SPLITS = 40
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def resolve_test_paths(
@@ -119,7 +131,7 @@ def compute_selection(
         # low-signal metadata). CI workflow and selector changes are test
         # infrastructure and escalate before this fallback.
         selected = ["tests/unit/"]
-    split_count = _split_count_for(selected)
+    split_count = _split_count_for(selected, repo_root=REPO_ROOT)
 
     return ModelTestSelection(
         selected_paths=selected,
@@ -140,16 +152,27 @@ def _full_suite(reason: EnumFullSuiteReason) -> ModelTestSelection:
     )
 
 
-def _split_count_for(selected_paths: list[str]) -> int:
-    """Initial conservative heuristic mapping path count to split count.
+def _split_count_for(selected_paths: list[str], repo_root: Path | None = None) -> int:
+    """Volume-aware split count for a set of selected unit-test paths.
 
-    These thresholds are a *starting* point chosen to keep small PRs on a single
-    shard (cheap) while preventing pathologically slow runs when many paths
-    survive selection. They are NOT empirically derived. Path count and test
-    count are different things; refine from shadow-mode duration data once
-    available.
+    Two signals combine:
+      1. Path-count floor — the original heuristic; keeps small PRs cheap.
+      2. Test-volume scaling — when expanded paths cover a large number of test
+         files (e.g. mixins → models adjacency pulls in ~700 test files under
+         tests/unit/models/), one-or-two splits cannot finish inside the
+         ``test-parallel`` job timeout. Scale up to match main's ~1K-tests-per-
+         split density (OMN-11026).
+
+    The final split count is ``max(path_floor, volume_scaled)``, capped at
+    ``VOLUME_MAX_SPLITS`` to match the main-branch full-suite shape.
     """
-    n = len(selected_paths)
+    path_floor = _path_count_floor(len(selected_paths))
+    volume_scaled = _volume_split_count(selected_paths, repo_root)
+    return min(max(path_floor, volume_scaled), VOLUME_MAX_SPLITS)
+
+
+def _path_count_floor(n: int) -> int:
+    """Original path-count heuristic, retained as a lower bound."""
     if n <= 2:
         return 1
     if n <= 5:
@@ -159,6 +182,32 @@ def _split_count_for(selected_paths: list[str]) -> int:
     if n <= 16:
         return 4
     return 5
+
+
+def _volume_split_count(selected_paths: list[str], repo_root: Path | None) -> int:
+    """Count actual test files under selected paths and scale splits.
+
+    Returns 0 when the test file count is below ``VOLUME_THRESHOLD_FILES`` —
+    the caller then falls back to the path-count floor. When ``repo_root`` is
+    None or the resolved directories don't exist (e.g. unit tests with a
+    synthetic path list), this also returns 0.
+    """
+    if repo_root is None:
+        return 0
+    total = _count_test_files(selected_paths, repo_root)
+    if total < VOLUME_THRESHOLD_FILES:
+        return 0
+    return math.ceil(total / VOLUME_TARGET_FILES_PER_SPLIT)
+
+
+def _count_test_files(selected_paths: list[str], repo_root: Path) -> int:
+    total = 0
+    for rel in selected_paths:
+        directory = repo_root / rel
+        if not directory.is_dir():
+            continue
+        total += sum(1 for _ in directory.rglob("test_*.py"))
+    return total
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -229,3 +229,107 @@ def test_merge_group_event_escalates_to_full_suite() -> None:
     assert selection.full_suite_reason == EnumFullSuiteReason.MERGE_GROUP
     assert selection.split_count == 40
     assert selection.matrix == list(range(1, 41))
+
+
+# ---------------------------------------------------------------------------
+# OMN-11026: volume-aware _split_count_for
+# ---------------------------------------------------------------------------
+
+from scripts.ci.detect_test_paths import (
+    VOLUME_MAX_SPLITS,
+    VOLUME_TARGET_FILES_PER_SPLIT,
+    VOLUME_THRESHOLD_FILES,
+    _split_count_for,
+)
+
+
+def test_split_count_small_path_set_unchanged_without_repo_root() -> None:
+    # No repo_root → volume scaling is inert; behavior matches the original
+    # path-count formula. Verifies the existing small-PR contract is preserved.
+    assert _split_count_for(["tests/unit/cli/"]) == 1
+    assert _split_count_for(["tests/unit/cli/", "tests/unit/agents/"]) == 1
+    assert _split_count_for(["a/", "b/", "c/"]) == 2
+    assert _split_count_for([f"p{i}/" for i in range(6)]) == 3
+    assert _split_count_for([f"p{i}/" for i in range(11)]) == 4
+    assert _split_count_for([f"p{i}/" for i in range(17)]) == 5
+
+
+def test_split_count_below_threshold_uses_path_floor(tmp_path: Path) -> None:
+    # 10 test files across 1 selected path is well under VOLUME_THRESHOLD_FILES;
+    # volume scaling does not engage and the path-count floor (1) wins.
+    target = tmp_path / "tests/unit/cli"
+    target.mkdir(parents=True)
+    for i in range(10):
+        (target / f"test_x{i}.py").write_text("")
+    assert _split_count_for(["tests/unit/cli/"], repo_root=tmp_path) == 1
+
+
+def test_split_count_above_threshold_scales_by_file_count(tmp_path: Path) -> None:
+    # 200 test files across 3 expanded paths must produce
+    # ceil(200 / VOLUME_TARGET_FILES_PER_SPLIT) splits — well above the
+    # path-floor of 2 that the old formula returned.
+    for module in ("mixins", "models", "nodes"):
+        d = tmp_path / "tests" / "unit" / module
+        d.mkdir(parents=True)
+    for i in range(200):
+        (tmp_path / "tests/unit/models" / f"test_m{i}.py").write_text("")
+    selected = ["tests/unit/mixins/", "tests/unit/models/", "tests/unit/nodes/"]
+    expected = -(-200 // VOLUME_TARGET_FILES_PER_SPLIT)  # ceil(200/40) = 5
+    assert _split_count_for(selected, repo_root=tmp_path) == expected
+    assert expected > 2  # would otherwise time out at the old path-floor
+
+
+def test_split_count_caps_at_max_splits(tmp_path: Path) -> None:
+    # 10K test files would push the volume scaler to 250 splits; the cap keeps
+    # the matrix shape consistent with the main-branch full-suite layout.
+    d = tmp_path / "tests/unit/models"
+    d.mkdir(parents=True)
+    for i in range(10_000):
+        (d / f"test_big{i}.py").write_text("")
+    assert (
+        _split_count_for(["tests/unit/models/"], repo_root=tmp_path)
+        == VOLUME_MAX_SPLITS
+    )
+
+
+def test_split_count_path_floor_wins_when_higher(tmp_path: Path) -> None:
+    # 17 paths → path-floor = 5; if test volume is below the threshold, the
+    # floor takes over and we don't regress to a smaller split count.
+    selected = [f"tests/unit/p{i}/" for i in range(17)]
+    for rel in selected:
+        (tmp_path / rel).mkdir(parents=True)
+    assert _split_count_for(selected, repo_root=tmp_path) == 5
+
+
+def test_split_count_mixins_change_against_real_tree_yields_enough_splits() -> None:
+    # Regression coverage for the mixins-adjacency timeout. With mixins →
+    # [models, nodes] expansion, the resolved unit-test directories must
+    # produce enough splits that no single split has to run hundreds of test
+    # files within the 35-minute job timeout. Lower bound is conservative; the
+    # actual value rises if the test tree grows.
+    selected = ["tests/unit/mixins/", "tests/unit/models/", "tests/unit/nodes/"]
+    split_count = _split_count_for(selected, repo_root=REPO_ROOT)
+    assert split_count >= 10, (
+        f"mixins-adjacency expansion must produce >=10 splits to fit the "
+        f"job timeout; got {split_count}"
+    )
+    assert split_count <= VOLUME_MAX_SPLITS
+
+
+def test_compute_selection_mixins_change_yields_volume_scaled_splits() -> None:
+    # End-to-end: a mixins-only PR must not be capped at the old 2-split shape.
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/mixins/mixin_caching.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.split_count >= 10
+    assert selection.matrix == list(range(1, selection.split_count + 1))
+
+
+def test_threshold_constant_is_consistent() -> None:
+    # Guardrail: the threshold must not be raised without intent; setting it
+    # too high reintroduces the OMN-11026 timeout regression.
+    assert VOLUME_THRESHOLD_FILES <= 100
+    assert VOLUME_TARGET_FILES_PER_SPLIT <= 50


### PR DESCRIPTION
## Summary
- `_split_count_for()` now counts test files under expanded paths in addition to path count.
- Prevents the 35-min `test-parallel` job timeout when adjacency expansion pulls in large test directories (e.g. `tests/unit/models/` with ~700 test files / ~20K test items).
- Unblocks PRs touching `mixins/*` and any module whose `reverse_deps` cover broad test surfaces.

## Root cause
PRs touching `src/omnibase_core/mixins/` expand via the adjacency map to `[models, nodes]`, giving 3 selected unit-test directories. The old formula assigned only 2 splits for 3 paths, putting ~350 test files (~10K test items) per worker on 2-vCPU `ubuntu-latest` runners with `PYTEST_XDIST_WORKERS=1`. Each split hit the 35-minute job timeout, blocking core#1076 and #1077.

Main branch already uses 40 splits over the full tree (~37 test files per split) and finishes in ~8 min, so the fix is to match that density when smart-selection produces a large file count.

## Implementation
- `_split_count_for()` now combines two signals:
  1. `_path_count_floor()` — the original heuristic, retained as a lower bound so small PRs stay on a single shard.
  2. `_volume_split_count()` — counts `test_*.py` files under each selected path and, when the total is at or above `VOLUME_THRESHOLD_FILES` (80), returns `ceil(total / VOLUME_TARGET_FILES_PER_SPLIT)` (40 files per split).
- Final result is `min(max(floor, volume), VOLUME_MAX_SPLITS=40)`.
- Behavior for small path sets is unchanged: the path-count floor wins when test volume is below threshold, so existing `compute_selection` results for `cli`, `agents`, etc. continue to produce 1-shard runs.

## Test plan
- [x] New unit tests for volume-aware splitting (threshold floor, scaling, cap, real-tree mixins regression, end-to-end `compute_selection` for mixins).
- [x] Existing split-count behavior preserved for small path sets (`test_split_count_small_path_set_unchanged_without_repo_root`).
- [x] All 33 `tests/unit/scripts/ci/` tests pass locally.
- [x] `ruff format` + `ruff check` clean.
- [x] `pre-commit` clean on edited files.
- [ ] This PR's own CI uses the new formula (`scripts/ci/` is in `test_infrastructure_paths` so it escalates to the 40-split full suite — meta-validation works the other way: a green build proves the new formula doesn't regress full-suite handling).

OMN-11026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI test execution through enhanced parallel shard distribution.
  * Expanded test coverage for CI infrastructure components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1078)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1021
Evidence-Ticket: OMN-11026