### PR TITLE
fix(OMN-11119): extend check-name validator to handle workflow_call composite check names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,7 @@ ignore = [
 "scripts/validation/validate_no_none_guard_publish.py" = ["T201"]
 "scripts/validation/validate_no_import_none_fallback.py" = ["T201"]
 "scripts/validation/check_ai_slop.py" = ["T201", "BLE001"]
+"scripts/validation/validate-check-names.py" = ["T201", "BLE001"]
 "scripts/validation/validate-stubbed-functionality.py" = ["T201", "BLE001"]
 "scripts/validation/validate-exception-handling.py" = ["T201", "BLE001"]
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]

--- a/scripts/validation/validate-check-names.py
+++ b/scripts/validation/validate-check-names.py
@@ -203,7 +203,11 @@ def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
                 raw_name = re.sub(r"\s*\$\{.*?\}", "", raw_name).strip()
                 job_names[current_job_key] = raw_name
 
-            uses_match = re.match(r"^\s+uses:\s+(.+)$", line)
+            # NOTE(OMN-11119): pattern is anchored at ^ and $ on a single line of
+            # a trusted YAML workflow file. No user-controlled input; ReDoS risk is
+            # nil. SonarCloud python:S5852 false-positive — suppress as hotspot
+            # reviewed.
+            uses_match = re.match(r"^[ \t]+uses:[ \t]+(.+)$", line)  # NOSONAR(python:S5852)
             if uses_match:
                 job_uses[current_job_key] = uses_match.group(1).strip().strip("\"'")
 

--- a/scripts/validation/validate-check-names.py
+++ b/scripts/validation/validate-check-names.py
@@ -207,7 +207,7 @@ def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
             # a trusted YAML workflow file. No user-controlled input; ReDoS risk is
             # nil. SonarCloud python:S5852 false-positive — suppress as hotspot
             # reviewed.
-            uses_match = re.match(r"^[ \t]+uses:[ \t]+(.+)$", line)  # NOSONAR(python:S5852)
+            uses_match = re.match(r"^[ \t]+uses:[ \t]+(.+)$", line)  # NOSONAR
             if uses_match:
                 job_uses[current_job_key] = uses_match.group(1).strip().strip("\"'")
 

--- a/scripts/validation/validate-check-names.py
+++ b/scripts/validation/validate-check-names.py
@@ -99,6 +99,9 @@ class WorkflowInfo(NamedTuple):
     has_paths_filter: bool
     """True if the workflow uses ``paths:`` at the top-level ``on:`` section."""
 
+    job_uses: dict[str, str]
+    """Map of job_key -> uses: value for workflow_call jobs (e.g. {'call-job': 'org/repo/.github/workflows/foo.yml@main'})."""
+
 
 # ---------------------------------------------------------------------------
 # YAML parsing helpers (line-based to avoid PyYAML dependency)
@@ -106,7 +109,7 @@ class WorkflowInfo(NamedTuple):
 
 
 def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
-    """Extract job keys, display names, and paths-filter presence from a workflow file.
+    """Extract job keys, display names, uses references, and paths-filter presence.
 
     Uses a simple line-based parser to avoid requiring PyYAML in CI environments.
     Handles standard GitHub Actions YAML structure reliably.
@@ -115,12 +118,14 @@ def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
         workflow_path: Absolute path to the workflow YAML file.
 
     Returns:
-        WorkflowInfo with job_keys, job_names mapping, and has_paths_filter flag.
+        WorkflowInfo with job_keys, job_names mapping, job_uses mapping, and
+        has_paths_filter flag.
     """
     lines = workflow_path.read_text(encoding="utf-8").splitlines()
 
     job_keys: set[str] = set()
     job_names: dict[str, str] = {}
+    job_uses: dict[str, str] = {}
     has_paths_filter = False
 
     in_jobs_block = False
@@ -185,7 +190,7 @@ def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
                 current_job_indent = indent
                 continue
 
-        # Detect display name for current job (indent must be one level deeper)
+        # Detect display name or uses: for current job (indent must be one level deeper)
         if (
             current_job_key is not None
             and current_job_indent is not None
@@ -198,10 +203,15 @@ def _parse_workflow_file(workflow_path: Path) -> WorkflowInfo:
                 raw_name = re.sub(r"\s*\$\{.*?\}", "", raw_name).strip()
                 job_names[current_job_key] = raw_name
 
+            uses_match = re.match(r"^\s+uses:\s+(.+)$", line)
+            if uses_match:
+                job_uses[current_job_key] = uses_match.group(1).strip().strip("\"'")
+
     return WorkflowInfo(
         job_keys=job_keys,
         job_names=job_names,
         has_paths_filter=has_paths_filter,
+        job_uses=job_uses,
     )
 
 
@@ -445,22 +455,46 @@ def _validate_gates(
             continue
 
         # --- Check 5: check_name matches job's display name ---
-        actual_name = wf_info.job_names.get(workflow_job_key, "")
-        if actual_name and actual_name != check_name:
-            violations.append(
-                CheckNameViolation(
-                    gate_check_name=check_name,
-                    workflow_file=workflow_file,
-                    workflow_job_key=workflow_job_key,
-                    error_type="CHECK_NAME_MISMATCH",
-                    detail=(
-                        f"Gate check_name '{check_name}' does not match the actual "
-                        f"job display name '{actual_name}' for job key '{workflow_job_key}' "
-                        f"in '{workflow_file}'. Branch protection requires the check_name to "
-                        f"match exactly what GitHub reports (the job 'name:' field)."
-                    ),
+        # For workflow_call jobs (uses: references), GitHub generates composite check
+        # names of the form "<caller-job-key> / <callee-job-name>". Validate that the
+        # check_name matches this composite form when the job has a uses: reference.
+        uses_ref = wf_info.job_uses.get(workflow_job_key, "")
+        if uses_ref:
+            # This is a workflow_call job — check_name must start with caller-job-key /
+            expected_prefix = f"{workflow_job_key} / "
+            if not check_name.startswith(expected_prefix):
+                violations.append(
+                    CheckNameViolation(
+                        gate_check_name=check_name,
+                        workflow_file=workflow_file,
+                        workflow_job_key=workflow_job_key,
+                        error_type="WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH",
+                        detail=(
+                            f"Job '{workflow_job_key}' in '{workflow_file}' invokes a reusable "
+                            f"workflow via 'uses: {uses_ref}'. GitHub generates composite "
+                            f"check-run names as '<caller-job-key> / <callee-job-name>', so "
+                            f"check_name must start with '{expected_prefix}'. "
+                            f"Got: '{check_name}'."
+                        ),
+                    )
                 )
-            )
+        else:
+            actual_name = wf_info.job_names.get(workflow_job_key, "")
+            if actual_name and actual_name != check_name:
+                violations.append(
+                    CheckNameViolation(
+                        gate_check_name=check_name,
+                        workflow_file=workflow_file,
+                        workflow_job_key=workflow_job_key,
+                        error_type="CHECK_NAME_MISMATCH",
+                        detail=(
+                            f"Gate check_name '{check_name}' does not match the actual "
+                            f"job display name '{actual_name}' for job key '{workflow_job_key}' "
+                            f"in '{workflow_file}'. Branch protection requires the check_name to "
+                            f"match exactly what GitHub reports (the job 'name:' field)."
+                        ),
+                    )
+                )
 
     return violations
 

--- a/tests/scripts/test_validate_check_names.py
+++ b/tests/scripts/test_validate_check_names.py
@@ -31,7 +31,6 @@ def _load_module():  # type: ignore[return]
 
 _mod = _load_module()
 _parse_workflow_file = _mod._parse_workflow_file
-_parse_required_checks = _mod._parse_required_checks
 _validate_gates = _mod._validate_gates
 
 
@@ -92,7 +91,7 @@ def test_parse_workflow_file_no_uses_for_regular_job(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_validate_gates_composite_name_correct(tmp_path: Path) -> None:
     """No violation when check_name starts with '<caller-job-key> /' for a workflow_call job."""
-    wf = _write_workflow(
+    _write_workflow(
         tmp_path,
         "call-reject-skip.yml",
         """
@@ -119,7 +118,7 @@ def test_validate_gates_composite_name_correct(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_validate_gates_composite_name_missing_prefix(tmp_path: Path) -> None:
     """WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH when check_name lacks '<caller-job-key> /' prefix."""
-    wf = _write_workflow(
+    _write_workflow(
         tmp_path,
         "call-reject-skip.yml",
         """

--- a/tests/scripts/test_validate_check_names.py
+++ b/tests/scripts/test_validate_check_names.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/validation/validate-check-names.py (OMN-11119).
+
+Covers:
+- _parse_workflow_file: job_uses populated for workflow_call jobs
+- _validate_gates: WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH for jobs with uses:
+- _validate_gates: composite name passes when check_name has correct prefix
+- Regression: non-workflow_call jobs still use CHECK_NAME_MISMATCH path
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "validate-check-names.py"
+
+
+def _load_module():  # type: ignore[return]
+    spec = importlib.util.spec_from_file_location("validate_check_names", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_mod = _load_module()
+_parse_workflow_file = _mod._parse_workflow_file
+_parse_required_checks = _mod._parse_required_checks
+_validate_gates = _mod._validate_gates
+
+
+def _write_workflow(tmp_path: Path, name: str, content: str) -> Path:
+    wf = tmp_path / name
+    wf.write_text(textwrap.dedent(content).lstrip())
+    return wf
+
+
+@pytest.mark.unit
+def test_parse_workflow_file_detects_uses_reference(tmp_path: Path) -> None:
+    """job_uses is populated for a job that calls a reusable workflow via uses:."""
+    wf = _write_workflow(
+        tmp_path,
+        "call-reject-skip.yml",
+        """
+        name: Reject skip-gate bypass tokens
+        on:
+          pull_request:
+        jobs:
+          call-reject-skip-token:
+            uses: OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main
+            secrets: inherit
+        """,
+    )
+    info = _parse_workflow_file(wf)
+    assert "call-reject-skip-token" in info.job_keys
+    assert info.job_uses.get("call-reject-skip-token") == (
+        "OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main"
+    )
+    assert "call-reject-skip-token" not in info.job_names
+
+
+@pytest.mark.unit
+def test_parse_workflow_file_no_uses_for_regular_job(tmp_path: Path) -> None:
+    """job_uses is empty for jobs that do not use workflow_call."""
+    wf = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+        name: CI
+        on:
+          push:
+        jobs:
+          quality-gate:
+            name: Quality Gate
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo ok
+        """,
+    )
+    info = _parse_workflow_file(wf)
+    assert "quality-gate" in info.job_keys
+    assert info.job_names.get("quality-gate") == "Quality Gate"
+    assert info.job_uses == {}
+
+
+@pytest.mark.unit
+def test_validate_gates_composite_name_correct(tmp_path: Path) -> None:
+    """No violation when check_name starts with '<caller-job-key> /' for a workflow_call job."""
+    wf = _write_workflow(
+        tmp_path,
+        "call-reject-skip.yml",
+        """
+        name: Reject skip-gate bypass tokens
+        on:
+          pull_request:
+        jobs:
+          call-reject-skip-token:
+            uses: OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main
+            secrets: inherit
+        """,
+    )
+    gates = [
+        {
+            "check_name": "call-reject-skip-token / scan / reject-skip-gate-token",
+            "workflow_file": "call-reject-skip.yml",
+            "workflow_job_key": "call-reject-skip-token",
+        }
+    ]
+    violations = _validate_gates(gates, tmp_path)
+    assert violations == [], f"Unexpected violations: {violations}"
+
+
+@pytest.mark.unit
+def test_validate_gates_composite_name_missing_prefix(tmp_path: Path) -> None:
+    """WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH when check_name lacks '<caller-job-key> /' prefix."""
+    wf = _write_workflow(
+        tmp_path,
+        "call-reject-skip.yml",
+        """
+        name: Reject skip-gate bypass tokens
+        on:
+          pull_request:
+        jobs:
+          call-reject-skip-token:
+            uses: OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main
+            secrets: inherit
+        """,
+    )
+    gates = [
+        {
+            "check_name": "scan / reject-skip-gate-token",
+            "workflow_file": "call-reject-skip.yml",
+            "workflow_job_key": "call-reject-skip-token",
+        }
+    ]
+    violations = _validate_gates(gates, tmp_path)
+    assert len(violations) == 1
+    assert violations[0].error_type == "WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH"
+    assert "call-reject-skip-token / " in violations[0].detail
+
+
+@pytest.mark.unit
+def test_validate_gates_regular_job_check_name_mismatch(tmp_path: Path) -> None:
+    """CHECK_NAME_MISMATCH still fires for regular (non-workflow_call) jobs."""
+    wf = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+        name: CI
+        on:
+          push:
+        jobs:
+          quality-gate:
+            name: Quality Gate
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo ok
+        """,
+    )
+    gates = [
+        {
+            "check_name": "wrong-name",
+            "workflow_file": "ci.yml",
+            "workflow_job_key": "quality-gate",
+        }
+    ]
+    violations = _validate_gates(gates, tmp_path)
+    assert len(violations) == 1
+    assert violations[0].error_type == "CHECK_NAME_MISMATCH"
+
+
+@pytest.mark.unit
+def test_validate_gates_regular_job_check_name_correct(tmp_path: Path) -> None:
+    """No violation when check_name matches display name for a regular job."""
+    wf = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+        name: CI
+        on:
+          push:
+        jobs:
+          quality-gate:
+            name: Quality Gate
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo ok
+        """,
+    )
+    gates = [
+        {
+            "check_name": "Quality Gate",
+            "workflow_file": "ci.yml",
+            "workflow_job_key": "quality-gate",
+        }
+    ]
+    violations = _validate_gates(gates, tmp_path)
+    assert violations == [], f"Unexpected violations: {violations}"
+
+
+@pytest.mark.unit
+def test_validate_gates_workflow_call_any_callee_name_valid(tmp_path: Path) -> None:
+    """Any check_name with the correct caller prefix is accepted (callee name is opaque)."""
+    _write_workflow(
+        tmp_path,
+        "call-some-reusable.yml",
+        """
+        name: Call reusable
+        on:
+          pull_request:
+        jobs:
+          call-some-job:
+            uses: org/repo/.github/workflows/reusable.yml@main
+        """,
+    )
+    for callee_suffix in [
+        "some-check",
+        "scan / nested-check",
+        "a / b / c",
+    ]:
+        gates = [
+            {
+                "check_name": f"call-some-job / {callee_suffix}",
+                "workflow_file": "call-some-reusable.yml",
+                "workflow_job_key": "call-some-job",
+            }
+        ]
+        violations = _validate_gates(gates, tmp_path)
+        assert violations == [], (
+            f"Unexpected violations for '{callee_suffix}': {violations}"
+        )


### PR DESCRIPTION
## Summary

- Extends `_parse_workflow_file` to populate `job_uses` — a new field on `WorkflowInfo` mapping job keys to their `uses:` reference when the job delegates to a reusable workflow via `workflow_call`
- Updates `_validate_gates` to emit `WORKFLOW_CALL_COMPOSITE_NAME_MISMATCH` when a job has a `uses:` reference but the gate's `check_name` does not start with `<caller-job-key> / `
- Adds `validate-check-names.py` to pyproject.toml T201/BLE001 per-file-ignores

## Tests

7 new unit tests in `tests/scripts/test_validate_check_names.py`.

## Ticket

OMN-11119

Evidence-Source: OCC#1089
Evidence-Ticket: OMN-11119