### PR TITLE
fix(OMN-12816): raise generation retry budget

### DIFF
--- a/src/omnibase_core/models/generation/model_node_generation_request.py
+++ b/src/omnibase_core/models/generation/model_node_generation_request.py
@@ -10,7 +10,7 @@ class ModelNodeGenerationRequest(BaseModel):
     task_description: str
     correlation_id: str
     target_node_type: str = "compute"
-    max_attempts: int = 2
+    max_attempts: int = 10
     generation_timeout_seconds: int = 60
     validation_timeout_seconds: int = 15
 

--- a/tests/unit/models/generation/test_model_node_generation.py
+++ b/tests/unit/models/generation/test_model_node_generation.py
@@ -15,7 +15,7 @@ def test_request_requires_fields() -> None:
         correlation_id=str(uuid4()),
     )
     assert req.target_node_type == "compute"
-    assert req.max_attempts == 2
+    assert req.max_attempts == 10
     assert req.generation_timeout_seconds == 60
 
 


### PR DESCRIPTION
Ticket: OMN-12816
Evidence-Ticket: OMN-12816
Evidence-Source: 3437a3cff596bb0afab67561b3eedef257f85520

## Summary
- raise ModelNodeGenerationRequest default max_attempts from 2 to 10
- update the generation model unit test expectation

## Verification
- PYTHONPATH=/Users/jonah/Code/omni_home/omni_worktrees/OMN-12816B/omnibase_core/src uv run pytest tests/unit/models/generation/test_model_node_generation.py -q
- git diff --check