### PR TITLE
fix(OMN-12159): Remove core→compat layer inversion in delegation models

### DIFF
--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -63,50 +63,6 @@ See Also:
     - docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md: Architecture overview
 """
 
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from omnibase_compat.contracts.delegation.model_delegation_dashboard_connection import (
-        ModelDelegationDashboardConnection,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_datastore import (
-        ModelDelegationDatastore,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_event_bus_endpoint import (
-        ModelDelegationEventBusEndpoint,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_llm_backend import (
-        ModelDelegationLlmBackend,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_pricing_manifest_ref import (
-        ModelDelegationPricingManifestRef,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_projection_api import (
-        ModelDelegationProjectionApi,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_runtime_profile import (
-        ModelDelegationRuntimeProfile,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_secret_ref import (
-        ModelDelegationSecretRef,
-    )
-    from omnibase_compat.contracts.delegation.model_delegation_security import (
-        ModelDelegationSecurity,
-    )
-
-_DELEGATION_COMPAT_EXPORTS = {
-    "ModelDelegationDashboardConnection": "omnibase_compat.contracts.delegation.model_delegation_dashboard_connection",
-    "ModelDelegationDatastore": "omnibase_compat.contracts.delegation.model_delegation_datastore",
-    "ModelDelegationEventBusEndpoint": "omnibase_compat.contracts.delegation.model_delegation_event_bus_endpoint",
-    "ModelDelegationLlmBackend": "omnibase_compat.contracts.delegation.model_delegation_llm_backend",
-    "ModelDelegationPricingManifestRef": "omnibase_compat.contracts.delegation.model_delegation_pricing_manifest_ref",
-    "ModelDelegationProjectionApi": "omnibase_compat.contracts.delegation.model_delegation_projection_api",
-    "ModelDelegationRuntimeProfile": "omnibase_compat.contracts.delegation.model_delegation_runtime_profile",
-    "ModelDelegationSecretRef": "omnibase_compat.contracts.delegation.model_delegation_secret_ref",  # pragma: allowlist secret
-    "ModelDelegationSecurity": "omnibase_compat.contracts.delegation.model_delegation_security",
-}
-
 from omnibase_core.mixins.mixin_node_type_validator import MixinNodeTypeValidator
 from omnibase_core.models.discovery.model_event_descriptor import ModelEventDescriptor
 from omnibase_core.models.runtime.model_descriptor_circuit_breaker import (
@@ -182,6 +138,15 @@ from .model_db_param import ModelDbParam
 from .model_db_repository_contract import ModelDbRepositoryContract
 from .model_db_return import ModelDbReturn
 from .model_db_safety_policy import ModelDbSafetyPolicy
+from .model_delegation_dashboard_connection import ModelDelegationDashboardConnection
+from .model_delegation_datastore import ModelDelegationDatastore
+from .model_delegation_event_bus_endpoint import ModelDelegationEventBusEndpoint
+from .model_delegation_llm_backend import ModelDelegationLlmBackend
+from .model_delegation_pricing_manifest_ref import ModelDelegationPricingManifestRef
+from .model_delegation_projection_api import ModelDelegationProjectionApi
+from .model_delegation_runtime_profile import ModelDelegationRuntimeProfile
+from .model_delegation_secret_ref import ModelDelegationSecretRef
+from .model_delegation_security import ModelDelegationSecurity
 from .model_dependency import ModelDependency
 from .model_dependency_spec import (
     DependencyType,
@@ -247,30 +212,6 @@ from .subcontracts import (
     ModelHandlerRoutingEntry,
     ModelHandlerRoutingSubcontract,
 )
-
-
-def __getattr__(name: str) -> Any:
-    """Resolve optional delegation model re-exports on first access."""
-    module_name = _DELEGATION_COMPAT_EXPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(  # error-ok: module __getattr__ protocol requires AttributeError
-            f"module {__name__!r} has no attribute {name!r}"
-        )
-
-    try:
-        module = import_module(module_name)
-    except ImportError as exc:
-        message = (
-            f"{name} requires the optional omnibase_compat package. "
-            "Install omnibase-core[compat] or omnibase-compat to use delegation "
-            "runtime profile contracts."
-        )
-        raise ImportError(message) from exc  # error-ok: optional import contract
-
-    value = getattr(module, name)
-    globals()[name] = value
-    return value
-
 
 __all__ = [
     # Mixins

--- a/src/omnibase_core/models/contracts/model_delegation_dashboard_connection.py
+++ b/src/omnibase_core/models/contracts/model_delegation_dashboard_connection.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dashboard connection contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.model_delegation_projection_api import (
+    ModelDelegationProjectionApi,
+)
+
+
+class ModelDelegationDashboardConnection(BaseModel):
+    """Dashboard connection configuration backed by the projection API."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_api_ref: ModelDelegationProjectionApi = Field(
+        ...,
+        description="Projection API configuration this dashboard connects to",
+    )
+    refresh_contract: dict[str, int] = Field(
+        default_factory=dict,
+        description="Refresh timing contract (e.g. {'interval_ms': 30000})",
+    )

--- a/src/omnibase_core/models/contracts/model_delegation_datastore.py
+++ b/src/omnibase_core/models/contracts/model_delegation_datastore.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Datastore contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDelegationDatastore(BaseModel):
+    """Datastore connection reference for projection persistence."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    projection_database_ref: str = Field(
+        ...,
+        description="Env var reference for the projection database connection",
+    )

--- a/src/omnibase_core/models/contracts/model_delegation_event_bus_endpoint.py
+++ b/src/omnibase_core/models/contracts/model_delegation_event_bus_endpoint.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Event bus endpoint contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDelegationEventBusEndpoint(BaseModel):
+    """Event bus endpoint configuration for delegation routing."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    provider: str = Field(
+        ..., description="Event bus provider identifier (e.g. redpanda, kafka)"
+    )
+    bootstrap_servers: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Bootstrap server addresses; at least one required",
+    )
+    topic_policy_ref: str = Field(..., description="Reference to topic policy contract")
+    consumer_groups: list[str] = Field(
+        default_factory=list,
+        description="Consumer group identifiers for this endpoint",
+    )

--- a/src/omnibase_core/models/contracts/model_delegation_llm_backend.py
+++ b/src/omnibase_core/models/contracts/model_delegation_llm_backend.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""LLM backend contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelDelegationLlmBackend(BaseModel):
+    """LLM backend configuration for delegation task routing."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    bifrost_endpoint_ref: str = Field(
+        ...,
+        description="Env var reference for the bifrost/LLM endpoint URL",
+    )
+    default_task_model_ref: str = Field(
+        ...,
+        description="Default model identifier for task classification",
+    )
+    max_tokens_default: int = Field(
+        ..., ge=1, description="Default max tokens per request"
+    )
+    max_tokens_hard_limit: int = Field(
+        ..., ge=1, description="Hard cap on tokens; cannot exceed"
+    )
+    timeout_ms: int = Field(..., ge=1000, description="Request timeout in milliseconds")
+    task_model_overrides: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-task-type model override map",
+    )
+
+    @model_validator(mode="after")
+    def validate_token_limits(self) -> ModelDelegationLlmBackend:
+        if self.max_tokens_default > self.max_tokens_hard_limit:
+            raise ValueError("max_tokens_default must be <= max_tokens_hard_limit")
+        return self

--- a/src/omnibase_core/models/contracts/model_delegation_pricing_manifest_ref.py
+++ b/src/omnibase_core/models/contracts/model_delegation_pricing_manifest_ref.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pricing manifest reference model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDelegationPricingManifestRef(BaseModel):
+    """Reference to a pricing manifest with version pinning."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    manifest_ref: str = Field(
+        ..., description="Reference to the pricing manifest resource"
+    )
+    version: int = Field(..., ge=1, description="Manifest version; must be >= 1")

--- a/src/omnibase_core/models/contracts/model_delegation_projection_api.py
+++ b/src/omnibase_core/models/contracts/model_delegation_projection_api.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Projection API contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDelegationProjectionApi(BaseModel):
+    """Projection API connection configuration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    base_url_ref: str = Field(
+        ...,
+        description="Env var reference for the projection API base URL",
+    )
+    endpoints: dict[str, str] = Field(
+        default_factory=dict,
+        description="Named endpoint path map (e.g. {'nodes': '/api/v1/nodes'})",
+    )
+    schema_version: str = Field(..., description="API schema version string")
+    freshness_sla_ms: int = Field(
+        ...,
+        ge=1,
+        description="Maximum acceptable data freshness in milliseconds",
+    )

--- a/src/omnibase_core/models/contracts/model_delegation_runtime_profile.py
+++ b/src/omnibase_core/models/contracts/model_delegation_runtime_profile.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Root delegation runtime profile contract model for OMN-10919.
+
+Typed Pydantic v2 schema for the delegation runtime configuration surface.
+Frozen + extra=forbid — pure schema with no env var reads or I/O.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.contracts.model_delegation_dashboard_connection import (
+    ModelDelegationDashboardConnection,
+)
+from omnibase_core.models.contracts.model_delegation_datastore import (
+    ModelDelegationDatastore,
+)
+from omnibase_core.models.contracts.model_delegation_event_bus_endpoint import (
+    ModelDelegationEventBusEndpoint,
+)
+from omnibase_core.models.contracts.model_delegation_llm_backend import (
+    ModelDelegationLlmBackend,
+)
+from omnibase_core.models.contracts.model_delegation_pricing_manifest_ref import (
+    ModelDelegationPricingManifestRef,
+)
+from omnibase_core.models.contracts.model_delegation_security import (
+    ModelDelegationSecurity,
+)
+
+
+class ModelDelegationRuntimeProfile(BaseModel):
+    """Root contract for delegation runtime profile configuration.
+
+    Defines all runtime dependencies for the delegation routing pipeline:
+    event bus, LLM backends, security, pricing, dashboard, and datastores.
+    All values are typed references — no raw secrets, no hardcoded endpoints.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(..., description="Human-readable profile name")
+    version: int = Field(..., ge=1, description="Profile version; must be >= 1")
+    runtime_profile: str = Field(
+        ...,
+        description="Runtime environment identifier (e.g. local, staging, production)",
+    )
+    event_bus: ModelDelegationEventBusEndpoint = Field(
+        ...,
+        description="Event bus endpoint configuration",
+    )
+    llm_backends: dict[str, ModelDelegationLlmBackend] = Field(
+        ...,
+        min_length=1,
+        description="Named LLM backend configurations (at least 'default' required)",
+    )
+    security: ModelDelegationSecurity | None = Field(
+        default=None,
+        description="Optional security configuration",
+    )
+    pricing: ModelDelegationPricingManifestRef | None = Field(
+        default=None,
+        description="Optional pricing manifest reference",
+    )
+    dashboard: ModelDelegationDashboardConnection | None = Field(
+        default=None,
+        description="Optional dashboard connection configuration",
+    )
+    datastores: dict[str, ModelDelegationDatastore] | None = Field(
+        default=None,
+        description="Optional named datastore configurations",
+    )
+
+    @model_validator(mode="after")
+    def validate_llm_backends(self) -> ModelDelegationRuntimeProfile:
+        if "default" not in self.llm_backends:
+            raise ValueError("llm_backends must include a 'default' entry")
+        return self

--- a/src/omnibase_core/models/contracts/model_delegation_secret_ref.py
+++ b/src/omnibase_core/models/contracts/model_delegation_secret_ref.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Secret reference contract model — raw values explicitly forbidden."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelDelegationSecretRef(BaseModel):
+    """Reference to a secret by name — raw values are explicitly forbidden."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ref_name: str = Field(
+        ..., description="Name of the secret reference (env var or Infisical key)"
+    )
+    raw_value: str | None = Field(
+        default=None,
+        description="Must remain None; raw secrets must never be embedded in contracts",
+    )
+
+    @model_validator(mode="after")
+    def reject_raw_value(self) -> ModelDelegationSecretRef:
+        if self.raw_value is not None:
+            raise ValueError(
+                "raw_value must not be set on ModelDelegationSecretRef — "
+                "use ref_name to reference the secret by name"
+            )
+        return self

--- a/src/omnibase_core/models/contracts/model_delegation_security.py
+++ b/src/omnibase_core/models/contracts/model_delegation_security.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Security contract model for delegation runtime configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.model_delegation_secret_ref import (
+    ModelDelegationSecretRef,
+)
+
+
+class ModelDelegationSecurity(BaseModel):
+    """Security configuration: allowlists and shared secret reference."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    broker_allowlist_ref: str = Field(
+        ...,
+        description="Ref to broker allowlist configuration",
+    )
+    endpoint_cidr_allowlist_ref: str = Field(
+        ...,
+        description="Ref to CIDR allowlist for endpoint access control",
+    )
+    shared_secret_ref: ModelDelegationSecretRef = Field(
+        ...,
+        description="Shared secret reference for service-to-service auth",
+    )

--- a/src/omnibase_core/validation/delegation/validator_delegation_profile.py
+++ b/src/omnibase_core/validation/delegation/validator_delegation_profile.py
@@ -14,10 +14,11 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from omnibase_compat.contracts.delegation.model_delegation_runtime_profile import (
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.model_delegation_runtime_profile import (
     ModelDelegationRuntimeProfile,
 )
-from pydantic import ValidationError
 
 __all__ = ["ValidationResult", "validate_delegation_profile"]
 


### PR DESCRIPTION
## Summary

- Graduates all 9 delegation runtime profile models from `omnibase_compat` to `omnibase_core/models/contracts/` as canonical core models
- Removes the lazy `__getattr__` re-export machinery and `_DELEGATION_COMPAT_EXPORTS` dict from `contracts/__init__.py`
- Fixes `validator_delegation_profile.py` to import from the canonical core path instead of compat
- All intra-module dependencies updated to use `omnibase_core` paths

OMN-12159

Evidence-Ticket: OMN-12159
Evidence-Source: OCC#1656

## Test plan
- [x] `uv run pytest tests/ -k delegation -v` — 112 tests pass
- [x] `uv run pre-commit run --files <changed files>` — all hooks pass on changed files
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean