### PR TITLE
feat(OMN-11193): add ModelDoctrineClause, ModelGatewayRouteBinding, projection health events

### DIFF
--- a/src/omnibase_core/models/events/model_projection_degraded_event.py
+++ b/src/omnibase_core/models/events/model_projection_degraded_event.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelProjectionDegradedEvent — projection SLA breach event model — OMN-11193."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ModelProjectionDegradedEvent"]
+
+
+class ModelProjectionDegradedEvent(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_name: str
+    sla_seconds: int
+    actual_staleness_seconds: float
+    degraded_behavior: str
+    observed_at: datetime
+    source_contract_hash: str

--- a/src/omnibase_core/models/events/model_projection_recovered_event.py
+++ b/src/omnibase_core/models/events/model_projection_recovered_event.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelProjectionRecoveredEvent — projection SLA recovery event model — OMN-11193."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ModelProjectionRecoveredEvent"]
+
+
+class ModelProjectionRecoveredEvent(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_name: str
+    recovered_at: datetime
+    recovery_staleness_seconds: float
+    source_contract_hash: str

--- a/src/omnibase_core/models/gateway/__init__.py
+++ b/src/omnibase_core/models/gateway/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/models/gateway/model_gateway_route_binding.py
+++ b/src/omnibase_core/models/gateway/model_gateway_route_binding.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelGatewayRouteBinding — gateway route-to-contract binding model — OMN-11193."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelGatewayRouteBinding"]
+
+
+class ModelGatewayRouteBinding(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
+    path_pattern: str = Field(..., min_length=1)
+    contract_id: str = Field(
+        ...,
+        min_length=1,
+        description="Must resolve to a registered wire schema or command contract. NOT merely a topic string.",
+    )

--- a/src/omnibase_core/models/governance/model_doctrine_clause.py
+++ b/src/omnibase_core/models/governance/model_doctrine_clause.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDoctrineClause — deterministic truth doctrine clause model — OMN-11193."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelDoctrineClause"]
+
+
+class ModelDoctrineClause(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # string-id-ok: domain-specific human-readable code (DT-NNN), not an internal UUID
+    clause_id: str = Field(..., pattern=r"^DT-\d{3}$")
+    title: str = Field(..., min_length=1)
+    check: str = Field(..., min_length=1)
+    ci_gate: str = Field(..., min_length=1)
+    adr: str | None = None
+    coverage: str = Field(default="uncovered")

--- a/tests/unit/models/events/test_projection_health_events.py
+++ b/tests/unit/models/events/test_projection_health_events.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelProjectionDegradedEvent and ModelProjectionRecoveredEvent — OMN-11193."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+
+@pytest.mark.unit
+def test_model_projection_degraded_event_create() -> None:
+    from omnibase_core.models.events.model_projection_degraded_event import (
+        ModelProjectionDegradedEvent,
+    )
+
+    now = datetime.now(UTC)
+    event = ModelProjectionDegradedEvent(
+        projection_name="dashboard_metrics",
+        sla_seconds=60,
+        actual_staleness_seconds=90.5,
+        degraded_behavior="serve_stale_with_warning",
+        observed_at=now,
+        source_contract_hash="abc123def456",
+    )
+    assert event.projection_name == "dashboard_metrics"
+    assert event.sla_seconds == 60
+    assert event.actual_staleness_seconds == 90.5
+    assert event.degraded_behavior == "serve_stale_with_warning"
+    assert event.observed_at == now
+    assert event.source_contract_hash == "abc123def456"
+
+
+@pytest.mark.unit
+def test_model_projection_degraded_event_frozen() -> None:
+    from omnibase_core.models.events.model_projection_degraded_event import (
+        ModelProjectionDegradedEvent,
+    )
+
+    event = ModelProjectionDegradedEvent(
+        projection_name="node_registry",
+        sla_seconds=30,
+        actual_staleness_seconds=45.0,
+        degraded_behavior="block_reads",
+        observed_at=datetime.now(UTC),
+        source_contract_hash="deadbeef",
+    )
+    with pytest.raises(Exception):
+        event.projection_name = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_model_projection_recovered_event_create() -> None:
+    from omnibase_core.models.events.model_projection_recovered_event import (
+        ModelProjectionRecoveredEvent,
+    )
+
+    now = datetime.now(UTC)
+    event = ModelProjectionRecoveredEvent(
+        projection_name="dashboard_metrics",
+        recovered_at=now,
+        recovery_staleness_seconds=5.2,
+        source_contract_hash="abc123def456",
+    )
+    assert event.projection_name == "dashboard_metrics"
+    assert event.recovered_at == now
+    assert event.recovery_staleness_seconds == 5.2
+    assert event.source_contract_hash == "abc123def456"
+
+
+@pytest.mark.unit
+def test_model_projection_recovered_event_frozen() -> None:
+    from omnibase_core.models.events.model_projection_recovered_event import (
+        ModelProjectionRecoveredEvent,
+    )
+
+    event = ModelProjectionRecoveredEvent(
+        projection_name="node_registry",
+        recovered_at=datetime.now(UTC),
+        recovery_staleness_seconds=1.0,
+        source_contract_hash="cafebabe",
+    )
+    with pytest.raises(Exception):
+        event.projection_name = "other"  # type: ignore[misc]

--- a/tests/unit/models/events/test_projection_health_events.py
+++ b/tests/unit/models/events/test_projection_health_events.py
@@ -21,14 +21,14 @@ def test_model_projection_degraded_event_create() -> None:
         actual_staleness_seconds=90.5,
         degraded_behavior="serve_stale_with_warning",
         observed_at=now,
-        source_contract_hash="abc123def456",
+        source_contract_hash="abc123def456",  # pragma: allowlist secret
     )
     assert event.projection_name == "dashboard_metrics"
     assert event.sla_seconds == 60
-    assert event.actual_staleness_seconds == 90.5
+    assert event.actual_staleness_seconds == pytest.approx(90.5)
     assert event.degraded_behavior == "serve_stale_with_warning"
     assert event.observed_at == now
-    assert event.source_contract_hash == "abc123def456"
+    assert event.source_contract_hash == "abc123def456"  # pragma: allowlist secret
 
 
 @pytest.mark.unit
@@ -60,12 +60,12 @@ def test_model_projection_recovered_event_create() -> None:
         projection_name="dashboard_metrics",
         recovered_at=now,
         recovery_staleness_seconds=5.2,
-        source_contract_hash="abc123def456",
+        source_contract_hash="abc123def456",  # pragma: allowlist secret
     )
     assert event.projection_name == "dashboard_metrics"
     assert event.recovered_at == now
-    assert event.recovery_staleness_seconds == 5.2
-    assert event.source_contract_hash == "abc123def456"
+    assert event.recovery_staleness_seconds == pytest.approx(5.2)
+    assert event.source_contract_hash == "abc123def456"  # pragma: allowlist secret
 
 
 @pytest.mark.unit

--- a/tests/unit/models/gateway/__init__.py
+++ b/tests/unit/models/gateway/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/gateway/test_model_gateway_route_binding.py
+++ b/tests/unit/models/gateway/test_model_gateway_route_binding.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelGatewayRouteBinding — OMN-11193."""
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.mark.unit
+def test_model_gateway_route_binding_create() -> None:
+    from omnibase_core.models.gateway.model_gateway_route_binding import (
+        ModelGatewayRouteBinding,
+    )
+
+    binding = ModelGatewayRouteBinding(
+        method="POST",
+        path_pattern="/api/v1/commands/run",
+        contract_id="node_run_command.v1",
+    )
+    assert binding.method == "POST"
+    assert binding.path_pattern == "/api/v1/commands/run"
+    assert binding.contract_id == "node_run_command.v1"
+
+
+@pytest.mark.unit
+def test_model_gateway_route_binding_all_methods() -> None:
+    from omnibase_core.models.gateway.model_gateway_route_binding import (
+        ModelGatewayRouteBinding,
+    )
+
+    for method in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+        binding = ModelGatewayRouteBinding(
+            method=method,  # type: ignore[arg-type]
+            path_pattern="/api/v1/resource",
+            contract_id="some.contract.v1",
+        )
+        assert binding.method == method
+
+
+@pytest.mark.unit
+def test_model_gateway_route_binding_invalid_method() -> None:
+    from omnibase_core.models.gateway.model_gateway_route_binding import (
+        ModelGatewayRouteBinding,
+    )
+
+    with pytest.raises(ValidationError):
+        ModelGatewayRouteBinding(
+            method="OPTIONS",  # type: ignore[arg-type]
+            path_pattern="/api/v1/resource",
+            contract_id="some.contract.v1",
+        )
+
+
+@pytest.mark.unit
+def test_model_gateway_route_binding_frozen() -> None:
+    from omnibase_core.models.gateway.model_gateway_route_binding import (
+        ModelGatewayRouteBinding,
+    )
+
+    binding = ModelGatewayRouteBinding(
+        method="GET",
+        path_pattern="/api/v1/status",
+        contract_id="node_status.v1",
+    )
+    with pytest.raises(Exception):
+        binding.method = "POST"  # type: ignore[misc]

--- a/tests/unit/models/gateway/test_model_gateway_route_binding.py
+++ b/tests/unit/models/gateway/test_model_gateway_route_binding.py
@@ -31,7 +31,7 @@ def test_model_gateway_route_binding_all_methods() -> None:
 
     for method in ("GET", "POST", "PUT", "DELETE", "PATCH"):
         binding = ModelGatewayRouteBinding(
-            method=method,  # type: ignore[arg-type]
+            method=method,  # type: ignore[arg-type]  # NOTE(OMN-11193): parametric loop over valid Literal values; Pydantic accepts the runtime strings but mypy cannot narrow.
             path_pattern="/api/v1/resource",
             contract_id="some.contract.v1",
         )
@@ -46,7 +46,7 @@ def test_model_gateway_route_binding_invalid_method() -> None:
 
     with pytest.raises(ValidationError):
         ModelGatewayRouteBinding(
-            method="OPTIONS",  # type: ignore[arg-type]
+            method="OPTIONS",  # type: ignore[arg-type]  # NOTE(OMN-11193): intentional invalid Literal value to verify ValidationError is raised.
             path_pattern="/api/v1/resource",
             contract_id="some.contract.v1",
         )
@@ -64,4 +64,4 @@ def test_model_gateway_route_binding_frozen() -> None:
         contract_id="node_status.v1",
     )
     with pytest.raises(Exception):
-        binding.method = "POST"  # type: ignore[misc]
+        binding.method = "POST"  # type: ignore[misc]  # NOTE(OMN-11193): intentional forbidden assignment to verify frozen model rejects mutation.

--- a/tests/unit/models/governance/test_model_doctrine_clause.py
+++ b/tests/unit/models/governance/test_model_doctrine_clause.py
@@ -86,4 +86,4 @@ def test_model_doctrine_clause_frozen() -> None:
         ci_gate="immutability-check",
     )
     with pytest.raises(Exception):
-        clause.title = "Changed"  # type: ignore[misc]
+        clause.title = "Changed"  # type: ignore[misc]  # NOTE(OMN-11193): intentional forbidden assignment to verify frozen model rejects mutation.

--- a/tests/unit/models/governance/test_model_doctrine_clause.py
+++ b/tests/unit/models/governance/test_model_doctrine_clause.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelDoctrineClause — OMN-11193."""
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.mark.unit
+def test_model_doctrine_clause_create() -> None:
+    from omnibase_core.models.governance.model_doctrine_clause import (
+        ModelDoctrineClause,
+    )
+
+    clause = ModelDoctrineClause(
+        clause_id="DT-001",
+        title="Replay Determinism",
+        check="All projections must replay deterministically",
+        ci_gate="replay-determinism-check",
+    )
+    assert clause.clause_id == "DT-001"
+    assert clause.title == "Replay Determinism"
+    assert clause.adr is None
+    assert clause.coverage == "uncovered"
+
+
+@pytest.mark.unit
+def test_model_doctrine_clause_with_adr() -> None:
+    from omnibase_core.models.governance.model_doctrine_clause import (
+        ModelDoctrineClause,
+    )
+
+    clause = ModelDoctrineClause(
+        clause_id="DT-042",
+        title="Event Ordering",
+        check="Events must be ordered by sequence number",
+        ci_gate="event-ordering-check",
+        adr="docs/adrs/ADR-0012.md",
+        coverage="covered",
+    )
+    assert clause.adr == "docs/adrs/ADR-0012.md"
+    assert clause.coverage == "covered"
+
+
+@pytest.mark.unit
+def test_model_doctrine_clause_invalid_clause_id() -> None:
+    from omnibase_core.models.governance.model_doctrine_clause import (
+        ModelDoctrineClause,
+    )
+
+    with pytest.raises(ValidationError):
+        ModelDoctrineClause(
+            clause_id="INVALID",
+            title="Bad ID",
+            check="some check",
+            ci_gate="some-gate",
+        )
+
+
+@pytest.mark.unit
+def test_model_doctrine_clause_invalid_clause_id_short() -> None:
+    from omnibase_core.models.governance.model_doctrine_clause import (
+        ModelDoctrineClause,
+    )
+
+    with pytest.raises(ValidationError):
+        ModelDoctrineClause(
+            clause_id="DT-1",
+            title="Too short",
+            check="some check",
+            ci_gate="some-gate",
+        )
+
+
+@pytest.mark.unit
+def test_model_doctrine_clause_frozen() -> None:
+    from omnibase_core.models.governance.model_doctrine_clause import (
+        ModelDoctrineClause,
+    )
+
+    clause = ModelDoctrineClause(
+        clause_id="DT-099",
+        title="Immutable",
+        check="Must not mutate",
+        ci_gate="immutability-check",
+    )
+    with pytest.raises(Exception):
+        clause.title = "Changed"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements OMN-11193 (Task 5 of epic OMN-11188): four new frozen Pydantic models in omnibase_core.

- `ModelDoctrineClause` (`models/governance/`): deterministic truth doctrine clause with `clause_id` (DT-NNN pattern), `title`, `check`, `ci_gate`, `adr`, `coverage`
- `ModelGatewayRouteBinding` (`models/gateway/`): HTTP route-to-contract binding with `method` (Literal), `path_pattern`, `contract_id`
- `ModelProjectionDegradedEvent` (`models/events/`): projection SLA breach event
- `ModelProjectionRecoveredEvent` (`models/events/`): projection SLA recovery event

All models: `frozen=True, extra="forbid", from_attributes=True`.

## Test plan

- [x] 13 unit tests covering creation, field validation, and immutability for all four models
- [x] `uv run pytest` — 13/13 passed
- [x] `mypy --strict` — no errors
- [x] `ruff format && ruff check` — clean
- [x] `pre-commit run --all-files` — all hooks passed (pre-existing failures in unrelated files only)
- [x] CI push hooks (mypy strict + pyright) passed on push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added projection SLA health events to signal degraded and recovered projection states.
  * Added gateway route binding model to declare API route → contract mappings.
  * Added governance doctrine clause model for tracking compliance clauses and coverage.

* **Tests**
  * Added unit tests covering creation, validation, allowed values, defaults, and immutability for all new models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1119
Evidence-Ticket: OMN-11193
