### PR TITLE
ci(OMN-11718): add dev branch workflow triggers

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -20,8 +20,9 @@ name: Receipt Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    branches: [main]
+    branches: [main, dev]
   merge_group:
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -15,8 +15,9 @@ name: Reject skip-gate bypass tokens
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev]
   merge_group:
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/check-check-names.yml
+++ b/.github/workflows/check-check-names.yml
@@ -12,13 +12,13 @@ name: check_name Validator
 
 on:
   push:
-    branches: [main, develop, "feature/*", "fix/*", "chore/*", "jonah/*", "jonahgabriel/*"]
+    branches: [main, develop, dev, "hotfix/**", "feature/*", "fix/*", "chore/*", "jonah/*", "jonahgabriel/*"]
     paths:
       - ".github/required-checks.yaml"
       - ".github/workflows/**.yml"
       - "scripts/validation/validate-check-names.py"
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
     paths:
       - ".github/required-checks.yaml"
       - ".github/workflows/**.yml"

--- a/.github/workflows/check-db-ownership.yml
+++ b/.github/workflows/check-db-ownership.yml
@@ -5,7 +5,7 @@ name: Check DB Ownership
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
     paths:
       - 'src/omnibase_core/models/contracts/model_db_ownership_metadata.py'
       - 'src/omnibase_core/validation/db/validator_db_ownership.py'
@@ -13,7 +13,7 @@ on:
       - 'tests/unit/validation/db/test_db_ownership.py'
       - '.github/workflows/check-db-ownership.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
     paths:
       - 'src/omnibase_core/models/contracts/model_db_ownership_metadata.py'
       - 'src/omnibase_core/validation/db/validator_db_ownership.py'

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -5,10 +5,11 @@ name: Check Architecture Handshake
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev, "hotfix/**"]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   merge_group:
+    branches: [main, dev]
   workflow_dispatch:
   schedule:
     - cron: "13 7 * * *"   # 07:13 UTC nightly

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -22,8 +22,9 @@ name: Contract Validation
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
   workflow_dispatch:
     inputs:
       branch-name:

--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -12,6 +12,7 @@ on:
     types: [created, edited, deleted]
   merge_group:
     types: [checks_requested]
+    branches: [main, dev]
 
 jobs:
   gate:

--- a/.github/workflows/cross-repo-validation.yml
+++ b/.github/workflows/cross-repo-validation.yml
@@ -21,7 +21,7 @@ on:
     - cron: '0 7 * * *'
   # Also run on pushes to main to keep the dashboard current
   push:
-    branches: [main]
+    branches: [main, dev, "hotfix/**"]
   workflow_dispatch:
     inputs:
       skip_kafka:

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -13,8 +13,9 @@ name: Deploy Gate
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 concurrency:
   group: deploy-gate-${{ github.ref }}

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -5,9 +5,9 @@ name: Omni* Ecosystem Standards Compliance
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
+    branches: [main, dev]
 
 jobs:
   reviewdog:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,9 +9,9 @@ name: Security Scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev, "hotfix/**"]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -19,7 +19,7 @@ name: Stale TODO Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   stale-todo-gate:

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -28,6 +28,7 @@ on:
     types: [closed]
     branches:
       - main
+      - dev
 
 jobs:
   todo-audit:

--- a/.github/workflows/validator-banned-compose-vars.yml
+++ b/.github/workflows/validator-banned-compose-vars.yml
@@ -22,10 +22,11 @@ name: Compose Drift
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-except-swallow.yml
+++ b/.github/workflows/validator-no-except-swallow.yml
@@ -13,10 +13,11 @@ name: No Except Swallow
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-import-none-fallback.yml
+++ b/.github/workflows/validator-no-import-none-fallback.yml
@@ -13,10 +13,11 @@ name: No Import None Fallback
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-none-guard-publish.yml
+++ b/.github/workflows/validator-no-none-guard-publish.yml
@@ -13,10 +13,11 @@ name: No None Guard Publish
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -21,10 +21,11 @@ name: Runtime Profiles
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, dev, "hotfix/**"]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, dev]
   merge_group:
+    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"


### PR DESCRIPTION
## Summary
- Adds dev alongside main for PR workflow branch filters.
- Adds dev coverage to merge_group branch filters where branch filters exist.
- Keeps release or deploy-only workflows scoped to main where they are not PR validation gates.

Evidence-Ticket: OMN-11718
Evidence-Source: OCC#1383
Related: OMN-11730, OMN-11731

## Verification
- Workflow YAML parse passed.
- Trigger audit passed: no main-targeted PR or merge_group branch filter is missing dev.
- git diff --check.
- actionlint scoped to modified files passed or only reported pre-existing findings outside this trigger edit.