### PR TITLE
feat(OMN-11186): add pre-commit + CI validator blocking new os.environ/os.getenv additions

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -351,3 +351,33 @@ jobs:
             fi
           done
           echo "CI naming convention: PASS"
+
+  no-new-env-vars:
+    name: No New os.environ/os.getenv Additions (OMN-11186)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check for new env var additions
+        run: |
+          find src/ -name "*.py" | xargs uv run python scripts/validation/validate_no_new_env_vars.py

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -370,14 +370,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Check for new env var additions
         run: |
-          find src/ -name "*.py" | xargs uv run python scripts/validation/validate_no_new_env_vars.py
+          find src/ -name "*.py" -print0 | xargs -0 python scripts/validation/validate_no_new_env_vars.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -964,6 +964,15 @@ repos:
           session files. See OMN-4569."
         stages: [pre-commit]
 
+      # OMN-11186: Block new os.environ / os.getenv additions outside allowlist
+      - id: no-new-env-vars
+        name: No New os.environ/os.getenv Additions (OMN-11186)
+        language: python
+        entry: python scripts/validation/validate_no_new_env_vars.py
+        types: [python]
+        pass_filenames: true
+        stages: [pre-commit]
+
       # OMN-5063: Block untyped metadata dict fields
       # Centralized in onex_change_control (OMN-5135)
       - id: no-untyped-metadata

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,8 +21,9 @@
 - id: check-local-paths
   name: Check for local path references
   description: >
-    Detect machine-specific absolute paths (/Volumes/..., /Users/..., /home/..., C:\Users\...) that break
-    portability when code or skills are distributed. Add `# local-path-ok` to suppress a specific line.
+    Detect machine-specific absolute paths that break portability when code or skills are distributed.
+    Covers /Volumes/, /Users/, /home/, and Windows user paths. Add `# local-path-ok` to suppress a specific
+    line.
   language: python
   entry: python -m omnibase_core.validation.validator_local_paths
   types: [text]
@@ -65,6 +66,19 @@
   entry: python -m omnibase_core.validators.handler_di_gate
   types: [python]
   files: (handlers/handler_.*\.py|nodes/node\.py)$
+  pass_filenames: true
+  stages: [pre-commit]
+
+- id: no-new-env-vars
+  name: No New os.environ/os.getenv Additions (OMN-11186)
+  description: >
+    Block new os.environ[...], os.environ.get(...), and os.getenv(...) calls outside the established allowlist.
+    All config must flow through contract YAML or Infisical. Exempts test files, scripts/, and lines annotated
+    with `# env-var-ok`. Extend _BOOTSTRAP_ALLOWLIST in scripts/validation/validate_no_new_env_vars.py
+    via PR review for structural bootstrap vars.
+  language: python
+  entry: python scripts/validation/validate_no_new_env_vars.py
+  types: [python]
   pass_filenames: true
   stages: [pre-commit]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,7 @@ ignore = [
 "scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation
 "scripts/validate_deterministic_skill_routing.py" = ["T201"]  # CLI output for CI gate report
 "scripts/migrate_dod_receipts.py" = ["T201"]  # CLI output for legacy DoD receipt migration [OMN-9790]
+"scripts/validation/validate_no_new_env_vars.py" = ["T201"]  # CLI output for pre-commit hook report (OMN-11186)
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]
 

--- a/scripts/validation/validate_no_new_env_vars.py
+++ b/scripts/validation/validate_no_new_env_vars.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Validator: no new os.environ / os.getenv additions (OMN-11186).
+
+All config must flow through contract YAML or Infisical — not bare env var reads.
+This hook flags any new os.environ[...], os.environ.get(...), or os.getenv(...)
+call that is not in the established allowlist.
+
+Bypass: add `# env-var-ok` on the line to suppress a specific instance.
+
+Allowlisted env vars are structurally required cross-machine bootstrap values
+(OMNI_HOME, PATH, CI, etc.) or pre-existing reads grandfathered at activation.
+New env vars outside the allowlist must go through contract YAML review.
+
+Usage:
+    python scripts/validation/validate_no_new_env_vars.py [files...]
+
+Exit codes:
+    0 - No violations
+    1 - Violations found
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Structurally required bootstrap env vars (zero-friction allowlist)
+# ---------------------------------------------------------------------------
+_BOOTSTRAP_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Cross-machine identity / path resolution
+        "OMNI_HOME",
+        "OMNI_WORKTREES",
+        "OMNIMARKET_ROOT",
+        "ONEX_SRC_DIR",
+        "PATH",
+        "HOME",
+        "USER",
+        "HOSTNAME",
+        # CI environment detection
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CI_RUNNER_TYPE",
+        "JENKINS_URL",
+        # ONEX runtime state roots
+        "ONEX_EVIDENCE_ROOT",
+        "ONEX_WORKTREES_ROOT",
+        "ONEX_STATE_ROOT",
+        "ONEX_STATE_DIR",
+        "ONEX_CORRELATION_ID",
+        "ONEX_HOOKS_MASK",
+        "ONEX_RUNTIME_CONTRACTS_DIR",
+        "ONEX_CONTEXT_SIZE_WARN_ON_CREATE",
+        "ONEX_DEBUG_THREAD_SAFETY",
+        "ONEX_VALIDATION_MODE",
+        # ONEX event bus config (existing reads grandfathered at OMN-11186 activation)
+        "ONEX_EVENT_BUS_BOOTSTRAP_SERVERS",
+        "ONEX_EVENT_BUS_TOPICS",
+        "ONEX_EVENT_BUS_ENABLE_AUTO_COMMIT",
+        "ONEX_EVENT_BUS_PARTITIONS",
+        "ONEX_EVENT_BUS_PRIORITY",
+        "ONEX_EVENT_BUS_REPLICATION_FACTOR",
+        "ONEX_EVENT_BUS_SASL_MECHANISM",
+        "ONEX_EVENT_BUS_SASL_PASSWORD",
+        "ONEX_EVENT_BUS_SASL_USERNAME",
+        "ONEX_EVENT_BUS_SECURITY_PROTOCOL",
+        "ONEX_EVENT_BUS_TIMEOUT_SECONDS",
+        # Kafka / event bus bootstrap (pre-existing; migrate to contract when feasible)
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "EVENT_BUS_BOOTSTRAP_SERVERS",
+        "EVENT_BUS_TOPICS",
+        # Postgres doctor checks (pre-existing; infra diagnostic tooling)
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        # Namespacing / allowed namespace overrides
+        "OMNIBASE_ALLOWED_NAMESPACES",
+        # Linear / external API (doctor checks only)
+        "LINEAR_API_KEY",
+        # LLM endpoints (inference tooling)
+        "LLM_LOCAL_MODEL",
+        "LLM_LOCAL_URL",
+        # ONEX agent / plugin paths
+        "OMNICLAUDE_AGENTS_PATH",
+        # Contract enforcement overrides
+        "CONTRACT_REQUIRED_AFTER",
+        "PLAN_CONTRACT_REQUIRED_AFTER",
+        # DB circuit breaker tuning
+        "DB_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+        "DB_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS",
+        "DB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT",
+        # Generic config used in existing tests / validators
+        "DEBUG",
+        "DEBUG_MODE",
+        "ENVIRONMENT",
+        "NODE_ENV",
+        "LOG_LEVEL",
+        "NODE_ID",
+        "NODE_VERSION",
+        "SERVICE_PORT",
+        "MAX_WORKFLOWS",
+        "WORKFLOW_TIMEOUT",
+        "METRICS_ENABLED",
+        "METRICS_PORT",
+        "HEALTH_CHECK_ENABLED",
+        "HEALTH_CHECK_INTERVAL",
+        "HEALTH_CHECK_TIMEOUT",
+        # Used in scripts/validation (these scripts are themselves tooling)
+        "DETERMINISTIC_SKILL_ROOT",
+        "ZONE_DIFF_FILTER_FAKE_DIFF",
+        # PYTHONPATH (tooling launchers)
+        "PYTHONPATH",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Patterns we scan for (line-level, no AST needed)
+# ---------------------------------------------------------------------------
+_ENV_VAR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"os\.environ\["),
+    re.compile(r"os\.environ\.get\("),
+    re.compile(r"os\.getenv\("),
+)
+
+# Extract the env var name from a line (best-effort; handles quoted keys)
+_NAME_EXTRACTOR = re.compile(
+    r'os\.(?:environ\.get|environ|getenv)\s*[\[(]\s*["\']([^"\']+)["\']'
+)
+
+# ---------------------------------------------------------------------------
+# Skip rules
+# ---------------------------------------------------------------------------
+
+
+def _is_test_file(path: Path) -> bool:
+    parts = path.parts
+    return "tests" in parts
+
+
+def _is_tooling_or_demo(path: Path) -> bool:
+    """Skip validator scripts and demo/example code."""
+    parts = path.parts
+    return "scripts" in parts or "examples" in parts
+
+
+def _line_has_bypass(line: str) -> bool:
+    return "# env-var-ok" in line
+
+
+def _is_comment_line(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+
+def check_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return list of (line_number, raw_line, extracted_var_name) violations."""
+    if not path.exists() or path.suffix != ".py":
+        return []
+    if _is_test_file(path):
+        return []
+    if _is_tooling_or_demo(path):
+        return []
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    violations: list[tuple[int, str, str]] = []
+    in_multiline_string = False
+    multiline_delim = ""
+
+    for lineno, line in enumerate(content.splitlines(), 1):
+        # Track multi-line string (docstring) boundaries
+        stripped = line.lstrip()
+        if not in_multiline_string:
+            for delim in ('"""', "'''"):
+                if delim in stripped:
+                    count = stripped.count(delim)
+                    if count % 2 == 1:
+                        in_multiline_string = True
+                        multiline_delim = delim
+                        break
+            if in_multiline_string:
+                continue
+        else:
+            if multiline_delim in line:
+                in_multiline_string = False
+            continue
+
+        if _line_has_bypass(line):
+            continue
+        if _is_comment_line(line):
+            continue
+
+        matched = any(pat.search(line) for pat in _ENV_VAR_PATTERNS)
+        if not matched:
+            continue
+
+        # Extract the var name if we can determine it (static string key only)
+        name_match = _NAME_EXTRACTOR.search(line)
+        var_name = name_match.group(1) if name_match else ""
+
+        if not var_name:
+            # Dynamic key (variable or f-string) — pre-existing pattern, skip
+            continue
+
+        if var_name in _BOOTSTRAP_ALLOWLIST:
+            continue
+
+        violations.append((lineno, line.rstrip(), var_name))
+
+    return violations
+
+
+def main() -> int:
+    files = [Path(f) for f in sys.argv[1:]]
+    if not files:
+        return 0
+
+    all_violations: dict[str, list[tuple[int, str, str]]] = {}
+
+    for f in files:
+        violations = check_file(f)
+        if violations:
+            all_violations[str(f)] = violations
+
+    if not all_violations:
+        return 0
+
+    print("no-new-env-vars: new os.environ/os.getenv calls found outside allowlist")
+    print(
+        "  All config must flow through contract YAML or Infisical."
+        " Add '# env-var-ok' to suppress if this is a structural bootstrap var,"
+        " or expand _BOOTSTRAP_ALLOWLIST in validate_no_new_env_vars.py via PR review."
+    )
+    print()
+
+    for file_path, violations in sorted(all_violations.items()):
+        for lineno, line, var_name in violations:
+            var_info = f" ({var_name!r})" if var_name else " (dynamic key)"
+            print(f"  {file_path}:{lineno}{var_info}")
+            print(f"    {line.strip()}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/validate_no_new_env_vars.py
+++ b/scripts/validation/validate_no_new_env_vars.py
@@ -157,6 +157,69 @@ def _is_comment_line(line: str) -> bool:
     return line.lstrip().startswith("#")
 
 
+def _should_skip_path(path: Path) -> bool:
+    return (
+        not path.exists()
+        or path.suffix != ".py"
+        or _is_test_file(path)
+        or _is_tooling_or_demo(path)
+    )
+
+
+def _read_python_file(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+
+def _opening_multiline_delimiter(stripped_line: str) -> str | None:
+    for delimiter in ('"""', "'''"):
+        if delimiter in stripped_line and stripped_line.count(delimiter) % 2 == 1:
+            return delimiter
+    return None
+
+
+def _iter_scannable_lines(content: str) -> list[tuple[int, str]]:
+    lines: list[tuple[int, str]] = []
+    in_multiline_string = False
+    multiline_delim = ""
+
+    for lineno, line in enumerate(content.splitlines(), 1):
+        if in_multiline_string:
+            if multiline_delim in line:
+                in_multiline_string = False
+            continue
+
+        delimiter = _opening_multiline_delimiter(line.lstrip())
+        if delimiter is not None:
+            in_multiline_string = True
+            multiline_delim = delimiter
+            continue
+
+        lines.append((lineno, line))
+
+    return lines
+
+
+def _extract_disallowed_env_name(line: str) -> str | None:
+    if _line_has_bypass(line) or _is_comment_line(line):
+        return None
+
+    if not any(pattern.search(line) for pattern in _ENV_VAR_PATTERNS):
+        return None
+
+    name_match = _NAME_EXTRACTOR.search(line)
+    if name_match is None:
+        return None
+
+    var_name = name_match.group(1)
+    if var_name in _BOOTSTRAP_ALLOWLIST:
+        return None
+
+    return var_name
+
+
 # ---------------------------------------------------------------------------
 # Core check
 # ---------------------------------------------------------------------------
@@ -164,61 +227,18 @@ def _is_comment_line(line: str) -> bool:
 
 def check_file(path: Path) -> list[tuple[int, str, str]]:
     """Return list of (line_number, raw_line, extracted_var_name) violations."""
-    if not path.exists() or path.suffix != ".py":
-        return []
-    if _is_test_file(path):
-        return []
-    if _is_tooling_or_demo(path):
+    if _should_skip_path(path):
         return []
 
-    try:
-        content = path.read_text(encoding="utf-8")
-    except (UnicodeDecodeError, OSError):
+    content = _read_python_file(path)
+    if content is None:
         return []
 
     violations: list[tuple[int, str, str]] = []
-    in_multiline_string = False
-    multiline_delim = ""
-
-    for lineno, line in enumerate(content.splitlines(), 1):
-        # Track multi-line string (docstring) boundaries
-        stripped = line.lstrip()
-        if not in_multiline_string:
-            for delim in ('"""', "'''"):
-                if delim in stripped:
-                    count = stripped.count(delim)
-                    if count % 2 == 1:
-                        in_multiline_string = True
-                        multiline_delim = delim
-                        break
-            if in_multiline_string:
-                continue
-        else:
-            if multiline_delim in line:
-                in_multiline_string = False
-            continue
-
-        if _line_has_bypass(line):
-            continue
-        if _is_comment_line(line):
-            continue
-
-        matched = any(pat.search(line) for pat in _ENV_VAR_PATTERNS)
-        if not matched:
-            continue
-
-        # Extract the var name if we can determine it (static string key only)
-        name_match = _NAME_EXTRACTOR.search(line)
-        var_name = name_match.group(1) if name_match else ""
-
-        if not var_name:
-            # Dynamic key (variable or f-string) — pre-existing pattern, skip
-            continue
-
-        if var_name in _BOOTSTRAP_ALLOWLIST:
-            continue
-
-        violations.append((lineno, line.rstrip(), var_name))
+    for lineno, line in _iter_scannable_lines(content):
+        var_name = _extract_disallowed_env_name(line)
+        if var_name is not None:
+            violations.append((lineno, line.rstrip(), var_name))
 
     return violations
 

--- a/tests/unit/validation/test_validate_no_new_env_vars.py
+++ b/tests/unit/validation/test_validate_no_new_env_vars.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for validate_no_new_env_vars.py (OMN-11186)."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_VALIDATOR_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "scripts"
+    / "validation"
+    / "validate_no_new_env_vars.py"
+)
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_no_new_env_vars", _VALIDATOR_PATH
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+check_file = _mod.check_file
+
+
+def _write_py(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@pytest.mark.unit
+class TestCheckFile:
+    def test_new_environ_key_is_flagged(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", 'import os\nx = os.environ["NEW_VAR"]\n')
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert violations[0][2] == "NEW_VAR"
+
+    def test_new_getenv_is_flagged(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", 'import os\nx = os.getenv("NEW_VAR")\n')
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert violations[0][2] == "NEW_VAR"
+
+    def test_new_environ_get_is_flagged(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", 'import os\nx = os.environ.get("NEW_VAR")\n')
+        violations = check_file(p)
+        assert len(violations) == 1
+        assert violations[0][2] == "NEW_VAR"
+
+    def test_allowlisted_omni_home_is_clean(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", 'import os\nx = os.environ["OMNI_HOME"]\n')
+        assert check_file(p) == []
+
+    def test_allowlisted_ci_is_clean(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", 'import os\nx = os.environ.get("CI")\n')
+        assert check_file(p) == []
+
+    def test_allowlisted_kafka_is_clean(self, tmp_path: Path) -> None:
+        p = _write_py(
+            tmp_path, "foo.py", 'import os\nx = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n'
+        )
+        assert check_file(p) == []
+
+    def test_env_var_ok_annotation_suppresses(self, tmp_path: Path) -> None:
+        p = _write_py(
+            tmp_path,
+            "foo.py",
+            'import os\nx = os.environ["NEW_VAR"]  # env-var-ok\n',
+        )
+        assert check_file(p) == []
+
+    def test_test_file_is_skipped(self, tmp_path: Path) -> None:
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        p = _write_py(
+            tests_dir, "test_foo.py", 'import os\nx = os.environ["NEW_VAR"]\n'
+        )
+        assert check_file(p) == []
+
+    def test_scripts_file_is_skipped(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        p = _write_py(
+            scripts_dir,
+            "validate_something.py",
+            'import os\nx = os.environ["NEW_VAR"]\n',
+        )
+        assert check_file(p) == []
+
+    def test_examples_file_is_skipped(self, tmp_path: Path) -> None:
+        examples_dir = tmp_path / "examples"
+        examples_dir.mkdir()
+        p = _write_py(
+            examples_dir, "demo.py", 'import os\nx = os.getenv("ANTHROPIC_API_KEY")\n'
+        )
+        assert check_file(p) == []
+
+    def test_clean_file_returns_empty(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", "x = 1\n")
+        assert check_file(p) == []
+
+    def test_comment_line_is_skipped(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "foo.py", '# os.environ["NEW_VAR"]\n')
+        assert check_file(p) == []
+
+    def test_multiple_violations_reported(self, tmp_path: Path) -> None:
+        p = _write_py(
+            tmp_path,
+            "foo.py",
+            'import os\na = os.environ["A_VAR"]\nb = os.getenv("B_VAR")\n',
+        )
+        violations = check_file(p)
+        assert len(violations) == 2
+
+    def test_non_python_file_ignored(self, tmp_path: Path) -> None:
+        p = tmp_path / "config.yaml"
+        p.write_text('env: os.environ["NEW_VAR"]\n', encoding="utf-8")
+        assert check_file(p) == []
+
+
+@pytest.mark.unit
+class TestMainExitCodes:
+    def _run(self, *args: str) -> int:
+        result = subprocess.run(
+            [sys.executable, str(_VALIDATOR_PATH), *args],
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode
+
+    def test_exit_0_when_no_violations(self, tmp_path: Path) -> None:
+        p = _write_py(tmp_path, "clean.py", "x = 1\n")
+        assert self._run(str(p)) == 0
+
+    def test_exit_1_when_violations(self, tmp_path: Path) -> None:
+        p = _write_py(
+            tmp_path, "bad.py", 'import os\nx = os.environ["BRAND_NEW_VAR"]\n'
+        )
+        assert self._run(str(p)) == 1
+
+    def test_exit_0_with_no_files(self) -> None:
+        assert self._run() == 0


### PR DESCRIPTION
## Summary

- Adds `no-new-env-vars` pre-commit hook and CI job that mechanically blocks new `os.environ[...]`, `os.environ.get(...)`, and `os.getenv(...)` calls outside an established allowlist
- Exempts `tests/`, `scripts/`, `examples/`, dynamic-key patterns (variable keys), multi-line docstrings, comment lines, and lines annotated with `# env-var-ok`
- 17 unit tests covering all skip rules, allowlist hits, bypass annotation, and exit codes
- Zero false positives verified against the full existing `src/` codebase before commit

## Ticket

OMN-11186

## dod_evidence

- Pre-commit hook passes on all files: `pre-commit run no-new-env-vars --all-files` → Passed
- 17/17 unit tests green: `uv run pytest tests/unit/validation/test_validate_no_new_env_vars.py -v`
- All pre-commit hooks pass on commit

Evidence-Ticket: OMN-11186
Evidence-Source: OCC#1098