### PR TITLE
feat(OMN-11920): ValidatorBase KB-Aware Extension

### DIFF
--- a/src/omnibase_core/models/validation/model_antipattern_entry_override.py
+++ b/src/omnibase_core/models/validation/model_antipattern_entry_override.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternEntryOverride — per-repo override for a single antipattern entry (OMN-11912)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAntipatternEntryOverride(BaseModel):
+    """A per-repo override for an existing antipattern entry."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Antipattern name to override")
+    severity: Literal["ERROR", "WARNING", "INFO"] | None = Field(
+        default=None, description="Override severity (None = keep default)"
+    )
+    enforcement: Literal["blocking", "advisory", "informational"] | None = Field(
+        default=None, description="Override enforcement level (None = keep default)"
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description="Set False to disable this antipattern for the repo (None = keep default)",
+    )
+    file_globs: list[str] | None = Field(
+        default=None, description="Override file globs (None = keep default)"
+    )
+
+
+__all__ = ["ModelAntipatternEntryOverride"]

--- a/src/omnibase_core/models/validation/model_antipattern_override_config.py
+++ b/src/omnibase_core/models/validation/model_antipattern_override_config.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternOverrideConfig — per-repo antipattern override config (OMN-11912)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_entry_override import (
+    ModelAntipatternEntryOverride,
+)
+
+
+class ModelAntipatternOverrideConfig(BaseModel):
+    """Per-repo antipattern configuration read from .onex/antipattern-overrides.yaml."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    overrides: list[ModelAntipatternEntryOverride] = Field(
+        default_factory=list,
+        description="Field-level overrides for existing antipattern entries",
+    )
+    custom_entries: list[ModelAntipatternEntry] = Field(
+        default_factory=list,
+        description="New antipattern entries to append to the registry",
+    )
+
+
+__all__ = ["ModelAntipatternOverrideConfig"]

--- a/src/omnibase_core/validation/antipattern_registry_loader.py
+++ b/src/omnibase_core/validation/antipattern_registry_loader.py
@@ -1,24 +1,26 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Antipattern registry loader: resolves effective registry for a repo (OMN-11911).
+"""Antipattern registry loader: resolves effective registry for a repo (OMN-11912).
 
 Resolution order:
   1. Load bundled defaults from contracts/antipattern_registry.yaml
   2. Load optional per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml
-  3. Merge: apply field overrides then append custom_entries
+  3. Merge: apply field overrides (including disable) then append custom_entries
 """
 
 from __future__ import annotations
 
 import importlib.resources
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 from omnibase_core.models.validation.model_antipattern_entry import (
     ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
 )
 from omnibase_core.models.validation.model_antipattern_registry import (
     ModelAntipatternRegistry,
@@ -29,7 +31,7 @@ _DEFAULT_YAML = "antipattern_registry.yaml"
 _OVERRIDES_PATH = ".onex/antipattern-overrides.yaml"
 
 
-def load_default_registry() -> ModelAntipatternRegistry:
+def load_default_antipatterns() -> ModelAntipatternRegistry:
     """Return the bundled default antipattern registry.
 
     Reads from omnibase_core/contracts/antipattern_registry.yaml via
@@ -51,38 +53,43 @@ def load_default_registry() -> ModelAntipatternRegistry:
     return ModelAntipatternRegistry.model_validate(data)
 
 
-def _load_overrides(repo_root: Path) -> dict[str, Any] | None:
+# Keep legacy name as an alias so existing callers (OMN-11911 tests) continue to work
+load_default_registry = load_default_antipatterns
+
+
+def load_repo_overrides(repo_root: Path) -> ModelAntipatternOverrideConfig | None:
     """Load per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml.
 
     Returns None if the file does not exist.
+    Raises ValidationError if the file exists but is malformed.
     """
     config_path = repo_root / _OVERRIDES_PATH
     if not config_path.exists():
         return None
-    return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    return ModelAntipatternOverrideConfig.model_validate(data)
 
 
-def _merge_registry(
+def merge_antipatterns(
     defaults: ModelAntipatternRegistry,
-    overrides_data: dict[str, Any] | None,
+    overrides: ModelAntipatternOverrideConfig | None,
 ) -> ModelAntipatternRegistry:
     """Apply per-repo overrides and custom entries on top of defaults.
 
     Override semantics (mirrors aislop_rule_loader.merge_rules):
     - Override fields that are None → keep the default value.
+    - enabled=False → entry is excluded from the merged registry.
     - Unknown name → ValueError (prevents silent typos).
     - custom_entries are appended after merging overrides.
     """
-    if overrides_data is None:
+    if overrides is None:
         return defaults
-
-    override_list: list[dict[str, Any]] = overrides_data.get("overrides", [])
-    custom_list: list[dict[str, Any]] = overrides_data.get("custom_entries", [])
 
     default_by_name: dict[str, ModelAntipatternEntry] = {
         e.name: e for e in defaults.entries
     }
-    override_by_name: dict[str, dict[str, Any]] = {o["name"]: o for o in override_list}
+
+    override_by_name = {o.name: o for o in overrides.overrides}
 
     # Validate all override names reference known entries
     for name in override_by_name:
@@ -92,23 +99,27 @@ def _merge_registry(
                 f"Unknown antipattern name '{name}' in overrides. Known: {known}"
             )
 
-    # Apply field overrides
+    # Apply field overrides; entries with enabled=False are dropped
     merged: list[ModelAntipatternEntry] = []
     for entry in defaults.entries:
         ov = override_by_name.get(entry.name)
         if ov is None:
             merged.append(entry)
             continue
-        # Rebuild entry with overridden fields; None values keep the default
+        if ov.enabled is False:
+            continue
         base = entry.model_dump()
-        for field in ("severity", "enforcement", "file_globs"):
-            if ov.get(field) is not None:
-                base[field] = ov[field]
+        if ov.severity is not None:
+            base["severity"] = ov.severity
+        if ov.enforcement is not None:
+            base["enforcement"] = ov.enforcement
+        if ov.file_globs is not None:
+            base["file_globs"] = ov.file_globs
         merged.append(ModelAntipatternEntry.model_validate(base))
 
     # Append custom entries
-    for raw in custom_list:
-        merged.append(ModelAntipatternEntry.model_validate(raw))
+    for custom in overrides.custom_entries:
+        merged.append(custom)
 
     return ModelAntipatternRegistry(
         version=defaults.version,
@@ -119,12 +130,15 @@ def _merge_registry(
 
 def resolve_antipatterns(repo_root: Path) -> ModelAntipatternRegistry:
     """Full resolution pipeline: defaults → per-repo overrides → merged result."""
-    defaults = load_default_registry()
-    overrides_data = _load_overrides(repo_root)
-    return _merge_registry(defaults, overrides_data)
+    defaults = load_default_antipatterns()
+    overrides = load_repo_overrides(repo_root)
+    return merge_antipatterns(defaults, overrides)
 
 
 __all__ = [
+    "load_default_antipatterns",
     "load_default_registry",
+    "load_repo_overrides",
+    "merge_antipatterns",
     "resolve_antipatterns",
 ]

--- a/src/omnibase_core/validation/validator_base.py
+++ b/src/omnibase_core/validation/validator_base.py
@@ -64,7 +64,9 @@ See Also:
 
 import argparse
 import fnmatch
+import hashlib
 import logging
+import re
 import sys
 import time
 from abc import ABC, abstractmethod
@@ -90,6 +92,9 @@ from omnibase_core.models.contracts.subcontracts.model_validator_subcontract imp
     ModelValidatorSubcontract,
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
 
 # Configure logger for this module
 logger = logging.getLogger(__name__)
@@ -109,6 +114,16 @@ SEVERITY_PRIORITY: dict[EnumSeverity, int] = {
     EnumSeverity.DEBUG: 5,
 }
 
+# Pattern types that support line-by-line regex/grep matching
+_REGEX_PATTERN_TYPES = frozenset({"regex_line", "grep_code", "regex_ast_docstring"})
+
+# Map antipattern entry severity strings to EnumSeverity
+_ANTIPATTERN_SEVERITY_MAP: dict[str, EnumSeverity] = {
+    "ERROR": EnumSeverity.ERROR,
+    "WARNING": EnumSeverity.WARNING,
+    "INFO": EnumSeverity.INFO,
+}
+
 
 class ValidatorBase(ABC):
     """Concrete base class for contract-driven file validators.
@@ -119,6 +134,7 @@ class ValidatorBase(ABC):
     - Suppression comment handling
     - Deterministic result ordering
     - CLI exit code mapping
+    - Optional KB-aware antipattern matching (OMN-11920)
 
     Subclasses must implement:
     - validator_id (class attribute): Unique identifier for this validator
@@ -151,19 +167,27 @@ class ValidatorBase(ABC):
     Attributes:
         validator_id: Unique identifier for this validator (must be set by subclass).
         contract: The validator contract (loaded lazily if not provided).
+        antipattern_registry: Optional KB registry for regex/grep pattern matching.
     """
 
     # ONEX_EXCLUDE: string_id - human-readable validator identifier
     validator_id: ClassVar[str]
 
-    def __init__(self, contract: ModelValidatorSubcontract | None = None) -> None:
-        """Initialize validator with optional pre-loaded contract.
+    def __init__(
+        self,
+        contract: ModelValidatorSubcontract | None = None,
+        antipattern_registry: ModelAntipatternRegistry | None = None,
+    ) -> None:
+        """Initialize validator with optional pre-loaded contract and KB registry.
 
         Args:
             contract: Pre-loaded validator contract. If None, the contract
                 will be loaded from the default YAML location when first accessed.
+            antipattern_registry: Optional antipattern registry for KB-aware
+                rule matching. If None, KB-based validation is skipped.
         """
         self._contract = contract
+        self._antipattern_registry = antipattern_registry
         # Thread Safety: This cache is NOT thread-safe. When using parallel
         # execution (e.g., pytest-xdist), create separate validator instances
         # per worker. Cache is cleared after validate() completes to prevent
@@ -177,6 +201,11 @@ class ValidatorBase(ABC):
         # usage, create separate validator instances per thread/worker.
         # See docs/guides/THREADING.md for details.
         self._rule_config_cache: dict[str, tuple[bool, EnumSeverity]] | None = None
+
+    @property
+    def antipattern_registry(self) -> ModelAntipatternRegistry | None:
+        """The antipattern registry used for KB-aware validation, or None."""
+        return self._antipattern_registry
 
     @property
     def contract(self) -> ModelValidatorSubcontract:
@@ -316,6 +345,73 @@ class ValidatorBase(ABC):
             proper suppression handling and ordering.
         """
         ...
+
+    def _validate_file_against_kb_rules(
+        self,
+        path: Path,
+    ) -> tuple[ModelValidationIssue, ...]:
+        """Match file lines against regex/grep antipattern registry entries.
+
+        Applies all registry entries whose pattern_type is regex_line, grep_code,
+        or regex_ast_docstring and whose file_globs match the given path.
+        Entries of type semantic or ast_check are skipped (require vector search
+        or AST infrastructure not available here).
+
+        Suppression is honored: if the matching line contains the entry's
+        suppression_annotation string, the issue is not emitted.
+
+        Args:
+            path: Path to the file to check.
+
+        Returns:
+            Tuple of ModelValidationIssue for all unsuppressed matches.
+        """
+        if self._antipattern_registry is None:
+            return ()
+
+        issues: list[ModelValidationIssue] = []
+        lines = self._get_file_lines(path)
+
+        for entry in self._antipattern_registry.entries:
+            if entry.pattern_type not in _REGEX_PATTERN_TYPES:
+                continue
+
+            # Check file_globs — skip this entry if no glob matches the file name
+            if not any(fnmatch.fnmatch(path.name, glob) for glob in entry.file_globs):
+                continue
+
+            try:
+                compiled = re.compile(entry.pattern)
+            except re.error as exc:
+                logger.warning(
+                    "Invalid regex in antipattern entry '%s': %s", entry.name, exc
+                )
+                continue
+
+            severity = _ANTIPATTERN_SEVERITY_MAP.get(entry.severity, EnumSeverity.ERROR)
+
+            for line_idx, line in enumerate(lines):
+                line_number = line_idx + 1
+                if not compiled.search(line):
+                    continue
+                # Honor entry-specific suppression annotation
+                if (
+                    entry.suppression_annotation
+                    and entry.suppression_annotation in line
+                ):
+                    continue
+                issues.append(
+                    ModelValidationIssue(
+                        severity=severity,
+                        message=entry.description,
+                        rule_name=entry.name,
+                        file_path=path,
+                        line_number=line_number,
+                        code=entry.name,
+                    )
+                )
+
+        return tuple(issues)
 
     def _validate_file_with_suppression(
         self,
@@ -727,6 +823,11 @@ class ValidatorBase(ABC):
 
         return module_dir / "contracts" / f"{self.validator_id}.validation.yaml"
 
+    def _compute_registry_hash(self, registry: ModelAntipatternRegistry) -> str:
+        """Compute a deterministic SHA-256 hash of the registry contents."""
+        canonical = registry.model_dump_json()
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
     def _build_result(
         self,
         files_checked: list[Path],
@@ -789,6 +890,23 @@ class ValidatorBase(ABC):
                 f"{total_issues} issue(s) in {len(files_with_violations)} file(s)"
             )
 
+        # Collect KB registry metadata for reproducibility tracking
+        extra_metadata: dict[
+            str, object
+        ] = {}  # ONEX_EXCLUDE: dict_str_any - KB registry metadata passed as **kwargs to ModelValidationMetadata extra fields
+        if self._antipattern_registry is not None:
+            extra_metadata["antipattern_registry_version"] = (
+                self._antipattern_registry.version
+            )
+            extra_metadata["antipattern_registry_hash"] = self._compute_registry_hash(
+                self._antipattern_registry
+            )
+            extra_metadata["rule_ids_applied"] = [
+                e.name
+                for e in self._antipattern_registry.entries
+                if e.pattern_type in _REGEX_PATTERN_TYPES
+            ]
+
         # Build metadata
         metadata = ModelValidationMetadata(
             validation_type=self.validator_id,
@@ -801,6 +919,7 @@ class ValidatorBase(ABC):
             files_with_violations=files_with_violations,
             files_with_violations_count=len(files_with_violations),
             strict_mode=self.contract.fail_on_warning,
+            **extra_metadata,
         )
 
         return ModelValidationResult[None](

--- a/src/omnibase_core/validation/validator_base.py
+++ b/src/omnibase_core/validation/validator_base.py
@@ -907,20 +907,22 @@ class ValidatorBase(ABC):
                 if e.pattern_type in _REGEX_PATTERN_TYPES
             ]
 
-        # Build metadata
-        metadata = ModelValidationMetadata(
-            validation_type=self.validator_id,
-            duration_ms=duration_ms,
-            files_processed=len(files_checked),
-            rules_applied=len([r for r in self.contract.rules if r.enabled]),
-            timestamp=datetime.now(tz=UTC).isoformat(),
-            validator_version=self.contract.version,
-            violations_found=total_issues,
-            files_with_violations=files_with_violations,
-            files_with_violations_count=len(files_with_violations),
-            strict_mode=self.contract.fail_on_warning,
-            **extra_metadata,
-        )
+        # Build metadata through Pydantic so extra KB fields remain validated
+        # without relying on mypy-hostile **kwargs expansion.
+        metadata_payload: dict[str, object] = {
+            "validation_type": self.validator_id,
+            "duration_ms": duration_ms,
+            "files_processed": len(files_checked),
+            "rules_applied": len([r for r in self.contract.rules if r.enabled]),
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "validator_version": self.contract.version,
+            "violations_found": total_issues,
+            "files_with_violations": files_with_violations,
+            "files_with_violations_count": len(files_with_violations),
+            "strict_mode": self.contract.fail_on_warning,
+        }
+        metadata_payload.update(extra_metadata)
+        metadata = ModelValidationMetadata.model_validate(metadata_payload)
 
         return ModelValidationResult[None](
             is_valid=is_valid,

--- a/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
+++ b/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the OMN-11912 canonical public API of antipattern_registry_loader.
+
+Covers the acceptance criteria:
+  - defaults only (no overrides file)
+  - override disable (enabled=False removes an entry)
+  - override severity
+  - custom append
+  - malformed override raises ValidationError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+from omnibase_core.validation.antipattern_registry_loader import (
+    load_default_antipatterns,
+    load_repo_overrides,
+    merge_antipatterns,
+    resolve_antipatterns,
+)
+
+
+@pytest.mark.unit
+class TestLoadDefaultAntipatterns:
+    def test_returns_registry(self) -> None:
+        result = load_default_antipatterns()
+        assert isinstance(result, ModelAntipatternRegistry)
+
+    def test_has_entries(self) -> None:
+        result = load_default_antipatterns()
+        assert len(result.entries) > 0
+
+    def test_version_present(self) -> None:
+        result = load_default_antipatterns()
+        assert result.version != ""
+
+
+@pytest.mark.unit
+class TestLoadRepoOverrides:
+    def test_no_file_returns_none(self, tmp_path: Path) -> None:
+        result = load_repo_overrides(tmp_path)
+        assert result is None
+
+    def test_valid_override_file_returns_config(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "hardcoded_ip", "severity": "WARNING"},
+                    ]
+                }
+            )
+        )
+        result = load_repo_overrides(tmp_path)
+        assert isinstance(result, ModelAntipatternOverrideConfig)
+        assert len(result.overrides) == 1
+        assert result.overrides[0].name == "hardcoded_ip"
+
+    def test_malformed_override_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {
+                            "name": "hardcoded_ip",
+                            "severity": "NOT_A_VALID_SEVERITY",
+                        }
+                    ]
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+    def test_unknown_extra_field_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "unknown_top_level_field": True,
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+
+@pytest.mark.unit
+class TestMergeAntipatterns:
+    def test_none_overrides_returns_defaults(self) -> None:
+        defaults = load_default_antipatterns()
+        result = merge_antipatterns(defaults, None)
+        assert len(result.entries) == len(defaults.entries)
+
+    def test_override_severity(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_override_enforcement(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "obvious_comment", "enforcement": "blocking"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "obvious_comment")
+        assert entry.enforcement == "blocking"
+
+    def test_override_disable_removes_entry(self) -> None:
+        defaults = load_default_antipatterns()
+        names_before = {e.name for e in defaults.entries}
+        assert "hardcoded_ip" in names_before
+
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "enabled": False}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names_after = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names_after
+        assert len(result.entries) == len(defaults.entries) - 1
+
+    def test_custom_entries_appended(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "custom_entries": [
+                    {
+                        "name": "custom_test_rule",
+                        "severity": "WARNING",
+                        "enforcement": "advisory",
+                        "category": "code_quality",
+                        "pattern_type": "regex_line",
+                        "pattern": r"CUSTOM_PATTERN",
+                        "description": "Custom test rule",
+                        "rationale": "Custom rationale for testing",
+                        "discovered_date": "2026-01-01",
+                        "source_ticket": "OMN-11912",
+                    }
+                ]
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names = {e.name for e in result.entries}
+        assert "custom_test_rule" in names
+        assert len(result.entries) == len(defaults.entries) + 1
+
+    def test_unknown_override_name_raises_value_error(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "nonexistent_rule_xyz", "severity": "ERROR"}],
+            }
+        )
+        with pytest.raises(ValueError, match="nonexistent_rule_xyz"):
+            merge_antipatterns(defaults, config)
+
+
+@pytest.mark.unit
+class TestResolveAntipatterns:
+    def test_defaults_only(self, tmp_path: Path) -> None:
+        result = resolve_antipatterns(tmp_path)
+        defaults = load_default_antipatterns()
+        assert {e.name for e in result.entries} == {e.name for e in defaults.entries}
+
+    def test_override_disable_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "enabled": False}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names
+
+    def test_override_severity_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_custom_append_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "custom_entries": [
+                        {
+                            "name": "repo_specific_rule",
+                            "severity": "ERROR",
+                            "enforcement": "blocking",
+                            "category": "architecture",
+                            "pattern_type": "grep_code",
+                            "pattern": "import_forbidden",
+                            "description": "Repo-specific forbidden import",
+                            "rationale": "This import is forbidden in this repo",
+                            "discovered_date": "2026-01-01",
+                            "source_ticket": "OMN-11912",
+                        }
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "repo_specific_rule" in names
+
+    def test_malformed_override_file_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {"overrides": [{"name": "hardcoded_ip", "severity": "BAD_VALUE"}]}
+            )
+        )
+        with pytest.raises(ValidationError):
+            resolve_antipatterns(tmp_path)

--- a/tests/unit/validation/test_validator_base_kb_extension_omn11920.py
+++ b/tests/unit/validation/test_validator_base_kb_extension_omn11920.py
@@ -1,0 +1,611 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ValidatorBase KB-aware extension (OMN-11920).
+
+Covers acceptance criteria:
+- ValidatorBase.__init__ accepts optional antipattern_registry (default None, backward compatible)
+- _validate_file_against_kb_rules() returns tuple[ModelValidationIssue, ...]
+- Pattern matching for regex_line and grep_code entries
+- Suppression annotations from registry entries honored
+- No changes to existing validator subclasses (backward compat)
+- Every validation result records: antipattern_registry_version, antipattern_registry_hash,
+  rule_ids_applied, validator_version
+- Validation results reproducible given same registry version and input
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from omnibase_core.enums import EnumSeverity
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+from omnibase_core.validation.validator_base import ValidatorBase
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    name: str,
+    pattern: str,
+    pattern_type: str = "regex_line",
+    severity: str = "ERROR",
+    suppression_annotation: str = "antipattern-ok",
+    file_globs: tuple[str, ...] = ("*.py",),
+) -> ModelAntipatternEntry:
+    return ModelAntipatternEntry(
+        name=name,
+        severity=severity,  # type: ignore[arg-type]
+        enforcement="blocking",
+        category="code_quality",
+        pattern_type=pattern_type,  # type: ignore[arg-type]
+        pattern=pattern,
+        file_globs=file_globs,
+        suppression_annotation=suppression_annotation,
+        description=f"Test entry {name}",
+        rationale="Test rationale",
+        discovered_date="2026-01-01",  # type: ignore[arg-type]
+        source_ticket="OMN-11920",
+    )
+
+
+def _make_registry(
+    entries: tuple[ModelAntipatternEntry, ...] = (),
+    version: str = "1.0.0",
+) -> ModelAntipatternRegistry:
+    return ModelAntipatternRegistry(
+        version=version,
+        last_updated=datetime(2026, 5, 24, tzinfo=UTC),
+        entries=entries,
+    )
+
+
+def _make_contract() -> ModelValidatorSubcontract:
+    return ModelValidatorSubcontract(
+        version=ModelSemVer(major=1, minor=0, patch=0),
+        validator_id="test_kb_validator",
+        validator_name="Test KB Validator",
+        validator_description="Test",
+        target_patterns=["**/*.py"],
+        exclude_patterns=[],
+        suppression_comments=["# noqa:"],
+        fail_on_error=True,
+        fail_on_warning=False,
+        max_violations=0,
+        severity_default=EnumSeverity.ERROR,
+    )
+
+
+class ConcreteKBValidator(ValidatorBase):
+    """Minimal concrete subclass for testing KB extension."""
+
+    validator_id: ClassVar[str] = "concrete_kb_validator"
+
+    def _validate_file(
+        self,
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# Test: backward compatibility — no registry param
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorBaseKBBackwardCompat:
+    def test_init_without_registry_still_works(self) -> None:
+        contract = _make_contract()
+        validator = ConcreteKBValidator(contract=contract)
+        assert validator.antipattern_registry is None
+
+    def test_validate_file_against_kb_rules_with_no_registry_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        contract = _make_contract()
+        validator = ConcreteKBValidator(contract=contract)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+        result = validator._validate_file_against_kb_rules(target)
+        assert result == ()
+
+    def test_validate_runs_without_registry(self, tmp_path: Path) -> None:
+        contract = _make_contract()
+        validator = ConcreteKBValidator(contract=contract)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+        result = validator.validate(target)
+        assert result.is_valid
+
+
+# ---------------------------------------------------------------------------
+# Test: constructor accepts registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorBaseKBConstructor:
+    def test_init_with_registry_stores_it(self) -> None:
+        registry = _make_registry()
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+        assert validator.antipattern_registry is registry
+
+    def test_registry_is_none_by_default(self) -> None:
+        contract = _make_contract()
+        validator = ConcreteKBValidator(contract=contract)
+        assert validator.antipattern_registry is None
+
+
+# ---------------------------------------------------------------------------
+# Test: _validate_file_against_kb_rules — regex_line matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateFileAgainstKBRules:
+    def test_regex_line_match_returns_issue(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"hardcoded_secret\s*=",
+            pattern_type="regex_line",
+            severity="ERROR",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("hardcoded_secret = 'abc'\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].rule_name == "test_rule"
+        assert issues[0].severity == EnumSeverity.ERROR
+
+    def test_regex_line_no_match_returns_empty(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"hardcoded_secret\s*=",
+            pattern_type="regex_line",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert issues == ()
+
+    def test_grep_code_match_returns_issue(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="hardcoded_ip_rule",
+            pattern=r"\b192\.168\.\d+\.\d+\b",
+            pattern_type="grep_code",
+            severity="ERROR",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text('HOST = "192.168.1.100"\n')
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].rule_name == "hardcoded_ip_rule"
+
+    def test_multiple_matching_lines_produces_multiple_issues(
+        self, tmp_path: Path
+    ) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD_PATTERN",
+            pattern_type="regex_line",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("BAD_PATTERN = 1\nBAD_PATTERN = 2\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 2
+
+    def test_issue_has_correct_file_path_and_line_number(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("good\nBAD\ngood\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].line_number == 2
+        assert issues[0].file_path == target
+
+    def test_warning_severity_entry_maps_correctly(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="warn_rule",
+            pattern=r"WARNING_PATTERN",
+            pattern_type="regex_line",
+            severity="WARNING",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("WARNING_PATTERN\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].severity == EnumSeverity.WARNING
+
+    def test_info_severity_entry_maps_correctly(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="info_rule",
+            pattern=r"INFO_PATTERN",
+            pattern_type="regex_line",
+            severity="INFO",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("INFO_PATTERN\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].severity == EnumSeverity.INFO
+
+
+# ---------------------------------------------------------------------------
+# Test: file_globs filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateFileAgainstKBRulesGlobFiltering:
+    def test_entry_only_applies_to_matching_globs(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="py_only",
+            pattern=r"BAD",
+            pattern_type="grep_code",
+            file_globs=("*.py",),
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        # .yaml file should NOT be checked by this entry
+        target = tmp_path / "config.yaml"
+        target.write_text("BAD: value\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert issues == ()
+
+    def test_entry_applies_when_glob_matches(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="yaml_rule",
+            pattern=r"BAD",
+            pattern_type="grep_code",
+            file_globs=("*.yaml",),
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "config.yaml"
+        target.write_text("BAD: value\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: suppression annotations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateFileAgainstKBRulesSuppressionAnnotations:
+    def test_suppression_annotation_suppresses_issue(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+            suppression_annotation="antipattern-ok",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("BAD  # antipattern-ok\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert issues == ()
+
+    def test_suppression_only_applies_to_same_line(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+            suppression_annotation="antipattern-ok",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        # First line suppressed, second line not
+        target.write_text("BAD  # antipattern-ok\nBAD\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+        assert issues[0].line_number == 2
+
+    def test_different_suppression_annotation_does_not_suppress(
+        self, tmp_path: Path
+    ) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+            suppression_annotation="my-specific-ok",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        # Wrong suppression annotation — should NOT suppress
+        target.write_text("BAD  # antipattern-ok\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert len(issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: semantic entries are skipped (not applicable for regex matching)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateFileAgainstKBRulesSemanticSkip:
+    def test_semantic_entry_is_skipped(self, tmp_path: Path) -> None:
+        entry = ModelAntipatternEntry(
+            name="semantic_entry",
+            severity="ERROR",
+            enforcement="blocking",
+            category="architecture",
+            pattern_type="semantic",
+            pattern="some semantic description",
+            file_globs=("*.py",),
+            suppression_annotation="antipattern-ok",
+            description="Semantic test entry",
+            rationale="Test",
+            discovered_date="2026-01-01",  # type: ignore[arg-type]
+            source_ticket="OMN-11920",
+            vector_enabled=True,
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("some semantic description\n")
+
+        # Semantic entries require vector search — not applicable here
+        issues = validator._validate_file_against_kb_rules(target)
+        assert issues == ()
+
+    def test_ast_check_entry_is_skipped(self, tmp_path: Path) -> None:
+        # ast_check entries can't be run via regex — should be skipped
+        entry = ModelAntipatternEntry(
+            name="ast_entry",
+            severity="ERROR",
+            enforcement="blocking",
+            category="code_quality",
+            pattern_type="ast_check",
+            pattern="some_ast_identifier",
+            file_globs=("*.py",),
+            suppression_annotation="antipattern-ok",
+            description="AST test entry",
+            rationale="Test",
+            discovered_date="2026-01-01",  # type: ignore[arg-type]
+            source_ticket="OMN-11920",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+        validator = ConcreteKBValidator(
+            contract=contract, antipattern_registry=registry
+        )
+
+        target = tmp_path / "test.py"
+        target.write_text("some_ast_identifier\n")
+
+        issues = validator._validate_file_against_kb_rules(target)
+        assert issues == ()
+
+
+# ---------------------------------------------------------------------------
+# Test: result metadata fields (registry version, hash, rule_ids_applied)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorBaseKBResultMetadata:
+    def _make_validator_with_registry(
+        self, registry: ModelAntipatternRegistry
+    ) -> ConcreteKBValidator:
+        contract = _make_contract()
+        return ConcreteKBValidator(contract=contract, antipattern_registry=registry)
+
+    def test_result_metadata_contains_registry_version(self, tmp_path: Path) -> None:
+        registry = _make_registry(version="2.3.4")
+        validator = self._make_validator_with_registry(registry)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        result = validator.validate(target)
+        assert result.metadata is not None
+        assert result.metadata.model_extra is not None
+        assert (
+            result.metadata.model_extra.get("antipattern_registry_version") == "2.3.4"
+        )
+
+    def test_result_metadata_contains_registry_hash(self, tmp_path: Path) -> None:
+        registry = _make_registry(version="1.0.0")
+        validator = self._make_validator_with_registry(registry)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        result = validator.validate(target)
+        assert result.metadata is not None
+        assert result.metadata.model_extra is not None
+        registry_hash = result.metadata.model_extra.get("antipattern_registry_hash")
+        assert registry_hash is not None
+        assert isinstance(registry_hash, str)
+        assert len(registry_hash) == 64  # SHA-256 hex digest
+
+    def test_result_metadata_contains_rule_ids_applied(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+        )
+        registry = _make_registry(entries=(entry,))
+        validator = self._make_validator_with_registry(registry)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        result = validator.validate(target)
+        assert result.metadata is not None
+        assert result.metadata.model_extra is not None
+        rule_ids = result.metadata.model_extra.get("rule_ids_applied")
+        assert rule_ids is not None
+        assert "test_rule" in rule_ids
+
+    def test_result_without_registry_does_not_add_registry_fields(
+        self, tmp_path: Path
+    ) -> None:
+        contract = _make_contract()
+        validator = ConcreteKBValidator(contract=contract)
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        result = validator.validate(target)
+        assert result.metadata is not None
+        # Without registry, no antipattern metadata fields should be set
+        extra = result.metadata.model_extra or {}
+        assert "antipattern_registry_version" not in extra
+        assert "antipattern_registry_hash" not in extra
+
+    def test_registry_hash_is_deterministic(self, tmp_path: Path) -> None:
+        registry = _make_registry(version="1.0.0")
+        validator1 = self._make_validator_with_registry(registry)
+        validator2 = self._make_validator_with_registry(registry)
+
+        target = tmp_path / "test.py"
+        target.write_text("x = 1\n")
+
+        result1 = validator1.validate(target)
+        result2 = validator2.validate(target)
+
+        assert result1.metadata is not None
+        assert result2.metadata is not None
+        assert result1.metadata.model_extra is not None
+        assert result2.metadata.model_extra is not None
+        hash1 = result1.metadata.model_extra.get("antipattern_registry_hash")
+        hash2 = result2.metadata.model_extra.get("antipattern_registry_hash")
+        assert hash1 == hash2
+
+
+# ---------------------------------------------------------------------------
+# Test: reproducibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorBaseKBReproducibility:
+    def test_same_input_produces_same_issues(self, tmp_path: Path) -> None:
+        entry = _make_entry(
+            name="test_rule",
+            pattern=r"BAD",
+            pattern_type="regex_line",
+        )
+        registry = _make_registry(entries=(entry,))
+        contract = _make_contract()
+
+        target = tmp_path / "test.py"
+        target.write_text("BAD\nBAD\n")
+
+        v1 = ConcreteKBValidator(contract=contract, antipattern_registry=registry)
+        v2 = ConcreteKBValidator(contract=contract, antipattern_registry=registry)
+
+        issues1 = v1._validate_file_against_kb_rules(target)
+        issues2 = v2._validate_file_against_kb_rules(target)
+
+        assert len(issues1) == len(issues2)
+        for i1, i2 in zip(issues1, issues2, strict=True):
+            assert i1.rule_name == i2.rule_name
+            assert i1.line_number == i2.line_number
+            assert i1.severity == i2.severity


### PR DESCRIPTION
## Summary

Stacked on OMN-11912 (already merged to queue). Extends `ValidatorBase` with optional antipattern registry support.

- `ValidatorBase.__init__` gains optional `antipattern_registry: ModelAntipatternRegistry | None = None` — fully backward compatible, no changes to existing subclasses
- `_validate_file_against_kb_rules(path)` applies `regex_line`/`grep_code`/`regex_ast_docstring` entries from the registry line-by-line; `semantic` and `ast_check` entries are skipped; each entry's `suppression_annotation` and `file_globs` are honored
- `_build_result()` injects `antipattern_registry_version`, `antipattern_registry_hash` (SHA-256), and `rule_ids_applied` into `ModelValidationMetadata` extra fields when a registry is present — enables deterministic reproducibility tracking

## Test plan

- [x] 25 new unit tests in `tests/unit/validation/test_validator_base_kb_extension_omn11920.py`
- [x] 566 targeted tests pass (validator_base, antipattern loader, models) with zero regressions
- [x] Pre-commit hooks pass on all changed files
- [x] TDD-first: tests written and confirmed failing before implementation

## Ticket

OMN-11920

Evidence-Source: OCC#1551
Evidence-Ticket: OMN-11920