### PR TITLE
fix(OMN-12762): accept quality gate overlay checks

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -18,9 +18,30 @@ EnumQualityContractMode = Literal["extend_task_class", "replace_task_class"]
 
 SUPPORTED_ACCEPTANCE_CRITERIA = frozenset(
     {
+        "compiles_without_errors",
+        "concise",
+        "covers_args_returns_raises",
+        "covers_edge_cases",
+        "covers_error_paths",
+        "cites_specific_lines",
+        "docstring_present",
         "exactly_two_sentences",
+        "explains_tradeoffs",
+        "final_artifact_only",
+        "follows_codebase_conventions",
+        "follows_google_style",
+        "methodical_analysis",
+        "no_obvious_regressions",
+        "no_refusal",
+        "output_parses",
+        "passes_existing_tests",
         "plain_text_only",
         "response_non_empty",
+        "signature_preserved",
+        "step_by_step_explanation",
+        "sub_tasks_verified",
+        "task_completed",
+        "uses_pytest_mark_unit",
     }
 )
 MAX_WORDS_PER_SENTENCE_RE = re.compile(r"^max_words_per_sentence_([1-9]\d*)$")

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -88,6 +88,33 @@ class TestModelDelegationRequest:
         r = self._make(acceptance_criteria=("response_non_empty",))
         assert "response_non_empty" in r.acceptance_criteria
 
+    def test_overlay_accepts_quality_gate_dod_checks(self) -> None:
+        r = self._make(
+            quality_contract_mode="replace_task_class",
+            acceptance_criteria=(
+                "compiles_without_errors",
+                "final_artifact_only",
+                "no_refusal",
+                "uses_pytest_mark_unit",
+                "covers_edge_cases",
+                "covers_error_paths",
+                "follows_codebase_conventions",
+                "no_obvious_regressions",
+            ),
+        )
+
+        assert r.quality_contract_mode == "replace_task_class"
+        assert r.acceptance_criteria == (
+            "compiles_without_errors",
+            "final_artifact_only",
+            "no_refusal",
+            "uses_pytest_mark_unit",
+            "covers_edge_cases",
+            "covers_error_paths",
+            "follows_codebase_conventions",
+            "no_obvious_regressions",
+        )
+
     @pytest.mark.parametrize(
         "task_type",
         [
@@ -119,8 +146,14 @@ class TestModelDelegationRequest:
 @pytest.mark.unit
 class TestValidateAcceptanceCriteria:
     def test_valid(self) -> None:
-        result = validate_acceptance_criteria(("response_non_empty", "plain_text_only"))
-        assert "response_non_empty" in result
+        result = validate_acceptance_criteria(
+            ("response_non_empty", "plain_text_only", "final_artifact_only")
+        )
+        assert result == (
+            "response_non_empty",
+            "plain_text_only",
+            "final_artifact_only",
+        )
 
     def test_max_words_pattern(self) -> None:
         result = validate_acceptance_criteria(("max_words_per_sentence_10",))


### PR DESCRIPTION
## Summary
- extend request-level delegation acceptance criteria to include the quality-gate DoD vocabulary already supported by the reducer
- add DTO tests for replace_task_class overlays using code/test quality checks

## Verification
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-12762/omnibase_core/src uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q -> 59 passed
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-12762/omnibase_core/src uv run ruff check src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py tests/unit/models/delegation/wire/test_delegation_wire_models.py -> pass
- git diff --check -> pass

## OCC
- Central evidence PR to follow for OMN-12762.

Evidence-Source: 476c3c0a17f428a710215527cb4d69b7c0a71b27
Evidence-Ticket: OMN-12762