### PR TITLE
fix(OMN-12163): Wire ServiceTimeInjector in omnibase_core mixins

### DIFF
--- a/src/omnibase_core/mixins/mixin_event_handler.py
+++ b/src/omnibase_core/mixins/mixin_event_handler.py
@@ -45,7 +45,6 @@ This mixin handles:
 import asyncio
 import fnmatch
 import inspect
-from datetime import datetime
 from pathlib import Path
 
 # Import protocol to avoid circular dependencies
@@ -57,9 +56,13 @@ from omnibase_core.models.core.model_event_type import (
 )
 from omnibase_core.models.core.model_log_context import ModelLogContext
 from omnibase_core.models.core.model_onex_event import OnexEvent
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
 
 # Component identifier for logging
 _COMPONENT_NAME = Path(__file__).stem
+
+# Module-level time service — injectable for replay determinism
+_time_svc = ServiceTimeInjector()
 
 # Background tasks set to prevent garbage collection of fire-and-forget tasks
 _background_tasks: set[asyncio.Task[None]] = set()
@@ -119,7 +122,7 @@ class MixinEventHandler:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_setup_event_handlers",
                 calling_line=67,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=(
                     UUID(node_id)
                     if isinstance(node_id, str) and node_id != "<unset>"
@@ -217,7 +220,7 @@ class MixinEventHandler:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_handle_introspection_request",
                 calling_line=124,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=(
                     UUID(node_id)
                     if isinstance(node_id, str) and node_id != "<unset>"
@@ -236,7 +239,7 @@ class MixinEventHandler:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_handle_introspection_request",
                 calling_line=137,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=(
                     UUID(node_id)
                     if isinstance(node_id, str) and node_id != "<unset>"
@@ -295,7 +298,7 @@ class MixinEventHandler:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_handle_node_discovery_request",
                 calling_line=170,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=(
                     UUID(node_id)
                     if isinstance(node_id, str) and node_id != "<unset>"
@@ -314,7 +317,7 @@ class MixinEventHandler:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_handle_node_discovery_request",
                 calling_line=183,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=(
                     UUID(node_id)
                     if isinstance(node_id, str) and node_id != "<unset>"
@@ -408,7 +411,7 @@ class MixinEventHandler:
                     calling_module=_COMPONENT_NAME,
                     calling_function="cleanup_event_handlers",
                     calling_line=248,
-                    timestamp=datetime.now().isoformat(),
+                    timestamp=_time_svc.now().isoformat(),
                     node_id=(
                         UUID(node_id)
                         if isinstance(node_id, str) and node_id != "<unset>"
@@ -428,7 +431,7 @@ class MixinEventHandler:
                     calling_module=_COMPONENT_NAME,
                     calling_function="cleanup_event_handlers",
                     calling_line=261,
-                    timestamp=datetime.now().isoformat(),
+                    timestamp=_time_svc.now().isoformat(),
                     node_id=(
                         UUID(node_id)
                         if isinstance(node_id, str) and node_id != "<unset>"

--- a/src/omnibase_core/mixins/mixin_introspection_publisher.py
+++ b/src/omnibase_core/mixins/mixin_introspection_publisher.py
@@ -10,7 +10,6 @@ from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 "\nIntrospection Publisher Mixin.\n\nThis mixin handles:\n- Gathering node introspection data from various sources\n- Publishing NODE_INTROSPECTION_EVENT for service discovery\n- Extracting actions, protocols, metadata from nodes\n- Retry logic for failed publishes\n"
 import re
-from datetime import datetime
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -27,8 +26,12 @@ from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.mixins.model_node_introspection_data import (
     ModelNodeIntrospectionData,
 )
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
 
 _COMPONENT_NAME = Path(__file__).stem
+
+# Module-level time service — injectable for replay determinism
+_time_svc = ServiceTimeInjector()
 DEFAULT_AUTHOR = "ONEX"
 
 _CANONICAL_NODE_TYPES = ("effect", "compute", "reducer", "orchestrator")
@@ -59,7 +62,7 @@ def _normalize_node_type(raw: str) -> str:
         calling_module=_COMPONENT_NAME,
         calling_function="_normalize_node_type",
         calling_line=0,
-        timestamp=datetime.now().isoformat(),
+        timestamp=_time_svc.now().isoformat(),
     )
     emit_log_event_sync(
         LogLevel.WARNING,
@@ -123,7 +126,7 @@ class MixinIntrospectionPublisher:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_introspection_event",
                 calling_line=71,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id_raw if isinstance(node_id_raw, UUID) else None,
             )
             emit_log_event_sync(
@@ -136,7 +139,7 @@ class MixinIntrospectionPublisher:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_introspection_event",
                 calling_line=95,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id_raw if isinstance(node_id_raw, UUID) else None,
             )
             emit_log_event_sync(
@@ -150,7 +153,7 @@ class MixinIntrospectionPublisher:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_introspection_event",
                 calling_line=95,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id_raw if isinstance(node_id_raw, UUID) else None,
             )
             emit_log_event_sync(
@@ -200,7 +203,7 @@ class MixinIntrospectionPublisher:
             calling_module=_COMPONENT_NAME,
             calling_function="_gather_introspection_data",
             calling_line=127,
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=node_id_raw if isinstance(node_id_raw, UUID) else None,
         )
         emit_log_event_sync(
@@ -461,7 +464,7 @@ class MixinIntrospectionPublisher:
                         calling_module=_COMPONENT_NAME,
                         calling_function="_publish_with_retry",
                         calling_line=350,
-                        timestamp=datetime.now().isoformat(),
+                        timestamp=_time_svc.now().isoformat(),
                         node_id=node_id_raw if isinstance(node_id_raw, UUID) else None,
                     )
                     emit_log_event_sync(

--- a/src/omnibase_core/mixins/mixin_node_executor.py
+++ b/src/omnibase_core/mixins/mixin_node_executor.py
@@ -45,7 +45,6 @@ import asyncio
 import contextlib
 import signal
 import time
-from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 
@@ -66,8 +65,12 @@ from omnibase_core.models.discovery.model_tool_response_event import (
     ModelToolResponseEvent,
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
 
 _COMPONENT_NAME = Path(__file__).stem
+
+# Module-level time service — injectable for replay determinism
+_time_svc = ServiceTimeInjector()
 
 
 class MixinNodeExecutor(MixinEventDrivenNode):
@@ -500,7 +503,7 @@ class MixinNodeExecutor(MixinEventDrivenNode):
             calling_module=_COMPONENT_NAME,
             calling_function="executor",
             calling_line=1,
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=UUID(node_id_raw) if isinstance(node_id_raw, str) else node_id_raw,
         )
         emit_log_event_sync(LogLevel.INFO, message, context=context)
@@ -514,7 +517,7 @@ class MixinNodeExecutor(MixinEventDrivenNode):
             calling_module=_COMPONENT_NAME,
             calling_function="executor",
             calling_line=1,
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=UUID(node_id_raw) if isinstance(node_id_raw, str) else node_id_raw,
         )
         emit_log_event_sync(LogLevel.WARNING, message, context=context)
@@ -528,7 +531,7 @@ class MixinNodeExecutor(MixinEventDrivenNode):
             calling_module=_COMPONENT_NAME,
             calling_function="executor",
             calling_line=1,
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=UUID(node_id_raw) if isinstance(node_id_raw, str) else node_id_raw,
         )
         emit_log_event_sync(LogLevel.ERROR, message, context=context)

--- a/src/omnibase_core/mixins/mixin_node_lifecycle.py
+++ b/src/omnibase_core/mixins/mixin_node_lifecycle.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-from datetime import datetime
-
 # === OmniNode:Metadata ===
 # author: OmniNode Team
 # copyright: OmniNode.ai
@@ -55,6 +53,7 @@ from omnibase_core.models.primitives.model_semver import (
     ModelSemVer,
     parse_semver_from_string,
 )
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
 from omnibase_core.types.type_json import JsonType
 from omnibase_core.types.typed_dict_lifecycle_event_fields import (
     TypedDictLifecycleEventFields,
@@ -62,6 +61,9 @@ from omnibase_core.types.typed_dict_lifecycle_event_fields import (
 
 # Component identifier for logging
 _COMPONENT_NAME = Path(__file__).stem
+
+# Module-level time service — injectable for replay determinism
+_time_svc = ServiceTimeInjector()
 
 
 def _ensure_uuid(value: UUID | None) -> UUID:
@@ -129,7 +131,7 @@ class MixinNodeLifecycle:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_register_node",
                 calling_line=67,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id,
             )
             emit_log_event_sync(
@@ -162,7 +164,7 @@ class MixinNodeLifecycle:
                 schema_version=parse_semver_from_string(
                     getattr(metadata_block, "schema_version", None) or "1.0.0"
                 ),
-                timestamp=datetime.now(),
+                timestamp=_time_svc.now(),
                 signature_block=getattr(self, "signature_block", None),
                 node_version=parse_semver_from_string(
                     getattr(self, "node_version", None)
@@ -190,7 +192,7 @@ class MixinNodeLifecycle:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_register_node",
                 calling_line=106,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id,
             )
             emit_log_event_sync(
@@ -205,7 +207,7 @@ class MixinNodeLifecycle:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_register_node",
                 calling_line=118,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id,
             )
             emit_log_event_sync(
@@ -253,7 +255,7 @@ class MixinNodeLifecycle:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_shutdown_event",
                 calling_line=152,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id,
             )
             emit_log_event_sync(
@@ -268,7 +270,7 @@ class MixinNodeLifecycle:
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_shutdown_event",
                 calling_line=164,
-                timestamp=datetime.now().isoformat(),
+                timestamp=_time_svc.now().isoformat(),
                 node_id=node_id,
             )
             emit_log_event_sync(
@@ -485,7 +487,7 @@ class MixinNodeLifecycle:
                     calling_module=_COMPONENT_NAME,
                     calling_function="cleanup_lifecycle_resources",
                     calling_line=283,
-                    timestamp=datetime.now().isoformat(),
+                    timestamp=_time_svc.now().isoformat(),
                     node_id=node_id,
                 )
                 emit_log_event_sync(

--- a/src/omnibase_core/mixins/mixin_node_service.py
+++ b/src/omnibase_core/mixins/mixin_node_service.py
@@ -33,7 +33,6 @@ import signal
 import time
 import types
 from collections.abc import Callable
-from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 from uuid import UUID, uuid4
@@ -55,11 +54,15 @@ from omnibase_core.models.discovery.model_tool_response_event import (
     ModelToolResponseEvent,
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
 from omnibase_core.types import TypedDictServiceHealth
 from omnibase_core.types.type_json import JsonType
 
 # Component identifier for logging
 _COMPONENT_NAME = Path(__file__).stem
+
+# Module-level time service — injectable for replay determinism
+_time_svc = ServiceTimeInjector()
 
 # Service lookup errors for container.get_service() calls.
 # Uses centralized PYDANTIC_MODEL_ERRORS (AttributeError, TypeError, ValidationError, ValueError)
@@ -842,7 +845,7 @@ class MixinNodeService:
             calling_module=_COMPONENT_NAME,
             calling_function="service",
             calling_line=1,  # Required field
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=node_id,
         )
         emit_log_event_sync(LogLevel.INFO, message, context=context)
@@ -855,7 +858,7 @@ class MixinNodeService:
             calling_module=_COMPONENT_NAME,
             calling_function="service",
             calling_line=1,  # Required field
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=node_id,
         )
         emit_log_event_sync(LogLevel.WARNING, message, context=context)
@@ -868,7 +871,7 @@ class MixinNodeService:
             calling_module=_COMPONENT_NAME,
             calling_function="service",
             calling_line=1,  # Required field
-            timestamp=datetime.now().isoformat(),
+            timestamp=_time_svc.now().isoformat(),
             node_id=node_id,
         )
         emit_log_event_sync(LogLevel.ERROR, message, context=context)

--- a/src/omnibase_core/utils/util_streaming_window.py
+++ b/src/omnibase_core/utils/util_streaming_window.py
@@ -45,6 +45,8 @@ See Also:
 from collections import deque
 from datetime import datetime, timedelta
 
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
+
 
 class UtilStreamingWindow:
     """
@@ -80,18 +82,25 @@ class UtilStreamingWindow:
         prefix indicates a utility class.
     """
 
-    def __init__(self, window_size_ms: int, overlap_ms: int = 0):
+    def __init__(
+        self,
+        window_size_ms: int,
+        overlap_ms: int = 0,
+        time_svc: ServiceTimeInjector | None = None,
+    ):
         """
         Initialize streaming window.
 
         Args:
             window_size_ms: Window size in milliseconds
             overlap_ms: Overlap size in milliseconds (default: 0)
+            time_svc: Optional time service for deterministic replay
         """
         self.window_size_ms = window_size_ms
         self.overlap_ms = overlap_ms
+        self._time_svc = time_svc if time_svc is not None else ServiceTimeInjector()
         self.buffer: deque[tuple[object, datetime]] = deque()
-        self.window_start = datetime.now()
+        self.window_start = self._time_svc.now()
 
     def add_item(self, item: object) -> bool:
         """
@@ -103,7 +112,7 @@ class UtilStreamingWindow:
         Returns:
             True if window is full and ready to process
         """
-        current_time = datetime.now()
+        current_time = self._time_svc.now()
         self.buffer.append((item, current_time))
 
         # Check if window is complete
@@ -137,7 +146,7 @@ class UtilStreamingWindow:
             # Clear all items
             self.buffer.clear()
 
-        self.window_start = datetime.now()
+        self.window_start = self._time_svc.now()
 
 
 def __getattr__(name: str) -> object:

--- a/tests/unit/services/replay/test_service_time_injector.py
+++ b/tests/unit/services/replay/test_service_time_injector.py
@@ -89,7 +89,7 @@ class TestUtilStreamingWindowWithInjectedTime:
         svc = ServiceTimeInjector(fixed_time=fixed)
         window = UtilStreamingWindow(window_size_ms=1000, time_svc=svc)
         window.add_item("event_a")
-        _item, ts = list(window.buffer)[0]
+        _item, ts = next(iter(window.buffer))
         assert ts == fixed
 
     @pytest.mark.unit
@@ -125,6 +125,6 @@ class TestUtilStreamingWindowWithInjectedTime:
         before = datetime.now(UTC)
         ready = window.add_item("event")
         after = datetime.now(UTC)
-        _item, ts = list(window.buffer)[0]
+        _item, ts = next(iter(window.buffer))
         assert before <= ts <= after
         assert not ready

--- a/tests/unit/services/replay/test_service_time_injector.py
+++ b/tests/unit/services/replay/test_service_time_injector.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for ServiceTimeInjector and UtilStreamingWindow replay determinism.
+
+Proves that timestamps are injectable — the acceptance criterion for OMN-12163.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.services.replay.service_time_injector import ServiceTimeInjector
+from omnibase_core.utils.util_streaming_window import UtilStreamingWindow
+
+
+class TestServiceTimeInjector:
+    """ServiceTimeInjector: production mode and replay mode behaviour."""
+
+    @pytest.mark.unit
+    def test_production_mode_returns_utc_datetime(self) -> None:
+        svc = ServiceTimeInjector()
+        result = svc.now()
+        assert result.tzinfo is not None
+        assert result.tzinfo == UTC
+
+    @pytest.mark.unit
+    def test_replay_mode_returns_fixed_time(self) -> None:
+        fixed = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        assert svc.now() == fixed
+
+    @pytest.mark.unit
+    def test_replay_mode_is_deterministic(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        t1 = svc.now()
+        t2 = svc.now()
+        assert t1 == t2 == fixed
+
+    @pytest.mark.unit
+    def test_two_injectors_same_fixed_time_are_equal(self) -> None:
+        fixed = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        a = ServiceTimeInjector(fixed_time=fixed)
+        b = ServiceTimeInjector(fixed_time=fixed)
+        assert a.now() == b.now() == fixed
+
+    @pytest.mark.unit
+    def test_naive_fixed_time_assumes_utc(self) -> None:
+        naive = datetime(2024, 6, 15, 12, 0, 0)
+        svc = ServiceTimeInjector(fixed_time=naive)
+        result = svc.now()
+        assert result.tzinfo == UTC
+
+    @pytest.mark.unit
+    def test_utc_now_alias_matches_now(self) -> None:
+        fixed = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        assert svc.utc_now() == svc.now()
+
+    @pytest.mark.unit
+    def test_fixed_time_property(self) -> None:
+        fixed = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        assert svc.fixed_time == fixed
+
+    @pytest.mark.unit
+    def test_production_mode_fixed_time_is_none(self) -> None:
+        svc = ServiceTimeInjector()
+        assert svc.fixed_time is None
+
+
+class TestUtilStreamingWindowWithInjectedTime:
+    """UtilStreamingWindow: injectable time for deterministic replay."""
+
+    @pytest.mark.unit
+    def test_window_start_uses_injected_time(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        window = UtilStreamingWindow(window_size_ms=1000, time_svc=svc)
+        assert window.window_start == fixed
+
+    @pytest.mark.unit
+    def test_add_item_uses_injected_time_for_timestamps(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        window = UtilStreamingWindow(window_size_ms=1000, time_svc=svc)
+        window.add_item("event_a")
+        _item, ts = list(window.buffer)[0]
+        assert ts == fixed
+
+    @pytest.mark.unit
+    def test_window_never_completes_when_time_is_frozen(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        window = UtilStreamingWindow(window_size_ms=5000, time_svc=svc)
+        for _ in range(10):
+            ready = window.add_item("event")
+            assert not ready
+
+    @pytest.mark.unit
+    def test_window_immediately_complete_when_size_is_zero(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        window = UtilStreamingWindow(window_size_ms=0, time_svc=svc)
+        ready = window.add_item("event")
+        assert ready
+
+    @pytest.mark.unit
+    def test_advance_window_uses_injected_time(self) -> None:
+        fixed = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        svc = ServiceTimeInjector(fixed_time=fixed)
+        window = UtilStreamingWindow(window_size_ms=1000, time_svc=svc)
+        window.add_item("event")
+        window.advance_window()
+        assert window.window_start == fixed
+        assert len(window.buffer) == 0
+
+    @pytest.mark.unit
+    def test_default_construction_uses_real_time(self) -> None:
+        window = UtilStreamingWindow(window_size_ms=1000)
+        before = datetime.now(UTC)
+        ready = window.add_item("event")
+        after = datetime.now(UTC)
+        _item, ts = list(window.buffer)[0]
+        assert before <= ts <= after
+        assert not ready


### PR DESCRIPTION
## Summary

- Replaces `datetime.now()` with `ServiceTimeInjector` in 6 key mixin/util files: `mixin_event_handler`, `mixin_node_lifecycle`, `mixin_node_executor`, `mixin_node_service`, `mixin_introspection_publisher`, `util_streaming_window`
- Each mixin gets a module-level `_time_svc = ServiceTimeInjector()` (production mode by default); `UtilStreamingWindow.__init__` also accepts an optional `time_svc` parameter for full per-instance injection
- Adds 14 unit tests in `test_service_time_injector.py` proving timestamps are injectable and replay determinism holds

Closes OMN-12163 (epic OMN-12152)

## Test plan

- [x] `uv run pytest tests/unit/services/replay/test_service_time_injector.py -v` — 14 tests pass
- [x] `uv run pytest tests/unit/mixins/ -q` — 822 tests pass
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean (pre-existing warnings only)
- [x] Pre-commit failures confirmed pre-existing on main (verified via `git stash`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deterministic replay mode now supports time-consistent execution, enabling reproducible scenario replay regardless of system clock variations.

* **Tests**
  * Added comprehensive test coverage for time injection services, replay determinism, and streaming window behavior with injected time sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OmniNode-ai/omnibase_core/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#1681
Evidence-Ticket: OMN-12163
