### PR TITLE
ci(OMN-10978): make boundary validation blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1318,8 +1318,8 @@ jobs:
           fi
 
   # CI Summary - final aggregator for all gates (OMN-2226)
-  # Cross-repo boundary validation (OMN-6576)
-  # Warn-only mode — does not block PRs, just surfaces boundary parity issues.
+  # Cross-repo boundary validation (OMN-6576, OMN-10978)
+  # Blocking mode: boundary parity is an architectural CI gate.
   boundary-validation:
     name: Cross-repo boundary validation
     runs-on: >-
@@ -1328,13 +1328,12 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    continue-on-error: true
     steps:
       - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@32a57e7b0797f4171891ed96047ea618e796f8db # main 2026-03-25
-        continue-on-error: true
         with:
           checks: "boundary-parity"
-          warn-only: "true"
+          warn-only: "false"
+          repos: "omniclaude,omnidash,omniintelligence,omnibase_infra,omnibase_core,omnimemory,onex_change_control"
 
   # API-STABLE check_name: "CI Summary"
   # Aggregates Quality Gate + Tests Gate into a single top-level status.
@@ -1378,7 +1377,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [quality-gate, tests-gate, contract-compliance]
+    needs: [quality-gate, tests-gate, contract-compliance, boundary-validation]
     if: always()
 
     steps:
@@ -1390,23 +1389,26 @@ jobs:
           quality="${{ needs.quality-gate.result }}"
           tests="${{ needs.tests-gate.result }}"
           compliance="${{ needs['contract-compliance'].result }}"
+          boundary="${{ needs['boundary-validation'].result }}"
 
           echo "| Gate | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Quality Gate | $quality |" >> $GITHUB_STEP_SUMMARY
           echo "| Tests Gate | $tests |" >> $GITHUB_STEP_SUMMARY
           echo "| Compliance | $compliance |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cross-repo Boundary Validation | $boundary |" >> $GITHUB_STEP_SUMMARY
 
-          # Accept "success" or "skipped" for both gates. Skipped is valid when
+          # Accept "success" or "skipped" for gates. Skipped is valid when
           # upstream jobs are correctly skipped (e.g. dependabot PRs).
           quality_ok=$([[ "$quality" == "success" || "$quality" == "skipped" ]] && echo true || echo false)
           tests_ok=$([[ "$tests" == "success" || "$tests" == "skipped" ]] && echo true || echo false)
           compliance_ok=$([[ "$compliance" == "success" || "$compliance" == "skipped" ]] && echo true || echo false)
+          boundary_ok=$([[ "$boundary" == "success" || "$boundary" == "skipped" ]] && echo true || echo false)
 
-          if [[ "$quality_ok" == "true" ]] && [[ "$tests_ok" == "true" ]] && [[ "$compliance_ok" == "true" ]]; then
+          if [[ "$quality_ok" == "true" ]] && [[ "$tests_ok" == "true" ]] && [[ "$compliance_ok" == "true" ]] && [[ "$boundary_ok" == "true" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**CI Summary: ALL GATES PASSED**" >> $GITHUB_STEP_SUMMARY
-            echo "All CI gates passed (quality=$quality, tests=$tests, compliance=$compliance)."
+            echo "All CI gates passed (quality=$quality, tests=$tests, compliance=$compliance, boundary=$boundary)."
             exit 0
           else
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -1416,5 +1418,6 @@ jobs:
             echo "  Quality Gate: $quality"
             echo "  Tests Gate: $tests"
             echo "  Compliance: $compliance"
+            echo "  Cross-repo Boundary Validation: $boundary"
             exit 1
           fi

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -18,6 +18,20 @@ def _ci_job(name: str) -> dict[str, object]:
     return data["jobs"][name]
 
 
+def _boundary_validation_step() -> dict[str, object]:
+    job = _ci_job("boundary-validation")
+    steps = job["steps"]
+
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and "validate-boundaries" in str(
+            step.get("uses", "")
+        ):
+            return step
+
+    raise AssertionError("boundary-validation job must run validate-boundaries")
+
+
 def test_parallel_unit_split_timeout_tolerates_self_hosted_runner_pressure() -> None:
     job = _ci_job("test-parallel")
 
@@ -38,3 +52,38 @@ def test_pr_and_merge_queue_use_bounded_xdist_workers() -> None:
     assert "github.event_name == 'merge_group'" in workers
     assert "OMNI_PUBLIC_PR_PYTEST_XDIST_WORKERS || '1'" in workers
     assert "OMNI_MERGE_GROUP_PYTEST_XDIST_WORKERS || '2'" in workers
+
+
+def test_cross_repo_boundary_validation_job_is_blocking() -> None:
+    job = _ci_job("boundary-validation")
+
+    assert "continue-on-error" not in job
+
+
+def test_cross_repo_boundary_validation_action_is_not_warn_only() -> None:
+    step = _boundary_validation_step()
+
+    assert "continue-on-error" not in step
+    assert step["with"]["checks"] == "boundary-parity"
+    assert step["with"]["warn-only"] == "false"
+
+
+def test_cross_repo_boundary_validation_clones_all_boundary_repos() -> None:
+    step = _boundary_validation_step()
+
+    repos = {repo.strip() for repo in step["with"]["repos"].split(",")}
+    assert repos == {
+        "omniclaude",
+        "omnidash",
+        "omniintelligence",
+        "omnibase_infra",
+        "omnibase_core",
+        "omnimemory",
+        "onex_change_control",
+    }
+
+
+def test_ci_summary_requires_cross_repo_boundary_validation() -> None:
+    job = _ci_job("ci-summary")
+
+    assert "boundary-validation" in job["needs"]


### PR DESCRIPTION
## Summary
- removes job-level and step-level `continue-on-error` from cross-repo boundary validation
- flips the boundary parity action from `warn-only: true` to `warn-only: false`
- makes `CI Summary` depend on boundary validation so the required aggregate gate reflects failures
- passes an explicit boundary repo list including `onex_change_control`, which the parity baseline needs for existing producer contracts

## Verification
- `uv run pytest tests/unit/validation/test_ci_workflow_shape.py -q`
- `uv run ruff check tests/unit/validation/test_ci_workflow_shape.py`
- `git diff --check`
- local pinned boundary parity equivalent: `uv run check-boundary-parity --repos-root <local sibling repo root>` from onex_change_control action SHA `32a57e7b0797f4171891ed96047ea618e796f8db` -> 6 OK, 0 mismatches

## Ticket
OMN-10978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow now enforces cross-repo boundary validation as a blocking gate requirement—builds will fail if validation does not pass.

* **Tests**
  * Added validation tests to ensure cross-repo boundary checks are properly configured and enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1080)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-10978
Evidence-Source: OCC#1027
