### PR TITLE
fix(OMN-12176): Annotate hardcoded IPs in omnibase_core tests

### DIFF
--- a/tests/unit/contracts/test_model_contract_config.py
+++ b/tests/unit/contracts/test_model_contract_config.py
@@ -48,10 +48,10 @@ class TestModelContractConfig:
 
     def test_llm_endpoint_config_valid(self):
         llm = ModelLlmEndpointConfig(
-            coder_url="http://192.168.86.201:8000",
+            coder_url="http://192.168.86.201:8000",  # onex-allow-internal-ip
             coder_model_name="Qwen3-Coder-30B",
         )
-        assert llm.coder_url == "http://192.168.86.201:8000"
+        assert llm.coder_url == "http://192.168.86.201:8000"  # onex-allow-internal-ip
         assert llm.coder_model_name == "Qwen3-Coder-30B"
 
     def test_llm_endpoint_config_rejects_unknown_fields(self):
@@ -60,11 +60,11 @@ class TestModelContractConfig:
 
     def test_storage_config_valid(self):
         s = ModelStorageConfig(
-            postgres_host="192.168.86.201",
+            postgres_host="192.168.86.201",  # onex-allow-internal-ip
             postgres_port=5436,
-            kafka_bootstrap_servers="192.168.86.201:19092",
+            kafka_bootstrap_servers="192.168.86.201:19092",  # onex-allow-internal-ip
         )
-        assert s.postgres_host == "192.168.86.201"
+        assert s.postgres_host == "192.168.86.201"  # onex-allow-internal-ip
         assert s.postgres_port == 5436
 
     def test_storage_config_rejects_unknown_fields(self):

--- a/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
+++ b/tests/unit/models/contracts/test_model_behavior_proven_receipt.py
@@ -36,7 +36,7 @@ def _base_fields() -> dict:
     return {
         "ticket_id": "OMN-9214",
         "evidence_item_id": "dod-behavior-001",
-        "command_run": "kcat -P -b 192.168.86.201:19092 -t onex.cmd.merge_sweep.v1",
+        "command_run": "kcat -P -b 192.168.86.201:19092 -t onex.cmd.merge_sweep.v1",  # onex-allow-internal-ip
         "query": "rpk topic consume onex.evt.merge_sweep.completed.v1 --num 1",
         "assertion": EnumBehaviorProvenAssertion.PASSED,
         "observed_at": datetime.now(tz=UTC),

--- a/tests/unit/models/contracts/test_model_delegation_runtime_profile.py
+++ b/tests/unit/models/contracts/test_model_delegation_runtime_profile.py
@@ -58,7 +58,7 @@ from pydantic import ValidationError
 def minimal_event_bus() -> ModelDelegationEventBusEndpoint:
     return ModelDelegationEventBusEndpoint(
         provider="redpanda",
-        bootstrap_servers=["192.168.86.201:19092"],
+        bootstrap_servers=["192.168.86.201:19092"],  # onex-allow-internal-ip
         topic_policy_ref="onex.topics.v1",
         consumer_groups=["delegation-consumer-group"],
     )
@@ -113,7 +113,9 @@ class TestMinimalValidProfile:
     ) -> None:
         eb = minimal_profile.event_bus
         assert eb.provider == "redpanda"
-        assert eb.bootstrap_servers == ["192.168.86.201:19092"]
+        assert eb.bootstrap_servers == [
+            "192.168.86.201:19092"  # onex-allow-internal-ip
+        ]
         assert eb.topic_policy_ref == "onex.topics.v1"
         assert eb.consumer_groups == ["delegation-consumer-group"]
 

--- a/tests/unit/models/contracts/test_runtime_sha_match.py
+++ b/tests/unit/models/contracts/test_runtime_sha_match.py
@@ -146,11 +146,11 @@ def _write_receipt(
         commit_sha=deployed_sha,
         runner="integration-sweep-verifier",
         verifier="receipt-gate-test-verifier",
-        probe_command="ssh 192.168.86.201 git -C /data/omninode/omni_home/omnimarket rev-parse HEAD",
+        probe_command="ssh 192.168.86.201 git -C /data/omninode/omni_home/omnimarket rev-parse HEAD",  # onex-allow-internal-ip
         probe_stdout=f"{deployed_sha}\n",
         actual_output=json.dumps(
             {
-                "runtime_host": "192.168.86.201",
+                "runtime_host": "192.168.86.201",  # onex-allow-internal-ip
                 "deployed_sha": deployed_sha,
                 "merge_sha": merge_sha,
                 "match": match,

--- a/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
+++ b/tests/unit/models/contracts/test_runtime_sha_match_dod_gate.py
@@ -107,7 +107,7 @@ class TestCheckTypeConstant:
 class TestModelRuntimeShaMatchOutput:
     def test_valid_matching_sha(self) -> None:
         out = ModelRuntimeShaMatchOutput(
-            runtime_host="192.168.86.201",
+            runtime_host="192.168.86.201",  # onex-allow-internal-ip
             deployed_sha="abc123def456",  # pragma: allowlist secret
             merge_sha="abc123def456",  # pragma: allowlist secret
             match=True,
@@ -116,7 +116,7 @@ class TestModelRuntimeShaMatchOutput:
 
     def test_valid_mismatched_sha(self) -> None:
         out = ModelRuntimeShaMatchOutput(
-            runtime_host="192.168.86.201",
+            runtime_host="192.168.86.201",  # onex-allow-internal-ip
             deployed_sha="aaaaaaaaaaaa",  # pragma: allowlist secret
             merge_sha="bbbbbbbbbbbb",  # pragma: allowlist secret
             match=False,
@@ -134,14 +134,14 @@ class TestModelRuntimeShaMatchOutput:
     def test_missing_deployed_sha_rejected(self) -> None:
         with pytest.raises(ValidationError):
             ModelRuntimeShaMatchOutput(
-                runtime_host="192.168.86.201",
+                runtime_host="192.168.86.201",  # onex-allow-internal-ip
                 merge_sha="abc123",
                 match=True,
             )
 
     def test_is_frozen(self) -> None:
         out = ModelRuntimeShaMatchOutput(
-            runtime_host="192.168.86.201",
+            runtime_host="192.168.86.201",  # onex-allow-internal-ip
             deployed_sha="abc123",
             merge_sha="abc123",
             match=True,

--- a/tests/unit/models/delegation/test_model_health_status.py
+++ b/tests/unit/models/delegation/test_model_health_status.py
@@ -15,7 +15,7 @@ from omnibase_core.models.delegation.model_model_health_status import (
     ModelModelHealthStatus,
 )
 
-_ENDPOINT = "http://192.168.86.201:8000"
+_ENDPOINT = "http://192.168.86.201:8000"  # onex-allow-internal-ip
 _NOW = datetime(2026, 5, 6, 10, 0, 0, tzinfo=UTC)
 
 

--- a/tests/unit/models/dispatch/test_model_dispatch_claim.py
+++ b/tests/unit/models/dispatch/test_model_dispatch_claim.py
@@ -13,12 +13,14 @@ from omnibase_core.models.dispatch.model_dispatch_claim import (
     compute_blocker_id,
 )
 
+_HOST = "192.168.86.201"  # onex-allow-internal-ip
+
 
 def _make_claim(**overrides) -> ModelDispatchClaim:
     defaults: dict = {
-        "blocker_id": compute_blocker_id("fix_containers", "192.168.86.201", "docker"),
+        "blocker_id": compute_blocker_id("fix_containers", _HOST, "docker"),
         "kind": "fix_containers",
-        "host": "192.168.86.201",
+        "host": _HOST,
         "resource": "docker",
         "claimant": "agent-abc123",
         "claimed_at": datetime.now(tz=UTC),
@@ -31,16 +33,16 @@ def _make_claim(**overrides) -> ModelDispatchClaim:
 
 @pytest.mark.unit
 def test_blocker_id_determinism() -> None:
-    id1 = compute_blocker_id("fix_containers", "192.168.86.201", "res")
-    id2 = compute_blocker_id("fix_containers", "192.168.86.201", "res")
+    id1 = compute_blocker_id("fix_containers", _HOST, "res")
+    id2 = compute_blocker_id("fix_containers", _HOST, "res")
     assert id1 == id2
     assert len(id1) == 40
 
 
 @pytest.mark.unit
 def test_blocker_id_distinct_inputs() -> None:
-    id1 = compute_blocker_id("fix_containers", "192.168.86.201", "docker")
-    id2 = compute_blocker_id("fix_containers", "192.168.86.201", "redpanda")
+    id1 = compute_blocker_id("fix_containers", _HOST, "docker")
+    id2 = compute_blocker_id("fix_containers", _HOST, "redpanda")
     assert id1 != id2
 
 

--- a/tests/unit/models/validation/test_model_event_destination.py
+++ b/tests/unit/models/validation/test_model_event_destination.py
@@ -581,7 +581,7 @@ class TestModelEventDestinationEdgeCases:
 class TestDecommissionedEndpointAbsent:
     """Ensure decommissioned M2 Ultra bus endpoint never appears in model code.
 
-    The M2 Ultra Redpanda at 192.168.86.200:29092 was decommissioned 2026-03-03
+    The M2 Ultra Redpanda at 192.168.86.200:29092 was decommissioned 2026-03-03  # onex-allow-internal-ip
     (OMN-3431). Any reference to this endpoint in docstrings or defaults is stale
     and misleading.
     """
@@ -592,7 +592,7 @@ class TestDecommissionedEndpointAbsent:
         import omnibase_core.models.validation.model_event_destination as mod
 
         docstring = mod.__doc__ or ""
-        assert "192.168.86.200:29092" not in docstring, (
+        assert "192.168.86.200:29092" not in docstring, (  # onex-allow-internal-ip
             "Decommissioned M2 Ultra endpoint found in module docstring. "
             "Use localhost:19092 (local Docker bus) instead."
         )
@@ -601,7 +601,7 @@ class TestDecommissionedEndpointAbsent:
     def test_no_decommissioned_endpoint_in_class_docstring(self) -> None:
         """Assert decommissioned M2 endpoint absent from ModelEventDestination docstring."""
         docstring = ModelEventDestination.__doc__ or ""
-        assert "192.168.86.200:29092" not in docstring, (
+        assert "192.168.86.200:29092" not in docstring, (  # onex-allow-internal-ip
             "Decommissioned M2 Ultra endpoint found in class docstring."
         )
 
@@ -609,7 +609,7 @@ class TestDecommissionedEndpointAbsent:
     def test_no_decommissioned_endpoint_in_create_kafka_docstring(self) -> None:
         """Assert decommissioned M2 endpoint absent from create_kafka docstring."""
         docstring = ModelEventDestination.create_kafka.__doc__ or ""
-        assert "192.168.86.200:29092" not in docstring, (
+        assert "192.168.86.200:29092" not in docstring, (  # onex-allow-internal-ip
             "Decommissioned M2 Ultra endpoint found in create_kafka docstring. "
             "Use localhost:19092 (local Docker bus) instead."
         )

--- a/tests/unit/validation/delegation/test_validator_delegation_profile.py
+++ b/tests/unit/validation/delegation/test_validator_delegation_profile.py
@@ -36,7 +36,7 @@ def test_valid_profile_passes() -> None:
 def test_rejects_endpoint_url_in_bifrost_ref() -> None:
     data = yaml.safe_load(VALID_YAML)
     data["llm_backends"]["default"]["bifrost_endpoint_ref"] = (
-        "https://192.168.86.201:8000"
+        "https://192.168.86.201:8000"  # onex-allow-internal-ip
     )
     result = validate_delegation_profile(data)
     assert not result.is_valid
@@ -45,7 +45,9 @@ def test_rejects_endpoint_url_in_bifrost_ref() -> None:
 
 def test_rejects_ip_in_bifrost_ref() -> None:
     data = yaml.safe_load(VALID_YAML)
-    data["llm_backends"]["default"]["bifrost_endpoint_ref"] = "192.168.86.201:8000"
+    data["llm_backends"]["default"]["bifrost_endpoint_ref"] = (
+        "192.168.86.201:8000"  # onex-allow-internal-ip
+    )
     result = validate_delegation_profile(data)
     assert not result.is_valid
     assert any("bifrost_endpoint_ref" in e for e in result.errors)


### PR DESCRIPTION
## Summary
- Annotates hardcoded 192.168.86.* references in omnibase_core tests with `# onex-allow-internal-ip`.
- Keeps the exception explicit and test-scoped for aislop-sweep enforcement.

## Verification
- PYTHONPATH="$PWD/src:$PWD/.venv/lib/python3.12/site-packages" uv run pytest tests/unit/models/dispatch/test_model_dispatch_claim.py tests/unit/models/delegation/test_model_health_status.py tests/unit/validation/delegation/test_validator_delegation_profile.py tests/unit/contracts/test_model_contract_config.py tests/unit/models/contracts/ -v
- grep scan for unannotated 192.168.86.* test references

Evidence-Source: OCC#1673
Evidence-Ticket: OMN-12176
