### PR TITLE
feat(OMN-12189): Migrate 3 enums from compat to core

### DIFF
--- a/tests/unit/enums/test_compat_enum_parity_omn12189.py
+++ b/tests/unit/enums/test_compat_enum_parity_omn12189.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-12189: Parity tests verifying compat enum values match canonical core definitions.
+
+These tests guard the migration contract: the compat copies of EnumNodeKind,
+EnumExecutionStatus, and EnumMessageCategory must have identical string values
+to the canonical omnibase_core versions. When compat is removed on 2026-07-01,
+these tests are also removed.
+"""
+
+import pytest
+
+pytest.importorskip(
+    "omnibase_compat",
+    reason="omnibase-compat optional extra not installed; run `uv sync --all-extras`",
+)
+
+
+@pytest.mark.unit
+class TestCompatEnumNodeKindParity:
+    """Verify omnibase_compat.EnumNodeKind values match omnibase_core.EnumNodeKind."""
+
+    def test_all_compat_values_exist_in_core(self) -> None:
+        from omnibase_compat.enums.enum_node_kind import (
+            EnumNodeKind as CompatEnumNodeKind,
+        )
+
+        from omnibase_core.enums.enum_node_kind import EnumNodeKind as CoreEnumNodeKind
+
+        core_values = {m.value for m in CoreEnumNodeKind}
+        for member in CompatEnumNodeKind:
+            assert member.value in core_values, (
+                f"Compat EnumNodeKind.{member.name}={member.value!r} "
+                f"not found in core enum values: {sorted(core_values)}"
+            )
+
+    def test_all_compat_values_round_trip_via_core(self) -> None:
+        from omnibase_compat.enums.enum_node_kind import (
+            EnumNodeKind as CompatEnumNodeKind,
+        )
+
+        from omnibase_core.enums.enum_node_kind import EnumNodeKind as CoreEnumNodeKind
+
+        for member in CompatEnumNodeKind:
+            core_member = CoreEnumNodeKind(member.value)
+            assert core_member.value == member.value
+
+
+@pytest.mark.unit
+class TestCompatEnumExecutionStatusParity:
+    """Verify omnibase_compat.EnumExecutionStatus values match omnibase_core."""
+
+    def test_all_compat_values_exist_in_core(self) -> None:
+        from omnibase_compat.enums.enum_execution_status import (
+            EnumExecutionStatus as CompatEnumExecutionStatus,
+        )
+
+        from omnibase_core.enums.enum_execution_status import (
+            EnumExecutionStatus as CoreEnumExecutionStatus,
+        )
+
+        core_values = {m.value for m in CoreEnumExecutionStatus}
+        for member in CompatEnumExecutionStatus:
+            assert member.value in core_values, (
+                f"Compat EnumExecutionStatus.{member.name}={member.value!r} "
+                f"not found in core enum values: {sorted(core_values)}"
+            )
+
+    def test_all_compat_values_round_trip_via_core(self) -> None:
+        from omnibase_compat.enums.enum_execution_status import (
+            EnumExecutionStatus as CompatEnumExecutionStatus,
+        )
+
+        from omnibase_core.enums.enum_execution_status import (
+            EnumExecutionStatus as CoreEnumExecutionStatus,
+        )
+
+        for member in CompatEnumExecutionStatus:
+            core_member = CoreEnumExecutionStatus(member.value)
+            assert core_member.value == member.value
+
+
+@pytest.mark.unit
+class TestCompatEnumMessageCategoryParity:
+    """Verify omnibase_compat.EnumMessageCategory values match omnibase_core."""
+
+    def test_all_compat_values_exist_in_core(self) -> None:
+        from omnibase_compat.enums.enum_message_category import (
+            EnumMessageCategory as CompatEnumMessageCategory,
+        )
+
+        from omnibase_core.enums.enum_execution_shape import (
+            EnumMessageCategory as CoreEnumMessageCategory,
+        )
+
+        core_values = {m.value for m in CoreEnumMessageCategory}
+        for member in CompatEnumMessageCategory:
+            assert member.value in core_values, (
+                f"Compat EnumMessageCategory.{member.name}={member.value!r} "
+                f"not found in core enum values: {sorted(core_values)}"
+            )
+
+    def test_all_compat_values_round_trip_via_core(self) -> None:
+        from omnibase_compat.enums.enum_message_category import (
+            EnumMessageCategory as CompatEnumMessageCategory,
+        )
+
+        from omnibase_core.enums.enum_execution_shape import (
+            EnumMessageCategory as CoreEnumMessageCategory,
+        )
+
+        for member in CompatEnumMessageCategory:
+            core_member = CoreEnumMessageCategory(member.value)
+            assert core_member.value == member.value
+
+    def test_migration_target_note(self) -> None:
+        """EnumMessageCategory lives in enum_execution_shape per canonical ownership docs (OMN-4032)."""
+        from omnibase_core.enums import EnumMessageCategory
+
+        assert EnumMessageCategory.EVENT.value == "event"
+        assert EnumMessageCategory.COMMAND.value == "command"
+        assert EnumMessageCategory.INTENT.value == "intent"


### PR DESCRIPTION
## Summary

- Three canonical enum definitions (`EnumNodeKind`, `EnumExecutionStatus`, `EnumMessageCategory`) already exist in `omnibase_core` — this PR adds migration parity tests that verify the `omnibase_compat` copies have identical string values to the core versions
- Parity tests skip gracefully when `omnibase-compat` optional extra is not installed (`pytest.importorskip`)
- Guards the 2026-07-01 removal contract: if anyone changes a compat enum value without updating core, tests fail

## Migration contract

| Compat module | Core module |
|---|---|
| `omnibase_compat.enums.enum_node_kind.EnumNodeKind` | `omnibase_core.enums.enum_node_kind.EnumNodeKind` |
| `omnibase_compat.enums.enum_execution_status.EnumExecutionStatus` | `omnibase_core.enums.enum_execution_status.EnumExecutionStatus` |
| `omnibase_compat.enums.enum_message_category.EnumMessageCategory` | `omnibase_core.enums.enum_execution_shape.EnumMessageCategory` |

Note: compat cannot re-export from core at the Python import level (zero runtime deps constraint). The migration evidence is the parity test proving value identity.

## Test plan

- [x] `pytest tests/unit/enums/test_compat_enum_parity_omn12189.py -v` — 7 passed
- [x] `pytest tests/unit/enums/test_enum_node_kind.py tests/unit/enums/test_enum_execution_status.py tests/unit/enums/test_enum_execution_shape.py -v` — 139 passed, no regressions
- [x] `pre-commit run --files tests/unit/enums/test_compat_enum_parity_omn12189.py` — all hooks passed
- [x] `ruff format` + `ruff check --fix` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating enum compatibility and consistency across enum definitions, ensuring proper value mapping and round-trip behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1677
Evidence-Ticket: OMN-12189