### PR TITLE
ci(OMN-12670): backmerge receipt gate timeout

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -65,7 +65,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     # OMN-10419 invariant I9: disable GHA cache + artifact reuse so merge_group
     # entry always re-evaluates fully. No stale PASS from a previous run can
     # satisfy the gate on a new merge_group event.


### PR DESCRIPTION
## Summary
- Backmerge the OMN-12670 reusable Receipt Gate timeout change to dev.
- Keeps dev aligned with the hotfix/main path for the central workflow timeout.

Evidence-Ticket: OMN-12670
Evidence-Source: 0a6c4effc61dda9f6b3b9370e2198b23b50110d4

## Verification
- `uv run python - <<PY ...` parsed `.github/workflows/receipt-gate.yml` and asserted `timeout-minutes=15`.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted workflow configuration for improved verification process reliability.

---

**Note:** This is an internal infrastructure update with no direct end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->