### PR TITLE
ci(OMN-12565): durable runner Python write-contract (remove --system installs)

### DIFF
--- a/.github/workflows/occ-preflight.yml
+++ b/.github/workflows/occ-preflight.yml
@@ -182,6 +182,50 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      # OMN-12565: Runner Python write-contract preflight.
+      #
+      # The merge-group eligibility check previously installed omnibase-core into
+      # the system interpreter via `uv pip install --system`, which writes
+      # /usr/local/lib/python3.12/dist-packages. On a freshly recreated
+      # self-hosted runner that path is not writable by the `runner` user, so the
+      # gate failed until each container was manually chowned — container state,
+      # not an image guarantee.
+      #
+      # The durable shape removes `--system` entirely and installs into a
+      # uv-managed virtual environment under $GITHUB_WORKSPACE (always writable
+      # on a fresh runner). This preflight asserts that contract up front and
+      # fails loudly if it is violated, before any install or gate step runs.
+      - name: Preflight runner Python write contract
+        env:
+          OCC_PREFLIGHT_VENV: ${{ github.workspace }}/.occ-preflight-venv
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+            echo "::error::OMN-12565 write-contract preflight: GITHUB_WORKSPACE is unset; cannot locate the writable venv root."
+            exit 1
+          fi
+
+          # Contract part 1: the workspace-rooted venv parent must be writable.
+          # This is the path the install step uses instead of the system path.
+          venv_parent="$(dirname "$OCC_PREFLIGHT_VENV")"
+          probe="${venv_parent}/.omn12565-write-probe"
+          if ! ( touch "$probe" && rm -f "$probe" ) 2>/dev/null; then
+            echo "::error::OMN-12565 write-contract preflight FAILED: ${venv_parent} is not writable by the runner user. The OCC preflight venv cannot be created. A freshly recreated runner must expose a writable workspace; check the runner image and mount permissions."
+            exit 1
+          fi
+
+          # Contract part 2: prove we do NOT depend on writing the system
+          # dist-packages path. If a workflow ever reintroduces `uv pip install
+          # --system`, this preflight is the canary — the venv-only path means
+          # /usr/local/lib/python3.12/dist-packages writability is irrelevant.
+          system_dist="/usr/local/lib/python3.12/dist-packages"
+          if [ -d "$system_dist" ] && [ ! -w "$system_dist" ]; then
+            echo "::notice::OMN-12565: ${system_dist} is not writable — that is fine. The OCC preflight installs into ${OCC_PREFLIGHT_VENV} (workspace venv), so the unwritable system path is not part of the contract."
+          fi
+
+          echo "::notice::OMN-12565 write-contract preflight PASSED: ${venv_parent} writable; gate uses workspace venv at ${OCC_PREFLIGHT_VENV}; no --system / dist-packages write required."
+
       # Install omnibase_compat and omnibase_core from source so the validator
       # module is available. Pattern mirrors receipt-gate.yml install block.
       - name: Check out omnibase_compat (transitive dep)
@@ -203,8 +247,22 @@ jobs:
           fetch-depth: 1
 
       - name: Install omnibase_core
+        # OMN-12565: install into a uv-managed virtual environment under
+        # $GITHUB_WORKSPACE instead of the system interpreter. `uv pip install
+        # --system` wrote /usr/local/lib/python3.12/dist-packages, which a
+        # freshly recreated self-hosted runner cannot write. The workspace venv
+        # is always writable, so the write contract no longer depends on a
+        # mutable, manually-chowned system path. The venv python is exported as
+        # OCC_PREFLIGHT_PY for the downstream eligibility step.
+        env:
+          OCC_PREFLIGHT_VENV: ${{ github.workspace }}/.occ-preflight-venv
         run: |
-          uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
+          set -euo pipefail
+
+          # Create a clean uv venv in the writable workspace. --clear makes the
+          # step idempotent across re-runs on a warm runner.
+          uv venv --clear --python 3.13 "$OCC_PREFLIGHT_VENV"
+          venv_py="$OCC_PREFLIGHT_VENV/bin/python"
 
           if [ -f "./omnibase_compat/pyproject.toml" ]; then
             compat_path="./omnibase_compat"
@@ -215,7 +273,7 @@ jobs:
           fi
 
           if [ -n "$compat_path" ]; then
-            uv pip install --system --refresh -e "$compat_path"
+            uv pip install --python "$venv_py" --refresh -e "$compat_path"
           fi
 
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
@@ -229,7 +287,7 @@ jobs:
             exit 1
           fi
 
-          uv pip install --system \
+          uv pip install --python "$venv_py" \
             'hatchling' \
             'editables' \
             'pydantic>=2.12.5,<3.0.0' \
@@ -246,16 +304,20 @@ jobs:
           mkdir -p /tmp/occ-preflight-wheels
           (cd "$core_path" && uv build --wheel --out-dir /tmp/occ-preflight-wheels)
 
-          uv pip install --system --no-deps --no-index \
+          uv pip install --python "$venv_py" --no-deps --no-index \
             --find-links /tmp/occ-preflight-wheels \
             --reinstall-package omnibase-core \
             omnibase-core
 
+          # Export the venv interpreter for the downstream gate steps so they run
+          # against this install instead of bare `python` (the system interpreter).
+          echo "OCC_PREFLIGHT_PY=$venv_py" >> "$GITHUB_ENV"
+
       - name: Verify eligibility validator importable
         run: |
-          python -c "from omnibase_core.validation.validator_occ_merge_eligibility import validate_occ_merge_eligibility" || {
+          "$OCC_PREFLIGHT_PY" -c "from omnibase_core.validation.validator_occ_merge_eligibility import validate_occ_merge_eligibility" || {
             echo "::error::validator_occ_merge_eligibility not importable after install"
-            python -c "import omnibase_core, os; print('omnibase_core at:', os.path.dirname(omnibase_core.__file__))" || true
+            "$OCC_PREFLIGHT_PY" -c "import omnibase_core, os; print('omnibase_core at:', os.path.dirname(omnibase_core.__file__))" || true
             exit 1
           }
 
@@ -285,7 +347,7 @@ jobs:
             [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
           done < /tmp/pr_commit_texts.txt
 
-          python -m omnibase_core.validation.validator_occ_merge_eligibility \
+          "$OCC_PREFLIGHT_PY" -m omnibase_core.validation.validator_occ_merge_eligibility \
             --repo "$REPO_SHORT" \
             --pr-number "$PR_NUMBER_RESOLVED" \
             --pr-title "$PR_TITLE" \
@@ -297,10 +359,10 @@ jobs:
             "${commit_args[@]}" \
             | tee /tmp/occ_preflight_result.json
 
-          result_eligible="$(python -c "import json,sys; d=json.load(open('/tmp/occ_preflight_result.json')); sys.exit(0 if d.get('eligible') else 1)" 2>/dev/null; echo $?)"
+          result_eligible="$("$OCC_PREFLIGHT_PY" -c "import json,sys; d=json.load(open('/tmp/occ_preflight_result.json')); sys.exit(0 if d.get('eligible') else 1)" 2>/dev/null; echo $?)"
           if [ "$result_eligible" != "0" ]; then
-            detail="$(python -c "import json; d=json.load(open('/tmp/occ_preflight_result.json')); print(d.get('detail','(no detail)'))" 2>/dev/null || true)"
-            reason="$(python -c "import json; d=json.load(open('/tmp/occ_preflight_result.json')); print(d.get('reason','(no reason)'))" 2>/dev/null || true)"
+            detail="$("$OCC_PREFLIGHT_PY" -c "import json; d=json.load(open('/tmp/occ_preflight_result.json')); print(d.get('detail','(no detail)'))" 2>/dev/null || true)"
+            reason="$("$OCC_PREFLIGHT_PY" -c "import json; d=json.load(open('/tmp/occ_preflight_result.json')); print(d.get('reason','(no reason)'))" 2>/dev/null || true)"
             echo "::error::OCC PREFLIGHT FAILED: reason=${reason} — ${detail}"
             echo "::error::Auto-merge cannot arm until OCC eligibility is satisfied."
             echo "::error::Add a passing receipt to drift/dod_receipts/ in onex_change_control for all dod_evidence items cited in this PR's ticket contract."

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -342,6 +342,50 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      # OMN-12565: Runner Python write-contract preflight.
+      #
+      # The merge-group Receipt Gate previously installed omnibase-core into the
+      # system interpreter via `uv pip install --system`, which writes
+      # /usr/local/lib/python3.12/dist-packages. On a freshly recreated
+      # self-hosted runner that path is owned by root and not writable by the
+      # `runner` user, so the gate failed until each container was manually
+      # chowned — container state, not an image guarantee.
+      #
+      # The durable shape removes `--system` entirely and installs into a
+      # uv-managed virtual environment under $GITHUB_WORKSPACE (always writable
+      # on a fresh runner). This preflight asserts that contract up front and
+      # fails loudly if it is violated, before any install or gate step runs.
+      - name: Preflight runner Python write contract
+        env:
+          RECEIPT_GATE_VENV: ${{ github.workspace }}/.receipt-gate-venv
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+            echo "::error::OMN-12565 write-contract preflight: GITHUB_WORKSPACE is unset; cannot locate the writable venv root."
+            exit 1
+          fi
+
+          # Contract part 1: the workspace-rooted venv parent must be writable.
+          # This is the path the install step uses instead of the system path.
+          venv_parent="$(dirname "$RECEIPT_GATE_VENV")"
+          probe="${venv_parent}/.omn12565-write-probe"
+          if ! ( touch "$probe" && rm -f "$probe" ) 2>/dev/null; then
+            echo "::error::OMN-12565 write-contract preflight FAILED: ${venv_parent} is not writable by the runner user. The Receipt Gate venv cannot be created. A freshly recreated runner must expose a writable workspace; check the runner image and mount permissions."
+            exit 1
+          fi
+
+          # Contract part 2: prove we do NOT depend on writing the system
+          # dist-packages path. If a workflow ever reintroduces `uv pip install
+          # --system`, this preflight is the canary — the venv-only path means
+          # /usr/local/lib/python3.12/dist-packages writability is irrelevant.
+          system_dist="/usr/local/lib/python3.12/dist-packages"
+          if [ -d "$system_dist" ] && [ ! -w "$system_dist" ]; then
+            echo "::notice::OMN-12565: ${system_dist} is not writable — that is fine. The Receipt Gate installs into ${RECEIPT_GATE_VENV} (workspace venv), so the unwritable system path is not part of the contract."
+          fi
+
+          echo "::notice::OMN-12565 write-contract preflight PASSED: ${venv_parent} writable; gate uses workspace venv at ${RECEIPT_GATE_VENV}; no --system / dist-packages write required."
+
       # Check out omnibase_compat + omnibase_core from source when running in a
       # caller repo (not omnibase_core itself). This avoids the broken PyPI
       # fallback where omnibase-core's published package references a git+https
@@ -369,7 +413,24 @@ jobs:
         # or a sibling checkout, or the .receipt-gate-deps source checkouts.
         # Never fall back to PyPI — the published package has a broken transitive
         # dep (git+https omnibase-compat URL) that fails in CI.
+        #
+        # OMN-12565: install into a uv-managed virtual environment under
+        # $GITHUB_WORKSPACE instead of the system interpreter. `uv pip install
+        # --system` wrote /usr/local/lib/python3.12/dist-packages, which a
+        # freshly recreated self-hosted runner cannot write. The workspace venv
+        # is always writable, so the write contract no longer depends on a
+        # mutable, manually-chowned system path. The venv python is exported as
+        # RECEIPT_GATE_PY for the downstream gate steps.
+        env:
+          RECEIPT_GATE_VENV: ${{ github.workspace }}/.receipt-gate-venv
         run: |
+          set -euo pipefail
+
+          # Create a clean uv venv in the writable workspace. --clear makes the
+          # step idempotent across re-runs on a warm runner.
+          uv venv --clear --python 3.13 "$RECEIPT_GATE_VENV"
+          venv_py="$RECEIPT_GATE_VENV/bin/python"
+
           # OMN-9198 history (see docs/diagnosis-omn-9198-receipt-gate-v3-resolver-prefers-index.md):
           #   - PR #850 --no-index on pass 2: uv couldn't satisfy caller's
           #     `omnibase-core>=X` with index disabled.
@@ -393,8 +454,6 @@ jobs:
           # The explicit dep list below mirrors omnibase_core/pyproject.toml
           # [dependencies]. If core adds a new runtime dep this list must be
           # updated (tracked as OMN-FOLLOWUP pre-merge drift check).
-          uv pip uninstall --system omnibase-core omnibase-compat 2>/dev/null || true
-
           if [ -f "./omnibase_compat/pyproject.toml" ]; then
             compat_path="./omnibase_compat"
           elif [ -f "./.receipt-gate-deps/omnibase_compat/pyproject.toml" ]; then
@@ -404,7 +463,7 @@ jobs:
           fi
 
           if [ -n "$compat_path" ]; then
-            uv pip install --system --refresh -e "$compat_path"
+            uv pip install --python "$venv_py" --refresh -e "$compat_path"
           fi
 
           if [ -f "./pyproject.toml" ] && grep -qE '^\s*name\s*=\s*["\x27]omnibase[-_.]core["\x27]' ./pyproject.toml 2>/dev/null; then
@@ -426,7 +485,7 @@ jobs:
           # because the editable install below uses --no-index, which disables
           # PyPI lookups for EVERYTHING including build-system requirements.
           # Without hatchling pre-installed, uv cannot build the editable source.
-          uv pip install --system \
+          uv pip install --python "$venv_py" \
             'hatchling' \
             'editables' \
             'pydantic>=2.12.5,<3.0.0' \
@@ -479,9 +538,13 @@ jobs:
             exit 1
           fi
 
-          uv pip install --no-config --system --no-deps --no-index \
+          uv pip install --python "$venv_py" --no-config --no-deps --no-index \
             --reinstall-package omnibase-core \
             "$wheel_path"
+
+          # Export the venv interpreter for the downstream gate steps so they run
+          # against this install instead of bare `python` (the system interpreter).
+          echo "RECEIPT_GATE_PY=$venv_py" >> "$GITHUB_ENV"
 
       - name: Verify receipt_gate_cli importable
         # Fail-fast check: the preceding install step claims success, but if uv
@@ -489,9 +552,9 @@ jobs:
         # installed package won't contain recent modules. Catch that here so the
         # actual gate step gets a clear error instead of a stack trace.
         run: |
-          python -c "from omnibase_core.validation import validator_receipt_gate_cli" || {
+          "$RECEIPT_GATE_PY" -c "from omnibase_core.validation import validator_receipt_gate_cli" || {
             echo "::error::omnibase_core.validation.validator_receipt_gate_cli not importable — install step silently picked a stale PyPI wheel"
-            python -c "import omnibase_core, os; print('omnibase_core at:', os.path.dirname(omnibase_core.__file__))" || true
+            "$RECEIPT_GATE_PY" -c "import omnibase_core, os; print('omnibase_core at:', os.path.dirname(omnibase_core.__file__))" || true
             exit 1
           }
 
@@ -615,7 +678,7 @@ jobs:
             [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
           done < /tmp/pr_commit_texts.txt
 
-          python -m omnibase_core.validation.validator_occ_merge_eligibility \
+          "$RECEIPT_GATE_PY" -m omnibase_core.validation.validator_occ_merge_eligibility \
             --repo "$REPO_SHORT" \
             --pr-number "$PR_NUMBER_RESOLVED" \
             --pr-title "$PR_TITLE" \
@@ -660,7 +723,7 @@ jobs:
           fi
 
           # shellcheck disable=SC2086
-          python -m omnibase_core.validation.validator_receipt_gate_cli \
+          "$RECEIPT_GATE_PY" -m omnibase_core.validation.validator_receipt_gate_cli \
             --pr-body "$PR_BODY" \
             --pr-title "$PR_TITLE" \
             --contracts-dir "${{ steps.evidence.outputs.contracts_dir }}" \

--- a/tests/unit/validation/test_runner_python_write_contract.py
+++ b/tests/unit/validation/test_runner_python_write_contract.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Durable runner Python write-contract guards (OMN-12565).
+
+Merge-group Receipt Gate failed because the self-hosted runner user could not
+write ``/usr/local/lib/python3.12/dist-packages``. All ``.201`` runner
+containers were chowned in place — container state, not an image guarantee; a
+restart reverts it.
+
+The durable shape (preferred, per
+``docs/plans/2026-06-01-infra-ci-durability-plan.md`` Task 1.2): remove
+``uv pip install --system`` from the merge-group workflows entirely and install
+into a uv-managed virtual environment inside ``$GITHUB_WORKSPACE`` (always
+writable on a freshly recreated runner). The write contract no longer depends on
+a mutable system path.
+
+A preflight step asserts the write contract before the gate runs and fails fast
+with a clear message if it is violated.
+
+These tests pin that contract structurally so the ``--system`` install cannot
+regress and the preflight cannot silently disappear.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_WORKFLOWS_DIR = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+
+RECEIPT_GATE_PATH = _WORKFLOWS_DIR / "receipt-gate.yml"
+OCC_PREFLIGHT_PATH = _WORKFLOWS_DIR / "occ-preflight.yml"
+
+# (workflow path, job name) pairs that run the system-Python installs that
+# caused the merge-group Receipt Gate failure.
+_GATED_WORKFLOWS = (
+    (RECEIPT_GATE_PATH, "verify"),
+    (OCC_PREFLIGHT_PATH, "eligibility"),
+)
+
+
+def _job_steps(workflow_path: Path, job_name: str) -> list[dict[str, object]]:
+    data = yaml.safe_load(workflow_path.read_text())
+    steps = data["jobs"][job_name]["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _step_by_name(workflow_path: Path, job_name: str, name: str) -> dict[str, object]:
+    for step in _job_steps(workflow_path, job_name):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{name!r} step not found in {workflow_path.name}")
+
+
+def _all_run_scripts(workflow_path: Path, job_name: str) -> str:
+    parts: list[str] = []
+    for step in _job_steps(workflow_path, job_name):
+        run = step.get("run")
+        if isinstance(run, str):
+            parts.append(run)
+    return "\n".join(parts)
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_no_system_install_into_dist_packages(
+    workflow_path: Path, job_name: str
+) -> None:
+    """No ``uv pip install --system`` survives — it writes the unwritable path."""
+    script = _all_run_scripts(workflow_path, job_name)
+    joined = re.sub(r"\\\n\s*", " ", script)
+    offenders = [
+        line.strip()
+        for line in joined.splitlines()
+        if "uv pip install" in line and "--system" in line
+    ]
+    assert not offenders, (
+        f"{workflow_path.name} still runs `uv pip install --system`, which writes "
+        f"/usr/local/lib/python3.12/dist-packages — the path a freshly recreated "
+        f"self-hosted runner cannot write (OMN-12565). Install into a workspace "
+        f"uv venv instead. Offenders: {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_no_system_flag_on_any_uv_pip_call(workflow_path: Path, job_name: str) -> None:
+    """Belt-and-suspenders: no ``--system`` flag on any uv pip call at all."""
+    script = _all_run_scripts(workflow_path, job_name)
+    joined = re.sub(r"\\\n\s*", " ", script)
+    offenders = [
+        line.strip()
+        for line in joined.splitlines()
+        if "uv pip" in line and "--system" in line
+    ]
+    assert not offenders, (
+        f"{workflow_path.name} still passes `--system` to uv pip (OMN-12565). "
+        f"The durable shape installs into a workspace venv, never the system "
+        f"interpreter. Offenders: {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_install_creates_workspace_uv_venv(workflow_path: Path, job_name: str) -> None:
+    """The install must create a uv venv in the writable workspace."""
+    script = _all_run_scripts(workflow_path, job_name)
+    assert "uv venv" in script, (
+        f"{workflow_path.name} must create a uv-managed virtual environment "
+        f"(`uv venv`) inside $GITHUB_WORKSPACE so installs land on a writable "
+        f"path instead of the system interpreter (OMN-12565)."
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_install_targets_venv_python_explicitly(
+    workflow_path: Path, job_name: str
+) -> None:
+    """uv pip installs must target the venv python via ``--python``."""
+    script = _all_run_scripts(workflow_path, job_name)
+    joined = re.sub(r"\\\n\s*", " ", script)
+    install_lines = [
+        line.strip()
+        for line in joined.splitlines()
+        if line.strip().startswith("uv pip install")
+    ]
+    assert install_lines, f"no `uv pip install` lines found in {workflow_path.name}"
+    for line in install_lines:
+        assert "--python" in line, (
+            f"{workflow_path.name}: `uv pip install` must bind the workspace venv "
+            f"explicitly via `--python` so it never falls back to the system "
+            f"interpreter (OMN-12565). Offending line: {line!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_write_contract_preflight_exists(workflow_path: Path, job_name: str) -> None:
+    """A preflight step must assert the write contract before the gate runs."""
+    names = [s.get("name", "") for s in _job_steps(workflow_path, job_name)]
+    assert any(
+        isinstance(n, str) and "Preflight" in n and "write contract" in n.lower()
+        for n in names
+    ), (
+        f"{workflow_path.name} must include a runner preflight step that asserts "
+        f"the Python write contract before the gate executes (OMN-12565). Steps "
+        f"found: {names}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name", "gate_step"),
+    [
+        (RECEIPT_GATE_PATH, "verify", "Run Receipt-Gate"),
+        (OCC_PREFLIGHT_PATH, "eligibility", "Run OCC eligibility check"),
+    ],
+    ids=["receipt-gate.yml", "occ-preflight.yml"],
+)
+def test_preflight_runs_before_the_gate(
+    workflow_path: Path, job_name: str, gate_step: str
+) -> None:
+    """Preflight must run before both the install and the gate step."""
+    names = [s.get("name", "") for s in _job_steps(workflow_path, job_name)]
+    preflight_idx = next(
+        (
+            i
+            for i, n in enumerate(names)
+            if isinstance(n, str) and "Preflight" in n and "write contract" in n.lower()
+        ),
+        -1,
+    )
+    assert preflight_idx >= 0, (
+        f"{workflow_path.name}: write-contract preflight step not found. Steps: {names}"
+    )
+    install_idx = names.index("Install omnibase_core")
+    gate_idx = names.index(gate_step)
+    assert preflight_idx < install_idx, (
+        f"{workflow_path.name}: write-contract preflight must precede the install "
+        f"step (fail fast before any write is attempted)."
+    )
+    assert preflight_idx < gate_idx, (
+        f"{workflow_path.name}: write-contract preflight must precede the gate."
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_preflight_fails_loud_on_unwritable_system_path(
+    workflow_path: Path, job_name: str
+) -> None:
+    """The preflight must fail loudly (exit 1 + ::error::) when the contract breaks."""
+    step = _step_by_name(
+        workflow_path,
+        job_name,
+        _preflight_step_name(workflow_path, job_name),
+    )
+    script = step["run"]
+    assert isinstance(script, str)
+    assert "exit 1" in script, (
+        f"{workflow_path.name}: preflight must `exit 1` when the write contract "
+        f"is violated (OMN-12565)."
+    )
+    assert "::error::" in script, (
+        f"{workflow_path.name}: preflight must emit a `::error::` annotation so the "
+        f"failure is legible in the job log (OMN-12565)."
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "job_name"),
+    _GATED_WORKFLOWS,
+    ids=[p.name for p, _ in _GATED_WORKFLOWS],
+)
+def test_preflight_asserts_workspace_writability(
+    workflow_path: Path, job_name: str
+) -> None:
+    """Preflight must prove the venv path is writable, not just narrate it."""
+    step = _step_by_name(
+        workflow_path,
+        job_name,
+        _preflight_step_name(workflow_path, job_name),
+    )
+    script = step["run"]
+    assert isinstance(script, str)
+    # The preflight proves writability by attempting an actual write under the
+    # workspace venv parent and asserting no --system/dist-packages path is used.
+    assert "GITHUB_WORKSPACE" in script, (
+        f"{workflow_path.name}: preflight must check writability of the "
+        f"$GITHUB_WORKSPACE-rooted venv path (OMN-12565)."
+    )
+    assert "dist-packages" in script, (
+        f"{workflow_path.name}: preflight must reference the dist-packages system "
+        f"path it is guaranteeing is NOT required (OMN-12565)."
+    )
+
+
+def _preflight_step_name(workflow_path: Path, job_name: str) -> str:
+    for step in _job_steps(workflow_path, job_name):
+        name = step.get("name", "")
+        if (
+            isinstance(name, str)
+            and "Preflight" in name
+            and "write contract" in name.lower()
+        ):
+            return name
+    raise AssertionError(
+        f"write-contract preflight step not found in {workflow_path.name}"
+    )


### PR DESCRIPTION
## Summary

Closes OMN-12565.

Merge-group **Receipt Gate** failed because the self-hosted runner user could not write `/usr/local/lib/python3.12/dist-packages`. All 48 `.201` runner containers were chowned in place — container state, not an image guarantee; a restart reverts it.

This removes the mutable system-path write contract entirely (preferred shape per `docs/plans/2026-06-01-infra-ci-durability-plan.md` Task 1.2 + adversarial review 2026-06-01).

## What changed

The two merge-group workflows that ran `uv pip install --system` — `receipt-gate.yml` and `occ-preflight.yml` (the central reusable workflows every repo calls) — now:

1. **Remove `--system` entirely.** Install omnibase_core/compat into a uv-managed virtual environment under `$GITHUB_WORKSPACE` (always writable on a freshly recreated runner) via `uv venv` + `uv pip install --python "$venv_py"`. Gate steps run the venv interpreter via `RECEIPT_GATE_PY` / `OCC_PREFLIGHT_PY`, never bare `python`.
2. **Add a `Preflight runner Python write contract` step** that runs *before* install + gate, proves the workspace venv path is writable, references the system `dist-packages` path it guarantees is NOT required, and fails loudly (`::error::` + `exit 1`) if the contract is violated.

The OMN-9198/9283 wheel-build pattern (build core from source, install the exact wheel with `--no-index`/`--no-config`) is preserved — only the install *target* changed from the system interpreter to the workspace venv.

## dod_evidence

- `tests/unit/validation/test_runner_python_write_contract.py` (TDD, written failing first then driven green): asserts no `--system` survives in either workflow, the install creates a workspace `uv venv` bound via `--python`, and the write-contract preflight exists, precedes install + gate, and fails loud. 16 tests.
- `tests/unit/validation/test_receipt_gate_workflow_shape.py`: the pre-existing OMN-9198/9283 wheel-build guards still pass (no regression).
- Local: `uv run pytest tests/unit/validation/ -k "workflow or receipt_gate or runner_python or occ"` → 301 passed, 1 skipped. `actionlint` clean on both workflows. `ruff` + `mypy --strict` clean. `pre-commit run --all-files` green (deterministic-skill-routing resolved against omniclaude@main snapshot).

Evidence-Source: OCC#2025
Evidence-Ticket: OMN-12565

## Gated actions remaining (runtime — require user)

- Recreate a `.201` self-hosted runner container fresh (no manual `chown` of `/usr/local/lib/python3.12/dist-packages`) and confirm a merge-group Receipt Gate passes on it. This is the "fresh runner recreation" acceptance step; it is a `.201` runtime action outside this PR's code scope.