### PR TITLE
feat(OMN-12453): wire gitignore-baseline as pre-commit hook + CI gate

### DIFF
--- a/.github/workflows/validator-gitignore-baseline.yml
+++ b/.github/workflows/validator-gitignore-baseline.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Gitignore baseline compliance gate [OMN-12453]
+#
+# Required status check context: "Gitignore Baseline Validator / validate"
+#
+# Runs unit tests for the validator then self-scans omnibase_core root.
+# Consumer repos wire this by adding the validate-gitignore-baseline pre-commit hook
+# and a mirror of the `validate` job in their own CI.
+
+name: Gitignore Baseline Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-gitignore-baseline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/validation/test_gitignore_baseline.py -v
+
+      - name: Self-scan omnibase_core root
+        run: |
+          uv run python -m omnibase_core.validators.gitignore_baseline .

--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,39 @@ PHASE*_*.md
 docs/recovery/
 *-validation-log-*.md
 *-recovery-log-*.md
+
+# =============================================================================
+# ONEX-MANAGED BASELINE BLOCKS (OMN-12453)
+# These blocks are enforced verbatim by the gitignore-baseline validator.
+# Do not edit lines between markers; update via the spec in
+# architecture-handshakes/gitignore-baseline.yaml.
+# =============================================================================
+
+# === onex-managed: universal ===
+.env
+.env.*
+!.env.example
+.DS_Store
+*.log
+.idea/
+.vscode/
+test-results/
+playwright-report/
+# === end onex-managed: universal ===
+
+# === onex-managed: python ===
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+env/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+# === end onex-managed: python ===

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -539,6 +539,18 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # OMN-12453: gitignore-baseline compliance gate
+      # Asserts managed blocks from architecture-handshakes/gitignore-baseline.yaml
+      # appear VERBATIM in this repo's .gitignore.
+      # Suppress all findings with: # gitignore-ok: <reason>
+      - id: validate-gitignore-baseline
+        name: Gitignore Baseline Validator (OMN-12453)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.validators.gitignore_baseline
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       # OMN-10741: Unified localhost/hardcoded-endpoint fallback validator
       # Covers all 6 pattern types from OMN-10658 enforcement sweep.
       # Annotation: add  # fallback-ok: <reason>  to exempt a justified line.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,6 +95,17 @@
   require_serial: true
   stages: [pre-commit]
 
+- id: validate-gitignore-baseline
+  name: Gitignore Baseline Validator (OMN-12453)
+  description: >
+    Assert that every managed block declared in architecture-handshakes/gitignore-baseline.yaml appears
+    VERBATIM in the target repo's .gitignore. Enforces universal block on all repos; python block on repos
+    that contain pyproject.toml. Suppress all findings for a file with: # gitignore-ok: <reason>
+  language: python
+  entry: python -m omnibase_core.validators.gitignore_baseline
+  pass_filenames: false
+  stages: [pre-commit]
+
 - id: check-antipatterns
   name: KB Antipattern Checker (offline, non-semantic rules only)
   description: >


### PR DESCRIPTION
## OMN-12453 — Wire gitignore-baseline as pre-commit hook + CI gate

**Epic:** OMN-12450 (canonical .gitignore baseline enforcement)
**Dependency:** OMN-12452 (T2 validator, merged to dev at f860ccb9)

### Changes

- `.pre-commit-hooks.yaml`: add `validate-gitignore-baseline` exported hook definition (mirrors `handler-di-gate` pattern — `language: python`, module entry, `pass_filenames: false`)
- `.pre-commit-config.yaml`: add `validate-gitignore-baseline` consumer entry (`env -u PYTHONPATH uv run python -m ...`, `always_run: true`, mirrors `contract-config-compliance`)
- `.github/workflows/validator-gitignore-baseline.yml`: new workflow running unit tests + self-scan; required status check context: `Gitignore Baseline Validator / validate` (mirrors `validator-no-none-guard-publish.yml`)
- `.gitignore`: add the two ONEX-managed baseline blocks (`universal` + `python`) so omnibase_core passes its own gate

### Verification

```
pre-commit run validate-gitignore-baseline --all-files   → Passed
uv run python -m omnibase_core.validators.gitignore_baseline .  → exit 0
uv run pytest tests/validation/test_gitignore_baseline.py -v    → 8/8 passed
uv run pytest tests/validation/ -q --timeout=60 -p no:xdist     → 279/279 passed
pre-commit run --all-files                                       → exit 0
```

### Evidence

Evidence-Source: OCC#1937
Evidence-Ticket: OMN-12453

OCC PR: OmniNode-ai/onex_change_control#1937

Closes OMN-12453.