### PR TITLE
feat(OMN-11132): configurable aislop validators with per-repo YAML overrides

### DIFF
--- a/.onex/aislop-rules.yaml
+++ b/.onex/aislop-rules.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Per-repo aislop rule overrides for omnibase_core (OMN-11132).
+# Schema: ModelAislopConfig (omnibase_core.models.validation.model_aislop_config)
+#
+# This file uses the default rules unchanged.
+#
+# To customise:
+#   overrides:
+#     - name: obvious_comment      # disable a noisy rule for this repo
+#       enabled: false
+#     - name: boilerplate_docstring
+#       severity: ERROR            # escalate from WARNING to ERROR
+#     - name: my_new_rule
+#       allow_new: true            # declare a new rule (add it in custom_rules too)
+#   custom_rules:
+#     - name: my_new_rule
+#       severity: WARNING
+#       pattern_type: grep_code
+#       pattern: "\\bDEPRECATED\\b"
+#       file_globs: ["*.py"]
+#       description: "Deprecated marker without replacement"
+
+overrides: []
+custom_rules: []

--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -345,6 +345,14 @@ allowed_files:
     added: "2026-05-12"
     review: "2026-06-13"
 
+  - file: "src/omnibase_core/validation/aislop_rule_loader.py"
+    reason: >-
+      Aislop rule loader — uses yaml.safe_load() as the first step in a two-step pipeline: yaml.safe_load()
+      → ModelAislopRuleSet.model_validate() and yaml.safe_load() → ModelAislopConfig.model_validate().
+      The raw dict is never used without Pydantic validation. Pattern matches util_safe_yaml_loader.py.
+    added: "2026-05-17"
+    review: "2026-12-13"
+
 # Specific filenames that are allowed (matched by basename)
 # Allows the same utility to be used across different module paths (e.g., copied utilities)
 allowed_filenames:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ ignore = [
 "scripts/validation/validate_no_except_swallow.py" = ["T201"]
 "scripts/validation/validate_no_none_guard_publish.py" = ["T201"]
 "scripts/validation/validate_no_import_none_fallback.py" = ["T201"]
+"scripts/validation/check_ai_slop.py" = ["T201", "BLE001"]
 "scripts/validation/validate-stubbed-functionality.py" = ["T201", "BLE001"]
 "scripts/validation/validate-exception-handling.py" = ["T201", "BLE001"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]

--- a/scripts/validation/check_ai_slop.py
+++ b/scripts/validation/check_ai_slop.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: MIT
 
 """
-ONEX AI-Slop Pattern Checker v1.0
+ONEX AI-Slop Pattern Checker v2.0
 
-This pre-commit hook and CI gate detects AI-generated boilerplate ("slop") patterns
-in Python and Markdown files. Uses AST analysis for docstring patterns and line-based
-regex for non-docstring patterns.
+Pre-commit hook and CI gate that detects AI-generated boilerplate ("slop") in
+Python and Markdown files.  Rule patterns are loaded from the bundled default
+YAML (omnibase_core/contracts/aislop_default_rules.yaml) and can be overridden
+per-repo via .onex/aislop-rules.yaml (OMN-11132).
 
-Rule set v1.0 (locked 2026-03-02, OMN-3191):
+Rule set v1.0 (locked 2026-03-02, OMN-3191) — unchanged defaults:
 - ERROR: sycophancy (sycophantic docstring openers: "Excellent", "Great", "Sure")
 - ERROR: rest_docstring (reST-style :param:, :type:, :returns:, :rtype:)
 - WARNING: boilerplate_docstring ("This module/class/function provides/implements/contains")
@@ -22,6 +23,8 @@ Rule set v1.0 (locked 2026-03-02, OMN-3191):
 - INFO: obvious_comment (self-evident inline comments, report mode only)
 
 Rule change log:
+  v2.0 (2026-05-17, OMN-11132): rules loaded from YAML; --config flag added.
+    Backwards-compatible: default behavior identical to v1.0.
   v1.0 (2026-03-02): step_narration scoped to Markdown files only; code fences skipped.
     Rationale: 48h post-rollout audit (OMN-3191) found "# Step N:" in Python code
     triggers 110+ false positives in omniintelligence and omniclaude alone.
@@ -46,8 +49,9 @@ Usage:
     python scripts/validation/check_ai_slop.py [files...]
     python scripts/validation/check_ai_slop.py --strict [files...]
     python scripts/validation/check_ai_slop.py --report src/
+    python scripts/validation/check_ai_slop.py --config /path/to/repo/root [files...]
 
-Linear tickets: OMN-2971 (original), OMN-3191 (v1.0 tuning)
+Linear tickets: OMN-2971 (original), OMN-3191 (v1.0 tuning), OMN-11132 (configurable)
 """
 
 from __future__ import annotations
@@ -73,29 +77,6 @@ CHECK_MD_SEPARATOR = "md_separator"
 CHECK_OBVIOUS_COMMENT = "obvious_comment"
 
 SUPPRESSION_MARKER = "ai-slop-ok"
-
-# Sycophantic openers (case-insensitive, must be at start of docstring content)
-_SYCOPHANCY_RE = re.compile(
-    r"^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to|"
-    r"I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,. ]",
-    re.IGNORECASE,
-)
-
-# reST docstring markers
-_REST_RE = re.compile(r"^\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\b")
-
-# Boilerplate "This <thing> provides/implements/contains/is responsible for"
-_BOILERPLATE_RE = re.compile(
-    r"^\s*This\s+(module|class|function|method|file|script|node|handler|service)"
-    r"\s+(provides?|implements?|contains?|is responsible for|handles?|manages?|offers?)",
-    re.IGNORECASE,
-)
-
-# Step narration: "# Step N:" or "# Step N -"
-_STEP_NARRATION_RE = re.compile(r"#\s*Step\s+\d+\s*[:\-]", re.IGNORECASE)
-
-# Markdown separator: 4+ = characters in a docstring line
-_MD_SEPARATOR_RE = re.compile(r"={4,}")
 
 
 class SlopViolation:
@@ -131,6 +112,88 @@ class SlopViolation:
 
 
 # ---------------------------------------------------------------------------
+# Rule loader — builds compiled regexes from the configured rule set
+# ---------------------------------------------------------------------------
+
+
+def _build_docstring_regexes(
+    repo_root: Path | None,
+) -> dict[str, tuple[re.Pattern[str], str]]:
+    """Return {rule_name: (compiled_pattern, severity)} for AST-docstring rules.
+
+    Falls back to hardcoded patterns if the rule loader is unavailable (e.g.
+    when running the script before omnibase_core is installed).
+    """
+    try:
+        from omnibase_core.validation.aislop_rule_loader import resolve_rules
+
+        ruleset = resolve_rules(repo_root or Path.cwd())
+        result: dict[str, tuple[re.Pattern[str], str]] = {}
+        for rule in ruleset.rules:
+            if rule.pattern_type == "regex_ast_docstring" and rule.enabled:
+                result[rule.name] = (
+                    re.compile(rule.pattern, re.IGNORECASE | re.VERBOSE),
+                    rule.severity,
+                )
+        return result
+    except Exception:
+        # Fallback: hardcoded v1.0 patterns (identical to original defaults)
+        return {
+            CHECK_SYCOPHANCY: (
+                re.compile(
+                    r"^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to|"
+                    r"I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,. ]",
+                    re.IGNORECASE,
+                ),
+                SEVERITY_ERROR,
+            ),
+            CHECK_REST_DOCSTRING: (
+                re.compile(r"^\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\b"),
+                SEVERITY_ERROR,
+            ),
+            CHECK_BOILERPLATE_DOCSTRING: (
+                re.compile(
+                    r"^\s*This\s+(module|class|function|method|file|script|node|handler|service)"
+                    r"\s+(provides?|implements?|contains?|is responsible for|handles?|manages?|offers?)",
+                    re.IGNORECASE,
+                ),
+                SEVERITY_WARNING,
+            ),
+            CHECK_MD_SEPARATOR: (
+                re.compile(r"={4,}"),
+                SEVERITY_WARNING,
+            ),
+        }
+
+
+def _build_line_regexes(
+    repo_root: Path | None,
+) -> dict[str, tuple[re.Pattern[str], str, list[str]]]:
+    """Return {rule_name: (compiled_pattern, severity, file_globs)} for line rules."""
+    try:
+        from omnibase_core.validation.aislop_rule_loader import resolve_rules
+
+        ruleset = resolve_rules(repo_root or Path.cwd())
+        result: dict[str, tuple[re.Pattern[str], str, list[str]]] = {}
+        for rule in ruleset.rules:
+            if rule.pattern_type == "regex_line" and rule.enabled:
+                result[rule.name] = (
+                    re.compile(rule.pattern, re.IGNORECASE),
+                    rule.severity,
+                    rule.file_globs,
+                )
+        return result
+    except Exception:
+        return {
+            CHECK_STEP_NARRATION: (
+                re.compile(r"#\s*Step\s+\d+\s*[:\-]", re.IGNORECASE),
+                SEVERITY_WARNING,
+                ["*.md"],
+            ),
+        }
+
+
+# ---------------------------------------------------------------------------
 # AST visitor — handles docstring patterns
 # ---------------------------------------------------------------------------
 
@@ -144,10 +207,17 @@ class _DocstringVisitor(ast.NodeVisitor):
     triple-quote and the first content line are on different lines.
     """
 
-    def __init__(self, filename: str, source_lines: list[str]) -> None:
+    def __init__(
+        self,
+        filename: str,
+        source_lines: list[str],
+        docstring_rules: dict[str, tuple[re.Pattern[str], str]] | None = None,
+    ) -> None:
         self.filename = filename
         self.source_lines = source_lines
         self.violations: list[SlopViolation] = []
+        # Accepts externally-resolved rules or falls back to defaults
+        self._rules = docstring_rules or _build_docstring_regexes(None)
 
     # ------------------------------------------------------------------
     # Suppression helpers
@@ -201,62 +271,24 @@ class _DocstringVisitor(ast.NodeVisitor):
         if self._has_suppression(def_lineno, docstring_lineno):
             return
 
-        # Check each line of the docstring for patterns
         doc_lines = docstring.splitlines()
         for offset, doc_line in enumerate(doc_lines):
             actual_lineno = docstring_lineno + offset
-
-            # Sycophancy (ERROR)
-            if _SYCOPHANCY_RE.match(doc_line):
-                self.violations.append(
-                    SlopViolation(
-                        filename=self.filename,
-                        line=actual_lineno,
-                        check=CHECK_SYCOPHANCY,
-                        severity=SEVERITY_ERROR,
-                        message=f"Sycophantic opener: {doc_line.strip()!r}",
-                        source_line=doc_line,
-                    )
+            for rule_name, (pattern, severity) in self._rules.items():
+                match_fn = (
+                    pattern.match if rule_name != CHECK_MD_SEPARATOR else pattern.search
                 )
-
-            # reST docstring (ERROR)
-            if _REST_RE.match(doc_line):
-                self.violations.append(
-                    SlopViolation(
-                        filename=self.filename,
-                        line=actual_lineno,
-                        check=CHECK_REST_DOCSTRING,
-                        severity=SEVERITY_ERROR,
-                        message=f"reST-style docstring marker: {doc_line.strip()!r}",
-                        source_line=doc_line,
+                if match_fn(doc_line):
+                    self.violations.append(
+                        SlopViolation(
+                            filename=self.filename,
+                            line=actual_lineno,
+                            check=rule_name,
+                            severity=severity,
+                            message=_format_docstring_message(rule_name, doc_line),
+                            source_line=doc_line,
+                        )
                     )
-                )
-
-            # Boilerplate opener (WARNING)
-            if _BOILERPLATE_RE.match(doc_line):
-                self.violations.append(
-                    SlopViolation(
-                        filename=self.filename,
-                        line=actual_lineno,
-                        check=CHECK_BOILERPLATE_DOCSTRING,
-                        severity=SEVERITY_WARNING,
-                        message=f"Boilerplate docstring opener: {doc_line.strip()!r}",
-                        source_line=doc_line,
-                    )
-                )
-
-            # Markdown separator (WARNING)
-            if _MD_SEPARATOR_RE.search(doc_line):
-                self.violations.append(
-                    SlopViolation(
-                        filename=self.filename,
-                        line=actual_lineno,
-                        check=CHECK_MD_SEPARATOR,
-                        severity=SEVERITY_WARNING,
-                        message=f"Markdown-style separator in docstring: {doc_line.strip()!r}",
-                        source_line=doc_line,
-                    )
-                )
 
     # ------------------------------------------------------------------
     # AST visit methods
@@ -279,12 +311,29 @@ class _DocstringVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+def _format_docstring_message(rule_name: str, doc_line: str) -> str:
+    stripped = doc_line.strip()
+    if rule_name == CHECK_SYCOPHANCY:
+        return f"Sycophantic opener: {stripped!r}"
+    if rule_name == CHECK_REST_DOCSTRING:
+        return f"reST-style docstring marker: {stripped!r}"
+    if rule_name == CHECK_BOILERPLATE_DOCSTRING:
+        return f"Boilerplate docstring opener: {stripped!r}"
+    if rule_name == CHECK_MD_SEPARATOR:
+        return f"Markdown-style separator in docstring: {stripped!r}"
+    return f"Violation in docstring: {stripped!r}"
+
+
 # ---------------------------------------------------------------------------
 # Line-based checks (non-docstring patterns)
 # ---------------------------------------------------------------------------
 
 
-def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
+def _check_lines(
+    filename: str,
+    source_lines: list[str],
+    line_rules: dict[str, tuple[re.Pattern[str], str, list[str]]] | None = None,
+) -> list[SlopViolation]:
     """
     Line-based regex checks for patterns that don't require AST analysis.
     Only applies outside of docstrings (we use a simple heuristic: skip
@@ -297,8 +346,24 @@ def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
     For Markdown files, lines inside fenced code blocks (``` ... ```) are skipped
     so that quoted Python examples with '# Step N:' comments are not flagged.
     """
+    if line_rules is None:
+        line_rules = _build_line_regexes(None)
+
     violations: list[SlopViolation] = []
     is_markdown = filename.endswith(".md")
+
+    # Filter rules to those that apply to this file type
+    applicable: list[tuple[str, re.Pattern[str], str]] = []
+    for rule_name, (pattern, severity, globs) in line_rules.items():
+        md_only = all(g == "*.md" for g in globs)
+        py_only = all(g == "*.py" for g in globs) and not any(
+            g == "*.md" for g in globs
+        )
+        if is_markdown and py_only:
+            continue
+        if not is_markdown and md_only:
+            continue
+        applicable.append((rule_name, pattern, severity))
 
     in_triple_quote = False
     triple_char = ""
@@ -308,7 +373,6 @@ def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
         stripped = line.rstrip()
 
         # Toggle triple-quote tracking for Python files (simple heuristic)
-        # Count occurrences of """ and '''
         if not is_markdown:
             for tq in ('"""', "'''"):
                 count = stripped.count(tq)
@@ -326,34 +390,42 @@ def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
                 continue
 
         # For Markdown: track fenced code blocks (``` or ~~~) to skip their content.
-        # Lines inside code fences are quoted code examples, not prose patterns.
         if is_markdown:
             if stripped.startswith(("```", "~~~")):
                 in_md_code_fence = not in_md_code_fence
             if in_md_code_fence or stripped.startswith(("```", "~~~")):
                 continue
 
-        # Step narration: "# Step N:" — Markdown files only, outside code fences.
-        # Python inline comments like "# Step 1: Clone repo" are legitimate code
-        # documentation for ordered multi-step functions; only flag in .md files
-        # where "## Step N:" / "### Step N:" is LLM-generated structural boilerplate.
-        if is_markdown:
-            comment_match = re.search(r"#(.+)", stripped)
-            if comment_match:
-                comment_text = comment_match.group(0)
-                if _STEP_NARRATION_RE.search(comment_text):
-                    # Check for suppression on this line
-                    if SUPPRESSION_MARKER not in stripped:
-                        violations.append(
-                            SlopViolation(
-                                filename=filename,
-                                line=lineno,
-                                check=CHECK_STEP_NARRATION,
-                                severity=SEVERITY_WARNING,
-                                message=f"Step narration comment: {comment_text.strip()!r}",
-                                source_line=stripped,
+        for rule_name, pattern, severity in applicable:
+            if rule_name == CHECK_STEP_NARRATION:
+                # step_narration: match only inside a heading/comment context in .md
+                comment_match = re.search(r"#(.+)", stripped)
+                if comment_match:
+                    comment_text = comment_match.group(0)
+                    if pattern.search(comment_text):
+                        if SUPPRESSION_MARKER not in stripped:
+                            violations.append(
+                                SlopViolation(
+                                    filename=filename,
+                                    line=lineno,
+                                    check=rule_name,
+                                    severity=severity,
+                                    message=f"Step narration comment: {comment_text.strip()!r}",
+                                    source_line=stripped,
+                                )
                             )
+            elif pattern.search(stripped):
+                if SUPPRESSION_MARKER not in stripped:
+                    violations.append(
+                        SlopViolation(
+                            filename=filename,
+                            line=lineno,
+                            check=rule_name,
+                            severity=severity,
+                            message=f"Pattern match ({rule_name}): {stripped!r}",
+                            source_line=stripped,
                         )
+                    )
 
     return violations
 
@@ -363,12 +435,11 @@ def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
 # ---------------------------------------------------------------------------
 
 
-def check_file(filepath: str | Path) -> list[SlopViolation]:
-    """
-    Check a single Python file for AI-slop patterns.
-
-    Returns a list of SlopViolation instances (may be empty).
-    """
+def check_file(
+    filepath: str | Path,
+    repo_root: Path | None = None,
+) -> list[SlopViolation]:
+    """Check a single Python or Markdown file for AI-slop patterns."""
     path = Path(filepath)
     violations: list[SlopViolation] = []
 
@@ -385,30 +456,33 @@ def check_file(filepath: str | Path) -> list[SlopViolation]:
             )
         ]
 
-    try:
-        tree = ast.parse(source, filename=str(filepath))
-    except SyntaxError as exc:
-        return [
-            SlopViolation(
-                filename=str(filepath),
-                line=exc.lineno or 0,
-                check="syntax_error",
-                severity=SEVERITY_ERROR,
-                message=f"Syntax error: {exc.msg}",
-            )
-        ]
-
     source_lines = source.splitlines()
+    line_rules = _build_line_regexes(repo_root)
 
-    # AST-based docstring checks
-    visitor = _DocstringVisitor(filename=str(filepath), source_lines=source_lines)
-    visitor.visit(tree)
-    violations.extend(visitor.violations)
+    if path.suffix == ".py":
+        try:
+            tree = ast.parse(source, filename=str(filepath))
+        except SyntaxError as exc:
+            return [
+                SlopViolation(
+                    filename=str(filepath),
+                    line=exc.lineno or 0,
+                    check="syntax_error",
+                    severity=SEVERITY_ERROR,
+                    message=f"Syntax error: {exc.msg}",
+                )
+            ]
 
-    # Line-based checks (step narration, etc.)
-    violations.extend(_check_lines(str(filepath), source_lines))
+        docstring_rules = _build_docstring_regexes(repo_root)
+        visitor = _DocstringVisitor(
+            filename=str(filepath),
+            source_lines=source_lines,
+            docstring_rules=docstring_rules,
+        )
+        visitor.visit(tree)
+        violations.extend(visitor.violations)
 
-    # Sort by line number
+    violations.extend(_check_lines(str(filepath), source_lines, line_rules))
     violations.sort(key=lambda v: v.line)
     return violations
 
@@ -453,8 +527,15 @@ def main(argv: list[str] | None = None) -> int:
         dest="json_output",
         help="Output results as JSON.",
     )
+    parser.add_argument(
+        "--config",
+        metavar="REPO_ROOT",
+        default=None,
+        help="Repo root containing .onex/aislop-rules.yaml for per-repo overrides.",
+    )
 
     args = parser.parse_args(argv)
+    repo_root = Path(args.config) if args.config else None
 
     # Collect files
     files: list[Path] = []
@@ -469,23 +550,8 @@ def main(argv: list[str] | None = None) -> int:
 
     all_violations: list[SlopViolation] = []
     for filepath in files:
-        if filepath.suffix == ".py":
-            all_violations.extend(check_file(filepath))
-        # Markdown files: no AST checks, only line-based (step_narration)
-        elif filepath.suffix == ".md":
-            try:
-                source_lines = filepath.read_text(encoding="utf-8").splitlines()
-                all_violations.extend(_check_lines(str(filepath), source_lines))
-            except OSError as exc:
-                all_violations.append(
-                    SlopViolation(
-                        filename=str(filepath),
-                        line=0,
-                        check="file_read",
-                        severity=SEVERITY_ERROR,
-                        message=f"Cannot read file: {exc}",
-                    )
-                )
+        if filepath.suffix in (".py", ".md"):
+            all_violations.extend(check_file(filepath, repo_root=repo_root))
 
     # Filter by severity
     if not args.report:

--- a/src/omnibase_core/contracts/aislop_default_rules.yaml
+++ b/src/omnibase_core/contracts/aislop_default_rules.yaml
@@ -57,8 +57,7 @@ rules:
     enabled: true
     pattern_type: regex_ast_docstring
     pattern: >-
-      ^\s*This\s+(module|class|function|method|file|script|node|handler|service) \s+(provides?|implements?|contains?|is
-      responsible for|handles?|manages?|offers?)
+      ^\s*This\s+(module|class|function|method|file|script|node|handler|service)\s+(provides?|implements?|contains?|is\s+responsible\s+for|handles?|manages?|offers?)
     file_globs: ["*.py"]
     suppression_annotation: ai-slop-ok
     description: >-

--- a/src/omnibase_core/contracts/aislop_default_rules.yaml
+++ b/src/omnibase_core/contracts/aislop_default_rules.yaml
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX aislop default rule set (OMN-11132)
+# Source of truth for all aislop detection rules.
+# Per-repo overrides live at .onex/aislop-rules.yaml (see ModelAislopConfig).
+#
+# pattern_type values:
+#   regex_ast_docstring  — applied per-line inside AST-extracted docstrings
+#   regex_line           — applied per line outside docstrings
+#   grep_code            — applied per line across all matched files
+#   ast_check            — identifier for a named AST visitor check
+#
+# Override example (.onex/aislop-rules.yaml):
+#   overrides:
+#     - name: boilerplate_docstring
+#       severity: ERROR        # escalate to error for this repo
+#     - name: obvious_comment
+#       enabled: false         # disable noisy rule for this repo
+#     - name: my_custom_rule
+#       allow_new: true        # marks this as a new rule; must also appear in custom_rules
+#   custom_rules:
+#     - name: my_custom_rule
+#       severity: WARNING
+#       pattern_type: regex_line
+#       pattern: "TODO\\(omn-"
+#       file_globs: ["*.py"]
+#       description: "Unresolved inline TODO with ticket reference"
+
+rules:
+  # ── Docstring rules (AST-based) ─────────────────────────────────────────────
+
+  - name: sycophancy
+    severity: ERROR
+    enabled: true
+    pattern_type: regex_ast_docstring
+    pattern: >-
+      ^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to| I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,.
+      ]
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Sycophantic opener in a docstring (e.g. "Great, here is..."). LLMs frequently start generated docstrings
+      with affirmations. #magic___^_^___line
+  - name: rest_docstring
+    severity: ERROR
+    enabled: true
+    pattern_type: regex_ast_docstring
+    pattern: "^\\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\\b"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      reST-style docstring markers (:param:, :type:, :returns:, :rtype:, etc.). Google-style docstrings
+      are the project standard. #magic___^_^___line
+  - name: boilerplate_docstring
+    severity: WARNING
+    enabled: true
+    pattern_type: regex_ast_docstring
+    pattern: >-
+      ^\s*This\s+(module|class|function|method|file|script|node|handler|service) \s+(provides?|implements?|contains?|is
+      responsible for|handles?|manages?|offers?)
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Boilerplate opener "This <thing> provides/implements/contains ...". Catches LLM-generated filler
+      that describes the obvious. #magic___^_^___line
+  - name: md_separator
+    severity: WARNING
+    enabled: true
+    pattern_type: regex_ast_docstring
+    pattern: "={4,}"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Markdown-style separator (4+ = chars) inside a Python docstring. LLMs sometimes insert visual dividers
+      that have no meaning in docstrings. #magic___^_^___line
+  # ── Line-based rules ────────────────────────────────────────────────────────
+
+  - name: step_narration
+    severity: WARNING
+    enabled: true
+    pattern_type: regex_line
+    pattern: "#\\s*Step\\s+\\d+\\s*[:\\-]"
+    file_globs: ["*.md"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      "# Step N:" or "## Step N:" headings in Markdown files. Python inline "# Step N:" comments are legitimate
+      and are NOT flagged (v1.0 tuning, OMN-3191). #magic___^_^___line
+  - name: obvious_comment
+    severity: INFO
+    enabled: true
+    pattern_type: regex_line
+    pattern: "#\\s*(TODO|FIXME|HACK|XXX|NOTE):\\s*$"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Self-evident inline comment with no content (e.g. "# TODO: "). Reported in INFO/report mode only;
+      not blocking by default. #magic___^_^___line
+  # ── Code hygiene rules (from NodeAislopSweep) ───────────────────────────────
+
+  - name: hardcoded_ip
+    severity: ERROR
+    enabled: true
+    pattern_type: grep_code
+    pattern: "\\b(?:192\\.168|10\\.0|172\\.(?:1[6-9]|2[0-9]|3[01]))\\.[0-9]+\\.[0-9]+\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml", "*.json"]
+    suppression_annotation: onex-allow-internal-ip
+    description: >-
+      Hardcoded private IP address. Use env vars or Infisical references. Annotate intentional exceptions
+      with # onex-allow-internal-ip. #magic___^_^___line
+  - name: hardcoded_localhost
+    severity: ERROR
+    enabled: true
+    pattern_type: grep_code
+    pattern: "\\b(localhost|127\\.0\\.0\\.1)\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml"]
+    suppression_annotation: onex-allow-internal-ip
+    description: >-
+      Hardcoded localhost/127.0.0.1 reference. Use env vars or service discovery. #magic___^_^___line
+  - name: hardcoded_port
+    severity: WARNING
+    enabled: true
+    pattern_type: grep_code
+    pattern: ":\\b(5432|6379|9092|19092|8080|8085|8086|3000|5000)\\b"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Hardcoded well-known port number. Pull from env vars or contract config. #magic___^_^___line
+  - name: hardcoded_topic
+    severity: ERROR
+    enabled: true
+    pattern_type: grep_code
+    pattern: "\"onex\\.(cmd|evt)\\.[a-z_]+\\.[a-z_]+\\.v[0-9]+\""
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Hardcoded Kafka topic string. Topics must be read from contract.yaml via TopicBase or the contract
+      loader -- never inlined as literals. #magic___^_^___line
+  - name: prohibited_env_pattern
+    severity: WARNING
+    enabled: true
+    pattern_type: grep_code
+    pattern: "os\\.environ\\.get\\([\"'][A-Z_]+[\"'],\\s*[\"'][^\"']+[\"']\\)"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      os.environ.get() with a non-empty default silently masks misconfiguration. Use os.environ[key] to
+      fail fast, or an explicit None default. #magic___^_^___line
+  - name: compat_shim
+    severity: WARNING
+    enabled: true
+    pattern_type: grep_code
+    pattern: "(?:^|\\s)_[a-zA-Z][a-zA-Z0-9_]*\\s*=\\s*[a-zA-Z]"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Possible backwards-compatibility alias (underscore-prefixed re-export). Remove compat shims; callers
+      should import from the canonical path. #magic___^_^___line
+  - name: empty_impl
+    severity: WARNING
+    enabled: true
+    pattern_type: grep_code
+    pattern: "^\\s*(pass|\\.\\.\\.)\\s*$"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Empty function or method body (pass / ...). Placeholder implementations must be completed before
+      merging; stubs accumulate as silent debt. #magic___^_^___line
+  - name: todo_fixme
+    severity: INFO
+    enabled: true
+    pattern_type: grep_code
+    pattern: "#\\s*(TODO|FIXME)\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Unresolved TODO or FIXME comment. Track work in Linear, not inline. Reported at INFO; escalate per-repo
+      via override if required.

--- a/src/omnibase_core/models/validation/__init__.py
+++ b/src/omnibase_core/models/validation/__init__.py
@@ -14,6 +14,11 @@ Import validation models directly when needed:
 # Only import non-circular models (Pydantic models that don't import from validation)
 # Contract validation event model (OMN-1146)
 # Violation baseline models (OMN-1774)
+# Aislop rule models (OMN-11132)
+from .model_aislop_config import ModelAislopConfig
+from .model_aislop_rule import ModelAislopRule
+from .model_aislop_rule_override import ModelAislopRuleOverride
+from .model_aislop_rule_set import ModelAislopRuleSet
 from .model_baseline_generator import ModelBaselineGenerator
 from .model_baseline_violation import ModelBaselineViolation
 from .model_contract_validation_event import (
@@ -77,6 +82,11 @@ from .model_workflow_validation_result import ModelWorkflowValidationResult
 # cause circular imports and should be imported directly from their modules when needed
 
 __all__ = [
+    # Aislop rule models (OMN-11132)
+    "ModelAislopConfig",
+    "ModelAislopRule",
+    "ModelAislopRuleOverride",
+    "ModelAislopRuleSet",
     # Contract validation event model (OMN-1146)
     "ContractValidationEventType",
     "ModelContractValidationEvent",

--- a/src/omnibase_core/models/validation/model_aislop_config.py
+++ b/src/omnibase_core/models/validation/model_aislop_config.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAislopConfig — per-repo aislop configuration (OMN-11132)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+from omnibase_core.models.validation.model_aislop_rule_override import (
+    ModelAislopRuleOverride,
+)
+
+
+class ModelAislopConfig(BaseModel):
+    """Per-repo aislop configuration read from .onex/aislop-rules.yaml."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    overrides: list[ModelAislopRuleOverride] = Field(default_factory=list)
+    custom_rules: list[ModelAislopRule] = Field(
+        default_factory=list,
+        description="New rules not in the default set; requires allow_new=True in the matching override",
+    )
+
+    @model_validator(mode="after")
+    def _validate_no_orphan_custom_rules(self) -> ModelAislopConfig:
+        """Every custom_rule must have a matching override with allow_new=True."""
+        allowed_new = {o.name for o in self.overrides if o.allow_new}
+        for rule in self.custom_rules:
+            if rule.name not in allowed_new:
+                raise ValueError(
+                    f"custom_rule '{rule.name}' has no matching override with allow_new=True"
+                )
+        return self
+
+
+__all__ = ["ModelAislopConfig"]

--- a/src/omnibase_core/models/validation/model_aislop_rule.py
+++ b/src/omnibase_core/models/validation/model_aislop_rule.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAislopRule — a single configurable aislop detection rule (OMN-11132)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAislopRule(BaseModel):
+    """A single aislop detection rule."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(description="Unique rule identifier, e.g. 'sycophancy'")
+    severity: Literal["ERROR", "WARNING", "INFO"] = Field(
+        description="Violation severity"
+    )
+    enabled: bool = Field(default=True, description="Whether the rule is active")
+    pattern_type: Literal[
+        "regex_line", "regex_ast_docstring", "grep_code", "ast_check"
+    ] = Field(description="How the pattern is matched")
+    pattern: str = Field(description="Regex string or AST check identifier")
+    file_globs: list[str] = Field(
+        default_factory=lambda: ["*.py"],
+        description="File glob patterns this rule applies to",
+    )
+    suppression_annotation: str = Field(
+        default="ai-slop-ok",
+        description="Inline comment suffix that suppresses this rule",
+    )
+    description: str = Field(description="Human-readable explanation of the rule")
+
+
+__all__ = ["ModelAislopRule"]

--- a/src/omnibase_core/models/validation/model_aislop_rule_override.py
+++ b/src/omnibase_core/models/validation/model_aislop_rule_override.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAislopRuleOverride — per-repo override for an aislop rule (OMN-11132)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAislopRuleOverride(BaseModel):
+    """A per-repo override for an existing rule or a new custom rule."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(description="Rule name to override or new rule name")
+    severity: Literal["ERROR", "WARNING", "INFO"] | None = Field(
+        default=None, description="Override severity (None = keep default)"
+    )
+    enabled: bool | None = Field(
+        default=None, description="Override enabled flag (None = keep default)"
+    )
+    file_globs: list[str] | None = Field(
+        default=None, description="Override file globs (None = keep default)"
+    )
+    allow_new: bool = Field(
+        default=False,
+        description="If True, treat as a new custom rule rather than an override",
+    )
+
+
+__all__ = ["ModelAislopRuleOverride"]

--- a/src/omnibase_core/models/validation/model_aislop_rule_set.py
+++ b/src/omnibase_core/models/validation/model_aislop_rule_set.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAislopRuleSet — versioned collection of aislop detection rules (OMN-11132)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+
+
+class ModelAislopRuleSet(BaseModel):
+    """A versioned set of aislop rules."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    rules: list[ModelAislopRule] = Field(default_factory=list)
+
+
+__all__ = ["ModelAislopRuleSet"]

--- a/src/omnibase_core/validation/aislop_rule_loader.py
+++ b/src/omnibase_core/validation/aislop_rule_loader.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aislop rule loader: resolves the effective rule set for a repo (OMN-11132).
+
+Resolution order:
+  1. Load bundled default rules from contracts/aislop_default_rules.yaml
+  2. Load optional per-repo config from <repo_root>/.onex/aislop-rules.yaml
+  3. Merge: apply overrides then append custom_rules
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.models.validation.model_aislop_config import ModelAislopConfig
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+from omnibase_core.models.validation.model_aislop_rule_override import (
+    ModelAislopRuleOverride,
+)
+from omnibase_core.models.validation.model_aislop_rule_set import ModelAislopRuleSet
+
+_CONTRACTS_PKG = "omnibase_core.contracts"
+_DEFAULT_YAML = "aislop_default_rules.yaml"
+
+
+def load_default_rules() -> ModelAislopRuleSet:
+    """Return the bundled default aislop rule set.
+
+    Reads from omnibase_core/contracts/aislop_default_rules.yaml via
+    importlib.resources so it works both in dev and in installed wheels.
+    """
+    try:
+        ref = importlib.resources.files(_CONTRACTS_PKG) / _DEFAULT_YAML
+        raw = ref.read_text(encoding="utf-8")
+    except (FileNotFoundError, TypeError) as exc:
+        # Fallback: resolve relative to this file's package location
+        fallback = Path(__file__).parent.parent / "contracts" / _DEFAULT_YAML
+        if fallback.exists():
+            raw = fallback.read_text(encoding="utf-8")
+        else:
+            raise FileNotFoundError(  # error-ok: bundled YAML is missing — fatal config error
+                f"Cannot locate {_DEFAULT_YAML}; tried importlib.resources and {fallback}"
+            ) from exc
+
+    data = yaml.safe_load(raw)
+    return ModelAislopRuleSet.model_validate(data)
+
+
+def load_repo_config(repo_root: Path) -> ModelAislopConfig | None:
+    """Load per-repo aislop config from <repo_root>/.onex/aislop-rules.yaml.
+
+    Returns None if the file does not exist (per-repo overrides are optional).
+    Raises ValidationError if the file exists but is malformed.
+    """
+    config_path = repo_root / ".onex" / "aislop-rules.yaml"
+    if not config_path.exists():
+        return None
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    return ModelAislopConfig.model_validate(data)
+
+
+def merge_rules(
+    defaults: ModelAislopRuleSet,
+    config: ModelAislopConfig | None,
+) -> ModelAislopRuleSet:
+    """Apply per-repo overrides and custom rules on top of defaults.
+
+    Override semantics:
+    - Override fields that are None → keep the default value.
+    - Unknown name + allow_new=False → ValidationError (prevents silent typos).
+    - Unknown name + allow_new=True → treated as a declaration for a custom_rule entry.
+    - custom_rules are appended after merging overrides.
+    """
+    if config is None:
+        return defaults
+
+    default_by_name: dict[str, ModelAislopRule] = {r.name: r for r in defaults.rules}
+    override_by_name: dict[str, ModelAislopRuleOverride] = {
+        o.name: o for o in config.overrides
+    }
+
+    # Validate overrides reference known rules (unless allow_new=True)
+    for name, override in override_by_name.items():
+        if name not in default_by_name and not override.allow_new:
+            known = sorted(default_by_name)
+            raise ValueError(  # error-ok: config validation, not runtime error
+                f"Unknown aislop rule name '{name}'. "
+                f"Set allow_new=True to declare a new rule. "
+                f"Known rules: {known}"
+            )
+
+    # Apply overrides to existing rules
+    merged: list[ModelAislopRule] = []
+    for rule in defaults.rules:
+        maybe_override: ModelAislopRuleOverride | None = override_by_name.get(rule.name)
+        if maybe_override is None:
+            merged.append(rule)
+            continue
+        ov: ModelAislopRuleOverride = maybe_override
+        merged.append(
+            ModelAislopRule(
+                name=rule.name,
+                severity=ov.severity if ov.severity is not None else rule.severity,
+                enabled=ov.enabled if ov.enabled is not None else rule.enabled,
+                pattern_type=rule.pattern_type,
+                pattern=rule.pattern,
+                file_globs=ov.file_globs
+                if ov.file_globs is not None
+                else rule.file_globs,
+                suppression_annotation=rule.suppression_annotation,
+                description=rule.description,
+            )
+        )
+
+    # Append custom rules
+    merged.extend(config.custom_rules)
+
+    return ModelAislopRuleSet(rules=merged)
+
+
+def resolve_rules(repo_root: Path) -> ModelAislopRuleSet:
+    """Full resolution pipeline: defaults → per-repo config → merged result."""
+    defaults = load_default_rules()
+    config = load_repo_config(repo_root)
+    return merge_rules(defaults, config)
+
+
+__all__ = [
+    "load_default_rules",
+    "load_repo_config",
+    "merge_rules",
+    "resolve_rules",
+]

--- a/tests/unit/models/validation/test_model_aislop_rule.py
+++ b/tests/unit/models/validation/test_model_aislop_rule.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelAislopRule Pydantic models (OMN-11132)."""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_aislop_config import ModelAislopConfig
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+from omnibase_core.models.validation.model_aislop_rule_override import (
+    ModelAislopRuleOverride,
+)
+from omnibase_core.models.validation.model_aislop_rule_set import ModelAislopRuleSet
+
+
+@pytest.mark.unit
+class TestModelAislopRule:
+    def test_minimal_rule(self) -> None:
+        rule = ModelAislopRule(
+            name="sycophancy",
+            severity="ERROR",
+            pattern_type="regex_ast_docstring",
+            pattern=r"^\s*Excellent",
+            description="Sycophantic opener",
+        )
+        assert rule.name == "sycophancy"
+        assert rule.severity == "ERROR"
+        assert rule.enabled is True
+        assert rule.file_globs == ["*.py"]
+        assert rule.suppression_annotation == "ai-slop-ok"
+
+    def test_rule_serialization_roundtrip(self) -> None:
+        rule = ModelAislopRule(
+            name="test_rule",
+            severity="WARNING",
+            pattern_type="grep_code",
+            pattern=r"\bFIXME\b",
+            file_globs=["*.py", "*.yaml"],
+            description="FIXME marker",
+        )
+        data = rule.model_dump()
+        restored = ModelAislopRule.model_validate(data)
+        assert restored == rule
+
+    def test_invalid_severity_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelAislopRule(
+                name="bad",
+                severity="FATAL",  # type: ignore[arg-type]
+                pattern_type="grep_code",
+                pattern="x",
+                description="bad severity",
+            )
+
+    def test_invalid_pattern_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelAislopRule(
+                name="bad",
+                severity="ERROR",
+                pattern_type="unknown_type",  # type: ignore[arg-type]
+                pattern="x",
+                description="bad pattern_type",
+            )
+
+
+@pytest.mark.unit
+class TestModelAislopRuleSet:
+    def test_empty_ruleset(self) -> None:
+        rs = ModelAislopRuleSet()
+        assert rs.rules == []
+
+    def test_ruleset_with_rules(self) -> None:
+        rs = ModelAislopRuleSet(
+            rules=[
+                ModelAislopRule(
+                    name="r1",
+                    severity="ERROR",
+                    pattern_type="grep_code",
+                    pattern="x",
+                    description="rule 1",
+                ),
+                ModelAislopRule(
+                    name="r2",
+                    severity="WARNING",
+                    pattern_type="regex_line",
+                    pattern="y",
+                    description="rule 2",
+                ),
+            ]
+        )
+        assert len(rs.rules) == 2
+
+    def test_ruleset_roundtrip(self) -> None:
+        rs = ModelAislopRuleSet(
+            rules=[
+                ModelAislopRule(
+                    name="x",
+                    severity="INFO",
+                    pattern_type="ast_check",
+                    pattern="check_id",
+                    description="info rule",
+                )
+            ],
+        )
+        data = rs.model_dump()
+        assert ModelAislopRuleSet.model_validate(data) == rs
+
+
+@pytest.mark.unit
+class TestModelAislopRuleOverride:
+    def test_all_none_fields(self) -> None:
+        override = ModelAislopRuleOverride(name="sycophancy")
+        assert override.severity is None
+        assert override.enabled is None
+        assert override.file_globs is None
+        assert override.allow_new is False
+
+    def test_partial_override(self) -> None:
+        override = ModelAislopRuleOverride(name="sycophancy", enabled=False)
+        assert override.enabled is False
+        assert override.severity is None
+
+    def test_allow_new_override(self) -> None:
+        override = ModelAislopRuleOverride(name="my_custom", allow_new=True)
+        assert override.allow_new is True
+
+
+@pytest.mark.unit
+class TestModelAislopConfig:
+    def test_empty_config(self) -> None:
+        cfg = ModelAislopConfig()
+        assert cfg.overrides == []
+        assert cfg.custom_rules == []
+
+    def test_config_with_overrides(self) -> None:
+        cfg = ModelAislopConfig(
+            overrides=[
+                ModelAislopRuleOverride(name="sycophancy", enabled=False),
+                ModelAislopRuleOverride(name="todo_fixme", severity="ERROR"),
+            ]
+        )
+        assert len(cfg.overrides) == 2
+
+    def test_custom_rule_requires_allow_new(self) -> None:
+        """custom_rules entry without matching allow_new=True override must fail."""
+        with pytest.raises(ValidationError, match="allow_new"):
+            ModelAislopConfig(
+                overrides=[],
+                custom_rules=[
+                    ModelAislopRule(
+                        name="my_rule",
+                        severity="WARNING",
+                        pattern_type="grep_code",
+                        pattern="x",
+                        description="orphan",
+                    )
+                ],
+            )
+
+    def test_custom_rule_with_allow_new_passes(self) -> None:
+        cfg = ModelAislopConfig(
+            overrides=[ModelAislopRuleOverride(name="my_rule", allow_new=True)],
+            custom_rules=[
+                ModelAislopRule(
+                    name="my_rule",
+                    severity="WARNING",
+                    pattern_type="grep_code",
+                    pattern="x",
+                    description="custom rule",
+                )
+            ],
+        )
+        assert len(cfg.custom_rules) == 1

--- a/tests/unit/scripts/test_check_ai_slop_parity.py
+++ b/tests/unit/scripts/test_check_ai_slop_parity.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Parity gate: old (hardcoded) vs new (loader-backed) check_ai_slop paths (OMN-11132).
+
+Verifies that refactoring check_ai_slop.py to use aislop_rule_loader produces
+identical findings on a shared fixture corpus.
+"""
+
+from __future__ import annotations
+
+# Old implementation re-implemented inline as reference (mirrors original v1.0)
+import ast
+import re as _re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import both implementations
+# ---------------------------------------------------------------------------
+# New implementation (loader-backed)
+from scripts.validation.check_ai_slop import (
+    check_file,
+)
+
+_OLD_SYCOPHANCY_RE = _re.compile(
+    r"^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to|"
+    r"I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,. ]",
+    _re.IGNORECASE,
+)
+_OLD_REST_RE = _re.compile(r"^\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\b")
+_OLD_BOILERPLATE_RE = _re.compile(
+    r"^\s*This\s+(module|class|function|method|file|script|node|handler|service)"
+    r"\s+(provides?|implements?|contains?|is responsible for|handles?|manages?|offers?)",
+    _re.IGNORECASE,
+)
+_OLD_STEP_NARRATION_RE = _re.compile(r"#\s*Step\s+\d+\s*[:\-]", _re.IGNORECASE)
+_OLD_MD_SEPARATOR_RE = _re.compile(r"={4,}")
+
+_OLD_SUPPRESSION = "ai-slop-ok"
+
+
+def _old_check_docstring_violations(
+    source: str, filename: str
+) -> set[tuple[int, str, str]]:
+    """Run original v1.0 docstring checks; returns {(lineno, check, severity)}."""
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return set()
+
+    source_lines = source.splitlines()
+    violations: set[tuple[int, str, str]] = set()
+
+    def _has_suppression(def_lineno: int, docstring_lineno: int) -> bool:
+        n = len(source_lines)
+
+        def _chk(ln: int) -> bool:
+            return 1 <= ln <= n and _OLD_SUPPRESSION in source_lines[ln - 1]
+
+        return _chk(def_lineno) or _chk(docstring_lineno) or _chk(def_lineno - 1)
+
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)
+        ):
+            continue
+        docstring = ast.get_docstring(node, clean=False)
+        if not docstring:
+            continue
+        if not node.body:
+            continue
+        first_stmt = node.body[0]
+        if not isinstance(first_stmt, ast.Expr) or not isinstance(
+            first_stmt.value, ast.Constant
+        ):
+            continue
+        if not isinstance(first_stmt.value.value, str):
+            continue
+        docstring_lineno = first_stmt.value.lineno
+        def_lineno = 1 if isinstance(node, ast.Module) else node.lineno
+        if _has_suppression(def_lineno, docstring_lineno):
+            continue
+        for offset, doc_line in enumerate(docstring.splitlines()):
+            ln = docstring_lineno + offset
+            if _OLD_SYCOPHANCY_RE.match(doc_line):
+                violations.add((ln, "sycophancy", "ERROR"))
+            if _OLD_REST_RE.match(doc_line):
+                violations.add((ln, "rest_docstring", "ERROR"))
+            if _OLD_BOILERPLATE_RE.match(doc_line):
+                violations.add((ln, "boilerplate_docstring", "WARNING"))
+            if _OLD_MD_SEPARATOR_RE.search(doc_line):
+                violations.add((ln, "md_separator", "WARNING"))
+    return violations
+
+
+def _old_check_line_violations(source: str, filename: str) -> set[tuple[int, str, str]]:
+    """Run original v1.0 line-based checks; returns {(lineno, check, severity)}."""
+    violations: set[tuple[int, str, str]] = set()
+    is_markdown = filename.endswith(".md")
+    lines = source.splitlines()
+    in_triple_quote = False
+    triple_char = ""
+    in_md_code_fence = False
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.rstrip()
+        if not is_markdown:
+            for tq in ('"""', "'''"):
+                count = stripped.count(tq)
+                if count:
+                    if not in_triple_quote:
+                        if count % 2 == 1:
+                            in_triple_quote = True
+                            triple_char = tq
+                    elif tq == triple_char:
+                        if count % 2 == 1:
+                            in_triple_quote = False
+                            triple_char = ""
+            if in_triple_quote:
+                continue
+        if is_markdown:
+            if stripped.startswith(("```", "~~~")):
+                in_md_code_fence = not in_md_code_fence
+            if in_md_code_fence or stripped.startswith(("```", "~~~")):
+                continue
+            comment_match = _re.search(r"#(.+)", stripped)
+            if comment_match:
+                comment_text = comment_match.group(0)
+                if _OLD_STEP_NARRATION_RE.search(comment_text):
+                    if _OLD_SUPPRESSION not in stripped:
+                        violations.add((lineno, "step_narration", "WARNING"))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Fixture corpus
+# ---------------------------------------------------------------------------
+
+FIXTURE_PY = textwrap.dedent("""\
+    def good_function():
+        \"\"\"Normal docstring — no slop.\"\"\"
+        pass
+
+
+    def sycophantic_fn():
+        \"\"\"Excellent function that does stuff.\"\"\"
+        pass
+
+
+    def rest_style():
+        \"\"\"Do something.
+
+        :param x: the input
+        :returns: the output
+        \"\"\"
+        pass
+
+
+    def boilerplate_fn():
+        \"\"\"This function provides a way to do stuff.\"\"\"
+        pass
+
+
+    class BadClass:
+        \"\"\"
+        ============================
+        This class implements stuff.
+        \"\"\"
+        pass
+
+
+    def suppressed():  # ai-slop-ok: intentional test
+        \"\"\"Excellent — this should NOT be flagged.\"\"\"
+        pass
+""")
+
+FIXTURE_MD = textwrap.dedent("""\
+    # Normal heading
+
+    Some prose.
+
+    ## Step 1: Do the thing
+
+    More prose.
+
+    ```python
+    # Step 2: This is inside a code block and should not be flagged
+    ```
+
+    ## Step 3: Another step
+""")
+
+
+@pytest.mark.unit
+def test_parity_python_docstring_rules(tmp_path: Path) -> None:
+    """New loader-backed path produces identical findings to v1.0 on .py fixture."""
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(FIXTURE_PY, encoding="utf-8")
+
+    # Old path
+    old_violations = _old_check_docstring_violations(
+        FIXTURE_PY, str(fixture)
+    ) | _old_check_line_violations(FIXTURE_PY, str(fixture))
+
+    # New path (no repo config → uses defaults, which match v1.0)
+    new_raw = check_file(fixture, repo_root=tmp_path)
+    # Filter to the same rules the old code handled: docstring + line-based originals
+    original_rules = {
+        "sycophancy",
+        "rest_docstring",
+        "boilerplate_docstring",
+        "md_separator",
+        "step_narration",
+    }
+    new_violations = {
+        (v.line, v.check, v.severity) for v in new_raw if v.check in original_rules
+    }
+
+    assert new_violations == old_violations, (
+        f"Parity failure on Python fixture.\n"
+        f"Old only: {old_violations - new_violations}\n"
+        f"New only: {new_violations - old_violations}"
+    )
+
+
+@pytest.mark.unit
+def test_parity_markdown_step_narration(tmp_path: Path) -> None:
+    """New loader-backed path produces identical step_narration findings on .md fixture."""
+    fixture = tmp_path / "fixture.md"
+    fixture.write_text(FIXTURE_MD, encoding="utf-8")
+
+    old_violations = _old_check_line_violations(FIXTURE_MD, str(fixture))
+
+    new_raw = check_file(fixture, repo_root=tmp_path)
+    new_violations = {
+        (v.line, v.check, v.severity) for v in new_raw if v.check == "step_narration"
+    }
+
+    assert new_violations == old_violations, (
+        f"Parity failure on Markdown fixture.\n"
+        f"Old only: {old_violations - new_violations}\n"
+        f"New only: {new_violations - old_violations}"
+    )
+
+
+@pytest.mark.unit
+def test_suppression_still_works(tmp_path: Path) -> None:
+    """Suppressed sycophancy must not appear in new output."""
+    fixture = tmp_path / "suppressed.py"
+    fixture.write_text(FIXTURE_PY, encoding="utf-8")
+    violations = check_file(fixture, repo_root=tmp_path)
+    # The suppressed() function must not produce any sycophancy finding
+    flagged_lines = {v.line for v in violations if v.check == "sycophancy"}
+    # Line 37 is the suppressed function's docstring — must not appear
+    # We check that no violations reference "suppressed" context (line 37)
+    source_lines = FIXTURE_PY.splitlines()
+    for line_no in flagged_lines:
+        line_content = source_lines[line_no - 1] if line_no <= len(source_lines) else ""
+        assert "NOT be flagged" not in line_content, (
+            f"Suppressed sycophancy was incorrectly flagged at line {line_no}"
+        )
+
+
+@pytest.mark.unit
+def test_override_disables_rule_parity(tmp_path: Path) -> None:
+    """With sycophancy disabled via per-repo config, no sycophancy violations appear."""
+    import textwrap as tw
+
+    onex_dir = tmp_path / ".onex"
+    onex_dir.mkdir()
+    (onex_dir / "aislop-rules.yaml").write_text(
+        tw.dedent("""\
+            overrides:
+              - name: sycophancy
+                enabled: false
+        """)
+    )
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text(FIXTURE_PY, encoding="utf-8")
+    violations = check_file(fixture, repo_root=tmp_path)
+    assert not any(v.check == "sycophancy" for v in violations), (
+        "sycophancy rule should be disabled by per-repo config"
+    )

--- a/tests/unit/validation/test_aislop_rule_loader.py
+++ b/tests/unit/validation/test_aislop_rule_loader.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for aislop_rule_loader (OMN-11132)."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.models.validation.model_aislop_config import ModelAislopConfig
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+from omnibase_core.models.validation.model_aislop_rule_override import (
+    ModelAislopRuleOverride,
+)
+from omnibase_core.models.validation.model_aislop_rule_set import ModelAislopRuleSet
+from omnibase_core.validation.aislop_rule_loader import (
+    load_default_rules,
+    load_repo_config,
+    merge_rules,
+    resolve_rules,
+)
+
+
+@pytest.mark.unit
+def test_load_default_rules() -> None:
+    ruleset = load_default_rules()
+    assert isinstance(ruleset, ModelAislopRuleSet)
+    names = {r.name for r in ruleset.rules}
+    # All 14 expected rules must be present
+    expected = {
+        "sycophancy",
+        "rest_docstring",
+        "boilerplate_docstring",
+        "md_separator",
+        "step_narration",
+        "obvious_comment",
+        "hardcoded_ip",
+        "hardcoded_localhost",
+        "hardcoded_port",
+        "hardcoded_topic",
+        "prohibited_env_pattern",
+        "compat_shim",
+        "empty_impl",
+        "todo_fixme",
+    }
+    assert expected.issubset(names), f"Missing rules: {expected - names}"
+
+
+@pytest.mark.unit
+def test_load_default_rules_parses_without_error() -> None:
+    ruleset = load_default_rules()
+    for rule in ruleset.rules:
+        assert rule.name
+        assert rule.pattern
+        assert rule.severity in ("ERROR", "WARNING", "INFO")
+
+
+@pytest.mark.unit
+def test_load_repo_config_missing_returns_none(tmp_path: Path) -> None:
+    result = load_repo_config(tmp_path)
+    assert result is None
+
+
+@pytest.mark.unit
+def test_load_repo_config_reads_file(tmp_path: Path) -> None:
+    onex_dir = tmp_path / ".onex"
+    onex_dir.mkdir()
+    (onex_dir / "aislop-rules.yaml").write_text(
+        textwrap.dedent("""\
+            overrides:
+              - name: obvious_comment
+                enabled: false
+        """)
+    )
+    config = load_repo_config(tmp_path)
+    assert config is not None
+    assert len(config.overrides) == 1
+    assert config.overrides[0].name == "obvious_comment"
+    assert config.overrides[0].enabled is False
+
+
+@pytest.mark.unit
+def test_merge_no_config_returns_defaults() -> None:
+    defaults = load_default_rules()
+    merged = merge_rules(defaults, None)
+    assert merged == defaults
+
+
+@pytest.mark.unit
+def test_merge_disables_rule() -> None:
+    defaults = load_default_rules()
+    config = ModelAislopConfig(
+        overrides=[ModelAislopRuleOverride(name="sycophancy", enabled=False)]
+    )
+    merged = merge_rules(defaults, config)
+    sycophancy = next(r for r in merged.rules if r.name == "sycophancy")
+    assert sycophancy.enabled is False
+
+
+@pytest.mark.unit
+def test_merge_changes_severity() -> None:
+    defaults = load_default_rules()
+    config = ModelAislopConfig(
+        overrides=[
+            ModelAislopRuleOverride(name="boilerplate_docstring", severity="ERROR")
+        ]
+    )
+    merged = merge_rules(defaults, config)
+    rule = next(r for r in merged.rules if r.name == "boilerplate_docstring")
+    assert rule.severity == "ERROR"
+
+
+@pytest.mark.unit
+def test_merge_changes_file_globs() -> None:
+    defaults = load_default_rules()
+    config = ModelAislopConfig(
+        overrides=[
+            ModelAislopRuleOverride(
+                name="todo_fixme", file_globs=["*.py", "*.yaml", "*.ts"]
+            )
+        ]
+    )
+    merged = merge_rules(defaults, config)
+    rule = next(r for r in merged.rules if r.name == "todo_fixme")
+    assert "*.ts" in rule.file_globs
+
+
+@pytest.mark.unit
+def test_merge_adds_custom_rule() -> None:
+    defaults = load_default_rules()
+    custom = ModelAislopRule(
+        name="my_custom",
+        severity="WARNING",
+        pattern_type="grep_code",
+        pattern=r"\bDEPRECATED\b",
+        description="Deprecated marker",
+    )
+    config = ModelAislopConfig(
+        overrides=[ModelAislopRuleOverride(name="my_custom", allow_new=True)],
+        custom_rules=[custom],
+    )
+    merged = merge_rules(defaults, config)
+    names = [r.name for r in merged.rules]
+    assert "my_custom" in names
+    # Custom rule appended after defaults
+    assert names.index("my_custom") == len(names) - 1
+
+
+@pytest.mark.unit
+def test_merge_unknown_name_without_allow_new_raises() -> None:
+    defaults = load_default_rules()
+    config = ModelAislopConfig(
+        overrides=[ModelAislopRuleOverride(name="nonexistent_rule_xyz")]
+    )
+    with pytest.raises(ValueError, match="nonexistent_rule_xyz"):
+        merge_rules(defaults, config)
+
+
+@pytest.mark.unit
+def test_merge_preserves_unoverridden_rules() -> None:
+    defaults = load_default_rules()
+    config = ModelAislopConfig(
+        overrides=[ModelAislopRuleOverride(name="sycophancy", enabled=False)]
+    )
+    merged = merge_rules(defaults, config)
+    # All default rules should still be present
+    assert len(merged.rules) == len(defaults.rules)
+
+
+@pytest.mark.unit
+def test_resolve_rules_no_config_uses_defaults(tmp_path: Path) -> None:
+    defaults = load_default_rules()
+    resolved = resolve_rules(tmp_path)
+    assert {r.name for r in resolved.rules} == {r.name for r in defaults.rules}
+
+
+@pytest.mark.unit
+def test_resolve_rules_with_config(tmp_path: Path) -> None:
+    onex_dir = tmp_path / ".onex"
+    onex_dir.mkdir()
+    (onex_dir / "aislop-rules.yaml").write_text(
+        textwrap.dedent("""\
+            overrides:
+              - name: rest_docstring
+                severity: WARNING
+        """)
+    )
+    resolved = resolve_rules(tmp_path)
+    rule = next(r for r in resolved.rules if r.name == "rest_docstring")
+    assert rule.severity == "WARNING"


### PR DESCRIPTION
## Summary

- Unifies 14 aislop detection rules (from `check_ai_slop.py` v1.0 and `NodeAislopSweep`) into a single bundled default YAML (`contracts/aislop_default_rules.yaml`)
- Adds 4 Pydantic models: `ModelAislopRule`, `ModelAislopRuleSet`, `ModelAislopRuleOverride`, `ModelAislopConfig` with frozen config, strict extras, and override merge semantics
- Adds `aislop_rule_loader.py` with `load_default_rules()`, `load_repo_config()`, `merge_rules()`, `resolve_rules()` — per-repo overrides at `.onex/aislop-rules.yaml`
- Refactors `check_ai_slop.py` to v2.0 using the loader, adds `--config REPO_ROOT` CLI flag, backward compatible
- 31 unit tests: model tests, loader tests, parity gate (new loader produces identical findings to v1.0 on fixture corpus)

## Test plan

- [x] 31 unit tests all pass: `env -u PYTHONPATH uv run pytest tests/unit/models/validation/test_model_aislop_rule.py tests/unit/validation/test_aislop_rule_loader.py tests/unit/scripts/test_check_ai_slop_parity.py -v`
- [x] mypy --strict clean
- [x] ruff format + check clean
- [x] All pre-commit hooks pass (commit hooks + push hooks)
- [x] Parity gate: `test_parity_python_docstring_rules` and `test_parity_markdown_step_narration` confirm identical findings vs original v1.0
- [x] Override gate: `test_override_disables_rule_parity` confirms per-repo config disables rules correctly

## OMN-11132

dod_evidence: 31/31 tests passing, mypy --strict clean, parity gate passing, all 14 rules present in default YAML, per-repo override mechanism working via `.onex/aislop-rules.yaml`

Evidence-Source: OCC#1119
Evidence-Ticket: OMN-11132
