### PR TITLE
feat(OMN-12188): Migrate EventEnvelopeV1Minimal from compat to core

### DIFF
--- a/src/omnibase_core/models/events/__init__.py
+++ b/src/omnibase_core/models/events/__init__.py
@@ -29,6 +29,9 @@ from omnibase_core.models.events.model_episode_event import (
     TOPIC_EPISODE_BOUNDARY,
     ModelEpisodeEvent,
 )
+from omnibase_core.models.events.model_event_envelope_v1_minimal import (
+    EventEnvelopeV1Minimal,
+)
 from omnibase_core.models.events.model_event_payload_base import (
     ModelEventPayloadBase,
 )
@@ -159,4 +162,6 @@ __all__ = [
     # Episode boundary events (OMN-5559)
     "TOPIC_EPISODE_BOUNDARY",
     "ModelEpisodeEvent",
+    # Minimal cross-repo wire envelope migrated from compat (OMN-12188)
+    "EventEnvelopeV1Minimal",
 ]

--- a/src/omnibase_core/models/events/__init__.py
+++ b/src/omnibase_core/models/events/__init__.py
@@ -31,6 +31,7 @@ from omnibase_core.models.events.model_episode_event import (
 )
 from omnibase_core.models.events.model_event_envelope_v1_minimal import (
     EventEnvelopeV1Minimal,
+    ModelEventEnvelopeV1Minimal,
 )
 from omnibase_core.models.events.model_event_payload_base import (
     ModelEventPayloadBase,
@@ -164,4 +165,5 @@ __all__ = [
     "ModelEpisodeEvent",
     # Minimal cross-repo wire envelope migrated from compat (OMN-12188)
     "EventEnvelopeV1Minimal",
+    "ModelEventEnvelopeV1Minimal",
 ]

--- a/src/omnibase_core/models/events/model_event_envelope_v1_minimal.py
+++ b/src/omnibase_core/models/events/model_event_envelope_v1_minimal.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Minimal shared transport envelope for cross-repo event compatibility.
+
+Migrated from omnibase_compat.models.event_envelope (OMN-12188).
+Canonical location is now omnibase_core.models.events.model_event_envelope_v1_minimal.
+"""
+
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.utils.util_decorators import allow_dict_str_any
+
+
+@allow_dict_str_any(
+    "payload is an open-schema wire transport field for cross-repo event compatibility; "
+    "schema is intentionally untyped to decouple producer and consumer schemas"
+)
+class EventEnvelopeV1Minimal(BaseModel):
+    """Minimal shared transport envelope for cross-repo event compatibility.
+
+    Intentionally narrow. Does not include timestamp, source, trace_id,
+    correlation_id, or category. Add those in a versioned successor or
+    additive minor release once real usage patterns are established.
+
+    For a full-featured envelope with tracing, QoS, and security context,
+    use ModelEventEnvelope[T] from omnibase_core.models.events.model_event_envelope.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    event_id: UUID = Field(default_factory=uuid4)
+    event_type: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    # string-version-ok: wire schema guard for cross-repo transport compatibility
+    schema_version: str = "1.0"
+    data_provenance: str | None = Field(
+        default=None,
+        description=(
+            "Data provenance label. Expected values: "
+            '"demo_seeded", "demo_projected_shortcut", "measured", "estimated", "unknown". '
+            "Uses str (not enum) to preserve cross-repo wire compatibility."
+        ),
+    )
+
+
+__all__: list[str] = ["EventEnvelopeV1Minimal"]

--- a/src/omnibase_core/models/events/model_event_envelope_v1_minimal.py
+++ b/src/omnibase_core/models/events/model_event_envelope_v1_minimal.py
@@ -19,7 +19,7 @@ from omnibase_core.utils.util_decorators import allow_dict_str_any
     "payload is an open-schema wire transport field for cross-repo event compatibility; "
     "schema is intentionally untyped to decouple producer and consumer schemas"
 )
-class EventEnvelopeV1Minimal(BaseModel):
+class ModelEventEnvelopeV1Minimal(BaseModel):
     """Minimal shared transport envelope for cross-repo event compatibility.
 
     Intentionally narrow. Does not include timestamp, source, trace_id,
@@ -47,4 +47,7 @@ class EventEnvelopeV1Minimal(BaseModel):
     )
 
 
-__all__: list[str] = ["EventEnvelopeV1Minimal"]
+EventEnvelopeV1Minimal = ModelEventEnvelopeV1Minimal
+
+
+__all__: list[str] = ["EventEnvelopeV1Minimal", "ModelEventEnvelopeV1Minimal"]

--- a/tests/unit/models/events/test_model_event_envelope_v1_minimal.py
+++ b/tests/unit/models/events/test_model_event_envelope_v1_minimal.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EventEnvelopeV1Minimal (migrated from omnibase_compat OMN-12188)."""
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.events.model_event_envelope_v1_minimal import (
+    EventEnvelopeV1Minimal,
+)
+
+
+@pytest.mark.unit
+def test_event_envelope_roundtrip() -> None:
+    eid = uuid4()
+    envelope = EventEnvelopeV1Minimal(
+        event_id=eid,
+        event_type="node.executed.v1",
+        payload={"result": "ok"},
+    )
+    serialized = envelope.model_dump_json()
+    restored = EventEnvelopeV1Minimal.model_validate_json(serialized)
+    assert restored.event_id == envelope.event_id
+    assert restored.event_type == envelope.event_type
+    assert restored.payload == envelope.payload
+
+
+@pytest.mark.unit
+def test_event_envelope_is_frozen() -> None:
+    envelope = EventEnvelopeV1Minimal(
+        event_id=uuid4(),
+        event_type="node.executed.v1",
+        payload={},
+    )
+    with pytest.raises((ValidationError, TypeError)):
+        envelope.event_id = uuid4()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_event_envelope_schema_export() -> None:
+    schema = EventEnvelopeV1Minimal.model_json_schema()
+    assert set(schema["properties"].keys()) == {
+        "event_id",
+        "event_type",
+        "payload",
+        "schema_version",
+        "data_provenance",
+    }
+
+
+@pytest.mark.unit
+def test_event_envelope_defaults() -> None:
+    envelope = EventEnvelopeV1Minimal(event_type="test.v1")
+    assert envelope.schema_version == "1.0"
+    assert envelope.data_provenance is None
+    assert envelope.payload == {}
+    assert isinstance(envelope.event_id, UUID)
+
+
+@pytest.mark.unit
+def test_event_envelope_data_provenance_values() -> None:
+    for label in (
+        "demo_seeded",
+        "demo_projected_shortcut",
+        "measured",
+        "estimated",
+        "unknown",
+    ):
+        envelope = EventEnvelopeV1Minimal(event_type="test.v1", data_provenance=label)
+        assert envelope.data_provenance == label
+
+
+@pytest.mark.unit
+def test_event_envelope_exported_from_events_init() -> None:
+    from omnibase_core.models.events import EventEnvelopeV1Minimal as Imported
+
+    assert Imported is EventEnvelopeV1Minimal

--- a/tests/unit/models/events/test_model_event_envelope_v1_minimal.py
+++ b/tests/unit/models/events/test_model_event_envelope_v1_minimal.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from omnibase_core.models.events.model_event_envelope_v1_minimal import (
     EventEnvelopeV1Minimal,
+    ModelEventEnvelopeV1Minimal,
 )
 
 
@@ -76,5 +77,8 @@ def test_event_envelope_data_provenance_values() -> None:
 @pytest.mark.unit
 def test_event_envelope_exported_from_events_init() -> None:
     from omnibase_core.models.events import EventEnvelopeV1Minimal as Imported
+    from omnibase_core.models.events import ModelEventEnvelopeV1Minimal as ModelImported
 
     assert Imported is EventEnvelopeV1Minimal
+    assert Imported is ModelEventEnvelopeV1Minimal
+    assert ModelImported is ModelEventEnvelopeV1Minimal


### PR DESCRIPTION
## Summary

- Adds `EventEnvelopeV1Minimal` to `omnibase_core.models.events` as canonical location, migrated from `omnibase_compat.models.event_envelope` (COMPAT_REMOVAL_DATE: 2026-07-01)
- Exports from `omnibase_core.models.events.__init__`
- 6 unit tests covering roundtrip, frozen enforcement, schema export, defaults, data_provenance values, and init re-export

## Changes from compat version

- `event_id` typed as `UUID` (was `str` in compat due to zero-dep constraint; uses canonical `UUID` now that core has full deps)
- `@allow_dict_str_any` decorator justifies open `payload: dict[str, Any]` wire field

## Note on compat re-export

The compat shim cannot re-export from core — `omnibase_compat` has zero runtime upstream dependencies and cannot import `omnibase_core`. Consumers of `omnibase_compat.models.event_envelope.EventEnvelopeV1Minimal` must update imports to `omnibase_core.models.events.model_event_envelope_v1_minimal.EventEnvelopeV1Minimal` directly.

## Repos needing import updates

Grep across all repos in omni_home found **no external consumers** of `EventEnvelopeV1Minimal` outside of omnibase_compat itself. The only usages are:
- `omnibase_compat/src/omnibase_compat/tests/test_contract_roundtrip.py` (compat's own tests)
- `omnibase_compat/src/omnibase_compat/contracts/delegation/wire/__init__.py` (references `ModelDelegationEventEnvelope`, not `EventEnvelopeV1Minimal`)

The compat `COMPAT_MIGRATION_TARGET` comment should be updated to `omnibase_core.models.events.model_event_envelope_v1_minimal` in a follow-up compat PR.

## Test plan

- [x] `uv run pytest tests/unit/models/events/test_model_event_envelope_v1_minimal.py -v` — 6 passed
- [x] `uv run pytest tests/unit/models/events/ -q` — 750 passed
- [x] `uv run mypy src/omnibase_core/models/events/model_event_envelope_v1_minimal.py --strict` — clean
- [x] `pre-commit run --files` on changed files — all passed (pre-existing failures on unrelated files)

Evidence-Source: OCC#1680
Evidence-Ticket: OMN-12188
