### PR TITLE
feat(OMN-12454): add gitignore-baseline-hook to propagation-targets.yaml (all repos)

### DIFF
--- a/.github/propagation-targets.yaml
+++ b/.github/propagation-targets.yaml
@@ -70,3 +70,57 @@ propagations:
         hook_id: normalization-symmetry
     auto_merge: true
     merge_method: queue_default
+
+  - name: gitignore-baseline-hook
+    source: .pre-commit-hooks.yaml
+    targets:
+      - repo: OmniNode-ai/omnibase_compat
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnibase_spi
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnibase_infra
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omniclaude
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnidash
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omniintelligence
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnimarket
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnimemory
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omninode_infra
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/onex_change_control
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnigemini
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+      - repo: OmniNode-ai/omnibase
+        path: .pre-commit-config.yaml
+        operation: append_hook_entry
+        hook_id: validate-gitignore-baseline
+    auto_merge: true
+    merge_method: queue_default


### PR DESCRIPTION
## Summary

Adds `gitignore-baseline-hook` propagation entry to `.github/propagation-targets.yaml` so the `validate-gitignore-baseline` pre-commit hook (defined in OMN-12453, PR #1184) fans out to all repos via `scripts/propagate-config.sh` on release.

This is the final ticket in the OMN-12450 epic.

## Target repos (12)

Same 10 as `normalization-symmetry-hook` plus two repos that received managed `.gitignore` blocks in this epic:
- `omnibase_compat`, `omnibase_spi`, `omnibase_infra`, `omniclaude`, `omnidash`, `omniintelligence`, `omnimarket`, `omnimemory`, `omninode_infra`, `onex_change_control`
- `omnigemini` — added in OMN-12457
- `omnibase` — added in OMN-12455

## Schema conformance

New entry matches the exact shape of the existing `normalization-symmetry-hook` entry:
- `operation: append_hook_entry`
- `auto_merge: true`
- `merge_method: queue_default`

## Tests

13/13 propagation-related tests pass:
- `tests/scripts/test_propagate_config.py` — 7/7
- `tests/validation/test_completion_verify_targets.py` — 6/6

## OCC Receipt Gate

### Evidence
Evidence-Source: b81919af556204da5a5c56bb07104ebbb9e3a99d
Evidence-Ticket: OMN-12454

## DoD Evidence

- dod-001: 13/13 propagation tests PASS (test_propagate_config.py + test_completion_verify_targets.py)
- dod-002: YAML parse + schema validation passes
- dod-occ-pr: OCC PR #1941 carries central contract and receipts (merged to OCC dev)

Closes OMN-12454