### PR TITLE
feat(OMN-10815): add config field to ModelContractBase

### DIFF
--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -241,6 +241,13 @@ class ModelContractBase(BaseModel, ABC):
         description="Non-load-bearing operational annotations preserved from legacy contract corpus.",
     )
 
+    # Static node configuration declared in the contract (OMN-10815)
+    config: dict[str, object] = Field(
+        default_factory=dict,
+        description="Static node configuration values declared in the contract. "
+        "Read by nodes via self.contract.config; never falls back to env vars.",
+    )
+
     feature_flags: list[ModelContractFeatureFlag] = Field(
         default_factory=list,
         description="Feature flags declared by this contract. "

--- a/tests/unit/contracts/test_model_contract_base.py
+++ b/tests/unit/contracts/test_model_contract_base.py
@@ -572,8 +572,7 @@ class TestModelContractBaseConfig:
         assert contract.config["count"] == 42
         assert contract.config["flag"] is True
 
-    def test_config_absent_from_yaml_gives_empty_dict(self):
-        # When no config: key in YAML, field defaults to {} — no error
+    def test_config_absent_in_constructor_gives_empty_dict(self):
         contract = SampleContractModel(**self.minimal_valid_data)
         assert isinstance(contract.config, dict)
         assert len(contract.config) == 0

--- a/tests/unit/contracts/test_model_contract_base.py
+++ b/tests/unit/contracts/test_model_contract_base.py
@@ -537,3 +537,43 @@ class TestModelContractBase:
         assert "input_type" in context
         assert "expected_type" in context
         assert "example" in context
+
+
+@pytest.mark.unit
+class TestModelContractBaseConfig:
+    """Tests for the config field on ModelContractBase (OMN-10815)."""
+
+    def setup_method(self):
+        self.minimal_valid_data = {
+            "name": "test_contract",
+            "contract_version": ModelSemVer(major=1, minor=0, patch=0),
+            "description": "Test contract",
+            "node_type": EnumNodeType.COMPUTE_GENERIC,
+            "input_model": "omnibase_core.models.test.TestInput",
+            "output_model": "omnibase_core.models.test.TestOutput",
+        }
+
+    def test_config_defaults_to_empty_dict(self):
+        contract = SampleContractModel(**self.minimal_valid_data)
+        assert contract.config == {}
+
+    def test_config_accepts_string_values(self):
+        data = {**self.minimal_valid_data, "config": {"key": "value", "env": "prod"}}
+        contract = SampleContractModel(**data)
+        assert contract.config["key"] == "value"
+        assert contract.config["env"] == "prod"
+
+    def test_config_accepts_mixed_value_types(self):
+        data = {
+            **self.minimal_valid_data,
+            "config": {"count": 42, "flag": True, "label": "x"},
+        }
+        contract = SampleContractModel(**data)
+        assert contract.config["count"] == 42
+        assert contract.config["flag"] is True
+
+    def test_config_absent_from_yaml_gives_empty_dict(self):
+        # When no config: key in YAML, field defaults to {} — no error
+        contract = SampleContractModel(**self.minimal_valid_data)
+        assert isinstance(contract.config, dict)
+        assert len(contract.config) == 0


### PR DESCRIPTION
## Summary

- Adds `config: dict[str, object]` to `ModelContractBase` with `default_factory=dict`
- All 4 node contract types (Compute, Effect, Reducer, Orchestrator) inherit the field
- Nodes using typed contracts can now access `self.contract.config["KEY"]` directly
- 4 unit tests added to `TestModelContractBaseConfig` covering default, string values, mixed types, and absent key

## Relation to OMN-10815

The first PR (#1123) added `contract_config` to `NodeCoreBase` (untyped YAML path) and `config` to `ModelYamlContract`. This PR adds the same field to `ModelContractBase` so typed contract models — used by nodes that load a `ModelContractCompute` / `ModelContractEffect` / etc. — also carry and expose the config section.

Evidence-Source: 3bdb2bd6b76659e6a498c2a9cc216fdb2576534d
Evidence-Ticket: OMN-10815

## Test results

- 4 new `TestModelContractBaseConfig` tests: all pass
- 192 API snapshot tests: all pass — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for static node configuration in contracts through a new `config` field that accepts various data types and defaults to an empty dictionary when not explicitly provided.

* **Tests**
  * Added comprehensive tests verifying the new `config` field behavior, including default values, data type handling, and YAML parsing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->