### PR TITLE
fix(OMN-11753): skip semantic diff graph on empty diff

### DIFF
--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -121,8 +121,14 @@ def _git_file_at(ref: str, rel_path: str, repo_root: Path) -> str:
 
 
 def _compute_report(base: str, head: str, repo_root: Path) -> ModelSemanticDiffReport:
-    consumer_graph = build_consumer_graph(repo_root)
     changed_files = _git_changed_py_files(base, head, repo_root)
+    if not changed_files:
+        return ModelSemanticDiffReport(
+            changes=(),
+            total_consumers_affected=0,
+        )
+
+    consumer_graph = build_consumer_graph(repo_root)
 
     all_changes: list[ModelSymbolChange] = []
     total_consumers = 0

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -4,12 +4,14 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -34,6 +36,15 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
         cwd=REPO_ROOT,
         env=_SUBPROCESS_ENV,
     )
+
+
+def _load_cli_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("semantic_diff_cli", CLI)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.mark.unit
@@ -94,6 +105,30 @@ def test_cli_missing_required_args_exits_nonzero() -> None:
     """CLI exits non-zero when required --base / --head args are absent."""
     result = _run_cli("--json")
     assert result.returncode != 0
+
+
+@pytest.mark.unit
+def test_compute_report_skips_consumer_graph_when_no_changed_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-diff runs should not build the expensive full-repo consumer graph."""
+    module = _load_cli_module()
+
+    monkeypatch.setattr(
+        module,
+        "_git_changed_py_files",
+        lambda _base, _head, _repo_root: [],
+    )
+
+    def fail_build_consumer_graph(_repo_root: Path) -> dict[str, int]:
+        raise AssertionError("consumer graph should not be built for an empty diff")
+
+    monkeypatch.setattr(module, "build_consumer_graph", fail_build_consumer_graph)
+
+    report = module._compute_report("origin/main", "HEAD", REPO_ROOT)
+
+    assert report.changes == ()
+    assert report.total_consumers_affected == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- skip the full consumer graph scan when semantic diff has no changed Python files
- add a regression test that fails if the empty-diff path builds the consumer graph

## Verification
- uv run --frozen pytest tests/scripts/test_semantic_diff_cli.py -q
- uv run --frozen pytest tests/scripts/test_semantic_diff_cli.py -q -n 4 --dist=loadgroup --timeout=60 --timeout-method=thread
- uv run --frozen ruff check scripts/analysis/semantic_diff.py tests/scripts/test_semantic_diff_cli.py
- pre-commit hooks passed during commit

Evidence-Ticket: OMN-11753
Evidence-Source: a3acae069f13a9ac48f9306b30cd477b70111393