### PR TITLE
feat(OMN-11927): add LLM routing DTO contracts

### DIFF
--- a/src/omnibase_core/enums/enum_routing_error_class.py
+++ b/src/omnibase_core/enums/enum_routing_error_class.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""RoutingErrorClass: structured failure classes for LLM route rejection."""
+"""EnumRoutingErrorClass: structured failure classes for LLM route rejection."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from enum import Enum, unique
 
 
 @unique
-class RoutingErrorClass(str, Enum):
+class EnumRoutingErrorClass(str, Enum):
     """Failure classes emitted when the LLM router rejects a route."""
 
     PRIMARY_UNHEALTHY = "primary_unhealthy"
@@ -23,4 +23,6 @@ class RoutingErrorClass(str, Enum):
     ENDPOINT_UNAVAILABLE = "endpoint_unavailable"
 
 
-__all__ = ["RoutingErrorClass"]
+RoutingErrorClass = EnumRoutingErrorClass
+
+__all__ = ["EnumRoutingErrorClass", "RoutingErrorClass"]

--- a/src/omnibase_core/enums/enum_routing_error_class.py
+++ b/src/omnibase_core/enums/enum_routing_error_class.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RoutingErrorClass: structured failure classes for LLM route rejection."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class RoutingErrorClass(str, Enum):
+    """Failure classes emitted when the LLM router rejects a route."""
+
+    PRIMARY_UNHEALTHY = "primary_unhealthy"
+    FALLBACK_UNAUTHORIZED = "fallback_unauthorized"
+    FALLBACK_UNAVAILABLE = "fallback_unavailable"
+    REGISTRY_MISSING = "registry_missing"
+    POLICY_INVALID = "policy_invalid"
+    NO_ELIGIBLE_MODEL = "no_eligible_model"
+    HEALTH_CHECK_FAILED = "health_check_failed"
+    EXHAUSTED_RETRIES = "exhausted_retries"
+    ENDPOINT_UNAVAILABLE = "endpoint_unavailable"
+
+
+__all__ = ["RoutingErrorClass"]

--- a/src/omnibase_core/models/routing/__init__.py
+++ b/src/omnibase_core/models/routing/__init__.py
@@ -35,6 +35,12 @@ from omnibase_core.models.routing.model_classification_gate import (
     ModelClassificationGate,
 )
 from omnibase_core.models.routing.model_hop_constraints import ModelHopConstraints
+from omnibase_core.models.routing.model_llm_route_rejected_event import (
+    ModelLlmRouteRejectedEvent,
+)
+from omnibase_core.models.routing.model_llm_route_resolved_event import (
+    ModelLlmRouteResolvedEvent,
+)
 from omnibase_core.models.routing.model_policy_bundle import ModelPolicyBundle
 from omnibase_core.models.routing.model_redaction_policy import ModelRedactionPolicy
 from omnibase_core.models.routing.model_resolution_event import ModelResolutionEvent
@@ -43,6 +49,10 @@ from omnibase_core.models.routing.model_resolution_route_hop import (
     ModelResolutionRouteHop,
 )
 from omnibase_core.models.routing.model_route_plan import ModelRoutePlan
+from omnibase_core.models.routing.model_routing_policy import (
+    ModelCiOverridePolicy,
+    ModelRoutingPolicy,
+)
 from omnibase_core.models.routing.model_tier_attempt import ModelTierAttempt
 from omnibase_core.models.routing.model_tiered_resolution_config import (
     ModelTieredResolutionConfig,
@@ -59,12 +69,16 @@ __all__ = [
     "ModelCapabilityToken",
     "ModelClassificationGate",
     "ModelHopConstraints",
+    "ModelLlmRouteRejectedEvent",
+    "ModelLlmRouteResolvedEvent",
     "ModelPolicyBundle",
     "ModelRedactionPolicy",
     "ModelResolutionEvent",
     "ModelResolutionProof",
     "ModelResolutionRouteHop",
     "ModelRoutePlan",
+    "ModelCiOverridePolicy",
+    "ModelRoutingPolicy",
     "ModelTierAttempt",
     "ModelTieredResolutionConfig",
     "ModelTieredResolutionResult",

--- a/src/omnibase_core/models/routing/model_llm_route_rejected_event.py
+++ b/src/omnibase_core/models/routing/model_llm_route_rejected_event.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelLlmRouteRejectedEvent: canonical event for rejected LLM routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_routing_error_class import RoutingErrorClass
+
+
+class ModelLlmRouteRejectedEvent(BaseModel):
+    """Event emitted when model routing fails closed without a served endpoint."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    routing_decision_id: str = Field(
+        ..., description="Stable identifier for this routing decision."
+    )
+    correlation_id: str = Field(..., description="Originating correlation id.")
+    logical_model_key: str = Field(
+        ..., description="Logical model key requested by policy."
+    )
+    served_model_id: str = Field(
+        default="",
+        description="Concrete model id if any model was attempted.",
+    )
+    endpoint_ref: str = Field(
+        default="",
+        description="Contract-owned endpoint reference if one was selected.",
+    )
+    provider: str = Field(default="", description="Provider if one was selected.")
+    registry_hash: str = Field(
+        ..., description="Hash of the model registry used for the decision."
+    )
+    routing_policy_hash: str = Field(
+        ..., description="Hash of the routing policy used for the decision."
+    )
+    policy_hash: str = Field(
+        ..., description="Alias for routing_policy_hash for consumers."
+    )
+    pricing_manifest_hash: str = Field(
+        ..., description="Hash of pricing manifest used for cost provenance."
+    )
+    fallback_reason: str = Field(
+        default="",
+        description="Fallback reason from policy or terminal rejection reason.",
+    )
+    failure_class: RoutingErrorClass = Field(
+        ..., description="Structured route rejection classification."
+    )
+    failure_reason: str = Field(
+        ..., description="Human-readable route rejection reason."
+    )
+    created_at: datetime = Field(..., description="UTC event creation time.")
+
+    @model_validator(mode="after")
+    def _policy_hash_alias_matches(self) -> Self:
+        if self.policy_hash != self.routing_policy_hash:
+            msg = "policy_hash must equal routing_policy_hash"
+            raise ValueError(msg)
+        return self
+
+
+__all__ = ["ModelLlmRouteRejectedEvent"]

--- a/src/omnibase_core/models/routing/model_llm_route_resolved_event.py
+++ b/src/omnibase_core/models/routing/model_llm_route_resolved_event.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelLlmRouteResolvedEvent: canonical event for resolved LLM routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelLlmRouteResolvedEvent(BaseModel):
+    """Event emitted when model routing resolves to a concrete endpoint."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    routing_decision_id: str = Field(
+        ..., description="Stable identifier for this routing decision."
+    )
+    correlation_id: str = Field(..., description="Originating correlation id.")
+    logical_model_key: str = Field(
+        ..., description="Logical model key requested by policy."
+    )
+    served_model_id: str = Field(
+        ..., description="Concrete served model id selected from the registry."
+    )
+    endpoint_ref: str = Field(
+        ..., description="Contract-owned endpoint reference; never a secret value."
+    )
+    provider: str = Field(..., description="Provider that owns the served model.")
+    registry_hash: str = Field(
+        ..., description="Hash of the model registry used for the decision."
+    )
+    routing_policy_hash: str = Field(
+        ..., description="Hash of the routing policy used for the decision."
+    )
+    policy_hash: str = Field(
+        ..., description="Alias for routing_policy_hash for consumers."
+    )
+    pricing_manifest_hash: str = Field(
+        ..., description="Hash of pricing manifest used for cost provenance."
+    )
+    fallback_reason: str = Field(
+        default="",
+        description="Reason fallback was used; empty when primary route resolved.",
+    )
+    used_fallback: bool = Field(
+        default=False, description="True when the resolved route used fallback."
+    )
+    created_at: datetime = Field(..., description="UTC event creation time.")
+
+    @model_validator(mode="after")
+    def _policy_hash_alias_matches(self) -> Self:
+        if self.policy_hash != self.routing_policy_hash:
+            msg = "policy_hash must equal routing_policy_hash"
+            raise ValueError(msg)
+        return self
+
+
+__all__ = ["ModelLlmRouteResolvedEvent"]

--- a/src/omnibase_core/models/routing/model_routing_policy.py
+++ b/src/omnibase_core/models/routing/model_routing_policy.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract-declared LLM routing policy models."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelCiOverridePolicy(BaseModel):
+    """CI-mode override: when ONEX_CI_MODE=true, use this primary model key."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    primary: str = Field(..., description="model_id key to use in CI mode.")
+
+
+class ModelRoutingPolicy(BaseModel):
+    """Contract-declared LLM routing policy for a node handler."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    primary: str = Field(..., description="model_id key for the primary route.")
+    fallback: str | None = Field(
+        default=None,
+        description="model_id key for fallback. Required when fallback roles exist.",
+    )
+    timeout_per_attempt_s: float = Field(
+        default=30.0,
+        description="Per-attempt budget in seconds.",
+        gt=0,
+    )
+    max_retries: int = Field(
+        default=2,
+        description="Maximum retry attempts per request.",
+        ge=1,
+    )
+    reason_for_fallback: str = Field(
+        default="",
+        description="Required when fallback is declared.",
+    )
+    fallback_allowed_roles: list[str] = Field(
+        default_factory=list,
+        description="Roles permitted to trigger fallback.",
+    )
+    max_tokens: int = Field(
+        default=4096,
+        description="Maximum tokens in the model response.",
+        gt=0,
+    )
+    temperature: float = Field(
+        default=0.2,
+        description="Sampling temperature.",
+        ge=0.0,
+        le=2.0,
+    )
+    call_style: Literal["sync", "async"] = Field(
+        default="async",
+        description="Whether to invoke the model synchronously or asynchronously.",
+    )
+    ci_override: ModelCiOverridePolicy | None = Field(
+        default=None,
+        description="Override policy applied when ONEX_CI_MODE=true.",
+    )
+
+    @model_validator(mode="after")
+    def _fallback_required_when_roles_declared(self) -> Self:
+        if self.fallback_allowed_roles and self.fallback is None:
+            msg = "fallback must be set when fallback_allowed_roles is non-empty"
+            raise ValueError(msg)
+        return self
+
+
+__all__ = [
+    "ModelCiOverridePolicy",
+    "ModelRoutingPolicy",
+]

--- a/tests/unit/models/routing/test_model_llm_route_events.py
+++ b/tests/unit/models/routing/test_model_llm_route_events.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for canonical LLM route event DTOs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_routing_error_class import RoutingErrorClass
+from omnibase_core.models.routing.model_llm_route_rejected_event import (
+    ModelLlmRouteRejectedEvent,
+)
+from omnibase_core.models.routing.model_llm_route_resolved_event import (
+    ModelLlmRouteResolvedEvent,
+)
+from omnibase_core.models.routing.model_routing_policy import ModelRoutingPolicy
+
+
+def test_resolved_route_event_requires_policy_hash_alias_match() -> None:
+    event = ModelLlmRouteResolvedEvent(
+        routing_decision_id="decision-1",
+        correlation_id="corr-1",
+        logical_model_key="coder",
+        served_model_id="qwen3-coder-30b",
+        endpoint_ref="LLM_LOCAL_PRIMARY_URL",
+        provider="local",
+        registry_hash="sha256:registry",
+        routing_policy_hash="sha256:policy",
+        policy_hash="sha256:policy",
+        pricing_manifest_hash="sha256:pricing",
+        fallback_reason="",
+        used_fallback=False,
+        created_at=datetime.now(UTC),
+    )
+
+    assert event.policy_hash == event.routing_policy_hash
+    assert event.logical_model_key == "coder"
+
+
+def test_resolved_route_event_rejects_mismatched_policy_hash_alias() -> None:
+    with pytest.raises(ValidationError, match="policy_hash must equal"):
+        ModelLlmRouteResolvedEvent(
+            routing_decision_id="decision-1",
+            correlation_id="corr-1",
+            logical_model_key="coder",
+            served_model_id="qwen3-coder-30b",
+            endpoint_ref="LLM_LOCAL_PRIMARY_URL",
+            provider="local",
+            registry_hash="sha256:registry",
+            routing_policy_hash="sha256:policy",
+            policy_hash="sha256:other",
+            pricing_manifest_hash="sha256:pricing",
+            fallback_reason="",
+            used_fallback=False,
+            created_at=datetime.now(UTC),
+        )
+
+
+def test_rejected_route_event_carries_failure_classification() -> None:
+    event = ModelLlmRouteRejectedEvent(
+        routing_decision_id="decision-2",
+        correlation_id="corr-2",
+        logical_model_key="coder",
+        registry_hash="sha256:registry",
+        routing_policy_hash="sha256:policy",
+        policy_hash="sha256:policy",
+        pricing_manifest_hash="sha256:pricing",
+        fallback_reason="primary unavailable",
+        failure_class=RoutingErrorClass.FALLBACK_UNAUTHORIZED,
+        failure_reason="role is not authorized for fallback",
+        created_at=datetime.now(UTC),
+    )
+
+    assert event.failure_class is RoutingErrorClass.FALLBACK_UNAUTHORIZED
+    assert event.served_model_id == ""
+
+
+def test_model_routing_policy_requires_fallback_when_roles_declared() -> None:
+    with pytest.raises(ValidationError, match="fallback must be set"):
+        ModelRoutingPolicy(primary="qwen3-coder-30b", fallback_allowed_roles=["fixer"])


### PR DESCRIPTION
## Summary
- Adds shared routing DTOs for ModelRoutingPolicy and route resolved/rejected events.
- Adds RoutingErrorClass enum for fail-loud routing errors.
- Provides core unit coverage for route event identity/provenance fields.

## Verification
- PYTHONPATH=src uv run pytest tests/unit/models/routing/test_model_llm_route_events.py -q
- uv run ruff check touched files

Parent epic: OMN-11917

Dependency note: omnimarket OMN-11927 consumer PR should merge after this core DTO PR.

Evidence-Source: 7cad0fe7ffa8c75ba6f5185e24921b9c5148294f

Evidence-Source: 7cad0fe7ffa8c75ba6f5185e24921b9c5148294f
Evidence-Ticket: OMN-11927


