### PR TITLE
fix(OMN-11029): install exact receipt gate wheel path

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -403,19 +403,29 @@ jobs:
           # project — uv collapses them into one node.
           #
           # Fix (Option B from diagnosis-receipt-gate-v4-subpath-editable.md):
-          # build a wheel from source, install from a local --find-links. The
-          # resolver operates on a named package from a wheel location, which
-          # unambiguously satisfies the cwd-project's version constraint.
+          # build a wheel from source, then install that exact wheel file. The
+          # final install must not ask uv to resolve the omnibase-core package
+          # name or read the caller repo's uv/pyproject config because downstream
+          # caller pyprojects can pin an older exact version (for example
+          # omnibase-core==0.40.1) while core main builds a newer wheel for the
+          # shared gate.
           # Not editable, but receipt-gate imports the module once and exits —
           # editability was never a functional requirement, only a means to use
           # source instead of PyPI.
+          rm -rf /tmp/receipt-gate-wheels
           mkdir -p /tmp/receipt-gate-wheels
           (cd "$core_path" && uv build --wheel --out-dir /tmp/receipt-gate-wheels)
 
-          uv pip install --system --no-deps --no-index \
-            --find-links /tmp/receipt-gate-wheels \
+          wheel_path="$(find /tmp/receipt-gate-wheels -maxdepth 1 -type f -name 'omnibase_core-*.whl' -print -quit)"
+          if [ -z "$wheel_path" ]; then
+            echo "::error::omnibase_core wheel build produced no wheel in /tmp/receipt-gate-wheels"
+            find /tmp/receipt-gate-wheels -maxdepth 1 -type f -print || true
+            exit 1
+          fi
+
+          uv pip install --no-config --system --no-deps --no-index \
             --reinstall-package omnibase-core \
-            omnibase-core
+            "$wheel_path"
 
       - name: Verify receipt_gate_cli importable
         # Fail-fast check: the preceding install step claims success, but if uv

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -6,11 +6,14 @@
 Guards against regressions in the OMN-9198 / OMN-9283 remediation:
 - The workflow must never fall back to PyPI for `omnibase-core` (the published
   wheel has a broken transitive `git+https` dep on `omnibase-compat`).
-- The workflow must use the build-a-wheel + `--find-links` pattern so the same
+- The workflow must use the build-a-wheel + exact wheel path pattern so the same
   install command works for both self-project (core_path=".") and downstream
   callers (core_path="./.receipt-gate-deps/omnibase_core"). Editable/`-e` +
   `--no-index` fails on subpath callers because uv auto-discovers the cwd's
   pyproject constraint separately from the -e candidate registration.
+- The final install must not resolve the bare `omnibase-core` package name,
+  or read the caller repo's uv/pyproject config, because downstream callers can
+  pin an older exact version while the gate intentionally builds core from main.
 """
 
 from __future__ import annotations
@@ -57,13 +60,18 @@ def test_install_step_builds_wheel_from_source() -> None:
     )
 
 
-def test_install_step_uses_find_links() -> None:
-    """Install must resolve omnibase-core from the local wheel dir."""
+def test_install_step_uses_exact_built_wheel_path() -> None:
+    """Install must use the built wheel file path, not resolve the package name."""
     script = _install_step_script()
-    assert "--find-links" in script, (
-        "receipt-gate install must use --find-links pointing at the locally-built "
-        "wheel directory so uv's resolver has a source that satisfies the caller's "
-        "`omnibase-core>=X` constraint without hitting PyPI"
+    assert "wheel_path=" in script
+    assert '"$wheel_path"' in script, (
+        "receipt-gate install must pass the exact built wheel path to uv so caller "
+        "pyproject pins such as `omnibase-core==0.40.1` cannot reject core main's "
+        "freshly built wheel"
+    )
+    assert "--no-config" in script, (
+        "receipt-gate install must disable uv config discovery for the final wheel "
+        "install so the caller repo's pyproject dependency pins are not included"
     )
 
 
@@ -73,11 +81,32 @@ def test_install_step_uses_no_index_for_core() -> None:
     # Join shell line-continuations before matching (the install command is
     # wrapped across multiple lines with trailing backslashes).
     joined = re.sub(r"\\\n\s*", " ", script)
-    pattern = re.compile(r"uv pip install\b[^\n]*--no-index[^\n]*omnibase-core")
+    pattern = re.compile(r"uv pip install\b[^\n]*--no-index[^\n]*\"\$wheel_path\"")
     assert pattern.search(joined), (
-        "the final `uv pip install ... omnibase-core` must include --no-index "
+        'the final `uv pip install ... "$wheel_path"` must include --no-index '
         "so uv cannot fall back to the broken PyPI wheel"
     )
+
+
+def test_install_step_does_not_install_core_by_package_name() -> None:
+    """Final core install must not ask uv to resolve `omnibase-core` by name."""
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    install_lines = [
+        line.strip()
+        for line in joined.splitlines()
+        if line.strip().startswith("uv pip install")
+        and "--reinstall-package omnibase-core" in line
+    ]
+    assert install_lines, "final omnibase-core install command not found"
+    for line in install_lines:
+        assert '"$wheel_path"' in line, (
+            "final omnibase-core install must use the exact built wheel path"
+        )
+        assert not re.search(r"\somnibase-core\s*$", line), (
+            "final omnibase-core install must not end with a bare package name; "
+            "that re-enters uv resolution against the caller repo's pyproject pin"
+        )
 
 
 def test_install_step_has_no_bare_pypi_core_install() -> None:


### PR DESCRIPTION
Closes OMN-11029

Evidence-Ticket: OMN-11029
Evidence-Source: 71b5b125b9ff139899caeaf6039945a378d0d8fc

## Summary
- Install the exact locally built `omnibase_core-*.whl` in the shared Receipt Gate workflow instead of resolving the bare `omnibase-core` package name.
- Add `--no-config` on the final wheel install so caller repo `pyproject.toml` pins do not participate.
- Extend workflow-shape regression tests to prevent returning to package-name resolution.

## Validation
- `uv run pytest tests/unit/validation/test_receipt_gate_workflow_shape.py -q`
- `git diff --check`
- Temp-venv repro from `omniintelligence`: old command fails on `omnibase-core==0.40.1`; patched command installs the locally built `omnibase-core==0.40.2` wheel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration build workflow to install core dependencies directly from exact locally built wheel files, replacing package name-based resolution.
  * Added and modified workflow validation tests to verify the new installation approach functions correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1079)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

