### PR TITLE
chore(release)(OMN-12765): bump omnibase_core to v0.44.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.44.1"
+version = "0.44.2"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.44.1"
+version = "0.44.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Evidence-Ticket: OMN-12765
Evidence-Source: OCC#2283
hotfix-evidence: OCC-12765
backmerge: #1216

## Summary
- Bump omnibase_core package version to v0.44.2 after the OMN-12765 dev integration promotion landed on main.
- Keep uv.lock editable package metadata aligned.

## Verification
- git diff --check
- pyproject/uv.lock version consistency check

Source ticket: OMN-12765
Evidence-Refresh: OCC#2283-clean
