### PR TITLE
feat(OMN-11927): add shared LLM routing DTOs to omnibase_core.models.llm_routing

### DIFF
--- a/src/omnibase_core/models/llm_routing/__init__.py
+++ b/src/omnibase_core/models/llm_routing/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Shared LLM routing DTOs for cross-repo consumption.
+
+ModelRouteRequest, ModelRouteResolved, and ModelRouteRejected are the
+canonical wire models for the node_model_router event bus topics:
+  onex.evt.omnimarket.model-route-resolved.v1
+  onex.evt.omnimarket.model-route-rejected.v1
+"""
+
+from omnibase_core.models.llm_routing.enum_route_rejection_reason import (
+    EnumRouteRejectionReason,
+)
+from omnibase_core.models.llm_routing.model_route_rejected import ModelRouteRejected
+from omnibase_core.models.llm_routing.model_route_request import ModelRouteRequest
+from omnibase_core.models.llm_routing.model_route_resolved import ModelRouteResolved
+
+__all__ = [
+    "EnumRouteRejectionReason",
+    "ModelRouteRejected",
+    "ModelRouteRequest",
+    "ModelRouteResolved",
+]

--- a/src/omnibase_core/models/llm_routing/enum_route_rejection_reason.py
+++ b/src/omnibase_core/models/llm_routing/enum_route_rejection_reason.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumRouteRejectionReason — structured error codes for route resolution failure."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnumRouteRejectionReason(str, Enum):
+    """Routing error class for node_model_router rejection events."""
+
+    UNKNOWN_KEY = "UNKNOWN_KEY"
+    ENDPOINT_UNAVAILABLE = "ENDPOINT_UNAVAILABLE"
+    POLICY_REJECTED = "POLICY_REJECTED"
+    FALLBACK_EXHAUSTED = "FALLBACK_EXHAUSTED"
+
+
+__all__: list[str] = ["EnumRouteRejectionReason"]

--- a/src/omnibase_core/models/llm_routing/model_route_rejected.py
+++ b/src/omnibase_core/models/llm_routing/model_route_rejected.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRouteRejected — emitted when model key resolution fails."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.llm_routing.enum_route_rejection_reason import (
+    EnumRouteRejectionReason,
+)
+
+
+class ModelRouteRejected(BaseModel):
+    """Event payload for onex.evt.omnimarket.model-route-rejected.v1.
+
+    Emitted when a logical model key cannot be resolved to a concrete
+    endpoint due to an UNKNOWN_KEY, ENDPOINT_UNAVAILABLE, POLICY_REJECTED,
+    or FALLBACK_EXHAUSTED condition.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    logical_model_key: str = Field(
+        ...,
+        description="The logical model key that failed resolution.",
+    )
+    rejection_reason: EnumRouteRejectionReason = Field(
+        ...,
+        description="Structured reason code for rejection.",
+    )
+    detail: str = Field(
+        default="",
+        description="Human-readable explanation for the rejection.",
+    )
+    correlation_id: str = Field(
+        ...,
+        description="Correlation ID from the originating route request.",
+    )
+    attempts: int = Field(
+        default=1,
+        description="Number of resolution attempts made (including fallback).",
+        ge=1,
+    )
+
+
+__all__: list[str] = ["ModelRouteRejected"]

--- a/src/omnibase_core/models/llm_routing/model_route_request.py
+++ b/src/omnibase_core/models/llm_routing/model_route_request.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRouteRequest — input DTO for node_model_router resolution."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRouteRequest(BaseModel):
+    """Request payload to resolve a logical model key to a concrete endpoint."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    logical_model_key: str = Field(
+        ...,
+        description="Logical model key to resolve (e.g. 'qwen3-coder-30b').",
+    )
+    role: str = Field(
+        ...,
+        description="Caller role (e.g. 'fixer', 'reviewer'). Used for fallback authorization.",
+    )
+    correlation_id: str = Field(
+        ...,
+        description="Correlation ID linking this request to the originating workflow.",
+    )
+    require_healthy: bool = Field(
+        default=True,
+        description="When True, router skips degraded endpoints and applies fallback policy.",
+    )
+
+
+__all__: list[str] = ["ModelRouteRequest"]

--- a/src/omnibase_core/models/llm_routing/model_route_resolved.py
+++ b/src/omnibase_core/models/llm_routing/model_route_resolved.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRouteResolved — emitted on successful model key resolution."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRouteResolved(BaseModel):
+    """Event payload for onex.evt.omnimarket.model-route-resolved.v1.
+
+    Emitted when a logical model key is successfully resolved to a
+    concrete endpoint URL and model ID.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    logical_model_key: str = Field(
+        ...,
+        description="The logical model key that was resolved.",
+    )
+    model_key: str = Field(
+        ...,
+        description="Registry model_id key used (may differ when CI override is active).",
+    )
+    endpoint_url: str = Field(
+        ...,
+        description="Resolved concrete endpoint base URL.",
+    )
+    model_id: str = Field(
+        ...,
+        description="Model identifier to pass to the API (e.g. HuggingFace model ID).",
+    )
+    protocol: str = Field(
+        default="openai_compatible",
+        description="Transport protocol: openai_compatible | anthropic.",
+    )
+    provider: str = Field(
+        ...,
+        description="Provider category: local | anthropic | openrouter | cloud.",
+    )
+    correlation_id: str = Field(
+        ...,
+        description="Correlation ID from the originating route request.",
+    )
+    was_fallback: bool = Field(
+        default=False,
+        description="True when primary was degraded and fallback endpoint was selected.",
+    )
+    context_window: int = Field(
+        default=0,
+        description="Context window size from the model registry.",
+        ge=0,
+    )
+
+
+__all__: list[str] = ["ModelRouteResolved"]

--- a/tests/models/llm_routing/__init__.py
+++ b/tests/models/llm_routing/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/models/llm_routing/test_llm_routing_dtos.py
+++ b/tests/models/llm_routing/test_llm_routing_dtos.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for shared LLM routing DTOs in omnibase_core.models.llm_routing."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.llm_routing.enum_route_rejection_reason import (
+    EnumRouteRejectionReason,
+)
+from omnibase_core.models.llm_routing.model_route_rejected import ModelRouteRejected
+from omnibase_core.models.llm_routing.model_route_request import ModelRouteRequest
+from omnibase_core.models.llm_routing.model_route_resolved import ModelRouteResolved
+
+
+@pytest.mark.unit
+class TestModelRouteRequest:
+    def test_valid_construction(self) -> None:
+        req = ModelRouteRequest(
+            logical_model_key="qwen3-coder-30b",
+            role="fixer",
+            correlation_id="corr-1",
+        )
+        assert req.logical_model_key == "qwen3-coder-30b"
+        assert req.role == "fixer"
+        assert req.correlation_id == "corr-1"
+        assert req.require_healthy is True
+
+    def test_require_healthy_optional(self) -> None:
+        req = ModelRouteRequest(
+            logical_model_key="qwen3-coder-30b",
+            role="fixer",
+            correlation_id="corr-2",
+            require_healthy=False,
+        )
+        assert req.require_healthy is False
+
+    def test_frozen(self) -> None:
+        req = ModelRouteRequest(
+            logical_model_key="qwen3-coder-30b",
+            role="fixer",
+            correlation_id="corr-3",
+        )
+        with pytest.raises((ValidationError, TypeError)):
+            req.role = "reviewer"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRouteRequest(  # type: ignore[call-arg]
+                logical_model_key="qwen3-coder-30b",
+                role="fixer",
+                correlation_id="corr-4",
+                unknown_field="bad",
+            )
+
+
+@pytest.mark.unit
+class TestModelRouteResolved:
+    def test_valid_construction(self) -> None:
+        resolved = ModelRouteResolved(
+            logical_model_key="qwen3-coder-30b",
+            model_key="qwen3-coder-30b",
+            endpoint_url="http://192.168.86.201:8000",
+            model_id="cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
+            provider="local",
+            correlation_id="corr-5",
+        )
+        assert resolved.endpoint_url == "http://192.168.86.201:8000"
+        assert resolved.was_fallback is False
+        assert resolved.context_window == 0
+
+    def test_fallback_flag(self) -> None:
+        resolved = ModelRouteResolved(
+            logical_model_key="qwen3-coder-30b",
+            model_key="claude-sonnet-4-6",
+            endpoint_url="https://api.anthropic.com",
+            model_id="claude-sonnet-4-6",
+            provider="anthropic",
+            correlation_id="corr-6",
+            was_fallback=True,
+        )
+        assert resolved.was_fallback is True
+
+    def test_context_window_ge_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRouteResolved(
+                logical_model_key="qwen3-coder-30b",
+                model_key="qwen3-coder-30b",
+                endpoint_url="http://localhost:8000",
+                model_id="model-id",
+                provider="local",
+                correlation_id="corr-7",
+                context_window=-1,
+            )
+
+
+@pytest.mark.unit
+class TestModelRouteRejected:
+    def test_unknown_key_rejection(self) -> None:
+        rejected = ModelRouteRejected(
+            logical_model_key="nonexistent-model",
+            rejection_reason=EnumRouteRejectionReason.UNKNOWN_KEY,
+            correlation_id="corr-8",
+        )
+        assert rejected.rejection_reason == EnumRouteRejectionReason.UNKNOWN_KEY
+        assert rejected.attempts == 1
+
+    def test_fallback_exhausted(self) -> None:
+        rejected = ModelRouteRejected(
+            logical_model_key="qwen3-coder-30b",
+            rejection_reason=EnumRouteRejectionReason.FALLBACK_EXHAUSTED,
+            detail="Both primary and fallback unreachable",
+            correlation_id="corr-9",
+            attempts=3,
+        )
+        assert rejected.rejection_reason == EnumRouteRejectionReason.FALLBACK_EXHAUSTED
+        assert rejected.attempts == 3
+        assert rejected.detail == "Both primary and fallback unreachable"
+
+    def test_attempts_ge_one(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRouteRejected(
+                logical_model_key="model",
+                rejection_reason=EnumRouteRejectionReason.ENDPOINT_UNAVAILABLE,
+                correlation_id="corr-10",
+                attempts=0,
+            )
+
+
+@pytest.mark.unit
+class TestEnumRouteRejectionReason:
+    def test_all_values_present(self) -> None:
+        expected = {
+            "UNKNOWN_KEY",
+            "ENDPOINT_UNAVAILABLE",
+            "POLICY_REJECTED",
+            "FALLBACK_EXHAUSTED",
+        }
+        actual = {e.value for e in EnumRouteRejectionReason}
+        assert actual == expected
+
+    def test_str_values(self) -> None:
+        assert EnumRouteRejectionReason.UNKNOWN_KEY == "UNKNOWN_KEY"
+        assert EnumRouteRejectionReason.POLICY_REJECTED == "POLICY_REJECTED"
+
+
+@pytest.mark.unit
+class TestLlmRoutingModuleExports:
+    def test_package_init_exports(self) -> None:
+        from omnibase_core.models.llm_routing import (
+            EnumRouteRejectionReason,
+            ModelRouteRejected,
+            ModelRouteRequest,
+            ModelRouteResolved,
+        )
+
+        assert EnumRouteRejectionReason is not None
+        assert ModelRouteRejected is not None
+        assert ModelRouteRequest is not None
+        assert ModelRouteResolved is not None


### PR DESCRIPTION
## Summary

- Adds `omnibase_core.models.llm_routing` package with canonical cross-repo DTOs for node_model_router routing events
- `ModelRouteRequest` — input DTO for logical model key resolution
- `ModelRouteResolved` — event payload for `onex.evt.omnimarket.model-route-resolved.v1`
- `ModelRouteRejected` — event payload for `onex.evt.omnimarket.model-route-rejected.v1`
- `EnumRouteRejectionReason` — structured error codes: UNKNOWN_KEY, ENDPOINT_UNAVAILABLE, POLICY_REJECTED, FALLBACK_EXHAUSTED
- 13 unit tests, mypy --strict clean, all pre-commit hooks pass

## Ticket

OMN-11927 — critical path for LLM hardcode elimination epic

Evidence-Source: OCC#1545
Evidence-Ticket: OMN-11927

## dod_evidence

- All 13 unit tests pass (`uv run pytest tests/models/llm_routing/ -v`)
- mypy --strict: no issues found in 5 source files
- ruff format/check: all clean
- pre-commit: all hooks pass
- OCC contract: OmniNode-ai/onex_change_control#1545

## Test plan

- [ ] `uv run pytest tests/models/llm_routing/ -v` — all 13 pass
- [ ] `uv run mypy src/omnibase_core/models/llm_routing/ --strict` — clean
- [ ] `pre-commit run --all-files` — clean