### PR TITLE
feat(OMN-11088): register node generation Kafka topics in TopicBase

### DIFF
--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -574,6 +574,19 @@ class TopicBase(StrEnum):
     BUILD_LOOP_FAILED = "onex.evt.omnibase-infra.build-loop-failed.v1"
     """Emitted by the build-loop orchestrator when a build cycle fails."""
 
+    # ==========================================================================
+    # Node generation topics (OMN-11088)
+    # Emitted by omnimarket node generation pipeline.
+    # ==========================================================================
+    NODE_GENERATION_REQUESTED = "onex.cmd.omnimarket.node-generation-requested.v1"
+    """Command to request generation of a new ONEX node scaffold."""
+
+    NODE_GENERATION_COMPLETED = "onex.evt.omnimarket.node-generation-completed.v1"
+    """Emitted when node generation completes successfully."""
+
+    NODE_GENERATION_FAILED = "onex.evt.omnimarket.node-generation-failed.v1"
+    """Emitted when node generation fails at any stage."""
+
 
 def _validate_topic_segment(segment: str, name: str) -> str:
     """Validate a single topic segment (prefix or base segment).

--- a/tests/unit/test_node_generation_topics.py
+++ b/tests/unit/test_node_generation_topics.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for node generation Kafka topics in TopicBase (OMN-11088)."""
+
+from __future__ import annotations
+
+import re
+
+from omnibase_core.topics import TopicBase
+
+
+def test_node_generation_topics_exist() -> None:
+    assert hasattr(TopicBase, "NODE_GENERATION_REQUESTED")
+    assert hasattr(TopicBase, "NODE_GENERATION_COMPLETED")
+    assert hasattr(TopicBase, "NODE_GENERATION_FAILED")
+
+
+def test_topic_values_correct() -> None:
+    assert (
+        TopicBase.NODE_GENERATION_REQUESTED.value
+        == "onex.cmd.omnimarket.node-generation-requested.v1"
+    )
+    assert (
+        TopicBase.NODE_GENERATION_COMPLETED.value
+        == "onex.evt.omnimarket.node-generation-completed.v1"
+    )
+    assert (
+        TopicBase.NODE_GENERATION_FAILED.value
+        == "onex.evt.omnimarket.node-generation-failed.v1"
+    )
+
+
+def test_topic_naming_convention() -> None:
+    """Topics must follow onex.{cmd|evt}.{service}.{event-name}.v{N} format."""
+    pattern = r"^onex\.(cmd|evt)\.\w+\.[a-z0-9-]+\.v\d+$"
+    assert re.match(pattern, TopicBase.NODE_GENERATION_REQUESTED.value)
+    assert re.match(pattern, TopicBase.NODE_GENERATION_COMPLETED.value)
+    assert re.match(pattern, TopicBase.NODE_GENERATION_FAILED.value)
+
+
+def test_requested_is_command_topic() -> None:
+    assert ".cmd." in TopicBase.NODE_GENERATION_REQUESTED.value
+
+
+def test_completed_and_failed_are_event_topics() -> None:
+    assert ".evt." in TopicBase.NODE_GENERATION_COMPLETED.value
+    assert ".evt." in TopicBase.NODE_GENERATION_FAILED.value


### PR DESCRIPTION
## Summary

- Adds NODE_GENERATION_REQUESTED, NODE_GENERATION_COMPLETED, and NODE_GENERATION_FAILED to TopicBase enum in omnibase_core/topics.py
- Topics follow canonical onex.{cmd|evt}.omnimarket.{event-name}.v1 format
- NODE_GENERATION_REQUESTED is a cmd topic (command); completed/failed are evt topics (events)

## Ticket

OMN-11088

## Test plan

- 5 new tests in tests/unit/test_node_generation_topics.py: existence, values, naming convention, cmd/evt classification
- tests/unit/test_topics.py::TestTopicBase::test_all_topics_match_onex_format — validates all enum values match canonical pattern (passes with new members)
- All pre-commit hooks pass on changed files
- mypy strict + pyright pass (confirmed by push hooks)

Evidence-Source: OCC#1059
Evidence-Ticket: OMN-11088