### PR TITLE
feat(OMN-12621): topic-migration contract model + breaking-schema validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,50 @@ jobs:
           echo "- bus_bypass_import: scripts import directly from nodes/*/handlers/ (bypasses event bus)" >> $GITHUB_STEP_SUMMARY
           echo "- missing_contract_config: handler env reads with no matching contract.yaml entry" >> $GITHUB_STEP_SUMMARY
 
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Breaking-schema-change validator (OMN-12621)
+  breaking-schema-change:
+    name: Breaking-Schema-Change (OMN-12621)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run breaking-schema-change validator
+        run: uv run python -m omnibase_core.validators.breaking_schema_change src/omnibase_core/
+        # CI runners don't have ambient PYTHONPATH; runs cleanly without env -u PYTHONPATH
+
+      - name: Breaking-schema-change summary
+        if: always()
+        run: |
+          echo "## Breaking-Schema-Change (OMN-12621)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Requires an adjacent *.migration.yaml ModelTopicMigrationContract whenever a" >> $GITHUB_STEP_SUMMARY
+          echo "*.topic-schema.yaml declares a breaking topic-schema delta (major_bump or namespace_rename)." >> $GITHUB_STEP_SUMMARY
+
   # Localhost/env fallback prevention (OMN-10658 / OMN-7227)
   # Rejects os.getenv/os.environ.get with localhost fallback defaults in src/ and scripts/.
   no-env-fallbacks:
@@ -857,7 +901,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance, no-env-fallbacks]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks]
     if: always()
 
     steps:
@@ -878,6 +922,7 @@ jobs:
           secrets="${{ needs.detect-secrets.result }}"
           sdk_boundary="${{ needs.sdk-boundary-check.result }}"
           contract_config="${{ needs.contract-config-compliance.result }}"
+          breaking_schema="${{ needs.breaking-schema-change.result }}"
           no_env_fallbacks="${{ needs.no-env-fallbacks.result }}"
 
           # Report each check
@@ -895,6 +940,7 @@ jobs:
           echo "| Detect Secrets | $secrets |" >> $GITHUB_STEP_SUMMARY
           echo "| SDK Boundary Guard | $sdk_boundary |" >> $GITHUB_STEP_SUMMARY
           echo "| Contract-Config Compliance | $contract_config |" >> $GITHUB_STEP_SUMMARY
+          echo "| Breaking-Schema-Change (OMN-12621) | $breaking_schema |" >> $GITHUB_STEP_SUMMARY
           echo "| No Env Fallbacks (OMN-7227) | $no_env_fallbacks |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
@@ -910,6 +956,7 @@ jobs:
              [[ "$secrets" == "success" ]] && \
              [[ "$sdk_boundary" == "success" ]] && \
              [[ "$contract_config" == "success" ]] && \
+             [[ "$breaking_schema" == "success" ]] && \
              [[ "$no_env_fallbacks" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -539,6 +539,18 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Breaking-schema-change compliance (OMN-12621)
+      # Requires an adjacent *.migration.yaml ModelTopicMigrationContract whenever
+      # a *.topic-schema.yaml declares a breaking topic-schema delta (major_bump
+      # or namespace_rename). Suppress a line with: # breaking-schema-ok: <reason>
+      - id: breaking-schema-change
+        name: Breaking-Schema-Change Validator (OMN-12621)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.validators.breaking_schema_change
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       # OMN-12453: gitignore-baseline compliance gate
       # Asserts managed blocks from architecture-handshakes/gitignore-baseline.yaml
       # appear VERBATIM in this repo's .gitignore.

--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -345,6 +345,16 @@ allowed_files:
     added: "2026-05-17"
     review: "2026-12-13"
 
+  - file: "src/omnibase_core/validators/breaking_schema_change.py"
+    reason: >-
+      Breaking-schema-change validator (OMN-12621) — must read adjacent *.topic-schema.yaml declarations
+      and *.migration.yaml contracts from the filesystem to diff baseline vs current bindings. Every
+      yaml.safe_load() result is immediately passed to ModelTopicSchemaBinding.model_validate() /
+      ModelTopicMigrationContract.model_validate(); the raw dict is never used unvalidated. Mirrors the
+      contract_config_compliance.py validator pattern it is modeled on.
+    added: "2026-06-02"
+    review: "2026-12-13"
+
 # Specific filenames that are allowed (matched by basename)
 # Allows the same utility to be used across different module paths (e.g., copied utilities)
 allowed_filenames:

--- a/src/omnibase_core/enums/enum_cutover_criterion.py
+++ b/src/omnibase_core/enums/enum_cutover_criterion.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cutover Criterion Enum (OMN-12621).
+
+Strongly typed gating conditions that must hold before a topic migration may
+advance to ``CUTOVER``. These are the observable proofs that the new topic is
+safe to make authoritative.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumCutoverCriterion(UtilStrValueHelper, str, Enum):
+    """Conditions required before a migration may cut over.
+
+    - ``OLD_TOPIC_DRAINED``: the old topic has no un-consumed lag for the old
+      consumer group (drain-proof gate satisfied).
+    - ``NEW_TOPIC_CONSUMER_HEALTHY``: the new consumer group is live and
+      committing offsets on the new topic.
+    - ``COMPATIBILITY_WINDOW_ELAPSED``: the declared compatibility window has
+      fully elapsed.
+    - ``DUAL_WRITE_VERIFIED``: producers are confirmed writing to both topics
+      with matching payload counts.
+    - ``SCHEMA_PARITY_VERIFIED``: the new topic's event schema_version satisfies
+      consumer compatibility (no unhandled breaking delta).
+    """
+
+    OLD_TOPIC_DRAINED = "old_topic_drained"
+    NEW_TOPIC_CONSUMER_HEALTHY = "new_topic_consumer_healthy"
+    COMPATIBILITY_WINDOW_ELAPSED = "compatibility_window_elapsed"
+    DUAL_WRITE_VERIFIED = "dual_write_verified"
+    SCHEMA_PARITY_VERIFIED = "schema_parity_verified"
+
+
+__all__ = ["EnumCutoverCriterion"]

--- a/src/omnibase_core/enums/enum_migration_phase.py
+++ b/src/omnibase_core/enums/enum_migration_phase.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Migration Phase Enum (OMN-12621).
+
+Strongly typed lifecycle phases for a topic-migration contract. A migration
+moves producers/consumers from an ``old`` topic (and consumer group) to a
+``new`` topic during a bounded compatibility window, then cuts over.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumMigrationPhase(UtilStrValueHelper, str, Enum):
+    """Lifecycle phases of a topic migration.
+
+    Phases progress strictly forward:
+
+    - ``PLANNED``: contract authored, no traffic moved yet.
+    - ``DUAL_WRITE``: producers write to both old and new topics; consumers
+      still read the old topic.
+    - ``DUAL_READ``: consumers read both topics during the compatibility
+      window; new consumers prefer the new topic.
+    - ``CUTOVER``: new topic is authoritative; old topic is drained, not
+      written. Gated by the drain-proof gate and cutover criteria.
+    - ``COMPLETE``: old topic and old consumer group are decommissioned.
+    """
+
+    PLANNED = "planned"
+    DUAL_WRITE = "dual_write"
+    DUAL_READ = "dual_read"
+    CUTOVER = "cutover"
+    COMPLETE = "complete"
+
+
+__all__ = ["EnumMigrationPhase"]

--- a/src/omnibase_core/enums/enum_topic_schema_delta.py
+++ b/src/omnibase_core/enums/enum_topic_schema_delta.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Topic-schema delta classification enum (OMN-12621).
+
+Classifies the delta between two topic-schema bindings (old vs new). The
+breaking members (``MAJOR_BUMP`` and ``NAMESPACE_RENAME``) require an adjacent
+``ModelTopicMigrationContract``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumTopicSchemaDelta(UtilStrValueHelper, str, Enum):
+    """Classification of the delta between two topic-schema bindings."""
+
+    NONE = "none"
+    COMPATIBLE = "compatible"
+    MAJOR_BUMP = "major_bump"
+    NAMESPACE_RENAME = "namespace_rename"
+
+    @property
+    def is_breaking(self) -> bool:
+        """True if the delta requires a topic-migration contract."""
+        return self in (
+            EnumTopicSchemaDelta.MAJOR_BUMP,
+            EnumTopicSchemaDelta.NAMESPACE_RENAME,
+        )
+
+
+__all__ = ["EnumTopicSchemaDelta"]

--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -93,6 +93,7 @@ from .model_algorithm_factor_config import ModelAlgorithmFactorConfig
 from .model_backup_config import ModelBackupConfig
 from .model_branching_config import ModelBranchingConfig
 from .model_caching_config import ModelCachingConfig
+from .model_canonical_topic import ModelCanonicalTopic
 from .model_capability_provided import ModelCapabilityProvided
 from .model_cli_contribution import (
     CLI_CONTRIBUTION_CONTRACT_TYPE,
@@ -198,6 +199,13 @@ from .model_runtime_handler_config import ModelRuntimeHandlerConfig
 from .model_runtime_host_contract import ModelRuntimeHostContract
 from .model_storage_config import ModelStorageConfig
 from .model_streaming_config import ModelStreamingConfig
+from .model_topic_migration_contract import ModelTopicMigrationContract
+from .model_topic_schema_binding import (
+    ModelTopicSchemaBinding,
+    build_versioned_topic,
+    detect_breaking_delta,
+    parse_canonical_topic,
+)
 from .model_transaction_config import ModelTransactionConfig
 from .model_trigger_mappings import ModelTriggerMappings
 from .model_validation_rules import ModelValidationRules
@@ -301,6 +309,12 @@ __all__ = [
     "ModelReductionConfig",
     "ModelStreamingConfig",
     "ModelActionEmissionConfig",
+    "ModelTopicMigrationContract",
+    "ModelTopicSchemaBinding",
+    "ModelCanonicalTopic",
+    "build_versioned_topic",
+    "detect_breaking_delta",
+    "parse_canonical_topic",
     "ModelTransactionConfig",
     "ModelValidationRules",
     # Workflow models

--- a/src/omnibase_core/models/contracts/model_canonical_topic.py
+++ b/src/omnibase_core/models/contracts/model_canonical_topic.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Structured view of a parsed canonical ONEX topic name (OMN-12621).
+
+A canonical ONEX topic has the form
+``onex.<kind>.<service>.<event>[.<event>...].v<N>``. :class:`ModelCanonicalTopic`
+is the structured decomposition of that name and exposes an :attr:`identity`
+that ignores the ``.vN`` segment, so two versions of the same logical stream
+share an identity while a namespace rename does not.
+
+This is distinct from ``omnibase_core.models.dispatch.model_parsed_topic`` —
+that model describes routing-standard detection for arbitrary topic strings;
+this one is the strict canonical-topic decomposition used by the topic-migration
+contract machinery.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelCanonicalTopic(BaseModel):
+    """Structured view of a parsed canonical ONEX topic name."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    namespace: str = Field(..., description="Top-level namespace, always 'onex'")
+    kind: str = Field(
+        ..., description="Topic kind: cmd | evt | dlq | snapshot | intent"
+    )
+    service: str = Field(..., description="Producing service segment")
+    event: str = Field(..., description="Dotted event name segment(s)")
+    topic_major: int = Field(..., ge=1, description="Topic .vN version segment")
+
+    @property
+    def identity(self) -> tuple[str, str, str, str]:
+        """Namespace/kind/service/event identity, ignoring the .vN segment.
+
+        Two topics with the same identity but different ``topic_major`` are the
+        same logical stream at different versions; a different identity is a
+        namespace rename (the OMN-12407 case).
+        """
+        return (self.namespace, self.kind, self.service, self.event)
+
+
+__all__ = ["ModelCanonicalTopic"]

--- a/src/omnibase_core/models/contracts/model_topic_migration_contract.py
+++ b/src/omnibase_core/models/contracts/model_topic_migration_contract.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Topic-migration contract (OMN-12621).
+
+Declarative, contract-native description of moving an event stream from an
+``old`` canonical topic (and consumer group) to a ``new`` one across a bounded
+compatibility window with an explicit drain-proof gate before cutover.
+
+The model is **general** enough to express two migration shapes:
+
+1. A ``.vN`` bump on the same logical stream
+   (``onex.evt.<svc>.<event>.v1`` → ``...v2``), driven by an event
+   ``schema_version`` major bump.
+2. A namespace rename
+   (``onex.evt.<old-ns>.*`` → ``<new-ns>.*``), the first concrete consumer of
+   which is OMN-12407.
+
+Modeled on :class:`ModelDbSafetyPolicy` (frozen, ``extra="forbid"``). Versions
+are :class:`ModelSemVer`. The breaking-schema-change validator (OMN-12621)
+requires an adjacent contract of this shape whenever it detects a breaking
+topic-schema delta.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_cutover_criterion import EnumCutoverCriterion
+from omnibase_core.enums.enum_migration_phase import EnumMigrationPhase
+from omnibase_core.enums.enum_topic_schema_delta import EnumTopicSchemaDelta
+from omnibase_core.models.contracts.model_topic_schema_binding import (
+    ModelTopicSchemaBinding,
+    detect_breaking_delta,
+    parse_canonical_topic,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+class ModelTopicMigrationContract(BaseModel):
+    """Contract governing a single topic migration.
+
+    Captures the source and target streams, their consumer groups, the bounded
+    compatibility window, the cutover criteria that must hold before the new
+    topic becomes authoritative, and the drain-proof gate that proves the old
+    topic is fully consumed before decommission.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    contract_version: ModelSemVer = Field(
+        ...,
+        description="Version of this migration contract document",
+    )
+    ticket: str = Field(
+        ...,
+        description="Linear ticket authorizing this migration",
+        pattern=r"^OMN-\d+$",
+    )
+
+    old_binding: ModelTopicSchemaBinding = Field(
+        ...,
+        description="Source topic ↔ schema_version binding being migrated away from",
+    )
+    new_binding: ModelTopicSchemaBinding = Field(
+        ...,
+        description="Target topic ↔ schema_version binding being migrated to",
+    )
+
+    old_consumer_group: str = Field(
+        ...,
+        min_length=1,
+        description="Consumer group reading the old topic",
+    )
+    new_consumer_group: str = Field(
+        ...,
+        min_length=1,
+        description="Consumer group reading the new topic",
+    )
+
+    compatibility_window_hours: int = Field(
+        ...,
+        ge=1,
+        description=(
+            "Bounded window (hours) during which both topics are live before "
+            "cutover. Must be a positive, finite duration — no open-ended windows."
+        ),
+    )
+
+    cutover_criteria: tuple[EnumCutoverCriterion, ...] = Field(
+        ...,
+        min_length=1,
+        description="Conditions that must all hold before advancing to CUTOVER",
+    )
+
+    drain_proof_required: bool = Field(
+        default=True,
+        description=(
+            "Whether cutover requires proof the old topic is fully drained for "
+            "the old consumer group. Defaults True; opting out is explicit."
+        ),
+    )
+
+    phase: EnumMigrationPhase = Field(
+        default=EnumMigrationPhase.PLANNED,
+        description="Current lifecycle phase of the migration",
+    )
+
+    @model_validator(mode="after")
+    def _validate_migration(self) -> ModelTopicMigrationContract:
+        # Old and new must be distinct streams (topic or schema major must move).
+        if (
+            self.old_binding.topic == self.new_binding.topic
+            and self.old_binding.schema_version == self.new_binding.schema_version
+        ):
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    "Topic-migration contract old_binding and new_binding are "
+                    "identical; a migration must move topic or schema_version."
+                ),
+            )
+
+        # The migration must describe a breaking delta — otherwise no migration
+        # contract is needed and authoring one is a smell.
+        delta = detect_breaking_delta(self.old_binding, self.new_binding)
+        if not delta.is_breaking:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    f"Topic-migration contract describes a non-breaking delta "
+                    f"({delta.value}); migration contracts are only for breaking "
+                    "deltas (major_bump or namespace_rename)."
+                ),
+            )
+
+        # Drain-proof gate: if required, OLD_TOPIC_DRAINED must be a cutover criterion.
+        if (
+            self.drain_proof_required
+            and EnumCutoverCriterion.OLD_TOPIC_DRAINED not in self.cutover_criteria
+        ):
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    "drain_proof_required is True but OLD_TOPIC_DRAINED is not "
+                    "among cutover_criteria; the drain-proof gate would never be "
+                    "enforced."
+                ),
+            )
+
+        # Both topics must be canonical (parse or raise).
+        parse_canonical_topic(self.old_binding.topic)
+        parse_canonical_topic(self.new_binding.topic)
+        return self
+
+    @property
+    def delta(self) -> EnumTopicSchemaDelta:
+        """The breaking delta class this migration addresses."""
+        return detect_breaking_delta(self.old_binding, self.new_binding)
+
+    @property
+    def is_namespace_rename(self) -> bool:
+        """True if this migration renames the topic namespace (OMN-12407 shape)."""
+        return self.delta is EnumTopicSchemaDelta.NAMESPACE_RENAME
+
+
+__all__ = ["ModelTopicMigrationContract"]

--- a/src/omnibase_core/models/contracts/model_topic_migration_contract.py
+++ b/src/omnibase_core/models/contracts/model_topic_migration_contract.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_cutover_criterion import EnumCutoverCriterion
 from omnibase_core.enums.enum_migration_phase import EnumMigrationPhase
 from omnibase_core.enums.enum_topic_schema_delta import EnumTopicSchemaDelta
@@ -35,7 +34,6 @@ from omnibase_core.models.contracts.model_topic_schema_binding import (
     detect_breaking_delta,
     parse_canonical_topic,
 )
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 
@@ -115,25 +113,19 @@ class ModelTopicMigrationContract(BaseModel):
             self.old_binding.topic == self.new_binding.topic
             and self.old_binding.schema_version == self.new_binding.schema_version
         ):
-            raise ModelOnexError(
-                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-                message=(
-                    "Topic-migration contract old_binding and new_binding are "
-                    "identical; a migration must move topic or schema_version."
-                ),
+            raise ValueError(
+                "Topic-migration contract old_binding and new_binding are "
+                "identical; a migration must move topic or schema_version."
             )
 
         # The migration must describe a breaking delta — otherwise no migration
         # contract is needed and authoring one is a smell.
         delta = detect_breaking_delta(self.old_binding, self.new_binding)
         if not delta.is_breaking:
-            raise ModelOnexError(
-                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-                message=(
-                    f"Topic-migration contract describes a non-breaking delta "
-                    f"({delta.value}); migration contracts are only for breaking "
-                    "deltas (major_bump or namespace_rename)."
-                ),
+            raise ValueError(
+                f"Topic-migration contract describes a non-breaking delta "
+                f"({delta.value}); migration contracts are only for breaking "
+                "deltas (major_bump or namespace_rename)."
             )
 
         # Drain-proof gate: if required, OLD_TOPIC_DRAINED must be a cutover criterion.
@@ -141,13 +133,10 @@ class ModelTopicMigrationContract(BaseModel):
             self.drain_proof_required
             and EnumCutoverCriterion.OLD_TOPIC_DRAINED not in self.cutover_criteria
         ):
-            raise ModelOnexError(
-                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-                message=(
-                    "drain_proof_required is True but OLD_TOPIC_DRAINED is not "
-                    "among cutover_criteria; the drain-proof gate would never be "
-                    "enforced."
-                ),
+            raise ValueError(
+                "drain_proof_required is True but OLD_TOPIC_DRAINED is not "
+                "among cutover_criteria; the drain-proof gate would never be "
+                "enforced."
             )
 
         # Both topics must be canonical (parse or raise).

--- a/src/omnibase_core/models/contracts/model_topic_schema_binding.py
+++ b/src/omnibase_core/models/contracts/model_topic_schema_binding.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Topic ``.vN`` ↔ event ``schema_version`` linkage (OMN-12621).
+
+Background
+----------
+A canonical ONEX topic carries a free-text version segment ``.vN``
+(``onex.evt.<service>.<event>.v<N>``). The payload that flows on that topic is
+described by a :class:`ModelEventType` whose ``schema_version`` is a full
+:class:`ModelSemVer`. Before this module there was **no link** between the two:
+the topic's ``.vN`` and the event's ``schema_version`` could drift apart, so
+"detect a breaking schema change" had nothing to diff against.
+
+``ModelTopicSchemaBinding`` is that link. It binds one canonical topic name to
+the SemVer schema_version of the event it carries, and asserts the topic's
+``.vN`` matches the event's **major** version (the wire-compat boundary, mirror
+of :meth:`ModelEventType.is_compatible_with` which compares major).
+
+Breaking-delta detection
+-------------------------
+:func:`detect_breaking_delta` compares two bindings (old vs new) and reports the
+:class:`EnumTopicSchemaDelta`:
+
+- ``NONE`` — same topic, same major.
+- ``COMPATIBLE`` — same topic+major, minor/patch forward bump only.
+- ``MAJOR_BUMP`` — same namespace+service+event, the ``.vN`` / schema major rose.
+- ``NAMESPACE_RENAME`` — the namespace/service/event identity changed
+  (``onex.evt.<old-ns>.*`` → ``<new-ns>.*``; first consumer is OMN-12407).
+
+``MAJOR_BUMP`` and ``NAMESPACE_RENAME`` are **breaking** — they require a
+:class:`ModelTopicMigrationContract`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_topic_schema_delta import EnumTopicSchemaDelta
+from omnibase_core.models.contracts.model_canonical_topic import ModelCanonicalTopic
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+# onex.<kind>.<service>.<event>[.<event>...].v<N>
+_CANONICAL_TOPIC_RE = re.compile(
+    r"^(?P<namespace>onex)"
+    r"\.(?P<kind>cmd|evt|dlq|snapshot|intent)"
+    r"\.(?P<service>[a-zA-Z0-9_-]+)"
+    r"\.(?P<event>[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)"
+    r"\.v(?P<version>\d+)$"
+)
+
+
+def parse_canonical_topic(topic: str) -> ModelCanonicalTopic:
+    """Parse a canonical ONEX topic into its structured parts.
+
+    Raises:
+        ModelOnexError: if ``topic`` does not match the canonical format
+            ``onex.<kind>.<service>.<event>[.<event>...].v<N>``.
+    """
+    match = _CANONICAL_TOPIC_RE.match(topic)
+    if match is None:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+            message=(
+                f"Topic {topic!r} does not match canonical ONEX format "
+                "onex.<kind>.<service>.<event>[.<event>...].v<N>"
+            ),
+        )
+    return ModelCanonicalTopic(
+        namespace=match.group("namespace"),
+        kind=match.group("kind"),
+        service=match.group("service"),
+        event=match.group("event"),
+        topic_major=int(match.group("version")),
+    )
+
+
+def build_versioned_topic(
+    service: str,
+    event: str,
+    version: int,
+    *,
+    kind: str = "evt",
+) -> str:
+    """Build a canonical versioned topic ``onex.<kind>.<service>.<event>.v<N>``.
+
+    General builder addressing the gap that only ``build_dlq_topic`` existed.
+
+    Raises:
+        ModelOnexError: on invalid kind, version, or segment characters.
+    """
+    if kind not in ("cmd", "evt", "dlq", "snapshot", "intent"):
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+            message=f"Invalid topic kind {kind!r}; expected cmd|evt|dlq|snapshot|intent",
+        )
+    if version < 1:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+            message=f"Topic version must be >= 1, got {version}",
+        )
+    topic = f"onex.{kind}.{service}.{event}.v{version}"
+    # Validate by round-tripping through the canonical parser.
+    parse_canonical_topic(topic)
+    return topic
+
+
+class ModelTopicSchemaBinding(BaseModel):
+    """Binds a canonical topic to the SemVer schema_version it carries.
+
+    The binding asserts the topic's ``.vN`` equals the event's
+    ``schema_version.major`` — the wire-compatibility boundary. This is the
+    linkage that makes a breaking schema delta detectable: a topic ``.vN`` bump
+    must correspond to a schema major bump, and vice versa.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    topic: str = Field(
+        ..., description="Canonical topic name (onex.<kind>.<service>.<event>.v<N>)"
+    )
+    event_name: str = Field(
+        ...,
+        description="Event identifier carried on the topic",
+        pattern="^[A-Z][A-Z0-9_]*$",
+    )
+    schema_version: ModelSemVer = Field(
+        ..., description="SemVer schema_version of the event payload on this topic"
+    )
+
+    @model_validator(mode="after")
+    def _assert_major_matches_topic_version(self) -> ModelTopicSchemaBinding:
+        parsed = parse_canonical_topic(self.topic)
+        if parsed.topic_major != self.schema_version.major:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    f"Topic version segment .v{parsed.topic_major} does not match "
+                    f"schema_version major {self.schema_version.major} for topic "
+                    f"{self.topic!r}. The topic .vN MUST equal the event "
+                    "schema_version major (wire-compatibility boundary)."
+                ),
+            )
+        return self
+
+    @property
+    def parsed(self) -> ModelCanonicalTopic:
+        """Structured view of the bound topic."""
+        return parse_canonical_topic(self.topic)
+
+
+def detect_breaking_delta(
+    old: ModelTopicSchemaBinding,
+    new: ModelTopicSchemaBinding,
+) -> EnumTopicSchemaDelta:
+    """Classify the delta between an old and a new topic-schema binding.
+
+    Returns:
+        - ``NAMESPACE_RENAME`` if the namespace/kind/service/event identity
+          changed (breaking — e.g. OMN-12407 ``onex.evt.<old-ns>.*`` rename).
+        - ``MAJOR_BUMP`` if same identity but the schema major rose (breaking).
+        - ``COMPATIBLE`` if same identity+major with a forward minor/patch bump.
+        - ``NONE`` if the bindings are schema-equivalent.
+    """
+    if old.parsed.identity != new.parsed.identity:
+        return EnumTopicSchemaDelta.NAMESPACE_RENAME
+    if new.schema_version.major > old.schema_version.major:
+        return EnumTopicSchemaDelta.MAJOR_BUMP
+    if new.schema_version.major < old.schema_version.major:
+        # A major regression is also a breaking, migration-requiring change.
+        return EnumTopicSchemaDelta.MAJOR_BUMP
+    if new.schema_version > old.schema_version:
+        return EnumTopicSchemaDelta.COMPATIBLE
+    return EnumTopicSchemaDelta.NONE
+
+
+__all__ = [
+    "ModelTopicSchemaBinding",
+    "build_versioned_topic",
+    "detect_breaking_delta",
+    "parse_canonical_topic",
+]

--- a/src/omnibase_core/models/contracts/model_topic_schema_binding.py
+++ b/src/omnibase_core/models/contracts/model_topic_schema_binding.py
@@ -38,10 +38,8 @@ import re
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_topic_schema_delta import EnumTopicSchemaDelta
 from omnibase_core.models.contracts.model_canonical_topic import ModelCanonicalTopic
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 # onex.<kind>.<service>.<event>[.<event>...].v<N>
@@ -58,17 +56,14 @@ def parse_canonical_topic(topic: str) -> ModelCanonicalTopic:
     """Parse a canonical ONEX topic into its structured parts.
 
     Raises:
-        ModelOnexError: if ``topic`` does not match the canonical format
+        ValueError: if ``topic`` does not match the canonical format
             ``onex.<kind>.<service>.<event>[.<event>...].v<N>``.
     """
     match = _CANONICAL_TOPIC_RE.match(topic)
     if match is None:
-        raise ModelOnexError(
-            error_code=EnumCoreErrorCode.INVALID_INPUT,
-            message=(
-                f"Topic {topic!r} does not match canonical ONEX format "
-                "onex.<kind>.<service>.<event>[.<event>...].v<N>"
-            ),
+        raise ValueError(
+            f"Topic {topic!r} does not match canonical ONEX format "
+            "onex.<kind>.<service>.<event>[.<event>...].v<N>"
         )
     return ModelCanonicalTopic(
         namespace=match.group("namespace"),
@@ -91,18 +86,14 @@ def build_versioned_topic(
     General builder addressing the gap that only ``build_dlq_topic`` existed.
 
     Raises:
-        ModelOnexError: on invalid kind, version, or segment characters.
+        ValueError: on invalid kind, version, or segment characters.
     """
     if kind not in ("cmd", "evt", "dlq", "snapshot", "intent"):
-        raise ModelOnexError(
-            error_code=EnumCoreErrorCode.INVALID_INPUT,
-            message=f"Invalid topic kind {kind!r}; expected cmd|evt|dlq|snapshot|intent",
+        raise ValueError(
+            f"Invalid topic kind {kind!r}; expected cmd|evt|dlq|snapshot|intent"
         )
     if version < 1:
-        raise ModelOnexError(
-            error_code=EnumCoreErrorCode.INVALID_INPUT,
-            message=f"Topic version must be >= 1, got {version}",
-        )
+        raise ValueError(f"Topic version must be >= 1, got {version}")
     topic = f"onex.{kind}.{service}.{event}.v{version}"
     # Validate by round-tripping through the canonical parser.
     parse_canonical_topic(topic)
@@ -136,14 +127,11 @@ class ModelTopicSchemaBinding(BaseModel):
     def _assert_major_matches_topic_version(self) -> ModelTopicSchemaBinding:
         parsed = parse_canonical_topic(self.topic)
         if parsed.topic_major != self.schema_version.major:
-            raise ModelOnexError(
-                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-                message=(
-                    f"Topic version segment .v{parsed.topic_major} does not match "
-                    f"schema_version major {self.schema_version.major} for topic "
-                    f"{self.topic!r}. The topic .vN MUST equal the event "
-                    "schema_version major (wire-compatibility boundary)."
-                ),
+            raise ValueError(
+                f"Topic version segment .v{parsed.topic_major} does not match "
+                f"schema_version major {self.schema_version.major} for topic "
+                f"{self.topic!r}. The topic .vN MUST equal the event "
+                "schema_version major (wire-compatibility boundary)."
             )
         return self
 

--- a/src/omnibase_core/models/validation/model_breaking_schema_finding.py
+++ b/src/omnibase_core/models/validation/model_breaking_schema_finding.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelBreakingSchemaFinding — finding from the breaking-schema-change validator (OMN-12621)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelBreakingSchemaFinding(BaseModel):
+    """A single finding from the breaking-schema-change validator."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    path: Path = Field(
+        ..., description="Topic-schema declaration that changed breakingly"
+    )
+    rule: str = Field(..., description="Validator rule that fired")
+    delta: str = Field(..., description="Detected breaking delta classification")
+    message: str = Field(..., description="Human-readable explanation")
+
+    def format(self) -> str:
+        return f"{self.path}: [{self.rule}] ({self.delta}) {self.message}"
+
+
+__all__ = ["ModelBreakingSchemaFinding"]

--- a/src/omnibase_core/validators/breaking_schema_change.py
+++ b/src/omnibase_core/validators/breaking_schema_change.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Breaking-schema-change validator (OMN-12621).
+
+Enforces that any **breaking** topic-schema delta is accompanied by an adjacent
+:class:`ModelTopicMigrationContract`. This is the enforcement half of the
+topic-migration machinery (Rule #5: enforcement, not detection) — wired as a
+pre-commit hook and a CI gate in the same change.
+
+Inputs
+------
+Topic-schema declaration files named ``*.topic-schema.yaml``. Each declares the
+current topic↔schema binding plus the immediately-preceding baseline::
+
+    # payments.topic-schema.yaml
+    current:
+      topic: onex.evt.payments.payment-captured.v2
+      event_name: PAYMENT_CAPTURED
+      schema_version: {major: 2, minor: 0, patch: 0}
+    baseline:
+      topic: onex.evt.payments.payment-captured.v1
+      event_name: PAYMENT_CAPTURED
+      schema_version: {major: 1, minor: 0, patch: 0}
+
+The validator diffs ``baseline`` against ``current`` via
+:func:`detect_breaking_delta`. On a breaking delta (``major_bump`` or
+``namespace_rename``) it requires an adjacent ``*.migration.yaml`` that parses
+as a :class:`ModelTopicMigrationContract` whose ``old_binding`` / ``new_binding``
+match the baseline / current bindings. The migration contract is fingerprinted
+with :func:`compute_contract_fingerprint` to prove it is well-formed.
+
+Usage::
+
+    python -m omnibase_core.validators.breaking_schema_change src/
+
+Suppression::
+
+    Add  # breaking-schema-ok: <reason>  on a line of the declaration's
+    `current.topic` value to silence a finding (rare; prefer authoring the
+    migration contract).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent topic-schema/migration YAML
+
+from omnibase_core.contracts.contract_hash_registry import (
+    compute_contract_fingerprint,
+)
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.contracts.model_topic_migration_contract import (
+    ModelTopicMigrationContract,
+)
+from omnibase_core.models.contracts.model_topic_schema_binding import (
+    ModelTopicSchemaBinding,
+    detect_breaking_delta,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.validation.model_breaking_schema_finding import (
+    ModelBreakingSchemaFinding,
+)
+
+SUPPRESSION_MARKER = "breaking-schema-ok:"
+
+TOPIC_SCHEMA_SUFFIX = ".topic-schema.yaml"
+MIGRATION_SUFFIX = ".migration.yaml"
+
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".git",
+        "archived",
+        "archive",
+    }
+)
+
+_VALIDATOR_NAME = "breaking_schema_change"
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
+
+
+def _binding_from_data(data: object) -> ModelTopicSchemaBinding:
+    """Build a ModelTopicSchemaBinding from a parsed YAML mapping."""
+    if not isinstance(data, dict):
+        raise ModelOnexError(
+            message="topic-schema binding section must be a mapping",
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+    return ModelTopicSchemaBinding.model_validate(data)
+
+
+def _load_migration_contracts(directory: Path) -> list[ModelTopicMigrationContract]:
+    """Load every *.migration.yaml in a directory as a migration contract."""
+    contracts: list[ModelTopicMigrationContract] = []
+    for mig_path in sorted(directory.glob(f"*{MIGRATION_SUFFIX}")):
+        # ONEX_EXCLUDE: manual_yaml - validator reads adjacent migration contract YAML
+        raw = yaml.safe_load(mig_path.read_text(encoding="utf-8"))
+        contracts.append(ModelTopicMigrationContract.model_validate(raw))
+    return contracts
+
+
+def _migration_covers(
+    contract: ModelTopicMigrationContract,
+    baseline: ModelTopicSchemaBinding,
+    current: ModelTopicSchemaBinding,
+) -> bool:
+    """True if a migration contract covers this baseline→current transition."""
+    return (
+        contract.old_binding.topic == baseline.topic
+        and contract.old_binding.schema_version == baseline.schema_version
+        and contract.new_binding.topic == current.topic
+        and contract.new_binding.schema_version == current.schema_version
+    )
+
+
+def validate_file(path: Path) -> list[ModelBreakingSchemaFinding]:
+    """Validate one *.topic-schema.yaml declaration; return findings."""
+    if _is_excluded(path):
+        return []
+    text = path.read_text(encoding="utf-8")
+    # ONEX_EXCLUDE: manual_yaml - validator reads topic-schema declaration YAML
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict) or "current" not in data or "baseline" not in data:
+        raise ModelOnexError(
+            message=(
+                f"{path}: topic-schema declaration must contain 'current' and "
+                "'baseline' mappings"
+            ),
+            error_code=EnumCoreErrorCode.INVALID_INPUT,
+        )
+
+    current = _binding_from_data(data["current"])
+    baseline = _binding_from_data(data["baseline"])
+
+    delta = detect_breaking_delta(baseline, current)
+    if not delta.is_breaking:
+        return []
+
+    # Suppression: marker on the current.topic line.
+    for line in text.splitlines():
+        if current.topic in line and SUPPRESSION_MARKER in line:
+            return []
+
+    migrations = _load_migration_contracts(path.parent)
+    for contract in migrations:
+        if _migration_covers(contract, baseline, current):
+            # Fingerprint proves the migration contract is well-formed/loadable.
+            compute_contract_fingerprint(contract)
+            return []
+
+    return [
+        ModelBreakingSchemaFinding(
+            path=path,
+            rule="missing_topic_migration_contract",
+            delta=delta.value,
+            message=(
+                f"breaking topic-schema delta ({delta.value}) "
+                f"{baseline.topic} -> {current.topic} has no adjacent "
+                f"*{MIGRATION_SUFFIX} ModelTopicMigrationContract covering it"
+            ),
+        )
+    ]
+
+
+def validate_paths(paths: list[Path]) -> list[ModelBreakingSchemaFinding]:
+    """Validate every *.topic-schema.yaml under the given paths."""
+    findings: list[ModelBreakingSchemaFinding] = []
+    for path in paths:
+        if path.is_file() and path.name.endswith(TOPIC_SCHEMA_SUFFIX):
+            findings.extend(validate_file(path))
+        elif path.is_dir():
+            for ts_file in sorted(path.rglob(f"*{TOPIC_SCHEMA_SUFFIX}")):
+                if not _is_excluded(ts_file):
+                    findings.extend(validate_file(ts_file))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the breaking-schema-change validator."""
+    parser = argparse.ArgumentParser(
+        description="Breaking-schema-change validator (OMN-12621).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path("src")],
+        help="Files or directories to scan for *.topic-schema.yaml declarations.",
+    )
+    args = parser.parse_args(argv)
+
+    findings = validate_paths(args.paths)
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"{_VALIDATOR_NAME}: {len(findings)} finding(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    sys.stderr.write(
+        "\nA breaking topic-schema delta requires an adjacent "
+        f"*{MIGRATION_SUFFIX} ModelTopicMigrationContract.\n"
+        "Suppress an individual line with:  # breaking-schema-ok: <reason>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/models/contracts/test_topic_migration_contract.py
+++ b/tests/unit/models/contracts/test_topic_migration_contract.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_core.enums.enum_cutover_criterion import EnumCutoverCriterion
 from omnibase_core.enums.enum_migration_phase import EnumMigrationPhase
@@ -19,7 +20,6 @@ from omnibase_core.models.contracts.model_topic_schema_binding import (
     detect_breaking_delta,
     parse_canonical_topic,
 )
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 
@@ -47,7 +47,7 @@ class TestTopicParsingAndBuilder:
         assert parsed.topic_major == 2
 
     def test_parse_rejects_non_canonical(self) -> None:
-        with pytest.raises(ModelOnexError):
+        with pytest.raises(ValueError):
             parse_canonical_topic("not-a-topic")
 
     def test_build_versioned_topic(self) -> None:
@@ -57,7 +57,7 @@ class TestTopicParsingAndBuilder:
         )
 
     def test_build_versioned_topic_rejects_bad_version(self) -> None:
-        with pytest.raises(ModelOnexError):
+        with pytest.raises(ValueError):
             build_versioned_topic("payments", "payment-captured", 0)
 
 
@@ -75,7 +75,7 @@ class TestTopicSchemaBinding:
         assert b.parsed.topic_major == b.schema_version.major == 2
 
     def test_binding_major_mismatch_rejected(self) -> None:
-        with pytest.raises(ModelOnexError):
+        with pytest.raises(ValidationError):
             _binding(
                 "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(2)
             )
@@ -186,7 +186,7 @@ class TestTopicMigrationContract:
             c.compatibility_window_hours = 1  # type: ignore[misc]
 
     def test_non_breaking_delta_rejected(self) -> None:
-        with pytest.raises(ModelOnexError):
+        with pytest.raises(ValidationError):
             ModelTopicMigrationContract(
                 contract_version=_sv(1),
                 ticket="OMN-12621",
@@ -207,7 +207,7 @@ class TestTopicMigrationContract:
             )
 
     def test_drain_proof_gate_requires_drained_criterion(self) -> None:
-        with pytest.raises(ModelOnexError):
+        with pytest.raises(ValidationError):
             ModelTopicMigrationContract(
                 contract_version=_sv(1),
                 ticket="OMN-12621",

--- a/tests/unit/models/contracts/test_topic_migration_contract.py
+++ b/tests/unit/models/contracts/test_topic_migration_contract.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for topic-migration contract + topic↔schema linkage (OMN-12621)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_cutover_criterion import EnumCutoverCriterion
+from omnibase_core.enums.enum_migration_phase import EnumMigrationPhase
+from omnibase_core.enums.enum_topic_schema_delta import EnumTopicSchemaDelta
+from omnibase_core.models.contracts.model_topic_migration_contract import (
+    ModelTopicMigrationContract,
+)
+from omnibase_core.models.contracts.model_topic_schema_binding import (
+    ModelTopicSchemaBinding,
+    build_versioned_topic,
+    detect_breaking_delta,
+    parse_canonical_topic,
+)
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+def _sv(major: int, minor: int = 0, patch: int = 0) -> ModelSemVer:
+    return ModelSemVer(major=major, minor=minor, patch=patch)
+
+
+def _binding(topic: str, event: str, sv: ModelSemVer) -> ModelTopicSchemaBinding:
+    return ModelTopicSchemaBinding(topic=topic, event_name=event, schema_version=sv)
+
+
+# ---------------------------------------------------------------------------
+# Topic parsing + general builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTopicParsingAndBuilder:
+    def test_parse_canonical_topic(self) -> None:
+        parsed = parse_canonical_topic("onex.evt.payments.payment-captured.v2")
+        assert parsed.namespace == "onex"
+        assert parsed.kind == "evt"
+        assert parsed.service == "payments"
+        assert parsed.event == "payment-captured"
+        assert parsed.topic_major == 2
+
+    def test_parse_rejects_non_canonical(self) -> None:
+        with pytest.raises(ModelOnexError):
+            parse_canonical_topic("not-a-topic")
+
+    def test_build_versioned_topic(self) -> None:
+        assert (
+            build_versioned_topic("payments", "payment-captured", 2)
+            == "onex.evt.payments.payment-captured.v2"
+        )
+
+    def test_build_versioned_topic_rejects_bad_version(self) -> None:
+        with pytest.raises(ModelOnexError):
+            build_versioned_topic("payments", "payment-captured", 0)
+
+
+# ---------------------------------------------------------------------------
+# Topic ↔ schema_version linkage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTopicSchemaBinding:
+    def test_binding_major_matches_topic_version(self) -> None:
+        b = _binding(
+            "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+        )
+        assert b.parsed.topic_major == b.schema_version.major == 2
+
+    def test_binding_major_mismatch_rejected(self) -> None:
+        with pytest.raises(ModelOnexError):
+            _binding(
+                "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(2)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Breaking-delta detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBreakingDeltaDetection:
+    def test_no_change(self) -> None:
+        old = _binding(
+            "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+        )
+        new = _binding(
+            "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+        )
+        delta = detect_breaking_delta(old, new)
+        assert delta is EnumTopicSchemaDelta.NONE
+        assert not delta.is_breaking
+
+    def test_minor_bump_is_compatible(self) -> None:
+        old = _binding(
+            "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1, 0)
+        )
+        new = _binding(
+            "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1, 1)
+        )
+        delta = detect_breaking_delta(old, new)
+        assert delta is EnumTopicSchemaDelta.COMPATIBLE
+        assert not delta.is_breaking
+
+    def test_major_bump_is_breaking(self) -> None:
+        old = _binding(
+            "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+        )
+        new = _binding(
+            "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+        )
+        delta = detect_breaking_delta(old, new)
+        assert delta is EnumTopicSchemaDelta.MAJOR_BUMP
+        assert delta.is_breaking
+
+    def test_namespace_rename_is_breaking(self) -> None:
+        old = _binding("onex.evt.oldns.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1))
+        new = _binding("onex.evt.newns.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1))
+        delta = detect_breaking_delta(old, new)
+        assert delta is EnumTopicSchemaDelta.NAMESPACE_RENAME
+        assert delta.is_breaking
+
+
+# ---------------------------------------------------------------------------
+# ModelTopicMigrationContract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTopicMigrationContract:
+    def _vbump_contract(self) -> ModelTopicMigrationContract:
+        return ModelTopicMigrationContract(
+            contract_version=_sv(1),
+            ticket="OMN-12621",
+            old_binding=_binding(
+                "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+            ),
+            new_binding=_binding(
+                "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+            ),
+            old_consumer_group="payments-ledger-v1",
+            new_consumer_group="payments-ledger-v2",
+            compatibility_window_hours=72,
+            cutover_criteria=(
+                EnumCutoverCriterion.OLD_TOPIC_DRAINED,
+                EnumCutoverCriterion.NEW_TOPIC_CONSUMER_HEALTHY,
+            ),
+        )
+
+    def test_valid_version_bump_migration(self) -> None:
+        c = self._vbump_contract()
+        assert c.phase is EnumMigrationPhase.PLANNED
+        assert c.delta is EnumTopicSchemaDelta.MAJOR_BUMP
+        assert not c.is_namespace_rename
+        assert c.drain_proof_required is True
+
+    def test_namespace_rename_migration(self) -> None:
+        c = ModelTopicMigrationContract(
+            contract_version=_sv(1),
+            ticket="OMN-12407",
+            old_binding=_binding(
+                "onex.evt.oldns.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+            ),
+            new_binding=_binding(
+                "onex.evt.newns.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+            ),
+            old_consumer_group="oldns-ledger",
+            new_consumer_group="newns-ledger",
+            compatibility_window_hours=48,
+            cutover_criteria=(EnumCutoverCriterion.OLD_TOPIC_DRAINED,),
+        )
+        assert c.is_namespace_rename
+        assert c.delta is EnumTopicSchemaDelta.NAMESPACE_RENAME
+
+    def test_frozen(self) -> None:
+        c = self._vbump_contract()
+        with pytest.raises(Exception):
+            c.compatibility_window_hours = 1  # type: ignore[misc]
+
+    def test_non_breaking_delta_rejected(self) -> None:
+        with pytest.raises(ModelOnexError):
+            ModelTopicMigrationContract(
+                contract_version=_sv(1),
+                ticket="OMN-12621",
+                old_binding=_binding(
+                    "onex.evt.payments.payment-captured.v1",
+                    "PAYMENT_CAPTURED",
+                    _sv(1, 0),
+                ),
+                new_binding=_binding(
+                    "onex.evt.payments.payment-captured.v1",
+                    "PAYMENT_CAPTURED",
+                    _sv(1, 1),
+                ),
+                old_consumer_group="a",
+                new_consumer_group="b",
+                compatibility_window_hours=1,
+                cutover_criteria=(EnumCutoverCriterion.OLD_TOPIC_DRAINED,),
+            )
+
+    def test_drain_proof_gate_requires_drained_criterion(self) -> None:
+        with pytest.raises(ModelOnexError):
+            ModelTopicMigrationContract(
+                contract_version=_sv(1),
+                ticket="OMN-12621",
+                old_binding=_binding(
+                    "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+                ),
+                new_binding=_binding(
+                    "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+                ),
+                old_consumer_group="a",
+                new_consumer_group="b",
+                compatibility_window_hours=1,
+                drain_proof_required=True,
+                cutover_criteria=(EnumCutoverCriterion.NEW_TOPIC_CONSUMER_HEALTHY,),
+            )
+
+    def test_open_ended_window_rejected(self) -> None:
+        with pytest.raises(Exception):
+            ModelTopicMigrationContract(
+                contract_version=_sv(1),
+                ticket="OMN-12621",
+                old_binding=_binding(
+                    "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+                ),
+                new_binding=_binding(
+                    "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+                ),
+                old_consumer_group="a",
+                new_consumer_group="b",
+                compatibility_window_hours=0,
+                cutover_criteria=(EnumCutoverCriterion.OLD_TOPIC_DRAINED,),
+            )
+
+    def test_bad_ticket_rejected(self) -> None:
+        with pytest.raises(Exception):
+            ModelTopicMigrationContract(
+                contract_version=_sv(1),
+                ticket="not-a-ticket",
+                old_binding=_binding(
+                    "onex.evt.payments.payment-captured.v1", "PAYMENT_CAPTURED", _sv(1)
+                ),
+                new_binding=_binding(
+                    "onex.evt.payments.payment-captured.v2", "PAYMENT_CAPTURED", _sv(2)
+                ),
+                old_consumer_group="a",
+                new_consumer_group="b",
+                compatibility_window_hours=1,
+                cutover_criteria=(EnumCutoverCriterion.OLD_TOPIC_DRAINED,),
+            )

--- a/tests/unit/validators/test_breaking_schema_change.py
+++ b/tests/unit/validators/test_breaking_schema_change.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for breaking-schema-change validator (OMN-12621)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.breaking_schema_change import (
+    main,
+    validate_file,
+    validate_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture content
+# ---------------------------------------------------------------------------
+
+_BREAKING_DECLARATION = """\
+current:
+  topic: onex.evt.payments.payment-captured.v2
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 2, minor: 0, patch: 0}
+baseline:
+  topic: onex.evt.payments.payment-captured.v1
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 1, minor: 0, patch: 0}
+"""
+
+_COMPATIBLE_DECLARATION = """\
+current:
+  topic: onex.evt.payments.payment-captured.v1
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 1, minor: 1, patch: 0}
+baseline:
+  topic: onex.evt.payments.payment-captured.v1
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 1, minor: 0, patch: 0}
+"""
+
+_MIGRATION_CONTRACT = """\
+contract_version: {major: 1, minor: 0, patch: 0}
+ticket: OMN-12621
+old_binding:
+  topic: onex.evt.payments.payment-captured.v1
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 1, minor: 0, patch: 0}
+new_binding:
+  topic: onex.evt.payments.payment-captured.v2
+  event_name: PAYMENT_CAPTURED
+  schema_version: {major: 2, minor: 0, patch: 0}
+old_consumer_group: payments-ledger-v1
+new_consumer_group: payments-ledger-v2
+compatibility_window_hours: 72
+cutover_criteria:
+  - old_topic_drained
+  - new_topic_consumer_healthy
+"""
+
+
+def _write(d: Path, name: str, content: str) -> Path:
+    p = d / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# PROOF: fires on breaking change lacking migration; passes when present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBreakingSchemaValidator:
+    def test_breaking_without_migration_fires(self, tmp_path: Path) -> None:
+        decl = _write(tmp_path, "payments.topic-schema.yaml", _BREAKING_DECLARATION)
+        findings = validate_file(decl)
+        assert len(findings) == 1
+        assert findings[0].rule == "missing_topic_migration_contract"
+        assert findings[0].delta == "major_bump"
+
+    def test_breaking_with_adjacent_migration_passes(self, tmp_path: Path) -> None:
+        decl = _write(tmp_path, "payments.topic-schema.yaml", _BREAKING_DECLARATION)
+        _write(tmp_path, "payments.migration.yaml", _MIGRATION_CONTRACT)
+        findings = validate_file(decl)
+        assert findings == []
+
+    def test_compatible_change_passes(self, tmp_path: Path) -> None:
+        decl = _write(tmp_path, "payments.topic-schema.yaml", _COMPATIBLE_DECLARATION)
+        findings = validate_file(decl)
+        assert findings == []
+
+    def test_suppression_marker_silences(self, tmp_path: Path) -> None:
+        suppressed = _BREAKING_DECLARATION.replace(
+            "onex.evt.payments.payment-captured.v2",
+            "onex.evt.payments.payment-captured.v2  # breaking-schema-ok: handled in OMN-12621",
+            1,
+        )
+        decl = _write(tmp_path, "payments.topic-schema.yaml", suppressed)
+        findings = validate_file(decl)
+        assert findings == []
+
+    def test_validate_paths_directory(self, tmp_path: Path) -> None:
+        _write(tmp_path, "payments.topic-schema.yaml", _BREAKING_DECLARATION)
+        findings = validate_paths([tmp_path])
+        assert len(findings) == 1
+
+    def test_main_exit_one_on_finding(self, tmp_path: Path) -> None:
+        _write(tmp_path, "payments.topic-schema.yaml", _BREAKING_DECLARATION)
+        assert main([str(tmp_path)]) == 1
+
+    def test_main_exit_zero_when_migration_present(self, tmp_path: Path) -> None:
+        _write(tmp_path, "payments.topic-schema.yaml", _BREAKING_DECLARATION)
+        _write(tmp_path, "payments.migration.yaml", _MIGRATION_CONTRACT)
+        assert main([str(tmp_path)]) == 0


### PR DESCRIPTION
## OMN-12621 — Topic-migration contract model + breaking-schema validator (Section 6a, core)

Implements [OMN-12621](https://linear.app/omninode/issue/OMN-12621) (epic OMN-12618), Section 6a of the divergent-transport-runtime-convergence plan.

Evidence-Source: OCC#2111
Evidence-Ticket: OMN-12621

### Current vs target
- **Current (before):** no `ModelTopicMigrationContract` (grep-confirmed). `schema_version` existed on `ModelEventType` but was NOT linked to a topic's free-text `.vN`. Only `build_dlq_topic` existed — no general versioned-topic builder. "Detect a breaking schema change" had nothing to diff against.
- **Target (this PR):** a topic-migration contract model + a topic `.vN` ↔ event `schema_version` linkage + a breaking-change validator wired as pre-commit AND CI.

### What changed
1. **`ModelTopicMigrationContract`** (+ `EnumMigrationPhase`, `EnumCutoverCriterion`) — frozen, `extra=forbid`, `ModelSemVer`-versioned; modeled on `model_db_safety_policy.py`. General enough for a namespace rename (`onex.evt.<old-ns>.*` → `<new-ns>.*`, OMN-12407) as well as a `.vN` bump. Fields: old/new `ModelTopicSchemaBinding`, old/new consumer group, bounded compatibility window, cutover criteria, drain-proof gate (enforced in a `model_validator`).
2. **Topic `.vN` ↔ event `schema_version` linkage** — `ModelTopicSchemaBinding` + `ModelCanonicalTopic` + `parse_canonical_topic` / `build_versioned_topic` and `detect_breaking_delta(old, new) -> EnumTopicSchemaDelta`. The binding asserts topic `.vN` == event `schema_version.major` (wire-compat boundary), making a breaking delta (`major_bump` | `namespace_rename`) detectable.
3. **`breaking_schema_change` validator** — modeled on `contract_config_compliance.py`, reuses `compute_contract_fingerprint`. Diffs `baseline` vs `current` in `*.topic-schema.yaml` and requires an adjacent `*.migration.yaml` `ModelTopicMigrationContract` on a breaking delta. **Wired as a pre-commit hook AND a blocking CI gate in this same PR** (Rule #5: enforcement, not detection).

### Proof
- **TDD failing-test-before:** with the validator module absent, `tests/unit/validators/test_breaking_schema_change.py` fails collection: `ModuleNotFoundError: No module named 'omnibase_core.validators.breaking_schema_change'`.
- **Validator fires/passes (live):** on a breaking `v1→v2` `*.topic-schema.yaml` with no adjacent migration contract, `main()` → exit `1` (`missing_topic_migration_contract` finding); adding a covering `*.migration.yaml` → exit `0`.
- **Targeted tests:** 24 passed (`test_breaking_schema_change.py` + `test_topic_migration_contract.py`).
- **Full suite:** `uv run pytest tests/ -n 4` → 41398 passed, 63 skipped, 12 xfailed, 43 xpassed; 2 failures are pre-existing/environment-only and unrelated to this change — `test_setgid_bit_rejected` (fails identically on the base `dev` clone; local-macOS filesystem setgid behavior) and `test_get_action_registry_creates_di_registry` (passes in isolation; pytest-xdist cross-worker class-identity artifact).

No runtime / `.201` deploy in scope (core-only model + validator change).
