### PR TITLE
feat(OMN-12857): add Bifrost logical secret refs

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
+++ b/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelDelegationShadowConfig(BaseModel):
@@ -150,7 +150,23 @@ class ModelDelegationBackendConfig(BaseModel):
     )
     api_key_env: str | None = Field(
         default=None,
-        description="Optional environment variable name holding the backend API key.",
+        description=(
+            "Legacy environment variable name holding the backend API key. "
+            "Use secret_ref for new backends."
+        ),
+    )
+    api_key_ref: str | None = Field(
+        default=None,
+        description=(
+            "Legacy non-secret API-key reference. Use secret_ref for new backends."
+        ),
+    )
+    secret_ref: str | None = Field(
+        default=None,
+        description=(
+            "Logical secret reference resolved through the lane secret mapping "
+            "and ProtocolSecretStore at the effect boundary."
+        ),
     )
     extra_headers: dict[str, str] | None = Field(
         default=None,
@@ -180,6 +196,24 @@ class ModelDelegationBackendConfig(BaseModel):
         default_factory=tuple,
         description="Capabilities this backend supports.",
     )
+
+    @model_validator(mode="after")
+    def _validate_secret_ref_fields(self) -> ModelDelegationBackendConfig:
+        """Reject ambiguous canonical secret refs while allowing migration aliases."""
+        canonical_refs = {
+            value
+            for value in (self.secret_ref, self.api_key_ref)
+            if value is not None and value.strip()
+        }
+        if len(canonical_refs) > 1:
+            msg = "secret_ref and api_key_ref must match when both are declared"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def resolved_secret_ref(self) -> str | None:
+        """Return the canonical non-secret reference for this backend."""
+        return self.secret_ref or self.api_key_ref or self.api_key_env
 
 
 class ModelDelegationCircuitBreakerConfig(BaseModel):

--- a/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
+++ b/src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py
@@ -212,7 +212,7 @@ class ModelDelegationBackendConfig(BaseModel):
 
     @property
     def resolved_secret_ref(self) -> str | None:
-        """Return the canonical non-secret reference for this backend."""
+        """Return secret_ref, then api_key_ref, then legacy api_key_env."""
         return self.secret_ref or self.api_key_ref or self.api_key_env
 
 

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -439,11 +439,11 @@ class TestModelBifrostDelegationConfig:
             endpoint_url="https://openrouter.ai/api/v1/chat/completions",
             model_name="openrouter-model",
             tier="cheap_cloud",
-            secret_ref="llm.openrouter.api_key",
-            api_key_env="OPENROUTER_API_KEY",
+            secret_ref="llm.openrouter.api_key",  # pragma: allowlist secret
+            api_key_env="OPENROUTER_API_KEY",  # pragma: allowlist secret
         )
 
-        assert backend.resolved_secret_ref == "llm.openrouter.api_key"
+        assert backend.resolved_secret_ref == "llm.openrouter.api_key"  # pragma: allowlist secret
 
     def test_backend_rejects_conflicting_secret_refs(self) -> None:
         with pytest.raises(ValidationError):
@@ -452,8 +452,8 @@ class TestModelBifrostDelegationConfig:
                 endpoint_url="https://openrouter.ai/api/v1/chat/completions",
                 model_name="openrouter-model",
                 tier="cheap_cloud",
-                secret_ref="llm.openrouter.api_key",
-                api_key_ref="llm.other.api_key",
+                secret_ref="llm.openrouter.api_key",  # pragma: allowlist secret
+                api_key_ref="llm.other.api_key",  # pragma: allowlist secret
             )
 
     def test_shadow_config_defaults(self) -> None:

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -456,6 +456,18 @@ class TestModelBifrostDelegationConfig:
                 api_key_ref="llm.other.api_key",  # pragma: allowlist secret
             )
 
+    def test_backend_allows_matching_secret_refs_for_migration(self) -> None:
+        backend = ModelDelegationBackendConfig(
+            backend_id="openrouter",
+            endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+            model_name="openrouter-model",
+            tier="cheap_cloud",
+            secret_ref="llm.openrouter.api_key",  # pragma: allowlist secret
+            api_key_ref="llm.openrouter.api_key",  # pragma: allowlist secret
+        )
+
+        assert backend.resolved_secret_ref == "llm.openrouter.api_key"  # pragma: allowlist secret
+
     def test_shadow_config_defaults(self) -> None:
         shadow = ModelDelegationShadowConfig()
         assert shadow.shadow_label == "SHADOW"

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -433,6 +433,29 @@ class TestModelBifrostDelegationConfig:
         assert cfg.failover.max_attempts == 3
         assert cfg.shadow_mode.enabled is False
 
+    def test_backend_prefers_logical_secret_ref(self) -> None:
+        backend = ModelDelegationBackendConfig(
+            backend_id="openrouter",
+            endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+            model_name="openrouter-model",
+            tier="cheap_cloud",
+            secret_ref="llm.openrouter.api_key",
+            api_key_env="OPENROUTER_API_KEY",
+        )
+
+        assert backend.resolved_secret_ref == "llm.openrouter.api_key"
+
+    def test_backend_rejects_conflicting_secret_refs(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDelegationBackendConfig(
+                backend_id="openrouter",
+                endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+                model_name="openrouter-model",
+                tier="cheap_cloud",
+                secret_ref="llm.openrouter.api_key",
+                api_key_ref="llm.other.api_key",
+            )
+
     def test_shadow_config_defaults(self) -> None:
         shadow = ModelDelegationShadowConfig()
         assert shadow.shadow_label == "SHADOW"

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -443,7 +443,8 @@ class TestModelBifrostDelegationConfig:
             api_key_env="OPENROUTER_API_KEY",  # pragma: allowlist secret
         )
 
-        assert backend.resolved_secret_ref == "llm.openrouter.api_key"  # pragma: allowlist secret
+        expected_secret_ref = "llm.openrouter.api_key"  # pragma: allowlist secret
+        assert backend.resolved_secret_ref == expected_secret_ref
 
     def test_backend_rejects_conflicting_secret_refs(self) -> None:
         with pytest.raises(ValidationError):
@@ -466,7 +467,8 @@ class TestModelBifrostDelegationConfig:
             api_key_ref="llm.openrouter.api_key",  # pragma: allowlist secret
         )
 
-        assert backend.resolved_secret_ref == "llm.openrouter.api_key"  # pragma: allowlist secret
+        expected_secret_ref = "llm.openrouter.api_key"  # pragma: allowlist secret
+        assert backend.resolved_secret_ref == expected_secret_ref
 
     def test_shadow_config_defaults(self) -> None:
         shadow = ModelDelegationShadowConfig()


### PR DESCRIPTION
## Summary
- Add canonical Bifrost backend secret_ref support with migration aliases for api_key_ref/api_key_env.
- Reject conflicting canonical secret refs while preserving legacy compatibility.
- Add focused schema tests for logical ref precedence and conflict validation.

Ticket: OMN-12857
Evidence-Source: OCC#2385
Evidence-Ticket: OMN-12857

## Verification
- uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py::TestModelBifrostDelegationConfig -q
- uv run ruff check src/omnibase_core/models/delegation/wire/model_bifrost_delegation_config.py tests/unit/models/delegation/wire/test_delegation_wire_models.py
- git diff --check