### PR TITLE
fix(OMN-11608): export domain plugin config from runtime models

### DIFF
--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -9,6 +9,7 @@ from omnibase_core.models.runtime.model_descriptor_circuit_breaker import (
 from omnibase_core.models.runtime.model_descriptor_retry_policy import (
     ModelDescriptorRetryPolicy,
 )
+from omnibase_core.models.runtime.model_domain_plugin import ModelDomainPluginConfig
 from omnibase_core.models.runtime.model_domain_plugin_result import (
     ModelDomainPluginResult,
 )
@@ -61,6 +62,7 @@ __all__ = [
     "ModelDescriptorRetryPolicy",
     "ModelDescriptorCircuitBreaker",
     "ModelHandlerMetadata",
+    "ModelDomainPluginConfig",
     "ModelDomainPluginResult",
     "ModelRuntimeDirective",
     "ModelRuntimeNodeInstance",

--- a/src/omnibase_core/models/runtime/model_domain_plugin.py
+++ b/src/omnibase_core/models/runtime/model_domain_plugin.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Domain plugin configuration model used by ProtocolDomainPlugin in omnibase_spi."""
+"""Canonical domain plugin lifecycle configuration model."""
 
 from __future__ import annotations
 
@@ -37,6 +37,9 @@ class ModelDomainPluginConfig:
         output_topic_map: Per-event-type topic routing from contract published_events.
 
     Note:
+        Cross-repo runtime plugins should import this canonical config from
+        ``omnibase_core.models.runtime``.
+
         event_bus, dispatch_engine, and node_identity are typed as ``Any`` here
         so SPI has zero runtime dependency on omnibase_infra. Callers in infra
         pass the concrete types; the protocol contract is satisfied structurally.

--- a/tests/unit/models/runtime/test_model_domain_plugin.py
+++ b/tests/unit/models/runtime/test_model_domain_plugin.py
@@ -9,6 +9,16 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+def test_domain_plugin_config_importable_from_runtime_package() -> None:
+    """Runtime package exports the config model for cross-repo consumers."""
+    from omnibase_core.models.runtime import ModelDomainPluginConfig as PackageConfig
+    from omnibase_core.models.runtime.model_domain_plugin import (
+        ModelDomainPluginConfig as CanonicalConfig,
+    )
+
+    assert PackageConfig is CanonicalConfig
+
+
 def test_domain_plugin_result_importable_from_compat_module() -> None:
     """The SPI protocol imports both domain plugin models from one module."""
     from omnibase_core.models.runtime.model_domain_plugin import (


### PR DESCRIPTION
## Summary
- Exports ModelDomainPluginConfig from omnibase_core.models.runtime as the canonical core import path.
- Documents the core model as the cross-repo runtime plugin config source.
- Adds regression coverage proving the package export resolves to the canonical class.

## Verification
- PYTHONPATH=src uv run pytest tests/unit/models/runtime/test_model_domain_plugin.py -q (3 passed)
- PYTHONPATH=src uv run ruff check src/omnibase_core/models/runtime/model_domain_plugin.py src/omnibase_core/models/runtime/__init__.py tests/unit/models/runtime/test_model_domain_plugin.py
- git diff --check
- commit pre-commit hooks: passed

## Follow-up
- omnibase_infra still has a duplicate runtime model path. Replace or re-export src/omnibase_infra/runtime/models/model_domain_plugin_config.py from omnibase_core.models.runtime.ModelDomainPluginConfig and validate service_kernel.py, protocol_domain_plugin.py, dlq/plugin_dlq.py, and registration plugin tests.

## Ticket
- OMN-11608

Evidence-Ticket: OMN-11608
Evidence-Source: 703cae4eced0ec1d2e7fb456299c5ee2c5030c18