### PR TITLE
feat(OMN-11912): antipattern registry loader public API with typed overrides

### DIFF
--- a/src/omnibase_core/models/validation/model_antipattern_entry_override.py
+++ b/src/omnibase_core/models/validation/model_antipattern_entry_override.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternEntryOverride — per-repo override for a single antipattern entry (OMN-11912)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAntipatternEntryOverride(BaseModel):
+    """A per-repo override for an existing antipattern entry."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Antipattern name to override")
+    severity: Literal["ERROR", "WARNING", "INFO"] | None = Field(
+        default=None, description="Override severity (None = keep default)"
+    )
+    enforcement: Literal["blocking", "advisory", "informational"] | None = Field(
+        default=None, description="Override enforcement level (None = keep default)"
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description="Set False to disable this antipattern for the repo (None = keep default)",
+    )
+    file_globs: list[str] | None = Field(
+        default=None, description="Override file globs (None = keep default)"
+    )
+
+
+__all__ = ["ModelAntipatternEntryOverride"]

--- a/src/omnibase_core/models/validation/model_antipattern_override_config.py
+++ b/src/omnibase_core/models/validation/model_antipattern_override_config.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternOverrideConfig — per-repo antipattern override config (OMN-11912)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_entry_override import (
+    ModelAntipatternEntryOverride,
+)
+
+
+class ModelAntipatternOverrideConfig(BaseModel):
+    """Per-repo antipattern configuration read from .onex/antipattern-overrides.yaml."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    overrides: list[ModelAntipatternEntryOverride] = Field(
+        default_factory=list,
+        description="Field-level overrides for existing antipattern entries",
+    )
+    custom_entries: list[ModelAntipatternEntry] = Field(
+        default_factory=list,
+        description="New antipattern entries to append to the registry",
+    )
+
+
+__all__ = ["ModelAntipatternOverrideConfig"]

--- a/src/omnibase_core/validation/antipattern_registry_loader.py
+++ b/src/omnibase_core/validation/antipattern_registry_loader.py
@@ -1,24 +1,26 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Antipattern registry loader: resolves effective registry for a repo (OMN-11911).
+"""Antipattern registry loader: resolves effective registry for a repo (OMN-11912).
 
 Resolution order:
   1. Load bundled defaults from contracts/antipattern_registry.yaml
   2. Load optional per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml
-  3. Merge: apply field overrides then append custom_entries
+  3. Merge: apply field overrides (including disable) then append custom_entries
 """
 
 from __future__ import annotations
 
 import importlib.resources
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 from omnibase_core.models.validation.model_antipattern_entry import (
     ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
 )
 from omnibase_core.models.validation.model_antipattern_registry import (
     ModelAntipatternRegistry,
@@ -29,7 +31,7 @@ _DEFAULT_YAML = "antipattern_registry.yaml"
 _OVERRIDES_PATH = ".onex/antipattern-overrides.yaml"
 
 
-def load_default_registry() -> ModelAntipatternRegistry:
+def load_default_antipatterns() -> ModelAntipatternRegistry:
     """Return the bundled default antipattern registry.
 
     Reads from omnibase_core/contracts/antipattern_registry.yaml via
@@ -51,38 +53,43 @@ def load_default_registry() -> ModelAntipatternRegistry:
     return ModelAntipatternRegistry.model_validate(data)
 
 
-def _load_overrides(repo_root: Path) -> dict[str, Any] | None:
+# Keep legacy name as an alias so existing callers (OMN-11911 tests) continue to work
+load_default_registry = load_default_antipatterns
+
+
+def load_repo_overrides(repo_root: Path) -> ModelAntipatternOverrideConfig | None:
     """Load per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml.
 
     Returns None if the file does not exist.
+    Raises ValidationError if the file exists but is malformed.
     """
     config_path = repo_root / _OVERRIDES_PATH
     if not config_path.exists():
         return None
-    return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    return ModelAntipatternOverrideConfig.model_validate(data)
 
 
-def _merge_registry(
+def merge_antipatterns(
     defaults: ModelAntipatternRegistry,
-    overrides_data: dict[str, Any] | None,
+    overrides: ModelAntipatternOverrideConfig | None,
 ) -> ModelAntipatternRegistry:
     """Apply per-repo overrides and custom entries on top of defaults.
 
     Override semantics (mirrors aislop_rule_loader.merge_rules):
     - Override fields that are None → keep the default value.
+    - enabled=False → entry is excluded from the merged registry.
     - Unknown name → ValueError (prevents silent typos).
     - custom_entries are appended after merging overrides.
     """
-    if overrides_data is None:
+    if overrides is None:
         return defaults
-
-    override_list: list[dict[str, Any]] = overrides_data.get("overrides", [])
-    custom_list: list[dict[str, Any]] = overrides_data.get("custom_entries", [])
 
     default_by_name: dict[str, ModelAntipatternEntry] = {
         e.name: e for e in defaults.entries
     }
-    override_by_name: dict[str, dict[str, Any]] = {o["name"]: o for o in override_list}
+
+    override_by_name = {o.name: o for o in overrides.overrides}
 
     # Validate all override names reference known entries
     for name in override_by_name:
@@ -92,23 +99,27 @@ def _merge_registry(
                 f"Unknown antipattern name '{name}' in overrides. Known: {known}"
             )
 
-    # Apply field overrides
+    # Apply field overrides; entries with enabled=False are dropped
     merged: list[ModelAntipatternEntry] = []
     for entry in defaults.entries:
         ov = override_by_name.get(entry.name)
         if ov is None:
             merged.append(entry)
             continue
-        # Rebuild entry with overridden fields; None values keep the default
+        if ov.enabled is False:
+            continue
         base = entry.model_dump()
-        for field in ("severity", "enforcement", "file_globs"):
-            if ov.get(field) is not None:
-                base[field] = ov[field]
+        if ov.severity is not None:
+            base["severity"] = ov.severity
+        if ov.enforcement is not None:
+            base["enforcement"] = ov.enforcement
+        if ov.file_globs is not None:
+            base["file_globs"] = ov.file_globs
         merged.append(ModelAntipatternEntry.model_validate(base))
 
     # Append custom entries
-    for raw in custom_list:
-        merged.append(ModelAntipatternEntry.model_validate(raw))
+    for custom in overrides.custom_entries:
+        merged.append(custom)
 
     return ModelAntipatternRegistry(
         version=defaults.version,
@@ -119,12 +130,15 @@ def _merge_registry(
 
 def resolve_antipatterns(repo_root: Path) -> ModelAntipatternRegistry:
     """Full resolution pipeline: defaults → per-repo overrides → merged result."""
-    defaults = load_default_registry()
-    overrides_data = _load_overrides(repo_root)
-    return _merge_registry(defaults, overrides_data)
+    defaults = load_default_antipatterns()
+    overrides = load_repo_overrides(repo_root)
+    return merge_antipatterns(defaults, overrides)
 
 
 __all__ = [
+    "load_default_antipatterns",
     "load_default_registry",
+    "load_repo_overrides",
+    "merge_antipatterns",
     "resolve_antipatterns",
 ]

--- a/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
+++ b/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the OMN-11912 canonical public API of antipattern_registry_loader.
+
+Covers the acceptance criteria:
+  - defaults only (no overrides file)
+  - override disable (enabled=False removes an entry)
+  - override severity
+  - custom append
+  - malformed override raises ValidationError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+from omnibase_core.validation.antipattern_registry_loader import (
+    load_default_antipatterns,
+    load_repo_overrides,
+    merge_antipatterns,
+    resolve_antipatterns,
+)
+
+
+@pytest.mark.unit
+class TestLoadDefaultAntipatterns:
+    def test_returns_registry(self) -> None:
+        result = load_default_antipatterns()
+        assert isinstance(result, ModelAntipatternRegistry)
+
+    def test_has_entries(self) -> None:
+        result = load_default_antipatterns()
+        assert len(result.entries) > 0
+
+    def test_version_present(self) -> None:
+        result = load_default_antipatterns()
+        assert result.version != ""
+
+
+@pytest.mark.unit
+class TestLoadRepoOverrides:
+    def test_no_file_returns_none(self, tmp_path: Path) -> None:
+        result = load_repo_overrides(tmp_path)
+        assert result is None
+
+    def test_valid_override_file_returns_config(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "hardcoded_ip", "severity": "WARNING"},
+                    ]
+                }
+            )
+        )
+        result = load_repo_overrides(tmp_path)
+        assert isinstance(result, ModelAntipatternOverrideConfig)
+        assert len(result.overrides) == 1
+        assert result.overrides[0].name == "hardcoded_ip"
+
+    def test_malformed_override_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {
+                            "name": "hardcoded_ip",
+                            "severity": "NOT_A_VALID_SEVERITY",
+                        }
+                    ]
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+    def test_unknown_extra_field_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "unknown_top_level_field": True,
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+
+@pytest.mark.unit
+class TestMergeAntipatterns:
+    def test_none_overrides_returns_defaults(self) -> None:
+        defaults = load_default_antipatterns()
+        result = merge_antipatterns(defaults, None)
+        assert len(result.entries) == len(defaults.entries)
+
+    def test_override_severity(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_override_enforcement(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "obvious_comment", "enforcement": "blocking"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "obvious_comment")
+        assert entry.enforcement == "blocking"
+
+    def test_override_disable_removes_entry(self) -> None:
+        defaults = load_default_antipatterns()
+        names_before = {e.name for e in defaults.entries}
+        assert "hardcoded_ip" in names_before
+
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "enabled": False}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names_after = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names_after
+        assert len(result.entries) == len(defaults.entries) - 1
+
+    def test_custom_entries_appended(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "custom_entries": [
+                    {
+                        "name": "custom_test_rule",
+                        "severity": "WARNING",
+                        "enforcement": "advisory",
+                        "category": "code_quality",
+                        "pattern_type": "regex_line",
+                        "pattern": r"CUSTOM_PATTERN",
+                        "description": "Custom test rule",
+                        "rationale": "Custom rationale for testing",
+                        "discovered_date": "2026-01-01",
+                        "source_ticket": "OMN-11912",
+                    }
+                ]
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names = {e.name for e in result.entries}
+        assert "custom_test_rule" in names
+        assert len(result.entries) == len(defaults.entries) + 1
+
+    def test_unknown_override_name_raises_value_error(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "nonexistent_rule_xyz", "severity": "ERROR"}],
+            }
+        )
+        with pytest.raises(ValueError, match="nonexistent_rule_xyz"):
+            merge_antipatterns(defaults, config)
+
+
+@pytest.mark.unit
+class TestResolveAntipatterns:
+    def test_defaults_only(self, tmp_path: Path) -> None:
+        result = resolve_antipatterns(tmp_path)
+        defaults = load_default_antipatterns()
+        assert {e.name for e in result.entries} == {e.name for e in defaults.entries}
+
+    def test_override_disable_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "enabled": False}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names
+
+    def test_override_severity_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_custom_append_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "custom_entries": [
+                        {
+                            "name": "repo_specific_rule",
+                            "severity": "ERROR",
+                            "enforcement": "blocking",
+                            "category": "architecture",
+                            "pattern_type": "grep_code",
+                            "pattern": "import_forbidden",
+                            "description": "Repo-specific forbidden import",
+                            "rationale": "This import is forbidden in this repo",
+                            "discovered_date": "2026-01-01",
+                            "source_ticket": "OMN-11912",
+                        }
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "repo_specific_rule" in names
+
+    def test_malformed_override_file_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {"overrides": [{"name": "hardcoded_ip", "severity": "BAD_VALUE"}]}
+            )
+        )
+        with pytest.raises(ValidationError):
+            resolve_antipatterns(tmp_path)


### PR DESCRIPTION
## Summary

Stacked on #1147 (OMN-11911). Extends the antipattern registry loader with the canonical public API matching `aislop_rule_loader`.

- Adds `ModelAntipatternEntryOverride` — per-repo override with `enabled`, `severity`, `enforcement`, `file_globs` fields
- Adds `ModelAntipatternOverrideConfig` — typed container for `overrides` + `custom_entries` (replaces raw dict)
- Exposes `load_default_antipatterns()`, `load_repo_overrides()`, `merge_antipatterns()` as public API
- `load_repo_overrides()` validates via Pydantic — malformed YAML raises `ValidationError` at load time
- `merge_antipatterns()` supports `enabled=False` to disable an entry per-repo
- `load_default_registry` kept as alias for backward compat with OMN-11911 tests
- 18 new acceptance-criteria tests + all 56 antipattern tests green

## Test plan

- [x] `load_default_antipatterns()` returns valid registry
- [x] `load_repo_overrides()` returns None when no file; raises ValidationError on malformed YAML
- [x] `merge_antipatterns()` with `enabled=False` removes the entry
- [x] `merge_antipatterns()` with severity/enforcement override applies correctly
- [x] custom entries appended via `custom_entries` list
- [x] unknown override name raises `ValueError`
- [x] `resolve_antipatterns()` full pipeline tested via file-backed overrides
- [x] All 56 antipattern tests pass (OMN-11910 + OMN-11911 + OMN-11912)
- [x] mypy --strict: 0 errors on new files
- [x] ruff: clean
- [x] pre-commit on changed files: all pass

Closes OMN-11912