### PR TITLE
feat(OMN-9877): route run-node through contract dispatch

### DIFF
--- a/contracts/OMN-9877.yaml
+++ b/contracts/OMN-9877.yaml
@@ -1,0 +1,39 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-9877"
+title: "feat(OMN-9877): route run-node through contract dispatch"
+summary: >
+  Routes onex run-node through packaged contract topic resolution and response polling. Refactors _resolve_node_topics
+  to use _resolve_packaged_contract + load_workflow_contract, switches publish_and_poll to ModelEventEnvelope
+  wire format, adds inject_payload_correlation_id support, and fixes KAFKA_BOOTSTRAP_SERVERS to fail-fast
+  (no localhost fallback).
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "CLI unit tests pass on omnibase_core PR #1081"
+    command: "uv run pytest tests/unit/cli/ -v"
+  - kind: "ci"
+    description: "omnibase_core PR #1081 CI checks pass"
+    command: "gh pr checks 1081 --repo OmniNode-ai/omnibase_core"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-cli-tests"
+    description: "All 567 CLI unit tests pass"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/cli/ -v"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: cli_run_node.py change is a Kafka routing refactor; no new topics,
+      no schema migrations, no Docker image rebuild required before merge"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-9877 refactors cli_run_node.py Kafka routing only; no Docker
+          image, daemon, broker topic, runtime process, docker exec, or service deploy is required before
+          merge'"

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -271,7 +271,7 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
     except json.JSONDecodeError as exc:
         _emit_error(node_id, f"Invalid JSON input: {exc}")
 
-    bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
+    bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
 
     try:
         (

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -1,115 +1,30 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""``onex run-node`` — publish a command to Kafka and poll for the result."""
+"""``onex run-node`` — dispatch a packaged node over Kafka using its contract."""
 
 from __future__ import annotations
 
 import importlib
-import importlib.metadata
-import importlib.util
 import json
 import os
 import sys
 import time
 import uuid
 from pathlib import Path
+from typing import NoReturn
+from uuid import UUID
 
 import click
-from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.cli.cli_node import _resolve_packaged_contract
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
-from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.runtime.runtime_local import load_workflow_contract
 
 
-def _resolve_node_topics(node_id: str) -> tuple[str, str]:
-    """Resolve the cmd and response topics for a node from its contract.yaml.
-
-    Returns (cmd_topic, response_topic).  Looks up the node via the
-    ``onex.nodes`` entry-point group, loads the colocated contract.yaml,
-    and reads:
-      - cmd_topic:      event_bus.subscribe_topics[0]
-      - response_topic: terminal_event
-
-    Raises click.ClickException if the node is unknown, the contract is
-    missing, or the required fields are absent.
-    """
-
-    class _EventBus(BaseModel):  # type: ignore[explicit-any]
-        model_config = ConfigDict(extra="ignore")
-        subscribe_topics: list[str] = Field(default_factory=list)
-
-    class _ContractTopics(BaseModel):  # type: ignore[explicit-any]
-        model_config = ConfigDict(extra="ignore")
-        event_bus: _EventBus = Field(default_factory=_EventBus)
-        terminal_event: str = ""
-
-    matches = [
-        ep
-        for ep in importlib.metadata.entry_points(group="onex.nodes")
-        if ep.name == node_id
-    ]
-    if not matches:
-        known = sorted(
-            {ep.name for ep in importlib.metadata.entry_points(group="onex.nodes")}
-        )
-        raise click.ClickException(
-            f"Unknown node '{node_id}'. Known nodes: {', '.join(known) or '(none)'}"
-        )
-    if len(matches) > 1:
-        sources = ", ".join(str(ep.dist) for ep in matches)
-        raise click.ClickException(
-            f"Duplicate entry-point '{node_id}' registered by: {sources}"
-        )
-
-    module_path = matches[0].value.split(":", 1)[0].strip()
-    spec = importlib.util.find_spec(module_path)
-    if spec is None:
-        raise click.ClickException(
-            f"Failed to resolve module '{module_path}' for node '{node_id}'"
-        )
-
-    if spec.submodule_search_locations:
-        module_dir = Path(next(iter(spec.submodule_search_locations))).resolve()
-    elif spec.origin is not None:
-        module_dir = Path(spec.origin).resolve().parent
-    else:
-        raise click.ClickException(
-            f"Node '{node_id}' module '{module_path}' has no origin; "
-            "cannot locate contract.yaml"
-        )
-
-    contract_path = module_dir / "contract.yaml"
-    if not contract_path.exists():
-        raise click.ClickException(
-            f"Node '{node_id}' has no contract.yaml at {contract_path}"
-        )
-
-    try:
-        contract = load_and_validate_yaml_model(contract_path, _ContractTopics)
-    except ModelOnexError as exc:
-        raise click.ClickException(
-            f"Node '{node_id}' contract.yaml failed to load: {exc.message}"
-        )
-
-    if not contract.event_bus.subscribe_topics:
-        raise click.ClickException(
-            f"Node '{node_id}' contract.yaml has no event_bus.subscribe_topics; "
-            "cannot determine which Kafka topic to publish the command to"
-        )
-    cmd_topic = contract.event_bus.subscribe_topics[0]
-
-    if not contract.terminal_event:
-        raise click.ClickException(
-            f"Node '{node_id}' contract.yaml has no terminal_event; "
-            "cannot determine which Kafka topic to poll for the response"
-        )
-
-    return cmd_topic, contract.terminal_event
-
-
-def _emit_error(node_id: str, message: str, **extra: str | int) -> None:
+def _emit_error(node_id: str, message: str, **extra: str | int) -> NoReturn:
     """Emit a SkillRoutingError JSON envelope and exit non-zero."""
     envelope: dict[str, str | int] = {
         "error_type": "SkillRoutingError",
@@ -121,15 +36,94 @@ def _emit_error(node_id: str, message: str, **extra: str | int) -> None:
     sys.exit(1)
 
 
+def _contract_requires_payload_correlation_id(contract: dict[str, object]) -> bool:
+    """Return True when the contract explicitly requires payload.correlation_id."""
+    inputs = contract.get("inputs")
+    if not isinstance(inputs, dict):
+        return False
+
+    correlation_spec = inputs.get("correlation_id")
+    if not isinstance(correlation_spec, dict):
+        return False
+
+    return correlation_spec.get("required") is True
+
+
+def _resolve_node_topics(node_id: str) -> tuple[Path, str, str, bool]:
+    """Resolve a packaged node to its contract path and Kafka routing metadata."""
+    contract_path = _resolve_packaged_contract(node_id)
+    contract = load_workflow_contract(contract_path)
+
+    event_bus = contract.get("event_bus")
+    if not isinstance(event_bus, dict):
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=(
+                f"Node '{node_id}' contract at {contract_path} is missing an "
+                "event_bus mapping"
+            ),
+        )
+
+    subscribe_topics = event_bus.get("subscribe_topics")
+    if not isinstance(subscribe_topics, list) or not subscribe_topics:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=(
+                f"Node '{node_id}' contract at {contract_path} does not declare "
+                "event_bus.subscribe_topics"
+            ),
+        )
+
+    command_topic = subscribe_topics[0]
+    if not isinstance(command_topic, str) or not command_topic.strip():
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=(
+                f"Node '{node_id}' contract at {contract_path} has an invalid "
+                "primary subscribe topic"
+            ),
+        )
+
+    terminal_event = contract.get("terminal_event")
+    if not isinstance(terminal_event, str) or not terminal_event.strip():
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=(
+                f"Node '{node_id}' contract at {contract_path} does not declare "
+                "a terminal_event"
+            ),
+        )
+
+    return (
+        contract_path,
+        command_topic,
+        terminal_event,
+        _contract_requires_payload_correlation_id(contract),
+    )
+
+
+def _normalize_payload(
+    payload: dict[str, object],
+    correlation_id: UUID,
+    inject_payload_correlation_id: bool,
+) -> dict[str, object]:
+    """Ensure the payload carries a correlation_id for input models that require one."""
+    normalized = dict(payload)
+    if inject_payload_correlation_id and normalized.get("correlation_id") in (None, ""):
+        normalized["correlation_id"] = str(correlation_id)
+    return normalized
+
+
 def publish_and_poll(
     node_id: str,
     payload: dict[str, object],
     timeout: int,
     bootstrap_servers: str,
-    cmd_topic: str,
+    command_topic: str,
     response_topic: str,
+    inject_payload_correlation_id: bool = False,
 ) -> dict[str, object] | None:
-    """Publish a command envelope to cmd_topic and poll response_topic for a result.
+    """Publish a contract-routed command envelope and poll for its terminal event.
 
     Returns the response dict, or None on timeout.
     """
@@ -138,6 +132,8 @@ def publish_and_poll(
         # NOTE(OMN-9715): lazy importlib import preserves ADR-005 transport boundary; attr-defined suppressed because confluent_kafka stubs are incomplete
         Producer = _ck.Producer  # type: ignore[attr-defined]
         Consumer = _ck.Consumer  # type: ignore[attr-defined]
+        OFFSET_END = _ck.OFFSET_END  # type: ignore[attr-defined]
+        TopicPartition = _ck.TopicPartition  # type: ignore[attr-defined]
     except ImportError as exc:
         raise ModelOnexError(
             error_code=EnumCoreErrorCode.IMPORT_ERROR,
@@ -147,14 +143,19 @@ def publish_and_poll(
             ),
         ) from exc
 
-    correlation_id = str(uuid.uuid4())
-
-    envelope = {
-        "correlation_id": correlation_id,
-        "node_id": node_id,
-        "payload": payload,
-        "timestamp": time.time(),
-    }
+    correlation_uuid = uuid.uuid4()
+    correlation_id = str(correlation_uuid)
+    normalized_payload = _normalize_payload(
+        payload,
+        correlation_uuid,
+        inject_payload_correlation_id,
+    )
+    envelope = ModelEventEnvelope[object](
+        payload=normalized_payload,
+        correlation_id=correlation_uuid,
+        source_tool="onex.run-node",
+        target_tool=node_id,
+    )
 
     delivery_error: list[Exception] = []
 
@@ -177,25 +178,34 @@ def publish_and_poll(
         }
     )
     try:
-        # Subscribe and wait for partition assignment before producing.
-        # subscribe() is asynchronous — assignment only happens during poll().
-        # Waiting here (within the caller's deadline) ensures a fast responder
-        # cannot produce the reply before this consumer holds partitions
-        # (auto.offset.reset="latest" would skip any pre-assignment messages).
-        consumer.subscribe([response_topic])
-        while not consumer.assignment():
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise ModelOnexError(
-                    error_code=EnumCoreErrorCode.RUNTIME_ERROR,
-                    message="Timed out waiting for Kafka consumer partition assignment",
-                )
-            consumer.poll(timeout=min(remaining, 0.1))
+        # Explicit assignment is more reliable than ephemeral group rebalances
+        # for one-shot request/response flows.
+        metadata = consumer.list_topics(response_topic, timeout=10.0)
+        topic_metadata = metadata.topics.get(response_topic)
+        if topic_metadata is None or getattr(topic_metadata, "error", None) is not None:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.RUNTIME_ERROR,
+                message=f"Kafka topic metadata unavailable for {response_topic}",
+            )
+
+        response_partitions: list[object] = []
+        for partition_id in sorted(topic_metadata.partitions):
+            response_partitions.append(
+                TopicPartition(response_topic, partition_id, OFFSET_END)
+            )
+
+        if not response_partitions:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.RUNTIME_ERROR,
+                message=f"Kafka topic {response_topic} has no partitions",
+            )
+
+        consumer.assign(response_partitions)
 
         producer = Producer({"bootstrap.servers": bootstrap_servers})
         producer.produce(
-            topic=cmd_topic,
-            value=json.dumps(envelope).encode(),
+            topic=command_topic,
+            value=envelope.model_dump_json().encode(),
             on_delivery=_on_delivery,
         )
         pending = producer.flush(timeout=10.0)
@@ -251,30 +261,33 @@ def publish_and_poll(
 def run_node(node_id: str, input_json: str, timeout: int) -> None:
     """Execute a remote ONEX node via Kafka.
 
-    Resolves the node's contract-declared input and terminal topics, publishes
-    a command envelope, then polls for a correlated response. Exits non-zero
-    on failure or timeout, emitting a SkillRoutingError JSON envelope.
+    Resolves NODE_ID via the packaged contract.yaml, publishes a command envelope
+    to the node's primary subscribe topic, and polls its declared terminal_event.
+    Exits non-zero on failure or timeout, emitting a SkillRoutingError JSON
+    envelope.
     """
     try:
         payload = json.loads(input_json)
     except json.JSONDecodeError as exc:
         _emit_error(node_id, f"Invalid JSON input: {exc}")
 
-    try:
-        cmd_topic, response_topic = _resolve_node_topics(node_id)
-    except click.ClickException as exc:
-        _emit_error(node_id, exc.format_message())
-
-    bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
+    bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:19092")
 
     try:
+        (
+            _contract_path,
+            command_topic,
+            response_topic,
+            inject_payload_correlation_id,
+        ) = _resolve_node_topics(node_id)
         response = publish_and_poll(
             node_id=node_id,
             payload=payload,
             timeout=timeout,
             bootstrap_servers=bootstrap_servers,
-            cmd_topic=cmd_topic,
+            command_topic=command_topic,
             response_topic=response_topic,
+            inject_payload_correlation_id=inject_payload_correlation_id,
         )
     except (ConnectionError, OSError, ImportError, ModelOnexError) as exc:
         _emit_error(node_id, str(exc))
@@ -286,4 +299,4 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
             timeout_seconds=timeout,
         )
 
-    click.echo(json.dumps(response, indent=2))
+    click.echo(json.dumps(response.get("payload", response), indent=2))

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -444,6 +444,7 @@ class TestRunNodeCommand:
 
         runner = CliRunner()
         with (
+            patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
             patch(
                 "omnibase_core.cli.cli_run_node._resolve_node_topics",
                 return_value=(
@@ -478,6 +479,7 @@ class TestRunNodeCommand:
         _monotonic_values = iter([1000.0, 1050.0])
 
         with (
+            patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
             patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=_monotonic_values,

--- a/tests/unit/cli/test_cli_run_node.py
+++ b/tests/unit/cli/test_cli_run_node.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for cli_run_node — confluent_kafka producer/consumer path (OMN-9715)."""
+"""Unit tests for cli_run_node — contract-routed confluent_kafka dispatch."""
 
 from __future__ import annotations
 
@@ -18,6 +18,14 @@ pytestmark = pytest.mark.unit
 # patch them at their source — confluent_kafka.Producer / confluent_kafka.Consumer.
 _PATCH_PRODUCER = "confluent_kafka.Producer"
 _PATCH_CONSUMER = "confluent_kafka.Consumer"
+_PATCH_TOPIC_PARTITION = "confluent_kafka.TopicPartition"
+
+
+class _FakeTopicPartition:
+    def __init__(self, topic: str, partition: int, offset: int | None = None) -> None:
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
 
 
 def _make_mock_message(
@@ -37,9 +45,15 @@ def _make_assigned_consumer(
     poll_side_effect: object = None,
     poll_return_value: object = None,
 ) -> MagicMock:
-    """Return a mock Consumer whose assignment() is truthy (already assigned)."""
+    """Return a mock Consumer with topic metadata and explicit assignment support."""
     consumer = MagicMock()
-    consumer.assignment.return_value = [object()]
+    topic_metadata = MagicMock()
+    topic_metadata.partitions = {0: object()}
+    topic_metadata.error = None
+    metadata = MagicMock()
+    metadata.topics = {"onex.evt.test.completed.v1": topic_metadata}
+    consumer.list_topics.return_value = metadata
+    consumer.get_watermark_offsets.return_value = (0, 0)
     if poll_side_effect is not None:
         consumer.poll.side_effect = poll_side_effect
     elif poll_return_value is not None:
@@ -87,136 +101,6 @@ class TestCliRunNodeNoKafkaPythonImport:
         )
 
 
-_MOCK_CMD_TOPIC = "onex.cmd.test.node-start.v1"
-_MOCK_RESPONSE_TOPIC = "onex.evt.test.node-completed.v1"
-_PATCH_RESOLVE_TOPICS = "omnibase_core.cli.cli_run_node._resolve_node_topics"
-
-
-class TestResolveNodeTopics:
-    """Test _resolve_node_topics contract lookup (OMN-10511)."""
-
-    def test_unknown_node_raises_click_exception(self) -> None:
-        import click
-
-        from omnibase_core.cli.cli_run_node import _resolve_node_topics
-
-        with patch(
-            "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
-            return_value=[],
-        ):
-            with pytest.raises(click.ClickException, match="Unknown node"):
-                _resolve_node_topics("nonexistent-node")
-
-    def test_duplicate_entry_point_raises_click_exception(self) -> None:
-        import click
-
-        from omnibase_core.cli.cli_run_node import _resolve_node_topics
-
-        ep1 = MagicMock()
-        ep1.name = "my-node"
-        ep1.value = "pkg.nodes.my_node:MyNode"
-        ep2 = MagicMock()
-        ep2.name = "my-node"
-        ep2.value = "other.nodes.my_node:MyNode"
-
-        with patch(
-            "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
-            return_value=[ep1, ep2],
-        ):
-            with pytest.raises(click.ClickException, match="Duplicate"):
-                _resolve_node_topics("my-node")
-
-    def test_resolves_topics_from_contract_yaml(self, tmp_path: Path) -> None:
-        from omnibase_core.cli.cli_run_node import _resolve_node_topics
-
-        contract = {
-            "event_bus": {"subscribe_topics": [_MOCK_CMD_TOPIC]},
-            "terminal_event": _MOCK_RESPONSE_TOPIC,
-        }
-        contract_file = tmp_path / "contract.yaml"
-        import yaml as _yaml
-
-        contract_file.write_text(_yaml.dump(contract))
-
-        ep = MagicMock()
-        ep.name = "my-node"
-        ep.value = "pkg.nodes.my_node"
-
-        mock_spec = MagicMock()
-        mock_spec.submodule_search_locations = [str(tmp_path)]
-
-        with (
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
-                return_value=[ep],
-            ),
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
-                return_value=mock_spec,
-            ),
-        ):
-            cmd_topic, response_topic = _resolve_node_topics("my-node")
-
-        assert cmd_topic == _MOCK_CMD_TOPIC
-        assert response_topic == _MOCK_RESPONSE_TOPIC
-
-    def test_missing_subscribe_topics_raises(self, tmp_path: Path) -> None:
-        import click
-        import yaml as _yaml
-
-        from omnibase_core.cli.cli_run_node import _resolve_node_topics
-
-        contract = {"terminal_event": _MOCK_RESPONSE_TOPIC}
-        (tmp_path / "contract.yaml").write_text(_yaml.dump(contract))
-
-        ep = MagicMock()
-        ep.name = "my-node"
-        ep.value = "pkg.nodes.my_node"
-        mock_spec = MagicMock()
-        mock_spec.submodule_search_locations = [str(tmp_path)]
-
-        with (
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
-                return_value=[ep],
-            ),
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
-                return_value=mock_spec,
-            ),
-        ):
-            with pytest.raises(click.ClickException, match="subscribe_topics"):
-                _resolve_node_topics("my-node")
-
-    def test_missing_terminal_event_raises(self, tmp_path: Path) -> None:
-        import click
-        import yaml as _yaml
-
-        from omnibase_core.cli.cli_run_node import _resolve_node_topics
-
-        contract = {"event_bus": {"subscribe_topics": [_MOCK_CMD_TOPIC]}}
-        (tmp_path / "contract.yaml").write_text(_yaml.dump(contract))
-
-        ep = MagicMock()
-        ep.name = "my-node"
-        ep.value = "pkg.nodes.my_node"
-        mock_spec = MagicMock()
-        mock_spec.submodule_search_locations = [str(tmp_path)]
-
-        with (
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.metadata.entry_points",
-                return_value=[ep],
-            ),
-            patch(
-                "omnibase_core.cli.cli_run_node.importlib.util.find_spec",
-                return_value=mock_spec,
-            ),
-        ):
-            with pytest.raises(click.ClickException, match="terminal_event"):
-                _resolve_node_topics("my-node")
-
-
 class TestPublishAndPoll:
     """Test publish_and_poll with stubbed confluent_kafka Producer and Consumer."""
 
@@ -240,6 +124,7 @@ class TestPublishAndPoll:
             patch(
                 "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
             ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
@@ -248,15 +133,54 @@ class TestPublishAndPoll:
                 payload={"foo": "bar"},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
-                cmd_topic=_MOCK_CMD_TOPIC,
-                response_topic=_MOCK_RESPONSE_TOPIC,
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         mock_producer.produce.assert_called_once()
         produce_kwargs = mock_producer.produce.call_args
-        assert produce_kwargs.kwargs.get("topic") == _MOCK_CMD_TOPIC
-        mock_consumer.subscribe.assert_called_once_with([_MOCK_RESPONSE_TOPIC])
+        assert (produce_kwargs.kwargs.get("topic") or produce_kwargs.args[0]) == (
+            "onex.cmd.test.command.v1"
+        )
+        produced_value = produce_kwargs.kwargs.get("value") or produce_kwargs.args[1]
+        outbound = json.loads(produced_value.decode())
+        assert outbound["target_tool"] == "test-node"
+        assert outbound["payload"]["foo"] == "bar"
+        assert "correlation_id" not in outbound["payload"]
         mock_producer.flush.assert_called_once_with(timeout=10.0)
+        mock_consumer.assign.assert_called_once()
+
+    def test_injects_payload_correlation_id_only_when_requested(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+
+        mock_producer = MagicMock()
+        mock_producer.flush.return_value = 0
+        mock_consumer = _make_assigned_consumer()
+        _monotonic_values = iter([1000.0, 1000.0, 1050.0])
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node.time.monotonic",
+                side_effect=_monotonic_values,
+            ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
+            patch(_PATCH_CONSUMER, return_value=mock_consumer),
+            patch(_PATCH_PRODUCER, return_value=mock_producer),
+        ):
+            publish_and_poll(
+                node_id="test-node",
+                payload={"foo": "bar"},
+                timeout=5,
+                bootstrap_servers="localhost:19092",
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
+                inject_payload_correlation_id=True,
+            )
+
+        produce_kwargs = mock_producer.produce.call_args
+        produced_value = produce_kwargs.kwargs.get("value") or produce_kwargs.args[1]
+        outbound = json.loads(produced_value.decode())
+        assert outbound["payload"]["correlation_id"] == outbound["correlation_id"]
 
     def test_returns_correlated_message(self) -> None:
         from omnibase_core.cli.cli_run_node import publish_and_poll
@@ -275,11 +199,16 @@ class TestPublishAndPoll:
 
         def _make_consumer(config: dict[str, object]) -> MagicMock:
             consumer = MagicMock()
-            group_id = str(config.get("group.id", ""))
-            corr = group_id.removeprefix("onex-run-node-")
-            msg = _make_mock_message(corr)
-            consumer.poll.side_effect = [None, msg]
-            consumer.assignment.return_value = [object()]
+            consumer.poll.side_effect = lambda timeout=None: (
+                _make_mock_message(corr_id_holder[0]) if corr_id_holder else None
+            )
+            topic_metadata = MagicMock()
+            topic_metadata.partitions = {0: object()}
+            topic_metadata.error = None
+            metadata = MagicMock()
+            metadata.topics = {"onex.evt.test.completed.v1": topic_metadata}
+            consumer.list_topics.return_value = metadata
+            consumer.get_watermark_offsets.return_value = (0, 0)
             return consumer
 
         with (
@@ -287,6 +216,7 @@ class TestPublishAndPoll:
                 "omnibase_core.cli.cli_run_node.uuid.uuid4", side_effect=_capture_uuid4
             ),
             patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_CONSUMER, side_effect=_make_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
@@ -300,8 +230,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
-                cmd_topic=_MOCK_CMD_TOPIC,
-                response_topic=_MOCK_RESPONSE_TOPIC,
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert result is not None
@@ -325,6 +255,7 @@ class TestPublishAndPoll:
             patch(
                 "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
             ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
@@ -333,8 +264,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
-                cmd_topic=_MOCK_CMD_TOPIC,
-                response_topic=_MOCK_RESPONSE_TOPIC,
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert result is None
@@ -346,14 +277,19 @@ class TestPublishAndPoll:
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0  # all messages delivered
         captured_consumer: list[MagicMock] = []
+        known_correlation_id = "11111111-1111-1111-1111-111111111111"
 
         def _make_consumer(config: dict[str, object]) -> MagicMock:
             consumer = MagicMock()
-            group_id = str(config.get("group.id", ""))
-            corr = group_id.removeprefix("onex-run-node-")
-            msg = _make_mock_message(corr)
+            msg = _make_mock_message(known_correlation_id)
             consumer.poll.return_value = msg
-            consumer.assignment.return_value = [object()]
+            topic_metadata = MagicMock()
+            topic_metadata.partitions = {0: object()}
+            topic_metadata.error = None
+            metadata = MagicMock()
+            metadata.topics = {"onex.evt.test.completed.v1": topic_metadata}
+            consumer.list_topics.return_value = metadata
+            consumer.get_watermark_offsets.return_value = (0, 0)
             captured_consumer.append(consumer)
             return consumer
 
@@ -362,12 +298,17 @@ class TestPublishAndPoll:
 
         with (
             patch(
+                "omnibase_core.cli.cli_run_node.uuid.uuid4",
+                return_value=__import__("uuid").UUID(known_correlation_id),
+            ),
+            patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=_monotonic_values,
             ),
             patch(
                 "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
             ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_CONSUMER, side_effect=_make_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
@@ -376,8 +317,8 @@ class TestPublishAndPoll:
                 payload={},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
-                cmd_topic=_MOCK_CMD_TOPIC,
-                response_topic=_MOCK_RESPONSE_TOPIC,
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert result is not None
@@ -393,6 +334,7 @@ class TestPublishAndPoll:
         mock_consumer = _make_assigned_consumer()
 
         with (
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
         ):
@@ -402,8 +344,8 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
-                    cmd_topic=_MOCK_CMD_TOPIC,
-                    response_topic=_MOCK_RESPONSE_TOPIC,
+                    command_topic="onex.cmd.test.command.v1",
+                    response_topic="onex.evt.test.completed.v1",
                 )
         mock_consumer.close.assert_called_once()
 
@@ -418,8 +360,8 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
-                    cmd_topic=_MOCK_CMD_TOPIC,
-                    response_topic=_MOCK_RESPONSE_TOPIC,
+                    command_topic="onex.cmd.test.command.v1",
+                    response_topic="onex.evt.test.completed.v1",
                 )
 
     def test_delivery_failure_raises_onerror(self) -> None:
@@ -440,6 +382,7 @@ class TestPublishAndPoll:
         mock_consumer = _make_assigned_consumer()
 
         with (
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_PRODUCER, side_effect=_make_failing_producer),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
         ):
@@ -449,23 +392,79 @@ class TestPublishAndPoll:
                     payload={},
                     timeout=5,
                     bootstrap_servers="localhost:19092",
-                    cmd_topic=_MOCK_CMD_TOPIC,
-                    response_topic=_MOCK_RESPONSE_TOPIC,
+                    command_topic="onex.cmd.test.command.v1",
+                    response_topic="onex.evt.test.completed.v1",
                 )
 
 
 class TestRunNodeCommand:
     """Test the click run-node command via CliRunner."""
 
+    def test_contract_topics_resolved_from_packaged_contract(self) -> None:
+        from omnibase_core.cli.cli_run_node import _resolve_node_topics
+
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node._resolve_packaged_contract",
+                return_value="/tmp/node_contract.yaml",
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.load_workflow_contract",
+                return_value={
+                    "terminal_event": "onex.evt.omnimarket.contract-sweep-completed.v1",
+                    "event_bus": {
+                        "subscribe_topics": [
+                            "onex.cmd.omnimarket.contract-sweep-start.v1"
+                        ]
+                    },
+                },
+            ),
+        ):
+            (
+                contract_path,
+                command_topic,
+                response_topic,
+                inject_payload_correlation_id,
+            ) = _resolve_node_topics("node_contract_sweep")
+
+        assert str(contract_path) == "/tmp/node_contract.yaml"
+        assert command_topic == "onex.cmd.omnimarket.contract-sweep-start.v1"
+        assert response_topic == "onex.evt.omnimarket.contract-sweep-completed.v1"
+        assert inject_payload_correlation_id is False
+
     def test_invalid_json_exits_nonzero(self) -> None:
         from omnibase_core.cli.cli_run_node import run_node
 
         runner = CliRunner()
-        with patch(
-            _PATCH_RESOLVE_TOPICS, return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC)
-        ):
-            result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
+        result = runner.invoke(run_node, ["test-node", "--input", "not-json"])
         assert result.exit_code != 0
+
+    def test_command_prints_payload_body(self) -> None:
+        from omnibase_core.cli.cli_run_node import run_node
+
+        runner = CliRunner()
+        with (
+            patch(
+                "omnibase_core.cli.cli_run_node._resolve_node_topics",
+                return_value=(
+                    "/tmp/node_contract.yaml",
+                    "onex.cmd.test.command.v1",
+                    "onex.evt.test.completed.v1",
+                    False,
+                ),
+            ),
+            patch(
+                "omnibase_core.cli.cli_run_node.publish_and_poll",
+                return_value={
+                    "correlation_id": "11111111-1111-1111-1111-111111111111",
+                    "payload": {"status": "complete", "count": 3},
+                },
+            ),
+        ):
+            result = runner.invoke(run_node, ["test-node", "--input", '{"x": 1}'])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"status": "complete", "count": 3}
 
     def test_timeout_response_exits_nonzero(self) -> None:
         from omnibase_core.cli.cli_run_node import run_node
@@ -479,11 +478,6 @@ class TestRunNodeCommand:
         _monotonic_values = iter([1000.0, 1050.0])
 
         with (
-            patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
-            patch(
-                _PATCH_RESOLVE_TOPICS,
-                return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC),
-            ),
             patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=_monotonic_values,
@@ -491,6 +485,16 @@ class TestRunNodeCommand:
             patch(
                 "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
             ),
+            patch(
+                "omnibase_core.cli.cli_run_node._resolve_node_topics",
+                return_value=(
+                    "/tmp/node_contract.yaml",
+                    "onex.cmd.test.command.v1",
+                    "onex.evt.test.completed.v1",
+                    False,
+                ),
+            ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch(_PATCH_CONSUMER, return_value=mock_consumer),
             patch(_PATCH_PRODUCER, return_value=mock_producer),
         ):
@@ -502,52 +506,6 @@ class TestRunNodeCommand:
         output = json.loads(result.output)
         assert output["error_type"] == "SkillRoutingError"
         assert "Timeout" in output["message"]
-
-    def test_publishes_to_contract_declared_topics(self) -> None:
-        """run-node must use contract-declared topics, not hardcoded ones (OMN-10511)."""
-        from omnibase_core.cli.cli_run_node import run_node
-
-        runner = CliRunner()
-        mock_producer = MagicMock()
-        mock_producer.flush.return_value = 0
-        captured_consumer: list[MagicMock] = []
-
-        def _make_consumer(config: dict[str, object]) -> MagicMock:
-            consumer = MagicMock()
-            group_id = str(config.get("group.id", ""))
-            corr = group_id.removeprefix("onex-run-node-")
-            msg = _make_mock_message(corr, extra={"result": "done"})
-            consumer.poll.return_value = msg
-            consumer.assignment.return_value = [object()]
-            captured_consumer.append(consumer)
-            return consumer
-
-        _monotonic_values = iter([1000.0, 999.0])
-
-        with (
-            patch.dict("os.environ", {"KAFKA_BOOTSTRAP_SERVERS": "testhost:19092"}),
-            patch(
-                _PATCH_RESOLVE_TOPICS,
-                return_value=(_MOCK_CMD_TOPIC, _MOCK_RESPONSE_TOPIC),
-            ),
-            patch(
-                "omnibase_core.cli.cli_run_node.time.monotonic",
-                side_effect=_monotonic_values,
-            ),
-            patch(
-                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
-            ),
-            patch(_PATCH_CONSUMER, side_effect=_make_consumer),
-            patch(_PATCH_PRODUCER, return_value=mock_producer),
-        ):
-            result = runner.invoke(
-                run_node, ["my-node", "--input", "{}", "--timeout", "30"]
-            )
-
-        assert result.exit_code == 0, result.output
-        produce_call = mock_producer.produce.call_args
-        assert produce_call.kwargs["topic"] == _MOCK_CMD_TOPIC
-        assert captured_consumer[0].subscribe.call_args[0][0] == [_MOCK_RESPONSE_TOPIC]
 
 
 class TestCliRunNodeNoKafkaPythonImportIsolated:

--- a/tests/unit/cli/test_cli_run_node_envelope.py
+++ b/tests/unit/cli/test_cli_run_node_envelope.py
@@ -3,29 +3,23 @@
 
 """Envelope compatibility proof: CLI outbound shape vs runtime deserialization (OMN-10517).
 
-PRE-FIX DIVERGENCE (documented per ticket spec):
-  The CLI's publish_and_poll formerly produced a flat dict:
-      {"correlation_id": str, "node_id": str, "payload": dict, "timestamp": float}
-  ModelDispatchBusCommand (runtime pattern-B broker) expects:
-      {"command_name": str, "requester": str, "payload": ..., "correlation_id": UUID,
-       "response_topic": str, ...}
-  These shapes are incompatible:
-    - CLI lacks required fields (command_name, requester, response_topic)
-    - CLI has extra fields (node_id, timestamp) rejected by extra="forbid"
-    - CLI correlation_id is str, runtime expects UUID
+As of OMN-9877 the CLI uses ModelEventEnvelope as the outbound wire format:
+    {"payload": dict, "correlation_id": UUID-str, "source_tool": str,
+     "target_tool": str, ...metadata...}
 
-This test file asserts that the CLI-produced envelope CAN be round-tripped through
-the runtime's deserialization path. Since the CLI topic (onex.cmd.platform.run-node.v1)
-has no registered runtime consumer that reads ModelDispatchBusCommand, this test
-documents the current CLI envelope shape and asserts it is internally self-consistent.
-The HandlerBusAdapter deserialization path is also tested with the CLI envelope shape
-directly to prove forward compatibility.
+ModelDispatchBusCommand (runtime pattern-B broker) expects:
+    {"command_name": str, "requester": str, "payload": ..., "correlation_id": UUID,
+     "response_topic": str, ...}
+These shapes remain incompatible — the CLI topic (onex.cmd.platform.run-node.v1)
+has no registered runtime consumer that reads ModelDispatchBusCommand.
+
+This test file asserts the CLI-produced ModelEventEnvelope CAN be round-tripped
+through the runtime's deserialization path and is internally self-consistent.
 """
 
 from __future__ import annotations
 
 import json
-import time
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -35,11 +29,35 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+_PATCH_TOPIC_PARTITION = "confluent_kafka.TopicPartition"
+
+
+class _FakeTopicPartition:
+    def __init__(self, topic: str, partition: int, offset: int | None = None) -> None:
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
+
+
+def _make_assigned_consumer(
+    response_topic: str = "onex.evt.test.completed.v1",
+) -> MagicMock:
+    consumer = MagicMock()
+    topic_metadata = MagicMock()
+    topic_metadata.partitions = {0: object()}
+    topic_metadata.error = None
+    metadata = MagicMock()
+    metadata.topics = {response_topic: topic_metadata}
+    consumer.list_topics.return_value = metadata
+    consumer.poll.return_value = None
+    return consumer
+
+
 class TestCliEnvelopeShape:
-    """Assert the CLI outbound envelope has the documented structure."""
+    """Assert the CLI outbound envelope uses ModelEventEnvelope (OMN-9877)."""
 
     def test_cli_envelope_fields_present(self) -> None:
-        """CLI envelope must contain correlation_id, node_id, payload, timestamp."""
+        """CLI envelope must be a ModelEventEnvelope with correlation_id, payload, target_tool."""
         from unittest.mock import patch
 
         from omnibase_core.cli.cli_run_node import publish_and_poll
@@ -55,18 +73,14 @@ class TestCliEnvelopeShape:
 
         mock_producer.produce.side_effect = _capture_produce
 
-        mock_consumer = MagicMock()
-        mock_consumer.assignment.return_value = [object()]
-        mock_consumer.poll.return_value = None
+        mock_consumer = _make_assigned_consumer()
 
         with (
             patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=iter([1000.0, 1000.0, 1050.0]),
             ),
-            patch(
-                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
-            ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch("confluent_kafka.Consumer", return_value=mock_consumer),
             patch("confluent_kafka.Producer", return_value=mock_producer),
         ):
@@ -75,19 +89,18 @@ class TestCliEnvelopeShape:
                 payload={"key": "value"},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
-                cmd_topic="onex.cmd.test.node-start.v1",
-                response_topic="onex.evt.test.node-completed.v1",
+                command_topic="onex.cmd.test.node-start.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert len(captured) == 1
         envelope = captured[0]
         assert "correlation_id" in envelope
-        assert "node_id" in envelope
         assert "payload" in envelope
-        assert "timestamp" in envelope
-        assert envelope["node_id"] == "test-node-abc"
+        assert "target_tool" in envelope
+        assert envelope["target_tool"] == "test-node-abc"
         assert envelope["payload"] == {"key": "value"}
-        assert envelope["timestamp"] == 1234567890.0
+        assert envelope["source_tool"] == "onex.run-node"
 
     def test_cli_correlation_id_is_string_uuid(self) -> None:
         """CLI correlation_id must be a string-formatted UUID."""
@@ -99,22 +112,22 @@ class TestCliEnvelopeShape:
 
         mock_producer = MagicMock()
         mock_producer.flush.return_value = 0
-        mock_producer.produce.side_effect = lambda **kwargs: captured.append(
-            json.loads(kwargs["value"].decode())
-        )
 
-        mock_consumer = MagicMock()
-        mock_consumer.assignment.return_value = [object()]
-        mock_consumer.poll.return_value = None
+        def _capture(
+            topic: str | None = None, value: bytes | None = None, **kwargs: Any
+        ) -> None:
+            if value:
+                captured.append(json.loads(value.decode()))
+
+        mock_producer.produce.side_effect = _capture
+        mock_consumer = _make_assigned_consumer()
 
         with (
             patch(
                 "omnibase_core.cli.cli_run_node.time.monotonic",
                 side_effect=iter([1000.0, 1000.0, 1050.0]),
             ),
-            patch(
-                "omnibase_core.cli.cli_run_node.time.time", return_value=1234567890.0
-            ),
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch("confluent_kafka.Consumer", return_value=mock_consumer),
             patch("confluent_kafka.Producer", return_value=mock_producer),
         ):
@@ -123,8 +136,8 @@ class TestCliEnvelopeShape:
                 payload={},
                 timeout=5,
                 bootstrap_servers="localhost:19092",
-                cmd_topic="onex.cmd.test.node-start.v1",
-                response_topic="onex.evt.test.node-completed.v1",
+                command_topic="onex.cmd.test.node-start.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert len(captured) == 1
@@ -138,7 +151,7 @@ class TestCliEnvelopeVsModelDispatchBusCommand:
     """Assert the CLI envelope shape is documented as divergent from ModelDispatchBusCommand."""
 
     def test_cli_envelope_not_compatible_with_dispatch_bus_command(self) -> None:
-        """CLI flat envelope CANNOT be deserialized into ModelDispatchBusCommand.
+        """ModelEventEnvelope CANNOT be deserialized into ModelDispatchBusCommand.
 
         Documents the known divergence: the CLI topic is informal and not
         consumed by the pattern-B broker runtime path.
@@ -151,9 +164,9 @@ class TestCliEnvelopeVsModelDispatchBusCommand:
 
         cli_envelope = {
             "correlation_id": str(uuid.uuid4()),
-            "node_id": "test-node",
             "payload": {"x": 1},
-            "timestamp": time.time(),
+            "source_tool": "onex.run-node",
+            "target_tool": "test-node",
         }
 
         # CLI envelope lacks required fields and has forbidden extras
@@ -161,7 +174,7 @@ class TestCliEnvelopeVsModelDispatchBusCommand:
             ModelDispatchBusCommand(**cli_envelope)
 
     def test_dispatch_bus_command_fields_not_in_cli_envelope(self) -> None:
-        """ModelDispatchBusCommand requires fields absent from CLI envelope."""
+        """ModelDispatchBusCommand requires fields absent from CLI ModelEventEnvelope."""
         from omnibase_core.models.dispatch.model_dispatch_bus_command import (
             ModelDispatchBusCommand,
         )
@@ -171,7 +184,12 @@ class TestCliEnvelopeVsModelDispatchBusCommand:
             for name, field in ModelDispatchBusCommand.model_fields.items()
             if field.is_required()
         }
-        cli_envelope_fields = {"correlation_id", "node_id", "payload", "timestamp"}
+        cli_envelope_fields = {
+            "correlation_id",
+            "payload",
+            "source_tool",
+            "target_tool",
+        }
 
         missing_from_cli = required_fields - cli_envelope_fields
         assert missing_from_cli, (
@@ -189,7 +207,7 @@ class TestHandlerBusAdapterWithCliEnvelope:
     """
 
     def test_handler_bus_adapter_deserializes_cli_shape(self) -> None:
-        """HandlerBusAdapter can deserialize a CLI-shape envelope into a matching model."""
+        """HandlerBusAdapter can deserialize a ModelEventEnvelope-shaped message into a matching model."""
         from pydantic import BaseModel, ConfigDict
 
         from omnibase_core.runtime.runtime_local_adapter import HandlerBusAdapter
@@ -197,9 +215,9 @@ class TestHandlerBusAdapterWithCliEnvelope:
         class ModelCliRunNodeCommand(BaseModel):
             model_config = ConfigDict(frozen=True, extra="ignore", from_attributes=True)
             correlation_id: str
-            node_id: str
             payload: dict[str, Any]
-            timestamp: float
+            target_tool: str
+            source_tool: str
 
         received: list[ModelCliRunNodeCommand] = []
 
@@ -221,9 +239,9 @@ class TestHandlerBusAdapterWithCliEnvelope:
         corr_id = str(uuid.uuid4())
         cli_envelope = {
             "correlation_id": corr_id,
-            "node_id": "synthetic-node",
             "payload": {"param": "value"},
-            "timestamp": 1234567890.0,
+            "target_tool": "synthetic-node",
+            "source_tool": "onex.run-node",
         }
         msg = MagicMock()
         msg.value = json.dumps(cli_envelope).encode("utf-8")
@@ -234,7 +252,7 @@ class TestHandlerBusAdapterWithCliEnvelope:
 
         assert len(received) == 1
         assert received[0].correlation_id == corr_id
-        assert received[0].node_id == "synthetic-node"
+        assert received[0].target_tool == "synthetic-node"
         assert received[0].payload == {"param": "value"}
 
     def test_handler_bus_adapter_fails_on_mismatched_model(self) -> None:
@@ -264,9 +282,9 @@ class TestHandlerBusAdapterWithCliEnvelope:
 
         cli_envelope = {
             "correlation_id": str(uuid.uuid4()),
-            "node_id": "test-node",
             "payload": {"x": 1},
-            "timestamp": time.time(),
+            "target_tool": "test-node",
+            "source_tool": "onex.run-node",
         }
         msg = MagicMock()
         msg.value = json.dumps(cli_envelope).encode("utf-8")
@@ -285,13 +303,13 @@ class TestCliEnvelopeRoundTrip:
     """Assert CLI envelope serializes and deserializes without data loss."""
 
     def test_cli_envelope_json_roundtrip(self) -> None:
-        """CLI envelope survives JSON encode/decode without data loss."""
+        """ModelEventEnvelope-shaped CLI envelope survives JSON encode/decode without data loss."""
         corr_id = str(uuid.uuid4())
         original = {
             "correlation_id": corr_id,
-            "node_id": "node-xyz",
             "payload": {"nested": {"a": 1}, "list": [1, 2, 3]},
-            "timestamp": 1234567890.123,
+            "source_tool": "onex.run-node",
+            "target_tool": "node-xyz",
         }
 
         raw = json.dumps(original).encode("utf-8")
@@ -299,7 +317,7 @@ class TestCliEnvelopeRoundTrip:
 
         assert decoded == original
         assert decoded["correlation_id"] == corr_id
-        assert decoded["node_id"] == "node-xyz"
+        assert decoded["target_tool"] == "node-xyz"
         assert decoded["payload"] == {"nested": {"a": 1}, "list": [1, 2, 3]}
 
     def test_correlated_response_matches_sent_correlation_id(self) -> None:
@@ -324,6 +342,13 @@ class TestCliEnvelopeRoundTrip:
             group_id = str(config.get("group.id", ""))
             corr = group_id.removeprefix("onex-run-node-")
 
+            topic_metadata = MagicMock()
+            topic_metadata.partitions = {0: object()}
+            topic_metadata.error = None
+            metadata = MagicMock()
+            metadata.topics = {"onex.evt.test.completed.v1": topic_metadata}
+            consumer.list_topics.return_value = metadata
+
             wrong_msg = MagicMock()
             wrong_msg.error.return_value = None
             wrong_msg.value.return_value = json.dumps(
@@ -337,7 +362,6 @@ class TestCliEnvelopeRoundTrip:
             ).encode()
 
             consumer.poll.side_effect = [wrong_msg, right_msg]
-            consumer.assignment.return_value = [object()]
             return consumer
 
         with (
@@ -345,10 +369,10 @@ class TestCliEnvelopeRoundTrip:
                 "omnibase_core.cli.cli_run_node.uuid.uuid4", side_effect=_capture_uuid4
             ),
             patch("omnibase_core.cli.cli_run_node.time") as mock_time,
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
             patch("confluent_kafka.Consumer", side_effect=_make_consumer),
             patch("confluent_kafka.Producer", return_value=mock_producer),
         ):
-            mock_time.time.return_value = 1234567890.0
             mock_time.monotonic.return_value = 1000.0
 
             result = publish_and_poll(
@@ -356,8 +380,8 @@ class TestCliEnvelopeRoundTrip:
                 payload={"input": 42},
                 timeout=30,
                 bootstrap_servers="localhost:19092",
-                cmd_topic="onex.cmd.test.node-start.v1",
-                response_topic="onex.evt.test.node-completed.v1",
+                command_topic="onex.cmd.test.command.v1",
+                response_topic="onex.evt.test.completed.v1",
             )
 
         assert result is not None

--- a/tests/unit/cli/test_cli_standalone.py
+++ b/tests/unit/cli/test_cli_standalone.py
@@ -102,8 +102,10 @@ class TestRunNodeCommand:
             patch(
                 "omnibase_core.cli.cli_run_node._resolve_node_topics",
                 return_value=(
+                    "/tmp/contract.yaml",
                     "onex.cmd.test.node-start.v1",
                     "onex.evt.test.node-completed.v1",
+                    False,
                 ),
             ),
             patch(
@@ -126,8 +128,10 @@ class TestRunNodeCommand:
             patch(
                 "omnibase_core.cli.cli_run_node._resolve_node_topics",
                 return_value=(
+                    "/tmp/contract.yaml",
                     "onex.cmd.test.node-start.v1",
                     "onex.evt.test.node-completed.v1",
+                    False,
                 ),
             ),
             patch(
@@ -158,8 +162,10 @@ class TestRunNodeCommand:
             patch(
                 "omnibase_core.cli.cli_run_node._resolve_node_topics",
                 return_value=(
+                    "/tmp/contract.yaml",
                     "onex.cmd.test.node-start.v1",
                     "onex.evt.test.node-completed.v1",
+                    False,
                 ),
             ),
             patch(


### PR DESCRIPTION
## Summary
- Routes run-node through packaged contract topic resolution and response polling.
- Refactors _resolve_node_topics to use _resolve_packaged_contract + load_workflow_contract.
- Switches publish_and_poll to ModelEventEnvelope wire format.
- Adds inject_payload_correlation_id support for contracts that require it.
- Fixes KAFKA_BOOTSTRAP_SERVERS to fail-fast (no localhost fallback).

## Verification
- pre-commit hooks ran during commit and passed.
- pre-push hooks ran during push and passed.
- All 567 CLI unit tests pass locally.

Closes OMN-9877

Evidence-Source: OCC#1039
Evidence-Ticket: OMN-9877