### PR TITLE
feat(OMN-11430): replace dict[str, object] config with ModelContractConfig

### DIFF
--- a/src/omnibase_core/infrastructure/node_core_base.py
+++ b/src/omnibase_core/infrastructure/node_core_base.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from omnibase_core.models.container.model_protocols_namespace import (
     ModelProtocolsNamespace,
 )
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
 from omnibase_core.models.contracts.subcontracts.model_protocol_dependency import (
     ModelProtocolDependency,
 )
@@ -408,16 +409,18 @@ class NodeCoreBase(ABC):
         return dict(self.state)
 
     @property
-    def contract_config(self) -> dict[str, object]:
-        """Contract-declared config section, or {} if absent.
+    def contract_config(self) -> ModelContractConfig:
+        """Contract-declared config section, or default ModelContractConfig if absent.
 
         Reads the `config:` key from self.contract_data (dict or Pydantic model).
-        Never falls back to env vars — absent config means empty dict.
+        Never falls back to env vars — absent config means empty ModelContractConfig.
         """
         raw = get_contract_attr(self.contract_data, "config")
-        if isinstance(raw, dict):
+        if isinstance(raw, ModelContractConfig):
             return raw
-        return {}
+        if isinstance(raw, dict):
+            return ModelContractConfig.model_validate(raw)
+        return ModelContractConfig()
 
     async def _load_contract(self) -> None:
         """

--- a/src/omnibase_core/infrastructure/node_core_base.py
+++ b/src/omnibase_core/infrastructure/node_core_base.py
@@ -416,11 +416,17 @@ class NodeCoreBase(ABC):
         Never falls back to env vars — absent config means empty ModelContractConfig.
         """
         raw = get_contract_attr(self.contract_data, "config")
+        if raw is None:
+            return ModelContractConfig()
         if isinstance(raw, ModelContractConfig):
             return raw
-        if isinstance(raw, dict):
-            return ModelContractConfig.model_validate(raw)
-        return ModelContractConfig()
+        if isinstance(raw, Mapping):
+            return ModelContractConfig.model_validate(dict(raw))
+        raise ModelOnexError(
+            message="Contract config must be a mapping or ModelContractConfig.",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            received_type=type(raw).__name__,
+        )
 
     async def _load_contract(self) -> None:
         """

--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -152,6 +152,7 @@ from .model_conflict_resolution_config import ModelConflictResolutionConfig
 from .model_consumed_event_entry import ModelConsumedEventEntry
 from .model_contract_base import ModelContractBase
 from .model_contract_compute import ModelContractCompute
+from .model_contract_config import ModelContractConfig
 from .model_contract_effect import ModelContractEffect
 from .model_contract_fingerprint import ModelContractFingerprint
 from .model_contract_meta import (
@@ -206,10 +207,12 @@ from .model_http_response_contract import ModelHttpResponseContract
 from .model_input_validation_config import ModelInputValidationConfig
 from .model_io_operation_config import ModelIOOperationConfig
 from .model_lifecycle_config import ModelLifecycleConfig
+from .model_llm_endpoint_config import ModelLlmEndpointConfig
 from .model_memory_management_config import ModelMemoryManagementConfig
 from .model_node_extensions import ModelNodeExtensions
 from .model_node_ref import ModelNodeRef
 from .model_omnimemory_contract import ModelOmniMemoryContract
+from .model_operational_config import ModelOperationalConfig
 from .model_output_transformation_config import ModelOutputTransformationConfig
 from .model_parallel_config import ModelParallelConfig
 from .model_performance_requirements import ModelPerformanceRequirements
@@ -228,6 +231,7 @@ from .model_retry_policy_contract import ModelRetryPolicyContract
 from .model_runtime_event_bus_config import ModelRuntimeEventBusConfig
 from .model_runtime_handler_config import ModelRuntimeHandlerConfig
 from .model_runtime_host_contract import ModelRuntimeHostContract
+from .model_storage_config import ModelStorageConfig
 from .model_streaming_config import ModelStreamingConfig
 from .model_transaction_config import ModelTransactionConfig
 from .model_trigger_mappings import ModelTriggerMappings
@@ -274,6 +278,10 @@ __all__ = [
     # Foundation models
     "ModelConsumedEventEntry",
     "ModelContractBase",
+    "ModelContractConfig",
+    "ModelLlmEndpointConfig",
+    "ModelOperationalConfig",
+    "ModelStorageConfig",
     "ModelContractFingerprint",
     "ModelContractMeta",
     "ModelContractEvidenceProof",

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -242,13 +242,6 @@ class ModelContractBase(BaseModel, ABC):
         description="Non-load-bearing operational annotations preserved from legacy contract corpus.",
     )
 
-    # Static node configuration declared in the contract (OMN-10815)
-    config: dict[str, object] = Field(
-        default_factory=dict,
-        description="Static node configuration values declared in the contract. "
-        "Read by nodes via self.contract.config; never falls back to env vars.",
-    )
-
     feature_flags: list[ModelContractFeatureFlag] = Field(
         default_factory=list,
         description="Feature flags declared by this contract. "

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 from omnibase_core.models.contracts.model_concurrency_contract_spec import (
     ModelConcurrencyContractSpec,
 )
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
 from omnibase_core.models.contracts.model_contract_feature_flag import (
     ModelContractFeatureFlag,
 )
@@ -268,6 +269,13 @@ class ModelContractBase(BaseModel, ABC):
         description="Structured Definition of Done evidence items. "
         "Each entry declares an evidence type and a check that must pass "
         "before a ticket touching this contract can be marked Done.",
+    )
+
+    # Static node configuration declared in the contract (OMN-10815, typed OMN-11430)
+    config: ModelContractConfig = Field(
+        default_factory=ModelContractConfig,
+        description="Strongly typed static node configuration declared in the contract. "
+        "Read by nodes via self.contract.config; never falls back to env vars.",
     )
 
     # Execution profile for contract-driven execution

--- a/src/omnibase_core/models/contracts/model_contract_config.py
+++ b/src/omnibase_core/models/contracts/model_contract_config.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Strongly typed top-level contract config model (OMN-11430).
+
+Composes LLM endpoint, storage, and operational sub-models.
+extra="allow" so node-specific fields not covered by the base schema pass through.
+Sub-models use extra="forbid" for strict validation within their scope.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.model_llm_endpoint_config import (
+    ModelLlmEndpointConfig,
+)
+from omnibase_core.models.contracts.model_operational_config import (
+    ModelOperationalConfig,
+)
+from omnibase_core.models.contracts.model_storage_config import ModelStorageConfig
+
+
+class ModelContractConfig(BaseModel):
+    """
+    Strongly typed contract config block.
+
+    Composes LLM endpoint, storage, and operational sub-models as optional
+    nested structures. extra="allow" lets node-specific fields not covered by
+    the base schema pass through at the top level — node-specific typed config
+    models are a follow-up.
+
+    All fields default to empty sub-models so contracts without a config section
+    still load cleanly.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="allow", from_attributes=True)
+
+    llm: ModelLlmEndpointConfig = Field(
+        default_factory=ModelLlmEndpointConfig,
+        description="LLM endpoint configuration",
+    )
+    storage: ModelStorageConfig = Field(
+        default_factory=ModelStorageConfig,
+        description="Storage connection configuration",
+    )
+    operational: ModelOperationalConfig = Field(
+        default_factory=ModelOperationalConfig,
+        description="Operational configuration",
+    )

--- a/src/omnibase_core/models/contracts/model_llm_endpoint_config.py
+++ b/src/omnibase_core/models/contracts/model_llm_endpoint_config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 
 class ModelLlmEndpointConfig(BaseModel):
-    """LLM endpoint URLs, model names, and timeouts declared in contract config."""
+    """LLM endpoint URLs and model names declared in contract config."""
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 

--- a/src/omnibase_core/models/contracts/model_llm_endpoint_config.py
+++ b/src/omnibase_core/models/contracts/model_llm_endpoint_config.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Strongly typed LLM endpoint configuration for contract config blocks (OMN-11430)."""
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+
+class ModelLlmEndpointConfig(BaseModel):
+    """LLM endpoint URLs, model names, and timeouts declared in contract config."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    coder_url: str | None = Field(
+        default=None, description="Primary coder LLM endpoint URL"
+    )
+    coder_fast_url: str | None = Field(
+        default=None, description="Fast coder LLM endpoint URL"
+    )
+    coder_model_name: str | None = Field(
+        default=None, description="Primary coder model name"
+    )
+    coder_fast_model_name: str | None = Field(
+        default=None, description="Fast coder model name"
+    )
+    deepseek_r1_url: str | None = Field(
+        default=None, description="DeepSeek R1 endpoint URL"
+    )
+    glm_url: str | None = Field(default=None, description="GLM endpoint URL")
+    glm_api_key: SecretStr | None = Field(default=None, description="GLM API key")
+    gemini_api_key: SecretStr | None = Field(default=None, description="Gemini API key")
+    openai_api_key: SecretStr | None = Field(default=None, description="OpenAI API key")

--- a/src/omnibase_core/models/contracts/model_operational_config.py
+++ b/src/omnibase_core/models/contracts/model_operational_config.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Strongly typed operational configuration for contract config blocks (OMN-11430)."""
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+
+class ModelOperationalConfig(BaseModel):
+    """Operational configuration: credentials and integration keys."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    linear_api_key: SecretStr | None = Field(default=None, description="Linear API key")
+    # string-id-ok: Linear team IDs are string slugs (e.g. 'OmniNode'), not UUIDs
+    linear_team_id: str | None = Field(
+        default=None, description="Linear team ID (string slug, e.g. 'OmniNode')"
+    )
+    github_token: SecretStr | None = Field(
+        default=None, description="GitHub personal access token"
+    )
+    slack_webhook_url: str | None = Field(
+        default=None, description="Slack incoming webhook URL"
+    )

--- a/src/omnibase_core/models/contracts/model_storage_config.py
+++ b/src/omnibase_core/models/contracts/model_storage_config.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Strongly typed storage configuration for contract config blocks (OMN-11430)."""
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+
+class ModelStorageConfig(BaseModel):
+    """Storage connection parameters declared in contract config."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    postgres_host: str | None = Field(default=None, description="PostgreSQL host")
+    postgres_port: int | None = Field(default=None, description="PostgreSQL port")
+    postgres_database: str | None = Field(
+        default=None, description="PostgreSQL database name"
+    )
+    postgres_user: str | None = Field(default=None, description="PostgreSQL user")
+    postgres_password: SecretStr | None = Field(
+        default=None, description="PostgreSQL password"
+    )
+    kafka_bootstrap_servers: str | None = Field(
+        default=None, description="Kafka bootstrap servers"
+    )
+    redpanda_admin_host: str | None = Field(
+        default=None, description="Redpanda admin host"
+    )
+    redpanda_admin_port: int | None = Field(
+        default=None, description="Redpanda admin port"
+    )

--- a/src/omnibase_core/models/contracts/model_yaml_contract.py
+++ b/src/omnibase_core/models/contracts/model_yaml_contract.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from omnibase_core.enums import EnumNodeType
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
 from omnibase_core.models.contracts.model_event_subscription import (
     ModelEventSubscription,
 )
@@ -66,10 +67,10 @@ class ModelYamlContract(BaseModel):
         description="Event subscription patterns for event-driven execution",
     )
 
-    # Node configuration declared in the contract (OMN-10815)
-    config: dict[str, object] = Field(
-        default_factory=dict,
-        description="Static node configuration values declared in the contract",
+    # Node configuration declared in the contract (OMN-10815, typed OMN-11430)
+    config: ModelContractConfig = Field(
+        default_factory=ModelContractConfig,
+        description="Strongly typed static node configuration declared in the contract",
     )
 
     # Verification and traceability (OMN-7731)

--- a/tests/unit/contracts/test_model_contract_base.py
+++ b/tests/unit/contracts/test_model_contract_base.py
@@ -25,6 +25,7 @@ from omnibase_core.enums import EnumNodeType
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_dependency_type import EnumDependencyType
 from omnibase_core.models.contracts.model_contract_base import ModelContractBase
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
 from omnibase_core.models.contracts.model_dependency import ModelDependency
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.primitives.model_semver import ModelSemVer
@@ -553,15 +554,16 @@ class TestModelContractBaseConfig:
             "output_model": "omnibase_core.models.test.TestOutput",
         }
 
-    def test_config_defaults_to_empty_dict(self):
+    def test_config_defaults_to_empty_model(self):
         contract = SampleContractModel(**self.minimal_valid_data)
-        assert contract.config == {}
+        assert isinstance(contract.config, ModelContractConfig)
+        assert contract.config.model_extra == {}
 
     def test_config_accepts_string_values(self):
         data = {**self.minimal_valid_data, "config": {"key": "value", "env": "prod"}}
         contract = SampleContractModel(**data)
-        assert contract.config["key"] == "value"
-        assert contract.config["env"] == "prod"
+        assert contract.config.key == "value"
+        assert contract.config.env == "prod"
 
     def test_config_accepts_mixed_value_types(self):
         data = {
@@ -569,10 +571,10 @@ class TestModelContractBaseConfig:
             "config": {"count": 42, "flag": True, "label": "x"},
         }
         contract = SampleContractModel(**data)
-        assert contract.config["count"] == 42
-        assert contract.config["flag"] is True
+        assert contract.config.count == 42
+        assert contract.config.flag is True
 
-    def test_config_absent_in_constructor_gives_empty_dict(self):
+    def test_config_absent_in_constructor_gives_empty_model(self):
         contract = SampleContractModel(**self.minimal_valid_data)
-        assert isinstance(contract.config, dict)
-        assert len(contract.config) == 0
+        assert isinstance(contract.config, ModelContractConfig)
+        assert contract.config.model_extra == {}

--- a/tests/unit/contracts/test_model_contract_config.py
+++ b/tests/unit/contracts/test_model_contract_config.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelContractConfig and sub-models (OMN-11430)."""
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from omnibase_core.enums import EnumNodeType
+from omnibase_core.models.contracts.model_contract_base import ModelContractBase
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
+from omnibase_core.models.contracts.model_llm_endpoint_config import (
+    ModelLlmEndpointConfig,
+)
+from omnibase_core.models.contracts.model_operational_config import (
+    ModelOperationalConfig,
+)
+from omnibase_core.models.contracts.model_storage_config import ModelStorageConfig
+from omnibase_core.models.contracts.model_yaml_contract import ModelYamlContract
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+class _SampleContract(ModelContractBase):
+    def validate_node_specific_config(self) -> None:
+        pass
+
+
+_SEMVER = ModelSemVer(major=1, minor=0, patch=0)
+_MINIMAL = {
+    "name": "test_contract",
+    "contract_version": _SEMVER,
+    "description": "Test",
+    "node_type": EnumNodeType.COMPUTE_GENERIC,
+    "input_model": "omnibase_core.models.test.In",
+    "output_model": "omnibase_core.models.test.Out",
+}
+
+
+@pytest.mark.unit
+class TestModelContractConfig:
+    """Unit tests for ModelContractConfig and its sub-models."""
+
+    def test_default_construction_gives_empty_submodels(self):
+        cfg = ModelContractConfig()
+        assert cfg.llm.coder_url is None
+        assert cfg.storage.postgres_host is None
+        assert cfg.operational.linear_api_key is None
+
+    def test_llm_endpoint_config_valid(self):
+        llm = ModelLlmEndpointConfig(
+            coder_url="http://192.168.86.201:8000",
+            coder_model_name="Qwen3-Coder-30B",
+        )
+        assert llm.coder_url == "http://192.168.86.201:8000"
+        assert llm.coder_model_name == "Qwen3-Coder-30B"
+
+    def test_llm_endpoint_config_rejects_unknown_fields(self):
+        with pytest.raises(ValidationError):
+            ModelLlmEndpointConfig(unknown_field="bad")  # type: ignore[call-arg]
+
+    def test_storage_config_valid(self):
+        s = ModelStorageConfig(
+            postgres_host="192.168.86.201",
+            postgres_port=5436,
+            kafka_bootstrap_servers="192.168.86.201:19092",
+        )
+        assert s.postgres_host == "192.168.86.201"
+        assert s.postgres_port == 5436
+
+    def test_storage_config_rejects_unknown_fields(self):
+        with pytest.raises(ValidationError):
+            ModelStorageConfig(bad_key="x")  # type: ignore[call-arg]
+
+    def test_operational_config_secrets_are_secret_str(self):
+        op = ModelOperationalConfig(linear_api_key="secret123")
+        assert isinstance(op.linear_api_key, SecretStr)
+        assert op.linear_api_key.get_secret_value() == "secret123"
+
+    def test_operational_config_rejects_unknown_fields(self):
+        with pytest.raises(ValidationError):
+            ModelOperationalConfig(bogus="x")  # type: ignore[call-arg]
+
+    def test_model_contract_config_allows_extra_fields(self):
+        """extra="allow" on ModelContractConfig lets node-specific keys pass through."""
+        cfg = ModelContractConfig.model_validate(
+            {"node_specific_key": "value", "llm": {}, "storage": {}, "operational": {}}
+        )
+        assert cfg.model_extra is not None
+        assert cfg.model_extra.get("node_specific_key") == "value"
+
+    def test_model_contract_config_is_frozen(self):
+        cfg = ModelContractConfig()
+        with pytest.raises(ValidationError):
+            cfg.llm = ModelLlmEndpointConfig()  # type: ignore[misc]
+
+    def test_llm_endpoint_config_is_frozen(self):
+        llm = ModelLlmEndpointConfig()
+        with pytest.raises(ValidationError):
+            llm.coder_url = "http://new"  # type: ignore[misc]
+
+    def test_storage_config_is_frozen(self):
+        s = ModelStorageConfig()
+        with pytest.raises(ValidationError):
+            s.postgres_port = 9999  # type: ignore[misc]
+
+    def test_nested_config_parsed_from_dict(self):
+        cfg = ModelContractConfig.model_validate(
+            {
+                "llm": {"coder_url": "http://host:8000", "coder_model_name": "model-x"},
+                "storage": {"postgres_host": "db.host", "postgres_port": 5432},
+                "operational": {"github_token": "ghp_abc"},
+            }
+        )
+        assert cfg.llm.coder_url == "http://host:8000"
+        assert cfg.storage.postgres_port == 5432
+        assert isinstance(cfg.operational.github_token, SecretStr)
+
+    def test_bad_type_for_port_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            ModelStorageConfig(postgres_port="not-an-int")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelYamlContractConfig:
+    """Config field on ModelYamlContract is ModelContractConfig."""
+
+    def test_config_defaults_to_empty_model_contract_config(self):
+        contract = ModelYamlContract(
+            contract_version=_SEMVER,
+            node_type=EnumNodeType.COMPUTE_GENERIC,
+        )
+        assert isinstance(contract.config, ModelContractConfig)
+        assert contract.config.llm.coder_url is None
+
+    def test_config_parsed_from_dict_at_load_time(self):
+        contract = ModelYamlContract.model_validate(
+            {
+                "contract_version": {"major": 1, "minor": 0, "patch": 0},
+                "node_type": "COMPUTE_GENERIC",
+                "config": {
+                    "llm": {"coder_url": "http://host:8000"},
+                    "storage": {"postgres_port": 5436},
+                },
+            }
+        )
+        assert contract.config.llm.coder_url == "http://host:8000"
+        assert contract.config.storage.postgres_port == 5436
+
+    def test_invalid_config_type_raises_at_load_time(self):
+        """Wrong type in config sub-model fails at parse time, not silently."""
+        with pytest.raises(ValidationError):
+            ModelYamlContract.model_validate(
+                {
+                    "contract_version": {"major": 1, "minor": 0, "patch": 0},
+                    "node_type": "COMPUTE_GENERIC",
+                    "config": {"storage": {"postgres_port": "bad"}},
+                }
+            )
+
+
+@pytest.mark.unit
+class TestModelContractBaseConfig:
+    """Config field on ModelContractBase is ModelContractConfig."""
+
+    def test_config_defaults_to_empty_model_contract_config(self):
+        contract = _SampleContract(**_MINIMAL)
+        assert isinstance(contract.config, ModelContractConfig)
+        assert contract.config.storage.postgres_host is None
+
+    def test_config_with_values_parsed(self):
+        data = {
+            **_MINIMAL,
+            "config": {
+                "llm": {"coder_model_name": "Qwen3"},
+                "operational": {"linear_team_id": "TEAM-1"},
+            },
+        }
+        contract = _SampleContract.model_validate(data)
+        assert contract.config.llm.coder_model_name == "Qwen3"
+        assert contract.config.operational.linear_team_id == "TEAM-1"
+
+    def test_bad_config_value_fails_at_construction(self):
+        data = {
+            **_MINIMAL,
+            "config": {"storage": {"redpanda_admin_port": "bad-port"}},
+        }
+        with pytest.raises(ValidationError):
+            _SampleContract.model_validate(data)

--- a/tests/unit/contracts/test_model_contract_config.py
+++ b/tests/unit/contracts/test_model_contract_config.py
@@ -56,7 +56,7 @@ class TestModelContractConfig:
 
     def test_llm_endpoint_config_rejects_unknown_fields(self):
         with pytest.raises(ValidationError):
-            ModelLlmEndpointConfig(unknown_field="bad")  # type: ignore[call-arg]
+            ModelLlmEndpointConfig(unknown_field="bad")  # type: ignore[call-arg]  # NOTE(OMN-11430): negative Pydantic validation case.
 
     def test_storage_config_valid(self):
         s = ModelStorageConfig(
@@ -69,7 +69,7 @@ class TestModelContractConfig:
 
     def test_storage_config_rejects_unknown_fields(self):
         with pytest.raises(ValidationError):
-            ModelStorageConfig(bad_key="x")  # type: ignore[call-arg]
+            ModelStorageConfig(bad_key="x")  # type: ignore[call-arg]  # NOTE(OMN-11430): negative Pydantic validation case.
 
     def test_operational_config_secrets_are_secret_str(self):
         op = ModelOperationalConfig(linear_api_key="secret123")
@@ -78,7 +78,7 @@ class TestModelContractConfig:
 
     def test_operational_config_rejects_unknown_fields(self):
         with pytest.raises(ValidationError):
-            ModelOperationalConfig(bogus="x")  # type: ignore[call-arg]
+            ModelOperationalConfig(bogus="x")  # type: ignore[call-arg]  # NOTE(OMN-11430): negative Pydantic validation case.
 
     def test_model_contract_config_allows_extra_fields(self):
         """extra="allow" on ModelContractConfig lets node-specific keys pass through."""
@@ -91,17 +91,17 @@ class TestModelContractConfig:
     def test_model_contract_config_is_frozen(self):
         cfg = ModelContractConfig()
         with pytest.raises(ValidationError):
-            cfg.llm = ModelLlmEndpointConfig()  # type: ignore[misc]
+            cfg.llm = ModelLlmEndpointConfig()  # type: ignore[misc]  # NOTE(OMN-11430): intentional frozen-model mutation test.
 
     def test_llm_endpoint_config_is_frozen(self):
         llm = ModelLlmEndpointConfig()
         with pytest.raises(ValidationError):
-            llm.coder_url = "http://new"  # type: ignore[misc]
+            llm.coder_url = "http://new"  # type: ignore[misc]  # NOTE(OMN-11430): intentional frozen-model mutation test.
 
     def test_storage_config_is_frozen(self):
         s = ModelStorageConfig()
         with pytest.raises(ValidationError):
-            s.postgres_port = 9999  # type: ignore[misc]
+            s.postgres_port = 9999  # type: ignore[misc]  # NOTE(OMN-11430): intentional frozen-model mutation test.
 
     def test_nested_config_parsed_from_dict(self):
         cfg = ModelContractConfig.model_validate(
@@ -117,7 +117,7 @@ class TestModelContractConfig:
 
     def test_bad_type_for_port_raises_validation_error(self):
         with pytest.raises(ValidationError):
-            ModelStorageConfig(postgres_port="not-an-int")  # type: ignore[arg-type]
+            ModelStorageConfig(postgres_port="not-an-int")  # type: ignore[arg-type]  # NOTE(OMN-11430): negative Pydantic validation case.
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/test_node_core_base_contract_config.py
+++ b/tests/unit/infrastructure/test_node_core_base_contract_config.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 """
-Tests for contract config resolution on NodeCoreBase (OMN-10815).
+Tests for contract config resolution on NodeCoreBase (OMN-11430).
 
 Proves that all nodes can access self.contract_config from their contract.yaml
-at construction time, without env var fallbacks.
+at construction time as a typed model, without env var fallbacks.
 """
 
 from typing import Any
@@ -13,8 +13,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.infrastructure.node_core_base import NodeCoreBase
 from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+from omnibase_core.models.contracts.model_contract_config import ModelContractConfig
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
 
 class _ConcreteNode(NodeCoreBase):
@@ -31,13 +34,13 @@ def container() -> ModelONEXContainer:
 
 @pytest.mark.unit
 class TestNodeCoreBaseContractConfig:
-    def test_contract_config_is_empty_dict_when_no_contract(
+    def test_contract_config_is_empty_model_when_no_contract(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
-        assert node.contract_config == {}
+        assert node.contract_config == ModelContractConfig()
 
-    def test_contract_config_is_empty_dict_when_contract_has_no_config_section(
+    def test_contract_config_is_empty_model_when_contract_has_no_config_section(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
@@ -45,9 +48,9 @@ class TestNodeCoreBaseContractConfig:
         object.__setattr__(
             node, "contract_data", {"name": "test_node", "node_type": "compute"}
         )
-        assert node.contract_config == {}
+        assert node.contract_config == ModelContractConfig()
 
-    def test_contract_config_returns_config_section_from_dict_contract(
+    def test_contract_config_returns_typed_config_from_dict_contract(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
@@ -60,26 +63,34 @@ class TestNodeCoreBaseContractConfig:
                 "config": {"timeout_ms": 5000, "max_retries": 3},
             },
         )
-        assert node.contract_config == {"timeout_ms": 5000, "max_retries": 3}
+        assert isinstance(node.contract_config, ModelContractConfig)
+        assert node.contract_config.model_extra == {
+            "timeout_ms": 5000,
+            "max_retries": 3,
+        }
 
-    def test_contract_config_returns_config_from_pydantic_model_contract(
+    def test_contract_config_returns_typed_config_from_pydantic_model_contract(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
         mock_contract = MagicMock()
         mock_contract.config = {"batch_size": 100, "dry_run": False}
         object.__setattr__(node, "contract_data", mock_contract)
-        assert node.contract_config == {"batch_size": 100, "dry_run": False}
+        assert isinstance(node.contract_config, ModelContractConfig)
+        assert node.contract_config.model_extra == {
+            "batch_size": 100,
+            "dry_run": False,
+        }
 
-    def test_contract_config_returns_empty_dict_when_pydantic_model_has_no_config_attr(
+    def test_contract_config_returns_empty_model_when_pydantic_model_has_no_config_attr(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
         mock_contract = MagicMock(spec=[])  # spec=[] means no attributes
         object.__setattr__(node, "contract_data", mock_contract)
-        assert node.contract_config == {}
+        assert node.contract_config == ModelContractConfig()
 
-    def test_contract_config_returns_empty_dict_when_contract_config_is_none(
+    def test_contract_config_returns_empty_model_when_contract_config_is_none(
         self, container: ModelONEXContainer
     ) -> None:
         node = _ConcreteNode(container)
@@ -88,4 +99,19 @@ class TestNodeCoreBaseContractConfig:
             "contract_data",
             {"name": "test_node", "config": None},
         )
-        assert node.contract_config == {}
+        assert node.contract_config == ModelContractConfig()
+
+    def test_contract_config_rejects_non_mapping_config(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node = _ConcreteNode(container)
+        object.__setattr__(
+            node,
+            "contract_data",
+            {"name": "test_node", "config": "not-a-config-map"},
+        )
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            _ = node.contract_config
+
+        assert exc_info.value.error_code == EnumCoreErrorCode.VALIDATION_ERROR


### PR DESCRIPTION
## OMN-11430 — Strongly typed contract config

Replaces `config: dict[str, object]` on both `ModelContractBase` and `ModelYamlContract` (shipped in OMN-10815) with a frozen Pydantic model hierarchy validated at load time.

## Changes

**New files (one class per file):**
- `model_llm_endpoint_config.py` — `ModelLlmEndpointConfig`: coder/deepseek/glm/gemini/openai endpoint URLs, model names, `SecretStr` API keys; `extra="forbid"`
- `model_storage_config.py` — `ModelStorageConfig`: postgres host/port/db/user/password, kafka bootstrap servers, redpanda admin; `extra="forbid"`
- `model_operational_config.py` — `ModelOperationalConfig`: linear_api_key, linear_team_id, github_token, slack_webhook_url; `extra="forbid"`
- `model_contract_config.py` — `ModelContractConfig`: frozen composer of the three sub-models; `extra="allow"` so node-specific keys pass through without breaking base schema

**Modified:**
- `ModelContractBase.config: ModelContractConfig` (replaces `dict[str, object]`)
- `ModelYamlContract.config: ModelContractConfig` (replaces `dict[str, object]`)
- `NodeCoreBase.contract_config` property returns `ModelContractConfig`; validates dict-from-YAML at read time via `model_validate`
- `contracts/__init__.py` exports all four new models

**Tests (`test_model_contract_config.py`):**
- 19 unit tests covering: default construction, frozen immutability, extra-field rejection on sub-models, extra-field passthrough on top model, SecretStr validation, bad type rejection at parse time, YAML round-trip on both ModelYamlContract and ModelContractBase

## Verification

- `uv run pytest tests/unit/contracts/ -q` → 816 passed
- `uv run mypy src/... --strict` → 0 errors on all 7 changed files
- All pre-commit hooks passed on commit

## Notes

This supersedes the pending PR for `jonah/omn-10815-contract-config-base` (which added `dict[str, object]` to ModelContractBase). That branch can be closed — OMN-11430 lands the typed version directly on top of post-#1123 main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strongly typed contract config models for LLM endpoints, storage, and operational settings, plus a top-level contract config model.

* **Refactor**
  * Contract configuration is now exposed as a validated, structured config object instead of a plain dictionary; invalid config types now raise a validation error.

* **Tests**
  * New and updated unit tests cover typed config parsing, defaults, immutability, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: 26300b0986c29121ed826d3da04ee4f4f9d9226d
Evidence-Ticket: OMN-11430