### PR TITLE
fix(OMN-11156,OMN-11157,OMN-11158,OMN-11159,OMN-11160): flip 5 advisory gates to blocking in omnibase_core

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -83,9 +83,8 @@ checks:
   - name: "Node Purity Check"
     workflow_file: ci.yml
     workflow_job_key: node-purity-check
-    reported_by: "Quality Gate"
-    note: "Non-blocking (continue-on-error: true) until tech debt resolved -- reported but excluded from
-      pass/fail"
+    aggregated_by: "Quality Gate"
+    note: "Blocking gate aggregated by Quality Gate"
 
   - name: "Enum Governance Check"
     workflow_file: ci.yml

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -31,9 +31,8 @@ gates:
     workflow_job_key: quality-gate
     rationale: >
       Aggregates all Phase 1 quality checks: lint (ruff + mypy), pyright, exports validation, mypy validation
-      scripts, core-infra boundary (ADR-005), documentation validation, enum governance, detect-secrets.
-      Node purity check is reported by this gate but non-blocking (continue-on-error: true). Replaces
-      6+ individual branch protection checks with a single stable gate.
+      scripts, core-infra boundary (ADR-005), documentation validation, enum governance, detect-secrets,
+      node purity (OMN-11156). Replaces 6+ individual branch protection checks with a single stable gate.
   - check_name: "Tests Gate"
     workflow_file: ci.yml
     workflow_job_key: tests-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -897,7 +897,6 @@ jobs:
           echo "| No Env Fallbacks (OMN-7227) | $no_env_fallbacks |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
-          # node-purity-check is NOT evaluated by this gate (continue-on-error until tech debt resolved)
           if [[ "$lint" == "success" ]] && \
              [[ "$pyright" == "success" ]] && \
              [[ "$exports" == "success" ]] && \
@@ -905,6 +904,7 @@ jobs:
              [[ "$core_infra" == "success" ]] && \
              [[ "$det_skills" == "success" ]] && \
              [[ "$docs" == "success" ]] && \
+             [[ "$purity" == "success" ]] && \
              [[ "$enum_gov" == "success" ]] && \
              [[ "$secrets" == "success" ]] && \
              [[ "$sdk_boundary" == "success" ]] && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,8 +483,7 @@ jobs:
           fi
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
-  # Node Purity Validation (OMN-203) - not blocking test-parallel
-  # Rationale: Currently non-blocking (continue-on-error: true) due to tech debt
+  # Node Purity Validation (OMN-203)
   # Ensures declarative nodes (COMPUTE, REDUCER) maintain purity guarantees
   node-purity-check:
     name: Node Purity Check
@@ -520,10 +519,7 @@ jobs:
         run: |
           # Node Purity Check (OMN-203)
           # Validates declarative nodes (COMPUTE, REDUCER) maintain purity guarantees
-          # TECH DEBT NOTE: Existing 'Any' type violations in node_compute.py and node_reducer.py
-          # are tracked tech debt. Once fixed, remove --continue-on-error and make blocking.
           uv run python scripts/check_node_purity.py --verbose
-        continue-on-error: true  # Non-blocking until tech debt resolved
 
       - name: Node purity check summary
         if: always()
@@ -583,7 +579,7 @@ jobs:
           echo "Validates enum governance with three rules:" >> $GITHUB_STEP_SUMMARY
           echo "- ENUM_001: Enforce UPPER_SNAKE_CASE naming for enum members" >> $GITHUB_STEP_SUMMARY
           echo "- ENUM_002: Detect Literal type aliases that should be enums" >> $GITHUB_STEP_SUMMARY
-          echo "- ENUM_003: Detect duplicate enum values across files (warn-only)" >> $GITHUB_STEP_SUMMARY
+          echo "- ENUM_003: Detect duplicate enum values across files" >> $GITHUB_STEP_SUMMARY
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Contract-config compliance validator (OMN-10688)

--- a/.github/workflows/cross-repo-validation.yml
+++ b/.github/workflows/cross-repo-validation.yml
@@ -46,8 +46,6 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     timeout-minutes: 20
-    # Validation findings are informational — do not block merges
-    continue-on-error: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -24,10 +24,6 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    # Pre-existing violations on main (9 as of activation). Non-blocking until resolved.
-    # See: mixin_event_bus.py, mixin_health_check.py, util_compute_path_resolver.py,
-    #      util_str_enum_base.py, model_github_pr_status_event.py
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -285,18 +285,14 @@ repos:
         stages: [pre-push]  # Moved to pre-push: ~14s full codebase scan
         # Architectural exemptions documented in validate_naming.py ARCHITECTURAL_EXEMPTIONS
 
-      # PHASE 1 (OMN-1224): File naming hook runs in WARNING mode (non-blocking)
-      # The codebase has 71 existing violations that need incremental migration.
-      # Once all files are renamed, change || true to make this blocking.
-      # See: src/omnibase_core/validation/checker_naming_convention.py (Migration Plan)
       # NOTE: always_run=true means files: pattern is ignored - script does its own discovery
       - id: validate-file-naming-conventions
-        name: ONEX File Naming Convention Validation (Warning Mode)
-        entry: bash -c 'uv run python -m omnibase_core.validation.checker_naming_convention || true'
+        name: ONEX File Naming Convention Validation
+        entry: uv run python -m omnibase_core.validation.checker_naming_convention
         language: system
         pass_filenames: false
         always_run: true
-        stages: [pre-push]  # Full directory scan, warning mode until Phase 4
+        stages: [pre-push]
 
       - id: validate-file-locations
         name: ONEX File Location Enforcement
@@ -884,13 +880,10 @@ repos:
       # Enforces enum governance rules to prevent enum/status duplication:
       # - E001: Enum members must use UPPER_SNAKE_CASE
       # - E002: Literal types should not duplicate existing enum values
-      # PHASE 1: Warning mode (non-blocking) until existing violations are fixed
-      # The codebase has 13 existing Literal duplication violations.
-      # Once cleaned up, remove "|| true" to make this blocking.
       # NOTE: always_run=true means files: pattern is ignored - script does its own discovery
       - id: check-enum-governance
-        name: ONEX Enum Governance Validation (Warning Mode)
-        entry: bash -c 'uv run python -m omnibase_core.validation.checker_enum_governance || true'
+        name: ONEX Enum Governance Validation
+        entry: uv run python -m omnibase_core.validation.checker_enum_governance src/
         language: system
         pass_filenames: false
         always_run: true

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -29,14 +29,8 @@
   validator: detect-secrets
   kind: MISSING_PRE_COMMIT
 - repo: omnibase_core
-  validator: enum-governance
-  kind: SILENT_SKIP_WRAPPER
-- repo: omnibase_core
   validator: hardcoded-local-paths
   kind: MISSING_CI_WORKFLOW
-- repo: omnibase_core
-  validator: naming-conventions
-  kind: SILENT_SKIP_WRAPPER
 - repo: omnibase_core
   validator: no-hardcoded-topics
   kind: MISSING_CI_WORKFLOW

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -129,11 +129,11 @@ def publish_and_poll(
     """
     try:
         _ck = importlib.import_module("confluent_kafka")
-        # NOTE(OMN-9715): lazy importlib import preserves ADR-005 transport boundary; attr-defined suppressed because confluent_kafka stubs are incomplete
-        Producer = _ck.Producer  # type: ignore[attr-defined]
-        Consumer = _ck.Consumer  # type: ignore[attr-defined]
-        OFFSET_END = _ck.OFFSET_END  # type: ignore[attr-defined]
-        TopicPartition = _ck.TopicPartition  # type: ignore[attr-defined]
+        # NOTE(OMN-9715): lazy importlib import preserves ADR-005 transport boundary
+        Producer = _ck.Producer
+        Consumer = _ck.Consumer
+        OFFSET_END = _ck.OFFSET_END
+        TopicPartition = _ck.TopicPartition
     except ImportError as exc:
         raise ModelOnexError(
             error_code=EnumCoreErrorCode.IMPORT_ERROR,

--- a/src/omnibase_core/discovery/discovery_external_nodes.py
+++ b/src/omnibase_core/discovery/discovery_external_nodes.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from importlib.metadata import EntryPoint, entry_points
+from typing import cast
 
 from omnibase_core.errors.error_node_discovery import NodeDiscoveryError
 
@@ -85,7 +86,7 @@ def _load_entry_point_class(ep: EntryPoint, dist_name: str) -> type | None:
     """Load and validate an entry-point class only when a caller needs code."""
     try:
         loaded = ep.load()
-    except Exception:  # noqa: BLE001  # catch-all-ok: entry point loading can fail in many ways
+    except Exception:  # noqa: BLE001  # fallback-ok: entry point loading can fail in many ways; None signals caller to skip
         logger.warning(
             "Failed to load entry point '%s' from '%s'",
             ep.name,
@@ -102,7 +103,8 @@ def _load_entry_point_class(ep: EntryPoint, dist_name: str) -> type | None:
             type(loaded).__name__,
         )
         return None
-    return loaded
+    # ep.load() returns object; _is_valid_node_class guarantees it is a type
+    return cast(type, loaded)
 
 
 def _is_valid_node_class(obj: object) -> bool:

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -97,7 +97,7 @@ except ImportError:
     from collections.abc import Coroutine
     from typing import Any
 
-    def run_coro_sync(coro: "Coroutine[Any, Any, Any]") -> Any:  # type: ignore[misc]
+    def run_coro_sync(coro: "Coroutine[Any, Any, Any]") -> Any:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
@@ -125,16 +125,12 @@ from omnibase_core.models.configuration.model_compute_cache_config import (
 try:
     from omnibase_core.cache.memory_mapped_tool_cache import MemoryMappedToolCache
 except ImportError:
-    # FALLBACK_REASON: cache module is optional performance enhancement,
-    # system can operate without it using standard container behavior
-    MemoryMappedToolCache = None
+    MemoryMappedToolCache = None  # fallback-ok: optional performance enhancement; container operates without caching
 
 try:
     from omnibase_core.monitoring.performance_monitor import PerformanceMonitor
 except ImportError:
-    # FALLBACK_REASON: performance monitoring is optional feature,
-    # container can function without monitoring capabilities
-    PerformanceMonitor = None
+    PerformanceMonitor = None  # fallback-ok: optional monitoring feature; container operates without performance metrics
 
 # Infrastructure protocol imports for database and service discovery
 from omnibase_core.protocols.infrastructure import (
@@ -607,7 +603,9 @@ class ModelONEXContainer:
             # run_coro_sync (OMN-9237) is safe from both sync and async
             # callers — handler __init__ may run inside an active loop during
             # auto-wiring; plain asyncio.run() would raise RuntimeError there.
-            return run_coro_sync(self.get_service_async(protocol_type, service_name))
+            return cast(
+                T, run_coro_sync(self.get_service_async(protocol_type, service_name))
+            )
 
         # Enhanced resolution with performance monitoring
         correlation_id = f"svc_{int(time.time() * 1000)}_{service_name or 'default'}"
@@ -630,8 +628,8 @@ class ModelONEXContainer:
 
             # Perform actual service resolution.
             # See run_coro_sync note on the standard-path call above.
-            service_instance = run_coro_sync(
-                self.get_service_async(protocol_type, service_name)
+            service_instance = cast(
+                T, run_coro_sync(self.get_service_async(protocol_type, service_name))
             )
 
             end_time = time.perf_counter()
@@ -1136,7 +1134,7 @@ def get_model_onex_container_sync() -> ModelONEXContainer:
     # No container exists — create one.
     # run_coro_sync works whether or not an event loop is already running,
     # so this path is safe from both sync and async callers.
-    container = run_coro_sync(create_model_onex_container())
+    container = cast("ModelONEXContainer", run_coro_sync(create_model_onex_container()))
 
     # Set in context for future access
     set_current_container(container)

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -95,9 +95,11 @@ try:
 except ImportError:
     import concurrent.futures
     from collections.abc import Coroutine
-    from typing import Any
+    from typing import Any, TypeVar
 
-    def run_coro_sync(coro: "Coroutine[Any, Any, Any]") -> Any:
+    _RunT = TypeVar("_RunT")
+
+    def run_coro_sync(coro: "Coroutine[Any, Any, _RunT]") -> "_RunT":
         try:
             asyncio.get_running_loop()
         except RuntimeError:
@@ -603,9 +605,7 @@ class ModelONEXContainer:
             # run_coro_sync (OMN-9237) is safe from both sync and async
             # callers — handler __init__ may run inside an active loop during
             # auto-wiring; plain asyncio.run() would raise RuntimeError there.
-            return cast(
-                T, run_coro_sync(self.get_service_async(protocol_type, service_name))
-            )
+            return run_coro_sync(self.get_service_async(protocol_type, service_name))
 
         # Enhanced resolution with performance monitoring
         correlation_id = f"svc_{int(time.time() * 1000)}_{service_name or 'default'}"
@@ -628,8 +628,8 @@ class ModelONEXContainer:
 
             # Perform actual service resolution.
             # See run_coro_sync note on the standard-path call above.
-            service_instance = cast(
-                T, run_coro_sync(self.get_service_async(protocol_type, service_name))
+            service_instance = run_coro_sync(
+                self.get_service_async(protocol_type, service_name)
             )
 
             end_time = time.perf_counter()
@@ -1134,7 +1134,7 @@ def get_model_onex_container_sync() -> ModelONEXContainer:
     # No container exists — create one.
     # run_coro_sync works whether or not an event loop is already running,
     # so this path is safe from both sync and async callers.
-    container = cast("ModelONEXContainer", run_coro_sync(create_model_onex_container()))
+    container = run_coro_sync(create_model_onex_container())
 
     # Set in context for future access
     set_current_container(container)

--- a/src/omnibase_core/normalization/contract_normalizer.py
+++ b/src/omnibase_core/normalization/contract_normalizer.py
@@ -387,10 +387,7 @@ def compose_normalization_pipeline(raw: Mapping[str, object]) -> dict[str, objec
     unconstrained ``dict[str, object]``.
     """
     out: dict[str, object] = strip_legacy_metadata(raw)
-    out = cast(
-        "dict[str, object]",
-        normalize_event_bus(cast("dict[str, JsonType]", out)),
-    )
+    out = normalize_event_bus(cast("dict[str, JsonType]", out))
     out = normalize_io_model_ref(out)
     out = normalize_handler_routing(out)
     if is_omnimarket_v0(out):


### PR DESCRIPTION
## Summary

Flips 5 advisory CI gates to blocking in omnibase_core as part of OMN-10972 gate hardening epic.

- **OMN-11156**: Remove `continue-on-error` from `node-purity-check` — verified 0 violations locally
- **OMN-11157**: Remove `|| true` from `validate-file-naming-conventions` pre-commit hook — verified 0 violations locally
- **OMN-11158**: Remove `|| true` from `check-enum-governance` pre-commit hook, scoped to `src/` to avoid `.venv` noise — verified 0 violations on `src/`
- **OMN-11159**: Remove `continue-on-error` from `cross-repo-validation.yml`
- **OMN-11160**: Remove `continue-on-error` from `omni-standards-compliance.yml` mypy job; fix 10 pre-existing mypy violations in `discovery_external_nodes.py`, `contract_normalizer.py`, `cli_run_node.py`, `model_onex_container.py`

## Evidence

- `uv run mypy src/ --strict` exits 0 (verified in worktree)
- `uv run python scripts/check_node_purity.py --verbose` exits 0 (0 pure node violations)
- `uv run python -m omnibase_core.validation.checker_naming_convention` exits 0
- `uv run python -m omnibase_core.validation.checker_enum_governance src/` exits 0
- All pre-commit hooks pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced stricter validation checks across CI workflows—quality gates now fail builds on validation errors instead of allowing non-blocking warnings.
  * Clarified Quality Gate documentation to reference additional aggregated checks.
  * Refined internal type annotations and error handling in core modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1151
Evidence-Ticket: OMN-11156