### PR TITLE
fix(OMN-11426): enforce receipt gate PR creation cutoff

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -452,6 +452,7 @@ jobs:
           PR_EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_EVENT_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_EVENT_CREATED_AT: ${{ github.event.pull_request.created_at }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
@@ -464,12 +465,13 @@ jobs:
             printf '%s' "$pr_json" | jq -r '.title // ""' > /tmp/pr_title.txt
             printf '%s' "$pr_json" | jq -r '.author.login // ""' > /tmp/pr_author.txt
             printf '%s' "$pr_json" | jq -r '.headRefName // ""' > /tmp/pr_branch.txt
+            printf '%s' "$pr_json" | jq -r '.createdAt // ""' > /tmp/pr_created_at.txt
             printf '%s' "$pr_json" | jq -r '.commits[]?.oid // empty' > /tmp/pr_commit_shas.txt
             printf '%s' "$pr_json" | jq -r '.commits[]? | ((.messageHeadline // "") + " " + (.messageBody // "" | gsub("\r?\n"; " ")))' > /tmp/pr_commit_texts.txt
           }
 
           if [ -n "$PR_NUMBER" ]; then
-            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title,author,headRefName,commits 2>/dev/null)"; then
+            if pr_json="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body,title,author,headRefName,createdAt,commits 2>/dev/null)"; then
               write_pr_snapshot "$pr_json"
               printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             else
@@ -479,13 +481,14 @@ jobs:
               printf '%s' "$PR_EVENT_TITLE" > /tmp/pr_title.txt
               printf '%s' "$PR_EVENT_AUTHOR" > /tmp/pr_author.txt
               printf '%s' "$PR_EVENT_BRANCH" > /tmp/pr_branch.txt
+              printf '%s' "$PR_EVENT_CREATED_AT" > /tmp/pr_created_at.txt
               printf '%s\n' "$PR_EVENT_SHA" > /tmp/pr_commit_shas.txt
               printf '%s' "$PR_NUMBER" > /tmp/pr_number.txt
             fi
           elif [ -n "$MERGE_GROUP_HEAD_REF" ]; then
             pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
             if [ -n "$pr_num" ] && [ "$pr_num" != "$MERGE_GROUP_HEAD_REF" ]; then
-              pr_json="$(gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title,author,headRefName,commits)"
+              pr_json="$(gh pr view "$pr_num" --repo "${{ github.repository }}" --json body,title,author,headRefName,createdAt,commits)"
               write_pr_snapshot "$pr_json"
               printf '%s' "$pr_num" > /tmp/pr_number.txt
             else
@@ -493,6 +496,7 @@ jobs:
               : > /tmp/pr_title.txt
               : > /tmp/pr_author.txt
               : > /tmp/pr_branch.txt
+              : > /tmp/pr_created_at.txt
               : > /tmp/pr_number.txt
             fi
           else
@@ -500,6 +504,7 @@ jobs:
             : > /tmp/pr_title.txt
             : > /tmp/pr_author.txt
             : > /tmp/pr_branch.txt
+            : > /tmp/pr_created_at.txt
             : > /tmp/pr_number.txt
           fi
 
@@ -572,6 +577,7 @@ jobs:
           PR_TITLE="$(cat /tmp/pr_title.txt)"
           PR_AUTHOR="$(cat /tmp/pr_author.txt 2>/dev/null || true)"
           PR_NUMBER_RESOLVED="$(cat /tmp/pr_number.txt 2>/dev/null || true)"
+          PR_OPENED_AT="$(cat /tmp/pr_created_at.txt 2>/dev/null || true)"
           REPO_NAME="${{ github.repository }}"
           REPO_SHORT="${REPO_NAME##*/}"
 
@@ -591,6 +597,11 @@ jobs:
             PR_NUMBER_ARG="--current-pr-number $PR_NUMBER_RESOLVED"
           fi
 
+          PR_OPENED_AT_ARG=""
+          if [ -n "$PR_OPENED_AT" ]; then
+            PR_OPENED_AT_ARG="--pr-opened-at $PR_OPENED_AT"
+          fi
+
           # shellcheck disable=SC2086
           python -m omnibase_core.validation.receipt_gate_cli \
             --pr-body "$PR_BODY" \
@@ -600,4 +611,5 @@ jobs:
             --current-repo "$REPO_SHORT" \
             $ALLOWLIST_ARG \
             $PR_AUTHOR_ARG \
-            $PR_NUMBER_ARG
+            $PR_NUMBER_ARG \
+            $PR_OPENED_AT_ARG

--- a/scripts/validation/validate_pr_receipts.py
+++ b/scripts/validation/validate_pr_receipts.py
@@ -23,7 +23,10 @@ import argparse
 import sys
 from pathlib import Path
 
-from omnibase_core.validation.receipt_gate import validate_pr_receipts
+from omnibase_core.validation.receipt_gate import (
+    parse_pr_opened_at,
+    validate_pr_receipts,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -44,12 +47,25 @@ def main(argv: list[str] | None = None) -> int:
         default="onex_change_control/drift/dod_receipts",
         help="Directory tree containing ModelDodReceipt YAML files.",
     )
+    parser.add_argument(
+        "--pr-opened-at",
+        default=None,
+        help=(
+            "UTC ISO-8601 timestamp when the PR was opened. Used to enforce "
+            "post-cutoff contract_sha256 receipt binding."
+        ),
+    )
     args = parser.parse_args(argv)
+    try:
+        pr_opened_at = parse_pr_opened_at(args.pr_opened_at)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     result = validate_pr_receipts(
         pr_body=args.pr_body,
         contracts_dir=Path(args.contracts_dir),
         receipts_dir=Path(args.receipts_dir),
+        pr_opened_at=pr_opened_at,
     )
 
     if result.friction_logged:

--- a/scripts/validation/validate_pr_receipts.py
+++ b/scripts/validation/validate_pr_receipts.py
@@ -56,6 +56,7 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    pr_opened_at = None
     try:
         pr_opened_at = parse_pr_opened_at(args.pr_opened_at)
     except ValueError as exc:

--- a/src/omnibase_core/validation/receipt_gate.py
+++ b/src/omnibase_core/validation/receipt_gate.py
@@ -190,6 +190,25 @@ def parse_evidence_source(pr_body: str) -> tuple[str | None, str | None]:
     return (None, None)
 
 
+def parse_pr_opened_at(value: str | None) -> datetime | None:
+    """Parse a PR-opened timestamp for receipt hash-binding enforcement."""
+    if value is None or not value.strip():
+        return None
+    raw = value.strip()
+    normalized = f"{raw[:-1]}+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(  # error-ok: argparse callers render this as CLI usage error.
+            f"pr_opened_at must be an ISO-8601 datetime with timezone, got {raw!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ValueError(  # error-ok: argparse callers render this as CLI usage error.
+            f"pr_opened_at must include a timezone offset, got {raw!r}"
+        )
+    return parsed.astimezone(UTC)
+
+
 def compute_contract_sha256(contract_path: Path) -> str:
     """Return the SHA-256 hex digest of a contract YAML file's raw bytes."""
     return hashlib.sha256(contract_path.read_bytes()).hexdigest()
@@ -957,5 +976,6 @@ __all__ = [
     "_CONTRACT_SHA256_REQUIRED_AFTER",
     "compute_contract_sha256",
     "parse_evidence_source",
+    "parse_pr_opened_at",
     "validate_pr_receipts",
 ]

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -135,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    pr_opened_at = None
     try:
         pr_opened_at = parse_pr_opened_at(args.pr_opened_at)
     except ValueError as exc:

--- a/src/omnibase_core/validation/receipt_gate_cli.py
+++ b/src/omnibase_core/validation/receipt_gate_cli.py
@@ -30,7 +30,10 @@ import argparse
 import sys
 from pathlib import Path
 
-from omnibase_core.validation.receipt_gate import validate_pr_receipts
+from omnibase_core.validation.receipt_gate import (
+    parse_pr_opened_at,
+    validate_pr_receipts,
+)
 from omnibase_core.validation.validator_receipt_reprobe import (
     ReprobeStatus,
     verify_receipts_by_reexecuting_probes,
@@ -94,6 +97,14 @@ def main(argv: list[str] | None = None) -> int:
         help="OMN-10417: PR number. Used for skip-token scope check.",
     )
     parser.add_argument(
+        "--pr-opened-at",
+        default=None,
+        help=(
+            "UTC ISO-8601 timestamp when the PR was opened. Used to enforce "
+            "post-cutoff contract_sha256 receipt binding."
+        ),
+    )
+    parser.add_argument(
         "--evidence-ticket",
         default=None,
         help=(
@@ -124,6 +135,10 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    try:
+        pr_opened_at = parse_pr_opened_at(args.pr_opened_at)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     result = validate_pr_receipts(
         pr_body=args.pr_body,
@@ -134,6 +149,7 @@ def main(argv: list[str] | None = None) -> int:
         pr_author=args.pr_author,
         current_repo=args.current_repo,
         current_pr_number=args.current_pr_number,
+        pr_opened_at=pr_opened_at,
         evidence_ticket=args.evidence_ticket,
         branch_name=args.branch_name,
     )

--- a/tests/unit/validation/test_receipt_gate_cli.py
+++ b/tests/unit/validation/test_receipt_gate_cli.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from pathlib import Path
+
 import pytest
+import yaml
 
 from omnibase_core.models.contracts.ticket.model_receipt_gate_result import (
     ModelReceiptGateResult,
@@ -32,6 +36,7 @@ def test_cli_accepts_workflow_context_args(monkeypatch: pytest.MonkeyPatch) -> N
     def fake_validate_pr_receipts(**kwargs: object) -> ModelReceiptGateResult:
         assert kwargs["pr_body"] == "Implements OMN-1"
         assert kwargs["pr_title"] == "feat: test"
+        assert kwargs["pr_opened_at"] == datetime(2026, 5, 21, 12, 30, tzinfo=UTC)
         return ModelReceiptGateResult(passed=True, message="ok")
 
     monkeypatch.setattr(
@@ -59,7 +64,89 @@ def test_cli_accepts_workflow_context_args(monkeypatch: pytest.MonkeyPatch) -> N
                 "jonahgabriel",
                 "--current-pr-number",
                 "1024",
+                "--pr-opened-at",
+                "2026-05-21T12:30:00Z",
             ]
         )
         == 0
     )
+
+
+def test_cli_rejects_pr_opened_at_without_timezone() -> None:
+    """PR-opened timestamps must be timezone-aware for deterministic cutoff checks."""
+    with pytest.raises(SystemExit) as exc_info:
+        receipt_gate_cli.main(
+            [
+                "--pr-body",
+                "Implements OMN-1",
+                "--contracts-dir",
+                "contracts",
+                "--receipts-dir",
+                "receipts",
+                "--pr-opened-at",
+                "2026-05-21T12:30:00",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_cli_enforces_post_cutoff_contract_sha256(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI must pass PR-opened time into the gate so hash binding is enforced."""
+    contracts_dir = tmp_path / "contracts"
+    receipts_dir = tmp_path / "receipts"
+    receipt_path = receipts_dir / "OMN-10421" / "dod-001" / "command.yaml"
+    contracts_dir.mkdir(parents=True)
+    receipt_path.parent.mkdir(parents=True)
+    (contracts_dir / "OMN-10421.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "ticket_id": "OMN-10421",
+                "schema_version": "1.0.0",
+                "summary": "hash binding",
+                "dod_evidence": [
+                    {
+                        "id": "dod-001",
+                        "description": "command check",
+                        "checks": [{"check_type": "command", "check_value": "echo ok"}],
+                    }
+                ],
+            }
+        )
+    )
+    receipt_path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "1.0.0",
+                "ticket_id": "OMN-10421",
+                "evidence_item_id": "dod-001",
+                "check_type": "command",
+                "check_value": "echo ok",
+                "status": "PASS",
+                "run_timestamp": datetime(2026, 5, 21, 12, 30, tzinfo=UTC),
+                "commit_sha": "a1b2c3d4",
+                "runner": "ci",
+                "verifier": "reviewer",
+                "probe_command": "echo ok",
+                "probe_stdout": "ok\n",
+            }
+        )
+    )
+
+    exit_code = receipt_gate_cli.main(
+        [
+            "--pr-body",
+            "Closes OMN-10421",
+            "--contracts-dir",
+            str(contracts_dir),
+            "--receipts-dir",
+            str(receipts_dir),
+            "--pr-opened-at",
+            "2026-05-21T12:30:00Z",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "contract_sha256" in capsys.readouterr().out

--- a/tests/unit/validation/test_receipt_gate_contract_sha256.py
+++ b/tests/unit/validation/test_receipt_gate_contract_sha256.py
@@ -23,6 +23,7 @@ import yaml
 from omnibase_core.validation.receipt_gate import (
     _CONTRACT_SHA256_REQUIRED_AFTER,
     compute_contract_sha256,
+    parse_pr_opened_at,
     validate_pr_receipts,
 )
 
@@ -215,3 +216,15 @@ class TestComputeContractSha256:
         f.write_bytes(b"mutated: true\n")
         sha2 = compute_contract_sha256(f)
         assert sha1 != sha2
+
+
+@pytest.mark.unit
+class TestParsePrOpenedAt:
+    def test_z_suffix_parses_as_utc(self) -> None:
+        parsed = parse_pr_opened_at("2026-05-21T12:30:00Z")
+
+        assert parsed == datetime(2026, 5, 21, 12, 30, tzinfo=UTC)
+
+    def test_naive_timestamp_rejected(self) -> None:
+        with pytest.raises(ValueError, match="timezone"):
+            parse_pr_opened_at("2026-05-21T12:30:00")

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -194,7 +194,8 @@ def test_workflow_captures_pr_snapshot_once_for_eligibility() -> None:
     step = _workflow_step("Resolve PR snapshot")
     script = step["run"]
 
-    assert "--json body,title,author,headRefName,commits" in script
+    assert "--json body,title,author,headRefName,createdAt,commits" in script
+    assert "/tmp/pr_created_at.txt" in script
     assert "/tmp/pr_commit_shas.txt" in script
     assert "/tmp/pr_commit_texts.txt" in script
     assert "MERGE_GROUP_HEAD_REF" in script


### PR DESCRIPTION
## Summary
- pass PR creation time into Receipt Gate CLI/proof paths
- enforce post-cutoff contract_sha256 behavior from workflow and validation script entrypoints
- add focused regression coverage for CLI timestamp parsing and receipt gate enforcement

## Verification
- pytest tests/unit/validation/test_receipt_gate_cli.py tests/unit/validation/test_receipt_gate_contract_sha256.py -q
- pytest tests/unit/validation/test_receipt_gate_*.py tests/unit/scripts/validation/test_validate_pr_receipts.py -q
- ruff check on touched Python files
- push hooks passed: mypy and pyright

Linear: OMN-11426

Evidence-Source: OCC#1297
Evidence-Ticket: OMN-11426
