### PR TITLE
ci(OMN-12825): receipt-honesty CI + pre-commit gate (queue-safe gate-prep)

### DIFF
--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Receipt-Honesty Gate [OMN-12791 validator / OMN-12825 CI wiring]
+#
+# Required status check context: "Receipt Honesty / validate"
+#
+# Runs the receipt-honesty validator unit tests (proves the validator is
+# importable and behaving on the runner), then scans any in-repo DoD receipt
+# YAMLs under drift/dod_receipts/ for gaming patterns (no-op echo probes marked
+# PASS, deferral language in PASS receipts, self-attestation, fake human
+# verifiers, deploy-keyword echo receipts). omnibase_core carries no in-repo
+# receipts today, so the scan passes cleanly when the directory is absent —
+# the check still emits, keeping the merge queue safe when this becomes a
+# required status check.
+#
+# Triggers on pull_request AND merge_group so a later additive flip to a
+# required status check cannot permanently wedge the merge queue.
+
+name: Receipt Honesty
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: receipt-honesty-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run receipt-honesty validator unit tests
+        run: |
+          uv run pytest tests/unit/validation/test_receipt_honesty_validator.py -v
+
+      - name: Scan in-repo DoD receipts (passes cleanly when none present)
+        run: |
+          if [ -d drift/dod_receipts ]; then
+            uv run python -m omnibase_core.validation.validator_receipt_honesty \
+              --receipts-dir drift/dod_receipts
+          else
+            echo "RECEIPT HONESTY GATE: no in-repo drift/dod_receipts/ tree — nothing to scan, passing."
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -793,6 +793,21 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # Receipt-Honesty Gate (OMN-12791 validator / OMN-12825 self-consume)
+      # Scans staged DoD receipt YAMLs under drift/dod_receipts/ for gaming
+      # patterns (echo probes marked PASS, deferred evidence in PASS receipts,
+      # self-attestation, fake human verifiers, deploy-keyword echo receipts).
+      # Fails loud if validator_receipt_honesty is not importable (not a silent
+      # skip). Only fires on receipt files matching the path pattern.
+      - id: check-receipt-honesty
+        name: Receipt Honesty Gate (OMN-12791)
+        entry: uv run python -m omnibase_core.validation.validator_receipt_honesty
+        language: system
+        types: [yaml]
+        files: drift/dod_receipts/.*\.yaml$
+        pass_filenames: true
+        stages: [pre-commit]
+
       - id: validate-exception-handling
         name: ONEX Exception Handling Validation
         entry: uv run python scripts/validation/validate-exception-handling.py


### PR DESCRIPTION
## OMN-12825 — Gate-coverage prep: receipt-honesty CI + pre-commit gate (queue-safe)

Prep-only work so the evidence gates are safe to require later. Does NOT touch branch protection / required_status_checks. The required-check flip is a separate later step.

### What changed
- **`.github/workflows/receipt-honesty.yml`** (new): runs the OMN-12791 receipt-honesty validator unit tests, then scans any in-repo `drift/dod_receipts/*.yaml` for gaming patterns. Triggers on **`pull_request` AND `merge_group`** so a later additive flip to a required status check cannot permanently wedge the merge queue. Check context: `Receipt Honesty / validate`. Passes cleanly when no in-repo receipts exist (omnibase_core carries none today).
- **`.pre-commit-config.yaml`**: self-consume the `check-receipt-honesty` hook this repo already exports in `.pre-commit-hooks.yaml` (OMN-12791).

### Inventory of the other evidence gates (no change needed)
- **Receipt Gate** (`call-receipt-gate.yml` -> `receipt-gate.yml`): already triggers on `pull_request` + `merge_group`. Live context: `verify / verify`. Queue-safe.
- **Deploy Gate** (`deploy-gate.yml`): already triggers on `pull_request` + `merge_group`. Live context: `deploy-gate / deploy-gate`. Queue-safe.
- **DoD Evidence / occ-preflight `eligibility`**: `occ-preflight.yml` is `workflow_call`-only with **no caller workflow in this repo**, so `occ-preflight / eligibility` does not currently emit on omnibase_core PRs. Not safe to require here until a caller is wired (out of scope for this prep PR).

### dod_evidence
- `Receipt Honesty / validate` workflow added on `pull_request` + `merge_group`; validator unit tests (82 passing locally) gate the runner.
- pre-commit `check-receipt-honesty` hook self-consumed; `pre-commit validate-config` passes; hook runs clean on the diff.
- Changed files pass all pre-commit hooks that target them; remaining `--all-files` findings are pre-existing baseline debt on `dev`, none referencing the two changed files.
- Paired OCC evidence: onex_change_control PR #2340 (open, base dev) carries contract OMN-12825 + three honesty-clean omnibase_core receipts (merged in from PR #2341).

Base branch: `dev` (dev->main promotion model; the OMN-12791 validator + exported hook live on `dev`, not yet promoted to `main`).

Evidence-Source: 9c9afcb384268d9221e578fc75ce5dcd9554ed9c
Evidence-Ticket: OMN-12825