### PR TITLE
feat(OMN-11189): add EnumDataProvenance, EnumDegradedBehavior, EnumDoctrineCoverage

### DIFF
--- a/src/omnibase_core/enums/enum_data_provenance.py
+++ b/src/omnibase_core/enums/enum_data_provenance.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Data provenance enum for tracking origin quality of displayed values."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+__all__ = ["EnumDataProvenance"]
+
+
+@unique
+class EnumDataProvenance(StrValueHelper, str, Enum):
+    """Origin quality classification for data values displayed in dashboards or reports."""
+
+    DEMO_SEEDED = "demo_seeded"
+    DEMO_PROJECTED_SHORTCUT = "demo_projected_shortcut"
+    MEASURED = "measured"
+    ESTIMATED = "estimated"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> EnumDataProvenance | None:
+        """Return no implicit aliases for unknown data-provenance values."""
+        return None

--- a/src/omnibase_core/enums/enum_degraded_behavior.py
+++ b/src/omnibase_core/enums/enum_degraded_behavior.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Degraded behavior enum for specifying fallback strategy when data is unavailable."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+__all__ = ["EnumDegradedBehavior"]
+
+
+@unique
+class EnumDegradedBehavior(StrValueHelper, str, Enum):
+    """Fallback strategy to apply when a data source is unavailable or stale."""
+
+    SERVE_STALE_WITH_WARNING = "serve_stale_with_warning"
+    RETURN_EMPTY = "return_empty"
+    FAIL_CLOSED = "fail_closed"
+
+    @classmethod
+    def _missing_(cls, value: object) -> EnumDegradedBehavior | None:
+        """Return no implicit aliases for unknown degraded-behavior values."""
+        return None

--- a/src/omnibase_core/enums/enum_doctrine_coverage.py
+++ b/src/omnibase_core/enums/enum_doctrine_coverage.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Doctrine coverage enum for classifying enforcement level of doctrine rules."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+__all__ = ["EnumDoctrineCoverage"]
+
+
+@unique
+class EnumDoctrineCoverage(StrValueHelper, str, Enum):
+    """Enforcement classification for doctrine coverage of a node or widget."""
+
+    UNCOVERED = "uncovered"
+    ADVISORY = "advisory"
+    ENFORCED = "enforced"
+
+    @classmethod
+    def _missing_(cls, value: object) -> EnumDoctrineCoverage | None:
+        """Return no implicit aliases for unknown doctrine-coverage values."""
+        return None

--- a/tests/unit/enums/test_enum_data_provenance.py
+++ b/tests/unit/enums/test_enum_data_provenance.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumDataProvenance."""
+
+import pytest
+
+from omnibase_core.enums.enum_data_provenance import EnumDataProvenance
+
+
+@pytest.mark.unit
+def test_member_count() -> None:
+    assert len(EnumDataProvenance) == 5
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("member", "value"),
+    [
+        (EnumDataProvenance.DEMO_SEEDED, "demo_seeded"),
+        (EnumDataProvenance.DEMO_PROJECTED_SHORTCUT, "demo_projected_shortcut"),
+        (EnumDataProvenance.MEASURED, "measured"),
+        (EnumDataProvenance.ESTIMATED, "estimated"),
+        (EnumDataProvenance.UNKNOWN, "unknown"),
+    ],
+)
+def test_member_values(member: EnumDataProvenance, value: str) -> None:
+    assert member == value
+    assert member.value == value
+
+
+@pytest.mark.unit
+def test_no_implicit_aliases() -> None:
+    with pytest.raises(ValueError):
+        EnumDataProvenance("not_a_real_value")
+
+
+@pytest.mark.unit
+def test_missing_returns_none_then_raises() -> None:
+    assert EnumDataProvenance._missing_("bogus") is None
+
+
+@pytest.mark.unit
+def test_canonical_lookup() -> None:
+    assert EnumDataProvenance("measured") is EnumDataProvenance.MEASURED
+    assert EnumDataProvenance("unknown") is EnumDataProvenance.UNKNOWN

--- a/tests/unit/enums/test_enum_degraded_behavior.py
+++ b/tests/unit/enums/test_enum_degraded_behavior.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumDegradedBehavior."""
+
+import pytest
+
+from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
+
+
+@pytest.mark.unit
+def test_member_count() -> None:
+    assert len(EnumDegradedBehavior) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("member", "value"),
+    [
+        (EnumDegradedBehavior.SERVE_STALE_WITH_WARNING, "serve_stale_with_warning"),
+        (EnumDegradedBehavior.RETURN_EMPTY, "return_empty"),
+        (EnumDegradedBehavior.FAIL_CLOSED, "fail_closed"),
+    ],
+)
+def test_member_values(member: EnumDegradedBehavior, value: str) -> None:
+    assert member == value
+    assert member.value == value
+
+
+@pytest.mark.unit
+def test_no_implicit_aliases() -> None:
+    with pytest.raises(ValueError):
+        EnumDegradedBehavior("not_a_real_value")
+
+
+@pytest.mark.unit
+def test_missing_returns_none_then_raises() -> None:
+    assert EnumDegradedBehavior._missing_("bogus") is None
+
+
+@pytest.mark.unit
+def test_canonical_lookup() -> None:
+    assert EnumDegradedBehavior("return_empty") is EnumDegradedBehavior.RETURN_EMPTY
+    assert EnumDegradedBehavior("fail_closed") is EnumDegradedBehavior.FAIL_CLOSED

--- a/tests/unit/enums/test_enum_doctrine_coverage.py
+++ b/tests/unit/enums/test_enum_doctrine_coverage.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumDoctrineCoverage."""
+
+import pytest
+
+from omnibase_core.enums.enum_doctrine_coverage import EnumDoctrineCoverage
+
+
+@pytest.mark.unit
+def test_member_count() -> None:
+    assert len(EnumDoctrineCoverage) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("member", "value"),
+    [
+        (EnumDoctrineCoverage.UNCOVERED, "uncovered"),
+        (EnumDoctrineCoverage.ADVISORY, "advisory"),
+        (EnumDoctrineCoverage.ENFORCED, "enforced"),
+    ],
+)
+def test_member_values(member: EnumDoctrineCoverage, value: str) -> None:
+    assert member == value
+    assert member.value == value
+
+
+@pytest.mark.unit
+def test_no_implicit_aliases() -> None:
+    with pytest.raises(ValueError):
+        EnumDoctrineCoverage("not_a_real_value")
+
+
+@pytest.mark.unit
+def test_missing_returns_none_then_raises() -> None:
+    assert EnumDoctrineCoverage._missing_("bogus") is None
+
+
+@pytest.mark.unit
+def test_canonical_lookup() -> None:
+    assert EnumDoctrineCoverage("uncovered") is EnumDoctrineCoverage.UNCOVERED
+    assert EnumDoctrineCoverage("enforced") is EnumDoctrineCoverage.ENFORCED


### PR DESCRIPTION
Evidence-Source: OCC#1109
Evidence-Ticket: OMN-11189

## Summary

- Adds `EnumDataProvenance` (5 members: DEMO_SEEDED, DEMO_PROJECTED_SHORTCUT, MEASURED, ESTIMATED, UNKNOWN) for classifying origin quality of displayed values
- Adds `EnumDegradedBehavior` (3 members: SERVE_STALE_WITH_WARNING, RETURN_EMPTY, FAIL_CLOSED) for specifying fallback strategy when data is unavailable
- Adds `EnumDoctrineCoverage` (3 members: UNCOVERED, ADVISORY, ENFORCED) for classifying enforcement level of doctrine rules
- All enums follow the `StrValueHelper` + `@unique` pattern used by `EnumUsageSource`, with `_missing_` returning `None` and `__all__` exports
- Unit tests for all three enums verify member count, values, `_missing_` behavior, and canonical lookups (23 tests, all passing)

## Ticket

OMN-11189 (epic OMN-11188)

## Test plan

- [x] 23/23 unit tests passed
- [x] ruff format + check — no changes needed
- [x] pre-commit run --files <new files> — all hooks passed
- [x] Pre-push hooks (mypy --strict, pyright) — passed