### PR TITLE
test(OMN-12178): Test worst-health files in omnibase_core

### DIFF
--- a/tests/unit/nodes/test_node_reducer_snapshot_deep_copy.py
+++ b/tests/unit/nodes/test_node_reducer_snapshot_deep_copy.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for NodeReducer snapshot deep_copy branches and _validate_fsm_snapshot flags.
+
+Covers high-CCN branches in node_reducer.py (CCN 23, 810 lines):
+- snapshot_state(deep_copy=True): returns a fully independent copy
+- get_state_snapshot(deep_copy=True): returns deep-copied dict
+- _validate_fsm_snapshot with validate_required_context=False: skips required key check
+- _validate_fsm_snapshot with validate_history_sequence=False: skips dup-history check
+- _validate_fsm_snapshot with allow_terminal_state=True via _validate_fsm_snapshot directly
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+from omnibase_core.models.contracts.subcontracts.model_fsm_state_definition import (
+    ModelFSMStateDefinition,
+)
+from omnibase_core.models.contracts.subcontracts.model_fsm_state_transition import (
+    ModelFSMStateTransition,
+)
+from omnibase_core.models.contracts.subcontracts.model_fsm_subcontract import (
+    ModelFSMSubcontract,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.fsm import ModelFSMStateSnapshot
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.nodes.node_reducer import NodeReducer
+
+pytestmark = pytest.mark.unit
+
+_V = ModelSemVer(major=1, minor=0, patch=0)
+
+
+@pytest.fixture
+def container() -> ModelONEXContainer:
+    return ModelONEXContainer()
+
+
+@pytest.fixture
+def fsm_with_required_data() -> ModelFSMSubcontract:
+    """FSM with a state that requires specific context keys."""
+    return ModelFSMSubcontract(
+        state_machine_name="required_data_fsm",
+        description="FSM for required_data testing",
+        state_machine_version=_V,
+        version=_V,
+        initial_state="idle",
+        states=[
+            ModelFSMStateDefinition(
+                state_name="idle",
+                state_type="operational",
+                description="Initial state",
+                version=_V,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+            ModelFSMStateDefinition(
+                state_name="processing",
+                state_type="operational",
+                description="Processing state needing context keys",
+                version=_V,
+                entry_actions=[],
+                exit_actions=[],
+                required_data=["batch_id", "source"],
+            ),
+        ],
+        transitions=[
+            ModelFSMStateTransition(
+                transition_name="start",
+                from_state="idle",
+                to_state="processing",
+                trigger="start_event",
+                version=_V,
+                conditions=[],
+                actions=[],
+            ),
+        ],
+        terminal_states=[],
+        error_states=[],
+        operations=[],
+        persistence_enabled=False,
+        recovery_enabled=False,
+    )
+
+
+@pytest.fixture
+def simple_fsm() -> ModelFSMSubcontract:
+    """Minimal two-state FSM for snapshot tests."""
+    return ModelFSMSubcontract(
+        state_machine_name="snapshot_test_fsm",
+        description="Snapshot test FSM",
+        state_machine_version=_V,
+        version=_V,
+        initial_state="idle",
+        states=[
+            ModelFSMStateDefinition(
+                state_name="idle",
+                state_type="operational",
+                description="Initial state",
+                version=_V,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+            ModelFSMStateDefinition(
+                state_name="done",
+                state_type="terminal",
+                description="Terminal state",
+                version=_V,
+                is_terminal=True,
+                is_recoverable=False,
+            ),
+        ],
+        transitions=[
+            ModelFSMStateTransition(
+                transition_name="finish",
+                from_state="idle",
+                to_state="done",
+                trigger="finish_event",
+                version=_V,
+                conditions=[],
+                actions=[],
+            ),
+        ],
+        terminal_states=["done"],
+        error_states=[],
+        operations=[],
+        persistence_enabled=False,
+        recovery_enabled=False,
+    )
+
+
+def _make_node_with_fsm(
+    container: ModelONEXContainer,
+    fsm: ModelFSMSubcontract,
+) -> NodeReducer:  # type: ignore[type-arg]
+    node: NodeReducer = NodeReducer.__new__(NodeReducer)
+    NodeReducer.__init__(node, container)
+    node.fsm_contract = fsm
+    node.initialize_fsm_state(fsm, context={})
+    return node
+
+
+class TestSnapshotStateDeepCopy:
+    """Tests for snapshot_state(deep_copy=True/False) branches."""
+
+    def test_snapshot_state_deep_copy_true_returns_independent_copy(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        snapshot = node.snapshot_state(deep_copy=True)
+        assert snapshot is not None
+        assert snapshot is not node._fsm_state
+
+    def test_snapshot_state_deep_copy_false_returns_same_reference(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        snapshot = node.snapshot_state(deep_copy=False)
+        assert snapshot is node._fsm_state
+
+    def test_snapshot_state_deep_copy_true_context_is_independent(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        # Inject a mutable context value
+        assert node._fsm_state is not None
+        node._fsm_state = ModelFSMStateSnapshot(
+            current_state="idle",
+            context={"key": ["a", "b"]},
+            history=[],
+        )
+        snapshot = node.snapshot_state(deep_copy=True)
+        assert snapshot is not None
+        # Mutating the deep copy's context does NOT affect the node
+        assert isinstance(snapshot.context["key"], list)
+        snapshot.context["key"].append("c")  # type: ignore[union-attr]
+        assert node._fsm_state.context["key"] == ["a", "b"]
+
+    def test_snapshot_state_deep_copy_preserves_state_values(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        assert node._fsm_state is not None
+        node._fsm_state = ModelFSMStateSnapshot(
+            current_state="idle",
+            context={"x": 42},
+            history=["idle"],
+        )
+        snapshot = node.snapshot_state(deep_copy=True)
+        assert snapshot is not None
+        assert snapshot.current_state == "idle"
+        assert snapshot.context == {"x": 42}
+        assert snapshot.history == ["idle"]
+
+    def test_snapshot_state_none_when_not_initialized(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node: NodeReducer = NodeReducer.__new__(NodeReducer)
+        NodeReducer.__init__(node, container)
+        node.fsm_contract = None
+        node._fsm_state = None
+        assert node.snapshot_state(deep_copy=True) is None
+        assert node.snapshot_state(deep_copy=False) is None
+
+
+class TestGetStateSnapshotDeepCopy:
+    """Tests for get_state_snapshot(deep_copy=True/False) branches."""
+
+    def test_get_state_snapshot_deep_copy_true_returns_dict(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        result = node.get_state_snapshot(deep_copy=True)
+        assert isinstance(result, dict)
+        assert "current_state" in result
+
+    def test_get_state_snapshot_deep_copy_true_is_independent(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        assert node._fsm_state is not None
+        node._fsm_state = ModelFSMStateSnapshot(
+            current_state="idle",
+            context={"nested": [1, 2, 3]},
+            history=[],
+        )
+        result = node.get_state_snapshot(deep_copy=True)
+        assert result is not None
+        # Modifying the returned dict does not affect node state
+        assert isinstance(result["context"], dict)
+        result["context"]["nested"].append(4)  # type: ignore[index,union-attr]
+        assert node._fsm_state.context["nested"] == [1, 2, 3]
+
+    def test_get_state_snapshot_deep_copy_false_returns_dict(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        result = node.get_state_snapshot(deep_copy=False)
+        assert isinstance(result, dict)
+
+    def test_get_state_snapshot_none_when_not_initialized(
+        self, container: ModelONEXContainer
+    ) -> None:
+        node: NodeReducer = NodeReducer.__new__(NodeReducer)
+        NodeReducer.__init__(node, container)
+        node._fsm_state = None
+        assert node.get_state_snapshot(deep_copy=True) is None
+        assert node.get_state_snapshot(deep_copy=False) is None
+
+
+class TestValidateFSMSnapshotFlags:
+    """Tests for _validate_fsm_snapshot optional flag branches."""
+
+    def _make_snapshot(
+        self, state: str, context: dict, history: list[str]
+    ) -> ModelFSMStateSnapshot:
+        return ModelFSMStateSnapshot(
+            current_state=state,
+            context=context,
+            history=history,
+        )
+
+    def test_validate_required_context_false_skips_required_key_check(
+        self,
+        container: ModelONEXContainer,
+        fsm_with_required_data: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, fsm_with_required_data)
+        # Snapshot for 'processing' which requires batch_id and source — but context is empty
+        snapshot = self._make_snapshot("processing", {}, [])
+        # Should NOT raise when validate_required_context=False
+        node._validate_fsm_snapshot(
+            snapshot,
+            fsm_with_required_data,
+            validate_required_context=False,
+        )
+
+    def test_validate_required_context_true_raises_on_missing_keys(
+        self,
+        container: ModelONEXContainer,
+        fsm_with_required_data: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, fsm_with_required_data)
+        snapshot = self._make_snapshot("processing", {}, [])
+        with pytest.raises(ModelOnexError) as exc_info:
+            node._validate_fsm_snapshot(
+                snapshot,
+                fsm_with_required_data,
+                validate_required_context=True,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.VALIDATION_ERROR
+        assert (
+            "batch_id" in exc_info.value.message or "source" in exc_info.value.message
+        )
+
+    def test_validate_history_sequence_false_skips_duplicate_consecutive_check(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        # Duplicate consecutive states — invalid, but skipped
+        snapshot = self._make_snapshot("idle", {}, ["idle", "idle"])
+        # Should NOT raise when validate_history_sequence=False
+        node._validate_fsm_snapshot(
+            snapshot,
+            simple_fsm,
+            validate_history_sequence=False,
+        )
+
+    def test_validate_history_sequence_true_raises_on_duplicates(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        snapshot = self._make_snapshot("idle", {}, ["idle", "idle"])
+        with pytest.raises(ModelOnexError) as exc_info:
+            node._validate_fsm_snapshot(
+                snapshot,
+                simple_fsm,
+                validate_history_sequence=True,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+    def test_allow_terminal_state_true_permits_terminal_restore(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        snapshot = self._make_snapshot("done", {}, [])
+        # Should NOT raise with allow_terminal_state=True
+        node._validate_fsm_snapshot(
+            snapshot,
+            simple_fsm,
+            allow_terminal_state=True,
+        )
+
+    def test_allow_terminal_state_false_raises_on_terminal_restore(
+        self,
+        container: ModelONEXContainer,
+        simple_fsm: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, simple_fsm)
+        snapshot = self._make_snapshot("done", {}, [])
+        with pytest.raises(ModelOnexError) as exc_info:
+            node._validate_fsm_snapshot(
+                snapshot,
+                simple_fsm,
+                allow_terminal_state=False,
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+    def test_all_flags_disabled_accepts_duplicate_history_and_missing_context(
+        self,
+        container: ModelONEXContainer,
+        fsm_with_required_data: ModelFSMSubcontract,
+    ) -> None:
+        node = _make_node_with_fsm(container, fsm_with_required_data)
+        # Both bad: duplicate history and missing required context
+        snapshot = self._make_snapshot("processing", {}, ["idle", "idle"])
+        node._validate_fsm_snapshot(
+            snapshot,
+            fsm_with_required_data,
+            validate_required_context=False,
+            validate_history_sequence=False,
+        )

--- a/tests/unit/validation/test_receipt_gate_internal_guards.py
+++ b/tests/unit/validation/test_receipt_gate_internal_guards.py
@@ -1,0 +1,485 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for validator_receipt_gate internal guard branches.
+
+Covers high-CCN paths in validator_receipt_gate.py (CCN 33, 747 lines):
+- _check_adversarial_invariants_raw: non-dict input, missing fields, empty fields
+- _validate_skip_token: corrupt YAML allowlist, non-dict allowlist, non-list approvals
+- _iter_dod_evidence: malformed contract structures
+- _normalized_branch: refs/heads/ and heads/ prefix stripping
+- _evidence_class_present: promotion / hotfix matching
+- parse_pr_opened_at: timezone-naive and missing-timezone errors
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation.validator_receipt_gate import (
+    _check_adversarial_invariants_raw,
+    _evidence_class_present,
+    _iter_dod_evidence,
+    _normalized_branch,
+    _validate_skip_token,
+    parse_pr_opened_at,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _check_adversarial_invariants_raw
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAdversarialInvariantsRaw:
+    """Direct tests for the pre-schema adversarial guard."""
+
+    def _dummy_path(self) -> Path:
+        return Path("/tmp/dummy/receipt.yaml")
+
+    def test_non_dict_returns_none(self) -> None:
+        result = _check_adversarial_invariants_raw("not a dict", self._dummy_path())
+        assert result is None
+
+    def test_non_dict_list_returns_none(self) -> None:
+        result = _check_adversarial_invariants_raw([1, 2, 3], self._dummy_path())
+        assert result is None
+
+    def test_missing_verifier_field_returns_failure(self) -> None:
+        raw = {
+            "probe_command": "uv run pytest",
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "verifier" in result
+
+    def test_missing_probe_command_field_returns_failure(self) -> None:
+        raw = {
+            "verifier": "agent-x",
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "probe_command" in result
+
+    def test_missing_probe_stdout_field_returns_failure(self) -> None:
+        raw = {
+            "verifier": "agent-x",
+            "probe_command": "uv run pytest",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "probe_stdout" in result
+
+    def test_empty_verifier_returns_failure(self) -> None:
+        raw = {
+            "verifier": "   ",
+            "probe_command": "uv run pytest",
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "verifier" in result
+
+    def test_empty_probe_command_returns_failure(self) -> None:
+        raw = {
+            "verifier": "agent-x",
+            "probe_command": "",
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "probe_command" in result
+
+    def test_all_fields_present_and_non_empty_returns_none(self) -> None:
+        raw = {
+            "verifier": "agent-x",
+            "probe_command": "uv run pytest",
+            "probe_stdout": "",  # probe_stdout may be empty for non-exec check types
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is None
+
+    def test_non_string_verifier_returns_failure(self) -> None:
+        raw = {
+            "verifier": 12345,
+            "probe_command": "uv run pytest",
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "verifier" in result
+
+    def test_none_probe_command_returns_failure(self) -> None:
+        raw = {
+            "verifier": "agent-x",
+            "probe_command": None,
+            "probe_stdout": "passed",
+        }
+        result = _check_adversarial_invariants_raw(raw, self._dummy_path())
+        assert result is not None
+        assert "probe_command" in result
+
+
+# ---------------------------------------------------------------------------
+# _validate_skip_token: corrupt/malformed allowlist branches
+# ---------------------------------------------------------------------------
+
+
+def _future(days: int = 7) -> str:
+    return (datetime.now(tz=UTC) + timedelta(days=days)).isoformat()
+
+
+def _valid_entry(
+    entry_id: str = "appr-001",
+    granted_by: str = "platform-lead",
+    repo: str = "omnibase_core",
+    pr_num: int = 999,
+) -> dict[object, object]:
+    return {
+        "id": entry_id,
+        "granted_by": granted_by,
+        "granted_at": "2026-04-30T00:00:00+00:00",
+        "expires_at": _future(),
+        "scope_repos": [repo],
+        "scope_pr_numbers": [pr_num],
+    }
+
+
+class TestValidateSkipTokenMalformedAllowlist:
+    """Tests for _validate_skip_token with corrupted or malformed allowlist files."""
+
+    def test_corrupt_yaml_allowlist_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text(": invalid: yaml: {{{{")
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "corrupt" in msg.lower() or "rejected" in msg.lower()
+
+    def test_non_dict_allowlist_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text("- just a list\n- not a mapping\n")
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "rejected" in msg.lower()
+
+    def test_non_list_approvals_key_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text("approvals: not-a-list\n")
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "rejected" in msg.lower()
+
+    def test_missing_allowlist_file_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "nonexistent.yaml"
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "not found" in msg.lower() or "rejected" in msg.lower()
+
+    def test_valid_entry_not_found_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text(yaml.safe_dump({"approvals": [_valid_entry("other-id")]}))
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "appr-001" in msg
+
+    def test_unparseable_expires_at_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        entry = dict(_valid_entry())
+        entry["expires_at"] = "not-a-datetime"
+        allowlist.write_text(yaml.safe_dump({"approvals": [entry]}))
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "rejected" in msg.lower()
+
+    def test_none_expires_at_returns_rejection(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        entry = dict(_valid_entry())
+        entry["expires_at"] = None
+        allowlist.write_text(yaml.safe_dump({"approvals": [entry]}))
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="dev",
+            current_repo="omnibase_core",
+            current_pr_number=999,
+            allowlist_path=allowlist,
+        )
+        assert not accepted
+        assert "expires_at" in msg
+
+    def test_pr_number_none_skips_pr_scope_check(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text(yaml.safe_dump({"approvals": [_valid_entry()]}))
+        # current_pr_number=None means PR scope check is skipped
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="other-person",
+            current_repo="omnibase_core",
+            current_pr_number=None,
+            allowlist_path=allowlist,
+        )
+        assert accepted
+        assert "bypass accepted" in msg.lower()
+
+    def test_repo_none_skips_repo_scope_check(self, tmp_path: Path) -> None:
+        allowlist = tmp_path / "skip_token_approvals.yaml"
+        allowlist.write_text(yaml.safe_dump({"approvals": [_valid_entry()]}))
+        # current_repo=None means repo scope check is skipped
+        accepted, msg = _validate_skip_token(
+            approval_id="appr-001",
+            pr_author="other-person",
+            current_repo=None,
+            current_pr_number=None,
+            allowlist_path=allowlist,
+        )
+        assert accepted
+        assert "bypass accepted" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# _iter_dod_evidence: malformed contract data branches
+# ---------------------------------------------------------------------------
+
+
+class TestIterDodEvidence:
+    """Tests for _iter_dod_evidence with malformed input."""
+
+    def test_non_dict_contract_returns_empty(self) -> None:
+        assert _iter_dod_evidence("not a dict") == []
+
+    def test_list_contract_returns_empty(self) -> None:
+        assert _iter_dod_evidence([{"id": "x"}]) == []
+
+    def test_none_contract_returns_empty(self) -> None:
+        assert _iter_dod_evidence(None) == []
+
+    def test_missing_dod_evidence_key_returns_empty(self) -> None:
+        assert _iter_dod_evidence({"ticket_id": "OMN-1234"}) == []
+
+    def test_non_list_dod_evidence_returns_empty(self) -> None:
+        contract = {"dod_evidence": "not a list"}
+        assert _iter_dod_evidence(contract) == []
+
+    def test_non_dict_item_in_dod_evidence_is_skipped(self) -> None:
+        contract = {"dod_evidence": ["string item", {"id": "real-item", "checks": []}]}
+        result = _iter_dod_evidence(contract)
+        # "string item" is skipped; real-item has no checks → also skipped
+        assert result == []
+
+    def test_item_missing_id_is_skipped(self) -> None:
+        contract = {
+            "dod_evidence": [
+                {"checks": [{"check_type": "unit_tests", "check_value": "pass"}]}
+            ]
+        }
+        assert _iter_dod_evidence(contract) == []
+
+    def test_item_with_non_list_checks_is_skipped(self) -> None:
+        contract = {"dod_evidence": [{"id": "ev-1", "checks": "not a list"}]}
+        assert _iter_dod_evidence(contract) == []
+
+    def test_check_missing_check_type_is_skipped(self) -> None:
+        contract = {
+            "dod_evidence": [{"id": "ev-1", "checks": [{"check_value": "pass"}]}]
+        }
+        assert _iter_dod_evidence(contract) == []
+
+    def test_check_missing_check_value_is_skipped(self) -> None:
+        contract = {
+            "dod_evidence": [{"id": "ev-1", "checks": [{"check_type": "unit_tests"}]}]
+        }
+        assert _iter_dod_evidence(contract) == []
+
+    def test_check_non_string_check_type_is_skipped(self) -> None:
+        contract = {
+            "dod_evidence": [
+                {"id": "ev-1", "checks": [{"check_type": 42, "check_value": "pass"}]}
+            ]
+        }
+        assert _iter_dod_evidence(contract) == []
+
+    def test_valid_contract_returns_expected_triples(self) -> None:
+        contract = {
+            "dod_evidence": [
+                {
+                    "id": "ev-1",
+                    "checks": [
+                        {"check_type": "unit_tests", "check_value": "pytest"},
+                        {"check_type": "lint", "check_value": "ruff"},
+                    ],
+                },
+                {
+                    "id": "ev-2",
+                    "checks": [{"check_type": "mypy", "check_value": "strict"}],
+                },
+            ]
+        }
+        result = _iter_dod_evidence(contract)
+        assert result == [
+            ("ev-1", "unit_tests", "pytest"),
+            ("ev-1", "lint", "ruff"),
+            ("ev-2", "mypy", "strict"),
+        ]
+
+    def test_mixed_valid_and_invalid_items(self) -> None:
+        contract = {
+            "dod_evidence": [
+                "skip me",
+                {
+                    "id": "ev-1",
+                    "checks": [{"check_type": "unit_tests", "check_value": "pytest"}],
+                },
+                {"missing_id": True, "checks": []},
+            ]
+        }
+        result = _iter_dod_evidence(contract)
+        assert result == [("ev-1", "unit_tests", "pytest")]
+
+
+# ---------------------------------------------------------------------------
+# _normalized_branch: refs/heads/ and heads/ prefix stripping
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizedBranch:
+    """Tests for _normalized_branch helper."""
+
+    def test_none_returns_empty_string(self) -> None:
+        assert _normalized_branch(None) == ""
+
+    def test_bare_branch_name_unchanged(self) -> None:
+        assert _normalized_branch("main") == "main"
+
+    def test_refs_heads_prefix_stripped(self) -> None:
+        assert _normalized_branch("refs/heads/main") == "main"
+
+    def test_heads_prefix_stripped(self) -> None:
+        assert _normalized_branch("heads/feature/x") == "feature/x"
+
+    def test_refs_heads_on_feature_branch(self) -> None:
+        assert (
+            _normalized_branch("refs/heads/jonah/omn-1234-foo") == "jonah/omn-1234-foo"
+        )
+
+    def test_whitespace_stripped(self) -> None:
+        assert _normalized_branch("  main  ") == "main"
+
+    def test_dev_branch_unchanged(self) -> None:
+        assert _normalized_branch("dev") == "dev"
+
+
+# ---------------------------------------------------------------------------
+# _evidence_class_present: promotion and hotfix detection
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceClassPresent:
+    """Tests for _evidence_class_present helper."""
+
+    def test_promotion_detected(self) -> None:
+        body = "Evidence-Class: promotion\nsome other content"
+        assert _evidence_class_present(body, "promotion") is True
+
+    def test_hotfix_detected(self) -> None:
+        body = "Evidence-Class: hotfix\n"
+        assert _evidence_class_present(body, "hotfix") is True
+
+    def test_wrong_class_returns_false(self) -> None:
+        body = "Evidence-Class: promotion\n"
+        assert _evidence_class_present(body, "hotfix") is False
+
+    def test_absent_returns_false(self) -> None:
+        assert _evidence_class_present("No evidence class here", "promotion") is False
+
+    def test_case_insensitive_class(self) -> None:
+        body = "Evidence-Class: PROMOTION\n"
+        assert _evidence_class_present(body, "promotion") is True
+
+    def test_multiple_evidence_class_lines_first_match_wins(self) -> None:
+        body = "Evidence-Class: hotfix\nEvidence-Class: promotion\n"
+        assert _evidence_class_present(body, "hotfix") is True
+        assert _evidence_class_present(body, "promotion") is True
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_opened_at: timezone and format error branches
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrOpenedAt:
+    """Tests for parse_pr_opened_at error branches."""
+
+    def test_none_returns_none(self) -> None:
+        assert parse_pr_opened_at(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_pr_opened_at("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert parse_pr_opened_at("   ") is None
+
+    def test_valid_utc_z_suffix_parsed(self) -> None:
+        result = parse_pr_opened_at("2026-04-30T12:00:00Z")
+        assert result is not None
+        assert result.tzinfo is not None
+        assert result.tzinfo == UTC
+
+    def test_valid_offset_parsed(self) -> None:
+        result = parse_pr_opened_at("2026-04-30T12:00:00+00:00")
+        assert result is not None
+
+    def test_invalid_format_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="ISO-8601"):
+            parse_pr_opened_at("not-a-date")
+
+    def test_naive_datetime_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="timezone"):
+            parse_pr_opened_at("2026-04-30T12:00:00")
+
+    def test_result_is_utc(self) -> None:
+        result = parse_pr_opened_at("2026-04-30T12:00:00+05:30")
+        assert result is not None
+        assert result.tzinfo == UTC


### PR DESCRIPTION
## Summary
- Adds regression coverage for NodeReducer snapshot deep-copy behavior.
- Adds receipt-gate internal guard coverage for central OCC evidence checks.

## Verification
- PYTHONPATH="$PWD/src:$PWD/.venv/lib/python3.12/site-packages" uv run pytest tests/unit/nodes/test_node_reducer_snapshot_deep_copy.py tests/unit/validation/test_receipt_gate_internal_guards.py -v
- PYTHONPATH="$PWD/src:$PWD/.venv/lib/python3.12/site-packages" uv run pytest tests/unit/nodes/ -v
- uv run ruff check tests/unit/nodes/test_node_reducer_snapshot_deep_copy.py tests/unit/validation/test_receipt_gate_internal_guards.py

Evidence-Source: OCC#1672
Evidence-Ticket: OMN-12178
