### PR TITLE
feat(OMN-11191): add standard evidence bundle models

### DIFF
--- a/src/omnibase_core/models/evidence_bundle/__init__.py
+++ b/src/omnibase_core/models/evidence_bundle/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Standard evidence bundle models for ONEX workflow proof artifacts."""
+
+from omnibase_core.models.evidence_bundle.model_artifact_entry import (
+    ModelArtifactEntry,
+)
+from omnibase_core.models.evidence_bundle.model_artifact_manifest import (
+    ModelArtifactManifest,
+)
+from omnibase_core.models.evidence_bundle.model_contract_snapshot import (
+    ModelContractSnapshot,
+)
+from omnibase_core.models.evidence_bundle.model_evidence_verifier_result import (
+    ModelEvidenceVerifierResult,
+)
+from omnibase_core.models.evidence_bundle.model_standard_evidence_bundle import (
+    ModelStandardEvidenceBundle,
+)
+from omnibase_core.models.evidence_bundle.model_standard_run_manifest import (
+    ModelStandardRunManifest,
+)
+
+__all__ = [
+    "ModelArtifactEntry",
+    "ModelArtifactManifest",
+    "ModelContractSnapshot",
+    "ModelEvidenceVerifierResult",
+    "ModelStandardEvidenceBundle",
+    "ModelStandardRunManifest",
+]

--- a/src/omnibase_core/models/evidence_bundle/model_artifact_entry.py
+++ b/src/omnibase_core/models/evidence_bundle/model_artifact_entry.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelArtifactEntry — single artifact record within a bundle manifest."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelArtifactEntry(BaseModel):
+    """Single artifact record within a bundle manifest."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    filename: str
+    sha256: str
+    write_order: int
+
+
+__all__ = ["ModelArtifactEntry"]

--- a/src/omnibase_core/models/evidence_bundle/model_artifact_manifest.py
+++ b/src/omnibase_core/models/evidence_bundle/model_artifact_manifest.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelArtifactManifest — records all artifacts written during an evidence bundle run."""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from omnibase_core.models.evidence_bundle.model_artifact_entry import ModelArtifactEntry
+
+
+class ModelArtifactManifest(BaseModel):
+    """Manifest of all artifacts produced during an evidence bundle run.
+
+    ``bundle_hash`` is a SHA-256 digest computed over the sorted artifact
+    hashes, providing a single fingerprint for the entire artifact set.
+    Sorting by hash (not by write_order) ensures the digest is stable
+    regardless of insertion ordering.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str
+    artifacts: tuple[ModelArtifactEntry, ...]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def bundle_hash(self) -> str:
+        sorted_hashes = sorted(a.sha256 for a in self.artifacts)
+        combined = "".join(sorted_hashes).encode()
+        return hashlib.sha256(combined).hexdigest()
+
+
+__all__ = ["ModelArtifactManifest"]

--- a/src/omnibase_core/models/evidence_bundle/model_contract_snapshot.py
+++ b/src/omnibase_core/models/evidence_bundle/model_contract_snapshot.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContractSnapshot — point-in-time snapshot of contracts used in a run."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelContractSnapshot(BaseModel):
+    """Snapshot of contracts that were active during an evidence bundle run.
+
+    Each entry in ``contracts`` is a dict containing at minimum ``name`` and
+    ``hash`` fields, providing an auditable record of which contract versions
+    were in effect when the bundle was produced.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str
+    contracts: tuple[dict[str, object], ...]
+
+
+__all__ = ["ModelContractSnapshot"]

--- a/src/omnibase_core/models/evidence_bundle/model_evidence_verifier_result.py
+++ b/src/omnibase_core/models/evidence_bundle/model_evidence_verifier_result.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelEvidenceVerifierResult — outcome of an evidence bundle verification run."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+
+
+class ModelEvidenceVerifierResult(BaseModel):
+    """Result produced by a verifier that checked an evidence bundle.
+
+    ``checks`` is an ordered tuple of dicts — each dict records an individual
+    check performed by the verifier (e.g. artifact presence, hash match,
+    contract compliance). The ``verifier`` field names the agent or system
+    that ran the checks.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str
+    status: EnumReceiptStatus
+    verifier: str
+    checks: tuple[dict[str, object], ...]
+
+
+__all__ = ["ModelEvidenceVerifierResult"]

--- a/src/omnibase_core/models/evidence_bundle/model_standard_evidence_bundle.py
+++ b/src/omnibase_core/models/evidence_bundle/model_standard_evidence_bundle.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelStandardEvidenceBundle — canonical 7-file evidence bundle."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from omnibase_core.models.evidence_bundle.model_artifact_manifest import (
+    ModelArtifactManifest,
+)
+from omnibase_core.models.evidence_bundle.model_contract_snapshot import (
+    ModelContractSnapshot,
+)
+from omnibase_core.models.evidence_bundle.model_evidence_verifier_result import (
+    ModelEvidenceVerifierResult,
+)
+from omnibase_core.models.evidence_bundle.model_standard_run_manifest import (
+    ModelStandardRunManifest,
+)
+
+# Maps canonical artifact filenames to ModelStandardEvidenceBundle field names.
+# Used by is_complete to check presence without inspecting file contents.
+_ARTIFACT_TO_FIELD: dict[str, str] = {
+    "run_manifest.json": "run_manifest",
+    "contract_snapshot.json": "contract_snapshot",
+    "input.json": "input_data",
+    "output.json": "output_data",
+    "verifier_result.json": "verifier_result",
+    "artifact_manifest.json": "artifact_manifest",
+}
+
+
+class ModelStandardEvidenceBundle(BaseModel):
+    """Complete evidence bundle for a single ONEX workflow run.
+
+    ``is_complete`` is True only when every filename declared in
+    ``run_manifest.expected_artifacts`` maps to a non-None field on this model.
+    Filenames not in ``_ARTIFACT_TO_FIELD`` (e.g., ``proof_summary.md``) are
+    considered present by default since they are not represented as typed fields.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str
+    run_manifest: ModelStandardRunManifest
+    artifact_manifest: ModelArtifactManifest | None = None
+    contract_snapshot: ModelContractSnapshot | None = None
+    verifier_result: ModelEvidenceVerifierResult | None = None
+    input_data: dict[str, object] | None = None
+    output_data: dict[str, object] | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_complete(self) -> bool:
+        for artifact in self.run_manifest.expected_artifacts:
+            field_name = _ARTIFACT_TO_FIELD.get(artifact)
+            if field_name is not None and getattr(self, field_name) is None:
+                return False
+        return True
+
+
+__all__ = ["ModelStandardEvidenceBundle"]

--- a/src/omnibase_core/models/evidence_bundle/model_standard_run_manifest.py
+++ b/src/omnibase_core/models/evidence_bundle/model_standard_run_manifest.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelStandardRunManifest — declares what an evidence bundle run covers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelStandardRunManifest(BaseModel):
+    """Top-level manifest for a single evidence bundle run.
+
+    Declares correlation identity, runner, timing, and which artifact files
+    are expected. Consumers use ``expected_artifacts`` to verify all canonical
+    files are present before treating a bundle as complete.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: str
+    runner: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    expected_artifacts: tuple[str, ...] = ()
+    ticket_id: str | None = None
+
+
+__all__ = ["ModelStandardRunManifest"]

--- a/tests/unit/models/evidence_bundle/__init__.py
+++ b/tests/unit/models/evidence_bundle/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/evidence_bundle/test_standard_evidence_bundle.py
+++ b/tests/unit/models/evidence_bundle/test_standard_evidence_bundle.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for standard evidence bundle models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.evidence_bundle.model_artifact_entry import (
+    ModelArtifactEntry,
+)
+from omnibase_core.models.evidence_bundle.model_artifact_manifest import (
+    ModelArtifactManifest,
+)
+from omnibase_core.models.evidence_bundle.model_contract_snapshot import (
+    ModelContractSnapshot,
+)
+from omnibase_core.models.evidence_bundle.model_evidence_verifier_result import (
+    ModelEvidenceVerifierResult,
+)
+from omnibase_core.models.evidence_bundle.model_standard_evidence_bundle import (
+    ModelStandardEvidenceBundle,
+)
+from omnibase_core.models.evidence_bundle.model_standard_run_manifest import (
+    ModelStandardRunManifest,
+)
+
+_NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+_CID = "test-correlation-id-001"
+
+_CANONICAL_ARTIFACTS = (
+    "run_manifest.json",
+    "contract_snapshot.json",
+    "input.json",
+    "output.json",
+    "verifier_result.json",
+    "artifact_manifest.json",
+    "proof_summary.md",
+)
+
+
+def _make_run_manifest(
+    expected: tuple[str, ...] = _CANONICAL_ARTIFACTS,
+) -> ModelStandardRunManifest:
+    return ModelStandardRunManifest(
+        correlation_id=_CID,
+        runner="test-runner",
+        started_at=_NOW,
+        expected_artifacts=expected,
+    )
+
+
+def _make_contract_snapshot() -> ModelContractSnapshot:
+    return ModelContractSnapshot(
+        correlation_id=_CID,
+        contracts=({"name": "contract_a", "hash": "abc123"},),
+    )
+
+
+def _make_verifier_result() -> ModelEvidenceVerifierResult:
+    return ModelEvidenceVerifierResult(
+        correlation_id=_CID,
+        status=EnumReceiptStatus.PASS,
+        verifier="ci-verifier",
+        checks=({"check": "artifact_present", "result": "pass"},),
+    )
+
+
+def _make_artifact_entry(filename: str, order: int) -> ModelArtifactEntry:
+    return ModelArtifactEntry(
+        filename=filename,
+        sha256="a" * 64,
+        write_order=order,
+    )
+
+
+def _make_artifact_manifest() -> ModelArtifactManifest:
+    return ModelArtifactManifest(
+        correlation_id=_CID,
+        artifacts=(
+            _make_artifact_entry("run_manifest.json", 0),
+            _make_artifact_entry("output.json", 1),
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_run_manifest_declares_expected_artifacts() -> None:
+    manifest = _make_run_manifest()
+    assert manifest.expected_artifacts == _CANONICAL_ARTIFACTS
+    assert manifest.correlation_id == _CID
+    assert manifest.runner == "test-runner"
+    assert manifest.ticket_id is None
+
+
+@pytest.mark.unit
+def test_artifact_manifest_records_write_order_and_hashes() -> None:
+    entry_a = ModelArtifactEntry(
+        filename="run_manifest.json", sha256="b" * 64, write_order=0
+    )
+    entry_b = ModelArtifactEntry(filename="output.json", sha256="c" * 64, write_order=1)
+    manifest = ModelArtifactManifest(
+        correlation_id=_CID,
+        artifacts=(entry_a, entry_b),
+    )
+    assert manifest.artifacts[0].write_order == 0
+    assert manifest.artifacts[1].write_order == 1
+    assert manifest.artifacts[0].sha256 == "b" * 64
+    assert manifest.artifacts[1].sha256 == "c" * 64
+    # bundle_hash is deterministic and based on sorted artifact hashes
+    assert len(manifest.bundle_hash) == 64
+    # Reversing insertion order must produce the same bundle_hash (sort-stable)
+    manifest_reversed = ModelArtifactManifest(
+        correlation_id=_CID,
+        artifacts=(entry_b, entry_a),
+    )
+    assert manifest.bundle_hash == manifest_reversed.bundle_hash
+
+
+@pytest.mark.unit
+def test_bundle_complete_when_all_declared_present() -> None:
+    run_manifest = _make_run_manifest(
+        expected=(
+            "run_manifest.json",
+            "contract_snapshot.json",
+            "input.json",
+            "output.json",
+            "verifier_result.json",
+            "artifact_manifest.json",
+            "proof_summary.md",
+        )
+    )
+    bundle = ModelStandardEvidenceBundle(
+        correlation_id=_CID,
+        run_manifest=run_manifest,
+        artifact_manifest=_make_artifact_manifest(),
+        contract_snapshot=_make_contract_snapshot(),
+        verifier_result=_make_verifier_result(),
+        input_data={"key": "value"},
+        output_data={"result": "ok"},
+    )
+    assert bundle.is_complete is True
+
+
+@pytest.mark.unit
+def test_bundle_incomplete_when_declared_artifact_missing() -> None:
+    run_manifest = _make_run_manifest(
+        expected=(
+            "run_manifest.json",
+            "contract_snapshot.json",
+            "verifier_result.json",
+        )
+    )
+    # contract_snapshot is declared but not provided
+    bundle = ModelStandardEvidenceBundle(
+        correlation_id=_CID,
+        run_manifest=run_manifest,
+        verifier_result=_make_verifier_result(),
+        # contract_snapshot intentionally omitted
+    )
+    assert bundle.is_complete is False


### PR DESCRIPTION
## Summary

- Adds `omnibase_core.models.evidence_bundle` package with 6 canonical frozen models: `ModelStandardRunManifest`, `ModelContractSnapshot`, `ModelEvidenceVerifierResult`, `ModelArtifactEntry`, `ModelArtifactManifest`, `ModelStandardEvidenceBundle`
- `ModelArtifactManifest.bundle_hash` computed field provides a stable SHA-256 fingerprint over sorted artifact hashes
- `ModelStandardEvidenceBundle.is_complete` computed field validates all declared `expected_artifacts` map to non-None fields
- All models: `frozen=True, extra="forbid", from_attributes=True`, SPDX headers, `dict[str, object]` typed fields, mypy --strict clean

## Test plan

- [x] `uv run pytest tests/unit/models/evidence_bundle/ -v` — 4 tests pass
- [x] `uv run mypy src/omnibase_core/models/evidence_bundle/ --strict` — 0 errors
- [x] `uv run ruff format && ruff check` — clean
- [x] `pre-commit run --files <new-files>` — all hooks pass

Ticket: OMN-11191
Epic: OMN-11188

Evidence-Source: OCC#1119
Evidence-Ticket: OMN-11191
