### PR TITLE
feat(OMN-11221): add architectural invariant enforcement models and enums

### DIFF
--- a/src/omnibase_core/enums/enum_enforcement_surface.py
+++ b/src/omnibase_core/enums/enum_enforcement_surface.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Enforcement surface enumeration for architectural invariant contracts."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumEnforcementSurface(StrValueHelper, str, Enum):
+    """Surfaces where an architectural invariant is enforced."""
+
+    STATIC_ARCHITECTURE = "static_architecture"
+    """AST/static analysis at commit time (pre-commit hooks, CI validators)."""
+
+    CI_GATE = "ci_gate"
+    """Required CI status check that blocks merge on violation."""
+
+    PRE_TOOL_USE = "pre_tool_use"
+    """Claude Code PreToolUse hook — developer ergonomics, not authoritative."""
+
+    RUNTIME_VALIDATION = "runtime_validation"
+    """Runtime guard enforced by the ONEX runtime before handler execution."""
+
+    CONTRACT_VALIDATION = "contract_validation"
+    """Contract YAML schema / cross-repo drift validation."""
+
+
+__all__ = ["EnumEnforcementSurface"]

--- a/src/omnibase_core/enums/enum_violation_category.py
+++ b/src/omnibase_core/enums/enum_violation_category.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Violation category enumeration for architectural invariant contracts."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class EnumViolationCategory(StrValueHelper, str, Enum):
+    """Category of an architectural invariant violation."""
+
+    STATIC_ARCHITECTURE = "static_architecture"
+    """Repo layering, import direction, or dependency graph violation."""
+
+    RUNTIME_TOPOLOGY = "runtime_topology"
+    """Node kind constraints, handler output purity, or execution shape violation."""
+
+    CONTRACT_VIOLATION = "contract_violation"
+    """Hardcoded topic strings, missing contract.yaml declarations, or schema drift."""
+
+    PROJECTION_AUTHORITY = "projection_authority"
+    """Client rendering truth rather than consuming authoritative projections."""
+
+    RECEIPT_GOVERNANCE = "receipt_governance"
+    """Missing dod_evidence, self-signed receipt, or missing verifier provenance."""
+
+
+__all__ = ["EnumViolationCategory"]

--- a/src/omnibase_core/models/invariant/__init__.py
+++ b/src/omnibase_core/models/invariant/__init__.py
@@ -68,6 +68,7 @@ from .model_invariant_result import ModelInvariantResult
 from .model_invariant_set import ModelInvariantSet
 from .model_invariant_violation_detail import ModelInvariantViolationDetail
 from .model_invariant_violation_report import ModelInvariantViolationReport
+from .model_invariant_waiver import ModelInvariantWaiver
 from .model_latency_config import ModelLatencyConfig
 from .model_schema_invariant_config import ModelSchemaInvariantConfig
 from .model_threshold_config import ModelThresholdConfig
@@ -81,6 +82,7 @@ __all__ = [
     "ModelInvariantViolationDetail",
     "ModelInvariantViolationReport",
     "ModelEvaluationSummary",
+    "ModelInvariantWaiver",
     # Config models
     "ModelSchemaInvariantConfig",
     "ModelFieldPresenceConfig",

--- a/src/omnibase_core/models/invariant/model_invariant.py
+++ b/src/omnibase_core/models/invariant/model_invariant.py
@@ -13,12 +13,14 @@ Thread Safety:
     making it thread-safe for concurrent read access.
 """
 
+from datetime import datetime
 from typing import Self
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums import EnumSeverity
+from omnibase_core.enums.enum_enforcement_surface import EnumEnforcementSurface
 from omnibase_core.enums.enum_invariant_type import EnumInvariantType
 
 # Required config keys for each invariant type
@@ -116,6 +118,34 @@ class ModelInvariant(BaseModel):
     description: str | None = Field(
         default=None,
         description="Optional detailed description of the invariant",
+    )
+    enforcement_surfaces: list[EnumEnforcementSurface] = Field(
+        default_factory=list,
+        description="Surfaces where this invariant is enforced",
+    )
+    violation_examples: list[str] = Field(
+        default_factory=list,
+        description="Representative code or config snippets that violate this invariant",
+    )
+    runtime_scope: str | None = Field(
+        default=None,
+        description="Runtime scope identifier (e.g. 'node', 'handler', 'contract')",
+    )
+    generated_from_principle: str | None = Field(
+        default=None,
+        description="Principle ID this invariant was generated from (e.g. 'ARCH-001')",
+    )
+    generated_at: datetime | None = Field(
+        default=None,
+        description="Timestamp when this invariant was generated",
+    )
+    source_incidents: list[str] = Field(
+        default_factory=list,
+        description="Linear ticket IDs or incident references that motivated this invariant",
+    )
+    generator_tag: str | None = Field(
+        default=None,
+        description="Tag or label of the generator that produced this invariant contract",
     )
 
     @model_validator(mode="after")

--- a/src/omnibase_core/models/invariant/model_invariant_waiver.py
+++ b/src/omnibase_core/models/invariant/model_invariant_waiver.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Waiver model for approved exceptions to architectural invariants."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelInvariantWaiver(BaseModel):
+    """An approved, time-bounded exception to an architectural invariant.
+
+    Waivers must have a reviewer and an expiry date. They are not self-issued —
+    the approved_exception_id must be a user-issued approval handle.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    approved_exception_receipt: str = Field(
+        ...,
+        description="User-issued approval receipt handle (not a self-written justification)",
+        min_length=1,
+    )
+    principle_code: str = Field(
+        ...,
+        description="Invariant principle code this waiver applies to (e.g. ARCH-001)",
+        min_length=1,
+    )
+    expires_at: datetime = Field(
+        ...,
+        description="Timezone-aware datetime after which this waiver is no longer valid",
+    )
+    reviewer: str = Field(
+        ...,
+        description="Identity of the human reviewer who approved the exception",
+        min_length=1,
+    )
+    justification: str = Field(
+        ...,
+        description="Brief rationale for the exception",
+        min_length=1,
+    )
+
+
+__all__ = ["ModelInvariantWaiver"]

--- a/tests/unit/models/invariant/test_arch_invariant_extensions.py
+++ b/tests/unit/models/invariant/test_arch_invariant_extensions.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for OMN-11221 architectural invariant extensions."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_enforcement_surface import EnumEnforcementSurface
+from omnibase_core.enums.enum_invariant_type import EnumInvariantType
+from omnibase_core.enums.enum_violation_category import EnumViolationCategory
+from omnibase_core.models.invariant import ModelInvariant
+from omnibase_core.models.invariant.model_invariant_waiver import ModelInvariantWaiver
+
+
+@pytest.mark.unit
+class TestEnumEnforcementSurface:
+    def test_all_values_present(self) -> None:
+        values = {s.value for s in EnumEnforcementSurface}
+        assert values == {
+            "static_architecture",
+            "ci_gate",
+            "pre_tool_use",
+            "runtime_validation",
+            "contract_validation",
+        }
+
+    def test_str_returns_value(self) -> None:
+        assert str(EnumEnforcementSurface.CI_GATE) == "ci_gate"
+
+
+@pytest.mark.unit
+class TestEnumViolationCategory:
+    def test_all_values_present(self) -> None:
+        values = {c.value for c in EnumViolationCategory}
+        assert values == {
+            "static_architecture",
+            "runtime_topology",
+            "contract_violation",
+            "projection_authority",
+            "receipt_governance",
+        }
+
+    def test_str_returns_value(self) -> None:
+        assert str(EnumViolationCategory.CONTRACT_VIOLATION) == "contract_violation"
+
+
+@pytest.mark.unit
+class TestModelInvariantExtensions:
+    def _base_invariant(self) -> ModelInvariant:
+        return ModelInvariant(
+            name="test-invariant",
+            type=EnumInvariantType.CUSTOM,
+            config={"callable_path": "my.module.check"},
+        )
+
+    def test_new_fields_have_defaults(self) -> None:
+        inv = self._base_invariant()
+        assert inv.enforcement_surfaces == []
+        assert inv.violation_examples == []
+        assert inv.runtime_scope is None
+        assert inv.generated_from_principle is None
+        assert inv.generated_at is None
+        assert inv.source_incidents == []
+        assert inv.generator_tag is None
+
+    def test_enforcement_surfaces_populated(self) -> None:
+        inv = ModelInvariant(
+            name="test",
+            type=EnumInvariantType.CUSTOM,
+            config={"callable_path": "my.module.check"},
+            enforcement_surfaces=[
+                EnumEnforcementSurface.CI_GATE,
+                EnumEnforcementSurface.STATIC_ARCHITECTURE,
+            ],
+        )
+        assert EnumEnforcementSurface.CI_GATE in inv.enforcement_surfaces
+        assert len(inv.enforcement_surfaces) == 2
+
+    def test_generated_from_principle_set(self) -> None:
+        inv = ModelInvariant(
+            name="test",
+            type=EnumInvariantType.CUSTOM,
+            config={"callable_path": "my.module.check"},
+            generated_from_principle="ARCH-001",
+            generated_at=datetime(2026, 5, 18, tzinfo=UTC),
+            generator_tag="1.0.0",
+        )
+        assert inv.generated_from_principle == "ARCH-001"
+        assert inv.generator_tag == "1.0.0"
+
+    def test_source_incidents_populated(self) -> None:
+        inv = ModelInvariant(
+            name="test",
+            type=EnumInvariantType.CUSTOM,
+            config={"callable_path": "my.module.check"},
+            source_incidents=["OMN-6925", "OMN-7093"],
+        )
+        assert "OMN-6925" in inv.source_incidents
+
+    def test_frozen_model_immutable(self) -> None:
+        inv = self._base_invariant()
+        with pytest.raises((ValidationError, TypeError)):
+            inv.runtime_scope = "node"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestModelInvariantWaiver:
+    def _valid_waiver(self) -> ModelInvariantWaiver:
+        return ModelInvariantWaiver(
+            approved_exception_receipt="approval-2026-001",
+            principle_code="ARCH-001",
+            expires_at=datetime(2026, 12, 31, tzinfo=UTC),
+            reviewer="jonah@omninode.ai",
+            justification="Legacy migration window — tracked in OMN-9999",
+        )
+
+    def test_valid_waiver_creation(self) -> None:
+        w = self._valid_waiver()
+        assert w.approved_exception_receipt == "approval-2026-001"
+        assert w.principle_code == "ARCH-001"
+        assert w.reviewer == "jonah@omninode.ai"
+
+    def test_waiver_requires_all_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelInvariantWaiver(  # type: ignore[call-arg]
+                approved_exception_receipt="x",
+                principle_code="ARCH-001",
+                expires_at=datetime(2026, 12, 31, tzinfo=UTC),
+                reviewer="user",
+                # missing justification
+            )
+
+    def test_waiver_frozen(self) -> None:
+        w = self._valid_waiver()
+        with pytest.raises((ValidationError, TypeError)):
+            w.reviewer = "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `EnumEnforcementSurface` (5 values: STATIC_ARCHITECTURE, CI_GATE, PRE_TOOL_USE, RUNTIME_VALIDATION, CONTRACT_VALIDATION)
- Adds `EnumViolationCategory` (5 values: STATIC_ARCHITECTURE, RUNTIME_TOPOLOGY, CONTRACT_VIOLATION, PROJECTION_AUTHORITY, RECEIPT_GOVERNANCE)
- Adds `ModelInvariantWaiver` — typed waiver model with `approved_exception_receipt`, `principle_code`, `expires_at`, `reviewer`, `justification`
- Extends `ModelInvariant` with 7 new optional fields: `enforcement_surfaces`, `violation_examples`, `runtime_scope`, `generated_from_principle`, `generated_at`, `source_incidents`, `generator_tag`
- 12 unit tests, all passing

## Test plan

- [x] `uv run pytest tests/unit/models/invariant/test_arch_invariant_extensions.py -v` — 12 passed
- [x] Pre-commit hooks all passed
- [x] All new fields are optional with defaults so existing code is unaffected

## Closes

Closes OMN-11221

Evidence-Ticket: OMN-11221
Evidence-Source: OCC#1133