### PR TITLE
feat(OMN-11262): add canonical contract evidence storage models to omnibase_core

### DIFF
--- a/src/omnibase_core/enums/enum_stable_proof_kind.py
+++ b/src/omnibase_core/enums/enum_stable_proof_kind.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumStableProofKind: stable proof categories for contract evidence."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ["EnumStableProofKind"]
+
+
+class EnumStableProofKind(str, Enum):
+    """Stable proof categories for ModelContractEvidenceProof.
+
+    These proof kinds validate artifacts or behaviors. PR-state checks are
+    intentionally excluded — PR metadata belongs in ModelEvidenceProvenance.
+    """
+
+    MODEL_IMPORT = "model_import"
+    ARTIFACT_VALIDATION = "artifact_validation"
+    SCHEMA_VALIDATION = "schema_validation"
+    FILE_EXISTS = "file_exists"
+    TEST_PASSES = "test_passes"
+    RECEIPT_VALIDATION = "receipt_validation"
+    EVIDENCE_BUNDLE_VALIDATION = "evidence_bundle_validation"
+    RUNTIME_PROJECTION_PROOF = "runtime_projection_proof"
+    COMMAND = "command"

--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -122,10 +122,10 @@ from omnibase_core.models.security.model_condition_value import ModelConditionVa
 
 from . import subcontracts
 from .evidence import (
+    EnumStableProofKind,
     ModelContractEvidenceProof,
     ModelContractEvidenceSpec,
     ModelEvidenceProvenance,
-    StableProofKind,
 )
 from .model_action_config_parameter import (
     ModelActionConfigParameter,
@@ -287,7 +287,7 @@ __all__ = [
     "ModelDependencySpec",
     "DependencyType",
     "SelectionStrategy",
-    "StableProofKind",
+    "EnumStableProofKind",
     "ModelDriftDetails",
     "ModelDriftResult",
     "ModelNodeExtensions",

--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -121,6 +121,12 @@ from omnibase_core.models.runtime.model_handler_behavior import (
 from omnibase_core.models.security.model_condition_value import ModelConditionValue
 
 from . import subcontracts
+from .evidence import (
+    ModelContractEvidenceProof,
+    ModelContractEvidenceSpec,
+    ModelEvidenceProvenance,
+    StableProofKind,
+)
 from .model_action_config_parameter import (
     ModelActionConfigParameter,
     ParameterType,
@@ -270,14 +276,18 @@ __all__ = [
     "ModelContractBase",
     "ModelContractFingerprint",
     "ModelContractMeta",
+    "ModelContractEvidenceProof",
+    "ModelContractEvidenceSpec",
     "ModelContractNodeMetadata",
     "ModelContractNormalizationConfig",
     "ModelContractVersion",
+    "ModelEvidenceProvenance",
     "ModelCorpusClassification",
     "ModelDependency",
     "ModelDependencySpec",
     "DependencyType",
     "SelectionStrategy",
+    "StableProofKind",
     "ModelDriftDetails",
     "ModelDriftResult",
     "ModelNodeExtensions",

--- a/src/omnibase_core/models/contracts/evidence/__init__.py
+++ b/src/omnibase_core/models/contracts/evidence/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed contract evidence storage models."""
+
+from omnibase_core.models.contracts.evidence.model_contract_evidence_proof import (
+    ModelContractEvidenceProof,
+    StableProofKind,
+)
+from omnibase_core.models.contracts.evidence.model_contract_evidence_spec import (
+    ModelContractEvidenceSpec,
+)
+from omnibase_core.models.contracts.evidence.model_evidence_provenance import (
+    ModelEvidenceProvenance,
+)
+
+__all__: list[str] = [
+    "ModelContractEvidenceProof",
+    "ModelContractEvidenceSpec",
+    "ModelEvidenceProvenance",
+    "StableProofKind",
+]

--- a/src/omnibase_core/models/contracts/evidence/__init__.py
+++ b/src/omnibase_core/models/contracts/evidence/__init__.py
@@ -3,9 +3,9 @@
 
 """Typed contract evidence storage models."""
 
+from omnibase_core.enums.enum_stable_proof_kind import EnumStableProofKind
 from omnibase_core.models.contracts.evidence.model_contract_evidence_proof import (
     ModelContractEvidenceProof,
-    StableProofKind,
 )
 from omnibase_core.models.contracts.evidence.model_contract_evidence_spec import (
     ModelContractEvidenceSpec,
@@ -15,8 +15,8 @@ from omnibase_core.models.contracts.evidence.model_evidence_provenance import (
 )
 
 __all__: list[str] = [
+    "EnumStableProofKind",
     "ModelContractEvidenceProof",
     "ModelContractEvidenceSpec",
     "ModelEvidenceProvenance",
-    "StableProofKind",
 ]

--- a/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
+++ b/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContractEvidenceProof: artifact-first or behavior-first proof item."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+StableProofKind = Literal[
+    "model_import",
+    "artifact_validation",
+    "schema_validation",
+    "file_exists",
+    "test_passes",
+    "receipt_validation",
+    "evidence_bundle_validation",
+    "runtime_projection_proof",
+    "command",
+]
+
+_PR_BOUND_PROOF_RE = re.compile(
+    r"\bgh\s+pr\s+view\b|github\.com/[^/\s]+/[^/\s]+/pull/\d+\b|/pull/\d+\b|\bpr_number\b",
+    re.IGNORECASE,
+)
+
+
+class ModelContractEvidenceProof(BaseModel):
+    """Stable proof requirement for a contract.
+
+    A proof item must validate an artifact or behavior. PR-state checks are
+    rejected here because PR metadata belongs in ModelEvidenceProvenance.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # string-id-ok: contract evidence proof IDs are stable human-authored keys, not object UUIDs.
+    proof_id: str = Field(..., min_length=1)
+    proof_kind: StableProofKind
+    description: str = Field(..., min_length=1)
+    target: str = Field(..., min_length=1)
+    command: str | None = Field(default=None, min_length=1)
+    model_path: str | None = Field(default=None, min_length=1)
+    artifact_path: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_required_fields(self) -> ModelContractEvidenceProof:
+        if self.proof_kind == "model_import" and not self.model_path:
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError("model_import proof requires model_path")
+        if self.proof_kind in {"artifact_validation", "schema_validation"} and (
+            not self.model_path or not self.artifact_path
+        ):
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError(
+                f"{self.proof_kind} proof requires model_path and artifact_path"
+            )
+        if self.proof_kind == "file_exists" and not self.artifact_path:
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError("file_exists proof requires artifact_path")
+        if self.proof_kind == "command" and not self.command:
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError("command proof requires command")
+        self._reject_pr_bound_stable_proof()
+        return self
+
+    def _reject_pr_bound_stable_proof(self) -> None:
+        combined = "\n".join((self.target, self.command or "", self.description))
+        if _PR_BOUND_PROOF_RE.search(combined):
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError(
+                "stable proof cannot be PR-number or PR-state bound; "
+                "put PR metadata in ModelEvidenceProvenance"
+            )
+
+
+__all__: list[str] = ["ModelContractEvidenceProof", "StableProofKind"]

--- a/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
+++ b/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
@@ -6,21 +6,10 @@
 from __future__ import annotations
 
 import re
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-StableProofKind = Literal[
-    "model_import",
-    "artifact_validation",
-    "schema_validation",
-    "file_exists",
-    "test_passes",
-    "receipt_validation",
-    "evidence_bundle_validation",
-    "runtime_projection_proof",
-    "command",
-]
+from omnibase_core.enums.enum_stable_proof_kind import EnumStableProofKind
 
 _PR_BOUND_PROOF_RE = re.compile(
     r"\bgh\s+pr\s+view\b|github\.com/[^/\s]+/[^/\s]+/pull/\d+\b|/pull/\d+\b|\bpr_number\b",
@@ -39,7 +28,7 @@ class ModelContractEvidenceProof(BaseModel):
 
     # string-id-ok: contract evidence proof IDs are stable human-authored keys, not object UUIDs.
     proof_id: str = Field(..., min_length=1)
-    proof_kind: StableProofKind
+    proof_kind: EnumStableProofKind
     description: str = Field(..., min_length=1)
     target: str = Field(..., min_length=1)
     command: str | None = Field(default=None, min_length=1)
@@ -48,20 +37,24 @@ class ModelContractEvidenceProof(BaseModel):
 
     @model_validator(mode="after")
     def _validate_required_fields(self) -> ModelContractEvidenceProof:
-        if self.proof_kind == "model_import" and not self.model_path:
+        if self.proof_kind == EnumStableProofKind.MODEL_IMPORT and not self.model_path:
             # error-ok: Pydantic validators must raise ValueError for field validation errors.
             raise ValueError("model_import proof requires model_path")
-        if self.proof_kind in {"artifact_validation", "schema_validation"} and (
-            not self.model_path or not self.artifact_path
-        ):
+        if self.proof_kind in {
+            EnumStableProofKind.ARTIFACT_VALIDATION,
+            EnumStableProofKind.SCHEMA_VALIDATION,
+        } and (not self.model_path or not self.artifact_path):
             # error-ok: Pydantic validators must raise ValueError for field validation errors.
             raise ValueError(
-                f"{self.proof_kind} proof requires model_path and artifact_path"
+                f"{self.proof_kind.value} proof requires model_path and artifact_path"
             )
-        if self.proof_kind == "file_exists" and not self.artifact_path:
+        if (
+            self.proof_kind == EnumStableProofKind.FILE_EXISTS
+            and not self.artifact_path
+        ):
             # error-ok: Pydantic validators must raise ValueError for field validation errors.
             raise ValueError("file_exists proof requires artifact_path")
-        if self.proof_kind == "command" and not self.command:
+        if self.proof_kind == EnumStableProofKind.COMMAND and not self.command:
             # error-ok: Pydantic validators must raise ValueError for field validation errors.
             raise ValueError("command proof requires command")
         self._reject_pr_bound_stable_proof()
@@ -77,4 +70,4 @@ class ModelContractEvidenceProof(BaseModel):
             )
 
 
-__all__: list[str] = ["ModelContractEvidenceProof", "StableProofKind"]
+__all__: list[str] = ["ModelContractEvidenceProof"]

--- a/src/omnibase_core/models/contracts/evidence/model_contract_evidence_spec.py
+++ b/src/omnibase_core/models/contracts/evidence/model_contract_evidence_spec.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContractEvidenceSpec: typed contract evidence storage format."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.contracts.evidence.model_contract_evidence_proof import (
+    ModelContractEvidenceProof,
+)
+from omnibase_core.models.contracts.evidence.model_evidence_provenance import (
+    ModelEvidenceProvenance,
+)
+
+_TICKET_ID_RE = re.compile(r"^[A-Z]+-\d+$")
+
+
+class ModelContractEvidenceSpec(BaseModel):
+    """Typed artifact-first replacement for PR-number-bound evidence checks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    schema_version: Literal["1.0.0"] = "1.0.0"
+    ticket_id: str = Field(..., min_length=1)
+    summary: str = Field(..., min_length=1)
+    artifact_names: tuple[str, ...] = Field(..., min_length=1)
+    repository_surfaces: tuple[str, ...] = Field(..., min_length=1)
+    acceptance_criteria: tuple[str, ...] = Field(..., min_length=1)
+    stable_proofs: tuple[ModelContractEvidenceProof, ...] = Field(..., min_length=1)
+    provenance: tuple[ModelEvidenceProvenance, ...] = Field(default_factory=tuple)
+    legacy_contract_path: str | None = Field(default=None, min_length=1)
+    # string-id-ok: migration tickets are Linear keys such as OMN-11262, not UUID identities.
+    migration_ticket_id: str | None = Field(default=None, min_length=1)
+
+    @field_validator("ticket_id", "migration_ticket_id")
+    @classmethod
+    def _validate_ticket_id(cls, value: str | None) -> str | None:
+        if value is not None and not _TICKET_ID_RE.match(value):
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError("ticket id must look like OMN-1234")
+        return value
+
+
+__all__: list[str] = ["ModelContractEvidenceSpec"]

--- a/src/omnibase_core/models/contracts/evidence/model_evidence_provenance.py
+++ b/src/omnibase_core/models/contracts/evidence/model_evidence_provenance.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelEvidenceProvenance: transient review/source metadata for evidence."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelEvidenceProvenance(BaseModel):
+    """Review and source metadata supporting a stable evidence proof.
+
+    PR metadata belongs here, not in the stable contract proof identity. This
+    preserves useful review traceability without making PR numbers the durable
+    truth that contracts validate.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(..., min_length=1)
+    commit_sha: str | None = Field(default=None, min_length=7)
+    branch: str | None = Field(default=None, min_length=1)
+    pr_number: int | None = Field(default=None, ge=1)
+    pr_url: str | None = Field(default=None, min_length=1)
+    ci_run_url: str | None = Field(default=None, min_length=1)
+    notes: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _require_some_trace(self) -> ModelEvidenceProvenance:
+        if not any(
+            (
+                self.commit_sha,
+                self.branch,
+                self.pr_number is not None,
+                self.pr_url,
+                self.ci_run_url,
+                self.notes,
+            )
+        ):
+            # error-ok: Pydantic validators must raise ValueError for field validation errors.
+            raise ValueError("provenance must include at least one trace field")
+        return self
+
+
+__all__: list[str] = ["ModelEvidenceProvenance"]

--- a/tests/unit/models/contracts/evidence/__init__.py
+++ b/tests/unit/models/contracts/evidence/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
+++ b/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
@@ -4,6 +4,7 @@
 import pytest
 from pydantic import ValidationError
 
+from omnibase_core.enums.enum_stable_proof_kind import EnumStableProofKind
 from omnibase_core.models.contracts.evidence import (
     ModelContractEvidenceProof,
     ModelContractEvidenceSpec,
@@ -22,7 +23,7 @@ def test_contract_evidence_spec_accepts_artifact_first_proof() -> None:
         stable_proofs=(
             ModelContractEvidenceProof(
                 proof_id="model-import",
-                proof_kind="model_import",
+                proof_kind=EnumStableProofKind.MODEL_IMPORT,
                 description="Model imports from the canonical core package.",
                 target="omnibase_core.models.contracts.evidence.ModelContractEvidenceSpec",
                 model_path="omnibase_core.models.contracts.evidence.ModelContractEvidenceSpec",
@@ -40,7 +41,7 @@ def test_contract_evidence_spec_accepts_artifact_first_proof() -> None:
     )
 
     assert spec.schema_version == "1.0.0"
-    assert spec.stable_proofs[0].proof_kind == "model_import"
+    assert spec.stable_proofs[0].proof_kind == EnumStableProofKind.MODEL_IMPORT
     assert spec.provenance[0].pr_number == 1
 
 
@@ -49,7 +50,7 @@ def test_stable_proof_rejects_pr_number_bound_command() -> None:
     with pytest.raises(ValidationError, match="PR-number or PR-state bound"):
         ModelContractEvidenceProof(
             proof_id="pr-open",
-            proof_kind="command",
+            proof_kind=EnumStableProofKind.COMMAND,
             description="PR is open against main.",
             target="gh pr view 123 --repo OmniNode-ai/onex_change_control",
             command="gh pr view 123 --repo OmniNode-ai/onex_change_control",
@@ -61,7 +62,7 @@ def test_stable_proof_rejects_github_pull_url() -> None:
     with pytest.raises(ValidationError, match="PR-number or PR-state bound"):
         ModelContractEvidenceProof(
             proof_id="pr-url",
-            proof_kind="command",
+            proof_kind=EnumStableProofKind.COMMAND,
             description="PR URL is not stable proof.",
             target="https://github.com/OmniNode-ai/onex_change_control/pull/1138",
             command="test -n https://github.com/OmniNode-ai/onex_change_control/pull/1138",
@@ -72,7 +73,7 @@ def test_stable_proof_rejects_github_pull_url() -> None:
 def test_stable_proof_allows_non_pr_github_artifact_url() -> None:
     proof = ModelContractEvidenceProof(
         proof_id="github-artifact",
-        proof_kind="command",
+        proof_kind=EnumStableProofKind.COMMAND,
         description="GitHub blob URL can identify a stable artifact path.",
         target="https://github.com/OmniNode-ai/omnibase_core/blob/main/pyproject.toml",
         command="test -n https://github.com/OmniNode-ai/omnibase_core/blob/main/pyproject.toml",
@@ -112,7 +113,7 @@ def test_artifact_validation_requires_model_and_artifact_path() -> None:
     with pytest.raises(ValidationError, match="requires model_path and artifact_path"):
         ModelContractEvidenceProof(
             proof_id="validate-artifact",
-            proof_kind="artifact_validation",
+            proof_kind=EnumStableProofKind.ARTIFACT_VALIDATION,
             description="Validate artifact against model.",
             target="artifact_manifest.json",
             model_path="omnibase_core.models.evidence_bundle.ModelArtifactManifest",

--- a/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
+++ b/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.evidence import (
+    ModelContractEvidenceProof,
+    ModelContractEvidenceSpec,
+    ModelEvidenceProvenance,
+)
+
+
+@pytest.mark.unit
+def test_contract_evidence_spec_accepts_artifact_first_proof() -> None:
+    spec = ModelContractEvidenceSpec(
+        ticket_id="OMN-11262",
+        summary="Migrate contract evidence models into omnibase_core.",
+        artifact_names=("ModelContractEvidenceSpec",),
+        repository_surfaces=("omnibase_core.models.contracts.evidence",),
+        acceptance_criteria=("stable proof validates the canonical model import",),
+        stable_proofs=(
+            ModelContractEvidenceProof(
+                proof_id="model-import",
+                proof_kind="model_import",
+                description="Model imports from the canonical core package.",
+                target="omnibase_core.models.contracts.evidence.ModelContractEvidenceSpec",
+                model_path="omnibase_core.models.contracts.evidence.ModelContractEvidenceSpec",
+            ),
+        ),
+        provenance=(
+            ModelEvidenceProvenance(
+                repo="omnibase_core",
+                branch="jonah/omn-11262-core-contract-evidence-model",
+                pr_number=1,
+            ),
+        ),
+        legacy_contract_path="onex_change_control/contracts/OMN-11261.yaml",
+        migration_ticket_id="OMN-11262",
+    )
+
+    assert spec.schema_version == "1.0.0"
+    assert spec.stable_proofs[0].proof_kind == "model_import"
+    assert spec.provenance[0].pr_number == 1
+
+
+@pytest.mark.unit
+def test_stable_proof_rejects_pr_number_bound_command() -> None:
+    with pytest.raises(ValidationError, match="PR-number or PR-state bound"):
+        ModelContractEvidenceProof(
+            proof_id="pr-open",
+            proof_kind="command",
+            description="PR is open against main.",
+            target="gh pr view 123 --repo OmniNode-ai/onex_change_control",
+            command="gh pr view 123 --repo OmniNode-ai/onex_change_control",
+        )
+
+
+@pytest.mark.unit
+def test_stable_proof_rejects_github_pull_url() -> None:
+    with pytest.raises(ValidationError, match="PR-number or PR-state bound"):
+        ModelContractEvidenceProof(
+            proof_id="pr-url",
+            proof_kind="command",
+            description="PR URL is not stable proof.",
+            target="https://github.com/OmniNode-ai/onex_change_control/pull/1138",
+            command="test -n https://github.com/OmniNode-ai/onex_change_control/pull/1138",
+        )
+
+
+@pytest.mark.unit
+def test_stable_proof_allows_non_pr_github_artifact_url() -> None:
+    proof = ModelContractEvidenceProof(
+        proof_id="github-artifact",
+        proof_kind="command",
+        description="GitHub blob URL can identify a stable artifact path.",
+        target="https://github.com/OmniNode-ai/omnibase_core/blob/main/pyproject.toml",
+        command="test -n https://github.com/OmniNode-ai/omnibase_core/blob/main/pyproject.toml",
+    )
+
+    assert proof.target.endswith("pyproject.toml")
+
+
+@pytest.mark.unit
+def test_pr_metadata_is_allowed_as_provenance() -> None:
+    provenance = ModelEvidenceProvenance(
+        repo="omnibase_core",
+        commit_sha="abcdef1",
+        pr_number=123,
+        pr_url="https://github.com/OmniNode-ai/omnibase_core/pull/123",
+    )
+
+    assert provenance.pr_number == 123
+    assert provenance.commit_sha == "abcdef1"
+
+
+@pytest.mark.unit
+def test_spec_requires_at_least_one_stable_proof() -> None:
+    with pytest.raises(ValidationError):
+        ModelContractEvidenceSpec(
+            ticket_id="OMN-11262",
+            summary="Invalid spec.",
+            artifact_names=("ModelContractEvidenceSpec",),
+            repository_surfaces=("omnibase_core.models.contracts.evidence",),
+            acceptance_criteria=("has proof",),
+            stable_proofs=(),
+        )
+
+
+@pytest.mark.unit
+def test_artifact_validation_requires_model_and_artifact_path() -> None:
+    with pytest.raises(ValidationError, match="requires model_path and artifact_path"):
+        ModelContractEvidenceProof(
+            proof_id="validate-artifact",
+            proof_kind="artifact_validation",
+            description="Validate artifact against model.",
+            target="artifact_manifest.json",
+            model_path="omnibase_core.models.evidence_bundle.ModelArtifactManifest",
+        )
+
+
+@pytest.mark.unit
+def test_extra_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ModelEvidenceProvenance(
+            repo="omnibase_core",
+            branch="main",
+            unexpected=True,  # type: ignore[call-arg]
+        )


### PR DESCRIPTION
Evidence-Source: 398180fd0473ed1051ed5fbe369f0583ede070e1
Evidence-Ticket: OMN-11262

## Summary

- Adds canonical ModelContractEvidenceSpec, ModelContractEvidenceProof, and ModelEvidenceProvenance under omnibase_core.models.contracts.evidence
- Exports all three models from omnibase_core.models.contracts public package
- 8 focused unit tests covering: artifact-first proof accepted; PR-number/PR-state proof rejected; PR metadata allowed only under provenance; at least one stable proof required; extra fields rejected

## Ticket

OMN-11262 — Migrate contract evidence storage model from omnibase_compat to omnibase_core

## dod_evidence

- type: model_import / from omnibase_core.models.contracts.evidence import ModelContractEvidenceSpec, ModelContractEvidenceProof, ModelEvidenceProvenance
- type: test_pass / 8 focused unit tests pass in tests/unit/models/contracts/evidence/
- type: public_export / all three models exported from omnibase_core.models.contracts __all__