### PR TITLE
feat(OMN-11928): add ModelKnowledgeContextBundle and sub-models

### DIFF
--- a/src/omnibase_core/models/context/__init__.py
+++ b/src/omnibase_core/models/context/__init__.py
@@ -94,6 +94,13 @@ Example:
 """
 
 __all__ = [
+    # Knowledge context bundle models (OMN-11928)
+    "ModelContextProvenance",
+    "ModelADRSummary",
+    "ModelAntipatternSummary",
+    "ModelLearningMatch",
+    "ModelGraphSnapshot",
+    "ModelKnowledgeContextBundle",
     # Error/Retry context models
     "ModelErrorContext",
     "ModelErrorMetadata",
@@ -140,6 +147,12 @@ from omnibase_core.models.context.model_action_execution_context import (
 )
 from omnibase_core.models.context.model_action_parameters import ModelActionParameters
 
+# Knowledge context bundle models (OMN-11928)
+from omnibase_core.models.context.model_adr_summary import ModelADRSummary
+from omnibase_core.models.context.model_antipattern_summary import (
+    ModelAntipatternSummary,
+)
+
 # Metadata context models
 from omnibase_core.models.context.model_audit_metadata import ModelAuditMetadata
 from omnibase_core.models.context.model_authorization_context import (
@@ -148,6 +161,7 @@ from omnibase_core.models.context.model_authorization_context import (
 from omnibase_core.models.context.model_checkpoint_metadata import (
     ModelCheckpointMetadata,
 )
+from omnibase_core.models.context.model_context_provenance import ModelContextProvenance
 from omnibase_core.models.context.model_detection_metadata import ModelDetectionMetadata
 
 # Effect context models
@@ -164,9 +178,14 @@ from omnibase_core.models.context.model_error_metadata import (
     SERVER_ERROR_CATEGORIES,
     ModelErrorMetadata,
 )
+from omnibase_core.models.context.model_graph_snapshot import ModelGraphSnapshot
 from omnibase_core.models.context.model_http_request_metadata import (
     ModelHttpRequestMetadata,
 )
+from omnibase_core.models.context.model_knowledge_context_bundle import (
+    ModelKnowledgeContextBundle,
+)
+from omnibase_core.models.context.model_learning_match import ModelLearningMatch
 from omnibase_core.models.context.model_metrics_context import ModelMetricsContext
 from omnibase_core.models.context.model_node_init_metadata import ModelNodeInitMetadata
 

--- a/src/omnibase_core/models/context/model_adr_summary.py
+++ b/src/omnibase_core/models/context/model_adr_summary.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelADRSummary — minimal ADR projection for context injection (OMN-11928)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.context.model_context_provenance import ModelContextProvenance
+
+__all__ = ["ModelADRSummary"]
+
+
+class ModelADRSummary(BaseModel):
+    """Minimal ADR projection for context injection."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    adr_id: str = (
+        Field(  # string-id-ok: ADR identifiers are human-readable slugs, not UUIDs
+            description="Stable ADR identifier (e.g. ADR-001)"
+        )
+    )
+    title: str = Field(description="ADR title")
+    decision: str = Field(description="One-sentence decision summary")
+    status: Literal["accepted", "deprecated", "superseded", "proposed"] = Field(
+        description="ADR lifecycle status"
+    )
+    provenance: ModelContextProvenance = Field(description="Source provenance")

--- a/src/omnibase_core/models/context/model_antipattern_summary.py
+++ b/src/omnibase_core/models/context/model_antipattern_summary.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternSummary — minimal antipattern projection for context injection (OMN-11928)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.context.model_context_provenance import ModelContextProvenance
+
+__all__ = ["ModelAntipatternSummary"]
+
+
+class ModelAntipatternSummary(BaseModel):
+    """Minimal antipattern projection for context injection."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(description="Unique antipattern identifier")
+    severity: Literal["ERROR", "WARNING", "INFO"] = Field(
+        description="Violation severity"
+    )
+    category: Literal[
+        "code_quality", "architecture", "security", "performance", "naming", "testing"
+    ] = Field(description="Antipattern category")
+    description: str = Field(description="Human-readable explanation")
+    provenance: ModelContextProvenance = Field(description="Source provenance")

--- a/src/omnibase_core/models/context/model_context_provenance.py
+++ b/src/omnibase_core/models/context/model_context_provenance.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContextProvenance — source provenance for a context section (OMN-11928)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelContextProvenance"]
+
+
+class ModelContextProvenance(BaseModel):
+    """Source provenance for a single context section."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source: str = Field(
+        description="Backend that produced this item (e.g. repowise, linear)"
+    )
+    source_id: str = (
+        Field(  # string-id-ok: external system identifier, not an internal UUID
+            description="Stable identifier within the source system"
+        )
+    )
+    source_hash: str = Field(description="Content hash for cache invalidation")
+    retrieved_at: datetime = Field(
+        description="UTC timestamp when this item was fetched"
+    )
+    confidence: float = Field(
+        ge=0.0, le=1.0, description="Retrieval confidence in [0, 1]"
+    )

--- a/src/omnibase_core/models/context/model_graph_snapshot.py
+++ b/src/omnibase_core/models/context/model_graph_snapshot.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelGraphSnapshot — lightweight architecture dependency graph snapshot (OMN-11928)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.context.model_context_provenance import ModelContextProvenance
+
+__all__ = ["ModelGraphSnapshot"]
+
+
+class ModelGraphSnapshot(BaseModel):
+    """Lightweight snapshot of the architecture dependency graph."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    node_count: int = Field(ge=0, description="Number of nodes in the snapshot")
+    edge_count: int = Field(ge=0, description="Number of edges in the snapshot")
+    summary: str = Field(description="Natural language summary of key dependencies")
+    provenance: ModelContextProvenance = Field(description="Source provenance")

--- a/src/omnibase_core/models/context/model_knowledge_context_bundle.py
+++ b/src/omnibase_core/models/context/model_knowledge_context_bundle.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelKnowledgeContextBundle — injectable knowledge context bundle (OMN-11928)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.context.model_adr_summary import ModelADRSummary
+from omnibase_core.models.context.model_antipattern_summary import (
+    ModelAntipatternSummary,
+)
+from omnibase_core.models.context.model_graph_snapshot import ModelGraphSnapshot
+from omnibase_core.models.context.model_learning_match import ModelLearningMatch
+
+__all__ = ["ModelKnowledgeContextBundle"]
+
+BundleLevel = Literal["L0", "L1", "L2", "L3"]
+
+_L2_MARKDOWN_CAP = 4000
+
+
+class ModelKnowledgeContextBundle(BaseModel):
+    """Injectable knowledge context bundle for agent sessions.
+
+    Bundle levels:
+        L0 — antipatterns only
+        L1 — + ADRs
+        L2 — + architecture context (markdown output capped at 4000 chars)
+        L3 — + dependency graph + prior learnings
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(description="Repository this bundle was built for")
+    ticket_id: str | None = Field(
+        default=None, description="Optional Linear ticket that scoped this bundle"
+    )
+    architecture_context: str = Field(
+        description="Free-text architecture summary from Repowise get_answer"
+    )
+    relevant_adrs: tuple[ModelADRSummary, ...] = Field(
+        default=(), description="ADRs applicable to this repo/ticket"
+    )
+    applicable_antipatterns: tuple[ModelAntipatternSummary, ...] = Field(
+        default=(), description="Antipatterns applicable to this repo/ticket"
+    )
+    prior_learnings: tuple[ModelLearningMatch, ...] = Field(
+        default=(), description="Prior learnings matched by semantic similarity"
+    )
+    dependency_graph: ModelGraphSnapshot | None = Field(
+        default=None, description="Dependency graph snapshot (L3 only)"
+    )
+    bundle_level: BundleLevel = Field(description="Completeness tier of this bundle")
+    degraded: bool = Field(
+        default=False, description="True when one or more backends failed"
+    )
+    degraded_backends: tuple[str, ...] = Field(
+        default=(), description="Names of backends that failed during assembly"
+    )
+    missing_sections: tuple[str, ...] = Field(
+        default=(), description="Section names omitted due to backend failure"
+    )
+    bundle_hash: str = Field(
+        description="Deterministic hash over all content fields for cache keying"
+    )
+    generated_at: datetime = Field(
+        description="UTC timestamp when bundle was assembled"
+    )
+
+    @field_validator("bundle_level", mode="before")
+    @classmethod
+    def _validate_bundle_level(cls, v: str) -> str:
+        if v not in ("L0", "L1", "L2", "L3"):
+            # error-ok: Pydantic field_validator requires ValueError
+            raise ValueError(f"bundle_level must be one of L0/L1/L2/L3, got {v!r}")
+        return v
+
+    def to_markdown(self) -> str:
+        """Render bundle as injectable context markdown.
+
+        L2 output is hard-capped at 4000 characters.
+        """
+        parts: list[str] = []
+        parts.append(f"# Knowledge Context — {self.repo}")
+        if self.ticket_id:
+            parts.append(f"**Ticket:** {self.ticket_id}")
+        parts.append(f"**Bundle level:** {self.bundle_level}")
+        if self.degraded:
+            backends = (
+                ", ".join(self.degraded_backends)
+                if self.degraded_backends
+                else "unknown"
+            )
+            parts.append(f"> **DEGRADED** — backends unavailable: {backends}")
+            if self.missing_sections:
+                parts.append(f"> Missing sections: {', '.join(self.missing_sections)}")
+
+        # L0+: antipatterns
+        if self.applicable_antipatterns:
+            parts.append("\n## Antipatterns")
+            for ap in self.applicable_antipatterns:
+                parts.append(
+                    f"- **{ap.name}** [{ap.severity}] ({ap.category}): {ap.description}"
+                )
+
+        # L1+: ADRs
+        if self.bundle_level in ("L1", "L2", "L3") and self.relevant_adrs:
+            parts.append("\n## ADR Decisions")
+            for adr in self.relevant_adrs:
+                parts.append(
+                    f"- **{adr.adr_id}** ({adr.status}): {adr.title} — {adr.decision}"
+                )
+
+        # L2+: architecture context
+        if self.bundle_level in ("L2", "L3") and self.architecture_context:
+            parts.append("\n## Architecture Context")
+            parts.append(self.architecture_context)
+
+        # L3: prior learnings + graph
+        if self.bundle_level == "L3":
+            if self.prior_learnings:
+                parts.append("\n## Prior Learnings")
+                for lm in self.prior_learnings:
+                    parts.append(f"- [{lm.relevance_score:.2f}] {lm.summary}")
+            if self.dependency_graph is not None:
+                parts.append("\n## Dependency Graph")
+                parts.append(
+                    f"Nodes: {self.dependency_graph.node_count}, "
+                    f"Edges: {self.dependency_graph.edge_count}"
+                )
+                parts.append(self.dependency_graph.summary)
+
+        result = "\n".join(parts)
+
+        if self.bundle_level == "L2" and len(result) > _L2_MARKDOWN_CAP:
+            result = result[:_L2_MARKDOWN_CAP]
+
+        return result

--- a/src/omnibase_core/models/context/model_learning_match.py
+++ b/src/omnibase_core/models/context/model_learning_match.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelLearningMatch — a prior learning relevant to current context (OMN-11928)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.context.model_context_provenance import ModelContextProvenance
+
+__all__ = ["ModelLearningMatch"]
+
+
+class ModelLearningMatch(BaseModel):
+    """A prior learning relevant to the current context."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    learning_id: str = (
+        Field(  # string-id-ok: external memory-system identifier, not an internal UUID
+            description="Stable identifier for this learning"
+        )
+    )
+    summary: str = Field(description="One-to-two sentence learning summary")
+    relevance_score: float = Field(
+        ge=0.0, le=1.0, description="Semantic relevance score in [0, 1]"
+    )
+    provenance: ModelContextProvenance = Field(description="Source provenance")

--- a/src/omnibase_core/models/validation/model_antipattern_entry.py
+++ b/src/omnibase_core/models/validation/model_antipattern_entry.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternEntry — single antipattern detection rule (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.validation.model_antipattern_example import (
+    ModelAntipatternExample,
+)
+
+
+class ModelAntipatternEntry(BaseModel):
+    """A single antipattern detection rule with enforcement metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Unique antipattern identifier")
+    severity: Literal["ERROR", "WARNING", "INFO"] = Field(
+        description="Violation severity"
+    )
+    enforcement: Literal["blocking", "advisory", "informational"] = Field(
+        description="Enforcement level: blocking=merge gate, advisory=warning, informational=log only"
+    )
+    category: Literal[
+        "code_quality", "architecture", "security", "performance", "naming", "testing"
+    ] = Field(description="Antipattern category")
+    pattern_type: Literal[
+        "regex_line", "regex_ast_docstring", "grep_code", "ast_check", "semantic"
+    ] = Field(description="How the pattern is matched")
+    pattern: str = Field(
+        description="Regex string, AST check identifier, or semantic description"
+    )
+    file_globs: tuple[str, ...] = Field(
+        default=("*.py",),
+        description="File glob patterns this entry applies to",
+    )
+    suppression_annotation: str = Field(
+        default="antipattern-ok",
+        description="Inline comment suffix that suppresses this entry",
+    )
+    description: str = Field(description="Human-readable explanation")
+    rationale: str = Field(description="Why this is an antipattern")
+    examples: tuple[ModelAntipatternExample, ...] = Field(
+        default=(),
+        description="Good and bad code snippet examples",
+    )
+    discovered_date: date = Field(
+        description="Date this antipattern was added to the registry"
+    )
+    source_ticket: str = Field(
+        description="Linear ticket that introduced this entry, e.g. OMN-XXXX"
+    )
+    vector_enabled: bool = Field(
+        default=False,
+        description="Whether this entry participates in vector-similarity search",
+    )
+
+    @model_validator(mode="after")
+    def _validate_semantic_requires_vector_enabled(self) -> ModelAntipatternEntry:
+        """semantic pattern_type entries must have vector_enabled=True."""
+        if self.pattern_type == "semantic" and not self.vector_enabled:
+            raise ValueError("pattern_type='semantic' requires vector_enabled=True")
+        return self
+
+
+__all__ = ["ModelAntipatternEntry"]

--- a/src/omnibase_core/models/validation/model_antipattern_example.py
+++ b/src/omnibase_core/models/validation/model_antipattern_example.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternExample — good or bad code snippet for an antipattern (OMN-11910)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAntipatternExample(BaseModel):
+    """A good or bad code snippet illustrating an antipattern."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: Literal["good", "bad"] = Field(
+        description="Whether this is a good or bad example"
+    )
+    code: str = Field(description="Code snippet")
+    label: str = Field(description="Short label for the example")
+
+
+__all__ = ["ModelAntipatternExample"]

--- a/src/omnibase_core/models/validation/model_antipattern_registry.py
+++ b/src/omnibase_core/models/validation/model_antipattern_registry.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternRegistry — versioned collection of antipattern entries (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+
+
+class ModelAntipatternRegistry(BaseModel):
+    """Versioned registry of antipattern detection entries."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    version: str = Field(description="Registry schema version, e.g. '1.0.0'")
+    last_updated: datetime = Field(description="Timestamp of the last registry update")
+    entries: tuple[ModelAntipatternEntry, ...] = Field(
+        default=(),
+        description="All antipattern entries in this registry",
+    )
+
+
+__all__ = ["ModelAntipatternRegistry"]

--- a/tests/unit/models/context/test_model_knowledge_context_bundle.py
+++ b/tests/unit/models/context/test_model_knowledge_context_bundle.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelKnowledgeContextBundle and sub-models (OMN-11928)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 5, 24, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def provenance(now: datetime):
+    from omnibase_core.models.context.model_context_provenance import (
+        ModelContextProvenance,
+    )
+
+    return ModelContextProvenance(
+        source="repowise",
+        source_id="doc-abc123",
+        source_hash="sha256:abc",
+        retrieved_at=now,
+        confidence=0.9,
+    )
+
+
+@pytest.fixture
+def adr_summary(provenance):
+    from omnibase_core.models.context.model_adr_summary import ModelADRSummary
+
+    return ModelADRSummary(
+        adr_id="ADR-001",
+        title="Use Pydantic for all models",
+        decision="All data models use Pydantic BaseModel",
+        status="accepted",
+        provenance=provenance,
+    )
+
+
+@pytest.fixture
+def antipattern_summary(provenance):
+    from omnibase_core.models.context.model_antipattern_summary import (
+        ModelAntipatternSummary,
+    )
+
+    return ModelAntipatternSummary(
+        name="no-optional-type",
+        severity="ERROR",
+        category="code_quality",
+        description="Use X | None not Optional[X]",
+        provenance=provenance,
+    )
+
+
+@pytest.fixture
+def learning_match(provenance):
+    from omnibase_core.models.context.model_learning_match import ModelLearningMatch
+
+    return ModelLearningMatch(
+        learning_id="learn-001",
+        summary="Always use uv run for Python commands",
+        relevance_score=0.85,
+        provenance=provenance,
+    )
+
+
+@pytest.fixture
+def graph_snapshot(provenance):
+    from omnibase_core.models.context.model_graph_snapshot import ModelGraphSnapshot
+
+    return ModelGraphSnapshot(
+        node_count=42,
+        edge_count=88,
+        summary="omnibase_core depends on omnibase_compat",
+        provenance=provenance,
+    )
+
+
+class TestModelContextProvenance:
+    def test_frozen(self, provenance) -> None:
+        with pytest.raises(Exception):
+            provenance.source = "changed"  # type: ignore[misc]
+
+    def test_extra_forbid(self, now: datetime) -> None:
+        from pydantic import ValidationError
+
+        from omnibase_core.models.context.model_context_provenance import (
+            ModelContextProvenance,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelContextProvenance(
+                source="x",
+                source_id="y",
+                source_hash="z",
+                retrieved_at=now,
+                confidence=0.5,
+                extra_field="boom",  # type: ignore[call-arg]
+            )
+
+    def test_confidence_bounds(self, now: datetime) -> None:
+        from pydantic import ValidationError
+
+        from omnibase_core.models.context.model_context_provenance import (
+            ModelContextProvenance,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelContextProvenance(
+                source="x",
+                source_id="y",
+                source_hash="z",
+                retrieved_at=now,
+                confidence=1.5,
+            )
+
+
+class TestModelADRSummary:
+    def test_fields(self, adr_summary) -> None:
+        assert adr_summary.adr_id == "ADR-001"
+        assert adr_summary.status == "accepted"
+
+    def test_frozen(self, adr_summary) -> None:
+        with pytest.raises(Exception):
+            adr_summary.title = "changed"  # type: ignore[misc]
+
+
+class TestModelAntipatternSummary:
+    def test_fields(self, antipattern_summary) -> None:
+        assert antipattern_summary.severity == "ERROR"
+        assert antipattern_summary.category == "code_quality"
+
+    def test_frozen(self, antipattern_summary) -> None:
+        with pytest.raises(Exception):
+            antipattern_summary.name = "changed"  # type: ignore[misc]
+
+
+class TestModelLearningMatch:
+    def test_fields(self, learning_match) -> None:
+        assert learning_match.relevance_score == 0.85
+
+    def test_frozen(self, learning_match) -> None:
+        with pytest.raises(Exception):
+            learning_match.summary = "changed"  # type: ignore[misc]
+
+
+class TestModelGraphSnapshot:
+    def test_fields(self, graph_snapshot) -> None:
+        assert graph_snapshot.node_count == 42
+        assert graph_snapshot.edge_count == 88
+
+    def test_frozen(self, graph_snapshot) -> None:
+        with pytest.raises(Exception):
+            graph_snapshot.node_count = 0  # type: ignore[misc]
+
+
+class TestModelKnowledgeContextBundle:
+    def _make_l0(self, antipattern_summary, now: datetime):
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        return ModelKnowledgeContextBundle(
+            repo="omnibase_core",
+            ticket_id=None,
+            architecture_context="",
+            relevant_adrs=(),
+            applicable_antipatterns=(antipattern_summary,),
+            prior_learnings=(),
+            dependency_graph=None,
+            bundle_level="L0",
+            degraded=False,
+            degraded_backends=(),
+            missing_sections=(),
+            bundle_hash="abc123",
+            generated_at=now,
+        )
+
+    def _make_l1(self, antipattern_summary, adr_summary, now: datetime):
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        return ModelKnowledgeContextBundle(
+            repo="omnibase_core",
+            ticket_id="OMN-11928",
+            architecture_context="",
+            relevant_adrs=(adr_summary,),
+            applicable_antipatterns=(antipattern_summary,),
+            prior_learnings=(),
+            dependency_graph=None,
+            bundle_level="L1",
+            degraded=False,
+            degraded_backends=(),
+            missing_sections=(),
+            bundle_hash="def456",
+            generated_at=now,
+        )
+
+    def _make_l2(self, antipattern_summary, adr_summary, now: datetime):
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        return ModelKnowledgeContextBundle(
+            repo="omnibase_core",
+            ticket_id="OMN-11928",
+            architecture_context="Architecture: layered, contract-first.",
+            relevant_adrs=(adr_summary,),
+            applicable_antipatterns=(antipattern_summary,),
+            prior_learnings=(),
+            dependency_graph=None,
+            bundle_level="L2",
+            degraded=False,
+            degraded_backends=(),
+            missing_sections=(),
+            bundle_hash="ghi789",
+            generated_at=now,
+        )
+
+    def _make_l3(
+        self,
+        antipattern_summary,
+        adr_summary,
+        learning_match,
+        graph_snapshot,
+        now: datetime,
+    ):
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        return ModelKnowledgeContextBundle(
+            repo="omnibase_core",
+            ticket_id="OMN-11928",
+            architecture_context="Architecture: layered, contract-first.",
+            relevant_adrs=(adr_summary,),
+            applicable_antipatterns=(antipattern_summary,),
+            prior_learnings=(learning_match,),
+            dependency_graph=graph_snapshot,
+            bundle_level="L3",
+            degraded=False,
+            degraded_backends=(),
+            missing_sections=(),
+            bundle_hash="jkl012",
+            generated_at=now,
+        )
+
+    def test_frozen(self, antipattern_summary, now: datetime) -> None:
+        bundle = self._make_l0(antipattern_summary, now)
+        with pytest.raises(Exception):
+            bundle.repo = "changed"  # type: ignore[misc]
+
+    def test_extra_forbid(self, antipattern_summary, now: datetime) -> None:
+        from pydantic import ValidationError
+
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelKnowledgeContextBundle(
+                repo="omnibase_core",
+                ticket_id=None,
+                architecture_context="",
+                relevant_adrs=(),
+                applicable_antipatterns=(antipattern_summary,),
+                prior_learnings=(),
+                dependency_graph=None,
+                bundle_level="L0",
+                degraded=False,
+                degraded_backends=(),
+                missing_sections=(),
+                bundle_hash="abc",
+                generated_at=now,
+                unknown_field="boom",  # type: ignore[call-arg]
+            )
+
+    def test_tuple_fields_not_list(self, antipattern_summary, now: datetime) -> None:
+        bundle = self._make_l0(antipattern_summary, now)
+        assert isinstance(bundle.applicable_antipatterns, tuple)
+        assert isinstance(bundle.relevant_adrs, tuple)
+        assert isinstance(bundle.prior_learnings, tuple)
+        assert isinstance(bundle.degraded_backends, tuple)
+        assert isinstance(bundle.missing_sections, tuple)
+
+    def test_to_markdown_l0_contains_antipatterns(
+        self, antipattern_summary, now: datetime
+    ) -> None:
+        bundle = self._make_l0(antipattern_summary, now)
+        md = bundle.to_markdown()
+        assert "Antipatterns" in md
+        assert "no-optional-type" in md
+        assert isinstance(md, str)
+
+    def test_to_markdown_l0_no_adrs(self, antipattern_summary, now: datetime) -> None:
+        bundle = self._make_l0(antipattern_summary, now)
+        md = bundle.to_markdown()
+        assert "ADR" not in md
+
+    def test_to_markdown_l1_contains_adrs(
+        self, antipattern_summary, adr_summary, now: datetime
+    ) -> None:
+        bundle = self._make_l1(antipattern_summary, adr_summary, now)
+        md = bundle.to_markdown()
+        assert "ADR" in md
+        assert "ADR-001" in md
+        assert "Antipatterns" in md
+
+    def test_to_markdown_l2_contains_architecture(
+        self, antipattern_summary, adr_summary, now: datetime
+    ) -> None:
+        bundle = self._make_l2(antipattern_summary, adr_summary, now)
+        md = bundle.to_markdown()
+        assert "Architecture" in md
+        assert "layered" in md
+
+    def test_to_markdown_l2_capped_at_4000(
+        self, antipattern_summary, adr_summary, now: datetime
+    ) -> None:
+        bundle = self._make_l2(antipattern_summary, adr_summary, now)
+        md = bundle.to_markdown()
+        assert len(md) <= 4000
+
+    def test_to_markdown_l3_contains_graph_and_learnings(
+        self,
+        antipattern_summary,
+        adr_summary,
+        learning_match,
+        graph_snapshot,
+        now: datetime,
+    ) -> None:
+        bundle = self._make_l3(
+            antipattern_summary, adr_summary, learning_match, graph_snapshot, now
+        )
+        md = bundle.to_markdown()
+        assert "Prior Learnings" in md
+        assert "Always use uv run" in md
+        assert "Dependency Graph" in md
+        assert "omnibase_core depends on omnibase_compat" in md
+
+    def test_degraded_flag_appears_in_markdown(
+        self, antipattern_summary, now: datetime
+    ) -> None:
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        bundle = ModelKnowledgeContextBundle(
+            repo="omnibase_core",
+            ticket_id=None,
+            architecture_context="",
+            relevant_adrs=(),
+            applicable_antipatterns=(antipattern_summary,),
+            prior_learnings=(),
+            dependency_graph=None,
+            bundle_level="L0",
+            degraded=True,
+            degraded_backends=("repowise",),
+            missing_sections=("architecture_context",),
+            bundle_hash="abc",
+            generated_at=now,
+        )
+        md = bundle.to_markdown()
+        assert "degraded" in md.lower() or "DEGRADED" in md
+
+    def test_bundle_level_invalid(self, antipattern_summary, now: datetime) -> None:
+        from pydantic import ValidationError
+
+        from omnibase_core.models.context.model_knowledge_context_bundle import (
+            ModelKnowledgeContextBundle,
+        )
+
+        with pytest.raises(ValidationError):
+            ModelKnowledgeContextBundle(
+                repo="omnibase_core",
+                ticket_id=None,
+                architecture_context="",
+                relevant_adrs=(),
+                applicable_antipatterns=(antipattern_summary,),
+                prior_learnings=(),
+                dependency_graph=None,
+                bundle_level="L9",  # type: ignore[arg-type]
+                degraded=False,
+                degraded_backends=(),
+                missing_sections=(),
+                bundle_hash="abc",
+                generated_at=now,
+            )

--- a/tests/unit/models/validation/test_model_antipattern_registry.py
+++ b/tests/unit/models/validation/test_model_antipattern_registry.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelAntipatternEntry and ModelAntipatternRegistry (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_example import (
+    ModelAntipatternExample,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+
+
+def _make_entry(**overrides: object) -> ModelAntipatternEntry:
+    defaults: dict[str, object] = {
+        "name": "no_bare_except",
+        "severity": "ERROR",
+        "enforcement": "blocking",
+        "category": "code_quality",
+        "pattern_type": "regex_line",
+        "pattern": r"except\s*:",
+        "file_globs": ("*.py",),
+        "suppression_annotation": "antipattern-ok",
+        "description": "Bare except clauses swallow all exceptions",
+        "rationale": "Masks errors and makes debugging impossible",
+        "examples": (),
+        "discovered_date": date(2025, 1, 15),
+        "source_ticket": "OMN-11910",
+        "vector_enabled": False,
+    }
+    defaults.update(overrides)
+    return ModelAntipatternEntry(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelAntipatternExample:
+    def test_basic_example(self) -> None:
+        ex = ModelAntipatternExample(
+            kind="bad",
+            code="except:\n    pass",
+            label="Bare except",
+        )
+        assert ex.kind == "bad"
+        assert ex.label == "Bare except"
+
+    def test_kind_literal_validation(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelAntipatternExample(
+                kind="unknown",  # type: ignore[arg-type]
+                code="x",
+                label="bad kind",
+            )
+
+    def test_example_roundtrip(self) -> None:
+        ex = ModelAntipatternExample(
+            kind="good", code="except ValueError:\n    pass", label="Typed except"
+        )
+        assert ModelAntipatternExample.model_validate(ex.model_dump()) == ex
+
+
+@pytest.mark.unit
+class TestModelAntipatternEntry:
+    def test_minimal_entry(self) -> None:
+        entry = _make_entry()
+        assert entry.name == "no_bare_except"
+        assert entry.severity == "ERROR"
+        assert entry.enforcement == "blocking"
+        assert entry.category == "code_quality"
+        assert entry.pattern_type == "regex_line"
+        assert entry.vector_enabled is False
+        assert isinstance(entry.file_globs, tuple)
+        assert isinstance(entry.examples, tuple)
+
+    def test_invalid_severity_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(severity="FATAL")  # type: ignore[arg-type]
+
+    def test_invalid_enforcement_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(enforcement="required")  # type: ignore[arg-type]
+
+    def test_invalid_category_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(category="style")  # type: ignore[arg-type]
+
+    def test_invalid_pattern_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(pattern_type="unknown")  # type: ignore[arg-type]
+
+    def test_semantic_pattern_type_requires_vector_enabled(self) -> None:
+        """pattern_type=semantic must have vector_enabled=True."""
+        with pytest.raises(ValidationError, match="vector_enabled"):
+            _make_entry(pattern_type="semantic", vector_enabled=False)
+
+    def test_semantic_pattern_type_with_vector_enabled_passes(self) -> None:
+        entry = _make_entry(pattern_type="semantic", vector_enabled=True)
+        assert entry.pattern_type == "semantic"
+        assert entry.vector_enabled is True
+
+    def test_semantic_defaults_to_advisory(self) -> None:
+        """Semantic antipatterns default to enforcement=advisory."""
+        entry = _make_entry(
+            pattern_type="semantic", vector_enabled=True, enforcement="advisory"
+        )
+        assert entry.enforcement == "advisory"
+
+    def test_entry_is_frozen(self) -> None:
+        entry = _make_entry()
+        with pytest.raises(Exception):
+            entry.name = "changed"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(unknown_field="x")  # type: ignore[call-arg]
+
+    def test_entry_dict_roundtrip(self) -> None:
+        entry = _make_entry()
+        restored = ModelAntipatternEntry.model_validate(entry.model_dump())
+        assert restored == entry
+
+    def test_entry_yaml_roundtrip(self) -> None:
+        entry = _make_entry()
+        data = entry.model_dump(mode="json")
+        yaml_str = yaml.dump(data, default_flow_style=False)
+        restored_data = yaml.safe_load(yaml_str)
+        restored = ModelAntipatternEntry.model_validate(restored_data)
+        assert restored == entry
+
+    def test_entry_with_examples(self) -> None:
+        examples = (
+            ModelAntipatternExample(kind="bad", code="except:\n    pass", label="Bare"),
+            ModelAntipatternExample(
+                kind="good", code="except ValueError:\n    pass", label="Typed"
+            ),
+        )
+        entry = _make_entry(examples=examples)
+        assert len(entry.examples) == 2
+        assert entry.examples[0].kind == "bad"
+
+    def test_source_ticket_format(self) -> None:
+        entry = _make_entry(source_ticket="OMN-99999")
+        assert entry.source_ticket == "OMN-99999"
+
+
+@pytest.mark.unit
+class TestModelAntipatternRegistry:
+    def _make_registry(self, **overrides: object) -> ModelAntipatternRegistry:
+        defaults: dict[str, object] = {
+            "version": "1.0.0",
+            "last_updated": datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC),
+            "entries": (_make_entry(),),
+        }
+        defaults.update(overrides)
+        return ModelAntipatternRegistry(**defaults)  # type: ignore[arg-type]
+
+    def test_basic_registry(self) -> None:
+        reg = self._make_registry()
+        assert reg.version == "1.0.0"
+        assert len(reg.entries) == 1
+        assert isinstance(reg.entries, tuple)
+
+    def test_registry_is_frozen(self) -> None:
+        reg = self._make_registry()
+        with pytest.raises(Exception):
+            reg.version = "2.0.0"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_registry(unknown="x")  # type: ignore[call-arg]
+
+    def test_empty_entries(self) -> None:
+        reg = self._make_registry(entries=())
+        assert len(reg.entries) == 0
+
+    def test_multiple_entries(self) -> None:
+        entries = (
+            _make_entry(name="rule_a"),
+            _make_entry(name="rule_b"),
+        )
+        reg = self._make_registry(entries=entries)
+        assert len(reg.entries) == 2
+
+    def test_registry_dict_roundtrip(self) -> None:
+        reg = self._make_registry()
+        restored = ModelAntipatternRegistry.model_validate(reg.model_dump())
+        assert restored == reg
+
+    def test_registry_yaml_roundtrip(self) -> None:
+        reg = self._make_registry()
+        data = reg.model_dump(mode="json")
+        yaml_str = yaml.dump(data, default_flow_style=False)
+        restored_data = yaml.safe_load(yaml_str)
+        restored = ModelAntipatternRegistry.model_validate(restored_data)
+        assert restored == reg


### PR DESCRIPTION
## Summary

- Adds `ModelKnowledgeContextBundle` with L0–L3 completeness tiers for injectable agent context (OMN-11928)
- Adds five sub-models in `omnibase_core/models/context/`: `ModelContextProvenance`, `ModelADRSummary`, `ModelAntipatternSummary`, `ModelLearningMatch`, `ModelGraphSnapshot`
- Each model is frozen, `extra=\"forbid\"`, uses `tuple[...]` for all repeated fields
- `to_markdown()` renders the bundle as injectable context text with a 4000-char hard cap at L2
- 22 unit tests covering all levels (L0–L3), frozen constraints, extra-field rejection, degraded state rendering, and bundle level validation

## Test plan

- [x] `uv run pytest tests/unit/models/context/test_model_knowledge_context_bundle.py -v` — 22 passed
- [x] `uv run pre-commit run --files <all changed files>` — all hooks passed
- [x] `uv run mypy src/omnibase_core/models/context/model_knowledge_context_bundle.py --strict` — no issues

OMN-11928
Evidence-Ticket: OMN-11928
Evidence-Source: OCC#1533
