### PR TITLE
chore(OMN-7466): auto-ship rescue of canonical omnibase_core work

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,14 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "repowise": {
+      "command": "repowise",
+      "args": [
+        "mcp",
+        "/Users/jonah/Code/omni_home/omnibase_core",
+        "--transport",
+        "stdio"
+      ],
+      "description": "repowise: codebase intelligence \u2014 docs, graph, git signals, dead code, decisions"
+    }
+  }
 }


### PR DESCRIPTION
## Auto-ship rescue

The auto-ship node (node_dirty_canonical_sweep) is undeployed. This PR manually rescues uncommitted work from the canonical omnibase_core clone on dev under omni_home so nothing is lost.

Refs OMN-7466

Evidence-Ticket: OMN-7466
Evidence-Source: ee34665af75e695221a45389fbfe490c736de96b

### Rescued content
- .mcp.json MCP server config edits