### PR TITLE
feat(OMN-12192): Migrate 3 evidence models from compat to core

### DIFF
--- a/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
+++ b/src/omnibase_core/models/contracts/evidence/model_contract_evidence_proof.py
@@ -24,7 +24,7 @@ class ModelContractEvidenceProof(BaseModel):
     rejected here because PR metadata belongs in ModelEvidenceProvenance.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     # string-id-ok: contract evidence proof IDs are stable human-authored keys, not object UUIDs.
     proof_id: str = Field(..., min_length=1)

--- a/src/omnibase_core/models/contracts/evidence/model_contract_evidence_spec.py
+++ b/src/omnibase_core/models/contracts/evidence/model_contract_evidence_spec.py
@@ -23,7 +23,7 @@ _TICKET_ID_RE = re.compile(r"^[A-Z]+-\d+$")
 class ModelContractEvidenceSpec(BaseModel):
     """Typed artifact-first replacement for PR-number-bound evidence checks."""
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     schema_version: Literal["1.0.0"] = "1.0.0"
     ticket_id: str = Field(..., min_length=1)

--- a/src/omnibase_core/models/contracts/evidence/model_evidence_provenance.py
+++ b/src/omnibase_core/models/contracts/evidence/model_evidence_provenance.py
@@ -16,7 +16,7 @@ class ModelEvidenceProvenance(BaseModel):
     truth that contracts validate.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     repo: str = Field(..., min_length=1)
     commit_sha: str | None = Field(default=None, min_length=7)

--- a/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
+++ b/tests/unit/models/contracts/evidence/test_contract_evidence_spec.py
@@ -128,3 +128,51 @@ def test_extra_fields_are_rejected() -> None:
             branch="main",
             unexpected=True,  # type: ignore[call-arg]
         )
+
+
+@pytest.mark.unit
+def test_provenance_requires_at_least_one_trace_field() -> None:
+    with pytest.raises(ValidationError, match="at least one trace field"):
+        ModelEvidenceProvenance(repo="omnibase_core")
+
+
+@pytest.mark.unit
+def test_evidence_models_support_from_attributes() -> None:
+    class _FakeORM:
+        repo = "omnibase_core"
+        commit_sha = "abc1234"
+        branch = None
+        pr_number = None
+        pr_url = None
+        ci_run_url = None
+        notes = None
+
+    provenance = ModelEvidenceProvenance.model_validate(
+        _FakeORM(), from_attributes=True
+    )
+    assert provenance.repo == "omnibase_core"
+    assert provenance.commit_sha == "abc1234"
+
+
+@pytest.mark.unit
+def test_file_exists_proof_requires_artifact_path() -> None:
+    with pytest.raises(
+        ValidationError, match="file_exists proof requires artifact_path"
+    ):
+        ModelContractEvidenceProof(
+            proof_id="file-check",
+            proof_kind=EnumStableProofKind.FILE_EXISTS,
+            description="Check artifact file exists.",
+            target="some/path/artifact.json",
+        )
+
+
+@pytest.mark.unit
+def test_command_proof_requires_command_field() -> None:
+    with pytest.raises(ValidationError, match="command proof requires command"):
+        ModelContractEvidenceProof(
+            proof_id="run-cmd",
+            proof_kind=EnumStableProofKind.COMMAND,
+            description="Run a verification command.",
+            target="some-target",
+        )


### PR DESCRIPTION
## Summary

Migrates the 3 evidence models with `COMPAT_REMOVAL_DATE: 2026-07-01` from `omnibase_compat` to their canonical home in `omnibase_core`.

- `ModelEvidenceProvenance` — transient review/source metadata
- `ModelContractEvidenceProof` — artifact-first or behavior-first proof item
- `ModelContractEvidenceSpec` — typed contract evidence storage format

The canonical definitions already existed in `omnibase_core.models.contracts.evidence`. This PR brings them into compliance with Pydantic model standards by adding `from_attributes=True` to all three `ConfigDict` declarations (pytest-xdist compatibility), and expands test coverage from 8 to 12 unit tests.

## Changes

- `from_attributes=True` added to `ModelEvidenceProvenance`, `ModelContractEvidenceProof`, `ModelContractEvidenceSpec`
- 4 new unit tests: provenance trace requirement, `from_attributes` ORM-style construction, `file_exists` proof validation, `command` proof validation

## Test plan

- [x] `uv run pytest tests/unit/models/contracts/evidence/ -v` — 12 passed
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — all checks passed
- [x] Pre-commit hooks run; 2 pre-existing failures in unrelated files (`model_adr_summary.py`, `antipattern_registry.yaml`) confirmed on main

Closes OMN-12192 | Epic OMN-12152

Evidence-Source: OCC#1678
Evidence-Ticket: OMN-12192