### PR TITLE
feat(OMN-10815): expose contract config on node base class

### DIFF
--- a/src/omnibase_core/infrastructure/node_core_base.py
+++ b/src/omnibase_core/infrastructure/node_core_base.py
@@ -407,6 +407,18 @@ class NodeCoreBase(ABC):
     def get_state(self) -> dict[str, str]:
         return dict(self.state)
 
+    @property
+    def contract_config(self) -> dict[str, object]:
+        """Contract-declared config section, or {} if absent.
+
+        Reads the `config:` key from self.contract_data (dict or Pydantic model).
+        Never falls back to env vars — absent config means empty dict.
+        """
+        raw = get_contract_attr(self.contract_data, "config")
+        if isinstance(raw, dict):
+            return raw
+        return {}
+
     async def _load_contract(self) -> None:
         """
         Load and validate contract configuration.

--- a/src/omnibase_core/models/contracts/model_yaml_contract.py
+++ b/src/omnibase_core/models/contracts/model_yaml_contract.py
@@ -66,6 +66,12 @@ class ModelYamlContract(BaseModel):
         description="Event subscription patterns for event-driven execution",
     )
 
+    # Node configuration declared in the contract (OMN-10815)
+    config: dict[str, object] = Field(
+        default_factory=dict,
+        description="Static node configuration values declared in the contract",
+    )
+
     # Verification and traceability (OMN-7731)
     golden_path: list[str] | None = Field(
         default=None,

--- a/tests/unit/infrastructure/test_node_core_base_contract_config.py
+++ b/tests/unit/infrastructure/test_node_core_base_contract_config.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for contract config resolution on NodeCoreBase (OMN-10815).
+
+Proves that all nodes can access self.contract_config from their contract.yaml
+at construction time, without env var fallbacks.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_core.infrastructure.node_core_base import NodeCoreBase
+from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+
+class _ConcreteNode(NodeCoreBase):
+    """Minimal concrete node for testing."""
+
+    async def process(self, input_data: Any) -> Any:
+        return input_data
+
+
+@pytest.fixture
+def container() -> ModelONEXContainer:
+    return ModelONEXContainer()
+
+
+@pytest.mark.unit
+class TestNodeCoreBaseContractConfig:
+    def test_contract_config_is_empty_dict_when_no_contract(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        assert node.contract_config == {}
+
+    def test_contract_config_is_empty_dict_when_contract_has_no_config_section(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        # contract_data without a config key
+        object.__setattr__(
+            node, "contract_data", {"name": "test_node", "node_type": "compute"}
+        )
+        assert node.contract_config == {}
+
+    def test_contract_config_returns_config_section_from_dict_contract(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        object.__setattr__(
+            node,
+            "contract_data",
+            {
+                "name": "test_node",
+                "node_type": "compute",
+                "config": {"timeout_ms": 5000, "max_retries": 3},
+            },
+        )
+        assert node.contract_config == {"timeout_ms": 5000, "max_retries": 3}
+
+    def test_contract_config_returns_config_from_pydantic_model_contract(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        mock_contract = MagicMock()
+        mock_contract.config = {"batch_size": 100, "dry_run": False}
+        object.__setattr__(node, "contract_data", mock_contract)
+        assert node.contract_config == {"batch_size": 100, "dry_run": False}
+
+    def test_contract_config_returns_empty_dict_when_pydantic_model_has_no_config_attr(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        mock_contract = MagicMock(spec=[])  # spec=[] means no attributes
+        object.__setattr__(node, "contract_data", mock_contract)
+        assert node.contract_config == {}
+
+    def test_contract_config_returns_empty_dict_when_contract_config_is_none(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        object.__setattr__(
+            node,
+            "contract_data",
+            {"name": "test_node", "config": None},
+        )
+        assert node.contract_config == {}


### PR DESCRIPTION
## Summary

- Adds contract_config property to NodeCoreBase that resolves the config: section from self.contract_data at runtime
- Returns {} when contract is absent, has no config key, or config value is None — no env var fallback
- Supports both dict-based (YAML-loaded) and Pydantic model contracts via the existing get_contract_attr utility
- Adds config: dict[str, object] field to ModelYamlContract with default_factory=dict

## Ticket

OMN-10815

Evidence-Source: 4771d24103231b0a9d756b488762a7b2122d2340
Evidence-PR: OCC#1289
Evidence-Ticket: OMN-10815