### PR TITLE
feat(OMN-11087): add benchmark models with provider provenance

### DIFF
--- a/src/omnibase_core/models/benchmark/__init__.py
+++ b/src/omnibase_core/models/benchmark/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Benchmark models for tracking model generation attempts, results, and receipts."""
+
+from omnibase_core.models.benchmark.model_generation_attempt import (
+    ModelGenerationAttempt,
+)
+from omnibase_core.models.benchmark.model_generation_benchmark import (
+    ModelGenerationBenchmark,
+)
+from omnibase_core.models.benchmark.model_generation_receipt import (
+    ModelGenerationReceipt,
+)
+
+__all__ = [
+    "ModelGenerationAttempt",
+    "ModelGenerationBenchmark",
+    "ModelGenerationReceipt",
+]

--- a/src/omnibase_core/models/benchmark/model_generation_attempt.py
+++ b/src/omnibase_core/models/benchmark/model_generation_attempt.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelGenerationAttempt(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    attempt_number: int
+    provider: str
+    model_id: str  # string-id-ok: human-readable model label (e.g. "gemini-flash")
+    endpoint_class: str
+    token_usage_input: int
+    token_usage_output: int
+    latency_inference_ms: int
+    contract_passed: bool
+    validation_errors: list[str]

--- a/src/omnibase_core/models/benchmark/model_generation_benchmark.py
+++ b/src/omnibase_core/models/benchmark/model_generation_benchmark.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from omnibase_core.models.benchmark.model_generation_attempt import (
+    ModelGenerationAttempt,
+)
+
+
+class ModelGenerationBenchmark(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID
+    track_id: str  # string-id-ok: semantic label ("track_a"/"track_b"), not a UUID
+    provider: str
+    model_id: str  # string-id-ok: human-readable model label (e.g. "gemini-flash")
+    endpoint_class: str
+    usage_source: str
+    cost_basis: str
+    task_description: str
+    attempts: list[ModelGenerationAttempt]
+    total_latency_e2e_ms: int
+    contract_passed: bool
+    cost_inference_usd: float
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def attempt_count(self) -> int:
+        return len(self.attempts)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def cost_to_contract_pass_usd(self) -> float:
+        return self.cost_inference_usd if self.contract_passed else -1.0

--- a/src/omnibase_core/models/benchmark/model_generation_receipt.py
+++ b/src/omnibase_core/models/benchmark/model_generation_receipt.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+class ModelGenerationReceipt(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID
+    task_description: str
+    generated_contract_hash: str
+    generated_handler_hash: str
+    validation_result_id: UUID
+    model_used: str
+    provider: str
+    attempts: int
+    mcp_tool_name: str
+    contract_version: ModelSemVer
+    invocation_result_hash: str

--- a/tests/unit/models/benchmark/__init__.py
+++ b/tests/unit/models/benchmark/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/benchmark/test_model_generation_benchmark.py
+++ b/tests/unit/models/benchmark/test_model_generation_benchmark.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_attempt_records_metrics() -> None:
+    from omnibase_core.models.benchmark import ModelGenerationAttempt
+
+    attempt = ModelGenerationAttempt(
+        attempt_number=1,
+        provider="google-ai-studio",
+        model_id="gemini-flash",
+        endpoint_class="cloud_api",
+        token_usage_input=1200,
+        token_usage_output=800,
+        latency_inference_ms=3400,
+        contract_passed=True,
+        validation_errors=[],
+    )
+    assert attempt.contract_passed is True
+    assert attempt.provider == "google-ai-studio"
+
+
+def test_benchmark_computed_fields() -> None:
+    from omnibase_core.models.benchmark import (
+        ModelGenerationAttempt,
+        ModelGenerationBenchmark,
+    )
+
+    attempts = [
+        ModelGenerationAttempt(
+            attempt_number=1,
+            provider="google-ai-studio",
+            model_id="gemini-flash",
+            endpoint_class="cloud_api",
+            token_usage_input=1200,
+            token_usage_output=800,
+            latency_inference_ms=3400,
+            contract_passed=False,
+            validation_errors=["missing output_model"],
+        ),
+        ModelGenerationAttempt(
+            attempt_number=2,
+            provider="google-ai-studio",
+            model_id="gemini-flash",
+            endpoint_class="cloud_api",
+            token_usage_input=1500,
+            token_usage_output=900,
+            latency_inference_ms=4100,
+            contract_passed=True,
+            validation_errors=[],
+        ),
+    ]
+    benchmark = ModelGenerationBenchmark(
+        correlation_id=uuid4(),
+        track_id="track_a",
+        provider="google-ai-studio",
+        model_id="gemini-flash",
+        endpoint_class="cloud_api",
+        usage_source="ai-studio-metering",
+        cost_basis="METERED_API_COST",
+        task_description="classify sentiment",
+        attempts=attempts,
+        total_latency_e2e_ms=14200,
+        contract_passed=True,
+        cost_inference_usd=0.004,
+    )
+    assert benchmark.attempt_count == 2
+    assert benchmark.cost_to_contract_pass_usd == 0.004
+
+
+def test_benchmark_failed_cost() -> None:
+    from omnibase_core.models.benchmark import ModelGenerationBenchmark
+
+    benchmark = ModelGenerationBenchmark(
+        correlation_id=uuid4(),
+        track_id="track_b",
+        provider="local-vllm",
+        model_id="qwen3-coder-30b",
+        endpoint_class="local_gpu",
+        usage_source="local-token-counter",
+        cost_basis="ZERO_MARGINAL_API_COST",
+        task_description="classify",
+        attempts=[],
+        total_latency_e2e_ms=6100,
+        contract_passed=False,
+        cost_inference_usd=0.0,
+    )
+    assert benchmark.cost_to_contract_pass_usd == -1.0
+    assert benchmark.cost_basis == "ZERO_MARGINAL_API_COST"
+
+
+def test_receipt_artifact_binding() -> None:
+    from omnibase_core.models.benchmark import ModelGenerationReceipt
+    from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+    receipt = ModelGenerationReceipt(
+        correlation_id=uuid4(),
+        task_description="classify sentiment",
+        generated_contract_hash="sha256:abc123",
+        generated_handler_hash="sha256:def456",
+        validation_result_id=uuid4(),
+        model_used="gemini-flash",
+        provider="google-ai-studio",
+        attempts=2,
+        mcp_tool_name="classify_sentiment",
+        contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        invocation_result_hash="sha256:ghi789",
+    )
+    assert receipt.generated_contract_hash.startswith("sha256:")
+    assert receipt.validation_result_id is not None
+    assert receipt.contract_version.major == 1
+
+
+def test_models_frozen() -> None:
+    from omnibase_core.models.benchmark import ModelGenerationAttempt
+
+    attempt = ModelGenerationAttempt(
+        attempt_number=1,
+        provider="test",
+        model_id="test",
+        endpoint_class="test",
+        token_usage_input=0,
+        token_usage_output=0,
+        latency_inference_ms=0,
+        contract_passed=True,
+        validation_errors=[],
+    )
+    with pytest.raises(ValidationError):
+        attempt.provider = "changed"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `ModelGenerationAttempt`, `ModelGenerationBenchmark`, and `ModelGenerationReceipt` to `omnibase_core.models.benchmark`
- `ModelGenerationBenchmark` includes computed fields `attempt_count` and `cost_to_contract_pass_usd`
- All models are frozen Pydantic BaseModels with `extra="forbid"` and `from_attributes=True`
- UUID types used for `correlation_id` and `validation_result_id`; `ModelSemVer` for `contract_version`

Closes OMN-11087

Evidence-Source: OCC#1061
Evidence-Ticket: OMN-11087

## Test plan

- [x] `uv run pytest tests/unit/models/benchmark/ -v` — 5 tests pass
- [x] `uv run mypy src/omnibase_core/models/benchmark/ --strict` — clean
- [x] `pre-commit run --all-files` — all hooks pass on staged files
- [x] Push hooks (mypy strict, pyright, naming conventions) — all passed