### PR TITLE
feat(OMN-4418): add @shim decorator for temporary compatibility shim annotation

### DIFF
--- a/src/omnibase_core/decorators/__init__.py
+++ b/src/omnibase_core/decorators/__init__.py
@@ -30,9 +30,18 @@ from .decorator_pattern_exclusions import (
     allow_mixed_types,
     exclude_from_onex_standards,
 )
+from .decorator_shim import (
+    SHIM_ATTR,
+    ModelShimMetadata,
+    get_shim_metadata,
+    has_shim,
+    shim,
+)
 
 __all__ = [
     "EFFECT_BOUNDARY_ATTR",
+    "SHIM_ATTR",
+    "ModelShimMetadata",
     "allow_any_type",
     "allow_dict_any",
     "allow_legacy_pattern",
@@ -44,8 +53,11 @@ __all__ = [
     "enforce_execution_shape",
     "exclude_from_onex_standards",
     "get_effect_boundary",
+    "get_shim_metadata",
     "has_effect_boundary",
+    "has_shim",
     "io_error_handling",
+    "shim",
     "standard_error_handling",
     "validation_error_handling",
 ]

--- a/src/omnibase_core/decorators/decorator_shim.py
+++ b/src/omnibase_core/decorators/decorator_shim.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""@shim decorator for annotating temporary compatibility shims.
+
+Marks functions or methods as shims that must be removed by a deadline.
+The scanner (node_shim_scanner in omnimarket) reads these annotations via
+AST to report expired or expiring shims.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+from omnibase_core.models.decorators.model_shim_metadata import ModelShimMetadata
+
+__all__ = [
+    "SHIM_ATTR",
+    "ModelShimMetadata",
+    "get_shim_metadata",
+    "has_shim",
+    "shim",
+]
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+SHIM_ATTR = "_shim_metadata"
+
+
+def shim(
+    ticket_id: str,
+    expires_on: datetime.date,
+    reason: str,
+    replacement: str,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Mark a function or method as a temporary compatibility shim.
+
+    Attaches ModelShimMetadata for introspection by node_shim_scanner.
+    Does NOT alter runtime behavior — the decorated callable executes unchanged.
+
+    Args:
+        ticket_id: Linear ticket tracking removal (e.g. "OMN-1234").
+        expires_on: Date by which the shim must be removed.
+        reason: Why the shim exists.
+        replacement: The canonical path or function to migrate to.
+
+    Example:
+        @shim(
+            ticket_id="OMN-9999",
+            expires_on=datetime.date(2026, 6, 1),
+            reason="Legacy wire DTO compatibility until OCC migration lands",
+            replacement="omnibase_compat.dtos.ModelFooDto",
+        )
+        def legacy_transform(data: dict) -> ModelFoo:
+            ...
+    """
+    metadata = ModelShimMetadata(
+        ticket_id=ticket_id,
+        expires_on=expires_on,
+        reason=reason,
+        replacement=replacement,
+    )
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            return func(*args, **kwargs)
+
+        setattr(wrapper, SHIM_ATTR, metadata)
+        return wrapper
+
+    return decorator
+
+
+def get_shim_metadata(func: object) -> ModelShimMetadata | None:
+    """Return the ModelShimMetadata attached to a @shim-decorated callable."""
+    return getattr(func, SHIM_ATTR, None)
+
+
+def has_shim(func: object) -> bool:
+    """Return True if the callable was decorated with @shim."""
+    return hasattr(func, SHIM_ATTR)

--- a/src/omnibase_core/models/decorators/__init__.py
+++ b/src/omnibase_core/models/decorators/__init__.py
@@ -6,5 +6,6 @@
 from omnibase_core.models.decorators.model_pattern_exclusion_info import (
     ModelPatternExclusionInfo,
 )
+from omnibase_core.models.decorators.model_shim_metadata import ModelShimMetadata
 
-__all__ = ["ModelPatternExclusionInfo"]
+__all__ = ["ModelPatternExclusionInfo", "ModelShimMetadata"]

--- a/src/omnibase_core/models/decorators/model_shim_metadata.py
+++ b/src/omnibase_core/models/decorators/model_shim_metadata.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelShimMetadata — data attached to @shim-decorated callables (OMN-4418)."""
+
+from __future__ import annotations
+
+import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ModelShimMetadata"]
+
+
+class ModelShimMetadata(BaseModel):
+    """Metadata attached to a @shim-decorated callable.
+
+    Read at commit-time by the pre-commit hook and at scan-time by
+    node_shim_scanner to detect expired or expiring shims.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ticket_id: str
+    expires_on: datetime.date
+    reason: str
+    replacement: str

--- a/tests/unit/decorators/test_decorator_shim.py
+++ b/tests/unit/decorators/test_decorator_shim.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the @shim decorator (OMN-4418)."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from omnibase_core.decorators.decorator_shim import (
+    SHIM_ATTR,
+    ModelShimMetadata,
+    get_shim_metadata,
+    has_shim,
+    shim,
+)
+
+
+@pytest.mark.unit
+class TestShimDecorator:
+    """Test suite for the @shim decorator."""
+
+    _EXPIRES = datetime.date(2026, 6, 1)
+
+    def _make_shim(self) -> ModelShimMetadata:
+        return ModelShimMetadata(
+            ticket_id="OMN-9999",
+            expires_on=self._EXPIRES,
+            reason="legacy compat",
+            replacement="omnibase_compat.dtos.NewModel",
+        )
+
+    def test_decorator_preserves_function_behavior(self) -> None:
+        @shim(
+            ticket_id="OMN-9999",
+            expires_on=self._EXPIRES,
+            reason="legacy compat",
+            replacement="omnibase_compat.dtos.NewModel",
+        )
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        assert add(2, 3) == 5
+
+    def test_decorator_preserves_docstring(self) -> None:
+        @shim(
+            ticket_id="OMN-9999",
+            expires_on=self._EXPIRES,
+            reason="r",
+            replacement="x",
+        )
+        def documented() -> None:
+            """Original docstring."""
+
+        assert documented.__doc__ == "Original docstring."
+
+    def test_shim_attr_attached(self) -> None:
+        @shim(
+            ticket_id="OMN-9999",
+            expires_on=self._EXPIRES,
+            reason="r",
+            replacement="x",
+        )
+        def fn() -> None: ...
+
+        meta = getattr(fn, SHIM_ATTR)
+        assert isinstance(meta, ModelShimMetadata)
+        assert meta.ticket_id == "OMN-9999"
+        assert meta.expires_on == self._EXPIRES
+
+    def test_has_shim_true(self) -> None:
+        @shim(
+            ticket_id="OMN-1",
+            expires_on=self._EXPIRES,
+            reason="r",
+            replacement="x",
+        )
+        def fn() -> None: ...
+
+        assert has_shim(fn) is True
+
+    def test_has_shim_false_for_plain_function(self) -> None:
+        def plain() -> None: ...
+
+        assert has_shim(plain) is False
+
+    def test_get_shim_metadata_returns_model(self) -> None:
+        @shim(
+            ticket_id="OMN-42",
+            expires_on=self._EXPIRES,
+            reason="reason text",
+            replacement="NewClass",
+        )
+        def fn() -> None: ...
+
+        meta = get_shim_metadata(fn)
+        assert meta is not None
+        assert meta.ticket_id == "OMN-42"
+        assert meta.reason == "reason text"
+        assert meta.replacement == "NewClass"
+
+    def test_get_shim_metadata_returns_none_for_plain(self) -> None:
+        def plain() -> None: ...
+
+        assert get_shim_metadata(plain) is None
+
+    def test_model_is_frozen(self) -> None:
+        meta = self._make_shim()
+        with pytest.raises(Exception):
+            meta.ticket_id = "changed"  # type: ignore[misc]
+
+    def test_metadata_fields_strongly_typed(self) -> None:
+        meta = self._make_shim()
+        assert isinstance(meta.expires_on, datetime.date)
+        assert isinstance(meta.ticket_id, str)
+
+    def test_decorator_stacks_with_other_decorators(self) -> None:
+        call_log: list[str] = []
+
+        def audit(f):  # type: ignore[no-untyped-def]
+            def wrapper(*a, **kw):  # type: ignore[no-untyped-def]
+                call_log.append("audit")
+                return f(*a, **kw)
+
+            return wrapper
+
+        @audit
+        @shim(
+            ticket_id="OMN-9999",
+            expires_on=self._EXPIRES,
+            reason="r",
+            replacement="x",
+        )
+        def fn() -> str:
+            call_log.append("fn")
+            return "ok"
+
+        assert fn() == "ok"
+        assert call_log == ["audit", "fn"]


### PR DESCRIPTION
## Summary

- Adds `@shim(ticket_id, expires_on, reason, replacement)` decorator in `omnibase_core/decorators/decorator_shim.py`
- `ModelShimMetadata` lives in `models/decorators/model_shim_metadata.py` (file location validator compliant)
- Decorator attaches metadata as `_shim_metadata` attribute; no runtime behavior change
- Exported from `decorators/__init__.py` and `models/decorators/__init__.py`
- 10 unit tests, mypy strict clean, all pre-commit hooks pass

## OMN-4418

Prerequisite for OMN-4419 (node_shim_scanner) and OMN-4421 (pre-commit hook).

## Test plan
- [x] `uv run pytest tests/unit/decorators/test_decorator_shim.py -v` — 10/10 passed
- [x] `uv run mypy src/omnibase_core/decorators/decorator_shim.py --strict` — clean
- [x] `pre-commit run --all-files` — all hooks pass

Evidence-Source: OCC#1800
Evidence-Ticket: OMN-4418