### PR TITLE
chore(OMN-6665): Document undocumented BLE001 suppressions and fix invalid noqa directives

### DIFF
--- a/src/omnibase_core/cli/cli_install.py
+++ b/src/omnibase_core/cli/cli_install.py
@@ -379,7 +379,7 @@ def cli_install(
                     click.echo(f"Warning: {package_path} is unsigned", err=True)
         except click.ClickException:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # fallback-ok: signature check failure is a warning, not a fatal install error
             click.echo("Warning: could not check package signature", err=True)
 
     if dry_run:

--- a/src/omnibase_core/decorators/decorator_error_handling.py
+++ b/src/omnibase_core/decorators/decorator_error_handling.py
@@ -80,7 +80,7 @@ def _has_pydantic_error_count_method(exc: Exception) -> bool:
     try:
         result = error_count_attr()
         return isinstance(result, int)
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001  # fallback-ok: error_count() call failure means not a Pydantic-like error
         # fallback-ok: error_count() call failed, not Pydantic-like
         return False
 
@@ -179,7 +179,7 @@ def _is_validation_error(exc: Exception) -> bool:
             errors_result = errors_attr()
             if _is_pydantic_validation_error_structure(errors_result):
                 return True
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # fallback-ok: errors() call failure means not Pydantic-structured, check next tier
             # fallback-ok: errors() call failed, continue to next tier
             pass
 
@@ -234,7 +234,7 @@ def standard_error_handling(
             raise  # Never suppress async cancellation
         except ModelOnexError:
             raise  # Always re-raise ModelOnexError as-is
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # boundary-ok: unknown exceptions wrapped in ModelOnexError at decorator boundary
             raise ModelOnexError(
                 f"{operation_name} failed: {str(e)}",
                 EnumCoreErrorCode.OPERATION_FAILED

--- a/src/omnibase_core/mixins/mixin_contract_publisher.py
+++ b/src/omnibase_core/mixins/mixin_contract_publisher.py
@@ -300,7 +300,7 @@ class MixinContractPublisher:
                 await asyncio.sleep(interval_seconds)
             except asyncio.CancelledError:
                 raise  # Propagate cancellation
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001  # fallback-ok: heartbeat transient errors must not stop liveness signals
                 # Swallow error and continue heartbeating - transient errors shouldn't
                 # stop liveness signals. Consumers can detect issues via heartbeat gaps.
                 await asyncio.sleep(interval_seconds)

--- a/src/omnibase_core/mixins/mixin_discovery_responder.py
+++ b/src/omnibase_core/mixins/mixin_discovery_responder.py
@@ -207,7 +207,7 @@ class MixinDiscoveryResponder:
         if self._discovery_unsubscribe:
             try:
                 await self._discovery_unsubscribe()
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001  # cleanup-resilience-ok: shutdown cleanup errors are non-critical
                 # cleanup-resilience-ok: cleanup errors during shutdown are non-critical
                 pass
 

--- a/src/omnibase_core/mixins/mixin_health_check.py
+++ b/src/omnibase_core/mixins/mixin_health_check.py
@@ -335,7 +335,7 @@ class MixinHealthCheck:
                 check_tasks.append((check_func.__name__, task))
 
             # fallback-ok: health check task creation should not crash the async health check
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: task creation error must not crash health check
                 emit_log_event(
                     LogLevel.ERROR,
                     f"Failed to create health check task: {check_func.__name__}",

--- a/src/omnibase_core/mixins/mixin_node_lifecycle.py
+++ b/src/omnibase_core/mixins/mixin_node_lifecycle.py
@@ -202,7 +202,7 @@ class MixinNodeLifecycle:
             )
 
         # fallback-ok: event publishing is non-critical, log and continue
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # fallback-ok: node announce publish error must not block registration
             context = ModelLogContext(
                 calling_module=_COMPONENT_NAME,
                 calling_function="_register_node",
@@ -265,7 +265,7 @@ class MixinNodeLifecycle:
             )
 
         # fallback-ok: shutdown event is non-critical, log and continue
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # fallback-ok: shutdown event publish error must not block shutdown
             context = ModelLogContext(
                 calling_module=_COMPONENT_NAME,
                 calling_function="_publish_shutdown_event",
@@ -481,7 +481,7 @@ class MixinNodeLifecycle:
             try:
                 self.cleanup_event_handlers()
             # fallback-ok: cleanup failure is non-critical, log and continue
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # cleanup-resilience-ok: event handler cleanup must not block lifecycle cleanup
                 node_id = _get_node_id_as_uuid(self)
                 context = ModelLogContext(
                     calling_module=_COMPONENT_NAME,

--- a/src/omnibase_core/mixins/mixin_node_service.py
+++ b/src/omnibase_core/mixins/mixin_node_service.py
@@ -237,7 +237,7 @@ class MixinNodeService:
             for callback in self._shutdown_callbacks:
                 try:
                     callback()
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:  # noqa: BLE001  # fallback-ok: user shutdown callbacks must not crash service shutdown
                     # fallback-ok: user callbacks must not crash shutdown
                     self._log_error(f"Shutdown callback failed: {e}")
 
@@ -253,7 +253,7 @@ class MixinNodeService:
             # Set service as not running before propagating cancellation.
             self._service_running = False
             raise
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # cleanup-resilience-ok: shutdown must complete regardless of cleanup errors
             # cleanup-resilience-ok: shutdown must complete even if cleanup fails
             self._log_error(f"Error during service shutdown: {e}")
             self._service_running = False
@@ -372,7 +372,7 @@ class MixinNodeService:
 
         # fallback-ok: service must emit error response for any failure
         # Fallback for truly unexpected exceptions not covered above.
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # fallback-ok: unexpected exceptions must produce error response, not crash service
             execution_time_ms = int((time.time() - start_time) * 1000)
             response_event = ModelToolResponseEvent.create_error_response(
                 correlation_id=correlation_id,

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -285,7 +285,7 @@ class ModelONEXContainer:
                     f"ServiceRegistry not available: {e}",
                 )
                 self._enable_service_registry = False
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # init-errors-ok: ServiceRegistry init failure uses safe defaults
                 # init-errors-ok: use safe defaults if ServiceRegistry initialization fails
                 emit_log_event(
                     LogLevel.ERROR,

--- a/src/omnibase_core/models/core/model_event_type_registry.py
+++ b/src/omnibase_core/models/core/model_event_type_registry.py
@@ -89,7 +89,7 @@ class ModelEventTypeRegistry:
         for contract_file in contract_files:
             try:
                 events_discovered += self._discover_from_contract(contract_file)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: resilient discovery skips invalid contracts
                 # fallback-ok: resilient discovery - skip invalid contracts with debug logging
                 logger.debug("Failed to discover events from %s: %s", contract_file, e)
                 continue

--- a/src/omnibase_core/models/detection/__init__.py
+++ b/src/omnibase_core/models/detection/__init__.py
@@ -18,6 +18,6 @@ try:
     )
 
     ModelServiceDetectionConfig.model_rebuild()
-except Exception:  # noqa: BLE001
+except Exception:  # noqa: BLE001  # init-errors-ok: model_rebuild may fail during circular import resolution
     # init-errors-ok: may fail during circular import, safe to ignore
     pass

--- a/src/omnibase_core/models/health/__init__.py
+++ b/src/omnibase_core/models/health/__init__.py
@@ -43,7 +43,7 @@ __all__: list[str] = [
 try:
     ModelHealthStatus.model_rebuild()
     ModelToolHealth.model_rebuild()
-except Exception:  # noqa: BLE001
+except Exception:  # noqa: BLE001  # init-errors-ok: model_rebuild may fail during circular import resolution
     # init-errors-ok: model_rebuild may fail during circular import resolution, safe to ignore
     pass
 
@@ -63,6 +63,6 @@ try:
         _types_namespace={"ModelCustomFields": _ModelCustomFields}
     )
     ModelHealthCheckConfig.model_rebuild()
-except Exception:  # noqa: BLE001
+except Exception:  # noqa: BLE001  # init-errors-ok: model_rebuild may fail during circular import resolution
     # init-errors-ok: model_rebuild may fail during circular import resolution, safe to ignore
     pass

--- a/src/omnibase_core/models/health/model_health_check_config.py
+++ b/src/omnibase_core/models/health/model_health_check_config.py
@@ -242,7 +242,7 @@ def _resolve_forward_references() -> None:
         # model_rebuild(), so we just need to rebuild this class to pick up
         # the resolved types from ModelHealthCheckMetadata
         ModelHealthCheckConfig.model_rebuild()
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001  # init-errors-ok: model_rebuild may fail during circular import resolution
         # init-errors-ok: model_rebuild may fail during circular import resolution
         pass
 

--- a/src/omnibase_core/models/health/model_health_check_metadata.py
+++ b/src/omnibase_core/models/health/model_health_check_metadata.py
@@ -124,7 +124,7 @@ def _resolve_forward_references() -> None:
         # init-errors-ok: Import may fail during early module loading
         # The forward reference will be resolved when health/__init__.py completes
         pass
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001  # init-errors-ok: model_rebuild may fail during circular import resolution
         # init-errors-ok: model_rebuild may fail during circular import resolution
         # This is safe to ignore as the forward reference will be resolved
         # when the full module graph is loaded

--- a/src/omnibase_core/models/infrastructure/model_result.py
+++ b/src/omnibase_core/models/infrastructure/model_result.py
@@ -236,7 +236,7 @@ class ModelResult[T, E](
             try:
                 new_value = f(self._get_value_or_raise())
                 return ModelResult.ok(new_value)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: monadic map converts exceptions to Err result
                 # fallback-ok: Monadic error handling - converting exceptions to error results
                 return ModelResult.err(e)
         # Pass through the original error
@@ -257,7 +257,7 @@ class ModelResult[T, E](
         try:
             new_error = f(self._get_error_or_raise())
             return ModelResult.err(new_error)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # fallback-ok: monadic map_err converts exceptions to Err result
             # fallback-ok: Monadic error handling - converting exceptions to error results
             return ModelResult.err(e)
 
@@ -282,7 +282,7 @@ class ModelResult[T, E](
                 # ModelResult[U, E | Exception] at runtime (same structure, wider error type)
                 result = f(self._get_value_or_raise())
                 return cast("ModelResult[U, E | Exception]", result)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: monadic and_then converts exceptions to Err result
                 # fallback-ok: Monadic error handling - converting exceptions to error results
                 return ModelResult.err(e)
         # Pass through the original error
@@ -309,7 +309,7 @@ class ModelResult[T, E](
             # ModelResult[T, F | Exception] at runtime (same structure, wider error type)
             result = f(self._get_error_or_raise())
             return cast("ModelResult[T, F | Exception]", result)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # fallback-ok: monadic or_else converts exceptions to Err result
             # fallback-ok: Monadic error handling - converting exceptions to error results
             return ModelResult.err(e)
 
@@ -410,7 +410,7 @@ def try_result[T](f: Callable[[], T]) -> ModelResult[T, Exception]:
     """
     try:
         return ModelResult.ok(f())
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001  # fallback-ok: try_result converts exceptions to Err result
         # fallback-ok: Monadic error handling - converting exceptions to error results
         return ModelResult.err(e)
 

--- a/src/omnibase_core/models/infrastructure/model_transaction.py
+++ b/src/omnibase_core/models/infrastructure/model_transaction.py
@@ -129,7 +129,7 @@ class ModelTransaction:
                         "error_type": type(e).__name__,
                     },
                 )
-            except BaseException as e:  # noqa: BLE001
+            except BaseException as e:  # noqa: BLE001  # cleanup-resilience-ok: deferred BaseException subclasses re-raised after cleanup
                 # cleanup-resilience-ok: catch-all for resilience
                 # Catch any remaining BaseException subclasses not explicitly handled
                 # above (e.g., custom BaseException subclasses). Store first occurrence

--- a/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
+++ b/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
@@ -265,7 +265,7 @@ class NodeContractVerifyReplayCompute:
         """Check 1: all overlay YAMLs parse as ModelContractPatch."""
         try:
             patches = reader.get_overlay_patches()
-        except (ModelOnexError, Exception) as exc:  # noqa: BLE001
+        except (ModelOnexError, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="schema_validation",
                 status=EnumCheckStatus.FAIL,
@@ -301,7 +301,7 @@ class NodeContractVerifyReplayCompute:
         """
         try:
             patches = reader.get_overlay_patches()
-        except (ModelOnexError, Exception) as exc:  # noqa: BLE001
+        except (ModelOnexError, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="capability_linting",
                 status=EnumCheckStatus.FAIL,
@@ -376,7 +376,7 @@ class NodeContractVerifyReplayCompute:
                     raw_content = zf.read(scenario_entry.path)
                     try:
                         scenario_data = yaml.safe_load(raw_content.decode("utf-8"))
-                    except Exception:  # noqa: BLE001
+                    except Exception:  # noqa: BLE001  # fallback-ok: unparseable YAML skipped, not a bundle integrity failure
                         continue  # unparseable YAML — not our problem here
 
                     if not isinstance(scenario_data, dict):
@@ -389,7 +389,7 @@ class NodeContractVerifyReplayCompute:
                                 f"scenario '{scenario_entry.id}': "
                                 f"fixture_path '{fixture_path}' not in bundle"
                             )
-        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001
+        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="fixture_presence",
                 status=EnumCheckStatus.FAIL,
@@ -422,7 +422,7 @@ class NodeContractVerifyReplayCompute:
         """
         try:
             patches = reader.get_overlay_patches()
-        except (ModelOnexError, Exception) as exc:  # noqa: BLE001
+        except (ModelOnexError, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="overlay_merge_correctness",
                 status=EnumCheckStatus.FAIL,
@@ -477,7 +477,7 @@ class NodeContractVerifyReplayCompute:
                 # Single overlay — use simple merge.
                 engine.merge(patch=base_patch)
 
-        except (ModelOnexError, Exception) as exc:  # noqa: BLE001
+        except (ModelOnexError, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="overlay_merge_correctness",
                 status=EnumCheckStatus.FAIL,
@@ -561,7 +561,7 @@ class NodeContractVerifyReplayCompute:
                         missing.append(
                             f"scenario '{scenario.id}': path '{scenario.path}' missing"
                         )
-        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001
+        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="all_scenarios_present",
                 status=EnumCheckStatus.FAIL,
@@ -601,7 +601,7 @@ class NodeContractVerifyReplayCompute:
                         missing.append(
                             f"invariant '{inv.id}': path '{inv.path}' missing"
                         )
-        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001
+        except (zipfile.BadZipFile, Exception) as exc:  # noqa: BLE001  # boundary-ok: check returns FAIL result, never raises
             return ModelVerifyCheckResult(
                 check_name="all_invariants_present",
                 status=EnumCheckStatus.FAIL,
@@ -684,7 +684,7 @@ class NodeContractVerifyReplayCompute:
 
             sig_bytes = private_key.sign(report_digest.encode("ascii"))
             return base64.b64encode(sig_bytes).decode("ascii")
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # fallback-ok: signing is best-effort for MVP; report is still valid unsigned
             # fallback-ok: signing is best-effort for MVP; report is still valid
             return None
 

--- a/src/omnibase_core/nodes/node_reducer.py
+++ b/src/omnibase_core/nodes/node_reducer.py
@@ -1099,7 +1099,7 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
 
             try:
                 result = await node.process(input_data)
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001  # boundary-ok: catch-all triggers FSM state restore on any failure before re-raise
                 # Restore to previous state on failure
                 if saved_snapshot:
                     node.restore_state(saved_snapshot)

--- a/src/omnibase_core/nodes/node_validation_orchestrator/node_cross_repo_validation_orchestrator.py
+++ b/src/omnibase_core/nodes/node_validation_orchestrator/node_cross_repo_validation_orchestrator.py
@@ -220,7 +220,7 @@ class NodeCrossRepoValidationOrchestrator:
             rules_applied = (
                 (result.metadata.rules_applied or 0) if result.metadata else 0
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001  # boundary-ok: validation errors captured for result, lifecycle must complete
             # Capture exception - lifecycle must complete
             error_message = f"{type(exc).__name__}: {exc}"
             issues = []

--- a/src/omnibase_core/pipeline/manifest_generator.py
+++ b/src/omnibase_core/pipeline/manifest_generator.py
@@ -710,7 +710,7 @@ class ManifestGenerator:
         for callback in list(self._on_manifest_built):
             try:
                 callback(manifest)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # callback-resilience-ok: callbacks must not crash manifest build
                 # callback-resilience-ok: callbacks must not crash manifest build
                 warnings.warn(
                     f"on_manifest_built callback failed: {e!r}. "

--- a/src/omnibase_core/pipeline/runner_pipeline.py
+++ b/src/omnibase_core/pipeline/runner_pipeline.py
@@ -187,7 +187,7 @@ class RunnerPipeline:  # ai-slop-ok: reST table
                     phase_errors = await self._execute_phase(phase, context)
                     errors.extend(phase_errors)
                 # boundary-ok: captures phase exceptions for controlled shutdown; finalize phase still runs
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:  # noqa: BLE001  # boundary-ok: phase errors captured for re-raise after finalize
                     # catch-all-ok: fail-fast phase raised exception, captured for re-raise after finalize
                     exception_to_raise = e
                     break  # Stop executing phases, but finalize will still run
@@ -242,7 +242,7 @@ class RunnerPipeline:  # ai-slop-ok: reST table
                     # Only clear hook_name after successful execution
                     current_hook_name = None
                 # cleanup-resilience-ok: finalize hooks must all execute; errors captured, not raised
-                except Exception as e:  # noqa: BLE001
+                except Exception as e:  # noqa: BLE001  # cleanup-resilience-ok: finalize hooks complete regardless of errors
                     # catch-all-ok: finalize hooks must complete; errors captured for reporting
                     errors.append(
                         ModelHookError(
@@ -256,7 +256,7 @@ class RunnerPipeline:  # ai-slop-ok: reST table
                     current_hook_name = None
 
         # boundary-ok: framework-level errors during finalize become ModelHookError, never raised
-        except Exception as framework_exc:  # noqa: BLE001
+        except Exception as framework_exc:  # noqa: BLE001  # boundary-ok: framework errors become ModelHookError, never escape
             # catch-all-ok: framework-level error captured for error list, no exception escapes finalize
             # Include last known hook_name if available for debugging context
             hook_name_context = (

--- a/src/omnibase_core/protocols/runtime/protocol_message_handler.py
+++ b/src/omnibase_core/protocols/runtime/protocol_message_handler.py
@@ -298,7 +298,7 @@ class ProtocolMessageHandler(Protocol):
                             projections=(result.projection,),
                             processing_time_ms=result.duration_ms,
                         )
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:  # noqa: BLE001  # boundary-ok: re-raised; noqa needed for broad except before re-raise
                         # Re-raise exceptions - dispatch engine handles errors
                         raise
         """

--- a/src/omnibase_core/runtime/runtime_envelope_router.py
+++ b/src/omnibase_core/runtime/runtime_envelope_router.py
@@ -991,7 +991,7 @@ class EnvelopeRouter(ProtocolNodeRuntime):  # ai-slop-ok: reST table
         except asyncio.CancelledError:
             # Never suppress async cancellation - required for proper task cleanup
             raise
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # boundary-ok: handler errors converted to error envelope per router contract
             # boundary-ok: handler errors converted to error envelope per router contract
             duration_ms = (time.perf_counter() - start_time) * 1000
             # Log the error for observability before converting to error envelope

--- a/src/omnibase_core/services/service_tiered_resolver.py
+++ b/src/omnibase_core/services/service_tiered_resolver.py
@@ -219,9 +219,9 @@ class ServiceTieredResolver:
         # Sort trust domains by canonical tier order
         sorted_domains = sorted(
             trust_domains,
-            key=lambda d: _TIER_ORDER.index(d.tier)
-            if d.tier in _TIER_ORDER
-            else len(_TIER_ORDER),
+            key=lambda d: (
+                _TIER_ORDER.index(d.tier) if d.tier in _TIER_ORDER else len(_TIER_ORDER)
+            ),
         )
 
         tier_attempts: list[ModelTierAttempt] = []
@@ -750,7 +750,7 @@ class ServiceTieredResolver:
             )
             self._resolution_event_publisher.publish(event)
 
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # fallback-ok: audit event publish failure must not block resolution
             logger.warning(
                 "Failed to publish resolution audit event for capability '%s'; "
                 "ignoring (best-effort)",

--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -128,7 +128,7 @@ class TopicBase(StrEnum):
     # Internal control plane — not an observability topic. No contract topic_base
     # (schema supports one topic_base per contract); governed via topic_allowlist.yaml.
     # Lifecycle: internal_control (OMN-3294)
-    ROUTING_DECISION_CMD = "onex.cmd.omniintelligence.routing-decision.v1"  # noqa: arch-topic-naming
+    ROUTING_DECISION_CMD = "onex.cmd.omniintelligence.routing-decision.v1"  # arch-topic-naming: hyphen in service segment allowed per OMN-3294
 
     # ==========================================================================
     # GitHub PR status topics (OMN-3294)
@@ -769,7 +769,7 @@ def build_topic(base: str) -> str:
 # Base prefix for per-agent directed inbox topics (OMN-8634).
 # Not a TopicBase member — not a full canonical topic name.
 # Full topic: AGENT_INBOX_DIRECTED_BASE + "." + agent_id + ".v1"
-AGENT_INBOX_DIRECTED_BASE: str = "onex.evt.omniclaude.agent-inbox"  # noqa: arch-topic-naming
+AGENT_INBOX_DIRECTED_BASE: str = "onex.evt.omniclaude.agent-inbox"  # arch-topic-naming: base prefix for directed inbox; full topic = base + "." + agent_id + ".v1"
 
 
 def build_agent_inbox_directed_topic(agent_id: str) -> str:

--- a/src/omnibase_core/validation/scripts/cross_platform_timeout.py
+++ b/src/omnibase_core/validation/scripts/cross_platform_timeout.py
@@ -56,7 +56,7 @@ class CrossPlatformTimeout:
         if self.cleanup_func:
             try:
                 self.cleanup_func()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # cleanup-resilience-ok: cleanup errors must not mask the timeout exception
                 # Don't let cleanup errors mask the timeout
                 print(f"Warning: Timeout cleanup failed: {e}", file=sys.stderr)
 

--- a/src/omnibase_core/validation/scripts/validate_string_versions.py
+++ b/src/omnibase_core/validation/scripts/validate_string_versions.py
@@ -379,7 +379,7 @@ class StringVersionValidator:
             try:
                 yaml_model = load_yaml_content_as_model(content, ModelGenericYaml)
                 yaml_data = yaml_model.model_dump()
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: Pydantic parse failure falls back to AST validation
                 # If we can't parse with Pydantic, log it but continue with AST validation
                 # This is not a fatal error since we have fallback validation
                 pass
@@ -568,7 +568,7 @@ class StringVersionValidator:
                     if not self.validate_python_file(file_path):
                         success = False
                 # Silently skip files with other extensions
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: per-file error captured, validation continues for remaining files
                 self.errors.append(f"Error processing file {file_path}: {e}")
                 success = False
 
@@ -585,7 +585,7 @@ class StringVersionValidator:
             try:
                 if not self.validate_yaml_file(yaml_path):
                     success = False
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001  # fallback-ok: per-YAML error captured, validation continues for remaining files
                 self.errors.append(f"Error processing YAML file {yaml_path}: {e}")
                 success = False
 
@@ -750,12 +750,12 @@ Examples:
                                                     file_path, verbose
                                                 ):
                                                     yaml_files.append(file_path)
-                                            except Exception as e:  # noqa: BLE001
+                                            except Exception as e:  # noqa: BLE001  # fallback-ok: file error logged, scan continues
                                                 print(
                                                     f"Warning: Error processing file {file_path}: {e}"
                                                 )
                                                 continue
-                                    except Exception as e:  # noqa: BLE001
+                                    except Exception as e:  # noqa: BLE001  # fallback-ok: filter error logged, directory scan continues
                                         print(
                                             f"Warning: Error filtering files in {path}: {e}"
                                         )
@@ -772,7 +772,7 @@ Examples:
                                 print(f"Warning: File does not exist: {path}")
                         else:
                             print(f"Warning: Unsupported file type: {path}")
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:  # noqa: BLE001  # fallback-ok: argument processing error logged, scan continues
                         print(f"Warning: Error processing argument '{arg}': {e}")
                         continue
             else:
@@ -793,7 +793,7 @@ Examples:
                             yaml_files.append(path)
                         else:
                             print(f"Warning: Unsupported file type: {path}")
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:  # noqa: BLE001  # fallback-ok: file argument processing error logged, scan continues
                         print(f"Warning: Error processing file argument '{arg}': {e}")
                         continue
         except (


### PR DESCRIPTION
## Summary

- **OMN-6665**: Lint suppression cleanup — omnibase_core (batch 1 of N)
- Documents 45 bare `# noqa: BLE001` directives across 26 source files by adding inline justification comments following the established `# noqa: BLE001  # <marker>: <reason>` pattern from CLAUDE.md
- Fixes 2 invalid `# noqa: arch-topic-naming` directives in `topics.py` that ruff warned about with \"expected a comma-separated list of codes\"; converted to plain comments preserving the explanatory text
- Net suppression reduction: 508 → 506 in `src/` (2 invalid noqa removed)

### Markers used
- `fallback-ok:` — graceful degradation, returns safe default
- `boundary-ok:` — API/framework boundary, converts exceptions to structured results
- `cleanup-resilience-ok:` — cleanup must complete regardless of errors
- `init-errors-ok:` — model_rebuild during circular import resolution

## Test plan
- [x] `uv run ruff check src/ tests/` — passes clean
- [x] `uv run ruff format src/ tests/` — 5526 files unchanged
- [x] `uv run mypy src/ --strict` — same 3 pre-existing errors, no regressions
- [x] `pytest tests/unit/nodes/node_contract_verify_replay_compute/ tests/unit/nodes/node_validation_orchestrator/ tests/unit/models/infrastructure/` — 445 passed
- [x] Pre-commit hooks: ruff-format, ruff-fix, substrate-silent-except-pass, normalization-symmetry, hook-bits-drift, validate-string-versions, reject-deploy-gate-skip-token, substrate-env-silent-fallback — all passed