### PR TITLE
fix(OMN-11754): restore cross-repo validation runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,11 +102,11 @@ spi = ["omnibase-spi>=0.20.2"]
 # model_onex_container falls back to an inline equivalent when not installed.
 compat = ["omnibase-compat>=0.4.1,<1.0.0"]
 cli = ["psutil>=7.2.1"]
-kafka = ["confluent-kafka>=2.12.0,<3.0.0"]
+kafka = ["aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0"]
 cache = ["redis>=5.0.0,<8.0.0"]
 metrics = ["prometheus-client>=0.21.0,<1.0.0"]
 sql-parser = ["sqlglot>=26.0.0,<31.0.0"]
-full = ["omnibase-spi>=0.20.2", "omnibase-compat>=0.4.1,<1.0.0", "psutil>=7.2.1", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<8.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
+full = ["omnibase-spi>=0.20.2", "omnibase-compat>=0.4.1,<1.0.0", "psutil>=7.2.1", "aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<8.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
 
 [dependency-groups]
 dev = [

--- a/src/omnibase_core/validation/cross_repo/rules/rule_repo_boundaries.py
+++ b/src/omnibase_core/validation/cross_repo/rules/rule_repo_boundaries.py
@@ -108,6 +108,10 @@ class RuleRepoBoundaries:
         if not import_path or import_path.startswith("."):
             return None
 
+        # Type-only imports do not create runtime boundary coupling.
+        if imp.is_type_checking_only:
+            return None
+
         # Check forbidden import prefixes
         for forbidden in self.config.forbidden_import_prefixes:
             if import_path.startswith(forbidden):

--- a/src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph.py
+++ b/src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph.py
@@ -36,6 +36,10 @@ class ModelImportInfo(BaseModel):
         default=False,
         description="Whether this is a 'from X import Y' style import",
     )
+    is_type_checking_only: bool = Field(
+        default=False,
+        description="Whether this import is guarded by TYPE_CHECKING",
+    )
 
     @property
     def full_import_path(self) -> str:
@@ -66,6 +70,7 @@ class _ImportVisitor(ast.NodeVisitor):
 
     def __init__(self) -> None:
         self.imports: list[ModelImportInfo] = []
+        self._type_checking_depth = 0
 
     def visit_Import(self, node: ast.Import) -> None:
         """Handle 'import X' statements."""
@@ -76,6 +81,7 @@ class _ImportVisitor(ast.NodeVisitor):
                     alias=alias.asname,
                     line_number=node.lineno,
                     is_from_import=False,
+                    is_type_checking_only=self._type_checking_depth > 0,
                 )
             )
         self.generic_visit(node)
@@ -96,9 +102,31 @@ class _ImportVisitor(ast.NodeVisitor):
                     alias=alias.asname,
                     line_number=node.lineno,
                     is_from_import=True,
+                    is_type_checking_only=self._type_checking_depth > 0,
                 )
             )
         self.generic_visit(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        """Track imports that are guarded by TYPE_CHECKING."""
+        if self._is_type_checking_guard(node.test):
+            self._type_checking_depth += 1
+            for statement in node.body:
+                self.visit(statement)
+            self._type_checking_depth -= 1
+            for statement in node.orelse:
+                self.visit(statement)
+            return
+
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_type_checking_guard(node: ast.expr) -> bool:
+        if isinstance(node, ast.Name):
+            return node.id == "TYPE_CHECKING"
+        if isinstance(node, ast.Attribute):
+            return node.attr == "TYPE_CHECKING"
+        return False
 
 
 class ScannerImportGraph:

--- a/tests/unit/validation/cross_repo/test_rule_repo_boundaries.py
+++ b/tests/unit/validation/cross_repo/test_rule_repo_boundaries.py
@@ -154,6 +154,30 @@ class TestRuleRepoBoundaries:
         assert len(issues) == 1
         assert issues[0].line_number == 5
 
+    def test_allows_type_checking_forbidden_import(
+        self, config: ModelRuleRepoBoundariesConfig
+    ) -> None:
+        """Test that type-only imports do not create runtime boundary issues."""
+        rule = RuleRepoBoundaries(config)
+
+        file_imports = {
+            Path("/test/good.py"): ModelFileImports(
+                file_path=Path("/test/good.py"),
+                imports=(
+                    ModelImportInfo(
+                        module="fake_infra.services.service_kafka",
+                        line_number=5,
+                        is_from_import=False,
+                        is_type_checking_only=True,
+                    ),
+                ),
+            ),
+        }
+
+        issues = rule.validate(file_imports, "fake_app")
+
+        assert len(issues) == 0
+
     def test_cross_repo_boundary_violation(
         self, config: ModelRuleRepoBoundariesConfig
     ) -> None:

--- a/tests/unit/validation/cross_repo/test_scanner_import_graph.py
+++ b/tests/unit/validation/cross_repo/test_scanner_import_graph.py
@@ -333,3 +333,29 @@ class TestScannerImportGraph:
         assert len(result.imports) == 1
         assert result.imports[0].name == "*"
         assert result.imports[0].is_from_import is True
+
+    def test_scan_type_checking_imports(
+        self, scanner: ScannerImportGraph, tmp_path: Path
+    ) -> None:
+        """Test marking imports guarded by TYPE_CHECKING."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text(
+            dedent(
+                """
+            from typing import TYPE_CHECKING
+
+            import os
+
+            if TYPE_CHECKING:
+                from redis.asyncio import Redis
+            """
+            ).strip()
+        )
+
+        result = scanner.scan_file(test_file)
+
+        assert result.parse_error is None
+        redis_import = next(i for i in result.imports if i.module == "redis.asyncio")
+        os_import = next(i for i in result.imports if i.module == "os")
+        assert redis_import.is_type_checking_only is True
+        assert os_import.is_type_checking_only is False

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,37 @@ revision = 2
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiokafka"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/5f/dfc1180fd22d1acdc91949ec36e97199c43742dacb057cb8efed3679ed04/aiokafka-0.14.0.tar.gz", hash = "sha256:8ffdc945798ba4d3d132b705d4244d0a1f493925efb57c637a2ca88ee82794e1", size = 601374, upload-time = "2026-04-29T10:43:03.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9d/3441db94829f9feb802a2f4052df61c0d1a01272accd174c351d7e9e1f6a/aiokafka-0.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:284a90d617584d7e42688a181aaa8c2a909d9c658ab9b69c6cf92f4df5c4b320", size = 348458, upload-time = "2026-04-29T10:42:37.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/10/7297589aac95654596af13301b31da2c9502c80e7e308530ee7a9bd5b9f1/aiokafka-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b4f211d9e03a1fc83871a37eefcf307bc0943ee99adae25aa39bd1722e70747b", size = 351057, upload-time = "2026-04-29T10:42:38.69Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4e/5c0aa8db717fff0ffb8f3e16deece8f98ded6ca17c6a543b6b20cc9a7f84/aiokafka-0.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be517b9b9513eba43ba19961dd770a6e26d08325743093feb47182770d235dd9", size = 1142238, upload-time = "2026-04-29T10:42:39.96Z" },
+    { url = "https://files.pythonhosted.org/packages/88/78/322f797b9593a4cc8afd647342fa66b9ad732ee55098e5e084188c6202aa/aiokafka-0.14.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:219d2dc66b97b1aaea100697c928024b6a0348b7baa370b824900054bf86916e", size = 1131567, upload-time = "2026-04-29T10:42:41.542Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0a/a45320778385142299a7fc3ae402152ec1f383537130b8aa8e8587742fad/aiokafka-0.14.0-cp312-cp312-win32.whl", hash = "sha256:1086b470f6c452471603a2d9c8d6933739230c75758d777d8d113ff8112bad68", size = 312160, upload-time = "2026-04-29T10:42:42.811Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fb/7802a0ed69200e3e8e8791df06bd6daf9b00523839d045662de4ff061b18/aiokafka-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:bcf3a8f6592d73f45965ca0750bfdfccf2555c8625358175c92f75f2cce1261a", size = 331897, upload-time = "2026-04-29T10:42:43.984Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b0/c9384541b2e4cc52a16402fc53fb9d44af0d78d37954cf8c7271c376ad47/aiokafka-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db16e43fac4c1c5006131046c1bf370c580d6ac4495a10ac7778245710943179", size = 345859, upload-time = "2026-04-29T10:42:45.449Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/fc266d9f4ffba4f197356c6ffdfbb0fe32e7cb874e240f299935d058ac06/aiokafka-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:32a8e91d88cf3ccf0778927715610d6579888c5f4748db4c2022cda25d628a48", size = 348284, upload-time = "2026-04-29T10:42:47.104Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8e/0c4c270786dac79f3fca74c6166c3a25b61b0d26132be0d69f0d7f206f0a/aiokafka-0.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aad4a575a506e7784e25e430f27026fe2f4378560b21b7f4e8c9a54f0d06eaee", size = 1117867, upload-time = "2026-04-29T10:42:48.394Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7f/3b89fbd0a3be9edfd5b51e20bb5cd695c851219b63c501c051cf84367fa9/aiokafka-0.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75e4a003502c9c3b5c705fa7c00d634ba146bf38fa5d525b80bb6ff6e3e779fe", size = 1108860, upload-time = "2026-04-29T10:42:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/59/849aba75cff93277bf6bf8b630de79e902949ff7ec48e4b12a64e6e32cae/aiokafka-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a128e213cbc2bce0ea3db65a68920e52cebeeb8209bf001ac7aa022a8bd54d7d", size = 310889, upload-time = "2026-04-29T10:42:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e5/52eab8f8515d23da7b5d90e2c5ba10eab9494a0314f749e3f73e003f4a50/aiokafka-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:d6fa16bef3544be87bd1a7a8317b9d85e3da59f3202326d9ff22735ed052746e", size = 329470, upload-time = "2026-04-29T10:42:53.536Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9d/984803315fe2b883ea6e08b1d9c8a752bd5c16e966d8714bacc67c72c417/aiokafka-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5d70615d1530ad19d0c4da8d87abaec0a12b9fdaabffdcd4e400efa0c50ef80c", size = 346672, upload-time = "2026-04-29T10:42:55.267Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/da314966b7f3c3117bd78b082563cb03dbe3007848cb8f4b0932faf390a0/aiokafka-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e2392360c370b1ba6564c57d2889e154ecdb43157a8f7b7d7afe5e3c02fcc1a", size = 349594, upload-time = "2026-04-29T10:42:56.565Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7a/160516944ea0e0f68ea78e38f944c52f5248c7c7df26cba22a40b9f25709/aiokafka-0.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:201e38ecc595f9f65a945f1ef9085157ddf28f25cd2e482fd9efa1fcf4638213", size = 1114112, upload-time = "2026-04-29T10:42:57.869Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c4/9841118a2157e913e8ebfbc0a2b58f7b60f1f7202040c3e1df8925ed1184/aiokafka-0.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cd651e1f56571baae306fdd0b5509047ab9625797a24cd75902e139c5a20318", size = 1098571, upload-time = "2026-04-29T10:42:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a1/0af8a37849a4108ae227f46c4c62f6beab31863cf66ba318fb73b0be5b26/aiokafka-0.14.0-cp314-cp314-win32.whl", hash = "sha256:128127eb96dab98150b636bb5f480c80e15f02f82a118eec206a521c8cf7cf7c", size = 314107, upload-time = "2026-04-29T10:43:01.111Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/fb46c65f758900c71d0f1c73b7802720f99cabcb1f4a11676573f9bc1b8f/aiokafka-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa385039aa9b235359319bbdcf48c9c86a75d81c9c547d645056d00361238903", size = 333320, upload-time = "2026-04-29T10:43:02.424Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -22,6 +53,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -686,6 +726,7 @@ compat = [
     { name = "omnibase-compat" },
 ]
 full = [
+    { name = "aiokafka" },
     { name = "confluent-kafka" },
     { name = "omnibase-compat" },
     { name = "omnibase-spi" },
@@ -695,6 +736,7 @@ full = [
     { name = "sqlglot" },
 ]
 kafka = [
+    { name = "aiokafka" },
     { name = "confluent-kafka" },
 ]
 metrics = [
@@ -735,6 +777,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiokafka", marker = "extra == 'full'", specifier = ">=0.12.0,<1.0.0" },
+    { name = "aiokafka", marker = "extra == 'kafka'", specifier = ">=0.12.0,<1.0.0" },
     { name = "blake3", specifier = ">=1.0.8,<2.0.0" },
     { name = "click", specifier = ">=8.3.1,<9.0.0" },
     { name = "confluent-kafka", marker = "extra == 'full'", specifier = ">=2.12.0,<3.0.0" },


### PR DESCRIPTION
## Summary
- declare aiokafka in the Kafka/full extras used by cross-repo validation
- track TYPE_CHECKING imports in the import graph scanner
- ignore type-only imports in the repo-boundary rule while preserving runtime forbidden-import enforcement

## Verification
- `uv run pytest tests/unit/validation/cross_repo/test_scanner_import_graph.py tests/unit/validation/cross_repo/test_rule_repo_boundaries.py -q`
- `uv run ruff check src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph.py src/omnibase_core/validation/cross_repo/rules/rule_repo_boundaries.py tests/unit/validation/cross_repo/test_scanner_import_graph.py tests/unit/validation/cross_repo/test_rule_repo_boundaries.py`
- `KAFKA_BOOTSTRAP_SERVERS= ROOT=/Volumes/PRO-G40/Code/omni_home/omni_worktrees/OMN-11754/omnibase_core uv run --all-extras python scripts/run_cross_repo_validation.py`
- `uv run pre-commit run --files pyproject.toml uv.lock src/omnibase_core/validation/cross_repo/scanners/scanner_import_graph.py src/omnibase_core/validation/cross_repo/rules/rule_repo_boundaries.py tests/unit/validation/cross_repo/test_scanner_import_graph.py tests/unit/validation/cross_repo/test_rule_repo_boundaries.py`

Evidence-Ticket: OMN-11754
Evidence-Source: 460ae6fb4299f9f3a07c4dabc979ca9f1e06ee7f