### PR TITLE
feat(OMN-11921): aislop validator KB integration

### DIFF
--- a/src/omnibase_core/contracts/antipattern_registry.yaml
+++ b/src/omnibase_core/contracts/antipattern_registry.yaml
@@ -1,0 +1,458 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX default antipattern registry (OMN-11911)
+# Merges the aislop rule set with architecture-level semantic antipatterns.
+# Per-repo overrides live at .onex/antipattern-overrides.yaml
+#
+# enforcement values:
+#   blocking     — merge gate; violations block PR merge
+#   advisory     — warning only; logged but not blocking
+#   informational — log/report mode only
+#
+# pattern_type values:
+#   regex_ast_docstring  — applied per-line inside AST-extracted docstrings
+#   regex_line           — applied per line outside docstrings
+#   grep_code            — applied per line across matched files
+#   ast_check            — named AST visitor check identifier
+#   semantic             — description used for vector-similarity search (vector_enabled required)
+
+version: "1.0.0"
+last_updated: "2026-05-24T00:00:00+00:00"
+
+entries:
+  # ── Migrated from aislop_default_rules.yaml ─────────────────────────────────
+
+  - name: sycophancy
+    severity: ERROR
+    enforcement: blocking
+    category: code_quality
+    pattern_type: regex_ast_docstring
+    pattern: >-
+      ^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to| I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,.
+      ]
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Sycophantic opener in a docstring (e.g. "Great, here is..."). LLMs frequently start generated docstrings
+      with affirmations.
+    rationale: >-
+      LLM-generated sycophantic openers pollute the codebase with filler text that conveys no information
+      and signals low-quality generation. They inflate cognitive load for human readers.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: rest_docstring
+    severity: ERROR
+    enforcement: blocking
+    category: code_quality
+    pattern_type: regex_ast_docstring
+    pattern: "^\\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\\b"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      reST-style docstring markers (:param:, :type:, :returns:, :rtype:, etc.). Google-style docstrings
+      are the project standard.
+    rationale: >-
+      The project standardizes on Google-style docstrings for consistency and readability. reST markers
+      are LLM default output — they indicate the docstring was generated without following project conventions.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: boilerplate_docstring
+    severity: WARNING
+    enforcement: advisory
+    category: code_quality
+    pattern_type: regex_ast_docstring
+    pattern: >-
+      ^\s*This\s+(module|class|function|method|file|script|node|handler|service)\s+(provides?|implements?|contains?|is\s+responsible\s+for|handles?|manages?|offers?)
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Boilerplate opener "This <thing> provides/implements/contains ...". Catches LLM-generated filler
+      that describes the obvious.
+    rationale: >-
+      Tautological docstrings ("This class provides...") add zero value — the name already says what it
+      is. They are a strong signal of LLM-generated filler and trained reviewers to skip docstrings entirely.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: md_separator
+    severity: WARNING
+    enforcement: advisory
+    category: code_quality
+    pattern_type: regex_ast_docstring
+    pattern: "={4,}"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Markdown-style separator (4+ = chars) inside a Python docstring. LLMs sometimes insert visual dividers
+      that have no meaning in docstrings.
+    rationale: >-
+      Python docstrings are not Markdown. Visual separators inside docstrings are LLM formatting artifacts
+      that render incorrectly in IDEs and documentation generators.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: step_narration
+    severity: WARNING
+    enforcement: advisory
+    category: code_quality
+    pattern_type: regex_line
+    pattern: "#\\s*Step\\s+\\d+\\s*[:\\-]"
+    file_globs: ["*.md"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      "# Step N:" or "## Step N:" headings in Markdown files. Python inline "# Step N:" comments are legitimate
+      and are NOT flagged.
+    rationale: >-
+      Numbered step headings in Markdown are LLM narration artifacts. Prose documentation should use descriptive
+      section headings, not enumerated step labels that imply a procedure.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: obvious_comment
+    severity: INFO
+    enforcement: informational
+    category: code_quality
+    pattern_type: regex_line
+    pattern: "#\\s*(TODO|FIXME|HACK|XXX|NOTE):\\s*$"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Self-evident inline comment with no content (e.g. "# TODO: "). Reported in INFO/report mode only;
+      not blocking by default.
+    rationale: >-
+      Empty TODO/FIXME tags are LLM placeholders that accumulate silently. They communicate intent to
+      fix something but provide no actionable information. Work should be tracked in Linear, not inline.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: hardcoded_ip
+    severity: ERROR
+    enforcement: blocking
+    category: security
+    pattern_type: grep_code
+    pattern: "\\b(?:192\\.168|10\\.0|172\\.(?:1[6-9]|2[0-9]|3[01]))\\.[0-9]+\\.[0-9]+\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml", "*.json"]
+    suppression_annotation: onex-allow-internal-ip
+    description: >-
+      Hardcoded private IP address. Use env vars or Infisical references. Annotate intentional exceptions
+      with # onex-allow-internal-ip.
+    rationale: >-
+      Hardcoded IPs are machine-specific and break portability across environments. They expose internal
+      network topology in source code. All addresses must come from env vars or Infisical.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: hardcoded_localhost
+    severity: ERROR
+    enforcement: blocking
+    category: security
+    pattern_type: grep_code
+    pattern: "\\b(localhost|127\\.0\\.0\\.1)\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml"]
+    suppression_annotation: onex-allow-internal-ip
+    description: >-
+      Hardcoded localhost/127.0.0.1 reference. Use env vars or service discovery.
+    rationale: >-
+      localhost references fail in containerized environments and CI. Service addresses must be resolved
+      via env vars or service discovery so the same code runs in dev, staging, and prod.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: hardcoded_port
+    severity: WARNING
+    enforcement: advisory
+    category: security
+    pattern_type: grep_code
+    pattern: ":\\b(5432|6379|9092|19092|8080|8085|8086|3000|5000)\\b"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Hardcoded well-known port number. Pull from env vars or contract config.
+    rationale: >-
+      Well-known port literals in source code are a portability and security risk. Port assignments change
+      across deployment environments; they must be externalized to env vars or contract config.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: hardcoded_topic
+    severity: ERROR
+    enforcement: blocking
+    category: architecture
+    pattern_type: grep_code
+    pattern: "\"onex\\.(cmd|evt)\\.[a-z_]+\\.[a-z_]+\\.v[0-9]+\""
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Hardcoded Kafka topic string. Topics must be read from contract.yaml via TopicBase or the contract
+      loader -- never inlined as literals.
+    rationale: >-
+      Hardcoded topic strings diverge from contract.yaml silently. The canonical topic source is the contract
+      YAML; any literal that bypasses it will survive a topic rename and cause invisible routing failures
+      at runtime.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: prohibited_env_pattern
+    severity: WARNING
+    enforcement: advisory
+    category: security
+    pattern_type: grep_code
+    pattern: "os\\.environ\\.get\\([\"'][A-Z_]+[\"'],\\s*[\"'][^\"']+[\"']\\)"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      os.environ.get() with a non-empty default silently masks misconfiguration. Use os.environ[key] to
+      fail fast, or an explicit None default.
+    rationale: >-
+      Silent fallback defaults hide misconfigured environments. When a required env var is missing the
+      code should raise immediately, not silently pick a wrong default that may look correct in tests.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: compat_shim
+    severity: WARNING
+    enforcement: advisory
+    category: architecture
+    pattern_type: grep_code
+    pattern: "(?:^|\\s)_[a-zA-Z][a-zA-Z0-9_]*\\s*=\\s*[a-zA-Z]"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Possible backwards-compatibility alias (underscore-prefixed re-export). Remove compat shims; callers
+      should import from the canonical path.
+    rationale: >-
+      Compat shims accumulate as invisible debt. They indicate the canonical path was renamed but callers
+      weren't updated — the shim delays that cleanup indefinitely and creates double-maintenance burden.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: empty_impl
+    severity: WARNING
+    enforcement: advisory
+    category: code_quality
+    pattern_type: grep_code
+    pattern: "^\\s*(pass|\\.\\.\\.)\\s*$"
+    file_globs: ["*.py"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Empty function or method body (pass / ...). Placeholder implementations must be completed before
+      merging; stubs accumulate as silent debt.
+    rationale: >-
+      Placeholder stubs pass type checks and tests while doing nothing. They accumulate in codebases and
+      block callers from trusting that a method is actually implemented.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  - name: todo_fixme
+    severity: INFO
+    enforcement: informational
+    category: code_quality
+    pattern_type: grep_code
+    pattern: "#\\s*(TODO|FIXME)\\b"
+    file_globs: ["*.py", "*.yaml", "*.yml"]
+    suppression_annotation: ai-slop-ok
+    description: >-
+      Unresolved TODO or FIXME comment. Track work in Linear, not inline. Reported at INFO; escalate per-repo
+      via override if required.
+    rationale: >-
+      Inline TODO/FIXME comments are invisible to project management tools. Work should be tracked in
+      Linear tickets so it can be prioritized, assigned, and verified — not buried in source files.
+    discovered_date: "2025-01-01"
+    source_ticket: OMN-11132
+    vector_enabled: false
+
+  # ── Architecture-level semantic antipatterns ─────────────────────────────────
+
+  - name: handler_imports_handler
+    severity: ERROR
+    enforcement: blocking
+    category: architecture
+    pattern_type: semantic
+    pattern: >-
+      A handler module directly imports or instantiates another handler class or handler module, creating
+      direct handler-to-handler coupling outside the event bus.
+    file_globs: ["*.py"]
+    suppression_annotation: antipattern-ok
+    description: >-
+      Handler imports another handler directly instead of communicating via the event bus.
+    rationale: >-
+      Handlers must be fully decoupled. Direct handler-to-handler imports create a hidden dependency graph
+      that bypasses the contract-declared event bus topology. This prevents independent deployment, versioning,
+      and testing of handlers.
+    examples:
+      - kind: bad
+        label: Direct handler import
+        code: |
+          from omnibase_core.handlers.handler_merge_sweep import NodeHandlerMergeSweep
+          class NodeHandlerX:
+              def handle(self, ...):
+                  NodeHandlerMergeSweep().handle(...)  # direct coupling
+      - kind: good
+        label: Event bus dispatch
+        code: |
+          class NodeHandlerX:
+              def handle(self, event_bus, ...):
+                  event_bus.publish(TopicBase.CMD_MERGE_SWEEP_V1.value, payload)
+    discovered_date: "2026-05-24"
+    source_ticket: OMN-11911
+    vector_enabled: true
+
+  - name: node_io_in_init
+    severity: ERROR
+    enforcement: blocking
+    category: architecture
+    pattern_type: semantic
+    pattern: >-
+      A node class performs I/O operations (file reads, network calls, database queries, subprocess execution)
+      inside its __init__ constructor instead of deferring to a handler method.
+    file_globs: ["*.py"]
+    suppression_annotation: antipattern-ok
+    description: >-
+      Node class contains I/O operations in __init__, violating the thin-node / handler-owns-logic rule.
+    rationale: >-
+      Node constructors must remain side-effect-free. I/O in __init__ makes nodes untestable without live
+      infrastructure, prevents dependency injection, and couples construction to execution. Handlers own
+      all logic including I/O; nodes are coordination shells.
+    examples:
+      - kind: bad
+        label: I/O in __init__
+        code: |
+          class NodeMyEffect:
+              def __init__(self, container):
+                  super().__init__(container)
+                  self.config = open("config.yaml").read()  # I/O in constructor
+      - kind: good
+        label: I/O deferred to handler
+        code: |
+          class NodeMyEffect:
+              def __init__(self, container):
+                  super().__init__(container)
+                  # no I/O here
+              def handle(self, ...):
+                  config = open("config.yaml").read()
+    discovered_date: "2026-05-24"
+    source_ticket: OMN-11911
+    vector_enabled: true
+
+  - name: contract_topic_not_in_enum
+    severity: ERROR
+    enforcement: blocking
+    category: architecture
+    pattern_type: semantic
+    pattern: >-
+      A contract.yaml declares a publish or subscribe topic whose string value does not correspond to
+      any entry in the TopicBase enum, meaning the topic is undeclared in the canonical enum registry.
+    file_globs: ["*.yaml", "*.yml"]
+    suppression_annotation: antipattern-ok
+    description: >-
+      contract.yaml declares a topic that has no corresponding TopicBase enum entry.
+    rationale: >-
+      Topics must be registered in TopicBase before they can be used in contracts. Undeclared topics bypass
+      the canonical naming registry, making them invisible to routing validation, contract diff tools,
+      and dead-topic detection. Register first, then use in contracts.
+    examples:
+      - kind: bad
+        label: Topic not in TopicBase
+        code: |
+          event_bus:
+            publish_topics:
+              - onex.cmd.myservice.do_thing.v1  # not in TopicBase enum
+      - kind: good
+        label: Topic registered in TopicBase first
+        code: |
+          # First add to TopicBase enum:
+          # CMD_MYSERVICE_DO_THING_V1 = onex.cmd.myservice.do_thing.v1
+          event_bus:
+            publish_topics:
+              - onex.cmd.myservice.do_thing.v1  # now in TopicBase
+    discovered_date: "2026-05-24"
+    source_ticket: OMN-11911
+    vector_enabled: true
+
+  - name: test_mocks_subject
+    severity: ERROR
+    enforcement: blocking
+    category: testing
+    pattern_type: semantic
+    pattern: >-
+      A test creates a mock or patch of the very class or function under test, meaning the test never
+      exercises the real implementation and cannot detect regressions in it.
+    file_globs: ["*.py"]
+    suppression_annotation: antipattern-ok
+    description: >-
+      Test mocks the thing it is testing, creating a vacuous test that cannot detect regressions.
+    rationale: >-
+      Mocking the subject under test produces a test that passes trivially because it never calls the
+      real code. This gives false coverage confidence and fails to catch bugs in the actual implementation.
+      Mock dependencies; test the real subject.
+    examples:
+      - kind: bad
+        label: Mock of subject under test
+        code: |
+          def test_my_handler():
+              with patch("my_module.MyHandler.handle") as mock_handle:
+                  mock_handle.return_value = "ok"
+                  assert MyHandler().handle(...) == "ok"  # tests the mock, not MyHandler
+      - kind: good
+        label: Real subject, mocked dependency
+        code: |
+          def test_my_handler(mock_event_bus):
+              handler = MyHandler(event_bus=mock_event_bus)
+              result = handler.handle(...)  # calls real MyHandler.handle
+              assert result == expected
+    discovered_date: "2026-05-24"
+    source_ticket: OMN-11911
+    vector_enabled: true
+
+  - name: orchestrator_returns_result
+    severity: ERROR
+    enforcement: blocking
+    category: architecture
+    pattern_type: semantic
+    pattern: >-
+      An ORCHESTRATOR node handler method returns a result payload or uses ModelHandlerOutput with a result
+      field set, violating the invariant that ORCHESTRATOR nodes emit events/intents and never return
+      typed results.
+    file_globs: ["*.py"]
+    suppression_annotation: antipattern-ok
+    description: >-
+      ORCHESTRATOR node handler returns a result, violating the four-node architecture invariant.
+    rationale: >-
+      The ONEX four-node architecture mandates that ORCHESTRATOR nodes emit events and intents only. Returning
+      a result from an ORCHESTRATOR collapses the distinction between coordination and computation, breaks
+      the unidirectional flow (EFFECT→COMPUTE→REDUCER→ORCHESTRATOR), and prevents the runtime from enforcing
+      node-kind output constraints.
+    examples:
+      - kind: bad
+        label: ORCHESTRATOR with result
+        code: |
+          class NodeMyOrchestrator:
+              kind = EnumNodeKind.ORCHESTRATOR
+              def handle(self, ...):
+                  return ModelHandlerOutput.for_orchestrator(result={"status": "ok"})  # ValueError!
+      - kind: good
+        label: ORCHESTRATOR with events only
+        code: |
+          class NodeMyOrchestrator:
+              kind = EnumNodeKind.ORCHESTRATOR
+              def handle(self, ...):
+                  return ModelHandlerOutput.for_orchestrator(events=[my_event])
+    discovered_date: "2026-05-24"
+    source_ticket: OMN-11911
+    vector_enabled: true

--- a/src/omnibase_core/models/validation/model_antipattern_entry.py
+++ b/src/omnibase_core/models/validation/model_antipattern_entry.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternEntry — single antipattern detection rule (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.validation.model_antipattern_example import (
+    ModelAntipatternExample,
+)
+
+
+class ModelAntipatternEntry(BaseModel):
+    """A single antipattern detection rule with enforcement metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Unique antipattern identifier")
+    severity: Literal["ERROR", "WARNING", "INFO"] = Field(
+        description="Violation severity"
+    )
+    enforcement: Literal["blocking", "advisory", "informational"] = Field(
+        description="Enforcement level: blocking=merge gate, advisory=warning, informational=log only"
+    )
+    category: Literal[
+        "code_quality", "architecture", "security", "performance", "naming", "testing"
+    ] = Field(description="Antipattern category")
+    pattern_type: Literal[
+        "regex_line", "regex_ast_docstring", "grep_code", "ast_check", "semantic"
+    ] = Field(description="How the pattern is matched")
+    pattern: str = Field(
+        description="Regex string, AST check identifier, or semantic description"
+    )
+    file_globs: tuple[str, ...] = Field(
+        default=("*.py",),
+        description="File glob patterns this entry applies to",
+    )
+    suppression_annotation: str = Field(
+        default="antipattern-ok",
+        description="Inline comment suffix that suppresses this entry",
+    )
+    description: str = Field(description="Human-readable explanation")
+    rationale: str = Field(description="Why this is an antipattern")
+    examples: tuple[ModelAntipatternExample, ...] = Field(
+        default=(),
+        description="Good and bad code snippet examples",
+    )
+    discovered_date: date = Field(
+        description="Date this antipattern was added to the registry"
+    )
+    source_ticket: str = Field(
+        description="Linear ticket that introduced this entry, e.g. OMN-XXXX"
+    )
+    vector_enabled: bool = Field(
+        default=False,
+        description="Whether this entry participates in vector-similarity search",
+    )
+
+    @model_validator(mode="after")
+    def _validate_semantic_requires_vector_enabled(self) -> ModelAntipatternEntry:
+        """semantic pattern_type entries must have vector_enabled=True."""
+        if self.pattern_type == "semantic" and not self.vector_enabled:
+            raise ValueError("pattern_type='semantic' requires vector_enabled=True")
+        return self
+
+
+__all__ = ["ModelAntipatternEntry"]

--- a/src/omnibase_core/models/validation/model_antipattern_entry_override.py
+++ b/src/omnibase_core/models/validation/model_antipattern_entry_override.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternEntryOverride — per-repo override for a single antipattern entry (OMN-11912)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAntipatternEntryOverride(BaseModel):
+    """A per-repo override for an existing antipattern entry."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Antipattern name to override")
+    severity: Literal["ERROR", "WARNING", "INFO"] | None = Field(
+        default=None, description="Override severity (None = keep default)"
+    )
+    enforcement: Literal["blocking", "advisory", "informational"] | None = Field(
+        default=None, description="Override enforcement level (None = keep default)"
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description="Set False to disable this antipattern for the repo (None = keep default)",
+    )
+    file_globs: list[str] | None = Field(
+        default=None, description="Override file globs (None = keep default)"
+    )
+
+
+__all__ = ["ModelAntipatternEntryOverride"]

--- a/src/omnibase_core/models/validation/model_antipattern_example.py
+++ b/src/omnibase_core/models/validation/model_antipattern_example.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternExample — good or bad code snippet for an antipattern (OMN-11910)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelAntipatternExample(BaseModel):
+    """A good or bad code snippet illustrating an antipattern."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: Literal["good", "bad"] = Field(
+        description="Whether this is a good or bad example"
+    )
+    code: str = Field(description="Code snippet")
+    label: str = Field(description="Short label for the example")
+
+
+__all__ = ["ModelAntipatternExample"]

--- a/src/omnibase_core/models/validation/model_antipattern_override_config.py
+++ b/src/omnibase_core/models/validation/model_antipattern_override_config.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternOverrideConfig — per-repo antipattern override config (OMN-11912)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_entry_override import (
+    ModelAntipatternEntryOverride,
+)
+
+
+class ModelAntipatternOverrideConfig(BaseModel):
+    """Per-repo antipattern configuration read from .onex/antipattern-overrides.yaml."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    overrides: list[ModelAntipatternEntryOverride] = Field(
+        default_factory=list,
+        description="Field-level overrides for existing antipattern entries",
+    )
+    custom_entries: list[ModelAntipatternEntry] = Field(
+        default_factory=list,
+        description="New antipattern entries to append to the registry",
+    )
+
+
+__all__ = ["ModelAntipatternOverrideConfig"]

--- a/src/omnibase_core/models/validation/model_antipattern_registry.py
+++ b/src/omnibase_core/models/validation/model_antipattern_registry.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelAntipatternRegistry — versioned collection of antipattern entries (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+
+
+class ModelAntipatternRegistry(BaseModel):
+    """Versioned registry of antipattern detection entries."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    version: str = Field(description="Registry schema version, e.g. '1.0.0'")
+    last_updated: datetime = Field(description="Timestamp of the last registry update")
+    entries: tuple[ModelAntipatternEntry, ...] = Field(
+        default=(),
+        description="All antipattern entries in this registry",
+    )
+
+
+__all__ = ["ModelAntipatternRegistry"]

--- a/src/omnibase_core/validation/aislop_rule_loader.py
+++ b/src/omnibase_core/validation/aislop_rule_loader.py
@@ -22,9 +22,17 @@ from omnibase_core.models.validation.model_aislop_rule_override import (
     ModelAislopRuleOverride,
 )
 from omnibase_core.models.validation.model_aislop_rule_set import ModelAislopRuleSet
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
 
 _CONTRACTS_PKG = "omnibase_core.contracts"
 _DEFAULT_YAML = "aislop_default_rules.yaml"
+
+# pattern_type values from ModelAntipatternEntry that map directly to ModelAislopRule
+_AISLOP_COMPATIBLE_PATTERN_TYPES = frozenset(
+    {"regex_line", "regex_ast_docstring", "grep_code", "ast_check"}
+)
 
 
 def load_default_rules() -> ModelAislopRuleSet:
@@ -129,9 +137,67 @@ def resolve_rules(repo_root: Path) -> ModelAislopRuleSet:
     return merge_rules(defaults, config)
 
 
+def resolve_rules_from_registry(
+    registry: ModelAntipatternRegistry,
+) -> ModelAislopRuleSet:
+    """Convert compatible antipattern registry entries to a ModelAislopRuleSet.
+
+    Filters to entries whose pattern_type is in _AISLOP_COMPATIBLE_PATTERN_TYPES
+    (excludes 'semantic' entries which require vector search). Each matching entry
+    is converted field-by-field into a ModelAislopRule.
+    """
+    rules: list[ModelAislopRule] = []
+    for entry in registry.entries:
+        if entry.pattern_type not in _AISLOP_COMPATIBLE_PATTERN_TYPES:
+            continue
+        rules.append(
+            ModelAislopRule(
+                name=entry.name,
+                severity=entry.severity,
+                enabled=True,
+                pattern_type=entry.pattern_type,  # type: ignore[arg-type]  # NOTE(OMN-11921): ModelAntipatternEntry pattern_type is a wider Literal that includes "semantic"; we guard above but mypy cannot narrow frozenset membership to Literal
+                pattern=entry.pattern,
+                file_globs=list(entry.file_globs),
+                suppression_annotation=entry.suppression_annotation,
+                description=entry.description,
+            )
+        )
+    return ModelAislopRuleSet(rules=rules)
+
+
+def resolve_rules_unified(repo_root: Path) -> ModelAislopRuleSet:
+    """Merge legacy aislop defaults and antipattern registry into one rule set.
+
+    Resolution order:
+      1. Load legacy aislop defaults (aislop_default_rules.yaml)
+      2. Load registry rules (antipattern_registry.yaml, filtered to compatible types)
+      3. Build merged list: start with registry rules, then append legacy rules whose
+         name does not appear in the registry (registry wins on duplicate names).
+    """
+    from omnibase_core.validation.antipattern_registry_loader import (
+        load_default_antipatterns,
+    )
+
+    legacy = load_default_rules()
+    registry = load_default_antipatterns()
+    registry_rules = resolve_rules_from_registry(registry)
+
+    registry_names = {r.name for r in registry_rules.rules}
+
+    # Registry rules first; legacy rules added only when not already covered
+    merged: list[ModelAislopRule] = list(registry_rules.rules)
+    for rule in legacy.rules:
+        if rule.name not in registry_names:
+            merged.append(rule)
+
+    return ModelAislopRuleSet(rules=merged)
+
+
 __all__ = [
     "load_default_rules",
     "load_repo_config",
     "merge_rules",
     "resolve_rules",
+    "resolve_rules_from_registry",
+    "resolve_rules_unified",
 ]

--- a/src/omnibase_core/validation/antipattern_registry_loader.py
+++ b/src/omnibase_core/validation/antipattern_registry_loader.py
@@ -1,24 +1,26 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Antipattern registry loader: resolves effective registry for a repo (OMN-11911).
+"""Antipattern registry loader: resolves effective registry for a repo (OMN-11912).
 
 Resolution order:
   1. Load bundled defaults from contracts/antipattern_registry.yaml
   2. Load optional per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml
-  3. Merge: apply field overrides then append custom_entries
+  3. Merge: apply field overrides (including disable) then append custom_entries
 """
 
 from __future__ import annotations
 
 import importlib.resources
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 from omnibase_core.models.validation.model_antipattern_entry import (
     ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
 )
 from omnibase_core.models.validation.model_antipattern_registry import (
     ModelAntipatternRegistry,
@@ -29,7 +31,7 @@ _DEFAULT_YAML = "antipattern_registry.yaml"
 _OVERRIDES_PATH = ".onex/antipattern-overrides.yaml"
 
 
-def load_default_registry() -> ModelAntipatternRegistry:
+def load_default_antipatterns() -> ModelAntipatternRegistry:
     """Return the bundled default antipattern registry.
 
     Reads from omnibase_core/contracts/antipattern_registry.yaml via
@@ -51,38 +53,43 @@ def load_default_registry() -> ModelAntipatternRegistry:
     return ModelAntipatternRegistry.model_validate(data)
 
 
-def _load_overrides(repo_root: Path) -> dict[str, Any] | None:
+# Keep legacy name as an alias so existing callers (OMN-11911 tests) continue to work
+load_default_registry = load_default_antipatterns
+
+
+def load_repo_overrides(repo_root: Path) -> ModelAntipatternOverrideConfig | None:
     """Load per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml.
 
     Returns None if the file does not exist.
+    Raises ValidationError if the file exists but is malformed.
     """
     config_path = repo_root / _OVERRIDES_PATH
     if not config_path.exists():
         return None
-    return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    return ModelAntipatternOverrideConfig.model_validate(data)
 
 
-def _merge_registry(
+def merge_antipatterns(
     defaults: ModelAntipatternRegistry,
-    overrides_data: dict[str, Any] | None,
+    overrides: ModelAntipatternOverrideConfig | None,
 ) -> ModelAntipatternRegistry:
     """Apply per-repo overrides and custom entries on top of defaults.
 
     Override semantics (mirrors aislop_rule_loader.merge_rules):
     - Override fields that are None → keep the default value.
+    - enabled=False → entry is excluded from the merged registry.
     - Unknown name → ValueError (prevents silent typos).
     - custom_entries are appended after merging overrides.
     """
-    if overrides_data is None:
+    if overrides is None:
         return defaults
-
-    override_list: list[dict[str, Any]] = overrides_data.get("overrides", [])
-    custom_list: list[dict[str, Any]] = overrides_data.get("custom_entries", [])
 
     default_by_name: dict[str, ModelAntipatternEntry] = {
         e.name: e for e in defaults.entries
     }
-    override_by_name: dict[str, dict[str, Any]] = {o["name"]: o for o in override_list}
+
+    override_by_name = {o.name: o for o in overrides.overrides}
 
     # Validate all override names reference known entries
     for name in override_by_name:
@@ -92,23 +99,27 @@ def _merge_registry(
                 f"Unknown antipattern name '{name}' in overrides. Known: {known}"
             )
 
-    # Apply field overrides
+    # Apply field overrides; entries with enabled=False are dropped
     merged: list[ModelAntipatternEntry] = []
     for entry in defaults.entries:
         ov = override_by_name.get(entry.name)
         if ov is None:
             merged.append(entry)
             continue
-        # Rebuild entry with overridden fields; None values keep the default
+        if ov.enabled is False:
+            continue
         base = entry.model_dump()
-        for field in ("severity", "enforcement", "file_globs"):
-            if ov.get(field) is not None:
-                base[field] = ov[field]
+        if ov.severity is not None:
+            base["severity"] = ov.severity
+        if ov.enforcement is not None:
+            base["enforcement"] = ov.enforcement
+        if ov.file_globs is not None:
+            base["file_globs"] = ov.file_globs
         merged.append(ModelAntipatternEntry.model_validate(base))
 
     # Append custom entries
-    for raw in custom_list:
-        merged.append(ModelAntipatternEntry.model_validate(raw))
+    for custom in overrides.custom_entries:
+        merged.append(custom)
 
     return ModelAntipatternRegistry(
         version=defaults.version,
@@ -119,12 +130,15 @@ def _merge_registry(
 
 def resolve_antipatterns(repo_root: Path) -> ModelAntipatternRegistry:
     """Full resolution pipeline: defaults → per-repo overrides → merged result."""
-    defaults = load_default_registry()
-    overrides_data = _load_overrides(repo_root)
-    return _merge_registry(defaults, overrides_data)
+    defaults = load_default_antipatterns()
+    overrides = load_repo_overrides(repo_root)
+    return merge_antipatterns(defaults, overrides)
 
 
 __all__ = [
+    "load_default_antipatterns",
     "load_default_registry",
+    "load_repo_overrides",
+    "merge_antipatterns",
     "resolve_antipatterns",
 ]

--- a/src/omnibase_core/validation/antipattern_registry_loader.py
+++ b/src/omnibase_core/validation/antipattern_registry_loader.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Antipattern registry loader: resolves effective registry for a repo (OMN-11911).
+
+Resolution order:
+  1. Load bundled defaults from contracts/antipattern_registry.yaml
+  2. Load optional per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml
+  3. Merge: apply field overrides then append custom_entries
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+
+_CONTRACTS_PKG = "omnibase_core.contracts"
+_DEFAULT_YAML = "antipattern_registry.yaml"
+_OVERRIDES_PATH = ".onex/antipattern-overrides.yaml"
+
+
+def load_default_registry() -> ModelAntipatternRegistry:
+    """Return the bundled default antipattern registry.
+
+    Reads from omnibase_core/contracts/antipattern_registry.yaml via
+    importlib.resources so it works both in dev and in installed wheels.
+    """
+    try:
+        ref = importlib.resources.files(_CONTRACTS_PKG) / _DEFAULT_YAML
+        raw = ref.read_text(encoding="utf-8")
+    except (FileNotFoundError, TypeError) as exc:
+        fallback = Path(__file__).parent.parent / "contracts" / _DEFAULT_YAML
+        if fallback.exists():
+            raw = fallback.read_text(encoding="utf-8")
+        else:
+            raise FileNotFoundError(  # error-ok: bundled YAML missing — fatal config error
+                f"Cannot locate {_DEFAULT_YAML}; tried importlib.resources and {fallback}"
+            ) from exc
+
+    data = yaml.safe_load(raw)
+    return ModelAntipatternRegistry.model_validate(data)
+
+
+def _load_overrides(repo_root: Path) -> dict[str, Any] | None:
+    """Load per-repo overrides from <repo_root>/.onex/antipattern-overrides.yaml.
+
+    Returns None if the file does not exist.
+    """
+    config_path = repo_root / _OVERRIDES_PATH
+    if not config_path.exists():
+        return None
+    return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+
+
+def _merge_registry(
+    defaults: ModelAntipatternRegistry,
+    overrides_data: dict[str, Any] | None,
+) -> ModelAntipatternRegistry:
+    """Apply per-repo overrides and custom entries on top of defaults.
+
+    Override semantics (mirrors aislop_rule_loader.merge_rules):
+    - Override fields that are None → keep the default value.
+    - Unknown name → ValueError (prevents silent typos).
+    - custom_entries are appended after merging overrides.
+    """
+    if overrides_data is None:
+        return defaults
+
+    override_list: list[dict[str, Any]] = overrides_data.get("overrides", [])
+    custom_list: list[dict[str, Any]] = overrides_data.get("custom_entries", [])
+
+    default_by_name: dict[str, ModelAntipatternEntry] = {
+        e.name: e for e in defaults.entries
+    }
+    override_by_name: dict[str, dict[str, Any]] = {o["name"]: o for o in override_list}
+
+    # Validate all override names reference known entries
+    for name in override_by_name:
+        if name not in default_by_name:
+            known = sorted(default_by_name)
+            raise ValueError(
+                f"Unknown antipattern name '{name}' in overrides. Known: {known}"
+            )
+
+    # Apply field overrides
+    merged: list[ModelAntipatternEntry] = []
+    for entry in defaults.entries:
+        ov = override_by_name.get(entry.name)
+        if ov is None:
+            merged.append(entry)
+            continue
+        # Rebuild entry with overridden fields; None values keep the default
+        base = entry.model_dump()
+        for field in ("severity", "enforcement", "file_globs"):
+            if ov.get(field) is not None:
+                base[field] = ov[field]
+        merged.append(ModelAntipatternEntry.model_validate(base))
+
+    # Append custom entries
+    for raw in custom_list:
+        merged.append(ModelAntipatternEntry.model_validate(raw))
+
+    return ModelAntipatternRegistry(
+        version=defaults.version,
+        last_updated=defaults.last_updated,
+        entries=tuple(merged),
+    )
+
+
+def resolve_antipatterns(repo_root: Path) -> ModelAntipatternRegistry:
+    """Full resolution pipeline: defaults → per-repo overrides → merged result."""
+    defaults = load_default_registry()
+    overrides_data = _load_overrides(repo_root)
+    return _merge_registry(defaults, overrides_data)
+
+
+__all__ = [
+    "load_default_registry",
+    "resolve_antipatterns",
+]

--- a/tests/unit/models/validation/test_model_antipattern_registry.py
+++ b/tests/unit/models/validation/test_model_antipattern_registry.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelAntipatternEntry and ModelAntipatternRegistry (OMN-11910)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_antipattern_entry import (
+    ModelAntipatternEntry,
+)
+from omnibase_core.models.validation.model_antipattern_example import (
+    ModelAntipatternExample,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+
+
+def _make_entry(**overrides: object) -> ModelAntipatternEntry:
+    defaults: dict[str, object] = {
+        "name": "no_bare_except",
+        "severity": "ERROR",
+        "enforcement": "blocking",
+        "category": "code_quality",
+        "pattern_type": "regex_line",
+        "pattern": r"except\s*:",
+        "file_globs": ("*.py",),
+        "suppression_annotation": "antipattern-ok",
+        "description": "Bare except clauses swallow all exceptions",
+        "rationale": "Masks errors and makes debugging impossible",
+        "examples": (),
+        "discovered_date": date(2025, 1, 15),
+        "source_ticket": "OMN-11910",
+        "vector_enabled": False,
+    }
+    defaults.update(overrides)
+    return ModelAntipatternEntry(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelAntipatternExample:
+    def test_basic_example(self) -> None:
+        ex = ModelAntipatternExample(
+            kind="bad",
+            code="except:\n    pass",
+            label="Bare except",
+        )
+        assert ex.kind == "bad"
+        assert ex.label == "Bare except"
+
+    def test_kind_literal_validation(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelAntipatternExample(
+                kind="unknown",  # type: ignore[arg-type]
+                code="x",
+                label="bad kind",
+            )
+
+    def test_example_roundtrip(self) -> None:
+        ex = ModelAntipatternExample(
+            kind="good", code="except ValueError:\n    pass", label="Typed except"
+        )
+        assert ModelAntipatternExample.model_validate(ex.model_dump()) == ex
+
+
+@pytest.mark.unit
+class TestModelAntipatternEntry:
+    def test_minimal_entry(self) -> None:
+        entry = _make_entry()
+        assert entry.name == "no_bare_except"
+        assert entry.severity == "ERROR"
+        assert entry.enforcement == "blocking"
+        assert entry.category == "code_quality"
+        assert entry.pattern_type == "regex_line"
+        assert entry.vector_enabled is False
+        assert isinstance(entry.file_globs, tuple)
+        assert isinstance(entry.examples, tuple)
+
+    def test_invalid_severity_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(severity="FATAL")  # type: ignore[arg-type]
+
+    def test_invalid_enforcement_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(enforcement="required")  # type: ignore[arg-type]
+
+    def test_invalid_category_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(category="style")  # type: ignore[arg-type]
+
+    def test_invalid_pattern_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(pattern_type="unknown")  # type: ignore[arg-type]
+
+    def test_semantic_pattern_type_requires_vector_enabled(self) -> None:
+        """pattern_type=semantic must have vector_enabled=True."""
+        with pytest.raises(ValidationError, match="vector_enabled"):
+            _make_entry(pattern_type="semantic", vector_enabled=False)
+
+    def test_semantic_pattern_type_with_vector_enabled_passes(self) -> None:
+        entry = _make_entry(pattern_type="semantic", vector_enabled=True)
+        assert entry.pattern_type == "semantic"
+        assert entry.vector_enabled is True
+
+    def test_semantic_defaults_to_advisory(self) -> None:
+        """Semantic antipatterns default to enforcement=advisory."""
+        entry = _make_entry(
+            pattern_type="semantic", vector_enabled=True, enforcement="advisory"
+        )
+        assert entry.enforcement == "advisory"
+
+    def test_entry_is_frozen(self) -> None:
+        entry = _make_entry()
+        with pytest.raises(Exception):
+            entry.name = "changed"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_entry(unknown_field="x")  # type: ignore[call-arg]
+
+    def test_entry_dict_roundtrip(self) -> None:
+        entry = _make_entry()
+        restored = ModelAntipatternEntry.model_validate(entry.model_dump())
+        assert restored == entry
+
+    def test_entry_yaml_roundtrip(self) -> None:
+        entry = _make_entry()
+        data = entry.model_dump(mode="json")
+        yaml_str = yaml.dump(data, default_flow_style=False)
+        restored_data = yaml.safe_load(yaml_str)
+        restored = ModelAntipatternEntry.model_validate(restored_data)
+        assert restored == entry
+
+    def test_entry_with_examples(self) -> None:
+        examples = (
+            ModelAntipatternExample(kind="bad", code="except:\n    pass", label="Bare"),
+            ModelAntipatternExample(
+                kind="good", code="except ValueError:\n    pass", label="Typed"
+            ),
+        )
+        entry = _make_entry(examples=examples)
+        assert len(entry.examples) == 2
+        assert entry.examples[0].kind == "bad"
+
+    def test_source_ticket_format(self) -> None:
+        entry = _make_entry(source_ticket="OMN-99999")
+        assert entry.source_ticket == "OMN-99999"
+
+
+@pytest.mark.unit
+class TestModelAntipatternRegistry:
+    def _make_registry(self, **overrides: object) -> ModelAntipatternRegistry:
+        defaults: dict[str, object] = {
+            "version": "1.0.0",
+            "last_updated": datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC),
+            "entries": (_make_entry(),),
+        }
+        defaults.update(overrides)
+        return ModelAntipatternRegistry(**defaults)  # type: ignore[arg-type]
+
+    def test_basic_registry(self) -> None:
+        reg = self._make_registry()
+        assert reg.version == "1.0.0"
+        assert len(reg.entries) == 1
+        assert isinstance(reg.entries, tuple)
+
+    def test_registry_is_frozen(self) -> None:
+        reg = self._make_registry()
+        with pytest.raises(Exception):
+            reg.version = "2.0.0"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_registry(unknown="x")  # type: ignore[call-arg]
+
+    def test_empty_entries(self) -> None:
+        reg = self._make_registry(entries=())
+        assert len(reg.entries) == 0
+
+    def test_multiple_entries(self) -> None:
+        entries = (
+            _make_entry(name="rule_a"),
+            _make_entry(name="rule_b"),
+        )
+        reg = self._make_registry(entries=entries)
+        assert len(reg.entries) == 2
+
+    def test_registry_dict_roundtrip(self) -> None:
+        reg = self._make_registry()
+        restored = ModelAntipatternRegistry.model_validate(reg.model_dump())
+        assert restored == reg
+
+    def test_registry_yaml_roundtrip(self) -> None:
+        reg = self._make_registry()
+        data = reg.model_dump(mode="json")
+        yaml_str = yaml.dump(data, default_flow_style=False)
+        restored_data = yaml.safe_load(yaml_str)
+        restored = ModelAntipatternRegistry.model_validate(restored_data)
+        assert restored == reg

--- a/tests/unit/validation/test_aislop_kb_integration_omn11921.py
+++ b/tests/unit/validation/test_aislop_kb_integration_omn11921.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TDD tests for OMN-11921: aislop validator KB integration.
+
+Covers:
+- resolve_rules_from_registry(): filters registry to regex/grep/ast types, converts to ModelAislopRule
+- resolve_rules_unified(): merges legacy aislop defaults + registry; registry wins on duplicate name
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.models.validation.model_aislop_rule import ModelAislopRule
+from omnibase_core.models.validation.model_aislop_rule_set import ModelAislopRuleSet
+from omnibase_core.validation.aislop_rule_loader import (
+    load_default_rules,
+    resolve_rules_from_registry,
+    resolve_rules_unified,
+)
+from omnibase_core.validation.antipattern_registry_loader import (
+    load_default_antipatterns,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_rules_from_registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveRulesFromRegistry:
+    def test_returns_rule_set(self) -> None:
+        registry = load_default_antipatterns()
+        result = resolve_rules_from_registry(registry)
+        assert isinstance(result, ModelAislopRuleSet)
+
+    def test_all_rules_are_model_aislop_rule(self) -> None:
+        registry = load_default_antipatterns()
+        result = resolve_rules_from_registry(registry)
+        for rule in result.rules:
+            assert isinstance(rule, ModelAislopRule)
+
+    def test_excludes_semantic_entries(self) -> None:
+        registry = load_default_antipatterns()
+        semantic_names = {
+            e.name for e in registry.entries if e.pattern_type == "semantic"
+        }
+        result = resolve_rules_from_registry(registry)
+        rule_names = {r.name for r in result.rules}
+        assert not semantic_names.intersection(rule_names), (
+            f"Semantic entries must be excluded: {semantic_names.intersection(rule_names)}"
+        )
+
+    def test_includes_regex_line_entries(self) -> None:
+        registry = load_default_antipatterns()
+        regex_names = {
+            e.name for e in registry.entries if e.pattern_type == "regex_line"
+        }
+        result = resolve_rules_from_registry(registry)
+        rule_names = {r.name for r in result.rules}
+        assert regex_names.issubset(rule_names), (
+            f"regex_line entries missing: {regex_names - rule_names}"
+        )
+
+    def test_includes_grep_code_entries(self) -> None:
+        registry = load_default_antipatterns()
+        grep_names = {e.name for e in registry.entries if e.pattern_type == "grep_code"}
+        result = resolve_rules_from_registry(registry)
+        rule_names = {r.name for r in result.rules}
+        assert grep_names.issubset(rule_names), (
+            f"grep_code entries missing: {grep_names - rule_names}"
+        )
+
+    def test_includes_ast_check_entries(self) -> None:
+        registry = load_default_antipatterns()
+        ast_names = {e.name for e in registry.entries if e.pattern_type == "ast_check"}
+        result = resolve_rules_from_registry(registry)
+        rule_names = {r.name for r in result.rules}
+        assert ast_names.issubset(rule_names)
+
+    def test_converted_rule_fields_match_entry(self) -> None:
+        registry = load_default_antipatterns()
+        # Find one regex_line or grep_code entry to verify field mapping
+        entry = next(
+            (
+                e
+                for e in registry.entries
+                if e.pattern_type in ("regex_line", "grep_code")
+            ),
+            None,
+        )
+        assert entry is not None, "Expected at least one regex_line or grep_code entry"
+
+        result = resolve_rules_from_registry(registry)
+        rule = next((r for r in result.rules if r.name == entry.name), None)
+        assert rule is not None
+        assert rule.name == entry.name
+        assert rule.severity == entry.severity
+        assert rule.pattern == entry.pattern
+        assert rule.pattern_type == entry.pattern_type
+        assert rule.description == entry.description
+
+    def test_file_globs_preserved(self) -> None:
+        registry = load_default_antipatterns()
+        entry = next(
+            (
+                e
+                for e in registry.entries
+                if e.pattern_type in ("regex_line", "grep_code")
+            ),
+            None,
+        )
+        assert entry is not None
+        result = resolve_rules_from_registry(registry)
+        rule = next(r for r in result.rules if r.name == entry.name)
+        assert list(rule.file_globs) == list(entry.file_globs)
+
+    def test_empty_registry_returns_empty_rule_set(self) -> None:
+        from datetime import datetime
+
+        from omnibase_core.models.validation.model_antipattern_registry import (
+            ModelAntipatternRegistry,
+        )
+
+        empty = ModelAntipatternRegistry(
+            version="0.0.0",
+            last_updated=datetime(2026, 1, 1),
+            entries=(),
+        )
+        result = resolve_rules_from_registry(empty)
+        assert result.rules == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules_unified
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveRulesUnified:
+    def test_returns_rule_set(self, tmp_path: Path) -> None:
+        result = resolve_rules_unified(tmp_path)
+        assert isinstance(result, ModelAislopRuleSet)
+
+    def test_contains_legacy_rules(self, tmp_path: Path) -> None:
+        defaults = load_default_rules()
+        result = resolve_rules_unified(tmp_path)
+        result_names = {r.name for r in result.rules}
+        for rule in defaults.rules:
+            assert rule.name in result_names, (
+                f"Legacy rule '{rule.name}' missing from unified"
+            )
+
+    def test_contains_registry_rules(self, tmp_path: Path) -> None:
+        registry = load_default_antipatterns()
+        registry_rules = resolve_rules_from_registry(registry)
+        result = resolve_rules_unified(tmp_path)
+        result_names = {r.name for r in result.rules}
+        for rule in registry_rules.rules:
+            assert rule.name in result_names, (
+                f"Registry rule '{rule.name}' missing from unified"
+            )
+
+    def test_no_duplicate_names(self, tmp_path: Path) -> None:
+        result = resolve_rules_unified(tmp_path)
+        names = [r.name for r in result.rules]
+        assert len(names) == len(set(names)), (
+            f"Duplicate rule names: {[n for n in names if names.count(n) > 1]}"
+        )
+
+    def test_registry_wins_on_duplicate_name(self, tmp_path: Path) -> None:
+        """When a name exists in both legacy defaults and registry, registry version wins."""
+        # sycophancy exists in both legacy aislop defaults and antipattern_registry.yaml
+        registry = load_default_antipatterns()
+        registry_entry = next(
+            (e for e in registry.entries if e.name == "sycophancy"), None
+        )
+        if registry_entry is None:
+            pytest.skip("sycophancy not in registry; cannot test duplicate resolution")
+
+        legacy_defaults = load_default_rules()
+        legacy_rule = next(
+            (r for r in legacy_defaults.rules if r.name == "sycophancy"), None
+        )
+        if legacy_rule is None:
+            pytest.skip(
+                "sycophancy not in legacy defaults; cannot test duplicate resolution"
+            )
+
+        result = resolve_rules_unified(tmp_path)
+        unified_rule = next(r for r in result.rules if r.name == "sycophancy")
+
+        # The registry version should win — verify at least one field differs or is registry-sourced
+        # We prove registry wins by checking the rule matches the registry entry, not the legacy rule
+        assert unified_rule.pattern == registry_entry.pattern, (
+            "registry version should win on duplicate name 'sycophancy'"
+        )
+
+    def test_additive_no_existing_config(self, tmp_path: Path) -> None:
+        """Without per-repo config, unified should contain all legacy + all registry rules (minus duplicates)."""
+        defaults = load_default_rules()
+        registry = load_default_antipatterns()
+        registry_rules = resolve_rules_from_registry(registry)
+
+        all_names = {r.name for r in defaults.rules} | {
+            r.name for r in registry_rules.rules
+        }
+        result = resolve_rules_unified(tmp_path)
+        result_names = {r.name for r in result.rules}
+
+        assert all_names == result_names, (
+            f"Unified missing names: {all_names - result_names}"
+        )
+
+    def test_result_rules_are_all_model_aislop_rule(self, tmp_path: Path) -> None:
+        result = resolve_rules_unified(tmp_path)
+        for rule in result.rules:
+            assert isinstance(rule, ModelAislopRule)

--- a/tests/unit/validation/test_antipattern_registry_loader.py
+++ b/tests/unit/validation/test_antipattern_registry_loader.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for antipattern_registry_loader and default antipattern_registry.yaml (OMN-11911)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+from omnibase_core.validation.antipattern_registry_loader import (
+    load_default_registry,
+    resolve_antipatterns,
+)
+
+# Names of the 17 rules migrated from aislop_default_rules.yaml
+_EXPECTED_AISLOP_NAMES = {
+    "sycophancy",
+    "rest_docstring",
+    "boilerplate_docstring",
+    "md_separator",
+    "step_narration",
+    "obvious_comment",
+    "hardcoded_ip",
+    "hardcoded_localhost",
+    "hardcoded_port",
+    "hardcoded_topic",
+    "prohibited_env_pattern",
+    "compat_shim",
+    "empty_impl",
+    "todo_fixme",
+}
+
+# At least these 5 semantic antipatterns must be present
+_EXPECTED_SEMANTIC_NAMES = {
+    "handler_imports_handler",
+    "node_io_in_init",
+    "contract_topic_not_in_enum",
+    "test_mocks_subject",
+    "orchestrator_returns_result",
+}
+
+
+@pytest.mark.unit
+class TestLoadDefaultRegistry:
+    def test_loads_without_error(self) -> None:
+        registry = load_default_registry()
+        assert isinstance(registry, ModelAntipatternRegistry)
+
+    def test_version_present(self) -> None:
+        registry = load_default_registry()
+        assert registry.version != ""
+
+    def test_all_aislop_rules_present(self) -> None:
+        registry = load_default_registry()
+        names = {e.name for e in registry.entries}
+        missing = _EXPECTED_AISLOP_NAMES - names
+        assert not missing, f"Missing aislop rules: {missing}"
+
+    def test_all_semantic_antipatterns_present(self) -> None:
+        registry = load_default_registry()
+        names = {e.name for e in registry.entries}
+        missing = _EXPECTED_SEMANTIC_NAMES - names
+        assert not missing, f"Missing semantic antipatterns: {missing}"
+
+    def test_semantic_entries_have_vector_enabled(self) -> None:
+        registry = load_default_registry()
+        semantic = [e for e in registry.entries if e.pattern_type == "semantic"]
+        assert len(semantic) >= 5
+        for entry in semantic:
+            assert entry.vector_enabled, f"{entry.name} must have vector_enabled=True"
+
+    def test_all_entries_have_rationale(self) -> None:
+        registry = load_default_registry()
+        missing = [e.name for e in registry.entries if not e.rationale.strip()]
+        assert not missing, f"Entries missing rationale: {missing}"
+
+    def test_all_entries_have_category(self) -> None:
+        registry = load_default_registry()
+        for entry in registry.entries:
+            assert entry.category in {
+                "code_quality",
+                "architecture",
+                "security",
+                "performance",
+                "naming",
+                "testing",
+            }
+
+    def test_yaml_round_trip(self) -> None:
+        registry = load_default_registry()
+        data = registry.model_dump(mode="json")
+        reparsed = ModelAntipatternRegistry.model_validate(data)
+        assert len(reparsed.entries) == len(registry.entries)
+
+
+@pytest.mark.unit
+class TestResolveAntipatterns:
+    def test_no_overrides_returns_defaults(self, tmp_path: Path) -> None:
+        result = resolve_antipatterns(tmp_path)
+        defaults = load_default_registry()
+        assert len(result.entries) == len(defaults.entries)
+
+    def test_override_severity(self, tmp_path: Path) -> None:
+        overrides_dir = tmp_path / ".onex"
+        overrides_dir.mkdir()
+        overrides_file = overrides_dir / "antipattern-overrides.yaml"
+        overrides_file.write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "hardcoded_ip", "severity": "WARNING"},
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_override_enforcement(self, tmp_path: Path) -> None:
+        overrides_dir = tmp_path / ".onex"
+        overrides_dir.mkdir()
+        overrides_file = overrides_dir / "antipattern-overrides.yaml"
+        overrides_file.write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "obvious_comment", "enforcement": "blocking"},
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        entry = next(e for e in result.entries if e.name == "obvious_comment")
+        assert entry.enforcement == "blocking"
+
+    def test_unknown_override_name_raises(self, tmp_path: Path) -> None:
+        overrides_dir = tmp_path / ".onex"
+        overrides_dir.mkdir()
+        overrides_file = overrides_dir / "antipattern-overrides.yaml"
+        overrides_file.write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "nonexistent_rule", "severity": "ERROR"},
+                    ]
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="nonexistent_rule"):
+            resolve_antipatterns(tmp_path)
+
+    def test_custom_entries_appended(self, tmp_path: Path) -> None:
+        overrides_dir = tmp_path / ".onex"
+        overrides_dir.mkdir()
+        overrides_file = overrides_dir / "antipattern-overrides.yaml"
+        overrides_file.write_text(
+            yaml.dump(
+                {
+                    "custom_entries": [
+                        {
+                            "name": "my_custom_rule",
+                            "severity": "WARNING",
+                            "enforcement": "advisory",
+                            "category": "code_quality",
+                            "pattern_type": "regex_line",
+                            "pattern": r"TODO\(omn-",
+                            "description": "Custom rule",
+                            "rationale": "Custom rationale",
+                            "discovered_date": "2026-01-01",
+                            "source_ticket": "OMN-99999",
+                        }
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "my_custom_rule" in names
+
+    def test_no_overrides_file_returns_defaults(self, tmp_path: Path) -> None:
+        result = resolve_antipatterns(tmp_path)
+        defaults = load_default_registry()
+        assert {e.name for e in result.entries} == {e.name for e in defaults.entries}

--- a/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
+++ b/tests/unit/validation/test_antipattern_registry_loader_omn11912.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the OMN-11912 canonical public API of antipattern_registry_loader.
+
+Covers the acceptance criteria:
+  - defaults only (no overrides file)
+  - override disable (enabled=False removes an entry)
+  - override severity
+  - custom append
+  - malformed override raises ValidationError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_antipattern_override_config import (
+    ModelAntipatternOverrideConfig,
+)
+from omnibase_core.models.validation.model_antipattern_registry import (
+    ModelAntipatternRegistry,
+)
+from omnibase_core.validation.antipattern_registry_loader import (
+    load_default_antipatterns,
+    load_repo_overrides,
+    merge_antipatterns,
+    resolve_antipatterns,
+)
+
+
+@pytest.mark.unit
+class TestLoadDefaultAntipatterns:
+    def test_returns_registry(self) -> None:
+        result = load_default_antipatterns()
+        assert isinstance(result, ModelAntipatternRegistry)
+
+    def test_has_entries(self) -> None:
+        result = load_default_antipatterns()
+        assert len(result.entries) > 0
+
+    def test_version_present(self) -> None:
+        result = load_default_antipatterns()
+        assert result.version != ""
+
+
+@pytest.mark.unit
+class TestLoadRepoOverrides:
+    def test_no_file_returns_none(self, tmp_path: Path) -> None:
+        result = load_repo_overrides(tmp_path)
+        assert result is None
+
+    def test_valid_override_file_returns_config(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {"name": "hardcoded_ip", "severity": "WARNING"},
+                    ]
+                }
+            )
+        )
+        result = load_repo_overrides(tmp_path)
+        assert isinstance(result, ModelAntipatternOverrideConfig)
+        assert len(result.overrides) == 1
+        assert result.overrides[0].name == "hardcoded_ip"
+
+    def test_malformed_override_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "overrides": [
+                        {
+                            "name": "hardcoded_ip",
+                            "severity": "NOT_A_VALID_SEVERITY",
+                        }
+                    ]
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+    def test_unknown_extra_field_raises_validation_error(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "unknown_top_level_field": True,
+                }
+            )
+        )
+        with pytest.raises(ValidationError):
+            load_repo_overrides(tmp_path)
+
+
+@pytest.mark.unit
+class TestMergeAntipatterns:
+    def test_none_overrides_returns_defaults(self) -> None:
+        defaults = load_default_antipatterns()
+        result = merge_antipatterns(defaults, None)
+        assert len(result.entries) == len(defaults.entries)
+
+    def test_override_severity(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_override_enforcement(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "obvious_comment", "enforcement": "blocking"}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        entry = next(e for e in result.entries if e.name == "obvious_comment")
+        assert entry.enforcement == "blocking"
+
+    def test_override_disable_removes_entry(self) -> None:
+        defaults = load_default_antipatterns()
+        names_before = {e.name for e in defaults.entries}
+        assert "hardcoded_ip" in names_before
+
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "hardcoded_ip", "enabled": False}],
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names_after = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names_after
+        assert len(result.entries) == len(defaults.entries) - 1
+
+    def test_custom_entries_appended(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "custom_entries": [
+                    {
+                        "name": "custom_test_rule",
+                        "severity": "WARNING",
+                        "enforcement": "advisory",
+                        "category": "code_quality",
+                        "pattern_type": "regex_line",
+                        "pattern": r"CUSTOM_PATTERN",
+                        "description": "Custom test rule",
+                        "rationale": "Custom rationale for testing",
+                        "discovered_date": "2026-01-01",
+                        "source_ticket": "OMN-11912",
+                    }
+                ]
+            }
+        )
+        result = merge_antipatterns(defaults, config)
+        names = {e.name for e in result.entries}
+        assert "custom_test_rule" in names
+        assert len(result.entries) == len(defaults.entries) + 1
+
+    def test_unknown_override_name_raises_value_error(self) -> None:
+        defaults = load_default_antipatterns()
+        config = ModelAntipatternOverrideConfig.model_validate(
+            {
+                "overrides": [{"name": "nonexistent_rule_xyz", "severity": "ERROR"}],
+            }
+        )
+        with pytest.raises(ValueError, match="nonexistent_rule_xyz"):
+            merge_antipatterns(defaults, config)
+
+
+@pytest.mark.unit
+class TestResolveAntipatterns:
+    def test_defaults_only(self, tmp_path: Path) -> None:
+        result = resolve_antipatterns(tmp_path)
+        defaults = load_default_antipatterns()
+        assert {e.name for e in result.entries} == {e.name for e in defaults.entries}
+
+    def test_override_disable_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "enabled": False}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "hardcoded_ip" not in names
+
+    def test_override_severity_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump({"overrides": [{"name": "hardcoded_ip", "severity": "WARNING"}]})
+        )
+        result = resolve_antipatterns(tmp_path)
+        entry = next(e for e in result.entries if e.name == "hardcoded_ip")
+        assert entry.severity == "WARNING"
+
+    def test_custom_append_via_file(self, tmp_path: Path) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {
+                    "custom_entries": [
+                        {
+                            "name": "repo_specific_rule",
+                            "severity": "ERROR",
+                            "enforcement": "blocking",
+                            "category": "architecture",
+                            "pattern_type": "grep_code",
+                            "pattern": "import_forbidden",
+                            "description": "Repo-specific forbidden import",
+                            "rationale": "This import is forbidden in this repo",
+                            "discovered_date": "2026-01-01",
+                            "source_ticket": "OMN-11912",
+                        }
+                    ]
+                }
+            )
+        )
+        result = resolve_antipatterns(tmp_path)
+        names = {e.name for e in result.entries}
+        assert "repo_specific_rule" in names
+
+    def test_malformed_override_file_raises_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        onex_dir = tmp_path / ".onex"
+        onex_dir.mkdir()
+        (onex_dir / "antipattern-overrides.yaml").write_text(
+            yaml.dump(
+                {"overrides": [{"name": "hardcoded_ip", "severity": "BAD_VALUE"}]}
+            )
+        )
+        with pytest.raises(ValidationError):
+            resolve_antipatterns(tmp_path)


### PR DESCRIPTION
## Summary

Implements OMN-11921 — aislop validator KB integration (Task 3.2 of OMN-11909).

Stacked on OMN-11912 (already merged to main).

**Changes:**
- `aislop_rule_loader.py`: adds `resolve_rules_from_registry(registry)` and `resolve_rules_unified(repo_root)` to the public API
- `test_aislop_kb_integration_omn11921.py`: 16 new unit tests (TDD-first)

**`resolve_rules_from_registry(registry: ModelAntipatternRegistry) -> ModelAislopRuleSet`**
- Filters registry entries to `pattern_type` in `{regex_line, regex_ast_docstring, grep_code, ast_check}` — excludes `semantic` entries which require vector search
- Converts each matching `ModelAntipatternEntry` → `ModelAislopRule` with all compatible fields preserved

**`resolve_rules_unified(repo_root: Path) -> ModelAislopRuleSet`**
- Merges legacy `aislop_default_rules.yaml` + antipattern registry
- Registry rules come first; legacy rules appended only when not covered by registry (registry wins on duplicate name)
- Additive: `resolve_rules()` unchanged and continues to work independently

## Verification

- 16 new unit tests green, 3960 existing unit validation tests passing (0 regressions)
- `mypy --strict` passes on changed file
- All pre-commit hooks pass

## Ticket

OMN-11921

Evidence-Source: OCC#1585
Evidence-Ticket: OMN-11921