### PR TITLE
chore(release)(OMN-12765): bump omnibase_core to v0.44.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.44.0"
+version = "0.44.1"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.44.0"
+version = "0.44.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Bump omnibase_core package version to v0.44.1 after OMN-12765 main promotion.
- Keep uv.lock editable package metadata aligned.

## Verification
- git diff --check
- pyproject/uv.lock version consistency check

Source ticket: OMN-12765