### PR TITLE
chore(OMN-12673): bump omnibase_core OCC workflow ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1429,7 +1429,7 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
-      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@49a230e677a66b4dae287e435875ae45a224b210 # main 2026-03-25
+      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@644d04a17f32114d84321cfc1fedafff99aa4924 # main 2026-03-25
         with:
           checks: "boundary-parity"
           warn-only: "false"


### PR DESCRIPTION
## Summary
- Replaces Dependabot PR #1224 on an OMN-named branch so Receipt Gate identity binding can pass.
- Applies the same onex_change_control reusable workflow reference bump.

## Evidence
- git diff --check origin/dev..HEAD
- OCC evidence: https://github.com/OmniNode-ai/onex_change_control/pull/2410

Evidence-Source: OCC#2410
Evidence-Ticket: OMN-12673

Replaces: https://github.com/OmniNode-ai/omnibase_core/pull/1224