### PR TITLE
feat(OMN-11138): add OmniGate receipt model

### DIFF
--- a/src/omnibase_core/gate/__init__.py
+++ b/src/omnibase_core/gate/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OmniGate core helpers."""
+
+from omnibase_core.gate.receipt_canonical import (
+    canonical_receipt_payload,
+    compute_receipt_schema_fingerprint,
+)
+
+__all__ = [
+    "canonical_receipt_payload",
+    "compute_receipt_schema_fingerprint",
+]

--- a/src/omnibase_core/gate/receipt_canonical.py
+++ b/src/omnibase_core/gate/receipt_canonical.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical OmniGate receipt serialization helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import cast
+
+from omnibase_core.models.gate.model_omnigate_receipt import ModelOmniGateReceipt
+from omnibase_core.types.type_json import JsonType
+
+
+def _normalize_json(value: JsonType) -> JsonType:
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, list):
+        return [_normalize_json(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _normalize_json(value[key]) for key in sorted(value)}
+    return value
+
+
+def canonical_receipt_payload(
+    receipt: ModelOmniGateReceipt,
+    *,
+    exclude_signature: bool = True,
+) -> bytes:
+    """Return deterministic JSON bytes for OmniGate receipt signing/verification."""
+    exclude = {"sigstore_bundle_json"} if exclude_signature else set()
+    data = cast(
+        JsonType,
+        receipt.model_dump(mode="json", exclude=exclude, by_alias=True),
+    )
+    normalized = _normalize_json(data)
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_receipt_schema_fingerprint() -> str:
+    """Return a deterministic SHA-256 fingerprint for the receipt JSON schema."""
+    schema = cast(JsonType, ModelOmniGateReceipt.model_json_schema())
+    payload = json.dumps(
+        _normalize_json(schema),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+__all__ = [
+    "canonical_receipt_payload",
+    "compute_receipt_schema_fingerprint",
+]

--- a/src/omnibase_core/models/gate/__init__.py
+++ b/src/omnibase_core/models/gate/__init__.py
@@ -9,6 +9,9 @@ from omnibase_core.enums.enum_omnigate import (
     EnumOmniGateCheckType,
 )
 from omnibase_core.models.gate.model_omnigate_check import ModelOmniGateCheck
+from omnibase_core.models.gate.model_omnigate_check_result import (
+    ModelOmniGateCheckResult,
+)
 from omnibase_core.models.gate.model_omnigate_config import ModelOmniGateConfig
 from omnibase_core.models.gate.model_omnigate_gate_decision import (
     ModelOmniGateGateDecision,
@@ -19,6 +22,7 @@ from omnibase_core.models.gate.model_omnigate_gate_policy import (
 from omnibase_core.models.gate.model_omnigate_identity_policy import (
     ModelOmniGateIdentityPolicy,
 )
+from omnibase_core.models.gate.model_omnigate_receipt import ModelOmniGateReceipt
 from omnibase_core.models.gate.model_omnigate_receipt_policy import (
     ModelOmniGateReceiptPolicy,
 )
@@ -31,10 +35,12 @@ __all__ = [
     "EnumGateResponse",
     "EnumOmniGateCheckType",
     "ModelOmniGateCheck",
+    "ModelOmniGateCheckResult",
     "ModelOmniGateConfig",
     "ModelOmniGateGateDecision",
     "ModelOmniGateGatePolicy",
     "ModelOmniGateIdentityPolicy",
+    "ModelOmniGateReceipt",
     "ModelOmniGateReceiptPolicy",
     "ModelOmniGateValidatorRef",
 ]

--- a/src/omnibase_core/models/gate/model_omnigate_check_result.py
+++ b/src/omnibase_core/models/gate/model_omnigate_check_result.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OmniGate check result model."""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ModelOmniGateCheckResult(BaseModel):
+    """Result of one OmniGate check captured in a receipt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    command: str
+    status: EnumReceiptStatus
+    duration_ms: int = Field(ge=0)
+    stdout_preview: str | None = Field(default=None, max_length=4096)
+    stdout_hash: str | None = None
+
+    @field_validator("stdout_hash")
+    @classmethod
+    def _validate_stdout_hash(cls, value: str | None) -> str | None:
+        if value is not None and not _SHA256_RE.match(value):
+            msg = f"stdout_hash must match sha256:<64 hex chars>, got: {value}"
+            raise ValueError(msg)
+        return value
+
+
+__all__ = ["ModelOmniGateCheckResult"]

--- a/src/omnibase_core/models/gate/model_omnigate_receipt.py
+++ b/src/omnibase_core/models/gate/model_omnigate_receipt.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OmniGate receipt model."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.gate.model_omnigate_check_result import (
+    ModelOmniGateCheckResult,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_BLOCKING_STATUSES = frozenset(
+    {
+        EnumReceiptStatus.FAIL,
+        EnumReceiptStatus.PENDING,
+    }
+)
+
+
+class ModelOmniGateReceipt(BaseModel):
+    """Signed OmniGate proof bound to repository authority fields and diff state."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    schema_version: ModelSemVer
+    project_name: str
+    project_url: HttpUrl
+    repository_identifier: str = Field(
+        min_length=1,
+        alias="repository_id",
+    )
+    base_sha: str
+    head_sha: str
+    commit_sha: str
+    diff_hash: str
+    config_hash: str
+    receipt_schema_fingerprint: str
+    branch: str
+    timestamp: datetime
+    checks: tuple[ModelOmniGateCheckResult, ...] = Field(default=())
+    signer_identity: str | None = None
+    signer_issuer: str | None = None
+    sigstore_bundle_json: str | None = None
+
+    @property
+    def repository_id(self) -> str:
+        """Return the serialized repository authority identifier."""
+        return self.repository_identifier
+
+    @field_validator("diff_hash", "config_hash", "receipt_schema_fingerprint")
+    @classmethod
+    def _validate_sha256_prefixed(cls, value: str) -> str:
+        if not _SHA256_RE.match(value):
+            msg = f"hash fields must match sha256:<64 hex chars>, got: {value}"
+            raise ValueError(msg)
+        return value
+
+    @field_validator("base_sha", "head_sha", "commit_sha")
+    @classmethod
+    def _validate_git_sha(cls, value: str) -> str:
+        if not _GIT_SHA_RE.match(value):
+            msg = f"git SHA fields must be exactly 40 hex chars, got: {value}"
+            raise ValueError(msg)
+        return value
+
+    def no_blocking_checks_failed(self, *, advisory_blocks: bool) -> bool:
+        """Return whether trusted policy allows this receipt's check outcomes."""
+        blocking_statuses = set(_BLOCKING_STATUSES)
+        if advisory_blocks:
+            blocking_statuses.add(EnumReceiptStatus.ADVISORY)
+        return all(check.status not in blocking_statuses for check in self.checks)
+
+
+__all__ = ["ModelOmniGateReceipt"]

--- a/tests/unit/models/gate/test_model_omnigate_receipt.py
+++ b/tests/unit/models/gate/test_model_omnigate_receipt.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for OmniGate receipt models."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.gate.receipt_canonical import (
+    canonical_receipt_payload,
+    compute_receipt_schema_fingerprint,
+)
+from omnibase_core.models.gate import (
+    ModelOmniGateCheckResult,
+    ModelOmniGateReceipt,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+def _receipt(
+    *,
+    checks: tuple[ModelOmniGateCheckResult, ...] = (),
+    sigstore_bundle_json: str | None = None,
+) -> ModelOmniGateReceipt:
+    return ModelOmniGateReceipt(
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
+        project_name="my-project",
+        project_url="https://github.com/org/repo",
+        repository_id="123456789",
+        base_sha="a" * 40,
+        head_sha="b" * 40,
+        commit_sha="b" * 40,
+        diff_hash="sha256:" + "c" * 64,
+        config_hash="sha256:" + "d" * 64,
+        receipt_schema_fingerprint="sha256:" + "e" * 64,
+        branch="fix/something",
+        timestamp=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        checks=checks,
+        signer_identity="https://github.com/org/repo/.github/workflows/omnigate.yml@refs/heads/main",
+        signer_issuer="https://token.actions.githubusercontent.com",
+        sigstore_bundle_json=sigstore_bundle_json,
+    )
+
+
+@pytest.mark.unit
+class TestModelOmniGateReceipt:
+    def test_valid_receipt_with_authority_fields(self) -> None:
+        receipt = _receipt(
+            checks=(
+                ModelOmniGateCheckResult(
+                    name="lint",
+                    command="npm run lint",
+                    status=EnumReceiptStatus.PASS,
+                    duration_ms=1200,
+                    stdout_preview="All files pass linting",
+                    stdout_hash="sha256:" + "f" * 64,
+                ),
+            ),
+        )
+
+        assert receipt.repository_identifier == "123456789"
+        assert receipt.repository_id == "123456789"
+        assert receipt.base_sha == "a" * 40
+        assert receipt.head_sha == receipt.commit_sha
+        assert receipt.diff_hash.startswith("sha256:")
+        assert receipt.config_hash.startswith("sha256:")
+        assert receipt.receipt_schema_fingerprint.startswith("sha256:")
+        assert receipt.no_blocking_checks_failed(advisory_blocks=False) is True
+
+    def test_failed_check_is_valid_model_but_blocks(self) -> None:
+        receipt = _receipt(
+            checks=(
+                ModelOmniGateCheckResult(
+                    name="test",
+                    command="npm test",
+                    status=EnumReceiptStatus.FAIL,
+                    duration_ms=5000,
+                ),
+            ),
+        )
+
+        assert receipt.checks[0].status == EnumReceiptStatus.FAIL
+        assert receipt.no_blocking_checks_failed(advisory_blocks=False) is False
+
+    def test_advisory_check_respects_trusted_policy(self) -> None:
+        receipt = _receipt(
+            checks=(
+                ModelOmniGateCheckResult(
+                    name="license",
+                    command="npm run license",
+                    status=EnumReceiptStatus.ADVISORY,
+                    duration_ms=100,
+                ),
+            ),
+        )
+
+        assert receipt.no_blocking_checks_failed(advisory_blocks=False) is True
+        assert receipt.no_blocking_checks_failed(advisory_blocks=True) is False
+
+    def test_pending_check_blocks(self) -> None:
+        receipt = _receipt(
+            checks=(
+                ModelOmniGateCheckResult(
+                    name="integration",
+                    command="npm run integration",
+                    status=EnumReceiptStatus.PENDING,
+                    duration_ms=0,
+                ),
+            ),
+        )
+
+        assert receipt.no_blocking_checks_failed(advisory_blocks=False) is False
+
+    def test_hash_fields_must_be_sha256_prefixed(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelOmniGateReceipt(
+                schema_version=ModelSemVer(major=1, minor=0, patch=0),
+                project_name="test",
+                project_url="https://github.com/org/repo",
+                repository_id="123456789",
+                base_sha="a" * 40,
+                head_sha="b" * 40,
+                commit_sha="b" * 40,
+                diff_hash="not-a-hash",
+                config_hash="sha256:" + "d" * 64,
+                receipt_schema_fingerprint="sha256:" + "e" * 64,
+                branch="main",
+                timestamp=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+            )
+
+    def test_git_sha_fields_must_be_full_hex_sha(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelOmniGateReceipt(
+                schema_version=ModelSemVer(major=1, minor=0, patch=0),
+                project_name="test",
+                project_url="https://github.com/org/repo",
+                repository_id="123456789",
+                base_sha="a" * 39,
+                head_sha="b" * 40,
+                commit_sha="b" * 40,
+                diff_hash="sha256:" + "c" * 64,
+                config_hash="sha256:" + "d" * 64,
+                receipt_schema_fingerprint="sha256:" + "e" * 64,
+                branch="main",
+                timestamp=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+            )
+
+    def test_stdout_hash_must_be_sha256_prefixed(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelOmniGateCheckResult(
+                name="lint",
+                command="npm run lint",
+                status=EnumReceiptStatus.PASS,
+                duration_ms=100,
+                stdout_hash="bad",
+            )
+
+    def test_sigstore_bundle_json_is_string(self) -> None:
+        receipt = _receipt(sigstore_bundle_json='{"mediaType":"application/json"}')
+
+        assert isinstance(receipt.sigstore_bundle_json, str)
+
+    def test_frozen(self) -> None:
+        receipt = _receipt()
+
+        with pytest.raises(ValidationError):
+            receipt.project_name = "changed"  # type: ignore[misc]
+
+    def test_canonical_payload_excludes_signature_by_default(self) -> None:
+        receipt = _receipt(sigstore_bundle_json='{"bundle":"signed"}')
+
+        payload = canonical_receipt_payload(receipt)
+        decoded = json.loads(payload.decode("utf-8"))
+
+        assert "sigstore_bundle_json" not in decoded
+        assert decoded["repository_id"] == "123456789"
+
+    def test_canonical_payload_can_include_signature(self) -> None:
+        receipt = _receipt(sigstore_bundle_json='{"bundle":"signed"}')
+
+        payload = canonical_receipt_payload(receipt, exclude_signature=False)
+        decoded = json.loads(payload.decode("utf-8"))
+
+        assert decoded["sigstore_bundle_json"] == '{"bundle":"signed"}'
+
+    def test_canonical_payload_is_deterministic(self) -> None:
+        receipt = _receipt()
+
+        assert canonical_receipt_payload(receipt) == canonical_receipt_payload(receipt)
+
+    def test_schema_fingerprint_is_deterministic_sha256(self) -> None:
+        fingerprint = compute_receipt_schema_fingerprint()
+
+        assert fingerprint == compute_receipt_schema_fingerprint()
+        assert fingerprint.startswith("sha256:")
+        assert len(fingerprint) == len("sha256:") + 64


### PR DESCRIPTION
## Summary
- add typed OmniGate receipt and check-result models
- add canonical receipt serialization and deterministic schema fingerprint helper
- keep Sigstore bundle as inspectable JSON text and make advisory blocking policy explicit

## Verification
- PYTHONPATH=src uv run pytest tests/unit/models/gate/ -q
- PYTHONPATH=src uv run ruff check src/omnibase_core/gate src/omnibase_core/models/gate tests/unit/models/gate
- PYTHONPATH=src uv run mypy src/omnibase_core/gate/receipt_canonical.py

Stacked on OMN-11137 / PR #1088.