### PR TITLE
feat(OMN-11932): generate typed LogicalModelKey and EndpointRef constants

### DIFF
--- a/.github/workflows/check-llm-refs-drift.yml
+++ b/.github/workflows/check-llm-refs-drift.yml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+name: Check LLM Refs Drift
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+    paths:
+      - 'src/omnibase_core/constants/constants_llm_refs.py'
+      - 'scripts/generate_llm_refs.py'
+      - 'tests/unit/constants/test_constants_llm_refs.py'
+      - '.github/workflows/check-llm-refs-drift.yml'
+  pull_request:
+    branches: [main, develop, dev]
+    paths:
+      - 'src/omnibase_core/constants/constants_llm_refs.py'
+      - 'scripts/generate_llm_refs.py'
+      - 'tests/unit/constants/test_constants_llm_refs.py'
+      - '.github/workflows/check-llm-refs-drift.yml'
+  workflow_dispatch:
+
+env:
+  UV_VERSION: "0.8.3"
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  check-llm-refs-drift:
+    name: LLM refs drift check (OMN-11932)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          # Check out the full repo so OMNI_HOME sub-path resolution works
+          fetch-depth: 1
+
+      - name: Checkout omnibase_infra for llm_endpoints.yaml
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnibase_infra
+          path: _omnibase_infra
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout omnimarket for model_registry_v1.yaml
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnimarket
+          path: _omnimarket
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Set OMNI_HOME for CI
+        run: |
+          mkdir -p _omni_home
+          ln -s "$PWD/_omnibase_infra" "_omni_home/omnibase_infra"
+          ln -s "$PWD/_omnimarket" "_omni_home/omnimarket"
+          echo "OMNI_HOME=$PWD/_omni_home" >> "$GITHUB_ENV"
+
+      - name: Check drift in constants_llm_refs.py
+        run: uv run python scripts/generate_llm_refs.py --check
+
+      - name: Run LLM refs unit tests
+        run: uv run pytest tests/unit/constants/test_constants_llm_refs.py -xvs

--- a/scripts/generate_llm_refs.py
+++ b/scripts/generate_llm_refs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Generate typed LogicalModelKey and EndpointRef constants (OMN-11932).
+
+Reads:
+  $OMNI_HOME/omnibase_infra/contracts/llm_endpoints.yaml
+  $OMNI_HOME/omnimarket/src/omnimarket/data/model_registry/model_registry_v1.yaml
+
+Writes:
+  src/omnibase_core/constants/constants_llm_refs.py
+
+Run:
+  uv run python scripts/generate_llm_refs.py          # generate + write
+  uv run python scripts/generate_llm_refs.py --check  # drift detection (CI mode)
+
+Exit codes:
+  0 - Success / no drift
+  1 - Drift detected (--check mode) or generation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+OMNI_HOME = Path(os.environ["OMNI_HOME"])
+
+ENDPOINTS_YAML = OMNI_HOME / "omnibase_infra" / "contracts" / "llm_endpoints.yaml"
+REGISTRY_YAML = (
+    OMNI_HOME
+    / "omnimarket"
+    / "src"
+    / "omnimarket"
+    / "data"
+    / "model_registry"
+    / "model_registry_v1.yaml"
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+OUTPUT_PATH = (
+    REPO_ROOT / "src" / "omnibase_core" / "constants" / "constants_llm_refs.py"
+)
+
+_INVALID_ID_CHARS = re.compile(r"[^A-Z0-9]")
+
+
+def _to_enum_name(value: str) -> str:
+    upper = value.upper()
+    # Replace runs of non-alphanumeric chars with _
+    name = re.sub(r"[^A-Z0-9]+", "_", upper)
+    # Strip leading/trailing underscores
+    name = name.strip("_")
+    return name
+
+
+def _load_yaml(path: Path) -> dict:  # type: ignore[type-arg]
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at top level of {path}")
+    return data
+
+
+def _generate(endpoints_yaml: Path, registry_yaml: Path) -> str:
+    endpoints_data = _load_yaml(endpoints_yaml)
+    registry_data = _load_yaml(registry_yaml)
+
+    endpoints = endpoints_data.get("endpoints", [])
+    models = registry_data.get("models", {})
+
+    model_entries: list[tuple[str, str]] = []
+    for model_id in models:
+        model_entries.append((_to_enum_name(model_id), model_id))
+
+    endpoint_entries: list[tuple[str, str]] = []
+    for slot in endpoints:
+        slot_id = slot["slot_id"]
+        endpoint_entries.append((_to_enum_name(slot_id), slot_id))
+
+    model_lines = "\n".join(f'    {name} = "{value}"' for name, value in model_entries)
+    endpoint_lines = "\n".join(
+        f'    {name} = "{value}"' for name, value in endpoint_entries
+    )
+
+    return f"""\
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# ============================================================
+# AUTO-GENERATED — do not edit by hand.
+# Source:
+#   omnibase_infra/contracts/llm_endpoints.yaml
+#   omnimarket/src/omnimarket/data/model_registry/model_registry_v1.yaml
+# Generator: scripts/generate_llm_refs.py (OMN-11932)
+# Regenerate: uv run python scripts/generate_llm_refs.py
+# ============================================================
+
+\"\"\"
+Typed compile-time constants for LLM model keys and endpoint slot references.
+
+Use these instead of bare string literals so that typos become import errors
+and IDEs can autocomplete slot/model identifiers.
+
+LogicalModelKey — canonical model identifiers from model_registry_v1.yaml.
+EndpointRef     — canonical slot IDs from llm_endpoints.yaml (all statuses).
+\"\"\"
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class LogicalModelKey(StrEnum):
+    \"\"\"Canonical model identifiers from model_registry_v1.yaml.\"\"\"
+
+{model_lines}
+
+
+class EndpointRef(StrEnum):
+    \"\"\"Canonical slot IDs from llm_endpoints.yaml (all statuses included).\"\"\"
+
+{endpoint_lines}
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Drift-detection mode: fail if generated output differs from on-disk file.",
+    )
+    args = parser.parse_args()
+
+    generated = _generate(ENDPOINTS_YAML, REGISTRY_YAML)
+
+    if args.check:
+        if not OUTPUT_PATH.exists():
+            print(
+                f"DRIFT: {OUTPUT_PATH} does not exist. Run generate_llm_refs.py to create it."
+            )
+            sys.exit(1)
+        on_disk = OUTPUT_PATH.read_text()
+        if generated != on_disk:
+            print(
+                f"DRIFT: {OUTPUT_PATH} is out of date.\n"
+                "Run: uv run python scripts/generate_llm_refs.py"
+            )
+            sys.exit(1)
+        print("OK: constants_llm_refs.py matches source YAMLs.")
+    else:
+        OUTPUT_PATH.write_text(generated)
+        print(f"Written: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_llm_refs.py
+++ b/scripts/generate_llm_refs.py
@@ -48,9 +48,6 @@ OUTPUT_PATH = (
     REPO_ROOT / "src" / "omnibase_core" / "constants" / "constants_llm_refs.py"
 )
 
-_INVALID_ID_CHARS = re.compile(r"[^A-Z0-9]")
-
-
 def _to_enum_name(value: str) -> str:
     upper = value.upper()
     # Replace runs of non-alphanumeric chars with _

--- a/src/omnibase_core/constants/__init__.py
+++ b/src/omnibase_core/constants/__init__.py
@@ -10,6 +10,7 @@ from omnibase_core.constants import (
     constants_error,
     constants_field_limits,
     constants_handler_capabilities,
+    constants_llm_refs,
     constants_omnimemory,
     constants_topic_taxonomy,
 )
@@ -100,6 +101,7 @@ from omnibase_core.constants.constants_handler_capabilities import (
     get_capabilities_by_node_kind,
     validate_capabilities,
 )
+from omnibase_core.constants.constants_llm_refs import EndpointRef, LogicalModelKey
 from omnibase_core.constants.constants_omnimemory import (
     FLOAT_COMPARISON_EPSILON,
 )
@@ -166,9 +168,13 @@ __all__ = [
     "constants_effect",
     "constants_error",
     "constants_field_limits",
+    "constants_llm_refs",
     "constants_omnimemory",
     "constants_topic_taxonomy",
     "constants_handler_capabilities",
+    # LLM reference enums (OMN-11932)
+    "EndpointRef",
+    "LogicalModelKey",
     "normalize_legacy_event_type",
     # Contract filename constant (OMN-1533)
     "CONTRACT_FILENAME",

--- a/src/omnibase_core/constants/constants_llm_refs.py
+++ b/src/omnibase_core/constants/constants_llm_refs.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# ============================================================
+# AUTO-GENERATED — do not edit by hand.
+# Source:
+#   omnibase_infra/contracts/llm_endpoints.yaml
+#   omnimarket/src/omnimarket/data/model_registry/model_registry_v1.yaml
+# Generator: scripts/generate_llm_refs.py (OMN-11932)
+# Regenerate: uv run python scripts/generate_llm_refs.py
+# ============================================================
+
+"""
+Typed compile-time constants for LLM model keys and endpoint slot references.
+
+Use these instead of bare string literals so that typos become import errors
+and IDEs can autocomplete slot/model identifiers.
+
+LogicalModelKey — canonical model identifiers from model_registry_v1.yaml.
+EndpointRef     — canonical slot IDs from llm_endpoints.yaml (all statuses).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class LogicalModelKey(StrEnum):
+    """Canonical model identifiers from model_registry_v1.yaml."""
+
+    QWEN3_CODER_30B = "qwen3-coder-30b"
+    DEEPSEEK_R1_14B = "deepseek-r1-14b"
+    DEEPSEEK_R1_32B = "deepseek-r1-32b"
+    QWEN3_NEXT_80B = "qwen3-next-80b"
+    LLAMA_3_3_70B_FREE = "llama-3.3-70b-free"
+    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
+    CLAUDE_OPUS_4_6 = "claude-opus-4-6"
+
+
+class EndpointRef(StrEnum):
+    """Canonical slot IDs from llm_endpoints.yaml (all statuses included)."""
+
+    CODER_5090 = "coder-5090"
+    CODER_FAST_4090 = "coder-fast-4090"
+    EMBEDDINGS_201 = "embeddings-201"
+    REASONING_DEEPSEEK_32B = "reasoning-deepseek-32b"
+    REASONING_MOE_35B = "reasoning-moe-35b"
+    EMBEDDINGS_200 = "embeddings-200"
+    SECOND_OPINION_GEMMA = "second-opinion-gemma"
+    VISION_PLANNED = "vision-planned"
+    STT_PLANNED = "stt-planned"
+    TTS_PLANNED = "tts-planned"
+    RERANKER_PLANNED = "reranker-planned"

--- a/tests/unit/constants/test_constants_llm_refs.py
+++ b/tests/unit/constants/test_constants_llm_refs.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for generated LLM reference constants (OMN-11932).
+
+Covers LogicalModelKey and EndpointRef StrEnum values generated from
+llm_endpoints.yaml and model_registry_v1.yaml.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.constants.constants_llm_refs import EndpointRef, LogicalModelKey
+
+
+@pytest.mark.unit
+class TestLogicalModelKey:
+    def test_all_registry_models_present(self) -> None:
+        expected = {
+            "qwen3-coder-30b",
+            "deepseek-r1-14b",
+            "deepseek-r1-32b",
+            "qwen3-next-80b",
+            "llama-3.3-70b-free",
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+        }
+        actual = {m.value for m in LogicalModelKey}
+        assert expected <= actual, f"Missing model keys: {expected - actual}"
+
+    def test_values_are_strings(self) -> None:
+        for key in LogicalModelKey:
+            assert isinstance(key.value, str)
+
+    def test_can_round_trip_from_string(self) -> None:
+        for key in LogicalModelKey:
+            assert LogicalModelKey(key.value) is key
+
+    def test_known_model_key_by_attribute(self) -> None:
+        assert LogicalModelKey.QWEN3_CODER_30B == "qwen3-coder-30b"
+        assert LogicalModelKey.CLAUDE_SONNET_4_6 == "claude-sonnet-4-6"
+        assert LogicalModelKey.CLAUDE_OPUS_4_6 == "claude-opus-4-6"
+
+    def test_no_empty_values(self) -> None:
+        for key in LogicalModelKey:
+            assert key.value.strip(), f"Empty value for {key.name}"
+
+
+@pytest.mark.unit
+class TestEndpointRef:
+    def test_all_running_slots_present(self) -> None:
+        expected = {
+            "coder-5090",
+            "coder-fast-4090",
+            "embeddings-201",
+            "reasoning-deepseek-32b",
+            "reasoning-moe-35b",
+        }
+        actual = {e.value for e in EndpointRef}
+        assert expected <= actual, f"Missing endpoint refs: {expected - actual}"
+
+    def test_values_are_strings(self) -> None:
+        for ref in EndpointRef:
+            assert isinstance(ref.value, str)
+
+    def test_can_round_trip_from_string(self) -> None:
+        for ref in EndpointRef:
+            assert EndpointRef(ref.value) is ref
+
+    def test_known_slot_by_attribute(self) -> None:
+        assert EndpointRef.CODER_5090 == "coder-5090"
+        assert EndpointRef.CODER_FAST_4090 == "coder-fast-4090"
+        assert EndpointRef.EMBEDDINGS_201 == "embeddings-201"
+
+    def test_no_empty_values(self) -> None:
+        for ref in EndpointRef:
+            assert ref.value.strip(), f"Empty value for {ref.name}"


### PR DESCRIPTION
## Summary

- Adds `scripts/generate_llm_refs.py`: reads `llm_endpoints.yaml` and `model_registry_v1.yaml`, emits `constants_llm_refs.py` with `StrEnum`-typed `LogicalModelKey` and `EndpointRef`
- Adds `src/omnibase_core/constants/constants_llm_refs.py`: auto-generated module (committed as source of truth; regenerated via `uv run python scripts/generate_llm_refs.py`)
- Wires `EndpointRef` and `LogicalModelKey` into `constants/__init__.py` `__all__`
- Adds `.github/workflows/check-llm-refs-drift.yml`: CI gate that runs `--check` mode and fails the build if the committed file drifts from the source YAMLs
- Adds 10 unit tests (TDD) covering membership, round-trip, attribute access, and no-empty-values invariants

## How to add a new model/endpoint

1. Add the entry to the relevant source YAML (`llm_endpoints.yaml` for a new slot, `model_registry_v1.yaml` for a new model)
2. Run `uv run python scripts/generate_llm_refs.py` from the `omnibase_core` worktree root
3. Commit both the YAML change and the regenerated `constants_llm_refs.py`

The CI drift check will fail if only the YAML is updated without regenerating.

## Test plan

- [x] `uv run pytest tests/unit/constants/test_constants_llm_refs.py -v` — 10/10 pass
- [x] `uv run python scripts/generate_llm_refs.py --check` — exits 0
- [x] `uv run mypy src/omnibase_core/constants/constants_llm_refs.py --strict` — 0 errors
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean
- [x] `pre-commit run --all-files` — new files pass all hooks; existing failures are pre-existing on main

Evidence-Source: OCC#1544
Evidence-Ticket: OMN-11932

Closes OMN-11932
