### PR TITLE
feat(OMN-12191): Migrate routing models from compat to core

### DIFF
--- a/src/omnibase_core/enums/routing/__init__.py
+++ b/src/omnibase_core/enums/routing/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Routing contract enums."""
+
+from .enum_capability_tier import EnumCapabilityTier
+from .enum_provider import EnumProvider
+from .enum_retry_type import EnumRetryType
+from .enum_risk_level import EnumRiskLevel
+
+__all__: list[str] = [
+    "EnumCapabilityTier",
+    "EnumProvider",
+    "EnumRetryType",
+    "EnumRiskLevel",
+]

--- a/src/omnibase_core/enums/routing/enum_capability_tier.py
+++ b/src/omnibase_core/enums/routing/enum_capability_tier.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Capability tier enum for routing policy decisions."""
+
+from enum import StrEnum
+
+
+class EnumCapabilityTier(StrEnum):
+    """Model capability tier used to select the appropriate inference backend."""
+
+    LOCAL = "local"
+    CHEAP_FRONTIER = "cheap_frontier"
+    MID_FRONTIER = "mid_frontier"
+    EXPENSIVE_FRONTIER = "expensive_frontier"
+
+
+__all__: list[str] = ["EnumCapabilityTier"]

--- a/src/omnibase_core/enums/routing/enum_provider.py
+++ b/src/omnibase_core/enums/routing/enum_provider.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Provider enum for routing policy decisions."""
+
+from enum import StrEnum
+
+
+class EnumProvider(StrEnum):
+    """LLM provider identifier used by routing decisions."""
+
+    LOCAL_VLLM = "local_vllm"
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GOOGLE = "google"
+    LOCAL_MLX = "local_mlx"
+
+
+__all__: list[str] = ["EnumProvider"]

--- a/src/omnibase_core/enums/routing/enum_retry_type.py
+++ b/src/omnibase_core/enums/routing/enum_retry_type.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Retry strategy enum for routing policy decisions."""
+
+from enum import StrEnum
+
+
+class EnumRetryType(StrEnum):
+    """Retry strategy for the selected routing model."""
+
+    NONE = "none"
+    SAME_MODEL = "same_model"
+    ESCALATE_TIER = "escalate_tier"
+    FALLBACK_MODEL = "fallback_model"
+
+
+__all__: list[str] = ["EnumRetryType"]

--- a/src/omnibase_core/enums/routing/enum_risk_level.py
+++ b/src/omnibase_core/enums/routing/enum_risk_level.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Risk level enum for routing policy decisions."""
+
+from enum import StrEnum
+
+
+class EnumRiskLevel(StrEnum):
+    """Risk level of the routing decision."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+__all__: list[str] = ["EnumRiskLevel"]

--- a/src/omnibase_core/models/routing/__init__.py
+++ b/src/omnibase_core/models/routing/__init__.py
@@ -49,6 +49,16 @@ from omnibase_core.models.routing.model_resolution_route_hop import (
     ModelResolutionRouteHop,
 )
 from omnibase_core.models.routing.model_route_plan import ModelRoutePlan
+from omnibase_core.models.routing.model_routing_decision import (
+    EnumCapabilityTier,
+    EnumProvider,
+    EnumRetryType,
+    EnumRiskLevel,
+    ModelRoutingDecision,
+)
+from omnibase_core.models.routing.model_routing_degraded_event import (
+    ModelRoutingDegradedEvent,
+)
 from omnibase_core.models.routing.model_routing_policy import (
     ModelCiOverridePolicy,
     ModelRoutingPolicy,
@@ -66,8 +76,13 @@ from omnibase_core.models.routing.model_trust_domain_config import (
 )
 
 __all__ = [
+    "EnumCapabilityTier",
+    "EnumProvider",
+    "EnumRetryType",
+    "EnumRiskLevel",
     "ModelCapabilityToken",
     "ModelClassificationGate",
+    "ModelCiOverridePolicy",
     "ModelHopConstraints",
     "ModelLlmRouteRejectedEvent",
     "ModelLlmRouteResolvedEvent",
@@ -77,7 +92,8 @@ __all__ = [
     "ModelResolutionProof",
     "ModelResolutionRouteHop",
     "ModelRoutePlan",
-    "ModelCiOverridePolicy",
+    "ModelRoutingDecision",
+    "ModelRoutingDegradedEvent",
     "ModelRoutingPolicy",
     "ModelTierAttempt",
     "ModelTieredResolutionConfig",

--- a/src/omnibase_core/models/routing/model_routing_decision.py
+++ b/src/omnibase_core/models/routing/model_routing_decision.py
@@ -5,46 +5,14 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
-
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
-class EnumCapabilityTier(StrEnum):
-    """Model capability tier — used to select the appropriate inference backend."""
-
-    LOCAL = "local"
-    CHEAP_FRONTIER = "cheap_frontier"
-    MID_FRONTIER = "mid_frontier"
-    EXPENSIVE_FRONTIER = "expensive_frontier"
-
-
-class EnumProvider(StrEnum):
-    """LLM provider identifier."""
-
-    LOCAL_VLLM = "local_vllm"
-    ANTHROPIC = "anthropic"
-    OPENAI = "openai"
-    GOOGLE = "google"
-    LOCAL_MLX = "local_mlx"
-
-
-class EnumRetryType(StrEnum):
-    """Retry strategy for the selected model."""
-
-    NONE = "none"
-    SAME_MODEL = "same_model"
-    ESCALATE_TIER = "escalate_tier"
-    FALLBACK_MODEL = "fallback_model"
-
-
-class EnumRiskLevel(StrEnum):
-    """Risk level of the routing decision — affects audit logging."""
-
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
+from omnibase_core.enums.routing import (
+    EnumCapabilityTier,
+    EnumProvider,
+    EnumRetryType,
+    EnumRiskLevel,
+)
 
 
 class ModelRoutingDecision(BaseModel):

--- a/src/omnibase_core/models/routing/model_routing_decision.py
+++ b/src/omnibase_core/models/routing/model_routing_decision.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRoutingDecision — output contract of the overseer routing policy engine."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class EnumCapabilityTier(StrEnum):
+    """Model capability tier — used to select the appropriate inference backend."""
+
+    LOCAL = "local"
+    CHEAP_FRONTIER = "cheap_frontier"
+    MID_FRONTIER = "mid_frontier"
+    EXPENSIVE_FRONTIER = "expensive_frontier"
+
+
+class EnumProvider(StrEnum):
+    """LLM provider identifier."""
+
+    LOCAL_VLLM = "local_vllm"
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GOOGLE = "google"
+    LOCAL_MLX = "local_mlx"
+
+
+class EnumRetryType(StrEnum):
+    """Retry strategy for the selected model."""
+
+    NONE = "none"
+    SAME_MODEL = "same_model"
+    ESCALATE_TIER = "escalate_tier"
+    FALLBACK_MODEL = "fallback_model"
+
+
+class EnumRiskLevel(StrEnum):
+    """Risk level of the routing decision — affects audit logging."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ModelRoutingDecision(BaseModel):
+    """Output contract of the overseer routing policy engine.
+
+    Frozen + extra=forbid: routing decisions are immutable once emitted.
+    HIGH/CRITICAL risk decisions are flagged in the audit log.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    selected_model: str = Field(
+        ...,
+        description="model_id key of the selected model (e.g. 'qwen3-coder-30b').",
+    )
+    capability_tier: EnumCapabilityTier = Field(
+        ...,
+        description="Capability tier of the selected model.",
+    )
+    provider: EnumProvider = Field(
+        ...,
+        description="Provider of the selected model.",
+    )
+    retry_type: EnumRetryType = Field(
+        default=EnumRetryType.NONE,
+        description="Retry strategy if the selected model fails.",
+    )
+    fallback_model: str | None = Field(
+        default=None,
+        description="model_id key to use on fallback. Required when retry_type=FALLBACK_MODEL.",
+    )
+    risk_level: EnumRiskLevel = Field(
+        default=EnumRiskLevel.LOW,
+        description="Risk level — HIGH/CRITICAL decisions are flagged in the audit log.",
+    )
+    retry_budget: int = Field(
+        default=0,
+        description="Remaining retry attempts available for this decision.",
+        ge=0,
+    )
+    rationale: str = Field(
+        default="",
+        description="Human-readable rationale for the routing decision.",
+    )
+    exploration_score: float | None = Field(
+        default=None,
+        description="Exploration score (0.0-1.0) for bandit-style routing. None = deterministic.",
+        ge=0.0,
+        le=1.0,
+    )
+    cost_estimate_usd: float | None = Field(
+        default=None,
+        description="Estimated cost in USD for this routing decision.",
+        ge=0.0,
+    )
+
+    @model_validator(mode="after")
+    def _validate_retry_fallback_consistency(self) -> ModelRoutingDecision:
+        if self.retry_type == EnumRetryType.FALLBACK_MODEL and not self.fallback_model:
+            raise ValueError(
+                "fallback_model is required when retry_type=FALLBACK_MODEL"
+            )
+        if (
+            self.retry_type != EnumRetryType.FALLBACK_MODEL
+            and self.fallback_model is not None
+        ):
+            raise ValueError(
+                "fallback_model must be None unless retry_type=FALLBACK_MODEL"
+            )
+        return self
+
+
+__all__: list[str] = [
+    "EnumCapabilityTier",
+    "EnumProvider",
+    "EnumRetryType",
+    "EnumRiskLevel",
+    "ModelRoutingDecision",
+]

--- a/src/omnibase_core/models/routing/model_routing_degraded_event.py
+++ b/src/omnibase_core/models/routing/model_routing_degraded_event.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRoutingDegradedEvent — emitted when the router flips to fallback."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelRoutingDegradedEvent(BaseModel):
+    """Event emitted on topic onex.evt.omnimarket.model-routing.degraded.v1.
+
+    Published when consecutive failure streak cap is reached for a
+    (endpoint, contract) pair and the router falls back to the secondary model.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    primary: str = Field(..., description="model_id of the degraded primary endpoint.")
+    reason: str = Field(..., description="Human-readable reason for degradation.")
+    attempts: int = Field(
+        ..., description="Number of consecutive failed attempts.", ge=1
+    )
+    elapsed_ms: float = Field(
+        ..., description="Wall-clock elapsed time in milliseconds.", ge=0
+    )
+    merge_sha: str = Field(
+        default="", description="Git SHA at time of event (if available)."
+    )
+    gate_name: str = Field(
+        default="", description="Gate or handler name that triggered routing."
+    )
+    model_key: str = Field(..., description="Registry model_id key that degraded.")
+    correlation_id: str = Field(
+        ..., description="Correlation ID from the originating request."
+    )
+
+
+__all__: list[str] = ["ModelRoutingDegradedEvent"]

--- a/src/omnibase_core/models/telemetry/__init__.py
+++ b/src/omnibase_core/models/telemetry/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Telemetry models for ONEX observability surfaces."""
+
+from omnibase_core.models.telemetry.model_sweep_result import ModelSweepResult
+
+__all__ = ["ModelSweepResult"]

--- a/src/omnibase_core/models/telemetry/model_sweep_result.py
+++ b/src/omnibase_core/models/telemetry/model_sweep_result.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelSweepResult — structured result from a sweep skill run."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelSweepResult(BaseModel):
+    """Structured result from a sweep skill run.
+
+    Emitted by sweep nodes after each run and projected into the sweep_results
+    table by the omnidash read-model consumer.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # string-version-ok: wire schema guard; semver string is the correct wire type here
+    schema_version: str = "1.0.0"
+    sweep_type: Literal[
+        "aislop",
+        "coverage",
+        "compliance",
+        "contract",
+        "dashboard",
+        "runtime",
+        "data_flow",
+    ]
+    session_id: str
+    correlation_id: str
+    ran_at: datetime
+    duration_seconds: float
+    passed: bool
+    finding_count: int = 0
+    critical_count: int = 0
+    warning_count: int = 0
+    repos_scanned: tuple[str, ...] = Field(default_factory=tuple)
+    summary: str
+    output_path: str | None = None
+
+
+__all__: list[str] = ["ModelSweepResult"]

--- a/tests/unit/models/routing/test_routing_decision_and_degraded.py
+++ b/tests/unit/models/routing/test_routing_decision_and_degraded.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelRoutingDecision and ModelRoutingDegradedEvent."""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.routing.model_routing_decision import (
+    EnumCapabilityTier,
+    EnumProvider,
+    EnumRetryType,
+    EnumRiskLevel,
+    ModelRoutingDecision,
+)
+from omnibase_core.models.routing.model_routing_degraded_event import (
+    ModelRoutingDegradedEvent,
+)
+
+
+@pytest.mark.unit
+class TestModelRoutingDecision:
+    def test_minimal_valid(self) -> None:
+        decision = ModelRoutingDecision(
+            selected_model="qwen3-coder-30b",
+            capability_tier=EnumCapabilityTier.LOCAL,
+            provider=EnumProvider.LOCAL_VLLM,
+        )
+        assert decision.selected_model == "qwen3-coder-30b"
+        assert decision.retry_type == EnumRetryType.NONE
+        assert decision.risk_level == EnumRiskLevel.LOW
+        assert decision.fallback_model is None
+
+    def test_fallback_model_required_when_retry_type_fallback(self) -> None:
+        with pytest.raises(ValidationError, match="fallback_model is required"):
+            ModelRoutingDecision(
+                selected_model="qwen3-coder-30b",
+                capability_tier=EnumCapabilityTier.LOCAL,
+                provider=EnumProvider.LOCAL_VLLM,
+                retry_type=EnumRetryType.FALLBACK_MODEL,
+                fallback_model=None,
+            )
+
+    def test_fallback_model_must_be_none_when_not_fallback_retry(self) -> None:
+        with pytest.raises(ValidationError, match="fallback_model must be None"):
+            ModelRoutingDecision(
+                selected_model="qwen3-coder-30b",
+                capability_tier=EnumCapabilityTier.LOCAL,
+                provider=EnumProvider.LOCAL_VLLM,
+                retry_type=EnumRetryType.SAME_MODEL,
+                fallback_model="claude-3-5-haiku",
+            )
+
+    def test_with_fallback_model(self) -> None:
+        decision = ModelRoutingDecision(
+            selected_model="qwen3-coder-30b",
+            capability_tier=EnumCapabilityTier.LOCAL,
+            provider=EnumProvider.LOCAL_VLLM,
+            retry_type=EnumRetryType.FALLBACK_MODEL,
+            fallback_model="claude-3-5-haiku",
+            risk_level=EnumRiskLevel.HIGH,
+        )
+        assert decision.fallback_model == "claude-3-5-haiku"
+        assert decision.risk_level == EnumRiskLevel.HIGH
+
+    def test_exploration_score_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDecision(
+                selected_model="m",
+                capability_tier=EnumCapabilityTier.MID_FRONTIER,
+                provider=EnumProvider.ANTHROPIC,
+                exploration_score=1.5,
+            )
+
+    def test_cost_estimate_non_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDecision(
+                selected_model="m",
+                capability_tier=EnumCapabilityTier.EXPENSIVE_FRONTIER,
+                provider=EnumProvider.OPENAI,
+                cost_estimate_usd=-0.01,
+            )
+
+    def test_frozen(self) -> None:
+        decision = ModelRoutingDecision(
+            selected_model="m",
+            capability_tier=EnumCapabilityTier.LOCAL,
+            provider=EnumProvider.LOCAL_VLLM,
+        )
+        with pytest.raises(ValidationError):
+            decision.selected_model = "other"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDecision(
+                selected_model="m",
+                capability_tier=EnumCapabilityTier.LOCAL,
+                provider=EnumProvider.LOCAL_VLLM,
+                unknown_field="x",  # type: ignore[call-arg]
+            )
+
+    def test_all_providers_and_tiers(self) -> None:
+        for provider in EnumProvider:
+            for tier in EnumCapabilityTier:
+                d = ModelRoutingDecision(
+                    selected_model="m",
+                    capability_tier=tier,
+                    provider=provider,
+                )
+                assert d.provider == provider
+                assert d.capability_tier == tier
+
+
+@pytest.mark.unit
+class TestModelRoutingDegradedEvent:
+    def test_valid(self) -> None:
+        event = ModelRoutingDegradedEvent(
+            primary="qwen3-coder-30b",
+            reason="consecutive timeouts",
+            attempts=3,
+            elapsed_ms=1500.0,
+            model_key="qwen3-coder-30b",
+            correlation_id="corr-001",
+        )
+        assert event.primary == "qwen3-coder-30b"
+        assert event.attempts == 3
+        assert event.merge_sha == ""
+        assert event.gate_name == ""
+
+    def test_attempts_must_be_at_least_one(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDegradedEvent(
+                primary="m",
+                reason="r",
+                attempts=0,
+                elapsed_ms=100.0,
+                model_key="m",
+                correlation_id="c",
+            )
+
+    def test_elapsed_ms_non_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDegradedEvent(
+                primary="m",
+                reason="r",
+                attempts=1,
+                elapsed_ms=-1.0,
+                model_key="m",
+                correlation_id="c",
+            )
+
+    def test_optional_fields(self) -> None:
+        event = ModelRoutingDegradedEvent(
+            primary="m",
+            reason="r",
+            attempts=1,
+            elapsed_ms=0.0,
+            model_key="m",
+            correlation_id="c",
+            merge_sha="abc123",
+            gate_name="handler_score_models",
+        )
+        assert event.merge_sha == "abc123"
+        assert event.gate_name == "handler_score_models"
+
+    def test_frozen(self) -> None:
+        event = ModelRoutingDegradedEvent(
+            primary="m",
+            reason="r",
+            attempts=1,
+            elapsed_ms=0.0,
+            model_key="m",
+            correlation_id="c",
+        )
+        with pytest.raises(ValidationError):
+            event.primary = "other"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRoutingDegradedEvent(
+                primary="m",
+                reason="r",
+                attempts=1,
+                elapsed_ms=0.0,
+                model_key="m",
+                correlation_id="c",
+                bogus="x",  # type: ignore[call-arg]
+            )

--- a/tests/unit/models/telemetry/test_model_sweep_result.py
+++ b/tests/unit/models/telemetry/test_model_sweep_result.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelSweepResult."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.telemetry.model_sweep_result import ModelSweepResult
+
+
+def _make_sweep(**overrides: object) -> ModelSweepResult:
+    defaults: dict[str, object] = {
+        "sweep_type": "compliance",
+        "session_id": "session-001",
+        "correlation_id": "corr-001",
+        "ran_at": datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC),
+        "duration_seconds": 12.5,
+        "passed": True,
+        "summary": "All checks passed.",
+    }
+    defaults.update(overrides)
+    return ModelSweepResult(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelSweepResult:
+    def test_minimal_valid(self) -> None:
+        result = _make_sweep()
+        assert result.passed is True
+        assert result.finding_count == 0
+        assert result.critical_count == 0
+        assert result.warning_count == 0
+        assert result.repos_scanned == ()
+        assert result.output_path is None
+        assert result.schema_version == "1.0.0"
+
+    def test_all_sweep_types_valid(self) -> None:
+        for sweep_type in (
+            "aislop",
+            "coverage",
+            "compliance",
+            "contract",
+            "dashboard",
+            "runtime",
+            "data_flow",
+        ):
+            r = _make_sweep(sweep_type=sweep_type)
+            assert r.sweep_type == sweep_type
+
+    def test_invalid_sweep_type(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_sweep(sweep_type="unknown_sweep")
+
+    def test_repos_scanned_tuple(self) -> None:
+        result = _make_sweep(repos_scanned=("omnibase_core", "omnibase_infra"))
+        assert result.repos_scanned == ("omnibase_core", "omnibase_infra")
+
+    def test_with_output_path(self) -> None:
+        result = _make_sweep(output_path="/tmp/sweep-output.json")
+        assert result.output_path == "/tmp/sweep-output.json"
+
+    def test_failed_with_findings(self) -> None:
+        result = _make_sweep(
+            passed=False,
+            finding_count=5,
+            critical_count=2,
+            warning_count=3,
+            summary="2 critical findings detected.",
+        )
+        assert result.passed is False
+        assert result.finding_count == 5
+        assert result.critical_count == 2
+        assert result.warning_count == 3
+
+    def test_frozen(self) -> None:
+        result = _make_sweep()
+        with pytest.raises(ValidationError):
+            result.passed = False  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_sweep(unknown_field="x")  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- Adds `ModelRoutingDecision` (overseer policy engine output with `EnumCapabilityTier`, `EnumProvider`, `EnumRetryType`, `EnumRiskLevel`) to `omnibase_core.models.routing`
- Adds `ModelRoutingDegradedEvent` (emitted when router falls back to secondary model) to `omnibase_core.models.routing`
- Adds `ModelSweepResult` (structured sweep skill run result) to new `omnibase_core.models.telemetry` module
- `ModelRoutingPolicy` was already present in core — no duplication
- The infra-local `ModelRoutingDecision` variants (`node_model_router_compute` and `services/observability/agent_actions`) are semantically distinct models (compute node output vs. Kafka ingest DTO) and intentionally remain in infra

Closes OMN-12191 (epic OMN-12152).

## Design Notes

The compat `overseer/model_routing_decision.py` note said `COMPAT_MIGRATION_TARGET: omnibase_infra.nodes.node_model_router.models.model_routing_decision` — but that target doesn't match the compat field set (capability_tier, provider, risk_level, etc.) and the two infra variants are different models. The canonical policy-engine version belongs in core as the single source of truth across repos; infra-local wire DTOs stay in infra.

## Test plan

- [x] 23 unit tests pass: `pytest tests/unit/models/routing/test_routing_decision_and_degraded.py tests/unit/models/telemetry/test_model_sweep_result.py -v`
- [x] `mypy --strict` passes on all 3 new source files
- [x] `ruff check` clean — no linting errors
- [x] CI green

Evidence-Source: OCC#1679
Evidence-Ticket: OMN-12191