### PR TITLE
feat(OMN-11272): add phase budget and parallel dispatch fields to ModelSessionPhaseSpec

### DIFF
--- a/.onex_state/evidence/omn-11272-phase-budget-fields.md
+++ b/.onex_state/evidence/omn-11272-phase-budget-fields.md
@@ -1,0 +1,40 @@
+# DoD Evidence — OMN-11272
+
+**Ticket:** OMN-11272 — Add phase budget and parallel dispatch fields to ModelSessionPhaseSpec
+**Verification grade:** medium — unit tests on model fields
+**Date:** 2026-05-19
+
+## Fields Added
+
+### ModelSessionPhaseSpec (model_session_phase_spec.py)
+- `max_duration_minutes: int | None = Field(default=None, gt=0)` — hard phase time cap
+- `budget_warning_pct: int = Field(default=80, gt=0, le=100)` — warning threshold as % of budget
+- `parallel_with: tuple[str, ...] = ()` — co-dispatch relationships by phase name
+
+### ModelSessionContract (model_session_contract.py)
+- `max_parallel_workers: int = Field(default=7, gt=0)` — contract-level worker concurrency limit
+- `max_daily_cost_usd: float | None = Field(default=None, gt=0)` — daily cost ceiling
+
+## Test Results
+
+```
+tests/unit/models/overseer/test_phase_budget.py — 9 passed
+  test_phase_has_budget_fields PASSED
+  test_phase_budget_defaults PASSED
+  test_phase_max_duration_must_be_positive PASSED
+  test_phase_budget_warning_pct_range PASSED
+  test_phase_parallel_with_multiple PASSED
+  test_contract_has_max_parallel_workers PASSED
+  test_contract_max_parallel_workers_default PASSED
+  test_contract_has_max_daily_cost PASSED
+  test_contract_max_daily_cost_default_none PASSED
+```
+
+## Acceptance Criteria
+
+- [x] All new fields have defaults (backwards-compatible)
+- [x] Phases declare time budgets independently of contract-level timeout
+- [x] `parallel_with` declares co-dispatch relationships by phase name
+- [x] Contract declares worker concurrency limit (`max_parallel_workers`)
+- [x] `max_duration_minutes` validated `gt=0` (rejects 0 and negative)
+- [x] `budget_warning_pct` validated `gt=0, le=100` (rejects 0 and 101+)


### PR DESCRIPTION
Evidence-Ticket: OMN-11272
Evidence-Source: 6d12b157c2afb16ff5695392b80be7e8fcde5cf3

## Summary

- Adds max_duration_minutes, budget_warning_pct, and parallel_with to ModelSessionPhaseSpec for per-phase time budgets and co-dispatch declarations
- Adds max_parallel_workers and max_daily_cost_usd to ModelSessionContract for contract-level concurrency and cost limits
- All fields have defaults — fully backwards-compatible

## Ticket

OMN-11272 — Task 3 of docs/plans/2026-05-18-session-phase-enforcement.md

## dod_evidence

Evidence file: .onex_state/evidence/omn-11272-phase-budget-fields.md

- 9 unit tests in tests/unit/models/overseer/test_phase_budget.py — all pass
- Fields validated: max_duration_minutes rejects 0; budget_warning_pct rejects 0 and 101+
- Implementation landed in omnibase_core #1109 (feat(OMN-11227))


## Test plan

- uv run pytest tests/unit/models/overseer/test_phase_budget.py -v — 9 passed
- uv run pytest tests/unit/models/overseer/ -v — 66 passed
- pre-commit run --all-files — all hooks passed
- uv run ruff format src/ tests/ and uv run ruff check --fix src/ tests/ — no issues