### PR TITLE
feat(OMN-11190): add ModelRuntimeManifest with ownership semantics

### DIFF
--- a/src/omnibase_core/models/runtime_manifest/__init__.py
+++ b/src/omnibase_core/models/runtime_manifest/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ONEX Runtime Manifest models with ownership semantics."""
+
+from omnibase_core.models.runtime_manifest.model_manifest_contract import (
+    ModelManifestContract,
+)
+from omnibase_core.models.runtime_manifest.model_manifest_handler import (
+    ModelManifestHandler,
+)
+from omnibase_core.models.runtime_manifest.model_ownership_violation import (
+    ModelOwnershipViolation,
+)
+from omnibase_core.models.runtime_manifest.model_runtime_manifest import (
+    ModelRuntimeManifest,
+)
+
+__all__ = [
+    "ModelManifestContract",
+    "ModelManifestHandler",
+    "ModelOwnershipViolation",
+    "ModelRuntimeManifest",
+]

--- a/src/omnibase_core/models/runtime_manifest/model_manifest_contract.py
+++ b/src/omnibase_core/models/runtime_manifest/model_manifest_contract.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelManifestContract(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+    node_type: str = Field(..., min_length=1)
+    contract_hash: str = Field(..., min_length=1)
+
+
+__all__ = ["ModelManifestContract"]

--- a/src/omnibase_core/models/runtime_manifest/model_manifest_handler.py
+++ b/src/omnibase_core/models/runtime_manifest/model_manifest_handler.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelManifestHandler(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(..., min_length=1)
+    module_path: str = Field(..., min_length=1)
+    routing_strategy: str = Field(..., min_length=1)
+
+
+__all__ = ["ModelManifestHandler"]

--- a/src/omnibase_core/models/runtime_manifest/model_ownership_violation.py
+++ b/src/omnibase_core/models/runtime_manifest/model_ownership_violation.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelOwnershipViolation(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    contract_name: str = Field(..., min_length=1)
+    violation_type: str = Field(..., min_length=1)
+    detail: str = Field(..., min_length=1)
+
+
+__all__ = ["ModelOwnershipViolation"]

--- a/src/omnibase_core/models/runtime_manifest/model_runtime_manifest.py
+++ b/src/omnibase_core/models/runtime_manifest/model_runtime_manifest.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import json
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from omnibase_core.models.runtime_manifest.model_manifest_contract import (
+    ModelManifestContract,
+)
+from omnibase_core.models.runtime_manifest.model_manifest_handler import (
+    ModelManifestHandler,
+)
+from omnibase_core.models.runtime_manifest.model_ownership_violation import (
+    ModelOwnershipViolation,
+)
+
+
+class ModelRuntimeManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    runtime_profile: str = Field(..., min_length=1)
+    contracts: tuple[ModelManifestContract, ...] = Field(default=())
+    owned_command_topics: frozenset[str] = Field(default_factory=frozenset)
+    subscribed_event_topics: frozenset[str] = Field(default_factory=frozenset)
+    handlers: tuple[ModelManifestHandler, ...] = Field(default=())
+    skipped_contracts: tuple[ModelManifestContract, ...] = Field(default=())
+    failed_contracts: tuple[ModelManifestContract, ...] = Field(default=())
+    ownership_violations: tuple[ModelOwnershipViolation, ...] = Field(default=())
+    image_digest: str | None = Field(default=None)
+    started_at: datetime = Field(...)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def contract_hash(self) -> str:
+        sorted_hashes = sorted(c.contract_hash for c in self.contracts)
+        payload = json.dumps(sorted_hashes, sort_keys=True)
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def topology_hash(self) -> str:
+        payload = json.dumps(
+            {
+                "runtime_profile": self.runtime_profile,
+                "contract_hash": self.contract_hash,
+                "owned_command_topics": sorted(self.owned_command_topics),
+                "subscribed_event_topics": sorted(self.subscribed_event_topics),
+                "handlers": sorted(h.name for h in self.handlers),
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+
+__all__ = ["ModelRuntimeManifest"]

--- a/tests/unit/models/runtime_manifest/__init__.py
+++ b/tests/unit/models/runtime_manifest/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/runtime_manifest/test_model_runtime_manifest.py
+++ b/tests/unit/models/runtime_manifest/test_model_runtime_manifest.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.models.runtime_manifest import (
+    ModelManifestContract,
+    ModelManifestHandler,
+    ModelOwnershipViolation,
+    ModelRuntimeManifest,
+)
+
+
+def _make_contract(name: str, contract_hash: str) -> ModelManifestContract:
+    return ModelManifestContract(
+        name=name,
+        version="1.0.0",
+        node_type="COMPUTE",
+        contract_hash=contract_hash,
+    )
+
+
+def _make_handler(name: str) -> ModelManifestHandler:
+    return ModelManifestHandler(
+        name=name,
+        module_path=f"omnibase_core.handlers.{name}",
+        routing_strategy="default",
+    )
+
+
+def _base_manifest(**kwargs: object) -> ModelRuntimeManifest:
+    defaults: dict[str, object] = {
+        "runtime_profile": "test",
+        "started_at": datetime(2025, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(kwargs)
+    return ModelRuntimeManifest(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelRuntimeManifest:
+    def test_create_manifest_with_ownership(self) -> None:
+        contract = _make_contract("node.compute.v1", "abc123")
+        handler = _make_handler("handle_compute")
+        violation = ModelOwnershipViolation(
+            contract_name="node.compute.v1",
+            violation_type="duplicate_ownership",
+            detail="Already claimed by node-b",
+        )
+        manifest = _base_manifest(
+            contracts=(contract,),
+            owned_command_topics=frozenset({"onex.cmd.compute.run.v1"}),
+            subscribed_event_topics=frozenset({"onex.evt.compute.done.v1"}),
+            handlers=(handler,),
+            ownership_violations=(violation,),
+        )
+
+        assert manifest.runtime_profile == "test"
+        assert len(manifest.contracts) == 1
+        assert len(manifest.ownership_violations) == 1
+        assert manifest.ownership_violations[0].violation_type == "duplicate_ownership"
+        assert "onex.cmd.compute.run.v1" in manifest.owned_command_topics
+
+    def test_contract_hash_deterministic_regardless_of_order(self) -> None:
+        c1 = _make_contract("node.a.v1", "hash-aaa")
+        c2 = _make_contract("node.b.v1", "hash-bbb")
+
+        manifest_ab = _base_manifest(contracts=(c1, c2))
+        manifest_ba = _base_manifest(contracts=(c2, c1))
+
+        assert manifest_ab.contract_hash == manifest_ba.contract_hash
+
+    def test_topology_hash_covers_profile_topics_handlers(self) -> None:
+        handler = _make_handler("handle_x")
+        manifest_a = _base_manifest(
+            runtime_profile="profile-a",
+            handlers=(handler,),
+            owned_command_topics=frozenset({"onex.cmd.x.v1"}),
+        )
+        manifest_b = _base_manifest(
+            runtime_profile="profile-b",
+            handlers=(handler,),
+            owned_command_topics=frozenset({"onex.cmd.x.v1"}),
+        )
+
+        assert manifest_a.topology_hash != manifest_b.topology_hash
+
+    def test_frozen(self) -> None:
+        manifest = _base_manifest()
+        with pytest.raises(Exception):
+            manifest.runtime_profile = "mutated"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `src/omnibase_core/models/runtime_manifest/` package with four frozen Pydantic models: `ModelManifestContract`, `ModelManifestHandler`, `ModelOwnershipViolation`, `ModelRuntimeManifest`
- `ModelRuntimeManifest` carries ownership semantics via `owned_command_topics` / `subscribed_event_topics` / `ownership_violations`, plus deterministic `contract_hash` and `topology_hash` computed fields (SHA-256, order-stable via sorted inputs)
- Ships four unit tests covering creation with ownership data, hash determinism regardless of contract insertion order, topology hash sensitivity to runtime profile, and immutability enforcement

## Ticket

OMN-11190

## Test plan

- [x] `uv run pytest tests/unit/models/runtime_manifest/ -v` — 4/4 passed
- [x] `uv run mypy src/omnibase_core/models/runtime_manifest/ --strict` — 0 errors
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] `pre-commit run --files <staged>` — all hooks passed

Evidence-Source: OCC#1119
Evidence-Ticket: OMN-11190
