### PR TITLE
feat(OMN-11226): Add typed exit conditions to ModelSessionPhaseSpec

### DIFF
--- a/src/omnibase_core/models/overseer/__init__.py
+++ b/src/omnibase_core/models/overseer/__init__.py
@@ -29,6 +29,9 @@ from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
 from omnibase_core.models.overseer.model_escalation_request import (
     ModelEscalationRequest,
 )
+from omnibase_core.models.overseer.model_phase_exit_condition import (
+    ModelPhaseExitCondition,
+)
 from omnibase_core.models.overseer.model_process_runner_state_transition import (
     ModelProcessRunnerStateTransition,
 )
@@ -69,6 +72,7 @@ __all__ = [
     "ModelContractAllowedActions",
     "ModelDispatchItem",
     "ModelEscalationRequest",
+    "ModelPhaseExitCondition",
     "ModelProcessRunnerStateTransition",
     "ModelSessionContract",
     "ModelSessionHaltCondition",

--- a/src/omnibase_core/models/overseer/model_phase_exit_condition.py
+++ b/src/omnibase_core/models/overseer/model_phase_exit_condition.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelPhaseExitCondition — typed exit condition for a session phase (OMN-11226)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelPhaseExitCondition(BaseModel):
+    """A single typed exit condition for a ModelSessionPhaseSpec."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    condition_type: Literal[
+        "pr_state", "worker_count", "custom_probe", "task_complete", "time_elapsed"
+    ]
+
+    # pr_state
+    repo: str | None = None
+    pr_number: int | None = None
+    required_state: Literal["merged", "closed", "open"] | None = None
+
+    # worker_count / time_elapsed
+    operator: Literal["eq", "lt", "gt", "le", "ge"] | None = None
+    value: int | None = None
+
+    # custom_probe
+    command: str | None = None
+    expected_exit_code: int | None = None
+
+    # task_complete
+    task_name: str | None = None
+
+
+__all__ = ["ModelPhaseExitCondition"]

--- a/src/omnibase_core/models/overseer/model_session_phase_spec.py
+++ b/src/omnibase_core/models/overseer/model_session_phase_spec.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.enums.overseer.enum_completion_outcome import EnumCompletionOutcome
 from omnibase_core.models.overseer.model_dispatch_item import ModelDispatchItem
+from omnibase_core.models.overseer.model_phase_exit_condition import (
+    ModelPhaseExitCondition,
+)
 from omnibase_core.models.overseer.model_session_halt_condition import (
     ModelSessionHaltCondition,
 )
@@ -27,6 +30,7 @@ class ModelSessionPhaseSpec(BaseModel):
     dispatch_items: tuple[ModelDispatchItem, ...] = ()
     required_outcomes: tuple[EnumCompletionOutcome, ...] = ()
     halt_conditions: tuple[ModelSessionHaltCondition, ...] = ()
+    exit_conditions: tuple[ModelPhaseExitCondition, ...] = ()
 
 
 __all__ = ["ModelSessionPhaseSpec"]

--- a/tests/unit/models/overseer/test_phase_exit_condition.py
+++ b/tests/unit/models/overseer/test_phase_exit_condition.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPhaseExitCondition and ModelSessionPhaseSpec.exit_conditions (OMN-11226)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.overseer.model_phase_exit_condition import (
+    ModelPhaseExitCondition,
+)
+from omnibase_core.models.overseer.model_session_phase_spec import ModelSessionPhaseSpec
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_pr_state() -> None:
+    cond = ModelPhaseExitCondition(
+        condition_type="pr_state",
+        repo="OmniNode-ai/omnimarket",
+        pr_number=686,
+        required_state="merged",
+    )
+    assert cond.condition_type == "pr_state"
+    assert cond.repo == "OmniNode-ai/omnimarket"
+    assert cond.pr_number == 686
+    assert cond.required_state == "merged"
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_worker_count() -> None:
+    cond = ModelPhaseExitCondition(
+        condition_type="worker_count",
+        operator="eq",
+        value=0,
+    )
+    assert cond.condition_type == "worker_count"
+    assert cond.operator == "eq"
+    assert cond.value == 0
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_custom_probe() -> None:
+    cond = ModelPhaseExitCondition(
+        condition_type="custom_probe",
+        command="curl -fsS http://192.168.86.201:18085/health",  # onex-allow-internal-ip
+        expected_exit_code=0,
+    )
+    assert cond.condition_type == "custom_probe"
+    assert cond.expected_exit_code == 0
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_task_complete() -> None:
+    cond = ModelPhaseExitCondition(
+        condition_type="task_complete",
+        task_name="merge-sweep",
+    )
+    assert cond.condition_type == "task_complete"
+    assert cond.task_name == "merge-sweep"
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_time_elapsed() -> None:
+    cond = ModelPhaseExitCondition(
+        condition_type="time_elapsed",
+        value=120,
+    )
+    assert cond.condition_type == "time_elapsed"
+    assert cond.value == 120
+
+
+@pytest.mark.unit
+def test_phase_spec_has_exit_conditions() -> None:
+    spec = ModelSessionPhaseSpec(
+        phase_name="merge",
+        exit_conditions=(
+            ModelPhaseExitCondition(
+                condition_type="worker_count", operator="eq", value=0
+            ),
+        ),
+    )
+    assert len(spec.exit_conditions) == 1
+    assert spec.exit_conditions[0].condition_type == "worker_count"
+
+
+@pytest.mark.unit
+def test_phase_spec_exit_conditions_default_empty() -> None:
+    spec = ModelSessionPhaseSpec(phase_name="warmup")
+    assert spec.exit_conditions == ()
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_is_frozen() -> None:
+    cond = ModelPhaseExitCondition(condition_type="task_complete", task_name="abc")
+    with pytest.raises(Exception):
+        cond.task_name = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_phase_exit_condition_rejects_extra_fields() -> None:
+    with pytest.raises(Exception):
+        ModelPhaseExitCondition(condition_type="task_complete", unknown_field="x")  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- Adds `ModelPhaseExitCondition` with 5 typed condition types: `pr_state`, `worker_count`, `custom_probe`, `task_complete`, `time_elapsed`
- Each condition type carries the fields needed for mechanical evaluation (repo/pr_number/required_state, operator/value, command/expected_exit_code, task_name)
- Adds `exit_conditions: tuple[ModelPhaseExitCondition, ...] = ()` to `ModelSessionPhaseSpec`; preserves `success_criteria: list[str]` for backwards compat
- Re-exports `ModelPhaseExitCondition` from `omnibase_core.models.overseer`

## Stacked on

This PR targets OMN-11225 (`jonah/omn-11225-task-1-unify-modelsessioncontract-and-modelovernightcontract`) and should be reviewed/merged after that PR lands.

## Evidence-Source

OMN-11226 — typed exit conditions for session phases

## Test plan

- [x] 9 new unit tests in `tests/unit/models/overseer/test_phase_exit_condition.py` — all passing
- [x] All 55 overseer model tests passing
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean
- [x] `uv run mypy src/omnibase_core/models/overseer/model_phase_exit_condition.py src/omnibase_core/models/overseer/model_session_phase_spec.py --strict` — no issues
- [x] `pre-commit run --all-files` — all hooks passed