### PR TITLE
ci(OMN-12670): raise receipt gate timeout

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -65,7 +65,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     # OMN-10419 invariant I9: disable GHA cache + artifact reuse so merge_group
     # entry always re-evaluates fully. No stale PASS from a previous run can
     # satisfy the gate on a new merge_group event.


### PR DESCRIPTION
## Summary
- Raise the reusable Receipt Gate job timeout from 5 to 15 minutes.
- Preserve existing Receipt Gate semantics: no cache reuse, no fallback to main, and no skip/bypass behavior.
- Unblocks merge-group evidence checks that can exceed five minutes while fetching OCC evidence or installing receipt-gate deps on self-hosted runners.

Evidence-Ticket: OMN-12670
Evidence-Source: 0a6c4effc61dda9f6b3b9370e2198b23b50110d4
hotfix-evidence: OCC-2147
backmerge: #1199

## Verification
- `uv run python - <<PY ...` parsed `.github/workflows/receipt-gate.yml` and asserted `timeout-minutes=15`.
- `git diff --check`

## Context
Found while merging omnibase_infra#1862: source Receipt Gate passed, but merge-group Receipt Gate repeatedly cancelled at the five-minute reusable job timeout before receipt validation could run.