### PR TITLE
refactor(OMN-12545): merge infra-only EnumDispatchStatus members into canonical core copy

### DIFF
--- a/src/omnibase_core/enums/enum_dispatch_status.py
+++ b/src/omnibase_core/enums/enum_dispatch_status.py
@@ -29,11 +29,13 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
         SUCCESS: Message was successfully routed, handled, and outputs published
         ROUTED: Message was successfully routed to a handler (not yet executed)
         NO_HANDLER: No handler was registered for the message type/topic
+        NO_DISPATCHER: No dispatcher was registered for the message type/topic
         HANDLER_ERROR: Handler execution failed with an exception
         TIMEOUT: Handler execution exceeded the configured timeout
         INVALID_MESSAGE: Message failed validation before dispatch
         PUBLISH_FAILED: Handler succeeded but output publishing failed
         SKIPPED: Message was intentionally skipped (e.g., filtered, deduplicated)
+        INTERNAL_ERROR: Internal error during dispatch result construction
 
     Example:
         >>> status = EnumDispatchStatus.SUCCESS
@@ -54,6 +56,9 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
     NO_HANDLER = "no_handler"
     """No handler was registered for the message type/topic."""
 
+    NO_DISPATCHER = "no_dispatcher"
+    """No dispatcher was registered for the message type/topic."""
+
     HANDLER_ERROR = "handler_error"
     """Handler execution failed with an exception."""
 
@@ -68,6 +73,9 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
 
     SKIPPED = "skipped"
     """Message was intentionally skipped (e.g., filtered, deduplicated)."""
+
+    INTERNAL_ERROR = "internal_error"
+    """Internal error during dispatch result construction (e.g., Pydantic ValidationError)."""
 
     def is_terminal(self) -> bool:
         """
@@ -88,11 +96,13 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
         return self in {
             EnumDispatchStatus.SUCCESS,
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
             EnumDispatchStatus.SKIPPED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         }
 
     def is_successful(self) -> bool:
@@ -125,10 +135,12 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
         """
         return self in {
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         }
 
     def requires_retry(self) -> bool:
@@ -171,11 +183,13 @@ class EnumDispatchStatus(UtilStrValueHelper, str, Enum):
             cls.SUCCESS: "Message was successfully routed, handled, and outputs published",
             cls.ROUTED: "Message was successfully routed to a handler (pending execution)",
             cls.NO_HANDLER: "No handler was registered for the message type/topic",
+            cls.NO_DISPATCHER: "No dispatcher was registered for the message type/topic",
             cls.HANDLER_ERROR: "Handler execution failed with an exception",
             cls.TIMEOUT: "Handler execution exceeded the configured timeout",
             cls.INVALID_MESSAGE: "Message failed validation before dispatch",
             cls.PUBLISH_FAILED: "Handler succeeded but output publishing failed",
             cls.SKIPPED: "Message was intentionally skipped",
+            cls.INTERNAL_ERROR: "Internal error during dispatch result construction",
         }
         return descriptions.get(status, "Unknown dispatch status")
 

--- a/tests/unit/enums/test_enum_dispatch_status.py
+++ b/tests/unit/enums/test_enum_dispatch_status.py
@@ -30,11 +30,13 @@ class TestEnumDispatchStatus:
             "SUCCESS": "success",
             "ROUTED": "routed",
             "NO_HANDLER": "no_handler",
+            "NO_DISPATCHER": "no_dispatcher",
             "HANDLER_ERROR": "handler_error",
             "TIMEOUT": "timeout",
             "INVALID_MESSAGE": "invalid_message",
             "PUBLISH_FAILED": "publish_failed",
             "SKIPPED": "skipped",
+            "INTERNAL_ERROR": "internal_error",
         }
 
         for name, value in expected_values.items():
@@ -43,7 +45,7 @@ class TestEnumDispatchStatus:
 
     def test_enum_count(self):
         """Test expected number of enum values."""
-        assert len(EnumDispatchStatus) == 8
+        assert len(EnumDispatchStatus) == 10
 
     def test_string_representation(self):
         """Test string representation of enum values."""
@@ -57,11 +59,13 @@ class TestEnumDispatchStatus:
         terminal_statuses = [
             EnumDispatchStatus.SUCCESS,
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
             EnumDispatchStatus.SKIPPED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         ]
 
         for status in terminal_statuses:
@@ -86,10 +90,12 @@ class TestEnumDispatchStatus:
         # All error states should be terminal
         error_states = [
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         ]
         for status in error_states:
             assert status.is_terminal() is True
@@ -110,10 +116,12 @@ class TestEnumDispatchStatus:
         # Error statuses
         error_statuses = [
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         ]
 
         for status in error_statuses:
@@ -145,9 +153,11 @@ class TestEnumDispatchStatus:
             EnumDispatchStatus.SUCCESS,
             EnumDispatchStatus.ROUTED,
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.SKIPPED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         ]
 
         for status in no_retry_statuses:
@@ -313,16 +323,18 @@ class TestEnumDispatchStatus:
     def test_is_terminal_exhaustive(self):
         """Test is_terminal returns correct values for ALL statuses.
 
-        Exhaustive test to ensure all 8 statuses are covered.
+        Exhaustive test to ensure all statuses are covered.
         """
         terminal_statuses = {
             EnumDispatchStatus.SUCCESS,
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
             EnumDispatchStatus.SKIPPED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         }
 
         for status in EnumDispatchStatus.__members__.values():
@@ -347,13 +359,13 @@ class TestEnumDispatchStatus:
         assert terminal_count + non_terminal_count == len(EnumDispatchStatus)
 
         # Expected counts based on the enum definition
-        assert terminal_count == 7  # All except ROUTED
+        assert terminal_count == 9  # All except ROUTED
         assert non_terminal_count == 1  # Only ROUTED
 
     def test_is_successful_exhaustive(self):
         """Test is_successful returns correct values for ALL statuses.
 
-        Exhaustive test to ensure all 8 statuses are covered.
+        Exhaustive test to ensure all statuses are covered.
         """
         for status in EnumDispatchStatus.__members__.values():
             expected = status == EnumDispatchStatus.SUCCESS
@@ -365,14 +377,16 @@ class TestEnumDispatchStatus:
     def test_is_error_exhaustive(self):
         """Test is_error returns correct values for ALL statuses.
 
-        Exhaustive test to ensure all 8 statuses are covered.
+        Exhaustive test to ensure all statuses are covered.
         """
         error_statuses = {
             EnumDispatchStatus.NO_HANDLER,
+            EnumDispatchStatus.NO_DISPATCHER,
             EnumDispatchStatus.HANDLER_ERROR,
             EnumDispatchStatus.TIMEOUT,
             EnumDispatchStatus.INVALID_MESSAGE,
             EnumDispatchStatus.PUBLISH_FAILED,
+            EnumDispatchStatus.INTERNAL_ERROR,
         }
 
         for status in EnumDispatchStatus.__members__.values():
@@ -385,7 +399,7 @@ class TestEnumDispatchStatus:
     def test_requires_retry_exhaustive(self):
         """Test requires_retry returns correct values for ALL statuses.
 
-        Exhaustive test to ensure all 8 statuses are covered.
+        Exhaustive test to ensure all statuses are covered.
         """
         retry_statuses = {
             EnumDispatchStatus.TIMEOUT,


### PR DESCRIPTION
## OMN-12545 — consolidate duplicated dispatch enums to single CORE copies (behavior-preserving)

Step 1 of the consolidation: make the canonical core `EnumDispatchStatus` a lossless
superset of the duplicate `omnibase_infra.enums.enum_dispatch_status` copy so the infra
dup can be deleted and importers repointed to core.

### What changed
- `src/omnibase_core/enums/enum_dispatch_status.py`: added the two infra-only members
  `NO_DISPATCHER` (`"no_dispatcher"`) and `INTERNAL_ERROR` (`"internal_error"`) and wired
  them into `is_terminal()`, `is_error()`, and `get_description()` exactly as the infra
  copy classified them. No existing member, value, or helper-method result changes.
- `tests/unit/enums/test_enum_dispatch_status.py`: updated expected member set, counts
  (8 → 10; terminal 7 → 9), and exhaustive classification assertions.

`ModelDispatchRoute` in core is **already canonical** (`handler_id` field with a
`dispatcher_id` AliasChoices + `dispatcher_id` property) and is unchanged by this PR.

### Behavior preservation
Purely additive enum members. Existing core dispatch consumers
(`runtime_message_dispatch.py`, `model_dispatch_result.py`) are unaffected. No SEA-owned
surface is touched (ModelHandlerOutput, ProtocolMessageHandler, EnumNodeType,
ModelInferenceResponseData, finish_reason / EnumInferenceFinishReason all untouched).

### Scope note (why infra/omnimarket are not in this PR)
The infra-side deletion of the duplicate modules cannot be completed without repointing
`omnimarket/src/omnimarket/nodes/node_delegation_orchestrator/wiring.py` (a SEA-consumed
live delegation node that the guardrails forbid touching). That deep-path import
(`from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute`)
is the blocker for the infra PR; it is reported back to the orchestrator as a STOP
condition rather than forced. This core PR is the safe, standalone foundation.

### dod_evidence
- `tests/unit/enums/test_enum_dispatch_status.py`: 24 passed (10-member set verified)
- core dispatch consumers green: `test_message_dispatch_engine.py`, `test_handler_registry.py` — 145 passed
- enums + dispatch-model trees: 4241 passed, 1 skipped
- `ruff format` + `ruff check`: clean on changed files
- `mypy --strict` on changed enum: clean (2 `contract_loader.py:570/704` errors confirmed
  PRE-EXISTING on pristine dev base — identical output, unrelated to this change)
- pre-commit: all hooks that apply to the changed files pass; the
  `validate-deterministic-skill-routing` failure is the documented cross-repo sibling-scan
  of `omniclaude/.../autopilot/SKILL.md` (a file not touched by this PR), confirmed
  identical on the pristine dev base.


Evidence-Source: 51f4ea17d81fbf4c7f23b5596d26c037d9e66898

Evidence-Ticket: OMN-12545
