### PR TITLE
feat(OMN-11675): graduate pipeline models to omnibase_core

### DIFF
--- a/src/omnibase_core/enums/pipeline/__init__.py
+++ b/src/omnibase_core/enums/pipeline/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pipeline enums."""
+
+from omnibase_core.enums.pipeline.enum_closeout_failure import EnumCloseoutFailure
+
+__all__ = ["EnumCloseoutFailure"]

--- a/src/omnibase_core/enums/pipeline/enum_closeout_failure.py
+++ b/src/omnibase_core/enums/pipeline/enum_closeout_failure.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Closeout failure reason enum for pipeline verification."""
+
+from enum import StrEnum, unique
+
+__all__ = ["EnumCloseoutFailure"]
+
+
+@unique
+class EnumCloseoutFailure(StrEnum):
+    """Reason a closeout verification failed."""
+
+    OBSERVED_CHAIN_MISSING = "observed_chain_missing"
+    CHAIN_EVENT_MISSING = "chain_event_missing"
+    CHAIN_ORDER_MISMATCH = "chain_order_mismatch"
+    UNEXPECTED_EVENT = "unexpected_event"
+    EVIDENCE_MISSING = "evidence_missing"
+    EVIDENCE_HASH_MISMATCH = "evidence_hash_mismatch"
+    TESTS_FAILED = "tests_failed"
+    VERIFIER_MISSING = "verifier_missing"

--- a/src/omnibase_core/models/pipeline/__init__.py
+++ b/src/omnibase_core/models/pipeline/__init__.py
@@ -3,6 +3,10 @@
 
 """Pipeline models."""
 
+from omnibase_core.models.pipeline.model_chain_diff import ModelChainDiff
+from omnibase_core.models.pipeline.model_closeout_result import ModelCloseoutResult
+from omnibase_core.models.pipeline.model_evidence_artifact import ModelEvidenceArtifact
+from omnibase_core.models.pipeline.model_golden_chain_entry import ModelGoldenChainEntry
 from omnibase_core.models.pipeline.model_hook_error import ModelHookError
 from omnibase_core.models.pipeline.model_phase_execution_plan import (
     ModelPhaseExecutionPlan,
@@ -21,11 +25,16 @@ from omnibase_core.models.pipeline.model_pipeline_state import (
     ModelPipelineState,
     PipelineState,
 )
+from omnibase_core.models.pipeline.model_readiness_result import ModelReadinessResult
 from omnibase_core.models.pipeline.model_validation_warning import (
     ModelValidationWarning,
 )
 
 __all__ = [
+    "ModelChainDiff",
+    "ModelCloseoutResult",
+    "ModelEvidenceArtifact",
+    "ModelGoldenChainEntry",
     "ModelHookError",
     "ModelPhaseExecutionPlan",
     "ModelPhaseRecord",
@@ -34,6 +43,7 @@ __all__ = [
     "ModelPipelineHook",
     "ModelPipelineResult",
     "ModelPipelineState",
+    "ModelReadinessResult",
     "ModelValidationWarning",
     "PipelinePhase",
     "PipelineState",

--- a/src/omnibase_core/models/pipeline/model_chain_diff.py
+++ b/src/omnibase_core/models/pipeline/model_chain_diff.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Chain diff model for golden chain verification."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.pipeline.model_golden_chain_entry import ModelGoldenChainEntry
+
+__all__ = ["ModelChainDiff"]
+
+
+class ModelChainDiff(BaseModel):
+    """Diff between an expected golden chain and an observed event chain."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    matches: bool
+    expected_count: int
+    observed_count: int
+    missing_events: tuple[ModelGoldenChainEntry, ...] = Field(default_factory=tuple)
+    unexpected_events: tuple[ModelGoldenChainEntry, ...] = Field(default_factory=tuple)
+    order_mismatches: tuple[str, ...] = Field(default_factory=tuple)
+    topic_mismatches: tuple[str, ...] = Field(default_factory=tuple)

--- a/src/omnibase_core/models/pipeline/model_closeout_result.py
+++ b/src/omnibase_core/models/pipeline/model_closeout_result.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Closeout result model for pipeline verification."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.pipeline.enum_closeout_failure import EnumCloseoutFailure
+from omnibase_core.models.pipeline.model_chain_diff import ModelChainDiff
+from omnibase_core.models.pipeline.model_evidence_artifact import ModelEvidenceArtifact
+
+__all__ = ["ModelCloseoutResult"]
+
+
+class ModelCloseoutResult(BaseModel):
+    """Full result of a pipeline closeout verification."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    passed: bool
+    chain_match: bool
+    chain_diff: ModelChainDiff | None = None
+    evidence_artifacts: tuple[ModelEvidenceArtifact, ...] = Field(default_factory=tuple)
+    missing_evidence: tuple[str, ...] = Field(default_factory=tuple)
+    test_result: bool = True
+    failure_class: EnumCloseoutFailure | None = None
+    verifier_identity: str | None = None

--- a/src/omnibase_core/models/pipeline/model_evidence_artifact.py
+++ b/src/omnibase_core/models/pipeline/model_evidence_artifact.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Evidence artifact model for pipeline closeout verification."""
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ModelEvidenceArtifact"]
+
+
+class ModelEvidenceArtifact(BaseModel):
+    """A single captured evidence artifact with hash and provenance."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    path: str
+    sha256: str
+    captured_at: str
+    source_surface: str
+    evidence_kind: str

--- a/src/omnibase_core/models/pipeline/model_golden_chain_entry.py
+++ b/src/omnibase_core/models/pipeline/model_golden_chain_entry.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Golden chain entry model for event chain verification."""
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ModelGoldenChainEntry"]
+
+
+class ModelGoldenChainEntry(BaseModel):
+    """A single event in a golden (expected) chain sequence."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    sequence: int
+    event_type: str
+    topic: str
+    source_node: str

--- a/src/omnibase_core/models/pipeline/model_readiness_result.py
+++ b/src/omnibase_core/models/pipeline/model_readiness_result.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Readiness result model for pipeline pre-execution gate checks."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelReadinessResult"]
+
+
+class ModelReadinessResult(BaseModel):
+    """Outcome of a readiness gate check before pipeline execution."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ready: bool
+    blocking: tuple[str, ...] = Field(default_factory=tuple)
+    conditional: tuple[str, ...] = Field(default_factory=tuple)
+    advisory: tuple[str, ...] = Field(default_factory=tuple)

--- a/tests/unit/models/pipeline/test_pipeline_chain_models.py
+++ b/tests/unit/models/pipeline/test_pipeline_chain_models.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for graduated pipeline chain models (OMN-11675)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.pipeline.enum_closeout_failure import EnumCloseoutFailure
+from omnibase_core.models.pipeline.model_chain_diff import ModelChainDiff
+from omnibase_core.models.pipeline.model_closeout_result import ModelCloseoutResult
+from omnibase_core.models.pipeline.model_evidence_artifact import ModelEvidenceArtifact
+from omnibase_core.models.pipeline.model_golden_chain_entry import ModelGoldenChainEntry
+from omnibase_core.models.pipeline.model_readiness_result import ModelReadinessResult
+
+
+@pytest.mark.unit
+class TestModelGoldenChainEntry:
+    def test_construction(self) -> None:
+        entry = ModelGoldenChainEntry(
+            sequence=1,
+            event_type="node.generated",
+            topic="onex.evt.omnimarket.node-generated.v1",
+            source_node="node_generation_consumer",
+        )
+        assert entry.sequence == 1
+        assert entry.event_type == "node.generated"
+
+    def test_frozen(self) -> None:
+        entry = ModelGoldenChainEntry(
+            sequence=0, event_type="e", topic="t", source_node="n"
+        )
+        with pytest.raises(Exception):
+            entry.sequence = 99  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestModelChainDiff:
+    def test_matches_empty(self) -> None:
+        diff = ModelChainDiff(matches=True, expected_count=0, observed_count=0)
+        assert diff.matches
+        assert diff.missing_events == ()
+        assert diff.unexpected_events == ()
+
+    def test_with_missing_events(self) -> None:
+        entry = ModelGoldenChainEntry(
+            sequence=1, event_type="e", topic="t", source_node="n"
+        )
+        diff = ModelChainDiff(
+            matches=False,
+            expected_count=2,
+            observed_count=1,
+            missing_events=(entry,),
+        )
+        assert not diff.matches
+        assert len(diff.missing_events) == 1
+
+
+@pytest.mark.unit
+class TestModelEvidenceArtifact:
+    def test_construction(self) -> None:
+        artifact = ModelEvidenceArtifact(
+            path=".onex_state/evidence/run.json",
+            sha256="abc123",
+            captured_at="2026-05-22T00:00:00Z",
+            source_surface="pipeline_closeout",
+            evidence_kind="chain_capture",
+        )
+        assert artifact.sha256 == "abc123"
+
+    def test_frozen(self) -> None:
+        artifact = ModelEvidenceArtifact(
+            path="p",
+            sha256="s",
+            captured_at="t",
+            source_surface="ss",
+            evidence_kind="ek",
+        )
+        with pytest.raises(Exception):
+            artifact.sha256 = "modified"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestEnumCloseoutFailure:
+    def test_all_values_unique(self) -> None:
+        values = [e.value for e in EnumCloseoutFailure]
+        assert len(values) == len(set(values))
+
+    def test_canonical_members(self) -> None:
+        assert EnumCloseoutFailure.EVIDENCE_MISSING == "evidence_missing"
+        assert EnumCloseoutFailure.TESTS_FAILED == "tests_failed"
+        assert EnumCloseoutFailure.CHAIN_ORDER_MISMATCH == "chain_order_mismatch"
+
+
+@pytest.mark.unit
+class TestModelReadinessResult:
+    def test_ready(self) -> None:
+        r = ModelReadinessResult(ready=True)
+        assert r.ready
+        assert r.blocking == ()
+        assert r.conditional == ()
+        assert r.advisory == ()
+
+    def test_not_ready_with_blockers(self) -> None:
+        r = ModelReadinessResult(ready=False, blocking=("missing env var",))
+        assert not r.ready
+        assert len(r.blocking) == 1
+
+
+@pytest.mark.unit
+class TestModelCloseoutResult:
+    def test_passed(self) -> None:
+        result = ModelCloseoutResult(passed=True, chain_match=True)
+        assert result.passed
+        assert result.chain_diff is None
+        assert result.failure_class is None
+        assert result.evidence_artifacts == ()
+
+    def test_failed_with_class(self) -> None:
+        result = ModelCloseoutResult(
+            passed=False,
+            chain_match=False,
+            failure_class=EnumCloseoutFailure.EVIDENCE_MISSING,
+            verifier_identity="node_closeout_verifier",
+        )
+        assert not result.passed
+        assert result.failure_class == EnumCloseoutFailure.EVIDENCE_MISSING
+        assert result.verifier_identity == "node_closeout_verifier"
+
+    def test_importable_from_package(self) -> None:
+        from omnibase_core.models.pipeline import (
+            ModelChainDiff,
+            ModelCloseoutResult,
+            ModelEvidenceArtifact,
+            ModelGoldenChainEntry,
+            ModelReadinessResult,
+        )
+
+        assert ModelCloseoutResult is not None
+        assert ModelChainDiff is not None
+        assert ModelEvidenceArtifact is not None
+        assert ModelGoldenChainEntry is not None
+        assert ModelReadinessResult is not None


### PR DESCRIPTION
## Summary
- Migrate `ModelGoldenChainEntry`, `ModelChainDiff`, `ModelCloseoutResult`, `ModelEvidenceArtifact`, `ModelReadinessResult`, and `EnumCloseoutFailure` from `onex-self-extending-agent/src/pipeline/models.py` to `omnibase_core`
- These models are shared across repos (omnimarket, SEA) and belong in core per repo layering rules
- All models follow omnibase_core conventions: `frozen=True` ConfigDict, PEP 604 unions, tuple not list, proper SPDX headers

## Context
Epic: OMN-11674 (Context Pack Pipeline)
Ticket: OMN-11675

## Test plan
- [x] mypy --strict passes (6 new source files, 0 errors)
- [x] All 13 new unit tests pass
- [x] All pipeline model tests pass (38 total)
- [x] All pre-commit hooks pass on changed files
- [x] Models importable from `omnibase_core.models.pipeline` package

Evidence-Ticket: OMN-11675
Evidence-Source: a5837f6c500ee36ececd005ade2b539d1547d875