### PR TITLE
ci(OMN-11424): add edited trigger to receipt-gate caller workflows

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -19,6 +19,7 @@ name: Receipt Gate
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
   merge_group:
 


### PR DESCRIPTION
## Summary

- Adds `edited` to the `pull_request` trigger types in the `call-receipt-gate.yml` caller workflow
- Fixes OMN-11424: PR body edits via `gh pr edit --body` did not re-trigger CI, requiring an empty commit to force a receipt-gate re-run

## Root Cause

The `pull_request` event only fires on `[opened, synchronize, reopened]` by default. When a developer adds `Evidence-Source:` or `Evidence-Ticket:` lines via `gh pr edit --body`, no new commit is created so CI is not re-triggered. Adding `edited` makes the receipt-gate workflow re-run on body edits.

## Repos Changed

All 8 repos with `call-receipt-gate.yml` caller workflows (excluding `onex-self-extending-agent` which already had the fix). The reusable workflow in `omnibase_core/receipt-gate.yml` is unchanged — only the per-repo caller files are modified.

Evidence-Source: e6cd8b900c55969dd272d242f1593b8e3cb4b127
Evidence-Ticket: OMN-11424