### PR TITLE
fix(OMN-12676): carry inference API key references

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -56,9 +56,13 @@ class ModelInferenceIntent(BaseModel):
         description="Backend-owned timeout for the downstream inference call.",
     )
     correlation_id: UUID
-    api_key: str | None = Field(
+    api_key_ref: str | None = Field(
         default=None,
-        description="Resolved API key for authenticated model backends.",
+        description=(
+            "Secret reference for authenticated model backends. The effect "
+            "boundary resolves the referenced secret value immediately before "
+            "making the outbound provider call."
+        ),
     )
     extra_headers: dict[str, str] | None = Field(
         default=None,

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -246,7 +246,30 @@ class TestModelInferenceIntent:
         )
         assert intent.intent == "llm_inference"
         assert intent.timeout_seconds == 30.0
-        assert intent.api_key is None
+        assert intent.api_key_ref is None
+
+    def test_carries_api_key_reference_not_secret_value(self) -> None:
+        intent = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=uuid.uuid4(),
+            api_key_ref="GEMINI_API_KEY",  # pragma: allowlist secret
+        )
+
+        assert intent.api_key_ref == "GEMINI_API_KEY"  # pragma: allowlist secret
+        with pytest.raises(ValidationError):
+            ModelInferenceIntent(
+                base_url="http://localhost:8000",
+                model="qwen3",
+                system_prompt="You are helpful.",
+                prompt="Write a test",
+                max_tokens=512,
+                correlation_id=uuid.uuid4(),
+                api_key="sk-test-secret",  # pragma: allowlist secret
+            )
 
     def test_rejects_invalid_intent_literal(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
Evidence-Source: 233dcd6c5ac452e73ef7d5618414b00bca45abab
Evidence-Ticket: OMN-12676

## Summary
- Rename ModelInferenceIntent secret-bearing `api_key` to reference-only `api_key_ref`.
- Keep default construction reference-free and reject the old `api_key` field.
- Add test coverage for the no-secret wire contract, with detect-secrets allowlists only on intentional dummy/reference literals.

## Verification
- env -u PYTHONPATH uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q
- uv run ruff format tests/unit/models/delegation/wire/test_delegation_wire_models.py
- uv run ruff check --fix tests/unit/models/delegation/wire/test_delegation_wire_models.py
- detect-secrets-hook --baseline .secrets.baseline --exclude-files 'uv\.lock' --exclude-files '\.venv/' --exclude-files 'tests/fixtures/' --exclude-files '\.git/' --exclude-files '\.secrets\.baseline' --exclude-files '\.github/workflows/.*\.yml' tests/unit/models/delegation/wire/test_delegation_wire_models.py

No runtime deploy, restart, or .201 mutation.