### PR TITLE
feat(OMN-12663): add omnibase-infra delegation topics to TopicBase + widen bifrost tier Literal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.43.0"
+version = "0.44.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
+++ b/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
@@ -156,8 +156,19 @@ class ModelDelegationBackendConfig(BaseModel):
         default=None,
         description="Optional static HTTP headers required by the backend provider.",
     )
-    tier: Literal["local", "frontier_api"] = Field(
-        ..., description="Routing tier: 'local' or 'frontier_api'."
+    tier: Literal[
+        "local", "frontier_api", "cheap_cloud", "cheap_frontier", "cli_agents"
+    ] = Field(
+        ...,
+        description=(
+            "Routing tier. Values verified against live bifrost_delegation.yaml and "
+            "routing_tiers.yaml (OMN-12663): "
+            "'local' = vLLM on .201; "
+            "'frontier_api' = Claude API; "
+            "'cheap_cloud' = OpenRouter/Gemini/GLM; "
+            "'cheap_frontier' = free-tier frontier models (OMN-12492); "
+            "'cli_agents' = subprocess-dispatched CLI agents (OMN-10137)."
+        ),
     )
     timeout_ms: int = Field(
         default=30000,

--- a/src/omnibase_core/topics.py
+++ b/src/omnibase_core/topics.py
@@ -487,6 +487,44 @@ class TopicBase(StrEnum):
     """
 
     # ==========================================================================
+    # Delegation inference pipeline topics (OMN-12663)
+    # Live runtime topics confirmed by D3 trace (OMN-12642): the omnibase-infra
+    # namespace is the authoritative runtime namespace for the inference
+    # request/response and delegation completion/failure events.
+    # ==========================================================================
+    DELEGATION_COMPLETED_INFRA = "onex.evt.omnibase-infra.delegation-completed.v1"
+    """Emitted by node_delegation_orchestrator when a delegation run completes successfully.
+
+    Producer: node_delegation_orchestrator (omnibase_infra runtime).
+    Confirmed in live D3 trace (OMN-12642, stability-test lane).
+    """
+
+    DELEGATION_FAILED_INFRA = "onex.evt.omnibase-infra.delegation-failed.v1"
+    """Emitted by node_delegation_orchestrator when a delegation run fails at any stage.
+
+    Producer: node_delegation_orchestrator (omnibase_infra runtime).
+    Confirmed in live D3 trace (OMN-12642, stability-test lane).
+    """
+
+    DELEGATION_INFERENCE_REQUEST = (
+        "onex.cmd.omnibase-infra.delegation-inference-request.v1"
+    )
+    """Command published by the delegation orchestrator to invoke LLM inference.
+
+    Consumed by node_llm_delegation_call_effect (effects runtime).
+    Confirmed in live D3 trace (OMN-12642): raw Kafka payload captured with this
+    exact topic name on stability-test lane.
+    """
+
+    DELEGATION_INFERENCE_RESPONSE = "onex.evt.omnibase-infra.inference-response.v1"
+    """Event published by node_llm_delegation_call_effect after LLM inference completes.
+
+    Published for both success and error outcomes (D4 defect: error_message field
+    indicates failure; no separate error topic exists as of OMN-12643).
+    Confirmed in live D3 trace (OMN-12642): response captured on this exact topic.
+    """
+
+    # ==========================================================================
     # Team lifecycle topics (OMN-7026)
     # Unified event schema for all dispatch surfaces (team_worker,
     # headless_claude, local_llm). Consumed by omnidash team timeline.

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -368,6 +368,29 @@ class TestModelBifrostDelegationConfig:
         with pytest.raises(ValidationError):
             ModelDelegationBackendConfig(backend_id="local_qwen3", tier="unknown")
 
+    def test_all_live_tier_values_accepted(self) -> None:
+        """All tier values present in live bifrost_delegation.yaml must be valid (OMN-12663).
+
+        Verified against bifrost_delegation.yaml and routing_tiers.yaml in omnimarket
+        and omnibase_infra; values confirmed in D3 trace (OMN-12642).
+        """
+        live_tiers = (
+            "local",
+            "frontier_api",
+            "cheap_cloud",
+            "cheap_frontier",
+            "cli_agents",
+        )
+        for tier in live_tiers:
+            backend = ModelDelegationBackendConfig(backend_id=f"test-{tier}", tier=tier)
+            assert backend.tier == tier, f"tier={tier!r} round-trip failed"
+
+    def test_previously_missing_tiers_now_accepted(self) -> None:
+        """cheap_cloud, cheap_frontier, and cli_agents were the three missing values (OMN-12663)."""
+        for tier in ("cheap_cloud", "cheap_frontier", "cli_agents"):
+            backend = ModelDelegationBackendConfig(backend_id=f"test-{tier}", tier=tier)
+            assert backend.tier == tier
+
 
 @pytest.mark.unit
 class TestModelTaskDelegatedEvent:

--- a/tests/unit/test_topic_base_delegation_infra.py
+++ b/tests/unit/test_topic_base_delegation_infra.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""TopicBase coverage for omnibase-infra delegation inference pipeline topics (OMN-12663).
+
+Blocker 1 fix: TopicBase was missing the four omnibase-infra-namespace delegation
+topics used by the live runtime (confirmed by D3 trace in OMN-12642).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.topics import TopicBase, build_topic
+
+pytestmark = pytest.mark.unit
+
+
+def test_delegation_completed_infra_topic_value() -> None:
+    assert (
+        TopicBase.DELEGATION_COMPLETED_INFRA
+        == "onex.evt.omnibase-infra.delegation-completed.v1"
+    )
+
+
+def test_delegation_failed_infra_topic_value() -> None:
+    assert (
+        TopicBase.DELEGATION_FAILED_INFRA
+        == "onex.evt.omnibase-infra.delegation-failed.v1"
+    )
+
+
+def test_delegation_inference_request_topic_value() -> None:
+    assert (
+        TopicBase.DELEGATION_INFERENCE_REQUEST
+        == "onex.cmd.omnibase-infra.delegation-inference-request.v1"
+    )
+
+
+def test_delegation_inference_response_topic_value() -> None:
+    assert (
+        TopicBase.DELEGATION_INFERENCE_RESPONSE
+        == "onex.evt.omnibase-infra.inference-response.v1"
+    )
+
+
+def test_delegation_infra_topics_pass_canonical_validation() -> None:
+    """All four new topics must satisfy the canonical ONEX topic format check."""
+    new_topics = [
+        TopicBase.DELEGATION_COMPLETED_INFRA,
+        TopicBase.DELEGATION_FAILED_INFRA,
+        TopicBase.DELEGATION_INFERENCE_REQUEST,
+        TopicBase.DELEGATION_INFERENCE_RESPONSE,
+    ]
+    for topic in new_topics:
+        result = build_topic(topic)
+        assert result == topic, f"build_topic round-trip failed for {topic!r}"
+
+
+def test_delegation_infra_topics_are_str_enum_members() -> None:
+    """Each new topic must be a member of TopicBase (StrEnum)."""
+    assert (
+        "onex.evt.omnibase-infra.delegation-completed.v1"
+        in TopicBase._value2member_map_
+    )
+    assert (
+        "onex.evt.omnibase-infra.delegation-failed.v1" in TopicBase._value2member_map_
+    )
+    assert (
+        "onex.cmd.omnibase-infra.delegation-inference-request.v1"
+        in TopicBase._value2member_map_
+    )
+    assert (
+        "onex.evt.omnibase-infra.inference-response.v1" in TopicBase._value2member_map_
+    )


### PR DESCRIPTION
## Summary

Prerequisite for OMN-12659 (WS-B1 omnimarket repoint). Two schema gaps narrowed the types without covering all in-use values.

**Blocker 1 — TopicBase missing omnibase-infra delegation topics (28 test failures in omnimarket):**

Added four topics confirmed by live D3 trace (OMN-12642, stability-test lane) and verified against `omnibase_infra/event_bus/topic_constants.py`:
- `DELEGATION_COMPLETED_INFRA` → `onex.evt.omnibase-infra.delegation-completed.v1`
- `DELEGATION_FAILED_INFRA` → `onex.evt.omnibase-infra.delegation-failed.v1`
- `DELEGATION_INFERENCE_REQUEST` → `onex.cmd.omnibase-infra.delegation-inference-request.v1`
- `DELEGATION_INFERENCE_RESPONSE` → `onex.evt.omnibase-infra.inference-response.v1`

**Blocker 2 — `ModelDelegationBackendConfig.tier` too narrow (7 test failures in omnimarket):**

Widened `Literal["local","frontier_api"]` to `Literal["local","frontier_api","cheap_cloud","cheap_frontier","cli_agents"]`. Values verified against:
- `omnimarket/src/omnimarket/configs/bifrost_delegation.yaml` (live backend tier assignments)
- `omnimarket/src/omnimarket/configs/routing_tiers.yaml` (tier escalation ladder)
- `omnibase_infra/src/omnibase_infra/configs/routing_tiers.yaml`
- `cheap_frontier` added in OMN-12492; `cli_agents` added in OMN-10137

Kept typed (Literal, not str) per typed-models doctrine.

**Version bump:** `0.43.0` → `0.44.0` for omnimarket to pin.

## Evidence

- OMN-12663 Linear ticket
- D3 trace: `docs/tracking/2026-06-03-omn12642-d3-trace.md` — raw Kafka payload confirms `onex.cmd.omnibase-infra.delegation-inference-request.v1` and `onex.evt.omnibase-infra.inference-response.v1`
- `omnibase_infra/event_bus/topic_constants.py` — `TOPIC_DELEGATION_COMPLETED`, `TOPIC_DELEGATION_FAILED`, `TOPIC_DELEGATION_INFERENCE_REQUEST`, `TOPIC_DELEGATION_INFERENCE_RESPONSE` all confirmed

## Test results

- 180 unit tests passing (topics + delegation wire suite)
- `mypy --strict` clean on both changed source files
- All pre-commit hooks passing on staged files

## Tickets

OMN-12663


Evidence-Source: OCC#2137


Evidence-Ticket: OMN-12663
