### PR TITLE
feat(OMN-11228): register session phase topics in TopicBase

### DIFF
--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -588,6 +588,25 @@ class TopicBase(StrEnum):
     """Emitted when node generation fails at any stage."""
 
     # ==========================================================================
+    # Session phase enforcement topics (OMN-11228)
+    # Produced and consumed by the four session phase enforcement nodes in omnimarket.
+    # ==========================================================================
+    SESSION_PHASE_EVALUATED = "onex.evt.omnimarket.session-phase-evaluated.v1"
+    """Emitted after a session phase evaluation completes with the resulting phase verdict."""
+
+    SESSION_PHASE_TRANSITION = "onex.cmd.omnimarket.session-phase-transition.v1"
+    """Command to trigger a session phase transition (e.g. ACTIVE → HALTED)."""
+
+    SESSION_PHASE_STATE = "onex.evt.omnimarket.session-phase-state.v1"
+    """Emitted to broadcast the current session phase state for downstream consumers."""
+
+    SESSION_PHASE_BUDGET_WARNING = "onex.evt.omnimarket.session-phase-budget-warning.v1"
+    """Emitted when a session approaches its budget threshold during phase evaluation."""
+
+    SESSION_HALT_REQUIRED = "onex.cmd.omnimarket.session-halt-required.v1"
+    """Command to halt a session immediately when enforcement rules require it."""
+
+    # ==========================================================================
     # Platform runtime and projection health topics (OMN-11194)
     # Consumed by omnidash platform health dashboard and runtime monitor.
     # ==========================================================================

--- a/tests/unit/test_session_phase_topics.py
+++ b/tests/unit/test_session_phase_topics.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for session phase Kafka topics in TopicBase (OMN-11228)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from omnibase_core.topics import TopicBase
+
+pytestmark = pytest.mark.unit
+
+
+def test_session_phase_topics_exist() -> None:
+    assert hasattr(TopicBase, "SESSION_PHASE_EVALUATED")
+    assert hasattr(TopicBase, "SESSION_PHASE_TRANSITION")
+    assert hasattr(TopicBase, "SESSION_PHASE_STATE")
+    assert hasattr(TopicBase, "SESSION_PHASE_BUDGET_WARNING")
+    assert hasattr(TopicBase, "SESSION_HALT_REQUIRED")
+
+
+def test_session_phase_topics_values() -> None:
+    assert (
+        TopicBase.SESSION_PHASE_EVALUATED.value
+        == "onex.evt.omnimarket.session-phase-evaluated.v1"
+    )
+    assert (
+        TopicBase.SESSION_PHASE_TRANSITION.value
+        == "onex.cmd.omnimarket.session-phase-transition.v1"
+    )
+    assert (
+        TopicBase.SESSION_PHASE_STATE.value
+        == "onex.evt.omnimarket.session-phase-state.v1"
+    )
+    assert (
+        TopicBase.SESSION_PHASE_BUDGET_WARNING.value
+        == "onex.evt.omnimarket.session-phase-budget-warning.v1"
+    )
+    assert (
+        TopicBase.SESSION_HALT_REQUIRED.value
+        == "onex.cmd.omnimarket.session-halt-required.v1"
+    )
+
+
+def test_session_phase_topic_naming_convention() -> None:
+    pattern = r"^onex\.(cmd|evt)\.omnimarket\.[a-z0-9-]+\.v\d+$"
+    for topic in (
+        TopicBase.SESSION_PHASE_EVALUATED,
+        TopicBase.SESSION_PHASE_TRANSITION,
+        TopicBase.SESSION_PHASE_STATE,
+        TopicBase.SESSION_PHASE_BUDGET_WARNING,
+        TopicBase.SESSION_HALT_REQUIRED,
+    ):
+        assert re.match(pattern, topic.value), (
+            f"Topic {topic.name} does not follow expected format: {topic.value}"
+        )
+
+
+def test_session_phase_transition_and_halt_are_commands() -> None:
+    assert ".cmd." in TopicBase.SESSION_PHASE_TRANSITION.value
+    assert ".cmd." in TopicBase.SESSION_HALT_REQUIRED.value
+
+
+def test_session_phase_evaluated_state_warning_are_events() -> None:
+    assert ".evt." in TopicBase.SESSION_PHASE_EVALUATED.value
+    assert ".evt." in TopicBase.SESSION_PHASE_STATE.value
+    assert ".evt." in TopicBase.SESSION_PHASE_BUDGET_WARNING.value


### PR DESCRIPTION
## Summary

- Registers 5 new session phase topics in `TopicBase` (OMN-11228):
  - `SESSION_PHASE_EVALUATED` — `onex.evt.omnimarket.session-phase-evaluated.v1`
  - `SESSION_PHASE_TRANSITION` — `onex.cmd.omnimarket.session-phase-transition.v1`
  - `SESSION_PHASE_STATE` — `onex.evt.omnimarket.session-phase-state.v1`
  - `SESSION_PHASE_BUDGET_WARNING` — `onex.evt.omnimarket.session-phase-budget-warning.v1`
  - `SESSION_HALT_REQUIRED` — `onex.cmd.omnimarket.session-halt-required.v1`
- All follow `onex.{cmd|evt}.omnimarket.session-phase-*.v1` naming convention
- Topic format validated by existing `test_all_topics_match_onex_format` (roundtrip via `build_topic()`)

## Ticket

OMN-11228 — part of epic OMN-11224

Evidence-Source: OCC#1131
Evidence-Ticket: OMN-11228

## Test plan

- [ ] `tests/unit/test_session_phase_topics.py` — 5 new tests, all passing
- [ ] All existing topic tests (`test_topics.py`, `test_node_generation_topics.py`, etc.) still pass
- [ ] All pre-commit hooks pass on changed files

Closes OMN-11228 (part of epic OMN-11224)