### PR TITLE
feat(OMN-11736): add branch-aware receipt gate policy

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -46,6 +46,11 @@ on:
         type: string
         required: false
         default: drift/dod_receipts
+      branch-policy-mode:
+        description: "Branch-aware receipt policy mode: legacy, dev-preflight, or main-release."
+        type: string
+        required: false
+        default: legacy
 
 permissions:
   contents: read
@@ -73,6 +78,43 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+
+      - name: Resolve receipt gate branch policy
+        id: branch_policy
+        env:
+          REQUESTED_POLICY_MODE: ${{ inputs.branch-policy-mode }}
+          PR_TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+        run: |
+          set -euo pipefail
+
+          normalize_branch() {
+            printf '%s' "$1" | sed -E 's@^refs/heads/@@; s@^heads/@@'
+          }
+
+          if [ -n "${PR_TARGET_BRANCH:-}" ]; then
+            target_branch="$(normalize_branch "$PR_TARGET_BRANCH")"
+          elif [ -n "${MERGE_GROUP_BASE_REF:-}" ]; then
+            target_branch="$(normalize_branch "$MERGE_GROUP_BASE_REF")"
+          else
+            target_branch=""
+          fi
+
+          case "${REQUESTED_POLICY_MODE:-legacy}" in
+            legacy|dev-preflight|main-release)
+              policy_mode="${REQUESTED_POLICY_MODE:-legacy}"
+              ;;
+            *)
+              echo "::error::invalid branch-policy-mode '${REQUESTED_POLICY_MODE}'. Expected legacy, dev-preflight, or main-release."
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "target_branch=${target_branch}"
+            echo "policy_mode=${policy_mode}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::receipt-gate target_branch=${target_branch:-unknown} policy_mode=${policy_mode}"
 
       # OMN-10419: Resolve Evidence-Source commit-ish to an exact OCC SHA before
       # checking out onex_change_control. Accepts two forms:
@@ -134,6 +176,7 @@ jobs:
             echo "::notice::Evidence-Source not required: OMN-10419 cutoff SHA is PENDING_MERGE and no Evidence-Source was provided, so this run is treated as pre-cutoff."
             echo "PENDING_MERGE" > /tmp/occ_sha.txt
             echo "occ_sha=PENDING_MERGE" >> "$GITHUB_OUTPUT"
+            echo "occ_source_kind=main" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -156,6 +199,7 @@ jobs:
             echo "::notice::Evidence-Source not required: PR predates OMN-10419 cutoff (pr_epoch=${pr_epoch} < cutoff_epoch=${cutoff_epoch}). Falling back to OCC main."
             echo "PENDING_MERGE" > /tmp/occ_sha.txt
             echo "occ_sha=PENDING_MERGE" >> "$GITHUB_OUTPUT"
+            echo "occ_source_kind=main" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -167,9 +211,18 @@ jobs:
 
           # Resolve the commit-ish to an exact OCC SHA.
           if printf '%s' "$evidence_source" | grep -qiE '^OCC#[0-9]+$'; then
-            # OCC PR form: resolve to the current head SHA of that PR.
+            # OCC PR form: resolve to the merged commit when merged, otherwise
+            # to the current head SHA of the open PR.
             occ_pr_num="$(printf '%s' "$evidence_source" | sed -E 's/^OCC#//i')"
-            occ_sha="$(gh pr view "$occ_pr_num" --repo "OmniNode-ai/onex_change_control" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
+            occ_json="$(gh pr view "$occ_pr_num" --repo "OmniNode-ai/onex_change_control" --json state,headRefOid,mergeCommit 2>/dev/null || true)"
+            occ_state="$(printf '%s' "$occ_json" | jq -r '.state // ""' 2>/dev/null || true)"
+            if [ "$occ_state" = "MERGED" ]; then
+              occ_sha="$(printf '%s' "$occ_json" | jq -r '.mergeCommit.oid // ""' 2>/dev/null || true)"
+              occ_source_kind="merged"
+            else
+              occ_sha="$(printf '%s' "$occ_json" | jq -r '.headRefOid // ""' 2>/dev/null || true)"
+              occ_source_kind="open-pr"
+            fi
             if [ -z "$occ_sha" ]; then
               echo "::error::RECEIPT GATE FAILED: OCC PR #${occ_pr_num} could not be resolved — OCC unavailable or PR not found. Cannot verify evidence (OMN-10419 invariant I8)."
               exit 1
@@ -185,6 +238,7 @@ jobs:
                 echo "::error::RECEIPT GATE FAILED: Evidence-Source SHA could not be canonicalized to a full OCC commit SHA (OMN-10419)."
                 exit 1
               fi
+              occ_source_kind="merged"
             else
               # Not an ancestor of main: check if it matches any open OCC PR head.
               matched_head="$(gh pr list --repo "OmniNode-ai/onex_change_control" --state open --json headRefOid --jq ".[] | select(.headRefOid | startswith(\"${occ_sha}\")) | .headRefOid" 2>/dev/null | head -1 || true)"
@@ -193,6 +247,7 @@ jobs:
                 exit 1
               fi
               occ_sha="$matched_head"
+              occ_source_kind="open-pr"
             fi
           else
             echo "::error::RECEIPT GATE FAILED: Evidence-Source value '${evidence_source}' is not a valid OCC#<number> or hex SHA. Accepted forms: 'OCC#1234' or '<sha>' (OMN-10419)."
@@ -203,6 +258,7 @@ jobs:
           printf '%s' "$occ_sha" > /tmp/occ_sha.txt
           # Expose as step output for the checkout step's ref field.
           echo "occ_sha=${occ_sha}" >> "$GITHUB_OUTPUT"
+          echo "occ_source_kind=${occ_source_kind}" >> "$GITHUB_OUTPUT"
           echo "::notice::Evidence-Source resolved to OCC SHA: ${occ_sha}"
 
       # We need the onex_change_control repo to find contracts + receipts.
@@ -575,6 +631,7 @@ jobs:
         run: |
           PR_BODY="$(cat /tmp/pr_body.txt)"
           PR_TITLE="$(cat /tmp/pr_title.txt)"
+          PR_BRANCH="$(cat /tmp/pr_branch.txt 2>/dev/null || true)"
           PR_AUTHOR="$(cat /tmp/pr_author.txt 2>/dev/null || true)"
           PR_NUMBER_RESOLVED="$(cat /tmp/pr_number.txt 2>/dev/null || true)"
           PR_OPENED_AT="$(cat /tmp/pr_created_at.txt 2>/dev/null || true)"
@@ -609,6 +666,10 @@ jobs:
             --contracts-dir "${{ steps.evidence.outputs.contracts_dir }}" \
             --receipts-dir "${{ steps.evidence.outputs.receipts_dir }}" \
             --current-repo "$REPO_SHORT" \
+            --branch-name "$PR_BRANCH" \
+            --target-branch "${{ steps.branch_policy.outputs.target_branch }}" \
+            --receipt-gate-policy-mode "${{ steps.branch_policy.outputs.policy_mode }}" \
+            --occ-source-kind "${{ steps.resolve_evidence_source.outputs.occ_source_kind || 'self' }}" \
             $ALLOWLIST_ARG \
             $PR_AUTHOR_ARG \
             $PR_NUMBER_ARG \

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -155,6 +155,18 @@ EVIDENCE_SOURCE_ANY_PATTERN = re.compile(
     r"^Evidence-Source:\s+\S",
     re.IGNORECASE | re.MULTILINE,
 )
+PROMOTION_RECEIPT_PATTERN = re.compile(
+    r"^Promotion-Receipt:\s+\S",
+    re.IGNORECASE | re.MULTILINE,
+)
+HOTFIX_RECEIPT_PATTERN = re.compile(
+    r"^Hotfix-Receipt:\s+\S",
+    re.IGNORECASE | re.MULTILINE,
+)
+EVIDENCE_CLASS_PATTERN = re.compile(
+    r"^Evidence-Class:\s+(promotion|hotfix)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 # The SHA of the commit that merged OMN-10419 (Task 9 / T6a). PRs opened after
 # this SHA are required to include Evidence-Source. PRs opened before it are
@@ -726,6 +738,75 @@ def _verify_ticket_identity(
     return None
 
 
+def _normalized_branch(value: str | None) -> str:
+    if value is None:
+        return ""
+    branch = value.strip()
+    for prefix in ("refs/heads/", "heads/"):
+        if branch.startswith(prefix):
+            branch = branch.removeprefix(prefix)
+    return branch
+
+
+def _evidence_class_present(pr_body: str, expected: str) -> bool:
+    for match in EVIDENCE_CLASS_PATTERN.finditer(pr_body):
+        if match.group(1).lower() == expected:
+            return True
+    return False
+
+
+def _validate_main_release_policy(
+    *,
+    pr_body: str,
+    target_branch: str | None,
+    branch_name: str | None,
+    current_repo: str | None,
+    occ_source_kind: str | None,
+) -> str | None:
+    """Return a failure message when a main release PR violates branch policy."""
+
+    if _normalized_branch(target_branch) != "main":
+        return None
+    if current_repo == "onex_change_control":
+        return None
+
+    source_kind = (occ_source_kind or "").strip().lower()
+    if source_kind != "merged":
+        return (
+            "RECEIPT GATE FAILED: main release policy requires merged OCC evidence. "
+            "Resolve Evidence-Source to an OCC commit on main before promotion or "
+            "hotfix merge; current evidence source kind is "
+            f"{source_kind or 'unknown'}."
+        )
+
+    head_branch = _normalized_branch(branch_name)
+    if head_branch == "dev" or head_branch.startswith("promotion/"):
+        if PROMOTION_RECEIPT_PATTERN.search(pr_body) or _evidence_class_present(
+            pr_body, "promotion"
+        ):
+            return None
+        return (
+            "RECEIPT GATE FAILED: PRs targeting main from dev/promotion branches "
+            "must declare Promotion-Receipt: <receipt-id-or-occ-ref> or "
+            "Evidence-Class: promotion."
+        )
+
+    if head_branch.startswith("hotfix/"):
+        if HOTFIX_RECEIPT_PATTERN.search(pr_body) or _evidence_class_present(
+            pr_body, "hotfix"
+        ):
+            return None
+        return (
+            "RECEIPT GATE FAILED: hotfix PRs targeting main must declare "
+            "Hotfix-Receipt: <receipt-id-or-occ-ref> or Evidence-Class: hotfix."
+        )
+
+    return (
+        "RECEIPT GATE FAILED: main accepts only promotion PRs from dev/promotion/* "
+        "or hotfix PRs from hotfix/* under main-release policy."
+    )
+
+
 def validate_pr_receipts(
     pr_body: str,
     contracts_dir: Path,
@@ -738,6 +819,9 @@ def validate_pr_receipts(
     pr_opened_at: datetime | None = None,
     evidence_ticket: str | None = None,
     branch_name: str | None = None,
+    target_branch: str | None = None,
+    receipt_gate_policy_mode: str = "legacy",
+    occ_source_kind: str | None = None,
 ) -> ModelReceiptGateResult:
     """Run the receipt-gate against a PR's body + the repo's contracts + receipts.
 
@@ -764,7 +848,31 @@ def validate_pr_receipts(
             arg is also ``None`` the detected value is used.  If neither source yields
             a value and ``Evidence-Source`` is present, the gate fails.
         branch_name: Git branch name for axis-2 identity binding.
+        target_branch: PR base branch. Used by branch-aware dev/main policy.
+        receipt_gate_policy_mode: ``legacy`` keeps current behavior. ``main-release``
+            additionally requires main-targeted PRs to be promotion or hotfix paths
+            backed by merged OCC evidence. ``dev-preflight`` intentionally preserves
+            current per-PR receipt behavior while allowing open OCC PR evidence.
+        occ_source_kind: Evidence snapshot provenance from the workflow
+            (``open-pr``, ``merged``, ``main``, or ``self``).
     """
+    policy_mode = receipt_gate_policy_mode.strip().lower()
+    if policy_mode not in {"legacy", "dev-preflight", "main-release"}:
+        return ModelReceiptGateResult(
+            passed=False,
+            message=f"Unknown receipt_gate_policy_mode: {policy_mode}",
+        )
+    if policy_mode == "main-release":
+        branch_policy_failure = _validate_main_release_policy(
+            pr_body=pr_body,
+            target_branch=target_branch,
+            branch_name=branch_name,
+            current_repo=current_repo,
+            occ_source_kind=occ_source_kind,
+        )
+        if branch_policy_failure is not None:
+            return ModelReceiptGateResult(passed=False, message=branch_policy_failure)
+
     override = OVERRIDE_PATTERN.search(pr_body)
     skip_match = SKIP_TOKEN_PATTERN.search(pr_body)
     if skip_match and override is None:
@@ -850,10 +958,18 @@ def validate_pr_receipts(
                 ),
             )
 
+        identity_branch_name = branch_name
+        if (
+            policy_mode == "main-release"
+            and _normalized_branch(target_branch) == "main"
+            and _normalized_branch(branch_name) == "dev"
+        ):
+            identity_branch_name = None
+
         identity_failure = _verify_ticket_identity(
             evidence_ticket=resolved_evidence_ticket,
             pr_title=pr_title,
-            branch_name=branch_name,
+            branch_name=identity_branch_name,
             contracts_dir=contracts_dir,
             receipts_dir=receipts_dir,
         )

--- a/src/omnibase_core/validation/validator_receipt_gate_cli.py
+++ b/src/omnibase_core/validation/validator_receipt_gate_cli.py
@@ -124,6 +124,32 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--target-branch",
+        default=None,
+        help=(
+            "OMN-11736: PR base branch. Used by branch-aware dev/main receipt policy."
+        ),
+    )
+    parser.add_argument(
+        "--receipt-gate-policy-mode",
+        choices=("legacy", "dev-preflight", "main-release"),
+        default="legacy",
+        help=(
+            "OMN-11736: branch policy mode. legacy preserves current behavior; "
+            "dev-preflight allows PR-head OCC evidence; main-release requires "
+            "merged OCC evidence plus promotion/hotfix classification for main."
+        ),
+    )
+    parser.add_argument(
+        "--occ-source-kind",
+        choices=("unknown", "open-pr", "merged", "main", "self"),
+        default="unknown",
+        help=(
+            "OMN-11736: provenance of the checked-out OCC evidence snapshot, as "
+            "resolved by the reusable workflow."
+        ),
+    )
+    parser.add_argument(
         "--reexecute-probes",
         action="store_true",
         default=False,
@@ -153,6 +179,9 @@ def main(argv: list[str] | None = None) -> int:
         pr_opened_at=pr_opened_at,
         evidence_ticket=args.evidence_ticket,
         branch_name=args.branch_name,
+        target_branch=args.target_branch,
+        receipt_gate_policy_mode=args.receipt_gate_policy_mode,
+        occ_source_kind=args.occ_source_kind,
     )
 
     if result.friction_logged:

--- a/tests/unit/scripts/validation/test_validate_pr_receipts.py
+++ b/tests/unit/scripts/validation/test_validate_pr_receipts.py
@@ -222,6 +222,218 @@ class TestReceiptGateGreedyRegression:
 
 
 @pytest.mark.unit
+class TestReceiptGateBranchPolicy:
+    def test_dev_preflight_allows_open_occ_pr_evidence(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: OCC#1397"
+            ),
+            pr_title="feat(OMN-11736): branch-aware receipt gate",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-11736-receipt-gate",
+            target_branch="dev",
+            receipt_gate_policy_mode="dev-preflight",
+            occ_source_kind="open-pr",
+        )
+
+        assert result.passed
+
+    def test_unknown_policy_mode_fails_closed(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: OCC#1397"
+            ),
+            pr_title="feat(OMN-11736): branch-aware receipt gate",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-11736-receipt-gate",
+            target_branch="dev",
+            receipt_gate_policy_mode="experimental",
+            occ_source_kind="open-pr",
+        )
+
+        assert not result.passed
+        assert result.message == "Unknown receipt_gate_policy_mode: experimental"
+
+    def test_main_release_rejects_open_occ_pr_evidence(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: OCC#1397\n"
+                "Promotion-Receipt: OCC#1397"
+            ),
+            pr_title="feat(OMN-11736): promote dev to main",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="dev",
+            target_branch="main",
+            receipt_gate_policy_mode="main-release",
+            occ_source_kind="open-pr",
+        )
+
+        assert not result.passed
+        assert "requires merged occ evidence" in result.message.lower()
+
+    def test_main_release_accepts_promotion_with_merged_occ_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: 9b134fd779d85dcb83db476940b12036b50c1825\n"
+                "Promotion-Receipt: OCC#1397"
+            ),
+            pr_title="feat(OMN-11736): promote dev to main",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="dev",
+            target_branch="main",
+            receipt_gate_policy_mode="main-release",
+            occ_source_kind="merged",
+        )
+
+        assert result.passed
+
+    def test_main_release_rejects_promotion_without_receipt_marker(
+        self, tmp_path: Path
+    ) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: 9b134fd779d85dcb83db476940b12036b50c1825"
+            ),
+            pr_title="feat(OMN-11736): promote dev to main",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="dev",
+            target_branch="main",
+            receipt_gate_policy_mode="main-release",
+            occ_source_kind="merged",
+        )
+
+        assert not result.passed
+        assert "promotion-receipt" in result.message.lower()
+
+    def test_main_release_accepts_hotfix_with_hotfix_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: 9b134fd779d85dcb83db476940b12036b50c1825\n"
+                "Hotfix-Receipt: OCC#1397"
+            ),
+            pr_title="fix(OMN-11736): emergency hotfix",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="hotfix/omn-11736-emergency",
+            target_branch="main",
+            receipt_gate_policy_mode="main-release",
+            occ_source_kind="merged",
+        )
+
+        assert result.passed
+
+    def test_main_release_rejects_regular_main_pr(self, tmp_path: Path) -> None:
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-11736")
+        _write_receipt(
+            receipts,
+            ticket_id="OMN-11736",
+            evidence_item_id="dod-001",
+            check_type="command",
+        )
+
+        result = validate_pr_receipts(
+            pr_body=(
+                "Closes OMN-11736\n"
+                "Evidence-Ticket: OMN-11736\n"
+                "Evidence-Source: abcdef1234567890"
+            ),
+            pr_title="feat(OMN-11736): regular main change",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="feature/omn-11736-regular",
+            target_branch="main",
+            receipt_gate_policy_mode="main-release",
+            occ_source_kind="merged",
+        )
+
+        assert not result.passed
+        assert "main accepts only promotion" in result.message.lower()
+
+
+@pytest.mark.unit
 class TestReceiptGateContractPresence:
     def test_missing_contract_fails(self, tmp_path: Path) -> None:
         result = validate_pr_receipts(

--- a/tests/unit/validation/test_receipt_gate_cli.py
+++ b/tests/unit/validation/test_receipt_gate_cli.py
@@ -39,6 +39,9 @@ def test_cli_accepts_workflow_context_args(monkeypatch: pytest.MonkeyPatch) -> N
         assert kwargs["pr_body"] == "Implements OMN-1"
         assert kwargs["pr_title"] == "feat: test"
         assert kwargs["pr_opened_at"] == datetime(2026, 5, 21, 12, 30, tzinfo=UTC)
+        assert kwargs["target_branch"] == "dev"
+        assert kwargs["receipt_gate_policy_mode"] == "dev-preflight"
+        assert kwargs["occ_source_kind"] == "open-pr"
         return ModelReceiptGateResult(passed=True, message="ok")
 
     monkeypatch.setattr(
@@ -68,6 +71,12 @@ def test_cli_accepts_workflow_context_args(monkeypatch: pytest.MonkeyPatch) -> N
                 "1024",
                 "--pr-opened-at",
                 "2026-05-21T12:30:00Z",
+                "--target-branch",
+                "dev",
+                "--receipt-gate-policy-mode",
+                "dev-preflight",
+                "--occ-source-kind",
+                "open-pr",
             ]
         )
         == 0

--- a/tests/unit/validation/test_receipt_gate_workflow_shape.py
+++ b/tests/unit/validation/test_receipt_gate_workflow_shape.py
@@ -179,6 +179,43 @@ def test_workflow_resolves_evidence_source_before_checkout() -> None:
     assert "git -C .onex_change_control rev-parse HEAD" in evidence_step["run"]
 
 
+def test_workflow_has_branch_policy_input_and_resolution_step() -> None:
+    """OMN-11736 exposes branch-aware receipt policy without changing defaults."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    inputs = data[True]["workflow_call"]["inputs"]
+
+    assert inputs["branch-policy-mode"]["default"] == "legacy"
+
+    step = _workflow_step("Resolve receipt gate branch policy")
+    script = step["run"]
+    assert step["id"] == "branch_policy"
+    assert "target_branch=" in script
+    assert "policy_mode=" in script
+    assert "dev-preflight|main-release" in script
+
+
+def test_workflow_passes_branch_policy_context_to_cli() -> None:
+    """Receipt gate CLI must receive branch policy and OCC source provenance."""
+    step = _workflow_step("Run Receipt-Gate")
+    script = step["run"]
+
+    assert 'PR_BRANCH="$(cat /tmp/pr_branch.txt 2>/dev/null || true)"' in script
+    assert '--branch-name "$PR_BRANCH"' in script
+    assert "--target-branch" in script
+    assert "--receipt-gate-policy-mode" in script
+    assert "--occ-source-kind" in script
+
+
+def test_workflow_distinguishes_open_and_merged_occ_sources() -> None:
+    """Main-release policy depends on whether OCC evidence is merged or PR-head."""
+    step = _workflow_step("Resolve Evidence-Source")
+    script = step["run"]
+
+    assert 'occ_source_kind="open-pr"' in script
+    assert 'occ_source_kind="merged"' in script
+    assert "mergeCommit" in script
+
+
 def test_workflow_validates_occ_pr_diff_without_main_dependency() -> None:
     """onex_change_control PRs validate same-PR evidence to avoid a circular gate."""
     evidence_step = _workflow_step("Resolve evidence snapshot")


### PR DESCRIPTION
Closes OMN-11736
Evidence-Ticket: OMN-11736
Evidence-Source: OCC#1399

## Summary
- add receipt-gate branch-policy-mode input with legacy default
- pass target branch, head branch, and OCC source provenance into the receipt gate CLI
- add main-release policy: merged OCC evidence only, promotion/hotfix PR classification, regular main PR rejection
- preserve dev-preflight behavior for PR-head OCC evidence

## Verification
- PYTHONPATH=src uv run pytest tests/unit/scripts/validation/test_validate_pr_receipts.py tests/unit/validation/test_receipt_gate_cli.py tests/unit/validation/test_receipt_gate_workflow_shape.py -q
- uv run ruff check src/omnibase_core/validation/validator_receipt_gate.py src/omnibase_core/validation/validator_receipt_gate_cli.py tests/unit/scripts/validation/test_validate_pr_receipts.py tests/unit/validation/test_receipt_gate_cli.py tests/unit/validation/test_receipt_gate_workflow_shape.py
- uv run pre-commit run --files .github/workflows/receipt-gate.yml src/omnibase_core/validation/validator_receipt_gate.py src/omnibase_core/validation/validator_receipt_gate_cli.py tests/unit/scripts/validation/test_validate_pr_receipts.py tests/unit/validation/test_receipt_gate_cli.py tests/unit/validation/test_receipt_gate_workflow_shape.py