### PR TITLE
fix(OMN-11605): add action registry caller helpers

### DIFF
--- a/src/omnibase_core/models/core/model_action_registry.py
+++ b/src/omnibase_core/models/core/model_action_registry.py
@@ -305,3 +305,23 @@ def reset_action_registry() -> None:
     except (AttributeError, KeyError, TypeError, ValueError):
         # If container is not initialized, nothing to reset
         pass
+
+
+def discover_actions_from_contracts(contracts_dir: Path) -> int:
+    """Discover actions from contracts and register them in the DI registry."""
+    registry = get_action_registry()
+    return registry.discover_from_contracts(contracts_dir)
+
+
+def get_registered_action(action_name: str) -> ModelCliAction | None:
+    """Get an action by display name from the DI registry."""
+    registry = get_action_registry()
+    return registry.get_action(action_name)
+
+
+def get_registered_action_by_qualified_name(
+    qualified_name: str,
+) -> ModelCliAction | None:
+    """Get an action by qualified name from the DI registry."""
+    registry = get_action_registry()
+    return registry.get_action_by_qualified_name(qualified_name)

--- a/tests/unit/models/core/test_model_action_registry.py
+++ b/tests/unit/models/core/test_model_action_registry.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for DI-backed action registry helpers."""
+
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from omnibase_core.models.cli.model_cli_action import ModelCliAction
+from omnibase_core.models.core.model_action_registry import (
+    ModelActionRegistry,
+    discover_actions_from_contracts,
+    get_action_registry,
+    get_registered_action,
+    get_registered_action_by_qualified_name,
+)
+
+
+@pytest.mark.serial
+@pytest.mark.unit
+class TestActionRegistryGlobalHelpers:
+    """Test module-level action registry helpers resolve through DI."""
+
+    @pytest.fixture(autouse=True)
+    def reset_container_context(self):
+        """Reset container context so each test gets an isolated DI registry."""
+        from omnibase_core.context.context_application import _current_container
+
+        context_token = _current_container.set(None)
+
+        yield
+
+        _current_container.reset(context_token)
+
+    def test_get_action_registry_creates_di_registry(self) -> None:
+        """The canonical getter creates and bootstraps the DI action registry."""
+        from omnibase_core.context.context_application import get_current_container
+
+        assert get_current_container() is None
+
+        registry = get_action_registry()
+
+        assert isinstance(registry, ModelActionRegistry)
+        assert registry.is_valid_action("execute_node")
+        assert get_current_container() is not None
+
+    def test_registered_action_helpers_use_di_registry(self) -> None:
+        """Action lookup helpers read from the DI-resolved registry instance."""
+        registry = get_action_registry()
+        action = ModelCliAction.from_contract_action(
+            action_name="sync_contract",
+            node_id=UUID("4cc66c36-cdf5-4e9f-81c8-5eb8bfce1956"),
+            node_name="node_contract",
+            description="Synchronize a contract",
+            category="execution",
+        )
+        registry.register_action(action)
+
+        assert get_registered_action("sync_contract") is action
+        assert (
+            get_registered_action_by_qualified_name("node_contract:sync_contract")
+            is action
+        )
+
+    def test_discover_actions_from_contracts_uses_di_registry(self, tmp_path) -> None:
+        """Contract discovery helper delegates to the DI-resolved registry."""
+        with patch.object(
+            ModelActionRegistry,
+            "discover_from_contracts",
+            return_value=1,
+        ) as mock_discover:
+            count = discover_actions_from_contracts(tmp_path)
+
+        assert count == 1
+        mock_discover.assert_called_once_with(tmp_path)


### PR DESCRIPTION
## Summary
- Adds DI-backed helper callers for contract action discovery and action lookup.
- Routes helper access through get_action_registry so the DI-resolved registry is the canonical entry point.
- Adds focused unit tests covering discovery, display-name lookup, and qualified-name lookup through the helper path.

## Verification
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-11605/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_infra/src uv run pytest tests/unit/models/core/test_model_action_registry.py tests/unit/models/container/test_model_base_container.py -q (14 passed)
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-11605/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_infra/src uv run ruff check src/omnibase_core/models/core/model_action_registry.py tests/unit/models/core/test_model_action_registry.py
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-11605/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_core/src:/Users/jonah/Code/omni_home/omnibase_infra/src uv run ruff format --check src/omnibase_core/models/core/model_action_registry.py tests/unit/models/core/test_model_action_registry.py
- git diff --check
- commit pre-commit hooks: passed

## Ticket
- OMN-11605

Evidence-Ticket: OMN-11605
Evidence-Source: 703cae4eced0ec1d2e7fb456299c5ee2c5030c18