### PR TITLE
feat(OMN-11274): register 5 session phase topics in TopicBase

### DIFF
--- a/tests/unit/test_topics.py
+++ b/tests/unit/test_topics.py
@@ -127,6 +127,51 @@ class TestAgentInboxDirectedTopic:
             build_agent_inbox_directed_topic("agent#1")
 
 
+class TestSessionPhaseTopics:
+    """Verify exact wire values for the 5 session phase topics (OMN-11274)."""
+
+    def test_session_phase_evaluated(self) -> None:
+        assert (
+            TopicBase.SESSION_PHASE_EVALUATED
+            == "onex.evt.omnimarket.session-phase-evaluated.v1"
+        )
+
+    def test_session_phase_transition(self) -> None:
+        assert (
+            TopicBase.SESSION_PHASE_TRANSITION
+            == "onex.cmd.omnimarket.session-phase-transition.v1"
+        )
+
+    def test_session_phase_state(self) -> None:
+        assert (
+            TopicBase.SESSION_PHASE_STATE
+            == "onex.evt.omnimarket.session-phase-state.v1"
+        )
+
+    def test_session_phase_budget_warning(self) -> None:
+        assert (
+            TopicBase.SESSION_PHASE_BUDGET_WARNING
+            == "onex.evt.omnimarket.session-phase-budget-warning.v1"
+        )
+
+    def test_session_halt_required(self) -> None:
+        assert (
+            TopicBase.SESSION_HALT_REQUIRED
+            == "onex.cmd.omnimarket.session-halt-required.v1"
+        )
+
+    def test_all_five_pass_build_topic_validation(self) -> None:
+        phase_topics = [
+            TopicBase.SESSION_PHASE_EVALUATED,
+            TopicBase.SESSION_PHASE_TRANSITION,
+            TopicBase.SESSION_PHASE_STATE,
+            TopicBase.SESSION_PHASE_BUDGET_WARNING,
+            TopicBase.SESSION_HALT_REQUIRED,
+        ]
+        for topic in phase_topics:
+            assert build_topic(topic) == topic.value
+
+
 class TestBuildTopicCanonicalEnforcement:
     def test_non_canonical_short_name_rejected(self) -> None:
         with pytest.raises(ModelOnexError, match="canonical ONEX format"):


### PR DESCRIPTION
Evidence-Source: d17784c62ae0377b4dfa99fe67e8f6cd05b62800
Evidence-Ticket: OMN-11274

## Summary

- The 5 session phase topics were already present in \`TopicBase\` (added in the OMN-11228 section of \`topics.py\`), confirming OMN-11274's core requirement is satisfied
- Adds \`TestSessionPhaseTopics\` class to \`tests/unit/test_topics.py\` with 6 tests asserting exact canonical wire values and \`build_topic()\` validation for all 5 topics
- All 28 unit tests pass; all pre-commit hooks pass

## Topics registered

| Enum member | Wire value |
|---|---|
| \`SESSION_PHASE_EVALUATED\` | \`onex.evt.omnimarket.session-phase-evaluated.v1\` |
| \`SESSION_PHASE_TRANSITION\` | \`onex.cmd.omnimarket.session-phase-transition.v1\` |
| \`SESSION_PHASE_STATE\` | \`onex.evt.omnimarket.session-phase-state.v1\` |
| \`SESSION_PHASE_BUDGET_WARNING\` | \`onex.evt.omnimarket.session-phase-budget-warning.v1\` |
| \`SESSION_HALT_REQUIRED\` | \`onex.cmd.omnimarket.session-halt-required.v1\` |

## Ticket

OMN-11274

## dod_evidence

- type: unit_test
- file: tests/unit/test_topics.py
- class: TestSessionPhaseTopics
- result: 28/28 passed
- validates: enum membership, exact wire values, build_topic() canonical enforcement for all 5 session phase topics