### PR TITLE
feat(OMN-11086): add ModelNodeGenerationRequest + ModelNodeGenerationResult

### DIFF
--- a/src/omnibase_core/models/generation/__init__.py
+++ b/src/omnibase_core/models/generation/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Node generation request/result models for the hackathon MVP pipeline."""
+
+from omnibase_core.models.generation.model_node_generation_request import (
+    ModelNodeGenerationRequest,
+)
+from omnibase_core.models.generation.model_node_generation_result import (
+    ModelNodeGenerationResult,
+)
+
+__all__ = [
+    "ModelNodeGenerationRequest",
+    "ModelNodeGenerationResult",
+]

--- a/src/omnibase_core/models/generation/model_node_generation_request.py
+++ b/src/omnibase_core/models/generation/model_node_generation_request.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class ModelNodeGenerationRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_description: str
+    correlation_id: str
+    target_node_type: str = "compute"
+    max_attempts: int = 2
+    generation_timeout_seconds: int = 60
+    validation_timeout_seconds: int = 15
+
+    @field_validator("target_node_type")
+    @classmethod
+    def must_be_compute(cls, v: str) -> str:
+        if v != "compute":
+            raise ValueError("Hackathon MVP only generates COMPUTE nodes")
+        return v

--- a/src/omnibase_core/models/generation/model_node_generation_result.py
+++ b/src/omnibase_core/models/generation/model_node_generation_result.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelNodeGenerationResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    node_name: str
+    contract_yaml: str
+    handler_source: str
+    artifact_paths: list[str]
+    generated_contract_hash: str
+    generated_handler_hash: str
+    stdout: str
+    stderr: str
+    returncode: int

--- a/tests/unit/models/generation/__init__.py
+++ b/tests/unit/models/generation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/generation/test_model_node_generation.py
+++ b/tests/unit/models/generation/test_model_node_generation.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_request_requires_fields() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationRequest
+
+    req = ModelNodeGenerationRequest(
+        task_description="Classify review sentiment",
+        correlation_id=str(uuid4()),
+    )
+    assert req.target_node_type == "compute"
+    assert req.max_attempts == 2
+    assert req.generation_timeout_seconds == 60
+
+
+def test_request_rejects_non_compute() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationRequest
+
+    with pytest.raises(ValidationError):
+        ModelNodeGenerationRequest(
+            task_description="foo",
+            correlation_id=str(uuid4()),
+            target_node_type="orchestrator",
+        )
+
+
+def test_result_structured_artifacts() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationResult
+
+    result = ModelNodeGenerationResult(
+        node_name="node_sentiment_classifier",
+        contract_yaml="name: node_sentiment_classifier\ncontract_version: '1.0.0'\nnode_type: compute\n",
+        handler_source="def handle(input): return {'sentiment': 'positive'}",
+        artifact_paths=[".onex_state/hackathon/generated/test/contract.yaml"],
+        generated_contract_hash="sha256:abc123def456",
+        generated_handler_hash="sha256:789ghi012jkl",
+        stdout="Generated successfully",
+        stderr="",
+        returncode=0,
+    )
+    assert result.generated_contract_hash.startswith("sha256:")
+    assert result.returncode == 0
+    assert result.node_name == "node_sentiment_classifier"
+
+
+def test_result_frozen() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationResult
+
+    result = ModelNodeGenerationResult(
+        node_name="test",
+        contract_yaml="",
+        handler_source="",
+        artifact_paths=[],
+        generated_contract_hash="sha256:x",
+        generated_handler_hash="sha256:y",
+        stdout="",
+        stderr="",
+        returncode=0,
+    )
+    with pytest.raises(ValidationError):
+        result.node_name = "changed"  # type: ignore[misc]
+
+
+def test_request_frozen() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationRequest
+
+    req = ModelNodeGenerationRequest(
+        task_description="test",
+        correlation_id=str(uuid4()),
+    )
+    with pytest.raises(ValidationError):
+        req.task_description = "changed"  # type: ignore[misc]
+
+
+def test_request_validation_timeout_default() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationRequest
+
+    req = ModelNodeGenerationRequest(
+        task_description="test",
+        correlation_id=str(uuid4()),
+    )
+    assert req.validation_timeout_seconds == 15
+
+
+def test_request_extra_fields_forbidden() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationRequest
+
+    with pytest.raises(ValidationError):
+        ModelNodeGenerationRequest(
+            task_description="test",
+            correlation_id=str(uuid4()),
+            unknown_field="oops",
+        )
+
+
+def test_result_extra_fields_forbidden() -> None:
+    from omnibase_core.models.generation import ModelNodeGenerationResult
+
+    with pytest.raises(ValidationError):
+        ModelNodeGenerationResult(
+            node_name="test",
+            contract_yaml="",
+            handler_source="",
+            artifact_paths=[],
+            generated_contract_hash="sha256:x",
+            generated_handler_hash="sha256:y",
+            stdout="",
+            stderr="",
+            returncode=0,
+            unknown_field="oops",
+        )


### PR DESCRIPTION
## Summary

- Adds `ModelNodeGenerationRequest` (frozen, `extra=forbid`) with compute-only validator enforcing hackathon MVP scope
- Adds `ModelNodeGenerationResult` (frozen, `extra=forbid`) capturing node name, YAML/source artifacts, sha256 hashes, and subprocess output
- Exports both from `omnibase_core.models.generation`

## Ticket

OMN-11086

## dod_evidence

- 8 unit tests added in `tests/unit/models/generation/test_model_node_generation.py`, all passing
- `uv run mypy src/omnibase_core/models/generation/ --strict` → clean
- `pre-commit run` on staged files → all hooks passed

Evidence-Source: OCC#1060
Evidence-Ticket: OMN-11086