### PR TITLE
feat(OMN-9334): runtime_sha_match DoD gate — classifier + receipt-gate integration

### DIFF
--- a/src/omnibase_core/models/ticket/model_ticket_contract.py
+++ b/src/omnibase_core/models/ticket/model_ticket_contract.py
@@ -330,6 +330,66 @@ class ModelTicketContract(BaseModel):
 
         return v.astimezone(UTC)
 
+    @classmethod
+    def classify_runtime_change(
+        cls,
+        touched_paths: list[str] | tuple[str, ...] | set[str] | frozenset[str],
+        *,
+        deployed_nodes: set[str] | frozenset[str] | None = None,
+    ) -> bool:
+        """Return True when changed paths require runtime_sha_match evidence.
+
+        The default policy intentionally only looks at paths, so PR and ticket
+        tooling can call it before contracts are enriched. ``deployed_nodes`` lets
+        callers narrow omnimarket node matches when they have a deployment
+        registry; absent that registry, node source paths are treated as deployed
+        runtime code.
+        """
+        for raw_path in touched_paths:
+            path = cls._normalize_touched_path(raw_path)
+            if not path or cls._is_docs_or_tests_path(path):
+                continue
+            if path.startswith(("omnibase_infra/src/", "src/omnibase_infra/")):
+                return True
+
+            node_name = cls._omnimarket_node_name_from_path(path)
+            if node_name and (deployed_nodes is None or node_name in deployed_nodes):
+                return True
+
+        return False
+
+    @staticmethod
+    def _normalize_touched_path(path: str) -> str:
+        return path.strip().replace("\\", "/").lstrip("./")
+
+    @staticmethod
+    def _is_docs_or_tests_path(path: str) -> bool:
+        if path.endswith((".md", ".rst", ".txt")):
+            return True
+        if "/docs/" in f"/{path}" or path.startswith("docs/"):
+            return True
+        test_markers = ("/tests/", "/test/", "/__tests__/", "/fixtures/")
+        if any(marker in f"/{path}/" for marker in test_markers):
+            return True
+        filename = path.rsplit("/", 1)[-1]
+        return filename.startswith("test_") or filename.endswith("_test.py")
+
+    @staticmethod
+    def _omnimarket_node_name_from_path(path: str) -> str | None:
+        markers = (
+            "omnimarket/src/omnimarket/nodes/",
+            "src/omnimarket/nodes/",
+            "src/nodes/",
+        )
+        for marker in markers:
+            if marker not in path:
+                continue
+            after_marker = path.split(marker, 1)[1]
+            node_name = after_marker.split("/", 1)[0]
+            if node_name.startswith("node_"):
+                return node_name
+        return None
+
     # =========================================================================
     # research_notes as @property (derived from context)
     # =========================================================================

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -101,6 +101,10 @@ from omnibase_core.models.contracts.ticket.model_receipt_gate_result import (
     ModelReceiptGateResult,
 )
 from omnibase_core.validation.completion_verify import verify as _completion_verify
+from omnibase_core.validation.runtime_sha_match import (
+    CHECK_TYPE_RUNTIME_SHA_MATCH,
+    classify_runtime_sha_match_receipt,
+)
 
 # PRs opened after this UTC datetime must include contract_sha256 in receipts;
 # earlier PRs get ADVISORY downgrade for the 7-day legacy window (OMN-10421).
@@ -388,6 +392,14 @@ def _check_one_receipt(
     )
     if adversarial_validated_failure is not None:
         return fail(adversarial_validated_failure)
+
+    if receipt.check_type == CHECK_TYPE_RUNTIME_SHA_MATCH:
+        runtime_sha_result = classify_runtime_sha_match_receipt(receipt)
+        if runtime_sha_result.blocking:
+            return fail(
+                f"runtime_sha_match receipt at {receipt_path} is blocking: "
+                f"{runtime_sha_result.reason}"
+            )
 
     # Hash-binding check (OMN-10421, invariant I4): verify the contract has
     # not mutated since this receipt was produced. Only active when the caller

--- a/src/omnibase_core/validation/runtime_sha_match.py
+++ b/src/omnibase_core/validation/runtime_sha_match.py
@@ -93,6 +93,16 @@ def classify_runtime_sha_match_receipt(
             ),
         )
 
+    if receipt.check_value != output.merge_sha:
+        return ModelRuntimeShaClassifyResult(
+            valid=True,
+            blocking=True,
+            reason=(
+                f"receipt check_value={receipt.check_value!r} does not match "
+                f"runtime_sha_match merge_sha={output.merge_sha!r}"
+            ),
+        )
+
     return ModelRuntimeShaClassifyResult(
         valid=True,
         blocking=False,

--- a/tests/unit/models/contracts/test_runtime_sha_match.py
+++ b/tests/unit/models/contracts/test_runtime_sha_match.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime SHA match contract classifier and receipt-gate semantics."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.models.ticket.model_ticket_contract import ModelTicketContract
+from omnibase_core.validation.receipt_gate import validate_pr_receipts
+from omnibase_core.validation.runtime_sha_match import CHECK_TYPE_RUNTIME_SHA_MATCH
+
+pytestmark = pytest.mark.unit
+
+_TICKET_ID = "OMN-9334"
+_EVIDENCE_ID = "dod-003"
+_MERGE_SHA = "abc123def456"  # pragma: allowlist secret
+_STALE_SHA = "deadbeef0000"  # pragma: allowlist secret
+
+
+def test_classify_runtime_change_requires_infra_source() -> None:
+    assert ModelTicketContract.classify_runtime_change(
+        ["omnibase_infra/src/omnibase_infra/runtime/service.py"]
+    )
+
+
+def test_classify_runtime_change_requires_deployed_omnimarket_node() -> None:
+    assert ModelTicketContract.classify_runtime_change(
+        ["omnimarket/src/omnimarket/nodes/node_redeploy/handlers/handler.py"],
+        deployed_nodes=frozenset({"node_redeploy"}),
+    )
+
+
+def test_classify_runtime_change_skips_undeployed_node_when_registry_supplied() -> None:
+    assert not ModelTicketContract.classify_runtime_change(
+        ["omnimarket/src/omnimarket/nodes/node_experiment/handlers/handler.py"],
+        deployed_nodes=frozenset({"node_redeploy"}),
+    )
+
+
+def test_classify_runtime_change_skips_docs_tests_and_local_plugins() -> None:
+    assert not ModelTicketContract.classify_runtime_change(
+        [
+            "omnibase_infra/tests/test_runtime.py",
+            "omnimarket/src/omnimarket/nodes/node_redeploy/tests/test_handler.py",
+            "omniclaude/plugins/onex/skills/foo/SKILL.md",
+            "docs/runtime.md",
+        ]
+    )
+
+
+def test_receipt_gate_rejects_stale_runtime_sha_receipt(tmp_path: Path) -> None:
+    contracts_dir = tmp_path / "contracts"
+    receipts_dir = tmp_path / "drift" / "dod_receipts"
+    _write_contract(contracts_dir)
+    _write_receipt(
+        receipts_dir,
+        status=EnumReceiptStatus.FAIL,
+        deployed_sha=_STALE_SHA,
+        merge_sha=_MERGE_SHA,
+        match=False,
+    )
+
+    result = validate_pr_receipts(
+        pr_body=f"Implements {_TICKET_ID}",
+        pr_title=f"{_TICKET_ID}: runtime sha gate",
+        contracts_dir=contracts_dir,
+        receipts_dir=receipts_dir,
+    )
+
+    assert result.passed is False
+    assert "runtime_sha_match" in result.message
+    assert "FAIL" in result.message or "blocking" in result.message
+
+
+def test_receipt_gate_accepts_matching_runtime_sha_receipt(tmp_path: Path) -> None:
+    contracts_dir = tmp_path / "contracts"
+    receipts_dir = tmp_path / "drift" / "dod_receipts"
+    _write_contract(contracts_dir)
+    _write_receipt(
+        receipts_dir,
+        status=EnumReceiptStatus.PASS,
+        deployed_sha=_MERGE_SHA,
+        merge_sha=_MERGE_SHA,
+        match=True,
+    )
+
+    result = validate_pr_receipts(
+        pr_body=f"Implements {_TICKET_ID}",
+        pr_title=f"{_TICKET_ID}: runtime sha gate",
+        contracts_dir=contracts_dir,
+        receipts_dir=receipts_dir,
+    )
+
+    assert result.passed is True
+
+
+def _write_contract(contracts_dir: Path) -> None:
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "ticket_id": _TICKET_ID,
+        "title": "Runtime SHA gate",
+        "dod_evidence": [
+            {
+                "id": _EVIDENCE_ID,
+                "description": "Runtime SHA matches merged SHA",
+                "checks": [
+                    {
+                        "check_type": CHECK_TYPE_RUNTIME_SHA_MATCH,
+                        "check_value": _MERGE_SHA,
+                    }
+                ],
+            }
+        ],
+    }
+    (contracts_dir / f"{_TICKET_ID}.yaml").write_text(
+        yaml.safe_dump(payload, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _write_receipt(
+    receipts_dir: Path,
+    *,
+    status: EnumReceiptStatus,
+    deployed_sha: str,
+    merge_sha: str,
+    match: bool,
+) -> None:
+    receipt = ModelDodReceipt(
+        schema_version="1.0.0",
+        ticket_id=_TICKET_ID,
+        evidence_item_id=_EVIDENCE_ID,
+        check_type=CHECK_TYPE_RUNTIME_SHA_MATCH,
+        check_value=merge_sha,
+        status=status,
+        run_timestamp=datetime.now(tz=UTC),
+        commit_sha=deployed_sha,
+        runner="integration-sweep-verifier",
+        verifier="receipt-gate-test-verifier",
+        probe_command="ssh 192.168.86.201 git -C /data/omninode/omni_home/omnimarket rev-parse HEAD",
+        probe_stdout=f"{deployed_sha}\n",
+        actual_output=json.dumps(
+            {
+                "runtime_host": "192.168.86.201",
+                "deployed_sha": deployed_sha,
+                "merge_sha": merge_sha,
+                "match": match,
+            }
+        ),
+    )
+    receipt_path = receipts_dir / _TICKET_ID / _EVIDENCE_ID / "runtime_sha_match.yaml"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        yaml.safe_dump(receipt.model_dump(mode="json"), sort_keys=True),
+        encoding="utf-8",
+    )

--- a/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
+++ b/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
@@ -39,6 +39,7 @@ from omnibase_core.validation.runtime_sha_match import (
 pytestmark = pytest.mark.unit
 
 _PROBE_CMD = "ssh jonah@192.168.86.201 git -C /opt/omninode/runtime rev-parse HEAD"  # onex-allow-internal-ip: test fixture only
+_MERGE_SHA = "abc123def456"  # pragma: allowlist secret
 
 
 def _base_receipt(
@@ -46,6 +47,7 @@ def _base_receipt(
     check_type: str = CHECK_TYPE_RUNTIME_SHA_MATCH,
     status: EnumReceiptStatus = EnumReceiptStatus.PASS,
     actual_output: str | None = None,
+    check_value: str = _MERGE_SHA,
 ) -> ModelDodReceipt:
     # `runtime_sha_match` is not in EXECUTABLE_CHECK_TYPES, so probe_stdout
     # may be empty without violating the adversarial invariants.
@@ -54,14 +56,14 @@ def _base_receipt(
         ticket_id="OMN-9356",
         evidence_item_id="dod-sha-001",
         check_type=check_type,
-        check_value=_PROBE_CMD,
+        check_value=check_value,
         status=status,
         run_timestamp=datetime.now(tz=UTC),
         commit_sha="a1b2c3d4e5f6",  # pragma: allowlist secret
         runner="integration-sweep-verifier",
         verifier="foreground-runtime-sha-verifier",
         probe_command=_PROBE_CMD,
-        probe_stdout=actual_output or "abc123def456\n",  # pragma: allowlist secret
+        probe_stdout=actual_output or f"{_MERGE_SHA}\n",
         actual_output=actual_output,
     )
 
@@ -74,7 +76,7 @@ def _make_evidence_items(
             id="dod-sha-001",
             description="Runtime SHA matches merge SHA",
             checks=[
-                ModelDodEvidenceCheck(check_type=check_type, check_value=_PROBE_CMD)
+                ModelDodEvidenceCheck(check_type=check_type, check_value=_MERGE_SHA)
             ],
         )
     ]
@@ -83,8 +85,8 @@ def _make_evidence_items(
 def _make_output_json(
     *,
     runtime_host: str = "192.168.86.201",  # onex-allow-internal-ip: test fixture only
-    deployed_sha: str = "abc123def456",  # pragma: allowlist secret
-    merge_sha: str = "abc123def456",  # pragma: allowlist secret
+    deployed_sha: str = _MERGE_SHA,
+    merge_sha: str = _MERGE_SHA,
     match: bool = True,
 ) -> str:
     return json.dumps(
@@ -209,6 +211,26 @@ class TestClassifyRuntimeShaMatchReceipt:
         result = classify_runtime_sha_match_receipt(receipt)
         assert result.blocking is True
 
+    def test_pass_receipt_with_check_value_not_merge_sha_is_blocking(self) -> None:
+        receipt = ModelDodReceipt(
+            schema_version="1.0.0",
+            ticket_id="OMN-9356",
+            evidence_item_id="dod-sha-001",
+            check_type=CHECK_TYPE_RUNTIME_SHA_MATCH,
+            check_value="deadbeef1234",  # pragma: allowlist secret
+            status=EnumReceiptStatus.PASS,
+            run_timestamp=datetime.now(tz=UTC),
+            commit_sha=_MERGE_SHA,
+            runner="integration-sweep-verifier",
+            verifier="foreground-runtime-sha-verifier",
+            probe_command=_PROBE_CMD,
+            probe_stdout=f"{_MERGE_SHA}\n",
+            actual_output=_make_output_json(match=True),
+        )
+        result = classify_runtime_sha_match_receipt(receipt)
+        assert result.blocking is True
+        assert "check_value" in result.reason
+
     def test_wrong_check_type_raises_onex_error(self) -> None:
         receipt = _base_receipt(check_type="command")
         with pytest.raises(ModelOnexError):
@@ -217,6 +239,7 @@ class TestClassifyRuntimeShaMatchReceipt:
     def test_pass_receipt_with_valid_output_reason(self) -> None:
         receipt = _base_receipt(
             status=EnumReceiptStatus.PASS,
+            check_value="deadbeef1234",  # pragma: allowlist secret
             actual_output=_make_output_json(
                 deployed_sha="deadbeef1234",  # pragma: allowlist secret
                 merge_sha="deadbeef1234",  # pragma: allowlist secret
@@ -246,7 +269,7 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
             ticket_id="OMN-9356",
             evidence_item_id="dod-sha-001",
             check_type="runtime_sha_match",
-            check_value=_PROBE_CMD,
+            check_value=_MERGE_SHA,
             status=EnumReceiptStatus.PASS,
             run_timestamp=datetime.now(tz=UTC),
             commit_sha="abc123def456",  # pragma: allowlist secret
@@ -273,7 +296,7 @@ class TestDodGuardBlocksWithoutRuntimeShaReceipt:
             ticket_id="OMN-9356",
             evidence_item_id="dod-sha-001",
             check_type="runtime_sha_match",
-            check_value=_PROBE_CMD,
+            check_value="bbbbbbbbbbbb",  # pragma: allowlist secret
             status=EnumReceiptStatus.FAIL,
             run_timestamp=datetime.now(tz=UTC),
             commit_sha="abc123def456",  # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Implements the `runtime_sha_match` check_type for the DoD gate infrastructure (OMN-9334). Structural fix for the "code on main, runtime not redeployed" regression class — root cause of OMN-9321 (5-day stale runtime discovered by human check).

- **`ModelTicketContract.classify_runtime_change(touched_paths)`** — classifies whether changed paths require `runtime_sha_match` evidence. Returns `True` for `omnibase_infra/src/` or deployed omnimarket nodes; `False` for docs/tests/omniclaude plugins.
- **`classify_runtime_sha_match_receipt(receipt)`** — validates receipt status, parses `ModelRuntimeShaMatchOutput` from `actual_output`, and cross-checks `check_value == output.merge_sha` to reject tampered receipts.
- **`assert_runtime_sha_receipts_present()`** — blocks Done transition when any `runtime_sha_match` evidence item lacks a PASS receipt.
- **`receipt_gate.py`** — routes `runtime_sha_match` receipts through the classifier; stale-runtime receipts fail the gate.

## Evidence

Implements OMN-9334

- `dod-001`: `test_passes` — `tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py` (27 tests: classifier, receipt classification, Done-guard, receipt-gate roundtrip)
- `dod-002`: `test_passes` — `tests/unit/models/contracts/test_runtime_sha_match.py` (6 tests: stale-runtime blocks Done, matching passes, classifier paths)

## Test plan

- [ ] `uv run pytest tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py tests/unit/models/contracts/test_runtime_sha_match.py -v` — 27 tests all green
- [ ] Pre-commit hooks pass (all 70+ hooks)
- [ ] mypy --strict clean on changed files
- [ ] CI green

## DoD Evidence

Evidence-Source: OCC#1157
Evidence-Ticket: OMN-9334
