### PR TITLE
fix(OMN-12753): carry provider request options

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -67,6 +67,14 @@ class ModelInferenceIntent(BaseModel):
     extra_headers: dict[str, str] | None = Field(
         default=None,
         description="Additional HTTP headers required by the selected backend.",
+    )
+    provider_request_options: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional OpenAI-compatible request body options required by the "
+            "selected model protocol. The inference effect merges these at the "
+            "provider-call boundary after core fields are constructed."
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- adds typed provider request options to inference intents so provider-specific protocol controls can travel with the request
- supports Qwen no-reasoning request options without altering the original prompt evidence

## Verification
- `PYTHONPATH=$OMNI_HOME/omni_worktrees/OMN-12753/omnibase_core/src uv run pytest tests/unit/inference/test_protocol_config.py tests/test_golden_chain_node_delegate_skill_orchestrator.py tests/unit/delegation/test_handler_inference_intent.py -q` from the omnimarket OMN-12753 worktree: 19 passed
- DTO validation for `ModelInferenceIntent(provider_request_options={"chat_template_kwargs": {"enable_thinking": False}})`

## Integration
Part of the delegation/SEA dev-lane useful-response closeout. Pair with the omnimarket OMN-12753 provider protocol branch after OMN-12738 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to pass additional request options for OpenAI-compatible model providers, enabling more granular control over inference requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-12753
Evidence-Source: OCC#2245
