### PR TITLE
feat(OMN-12960): single transport-envelope unwrap predicate + dispatch-surface test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,6 +939,63 @@ jobs:
           echo "- No orphan producers or consumers" >> $GITHUB_STEP_SUMMARY
           echo "- Every widget topic has a producing node" >> $GITHUB_STEP_SUMMARY
 
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Dispatch-surface real-dispatch-test gate (OMN-12960)
+  dispatch-surface-test-required:
+    name: Dispatch-Surface Test Required (OMN-12960)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Resolve base ref
+        id: base
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run dispatch-surface-test-required validator
+        run: |
+          uv run python -m omnibase_core.validators.dispatch_surface_test_required \
+            --base "${{ steps.base.outputs.ref }}"
+
+      - name: Dispatch-surface gate summary
+        if: always()
+        run: |
+          echo "## Dispatch-Surface Test Required (OMN-12960)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "PRs touching dispatch / routing / handler-registration / message-envelope source surfaces" >> $GITHUB_STEP_SUMMARY
+          echo "must include a real-dispatch-path test. Handler-isolation tests pass while live dispatch fails." >> $GITHUB_STEP_SUMMARY
+
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
   # ---------------------------------------------------------------------------
@@ -954,7 +1011,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required]
     if: always()
 
     steps:
@@ -978,6 +1035,7 @@ jobs:
           breaking_schema="${{ needs.breaking-schema-change.result }}"
           no_env_fallbacks="${{ needs.no-env-fallbacks.result }}"
           demo_path_gate="${{ needs.demo-path-topic-coherence.result }}"
+          dispatch_surface="${{ needs.dispatch-surface-test-required.result }}"
 
           # Report each check
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
@@ -997,6 +1055,7 @@ jobs:
           echo "| Breaking-Schema-Change (OMN-12621) | $breaking_schema |" >> $GITHUB_STEP_SUMMARY
           echo "| No Env Fallbacks (OMN-7227) | $no_env_fallbacks |" >> $GITHUB_STEP_SUMMARY
           echo "| Demo-Path Topic Coherence (OMN-12777) | $demo_path_gate |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dispatch-Surface Test Required (OMN-12960) | $dispatch_surface |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
           if [[ "$lint" == "success" ]] && \
@@ -1013,7 +1072,8 @@ jobs:
              [[ "$contract_config" == "success" ]] && \
              [[ "$breaking_schema" == "success" ]] && \
              [[ "$no_env_fallbacks" == "success" ]] && \
-             [[ "$demo_path_gate" == "success" ]]; then
+             [[ "$demo_path_gate" == "success" ]] && \
+             [[ "$dispatch_surface" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY
             echo "All quality checks passed."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -539,6 +539,21 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Dispatch-surface real-dispatch-test gate (OMN-12960)
+      # Requires a real-dispatch-path test for any commit touching dispatch,
+      # routing, handler-registration, or message-envelope source surfaces.
+      # Handler-isolation tests pass while live dispatch fails — the only durable
+      # guard is a test that drives the real dispatcher registration.
+      # Suppress a genuinely test-irrelevant change with:
+      #   # dispatch-surface-test-ok: <reason>
+      - id: dispatch-surface-test-required
+        name: Dispatch-Surface Test Required (OMN-12960)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.validators.dispatch_surface_test_required
+        language: system
+        pass_filenames: true
+        files: ^(src|tests)/.*\.py$
+        stages: [pre-commit]
+
       # Breaking-schema-change compliance (OMN-12621)
       # Requires an adjacent *.migration.yaml ModelTopicMigrationContract whenever
       # a *.topic-schema.yaml declares a breaking topic-schema delta (major_bump

--- a/src/omnibase_core/utils/util_envelope_unwrap.py
+++ b/src/omnibase_core/utils/util_envelope_unwrap.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Single authoritative transport-envelope unwrap predicate (OMN-12960).
+
+The runtime wraps a domain payload in a transport envelope before it reaches a
+handler. Two distinct outer shapes reach the coercion / dispatch boundary and
+BOTH must be recognised:
+
+1. The dispatch-engine *materialized* shape — the only shape the live runtime
+   actually delivers to ``handle()`` for contracts whose ``handler_routing``
+   declares no ``event_model`` (auto-wiring passes the materialized dict raw).
+   Outer keys are exactly ``{"payload", "__bindings", "__debug_trace"}`` — the
+   real ``partition_key`` lives *inside* ``__debug_trace``, not at the top
+   level. See
+   ``omnibase_infra.runtime.message_dispatch_engine._materialize_envelope_with_bindings``.
+2. The bare envelope-field shape (``partition_key`` / ``event_type`` /
+   ``correlation_id`` at the top level) — non-materialized deliveries.
+
+Domain models never declare these transport keys, so splatting the raw envelope
+into ``Model(**payload)`` raises a ``ValidationError`` with every required field
+reported missing. Unwrapping recursively at the boundary keeps the domain models
+transport-agnostic.
+
+History and rationale
+---------------------
+This predicate previously existed as **two** hand-maintained marker-key sets —
+``omnibase_infra.runtime.auto_wiring.handler_wiring._ENVELOPE_MARKER_KEYS`` and
+``omnimarket.nodes.evidence_pipeline_native._ENVELOPE_MARKER_KEYS``. Each was
+"fixed" once already (OMN-12940 added the infra recursion; OMN-12946 added
+``__debug_trace`` / ``__bindings`` to the omnimarket set), and they drifted
+again: as of OMN-12960 the infra set was missing ``__bindings`` while the
+omnimarket set carried it. A materialized envelope whose only marker is
+``__bindings`` would therefore unwrap on the omnimarket side and silently fail
+to unwrap on the infra side. A hand-synced cross-repo constant cannot be made
+safe; the single source of truth lives here and both call sites import it.
+
+Layering note (OMN-12960)
+-------------------------
+By layering this wire-level concern belongs in ``omnibase_compat`` (lowest,
+zero upstream runtime deps). The compat pin is policy-frozen — bumping it is a
+symptom of models that should have graduated, not a fix — so per the P1.4 plan
+the predicate is sited in ``omnibase_core`` (already a runtime dependency of
+both ``omnibase_infra`` and ``omnimarket``) instead. When the compat pin
+un-freezes, this module moves to compat verbatim and the imports follow.
+"""
+
+from __future__ import annotations
+
+# dispatch-surface-test-ok: omnibase_core hosts no live dispatcher; this is the
+# pure unwrap predicate. Its real-dispatch-path coverage lives in omnibase_infra
+# (handler_wiring) and omnimarket (evidence_pipeline_native), where the predicate
+# is wired into the dispatcher and the mandatory real-dispatch fixture exercises it.
+from collections.abc import Mapping
+from typing import cast
+
+__all__ = [
+    "ENVELOPE_MARKER_KEYS",
+    "is_transport_envelope",
+    "unwrap_transport_envelope",
+]
+
+# Transport-envelope keys that the runtime adds around the domain payload.
+# A mapping that carries a ``payload`` mapping plus at least one of these keys
+# is a transport envelope, not a domain model that merely declares its own
+# ``payload`` field. ``__bindings`` and ``__debug_trace`` are the
+# dispatch-engine *materialized* markers and MUST stay in this set — dropping
+# either silently turns the unwrap back into a no-op on live dispatch (the
+# OMN-12946 / OMN-12960 defect class).
+ENVELOPE_MARKER_KEYS: frozenset[str] = frozenset(
+    {
+        "partition_key",
+        "event_type",
+        "envelope_id",
+        "event_id",
+        "correlation_id",
+        "__debug_trace",
+        "__bindings",
+    }
+)
+
+
+def is_transport_envelope(value: object) -> bool:
+    """Return True when ``value`` is a transport envelope wrapping a payload.
+
+    A transport envelope is a mapping that carries a ``payload`` mapping plus at
+    least one transport marker key. Requiring a marker avoids over-unwrapping a
+    legitimate domain model that happens to declare its own ``payload`` field.
+    """
+    return (
+        isinstance(value, Mapping)
+        and isinstance(value.get("payload"), Mapping)
+        and bool(ENVELOPE_MARKER_KEYS & value.keys())
+    )
+
+
+def unwrap_transport_envelope[T](payload: T) -> T | Mapping[str, object]:
+    """Return the domain payload, unwrapping any transport envelope around it.
+
+    Handles three delivery shapes, recursively, until the domain payload is
+    reached:
+
+    * an object exposing a populated ``.payload`` attribute
+      (a ``ModelEventEnvelope`` instance);
+    * a materialized dispatch dict
+      (``{"payload": {...}, "__bindings": ..., "__debug_trace": ...}``);
+    * a bare-marker envelope dict
+      (``{"payload": {...}, "partition_key": ...}``).
+
+    A mapping that carries a ``payload`` field but **no** transport marker is
+    returned unchanged — it is treated as a domain model that legitimately owns
+    a ``payload`` field, never as an envelope.
+    """
+    # Object form: ModelEventEnvelope (or any object exposing a populated
+    # ``payload`` attribute). Mappings are handled by the marker check below.
+    if not isinstance(payload, Mapping):
+        nested = getattr(payload, "payload", None)
+        if nested is not None:
+            return unwrap_transport_envelope(nested)
+        return payload
+    # Mapping form: only unwrap when it is a transport envelope (carries a
+    # ``payload`` mapping plus a marker), never when ``payload`` is a domain
+    # field on the model itself.
+    if is_transport_envelope(payload):
+        inner = cast("Mapping[str, object]", payload["payload"])
+        return unwrap_transport_envelope(inner)
+    return payload

--- a/src/omnibase_core/validators/dispatch_surface_test_required.py
+++ b/src/omnibase_core/validators/dispatch_surface_test_required.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dispatch-surface real-dispatch-test gate (OMN-12960).
+
+Path-heuristic ratchet: a PR (or commit) that touches a **dispatch surface** —
+message dispatch, handler routing, handler registration / auto-wiring, or the
+transport-envelope unwrap predicate — MUST also touch at least one
+**real-dispatch-path test**. Handler-isolation unit tests pass while the live
+dispatch path fails (the OMN-12940 / OMN-12946 / OMN-12960 defect class); the
+only durable guard is a test that drives the real dispatcher registration.
+
+Why a path heuristic
+--------------------
+The live failures in the 2026-06-11 full-feature pass all shared the same shape:
+the change was covered by a handler-isolation test that constructed the handler
+directly and called ``handle()`` with a hand-built domain payload, so it never
+exercised the materialized transport envelope the runtime actually delivers.
+The fix (``repro_real_dispatch.py`` promoted to a reusable fixture) only helps
+if PRs that change dispatch behaviour are *required* to use it. This validator
+enforces that requirement mechanically.
+
+Definitions
+-----------
+A changed file is a **dispatch surface** when its path matches any
+``_DISPATCH_SURFACE_PATTERNS`` substring (e.g. ``message_dispatch_engine``,
+``auto_wiring/``, ``handler_wiring``, ``handler_routing``, ``util_envelope_unwrap``,
+``evidence_pipeline_native``) and it lives under a ``src/`` tree.
+
+A changed file is a **real-dispatch-path test** when it is a test file
+(``test_*.py`` / ``*_test.py`` under a ``tests/`` tree) whose contents reference
+the reusable real-dispatch fixture or drive the real dispatcher directly
+(``real_dispatch`` / ``drive_real_dispatch`` / ``MessageDispatchEngine`` /
+``_make_dispatch_callback`` / ``_materialize_envelope_with_bindings``).
+
+Exit codes
+----------
+``0`` — no dispatch surface touched, or a real-dispatch-path test is present.
+``1`` — a dispatch surface was touched with no accompanying real-dispatch test.
+
+Suppression
+-----------
+Add ``# dispatch-surface-test-ok: <reason>`` anywhere in any staged file to
+acknowledge a genuinely test-irrelevant dispatch-surface change (e.g. a comment
+or docstring-only edit). The reason is recorded in the failure output.
+
+Usage::
+
+    # Pre-commit (staged-file args)
+    python -m omnibase_core.validators.dispatch_surface_test_required FILE [FILE ...]
+
+    # CI (diff against a base ref)
+    python -m omnibase_core.validators.dispatch_surface_test_required --base origin/dev
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+__all__ = [
+    "DISPATCH_SURFACE_PATTERNS",
+    "REAL_DISPATCH_TEST_MARKERS",
+    "SUPPRESSION_TOKEN",
+    "is_dispatch_surface",
+    "is_real_dispatch_test",
+    "main",
+]
+
+# Path substrings that identify a dispatch / routing / handler-registration /
+# message-envelope source surface. Matched against the POSIX path.
+DISPATCH_SURFACE_PATTERNS: tuple[str, ...] = (
+    "message_dispatch_engine",
+    "auto_wiring/",
+    "handler_wiring",
+    "handler_routing",
+    "dispatch_engine",
+    "util_envelope_unwrap",
+    "evidence_pipeline_native",
+)
+
+# Content markers that prove a test drives the real dispatch path rather than
+# constructing a handler in isolation.
+REAL_DISPATCH_TEST_MARKERS: tuple[str, ...] = (
+    "real_dispatch",
+    "drive_real_dispatch",
+    "MessageDispatchEngine",
+    "_make_dispatch_callback",
+    "_materialize_envelope_with_bindings",
+)
+
+SUPPRESSION_TOKEN = "# dispatch-surface-test-ok:"
+
+
+def _is_source(path: str) -> bool:
+    return "/src/" in path or path.startswith("src/")
+
+
+def _is_test_file(path: str) -> bool:
+    name = Path(path).name
+    is_test_named = name.startswith("test_") or name.endswith("_test.py")
+    in_tests_tree = "/tests/" in path or path.startswith("tests/")
+    return path.endswith(".py") and is_test_named and in_tests_tree
+
+
+def is_dispatch_surface(path: str) -> bool:
+    """True when ``path`` is a dispatch-surface SOURCE file (not a test)."""
+    posix = path.replace("\\", "/")
+    if not posix.endswith(".py") or not _is_source(posix):
+        return False
+    if _is_test_file(posix):
+        return False
+    return any(pattern in posix for pattern in DISPATCH_SURFACE_PATTERNS)
+
+
+def is_real_dispatch_test(path: str, text: str) -> bool:
+    """True when ``path`` is a test file that drives the real dispatch path."""
+    if not _is_test_file(path.replace("\\", "/")):
+        return False
+    return any(marker in text for marker in REAL_DISPATCH_TEST_MARKERS)
+
+
+def _read(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _suppression_reason(paths: Iterable[str]) -> str | None:
+    for path in paths:
+        text = _read(path)
+        for line in text.splitlines():
+            if SUPPRESSION_TOKEN in line:
+                return line.split(SUPPRESSION_TOKEN, 1)[1].strip()
+    return None
+
+
+def _git_changed_files(base: str) -> list[str]:
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(2)
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _evaluate(paths: Sequence[str]) -> int:
+    surfaces = [p for p in paths if is_dispatch_surface(p)]
+    if not surfaces:
+        return 0
+
+    has_real_dispatch_test = any(
+        is_real_dispatch_test(p, _read(p)) for p in paths if _is_test_file(p)
+    )
+    if has_real_dispatch_test:
+        return 0
+
+    reason = _suppression_reason(paths)
+    if reason is not None:
+        sys.stderr.write(
+            "dispatch-surface-test-required: SUPPRESSED via "
+            f"'{SUPPRESSION_TOKEN} {reason}'\n"
+        )
+        return 0
+
+    sys.stderr.write(
+        "dispatch-surface-test-required: FAIL\n"
+        "  A dispatch / routing / handler-registration / message-envelope "
+        "surface was changed without an accompanying real-dispatch-path test.\n"
+        "  Changed dispatch surfaces:\n"
+    )
+    for surface in surfaces:
+        sys.stderr.write(f"    - {surface}\n")
+    sys.stderr.write(
+        "  Add a test that drives the real dispatcher (use the reusable "
+        "real-dispatch fixture / MessageDispatchEngine materialized envelope). "
+        "Handler-isolation tests are not sufficient — they pass while live "
+        "dispatch fails (OMN-12940 / OMN-12946 / OMN-12960).\n"
+        f"  Test markers that satisfy this gate: {', '.join(REAL_DISPATCH_TEST_MARKERS)}\n"
+        f"  Genuinely test-irrelevant change? Add '{SUPPRESSION_TOKEN} <reason>'.\n"
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="dispatch-surface-test-required",
+        description=(
+            "Require a real-dispatch-path test for PRs touching dispatch, "
+            "routing, handler-registration, or message-envelope surfaces."
+        ),
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Explicit changed-file paths (pre-commit passes staged files).",
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Git base ref to diff HEAD against (CI mode). Mutually exclusive "
+        "with positional file args.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.base is not None:
+        paths = _git_changed_files(args.base)
+    else:
+        paths = list(args.files)
+
+    return _evaluate(paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/utils/test_envelope_unwrap.py
+++ b/tests/utils/test_envelope_unwrap.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the single transport-envelope unwrap predicate (OMN-12960).
+
+These are the consolidated coverage for the predicate that previously lived as
+two hand-synced copies in omnibase_infra and omnimarket. The materialized-shape
+cases are the regression guard for the OMN-12946 / OMN-12960 drift: the marker
+set MUST recognise the dispatch-engine materialized outer keys
+(``{"payload", "__bindings", "__debug_trace"}``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.utils.util_envelope_unwrap import (
+    ENVELOPE_MARKER_KEYS,
+    is_transport_envelope,
+    unwrap_transport_envelope,
+)
+
+
+class _Domain(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    correlation_id: str
+    value: int
+
+
+class _EnvelopeLike:
+    """Object exposing a ``.payload`` attribute, like ``ModelEventEnvelope``."""
+
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+
+def _domain_dict() -> dict[str, object]:
+    return {"correlation_id": "cid-1", "value": 7}
+
+
+def test_marker_set_covers_materialized_dispatch_keys() -> None:
+    """The marker set must intersect the dispatch-engine materialized shape.
+
+    ``unwrap_transport_envelope`` only unwraps when ``ENVELOPE_MARKER_KEYS``
+    intersects the outer mapping's keys. The dispatch engine's materialized
+    outer keys are ``{"payload", "__bindings", "__debug_trace"}`` — if neither
+    ``__bindings`` nor ``__debug_trace`` is in the marker set the live unwrap
+    silently no-ops. This is the regression that OMN-12960 makes structurally
+    impossible by collapsing the two hand-synced sets into this one source.
+    """
+    materialized_outer_keys = {"payload", "__bindings", "__debug_trace"}
+    assert ENVELOPE_MARKER_KEYS & materialized_outer_keys
+    assert "__bindings" in ENVELOPE_MARKER_KEYS
+    assert "__debug_trace" in ENVELOPE_MARKER_KEYS
+
+
+def test_unwraps_bare_marker_envelope() -> None:
+    env = {"payload": _domain_dict(), "partition_key": None}
+    assert unwrap_transport_envelope(env) == _domain_dict()
+
+
+def test_unwraps_materialized_dispatch_envelope() -> None:
+    env = {
+        "payload": _domain_dict(),
+        "__bindings": {"k": "v"},
+        "__debug_trace": {"topic": "t"},
+    }
+    assert unwrap_transport_envelope(env) == _domain_dict()
+
+
+def test_unwraps_materialized_envelope_with_only_bindings_marker() -> None:
+    """The exact OMN-12960 drift case: only ``__bindings`` present.
+
+    The pre-OMN-12960 infra marker set lacked ``__bindings``; a materialized
+    envelope whose only top-level marker was ``__bindings`` failed to unwrap on
+    the infra side while unwrapping on the omnimarket side. The single source
+    handles it unconditionally.
+    """
+    env = {"payload": _domain_dict(), "__bindings": {"k": "v"}}
+    assert unwrap_transport_envelope(env) == _domain_dict()
+
+
+def test_unwraps_double_wrapped_envelope() -> None:
+    inner = {"payload": _domain_dict(), "partition_key": None}
+    outer = {"payload": inner, "__debug_trace": {"topic": "t"}}
+    assert unwrap_transport_envelope(outer) == _domain_dict()
+
+
+def test_unwraps_object_with_payload_attribute() -> None:
+    env = _EnvelopeLike(_domain_dict())
+    assert unwrap_transport_envelope(env) == _domain_dict()
+
+
+def test_unwraps_nested_object_then_mapping() -> None:
+    env = _EnvelopeLike({"payload": _domain_dict(), "event_type": "x"})
+    assert unwrap_transport_envelope(env) == _domain_dict()
+
+
+def test_bare_domain_dict_passthrough() -> None:
+    """A domain dict with no ``payload`` field is returned unchanged."""
+    assert unwrap_transport_envelope(_domain_dict()) == _domain_dict()
+
+
+def test_domain_model_with_payload_field_not_unwrapped() -> None:
+    """A mapping with a ``payload`` field but no marker is NOT an envelope."""
+    legit = {"payload": {"some": "domain-data"}}
+    assert unwrap_transport_envelope(legit) == legit
+
+
+def test_domain_model_instance_passthrough() -> None:
+    """A model instance with no ``.payload`` attribute is returned unchanged."""
+    model = _Domain(correlation_id="cid-1", value=7)
+    assert unwrap_transport_envelope(model) is model
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({"payload": {"a": 1}, "partition_key": None}, True),
+        ({"payload": {"a": 1}, "__bindings": {}}, True),
+        ({"payload": {"a": 1}, "__debug_trace": {}}, True),
+        ({"payload": {"a": 1}}, False),  # no marker
+        ({"partition_key": None}, False),  # no payload mapping
+        ({"payload": "not-a-mapping", "partition_key": None}, False),
+        ("not-a-mapping", False),
+    ],
+)
+def test_is_transport_envelope(value: object, expected: bool) -> None:
+    assert is_transport_envelope(value) is expected

--- a/tests/validators/test_dispatch_surface_test_required.py
+++ b/tests/validators/test_dispatch_surface_test_required.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the dispatch-surface real-dispatch-test gate (OMN-12960)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.dispatch_surface_test_required import (
+    is_dispatch_surface,
+    is_real_dispatch_test,
+    main,
+)
+
+_REAL_DISPATCH_TEST_BODY = (
+    "from omnibase_infra.runtime.message_dispatch_engine import "
+    "MessageDispatchEngine\n\n"
+    "def test_live():\n"
+    "    eng = MessageDispatchEngine\n"
+)
+_ISOLATION_TEST_BODY = "def test_handler():\n    handler.handle({})\n"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("src/omnibase_infra/runtime/auto_wiring/handler_wiring.py", True),
+        ("repo/src/omnibase_infra/runtime/message_dispatch_engine.py", True),
+        ("src/omnibase_core/utils/util_envelope_unwrap.py", True),
+        ("src/omnimarket/nodes/evidence_pipeline_native.py", True),
+        ("src/omnibase_core/utils/util_canonical_hash.py", False),  # not a surface
+        ("tests/test_handler_wiring.py", False),  # a test, not a source surface
+        ("docs/handler_wiring.md", False),  # not python/src
+    ],
+)
+def test_is_dispatch_surface(path: str, expected: bool) -> None:
+    assert is_dispatch_surface(path) is expected
+
+
+def test_is_real_dispatch_test_recognises_real_driver() -> None:
+    assert is_real_dispatch_test("tests/test_x.py", _REAL_DISPATCH_TEST_BODY)
+
+
+def test_is_real_dispatch_test_rejects_isolation_test() -> None:
+    assert not is_real_dispatch_test("tests/test_x.py", _ISOLATION_TEST_BODY)
+
+
+def test_is_real_dispatch_test_rejects_non_test_file() -> None:
+    assert not is_real_dispatch_test("src/x.py", _REAL_DISPATCH_TEST_BODY)
+
+
+def test_main_passes_when_no_surface_touched(tmp_path: Path) -> None:
+    f = tmp_path / "src" / "omnibase_core" / "utils" / "util_canonical_hash.py"
+    f.parent.mkdir(parents=True)
+    f.write_text("x = 1\n")
+    assert main([str(f)]) == 0
+
+
+def test_main_fails_on_surface_without_real_dispatch_test(tmp_path: Path) -> None:
+    surface = tmp_path / "src" / "pkg" / "auto_wiring" / "handler_wiring.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("x = 1\n")
+    iso = tmp_path / "tests" / "test_iso.py"
+    iso.parent.mkdir(parents=True)
+    iso.write_text(_ISOLATION_TEST_BODY)
+    assert main([str(surface), str(iso)]) == 1
+
+
+def test_main_passes_on_surface_with_real_dispatch_test(tmp_path: Path) -> None:
+    surface = tmp_path / "src" / "pkg" / "auto_wiring" / "handler_wiring.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("x = 1\n")
+    real = tmp_path / "tests" / "test_real.py"
+    real.parent.mkdir(parents=True)
+    real.write_text(_REAL_DISPATCH_TEST_BODY)
+    assert main([str(surface), str(real)]) == 0
+
+
+def test_main_respects_suppression_token(tmp_path: Path) -> None:
+    surface = tmp_path / "src" / "pkg" / "auto_wiring" / "handler_wiring.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("x = 1  # dispatch-surface-test-ok: comment-only edit\n")
+    assert main([str(surface)]) == 0


### PR DESCRIPTION
## OMN-12960 — Single transport-envelope unwrap predicate + dispatch-surface test gate

Generalizes OMN-12940/12946. The transport-envelope unwrap predicate existed as **two hand-synced marker-key sets**:
- `omnibase_infra.runtime.auto_wiring.handler_wiring._ENVELOPE_MARKER_KEYS`
- `omnimarket.nodes.evidence_pipeline_native._ENVELOPE_MARKER_KEYS`

Each was "fixed" once already, and they **drifted again**: the infra set was missing the `__bindings` marker that the omnimarket set carried. A dispatch-engine *materialized* envelope whose only top-level marker is `__bindings` therefore unwrapped on the omnimarket side and silently no-op'd on the infra side — the OMN-12946 defect class re-introduced.

### Fix (this PR — omnibase_core)
- **`src/omnibase_core/utils/util_envelope_unwrap.py`** — single authoritative predicate: `ENVELOPE_MARKER_KEYS`, `is_transport_envelope`, `unwrap_transport_envelope`. Recursively unwraps object-form (`ModelEventEnvelope`), materialized-dispatch-dict, and bare-marker envelopes; never unwraps a domain model that merely owns a `payload` field.
  - **Layering note:** by layering this wire-level concern belongs in `omnibase_compat`, but the compat pin is policy-frozen (bumping it is a symptom, not a fix), so per the P1.4 plan it lands in `omnibase_core` (already a runtime dep of both consumers), documented in the module docstring. Moves to compat verbatim when the pin un-freezes.
- **`src/omnibase_core/validators/dispatch_surface_test_required.py`** — path-heuristic ratchet. Makes a real-dispatch-path test **MANDATORY** for any change touching dispatch / routing / handler-registration / message-envelope source surfaces. Handler-isolation tests pass while live dispatch fails; this is the durable guard. Wired as pre-commit hook + CI quality-gate dependency. Documented suppression: `# dispatch-surface-test-ok: <reason>`.

### Follow-on (gated on this PR + a core pin bump, separate PRs)
- omnibase_infra `handler_wiring` imports the shared predicate, deletes its local `_ENVELOPE_MARKER_KEYS` / `_is_transport_envelope`.
- omnimarket `evidence_pipeline_native` imports the shared predicate, deletes its local `_ENVELOPE_MARKER_KEYS`, deletes the hand-synced cross-repo consistency test `test_marker_set_covers_materialized_dispatch_keys`, and promotes `repro_real_dispatch.py` into the reusable real-dispatch fixture.

### Verification
- 31 new unit tests pass (`tests/utils/test_envelope_unwrap.py`, `tests/validators/test_dispatch_surface_test_required.py`), including the exact `__bindings`-only drift regression and the validator self-check.
- `mypy --strict` clean on both new modules. `ruff check`/`format` clean. Pre-commit clean on staged files.

Evidence-Ticket: OMN-12960
Evidence-Source: fd847363608ce0656fb819059db042083bbe021e

