### PR TITLE
feat(OMN-11141): add OmniGate CLI surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ state_disk = "omnibase_core.services.state.service_state_disk:ServiceStateDisk"
 [project.entry-points."onex.cli"]
 # Core CLI commands are registered directly via [project.scripts]
 # This group is for extensions from other packages
+gate = "omnibase_core.cli.cli_gate:gate"
 
 [project.entry-points."onex.doctor"]
 docker = "omnibase_core.doctor.checks.check_docker:CheckDocker"

--- a/src/omnibase_core/cli/cli_gate.py
+++ b/src/omnibase_core/cli/cli_gate.py
@@ -1,0 +1,396 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Thin OmniGate CLI surface owned by omnibase_core."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import subprocess
+from pathlib import Path
+
+import click
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.gate import (
+    compute_config_hash,
+    compute_pr_diff_hash,
+    compute_staged_diff_hash,
+    discover_omnigate_config,
+    load_omnigate_config,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+_CONFIG_NAME = ".omnigate.yaml"
+_HOOK_NAME = "pre-push"
+_INFRA_SERVICES_MODULE = "omnibase_infra.gate.cli_services"
+
+
+def _json_echo(payload: dict[str, object]) -> None:
+    click.echo(json.dumps(payload, sort_keys=True))
+
+
+def _click_error_from_exception(exc: Exception) -> click.ClickException:
+    if isinstance(exc, ModelOnexError):
+        return click.ClickException(str(exc))
+    if isinstance(exc, ValidationError):
+        return click.ClickException(str(exc))
+    return click.ClickException(f"{type(exc).__name__}: {exc}")
+
+
+def _resolve_config_path(repo: Path, config: Path | None) -> Path:
+    if config is not None:
+        return config
+
+    discovered = discover_omnigate_config(repo)
+    if discovered is None:
+        raise click.ClickException(
+            f"OmniGate config not found under {repo}. Run `onex gate install` first."
+        )
+    return discovered
+
+
+_CLI_ERROR_TYPES = (
+    ModelOnexError,
+    ValidationError,
+    OSError,
+    ValueError,
+    yaml.YAMLError,
+    subprocess.CalledProcessError,
+)
+
+
+def _default_config(
+    repo: Path,
+    project_name: str | None,
+    project_url: str | None,
+) -> dict[str, object]:
+    resolved_project_name = project_name or repo.resolve().name
+    resolved_project_url = (
+        project_url or f"https://github.com/example/{resolved_project_name}"
+    )
+    return {
+        "version": {"major": 1, "minor": 0, "patch": 0},
+        "project_name": resolved_project_name,
+        "project_url": resolved_project_url,
+        "checks": [
+            {
+                "name": "unit",
+                "run": "pytest -q",
+            }
+        ],
+        "gate": {
+            "scope": "forks-only",
+            "on_missing_receipt": "auto-close",
+            "grace_period_minutes": 10,
+        },
+        "receipt": {
+            "max_age_minutes": 120,
+            "require_diff_binding": True,
+            "signing": "sigstore",
+            "allow_unsigned": False,
+            "advisory_blocks": False,
+        },
+    }
+
+
+def _hook_content() -> str:
+    return """#!/bin/sh
+# OmniGate pre-push hook. Installed by `onex gate install`.
+exec onex gate run "$@"
+"""
+
+
+def _resolve_hooks_dir(repo: Path) -> Path:
+    git_path = repo / ".git"
+    if git_path.is_dir():
+        return git_path / "hooks"
+
+    if git_path.is_file():
+        first_line = git_path.read_text(encoding="utf-8").splitlines()[0]
+        prefix = "gitdir: "
+        if first_line.startswith(prefix):
+            git_dir = Path(first_line.removeprefix(prefix))
+            if not git_dir.is_absolute():
+                git_dir = (repo / git_dir).resolve()
+            return git_dir / "hooks"
+
+    raise click.ClickException(
+        f"Git metadata not found under {repo}. Run this inside a Git repository."
+    )
+
+
+def _load_infra_services() -> object:
+    try:
+        return importlib.import_module(_INFRA_SERVICES_MODULE)
+    except ModuleNotFoundError as exc:
+        if exc.name is not None and exc.name.startswith("omnibase_infra"):
+            raise click.ClickException(
+                "OmniGate command requires omnibase_infra. "
+                "Install omnibase_infra or the omnigate distribution package."
+            ) from exc
+        raise
+    except ImportError as exc:
+        raise click.ClickException(
+            f"Failed to import {_INFRA_SERVICES_MODULE}: {exc}"
+        ) from exc
+
+
+def _delegate_to_infra(command_name: str, args: tuple[str, ...]) -> None:
+    services = _load_infra_services()
+    try:
+        handler = getattr(services, command_name)
+    except AttributeError as exc:
+        raise click.ClickException(
+            f"{_INFRA_SERVICES_MODULE} does not expose `{command_name}`."
+        ) from exc
+
+    signature = inspect.signature(handler)
+    if "args" in signature.parameters:
+        result = handler(args=list(args))
+    else:
+        result = handler(*args)
+
+    if result is not None:
+        click.echo(result)
+
+
+@click.group()
+def gate() -> None:
+    """OmniGate PR quality gate commands."""
+    click.get_current_context().ensure_object(dict)
+
+
+@gate.command()
+@click.option(
+    "--repo",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Repository root to scaffold.",
+)
+@click.option("--project-name", help="Project name for generated config.")
+@click.option("--project-url", help="Project URL for generated config.")
+@click.option("--force", is_flag=True, help="Overwrite existing OmniGate files.")
+def install(
+    repo: Path,
+    project_name: str | None,
+    project_url: str | None,
+    *,
+    force: bool,
+) -> None:
+    """Scaffold `.omnigate.yaml` and a pre-push hook without running checks."""
+    repo = repo.resolve()
+    config_path = repo / _CONFIG_NAME
+    hook_path = _resolve_hooks_dir(repo) / _HOOK_NAME
+
+    if config_path.exists() and not force:
+        raise click.ClickException(f"Config already exists: {config_path}")
+    if hook_path.exists() and not force:
+        raise click.ClickException(f"Pre-push hook already exists: {hook_path}")
+
+    config_data = _default_config(repo, project_name, project_url)
+    config_text = yaml.safe_dump(config_data, sort_keys=False)
+    from omnibase_core.gate.config_loader import from_yaml_omnigate_config
+
+    from_yaml_omnigate_config(config_text, config_path=config_path)
+
+    config_path.write_text(config_text, encoding="utf-8")
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_path.write_text(_hook_content(), encoding="utf-8")
+    hook_path.chmod(0o755)
+
+    click.echo(f"Wrote {config_path}")
+    click.echo(f"Wrote {hook_path}")
+
+
+@gate.command("validate-config")
+@click.option(
+    "--repo",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Repository root used for config discovery.",
+)
+@click.option(
+    "--config",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Explicit OmniGate config path.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+def validate_config(repo: Path, config: Path | None, *, json_output: bool) -> None:
+    """Validate an OmniGate config file against ModelOmniGateConfig."""
+    try:
+        config_path = _resolve_config_path(repo.resolve(), config)
+        loaded = load_omnigate_config(config_path)
+    except click.ClickException as exc:
+        if json_output:
+            _json_echo({"valid": False, "error": exc.message})
+            raise click.exceptions.Exit(1)
+        raise
+    except _CLI_ERROR_TYPES as exc:
+        if json_output:
+            _json_echo({"valid": False, "error": str(exc)})
+            raise click.exceptions.Exit(1)
+        raise _click_error_from_exception(exc)
+
+    payload = {
+        "valid": True,
+        "config_path": str(config_path),
+        "project_name": loaded.project_name,
+        "checks": len(loaded.checks),
+        "validators": len(loaded.validators),
+        "config_hash": compute_config_hash(config_path),
+    }
+    if json_output:
+        _json_echo(payload)
+        return
+
+    click.echo(f"valid: {payload['valid']}")
+    click.echo(f"config_path: {payload['config_path']}")
+    click.echo(f"project_name: {payload['project_name']}")
+    click.echo(f"checks: {payload['checks']}")
+    click.echo(f"validators: {payload['validators']}")
+    click.echo(f"config_hash: {payload['config_hash']}")
+
+
+@gate.command("diff-hash")
+@click.option(
+    "--repo",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Repository root.",
+)
+@click.option("--base-ref", help="Base ref/SHA for PR diff hashing.")
+@click.option("--head-ref", help="Head ref/SHA for PR diff hashing.")
+@click.option("--allow-empty", is_flag=True, help="Allow empty diffs.")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+def diff_hash(
+    repo: Path,
+    base_ref: str | None,
+    head_ref: str | None,
+    *,
+    allow_empty: bool,
+    json_output: bool,
+) -> None:
+    """Compute the deterministic OmniGate diff hash."""
+    try:
+        if base_ref is not None or head_ref is not None:
+            if base_ref is None or head_ref is None:
+                raise click.ClickException(
+                    "--base-ref and --head-ref must be provided together."
+                )
+            diff_hash_value = compute_pr_diff_hash(
+                repo.resolve(),
+                base_sha=base_ref,
+                head_sha=head_ref,
+                allow_empty=allow_empty,
+            )
+            mode = "pr"
+        else:
+            diff_hash_value = compute_staged_diff_hash(
+                repo.resolve(),
+                allow_empty=allow_empty,
+            )
+            mode = "staged"
+    except click.ClickException:
+        raise
+    except _CLI_ERROR_TYPES as exc:
+        raise _click_error_from_exception(exc)
+
+    if json_output:
+        _json_echo({"diff_hash": diff_hash_value, "mode": mode})
+        return
+    click.echo(diff_hash_value)
+
+
+@gate.command()
+@click.option(
+    "--repo",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Repository root used for config discovery.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+def status(repo: Path, *, json_output: bool) -> None:
+    """Report local OmniGate config and hook status."""
+    repo = repo.resolve()
+    config_path = discover_omnigate_config(repo)
+    hooks_dir = _resolve_hooks_dir(repo)
+    hook_path = hooks_dir / _HOOK_NAME
+    payload: dict[str, object] = {
+        "repo": str(repo),
+        "config_found": config_path is not None,
+        "config_path": str(config_path) if config_path else None,
+        "pre_push_hook_installed": hook_path.is_file(),
+        "pre_push_hook_path": str(hook_path),
+    }
+
+    if config_path is not None:
+        try:
+            loaded = load_omnigate_config(config_path)
+            payload.update(
+                {
+                    "config_valid": True,
+                    "project_name": loaded.project_name,
+                    "checks": len(loaded.checks),
+                    "validators": len(loaded.validators),
+                    "config_hash": compute_config_hash(config_path),
+                }
+            )
+        except _CLI_ERROR_TYPES as exc:
+            payload.update({"config_valid": False, "error": str(exc)})
+    else:
+        payload["config_valid"] = False
+
+    if json_output:
+        _json_echo(payload)
+        return
+
+    click.echo(f"repo: {payload['repo']}")
+    click.echo(f"config_found: {payload['config_found']}")
+    click.echo(f"config_valid: {payload['config_valid']}")
+    if payload["config_path"]:
+        click.echo(f"config_path: {payload['config_path']}")
+    if "project_name" in payload:
+        click.echo(f"project_name: {payload['project_name']}")
+        click.echo(f"checks: {payload['checks']}")
+        click.echo(f"validators: {payload['validators']}")
+        click.echo(f"config_hash: {payload['config_hash']}")
+    click.echo(f"pre_push_hook_installed: {payload['pre_push_hook_installed']}")
+    click.echo(f"pre_push_hook_path: {payload['pre_push_hook_path']}")
+
+
+@gate.command(
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True}
+)
+@click.pass_context
+def run(ctx: click.Context) -> None:
+    """Run OmniGate checks via omnibase_infra."""
+    _delegate_to_infra("run", tuple(ctx.args))
+
+
+@gate.command(
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True}
+)
+@click.pass_context
+def sign(ctx: click.Context) -> None:
+    """Sign an OmniGate receipt via omnibase_infra."""
+    _delegate_to_infra("sign", tuple(ctx.args))
+
+
+@gate.command(
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True}
+)
+@click.pass_context
+def verify(ctx: click.Context) -> None:
+    """Verify an OmniGate receipt via omnibase_infra."""
+    _delegate_to_infra("verify", tuple(ctx.args))
+
+
+__all__ = ["gate"]

--- a/src/omnibase_core/gate/__init__.py
+++ b/src/omnibase_core/gate/__init__.py
@@ -8,9 +8,21 @@ from omnibase_core.gate.config_loader import (
     discover_omnigate_config,
     load_omnigate_config,
 )
+from omnibase_core.gate.diff_hash import (
+    DETERMINISTIC_DIFF_FLAGS,
+    compute_config_hash,
+    compute_diff_hash,
+    compute_pr_diff_hash,
+    compute_staged_diff_hash,
+)
 
 __all__ = [
     "DEFAULT_OMNIGATE_CONFIG_NAMES",
+    "DETERMINISTIC_DIFF_FLAGS",
+    "compute_config_hash",
+    "compute_diff_hash",
+    "compute_pr_diff_hash",
+    "compute_staged_diff_hash",
     "discover_omnigate_config",
     "load_omnigate_config",
 ]

--- a/src/omnibase_core/gate/diff_hash.py
+++ b/src/omnibase_core/gate/diff_hash.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deterministic OmniGate diff and config hashing helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+DETERMINISTIC_DIFF_FLAGS: tuple[str, ...] = (
+    "--binary",
+    "--full-index",
+    "--no-renames",
+)
+
+
+def _sha256_prefixed(content: bytes) -> str:
+    digest = hashlib.sha256(content).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _build_diff_args(base_ref: str | None, head_ref: str | None) -> list[str]:
+    if (base_ref is None) != (head_ref is None):
+        raise ModelOnexError(
+            "base_ref and head_ref must be provided together",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    if base_ref is not None and head_ref is not None:
+        return [
+            "git",
+            "diff",
+            *DETERMINISTIC_DIFF_FLAGS,
+            f"{base_ref}...{head_ref}",
+        ]
+
+    return ["git", "diff", "--staged", *DETERMINISTIC_DIFF_FLAGS]
+
+
+def compute_diff_hash(
+    repo_path: Path,
+    *,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+    allow_empty: bool = False,
+) -> str:
+    """Compute a SHA256 hash for a staged or explicit base/head git diff."""
+    args = _build_diff_args(base_ref, head_ref)
+    result = subprocess.run(
+        args,
+        cwd=repo_path,
+        capture_output=True,
+        check=True,
+    )
+    diff_content = result.stdout
+    if diff_content or allow_empty:
+        return _sha256_prefixed(diff_content)
+
+    if base_ref is not None and head_ref is not None:
+        raise ModelOnexError(
+            "No PR diff found for the provided base_ref and head_ref. "
+            "OmniGate receipts must bind to a non-empty PR diff unless "
+            "allow_empty is explicitly enabled for development or tests.",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    raise ModelOnexError(
+        "No staged diff found. Stage changes with `git add` before running "
+        "OmniGate, or pass allow_empty=True for empty-diff receipts.",
+        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+    )
+
+
+def compute_staged_diff_hash(repo_path: Path, *, allow_empty: bool = False) -> str:
+    """Compute the deterministic hash for the local staged diff."""
+    return compute_diff_hash(repo_path, allow_empty=allow_empty)
+
+
+def compute_pr_diff_hash(
+    repo_path: Path,
+    *,
+    base_sha: str,
+    head_sha: str,
+    allow_empty: bool = False,
+) -> str:
+    """Compute the deterministic hash for a trusted PR base/head diff."""
+    return compute_diff_hash(
+        repo_path,
+        base_ref=base_sha,
+        head_ref=head_sha,
+        allow_empty=allow_empty,
+    )
+
+
+def compute_config_hash(config_path: Path) -> str:
+    """Compute a SHA256 hash from raw config file bytes."""
+    return _sha256_prefixed(config_path.read_bytes())

--- a/tests/unit/cli/test_cli_gate.py
+++ b/tests/unit/cli/test_cli_gate.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the thin OmniGate CLI surface."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_core.cli.cli_gate import gate
+from omnibase_core.gate import load_omnigate_config
+
+pytestmark = pytest.mark.unit
+
+
+def _init_git_dir(repo: Path) -> None:
+    (repo / ".git" / "hooks").mkdir(parents=True)
+
+
+def test_install_scaffolds_valid_config_and_pre_push_hook(tmp_path: Path) -> None:
+    _init_git_dir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gate,
+        [
+            "install",
+            "--repo",
+            str(tmp_path),
+            "--project-name",
+            "demo",
+            "--project-url",
+            "https://github.com/org/demo",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config_path = tmp_path / ".omnigate.yaml"
+    hook_path = tmp_path / ".git" / "hooks" / "pre-push"
+    config = load_omnigate_config(config_path)
+    assert config.project_name == "demo"
+    assert config.project_url.unicode_string() == "https://github.com/org/demo"
+    assert config.checks[0].name == "unit"
+    assert hook_path.read_text(encoding="utf-8").startswith("#!/bin/sh")
+    assert "onex gate run" in hook_path.read_text(encoding="utf-8")
+
+
+def test_install_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    _init_git_dir(tmp_path)
+    config_path = tmp_path / ".omnigate.yaml"
+    config_path.write_text("already here\n", encoding="utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(gate, ["install", "--repo", str(tmp_path)])
+
+    assert result.exit_code != 0
+    assert "Config already exists" in result.output
+
+
+def test_validate_config_reports_hash_json(tmp_path: Path) -> None:
+    _init_git_dir(tmp_path)
+    runner = CliRunner()
+    install_result = runner.invoke(gate, ["install", "--repo", str(tmp_path)])
+    assert install_result.exit_code == 0, install_result.output
+
+    result = runner.invoke(
+        gate,
+        ["validate-config", "--repo", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["valid"] is True
+    assert payload["checks"] == 1
+    assert payload["config_hash"].startswith("sha256:")
+
+
+def test_validate_config_missing_file_fails_json(tmp_path: Path) -> None:
+    _init_git_dir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gate,
+        ["validate-config", "--repo", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["valid"] is False
+    assert "OmniGate config not found" in payload["error"]
+
+
+def test_diff_hash_delegates_to_staged_helper(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    with patch(
+        "omnibase_core.cli.cli_gate.compute_staged_diff_hash",
+        return_value="sha256:abc",
+    ) as compute:
+        result = runner.invoke(gate, ["diff-hash", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "sha256:abc"
+    compute.assert_called_once_with(tmp_path.resolve(), allow_empty=False)
+
+
+def test_diff_hash_delegates_to_pr_helper_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    with patch(
+        "omnibase_core.cli.cli_gate.compute_pr_diff_hash",
+        return_value="sha256:def",
+    ) as compute:
+        result = runner.invoke(
+            gate,
+            [
+                "diff-hash",
+                "--repo",
+                str(tmp_path),
+                "--base-ref",
+                "base",
+                "--head-ref",
+                "head",
+                "--allow-empty",
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"diff_hash": "sha256:def", "mode": "pr"}
+    compute.assert_called_once_with(
+        tmp_path.resolve(),
+        base_sha="base",
+        head_sha="head",
+        allow_empty=True,
+    )
+
+
+def test_status_reports_config_and_hook(tmp_path: Path) -> None:
+    _init_git_dir(tmp_path)
+    runner = CliRunner()
+    install_result = runner.invoke(gate, ["install", "--repo", str(tmp_path)])
+    assert install_result.exit_code == 0, install_result.output
+
+    result = runner.invoke(gate, ["status", "--repo", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["config_found"] is True
+    assert payload["config_valid"] is True
+    assert payload["pre_push_hook_installed"] is True
+    assert payload["checks"] == 1
+
+
+def test_effectful_command_fails_cleanly_without_infra() -> None:
+    runner = CliRunner()
+
+    with patch.dict(sys.modules, {"omnibase_infra": None}):
+        result = runner.invoke(gate, ["run"])
+
+    assert result.exit_code != 0
+    assert "requires omnibase_infra" in result.output
+
+
+def test_effectful_command_delegates_to_infra_service() -> None:
+    runner = CliRunner()
+    services = ModuleType("omnibase_infra.gate.cli_services")
+    captured: dict[str, list[str]] = {}
+
+    def verify(*, args: list[str]) -> str:
+        captured["args"] = args
+        return "verified"
+
+    services.verify = verify  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"omnibase_infra.gate.cli_services": services}):
+        result = runner.invoke(gate, ["verify", "--receipt", "receipt.json"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "verified"
+    assert captured["args"] == ["--receipt", "receipt.json"]

--- a/tests/unit/gate/test_diff_hash.py
+++ b/tests/unit/gate/test_diff_hash.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.gate.diff_hash import (
+    DETERMINISTIC_DIFF_FLAGS,
+    compute_config_hash,
+    compute_diff_hash,
+    compute_pr_diff_hash,
+    compute_staged_diff_hash,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+pytestmark = pytest.mark.unit
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test User")
+
+
+def _init_repo_with_staged_change(repo: Path) -> None:
+    _init_repo(repo)
+    (repo / "file.txt").write_text("hello\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _run_git(repo, "commit", "-m", message)
+    return _run_git(repo, "rev-parse", "HEAD").stdout.decode("utf-8").strip()
+
+
+def _sha256_prefixed(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+class TestComputeDiffHash:
+    def test_returns_sha256_prefixed(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_staged_change(repo)
+
+        result = compute_staged_diff_hash(repo)
+
+        assert result.startswith("sha256:")
+        assert len(result) == 7 + 64
+
+    def test_deterministic(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_staged_change(repo)
+
+        h1 = compute_staged_diff_hash(repo)
+        h2 = compute_staged_diff_hash(repo)
+
+        assert h1 == h2
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_staged_change(repo)
+        h1 = compute_staged_diff_hash(repo)
+
+        (repo / "file.txt").write_text("world\n", encoding="utf-8")
+        _run_git(repo, "add", "file.txt")
+        h2 = compute_staged_diff_hash(repo)
+
+        assert h1 != h2
+
+    def test_staged_diff_hashes_exact_diff_bytes(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_staged_change(repo)
+
+        expected_diff = _run_git(
+            repo,
+            "diff",
+            "--staged",
+            *DETERMINISTIC_DIFF_FLAGS,
+        ).stdout
+
+        assert compute_staged_diff_hash(repo) == _sha256_prefixed(expected_diff)
+
+    def test_pr_diff_hash_uses_explicit_base_and_head(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+        (repo / "file.txt").write_text("base\n", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        base_sha = _commit(repo, "base")
+        (repo / "file.txt").write_text("head\n", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        head_sha = _commit(repo, "head")
+
+        expected_diff = _run_git(
+            repo,
+            "diff",
+            *DETERMINISTIC_DIFF_FLAGS,
+            f"{base_sha}...{head_sha}",
+        ).stdout
+
+        assert compute_pr_diff_hash(
+            repo, base_sha=base_sha, head_sha=head_sha
+        ) == _sha256_prefixed(expected_diff)
+
+    def test_empty_staged_diff_fails_by_default(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        with pytest.raises(ModelOnexError, match="No staged diff found"):
+            compute_staged_diff_hash(repo)
+
+    def test_empty_pr_diff_fails_by_default(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+        (repo / "file.txt").write_text("base\n", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        head_sha = _commit(repo, "base")
+
+        with pytest.raises(ModelOnexError, match="No PR diff found"):
+            compute_pr_diff_hash(repo, base_sha=head_sha, head_sha=head_sha)
+
+    def test_pr_diff_hash_does_not_fallback_to_staged_diff(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+        (repo / "file.txt").write_text("base\n", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        head_sha = _commit(repo, "base")
+        (repo / "local-only.txt").write_text("staged\n", encoding="utf-8")
+        _run_git(repo, "add", "local-only.txt")
+
+        with pytest.raises(ModelOnexError, match="No PR diff found"):
+            compute_pr_diff_hash(repo, base_sha=head_sha, head_sha=head_sha)
+
+    def test_allow_empty_hashes_empty_diff_bytes(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        assert compute_staged_diff_hash(repo, allow_empty=True) == _sha256_prefixed(b"")
+
+    def test_base_and_head_refs_must_be_paired(self, tmp_path: Path) -> None:
+        with pytest.raises(ModelOnexError, match="provided together"):
+            compute_diff_hash(tmp_path, base_ref="abc123")
+
+
+class TestComputeConfigHash:
+    def test_hashes_config_file_bytes(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".omnigate.yaml"
+        content = b"version: 1.0.0\nproject_name: test\n"
+        config_path.write_bytes(content)
+
+        assert compute_config_hash(config_path) == _sha256_prefixed(content)
+
+    def test_byte_level_changes_affect_config_hash(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".omnigate.yaml"
+        config_path.write_bytes(b"version: 1.0.0\n")
+        h1 = compute_config_hash(config_path)
+
+        config_path.write_bytes(b"version: 1.0.0\r\n")
+        h2 = compute_config_hash(config_path)
+
+        assert h1 != h2


### PR DESCRIPTION
## Summary
- add core-only `onex gate` Click command group
- implement pure install, validate-config, diff-hash, and status commands
- keep run/sign/verify as dynamic infra delegations so core does not own effects

## Verification
- `PYTHONPATH=$PWD/src uv run pytest tests/unit/cli/test_cli_gate.py -q`
- `PYTHONPATH=$PWD/src uv run ruff check src/omnibase_core/cli/cli_gate.py tests/unit/cli/test_cli_gate.py`

Stacked on OMN-11137/11139 plus OMN-11140 diff-hash.
