### PR TITLE
fix(OMN-11428): split validation script hotspots

### DIFF
--- a/scripts/validate_no_transport_imports.py
+++ b/scripts/validate_no_transport_imports.py
@@ -297,52 +297,39 @@ def iter_python_files(root_dir: Path, excludes: set[Path]) -> Iterator[Path]:
         ...     print(py_file)
     """
     for path in root_dir.rglob("*.py"):
-        # Skip files in excluded directories
-        if any(skip_dir in path.parts for skip_dir in SKIP_DIRECTORIES):
-            continue
-
-        # Check against user-provided exclusions
-        should_exclude = False
-        for exclude_path in excludes:
-            try:
-                path.relative_to(exclude_path)
-                should_exclude = True
-                break
-            except ValueError:
-                # path is not relative to exclude_path, use path component matching
-                try:
-                    # Check if exclude_path appears as a contiguous subsequence in path
-                    # using PATH COMPONENT matching (not string matching).
-                    #
-                    # Why path components? This prevents partial string matches:
-                    #   - path.parts gives tuples like ('src', 'tests', 'file.py')
-                    #   - exclude "tests" (parts: ('tests',)) matches ('src', 'tests', 'file.py')
-                    #   - exclude "tests" does NOT match ('src', 'tests_util', 'file.py')
-                    #     because ('tests',) != ('tests_util',) as tuples
-                    #
-                    # Examples:
-                    #   - Exclude "tests" MATCHES "src/tests/file.py"
-                    #   - Exclude "tests" does NOT match "src/tests_util/file.py"
-                    #   - Exclude "foo" does NOT match "foobar/file.py"
-                    path_parts = path.parts
-                    exclude_parts = exclude_path.parts
-                    exclude_len = len(exclude_parts)
-                    for i in range(len(path_parts) - exclude_len + 1):
-                        if path_parts[i : i + exclude_len] == exclude_parts:
-                            should_exclude = True
-                            break
-                    if should_exclude:
-                        break
-                    # Also check exact filename match (for single-file exclusions)
-                    if exclude_path.name == path.name:
-                        should_exclude = True
-                        break
-                except Exception:
-                    # fallback-ok: skip exclusion check on path parsing errors
-                    pass
-
-        if not should_exclude:
+        if not _should_exclude_python_file(path, excludes):
             yield path
+
+
+def _has_contiguous_parts(path: Path, exclude_path: Path) -> bool:
+    """Return True when exclude_path parts appear exactly in path parts."""
+    path_parts = path.parts
+    exclude_parts = exclude_path.parts
+    exclude_len = len(exclude_parts)
+    return any(
+        path_parts[index : index + exclude_len] == exclude_parts
+        for index in range(len(path_parts) - exclude_len + 1)
+    )
+
+
+def _matches_exclude_path(path: Path, exclude_path: Path) -> bool:
+    try:
+        path.relative_to(exclude_path)
+    except ValueError:
+        return (
+            _has_contiguous_parts(path, exclude_path) or exclude_path.name == path.name
+        )
+    return True
+
+
+def _should_exclude_python_file(path: Path, excludes: set[Path]) -> bool:
+    if any(skip_dir in path.parts for skip_dir in SKIP_DIRECTORIES):
+        return True
+
+    for exclude_path in excludes:
+        if _matches_exclude_path(path, exclude_path):
+            return True
+    return False
 
 
 def check_file(

--- a/scripts/validation/check_ai_slop.py
+++ b/scripts/validation/check_ai_slop.py
@@ -329,6 +329,103 @@ def _format_docstring_message(rule_name: str, doc_line: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+LineRule = tuple[str, re.Pattern[str], str]
+
+
+def _applicable_line_rules(
+    line_rules: dict[str, tuple[re.Pattern[str], str, list[str]]],
+    *,
+    is_markdown: bool,
+) -> list[LineRule]:
+    applicable: list[LineRule] = []
+    for rule_name, (pattern, severity, globs) in line_rules.items():
+        md_only = all(g == "*.md" for g in globs)
+        py_only = all(g == "*.py" for g in globs) and not any(
+            g == "*.md" for g in globs
+        )
+        if is_markdown and py_only:
+            continue
+        if not is_markdown and md_only:
+            continue
+        applicable.append((rule_name, pattern, severity))
+    return applicable
+
+
+def _toggle_triple_quote_state(
+    stripped: str, *, in_triple_quote: bool, triple_char: str
+) -> tuple[bool, str]:
+    for quote in ('"""', "'''"):
+        count = stripped.count(quote)
+        if not count:
+            continue
+        if not in_triple_quote and count % 2 == 1:
+            return True, quote
+        if quote == triple_char and count % 2 == 1:
+            return False, ""
+    return in_triple_quote, triple_char
+
+
+def _build_line_violation(
+    *,
+    filename: str,
+    lineno: int,
+    rule_name: str,
+    severity: str,
+    message: str,
+    source_line: str,
+) -> SlopViolation:
+    return SlopViolation(
+        filename=filename,
+        line=lineno,
+        check=rule_name,
+        severity=severity,
+        message=message,
+        source_line=source_line,
+    )
+
+
+def _check_line_rules(
+    *,
+    filename: str,
+    lineno: int,
+    stripped: str,
+    applicable: list[LineRule],
+) -> list[SlopViolation]:
+    if SUPPRESSION_MARKER in stripped:
+        return []
+
+    violations: list[SlopViolation] = []
+    for rule_name, pattern, severity in applicable:
+        if rule_name == CHECK_STEP_NARRATION:
+            comment_match = re.search(r"#(.+)", stripped)
+            if comment_match and pattern.search(comment_match.group(0)):
+                comment_text = comment_match.group(0)
+                violations.append(
+                    _build_line_violation(
+                        filename=filename,
+                        lineno=lineno,
+                        rule_name=rule_name,
+                        severity=severity,
+                        message=f"Step narration comment: {comment_text.strip()!r}",
+                        source_line=stripped,
+                    )
+                )
+            continue
+
+        if pattern.search(stripped):
+            violations.append(
+                _build_line_violation(
+                    filename=filename,
+                    lineno=lineno,
+                    rule_name=rule_name,
+                    severity=severity,
+                    message=f"Pattern match ({rule_name}): {stripped!r}",
+                    source_line=stripped,
+                )
+            )
+    return violations
+
+
 def _check_lines(
     filename: str,
     source_lines: list[str],
@@ -352,18 +449,7 @@ def _check_lines(
     violations: list[SlopViolation] = []
     is_markdown = filename.endswith(".md")
 
-    # Filter rules to those that apply to this file type
-    applicable: list[tuple[str, re.Pattern[str], str]] = []
-    for rule_name, (pattern, severity, globs) in line_rules.items():
-        md_only = all(g == "*.md" for g in globs)
-        py_only = all(g == "*.py" for g in globs) and not any(
-            g == "*.md" for g in globs
-        )
-        if is_markdown and py_only:
-            continue
-        if not is_markdown and md_only:
-            continue
-        applicable.append((rule_name, pattern, severity))
+    applicable = _applicable_line_rules(line_rules, is_markdown=is_markdown)
 
     in_triple_quote = False
     triple_char = ""
@@ -374,18 +460,11 @@ def _check_lines(
 
         # Toggle triple-quote tracking for Python files (simple heuristic)
         if not is_markdown:
-            for tq in ('"""', "'''"):
-                count = stripped.count(tq)
-                if count:
-                    if not in_triple_quote:
-                        if count % 2 == 1:
-                            in_triple_quote = True
-                            triple_char = tq
-                    elif tq == triple_char:
-                        if count % 2 == 1:
-                            in_triple_quote = False
-                            triple_char = ""
-
+            in_triple_quote, triple_char = _toggle_triple_quote_state(
+                stripped,
+                in_triple_quote=in_triple_quote,
+                triple_char=triple_char,
+            )
             if in_triple_quote:
                 continue
 
@@ -396,36 +475,14 @@ def _check_lines(
             if in_md_code_fence or stripped.startswith(("```", "~~~")):
                 continue
 
-        for rule_name, pattern, severity in applicable:
-            if rule_name == CHECK_STEP_NARRATION:
-                # step_narration: match only inside a heading/comment context in .md
-                comment_match = re.search(r"#(.+)", stripped)
-                if comment_match:
-                    comment_text = comment_match.group(0)
-                    if pattern.search(comment_text):
-                        if SUPPRESSION_MARKER not in stripped:
-                            violations.append(
-                                SlopViolation(
-                                    filename=filename,
-                                    line=lineno,
-                                    check=rule_name,
-                                    severity=severity,
-                                    message=f"Step narration comment: {comment_text.strip()!r}",
-                                    source_line=stripped,
-                                )
-                            )
-            elif pattern.search(stripped):
-                if SUPPRESSION_MARKER not in stripped:
-                    violations.append(
-                        SlopViolation(
-                            filename=filename,
-                            line=lineno,
-                            check=rule_name,
-                            severity=severity,
-                            message=f"Pattern match ({rule_name}): {stripped!r}",
-                            source_line=stripped,
-                        )
-                    )
+        violations.extend(
+            _check_line_rules(
+                filename=filename,
+                lineno=lineno,
+                stripped=stripped,
+                applicable=applicable,
+            )
+        )
 
     return violations
 

--- a/scripts/validation/check_no_print_statements.py
+++ b/scripts/validation/check_no_print_statements.py
@@ -109,57 +109,87 @@ def check_docstring_prints(
         return violations
 
     for node in ast.walk(tree):
-        # Check docstrings in functions, classes, and modules
-        docstring = None
-        if isinstance(
-            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)
-        ):
-            docstring = ast.get_docstring(node)
+        violations.extend(_docstring_print_violations(node, source_lines))
 
-        if docstring and "print(" in docstring:
-            # Find the actual line number of the docstring
-            if hasattr(node, "body") and node.body:
-                first_stmt = node.body[0]
-                if isinstance(first_stmt, ast.Expr) and isinstance(
-                    first_stmt.value, ast.Constant
-                ):
-                    # Find print( in the docstring and report it
-                    docstring_start = first_stmt.lineno
-                    # Detect if opening quotes are on separate line (accounts for off-by-one)
-                    opening_line = (
-                        source_lines[docstring_start - 1].strip()
-                        if docstring_start <= len(source_lines)
-                        else ""
-                    )
-                    offset = 1 if opening_line in ('"""', "'''") else 0
-                    docstring_lines = docstring.split("\n")
+    return violations
 
-                    for i, doc_line in enumerate(docstring_lines):
-                        if "print(" in doc_line:
-                            actual_line = docstring_start + i + offset
-                            line_content = (
-                                source_lines[actual_line - 1].strip()
-                                if actual_line <= len(source_lines)
-                                else doc_line.strip()
-                            )
 
-                            # Check for print-ok comment
-                            if "# print-ok:" in line_content:
-                                continue
+def _docstring_source_start(
+    node: ast.AST, source_lines: list[str]
+) -> tuple[int, int] | None:
+    if not hasattr(node, "body") or not node.body:
+        return None
 
-                            violations.append(
-                                {
-                                    "type": "docstring_print",
-                                    "line": actual_line,
-                                    "code": line_content,
-                                    "message": (
-                                        "print() in docstring example. Documentation should demonstrate "
-                                        "best practices using logger.debug/info/warning/error()"
-                                    ),
-                                    "severity": "warning",
-                                }
-                            )
+    first_stmt = node.body[0]
+    if not (
+        isinstance(first_stmt, ast.Expr) and isinstance(first_stmt.value, ast.Constant)
+    ):
+        return None
 
+    docstring_start = first_stmt.lineno
+    opening_line = (
+        source_lines[docstring_start - 1].strip()
+        if docstring_start <= len(source_lines)
+        else ""
+    )
+    offset = 1 if opening_line in ('"""', "'''") else 0
+    return docstring_start, offset
+
+
+def _docstring_line_content(
+    source_lines: list[str], actual_line: int, fallback: str
+) -> str:
+    if actual_line <= len(source_lines):
+        return source_lines[actual_line - 1].strip()
+    return fallback.strip()
+
+
+def _build_docstring_print_violation(
+    *, actual_line: int, line_content: str
+) -> dict[str, Any]:
+    return {
+        "type": "docstring_print",
+        "line": actual_line,
+        "code": line_content,
+        "message": (
+            "print() in docstring example. Documentation should demonstrate "
+            "best practices using logger.debug/info/warning/error()"
+        ),
+        "severity": "warning",
+    }
+
+
+def _docstring_print_violations(
+    node: ast.AST, source_lines: list[str]
+) -> list[dict[str, Any]]:
+    if not isinstance(
+        node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)
+    ):
+        return []
+
+    docstring = ast.get_docstring(node)
+    if not docstring or "print(" not in docstring:
+        return []
+
+    start = _docstring_source_start(node, source_lines)
+    if start is None:
+        return []
+
+    docstring_start, offset = start
+    violations: list[dict[str, Any]] = []
+    for index, doc_line in enumerate(docstring.split("\n")):
+        if "print(" not in doc_line:
+            continue
+        actual_line = docstring_start + index + offset
+        line_content = _docstring_line_content(source_lines, actual_line, doc_line)
+        if "# print-ok:" in line_content:
+            continue
+        violations.append(
+            _build_docstring_print_violation(
+                actual_line=actual_line,
+                line_content=line_content,
+            )
+        )
     return violations
 
 


### PR DESCRIPTION
## Summary
- split repeated validation-script hotspot logic into focused helpers
- keep AI-slop line checks, transport import exclusions, and docstring print reporting behavior-preserving
- choose in-place cleanup for the highest-impact omnibase_core surface before any shared helper extraction

## Verification
- uv run ruff format scripts/validation/check_ai_slop.py scripts/validate_no_transport_imports.py scripts/validation/check_no_print_statements.py
- uv run ruff check --ignore T201 scripts/validation/check_ai_slop.py scripts/validate_no_transport_imports.py scripts/validation/check_no_print_statements.py
- uv run python scripts/validation/check_ai_slop.py --strict scripts/validation/check_ai_slop.py scripts/validate_no_transport_imports.py scripts/validation/check_no_print_statements.py
- uv run python scripts/validate_no_transport_imports.py --src-dir src/omnibase_core
- uv run pytest tests/unit/scripts/validation/test_check_ai_slop.py tests/unit/scripts/test_check_ai_slop_parity.py tests/unit/scripts/test_validate_no_transport_imports.py tests/unit/scripts/validation/test_check_no_print_statements.py -q

## Change Control
Evidence-Source: b9947ca33121ab87fc5a8b14cd9d6d06b8a8ad22

Evidence-Ticket: OMN-11428