### PR TITLE
feat(OMN-12957): runtime-profile contract validator — registered-profile + consumer-lane rules

### DIFF
--- a/src/omnibase_core/constants/constants_runtime_profiles.py
+++ b/src/omnibase_core/constants/constants_runtime_profiles.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical registry of runtime-profile names (OMN-12957).
+
+This module is the **single source of truth** for the set of runtime-profile
+names that the ONEX runtime knows how to boot. A contract that declares a
+``runtime_profiles`` value not present in :data:`REGISTERED_RUNTIME_PROFILES`
+silently orphans the node: the runtime never wires its subscriptions to any
+process, so it has zero consumers and zero errors. ``ValidatorRuntimeProfiles``
+enforces ``contract.runtime_profiles ⊆ REGISTERED_RUNTIME_PROFILES`` so the
+orphan is caught at commit/CI time instead of at runtime.
+
+Layering note: the concrete profile *behaviour* (prefetch policy, subsystem
+gating) lives in ``omnibase_infra.runtime.runtime_profile._PROFILES``. That
+registry derives its key set from this constant — core owns the **names**,
+infra owns the **behaviour**. ``omnibase_infra`` carries a parity test
+(``test_profiles_match_core_registry``) that fails if the two drift, so the
+infra ``_PROFILES`` dict can never declare a profile core does not know about
+and core can never bless a name infra does not implement.
+
+Consumer-attached subset
+------------------------
+:data:`CONSUMER_ATTACHED_RUNTIME_PROFILES` is the subset of profiles that run a
+*standalone Kafka consumer* — i.e. a process that actually attaches a consumer
+group and drains its owned topics. ``main``, ``effects``, and ``workers`` host
+the orchestrator / effect / worker consumer lanes respectively. ``local-dev``,
+``default``, ``staging``, and ``production`` are policy overlays (prefetch
+posture), not distinct consumer lanes; ``canary`` and ``projection-api`` run
+isolated lanes that do NOT consume the general command/event groups a
+REDUCER/EFFECT needs.
+
+A REDUCER or EFFECT contract that subscribes to topics but names *only*
+non-consumer-attached profiles is the second, subtler class of silent
+orphaning: the name is registered (passes the subset check) but no process ever
+drains its subscriptions. ``ValidatorRuntimeProfiles`` flags that too.
+"""
+
+from __future__ import annotations
+
+# Every runtime-profile name the ONEX runtime can boot. Lower-cased; the
+# validator and ownership filter normalize declared profiles before comparison.
+REGISTERED_RUNTIME_PROFILES: frozenset[str] = frozenset(
+    {
+        "local-dev",
+        "default",
+        "main",
+        "effects",
+        "workers",
+        "projection-api",
+        "canary",
+        "staging",
+        "production",
+    }
+)
+
+# Profiles that run a standalone Kafka consumer (attach a consumer group and
+# drain owned topics). A subscribing REDUCER/EFFECT must name at least one of
+# these or its subscriptions are never consumed by any process.
+CONSUMER_ATTACHED_RUNTIME_PROFILES: frozenset[str] = frozenset(
+    {
+        "main",
+        "effects",
+        "workers",
+    }
+)
+
+
+__all__ = [
+    "CONSUMER_ATTACHED_RUNTIME_PROFILES",
+    "REGISTERED_RUNTIME_PROFILES",
+]

--- a/src/omnibase_core/validation/contracts/runtime_profiles.validation.yaml
+++ b/src/omnibase_core/validation/contracts/runtime_profiles.validation.yaml
@@ -12,10 +12,14 @@ validation:
   validator_description: |
     Enforces that every node contract whose event_bus subscribes to at
     least one onex.cmd.* topic also declares runtime_profiles (top-level
-    or under descriptor). Allowlist:
-      src/omnibase_core/validation/data/runtime_profiles_allowlist.yaml
-    Plan: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4).
-    Linear: OMN-9886.
+    or under descriptor), that declared profiles are members of the
+    canonical REGISTERED_RUNTIME_PROFILES registry, and that subscribing
+    REDUCER/EFFECT contracts name at least one consumer-attached profile.
+    Allowlist:
+      src/omnibase_core/validation/runtime_profiles_allowlist.yaml
+    Plans: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4);
+    docs/plans/2026-06-11-open-issues-remediation-plan.md (P1.1).
+    Linear: OMN-9886, OMN-12957.
 
   target_patterns:
     - "**/contract.yaml"
@@ -37,6 +41,22 @@ validation:
         Reject command-consuming contracts (any event_bus subscription on onex.cmd.*) that omit runtime_profiles.
         Declare 'runtime_profiles: [<profile>]' at the top level or under 'descriptor', or add the node
         id to the allowlist with a reason.
+      severity: error
+      enabled: true
+
+    - rule_id: runtime_profile_unregistered
+      description: >-
+        Reject contracts that declare a runtime_profiles value not present in the canonical REGISTERED_RUNTIME_PROFILES
+        registry (omnibase_core.constants.constants_runtime_profiles). A nonexistent profile name silently
+        orphans the node: no runtime process wires its subscriptions.
+      severity: error
+      enabled: true
+
+    - rule_id: runtime_profile_no_consumer_lane
+      description: >-
+        Reject subscribing REDUCER/EFFECT contracts whose declared runtime_profiles are all registered
+        but none runs a standalone consumer (CONSUMER_ATTACHED_RUNTIME_PROFILES: main, effects, workers),
+        so the subscriptions are never drained. Name at least one consumer-attached profile.
       severity: error
       enabled: true
 

--- a/src/omnibase_core/validation/validator_runtime_profiles.py
+++ b/src/omnibase_core/validation/validator_runtime_profiles.py
@@ -11,6 +11,22 @@ to at least one topic matching ``onex.cmd.*``. The validator fails when such
 a contract has empty/absent ``runtime_profiles`` and the node id is not in
 the explicit allowlist.
 
+Three rules (OMN-9886 + OMN-12957):
+
+- ``runtime_profiles_missing`` (OMN-9886) — a command-consuming contract that
+  declares no ``runtime_profiles`` and is not allowlisted.
+- ``runtime_profile_unregistered`` (OMN-12957) — a contract declares a
+  ``runtime_profiles`` value not in the canonical
+  ``omnibase_core.constants.constants_runtime_profiles.REGISTERED_RUNTIME_PROFILES``.
+  A nonexistent profile name silently orphans the node: the runtime never wires
+  its subscriptions to any process, so it has zero consumers and zero errors.
+- ``runtime_profile_no_consumer_lane`` (OMN-12957) — a REDUCER or EFFECT
+  contract that subscribes to topics but names *only* profiles that do not run
+  a standalone consumer (``CONSUMER_ATTACHED_RUNTIME_PROFILES``). The name is
+  registered (passes the subset check) but no process ever drains the
+  subscriptions — the second, subtler class of silent orphaning flagged in
+  operator review: manifest-declares-node ≠ consumer-attached.
+
 Both contract shapes for ``runtime_profiles`` are accepted (mirrors the
 canonical extractor in
 ``omnibase_infra.runtime.auto_wiring.discovery._extract_runtime_profiles``):
@@ -24,12 +40,17 @@ validator must not under-detect command consumers in the meantime):
 - classic: ``event_bus.subscribe_topics: [str, ...]``
 - nested: ``event_bus.subscribe: [{topic: str, ...}, ...]``
 
-The allowlist is loaded from
-``src/omnibase_core/validation/runtime_profiles_allowlist.yaml``. Every
-entry MUST carry a non-empty ``reason`` string; the loader raises
-``ValueError`` on a blank reason so a "drop in to silence the gate" PR
-cannot land. Per-call overrides via the ``allowlist`` constructor argument
-are intended for tests.
+The base allowlist is loaded from
+``src/omnibase_core/validation/runtime_profiles_allowlist.yaml``. When the
+validator scans a consumer repo, it additionally discovers that repo's frozen
+baseline allowlist at ``<repo>/validation/runtime_profiles_allowlist.yaml`` by
+walking up from each scanned contract to the repo root (the directory holding
+``pyproject.toml``). No environment variable is consulted — discovery is
+deterministic from the contract path. The effective allowlist for a contract is
+``the union of core_default and repo_baseline``. Every entry MUST carry a non-empty ``reason``
+string; the loader raises on a blank reason so a "drop in to silence the gate"
+PR cannot land. Per-call overrides via the ``allowlist`` constructor argument
+are intended for tests (and disable repo discovery for isolation).
 """
 
 from __future__ import annotations
@@ -40,6 +61,10 @@ from typing import ClassVar
 
 import yaml
 
+from omnibase_core.constants.constants_runtime_profiles import (
+    CONSUMER_ATTACHED_RUNTIME_PROFILES,
+    REGISTERED_RUNTIME_PROFILES,
+)
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
 from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
@@ -50,12 +75,21 @@ from omnibase_core.validation.validator_base import ValidatorBase
 from omnibase_core.validation.validator_topic_suffix import TOPIC_PREFIX
 
 RULE_RUNTIME_PROFILES_MISSING = "runtime_profiles_missing"
+RULE_RUNTIME_PROFILE_UNREGISTERED = "runtime_profile_unregistered"
+RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE = "runtime_profile_no_consumer_lane"
 ALLOWLIST_REASON_REQUIRED = (
     "every allowlist entry must declare a non-empty 'reason' explaining why "
     "the node is exempt from runtime_profiles enforcement"
 )
 
 _DEFAULT_ALLOWLIST_PATH = Path(__file__).parent / "runtime_profiles_allowlist.yaml"
+
+# Consumer repos vendor a frozen baseline allowlist at this repo-relative path.
+# The validator discovers it deterministically by walking up from each scanned
+# contract to the repo root (no env var, no config-via-env). Pre-existing
+# orphans are frozen here so the gate blocks NEW orphans without forcing a mass
+# remediation; the drain is tracked separately (OMN-12982).
+_REPO_ALLOWLIST_RELPATH = Path("validation") / "runtime_profiles_allowlist.yaml"
 
 
 def load_default_allowlist(
@@ -109,6 +143,31 @@ def load_default_allowlist(
     return out
 
 
+def _discover_repo_allowlist_path(contract_path: Path) -> Path | None:
+    """Walk up from a contract path to a repo-root baseline allowlist.
+
+    A repo declares a frozen baseline at ``<repo>/validation/runtime_profiles_
+    allowlist.yaml``. The repo root is identified by the presence of a
+    ``pyproject.toml`` (every ONEX package has one). Returns the allowlist path
+    if it exists at that root, else ``None``. Deterministic, no env var.
+    """
+    try:
+        current = contract_path.resolve().parent
+    except OSError:
+        return None
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        if (current / "pyproject.toml").is_file():
+            candidate = current / _REPO_ALLOWLIST_RELPATH
+            return candidate if candidate.is_file() else None
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
 def _extract_runtime_profiles(raw: dict[str, object]) -> tuple[str, ...]:
     """Return declared runtime_profiles from either supported location."""
     profiles_raw = raw.get("runtime_profiles")
@@ -156,6 +215,29 @@ def _is_command_consuming(raw: dict[str, object]) -> bool:
     return any(t.startswith(_COMMAND_TOPIC_PREFIX) for t in _iter_subscribe_topics(raw))
 
 
+def _node_kind(raw: dict[str, object]) -> str:
+    """Return normalized node archetype: 'reducer' | 'effect' | 'compute' | ...
+
+    Accepts both the bare form (``node_type: effect``) and the generic-suffix
+    form (``node_type: EFFECT_GENERIC``), plus ``descriptor.node_archetype``.
+    Returns an empty string when the archetype cannot be determined.
+    """
+    candidates: list[object] = [raw.get("node_type")]
+    descriptor = raw.get("descriptor")
+    if isinstance(descriptor, dict):
+        candidates.append(descriptor.get("node_archetype"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            token = candidate.strip().lower()
+            # Strip the "_generic" suffix on the canonical contract form.
+            return token.removesuffix("_generic")
+    return ""
+
+
+# Archetypes whose subscriptions must be drained by a standalone consumer lane.
+_CONSUMER_REQUIRING_KINDS: frozenset[str] = frozenset({"reducer", "effect"})
+
+
 class ValidatorRuntimeProfiles(ValidatorBase):
     """Reject command-consuming node contracts that omit runtime_profiles."""
 
@@ -166,12 +248,35 @@ class ValidatorRuntimeProfiles(ValidatorBase):
         contract: ModelValidatorSubcontract | None = None,
         allowlist: set[str] | None = None,
         allowlist_path: Path | None = None,
+        discover_repo_allowlist: bool = True,
     ) -> None:
         super().__init__(contract=contract)
+        # Base allowlist: explicit set (tests) > explicit path > core default.
         if allowlist is not None:
-            self._allowlist: frozenset[str] = frozenset(allowlist)
+            self._base_allowlist: frozenset[str] = frozenset(allowlist)
         else:
-            self._allowlist = frozenset(load_default_allowlist(allowlist_path).keys())
+            self._base_allowlist = frozenset(
+                load_default_allowlist(allowlist_path).keys()
+            )
+        # When True (default), each scanned contract additionally consults the
+        # repo-root baseline allowlist discovered by walking up to pyproject.toml.
+        # Tests that pass an explicit allowlist disable discovery for isolation.
+        self._discover_repo_allowlist = discover_repo_allowlist and allowlist is None
+        # Cache discovered repo allowlists keyed by resolved allowlist-file path.
+        self._repo_allowlist_cache: dict[Path, frozenset[str]] = {}
+
+    def _allowlist_for(self, contract_path: Path) -> frozenset[str]:
+        """Return the effective allowlist (base union repo baseline) for a file."""
+        if not self._discover_repo_allowlist:
+            return self._base_allowlist
+        repo_allowlist_path = _discover_repo_allowlist_path(contract_path)
+        if repo_allowlist_path is None:
+            return self._base_allowlist
+        cached = self._repo_allowlist_cache.get(repo_allowlist_path)
+        if cached is None:
+            cached = frozenset(load_default_allowlist(repo_allowlist_path).keys())
+            self._repo_allowlist_cache[repo_allowlist_path] = cached
+        return self._base_allowlist | cached
 
     def _validate_file(
         self,
@@ -191,21 +296,52 @@ class ValidatorRuntimeProfiles(ValidatorBase):
         if not isinstance(raw, dict):
             return ()
 
+        node_id = raw.get("name")
+        # An allowlisted node is a frozen baseline entry: it is exempt from ALL
+        # runtime_profiles rules (missing, unregistered, no-consumer-lane). This
+        # is how consumer repos adopt the gate without remediating every
+        # pre-existing violator at once (drain tracked per-repo). NEW nodes are
+        # not in any allowlist, so the gate still blocks new orphans. The
+        # effective allowlist is the core default unioned with the repo-root
+        # baseline discovered next to the scanned contract.
+        if isinstance(node_id, str) and node_id in self._allowlist_for(path):
+            return ()
+
+        declared_profiles = _extract_runtime_profiles(raw)
+
+        issues: list[ModelValidationIssue] = []
+        issues.extend(self._check_missing(raw, path, node_id, contract))
+        issues.extend(
+            self._check_unregistered(declared_profiles, path, node_id, contract)
+        )
+        issues.extend(
+            self._check_no_consumer_lane(
+                raw, declared_profiles, path, node_id, contract
+            )
+        )
+        return tuple(issues)
+
+    def _check_missing(
+        self,
+        raw: dict[str, object],
+        path: Path,
+        node_id: object,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        """OMN-9886: command-consuming contract with no declared profiles.
+
+        Allowlist exemption is handled by the caller (frozen-baseline
+        short-circuit), so this method assumes the node is not allowlisted.
+        """
         if not _is_command_consuming(raw):
             return ()
         if _extract_runtime_profiles(raw):
             return ()
-
-        node_id = raw.get("name")
-        if isinstance(node_id, str) and node_id in self._allowlist:
-            return ()
-
         enabled, severity = self._get_rule_config(
             RULE_RUNTIME_PROFILES_MISSING, contract
         )
         if not enabled:
             return ()
-
         message = (
             "runtime_profiles missing on command-consuming contract "
             f"{node_id!r}: declare 'runtime_profiles: [<profile>]' at the top "
@@ -220,6 +356,96 @@ class ValidatorRuntimeProfiles(ValidatorBase):
                 file_path=path,
                 line_number=1,
                 rule_name=RULE_RUNTIME_PROFILES_MISSING,
+            ),
+        )
+
+    def _check_unregistered(
+        self,
+        declared_profiles: tuple[str, ...],
+        path: Path,
+        node_id: object,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        """OMN-12957: declared profile not in the canonical registry."""
+        unknown = tuple(
+            p for p in declared_profiles if p not in REGISTERED_RUNTIME_PROFILES
+        )
+        if not unknown:
+            return ()
+        enabled, severity = self._get_rule_config(
+            RULE_RUNTIME_PROFILE_UNREGISTERED, contract
+        )
+        if not enabled:
+            return ()
+        known = ", ".join(sorted(REGISTERED_RUNTIME_PROFILES))
+        message = (
+            f"runtime_profiles on contract {node_id!r} names unregistered "
+            f"profile(s) {', '.join(repr(p) for p in unknown)}: a nonexistent "
+            "profile silently orphans the node (no runtime process wires its "
+            f"subscriptions). Use one of the registered profiles: {known}."
+        )
+        return (
+            ModelValidationIssue(
+                severity=severity,
+                message=message,
+                code=RULE_RUNTIME_PROFILE_UNREGISTERED,
+                file_path=path,
+                line_number=1,
+                rule_name=RULE_RUNTIME_PROFILE_UNREGISTERED,
+            ),
+        )
+
+    def _check_no_consumer_lane(
+        self,
+        raw: dict[str, object],
+        declared_profiles: tuple[str, ...],
+        path: Path,
+        node_id: object,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        """OMN-12957: subscribing REDUCER/EFFECT names no consumer-attached lane.
+
+        The declared profile names may all be registered yet none of them runs a
+        standalone consumer, so the subscriptions are never drained. Only fires
+        for REDUCER/EFFECT archetypes that actually subscribe to topics and
+        declare a (registered) profile set — the missing-profiles case is owned
+        by ``_check_missing`` and unregistered names by ``_check_unregistered``.
+        Allowlist exemption is handled by the caller (frozen-baseline
+        short-circuit).
+        """
+        if _node_kind(raw) not in _CONSUMER_REQUIRING_KINDS:
+            return ()
+        if not _iter_subscribe_topics(raw):
+            return ()
+        # Only registered profiles count toward consumer-lane membership; an
+        # unregistered name is already reported and must not mask this rule.
+        registered_declared = tuple(
+            p for p in declared_profiles if p in REGISTERED_RUNTIME_PROFILES
+        )
+        if not registered_declared:
+            return ()
+        if any(p in CONSUMER_ATTACHED_RUNTIME_PROFILES for p in registered_declared):
+            return ()
+        enabled, severity = self._get_rule_config(
+            RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE, contract
+        )
+        if not enabled:
+            return ()
+        consumer_lanes = ", ".join(sorted(CONSUMER_ATTACHED_RUNTIME_PROFILES))
+        message = (
+            f"subscribing {_node_kind(raw)} contract {node_id!r} names only "
+            f"runtime_profiles {list(registered_declared)} that run no standalone "
+            "consumer, so its subscriptions are never drained (silent orphan). "
+            f"Name at least one consumer-attached profile: {consumer_lanes}."
+        )
+        return (
+            ModelValidationIssue(
+                severity=severity,
+                message=message,
+                code=RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE,
+                file_path=path,
+                line_number=1,
+                rule_name=RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE,
             ),
         )
 

--- a/tests/unit/validation/test_validator_runtime_profiles.py
+++ b/tests/unit/validation/test_validator_runtime_profiles.py
@@ -38,6 +38,8 @@ from omnibase_core.models.contracts.subcontracts.model_validator_subcontract imp
 from omnibase_core.models.primitives.model_semver import ModelSemVer
 from omnibase_core.validation.validator_runtime_profiles import (
     ALLOWLIST_REASON_REQUIRED,
+    RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE,
+    RULE_RUNTIME_PROFILE_UNREGISTERED,
     RULE_RUNTIME_PROFILES_MISSING,
     ValidatorRuntimeProfiles,
     load_default_allowlist,
@@ -61,6 +63,18 @@ def _contract() -> ModelValidatorSubcontract:
             ModelValidatorRule(
                 rule_id=RULE_RUNTIME_PROFILES_MISSING,
                 description="Reject command-consuming contracts without runtime_profiles.",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+            ModelValidatorRule(
+                rule_id=RULE_RUNTIME_PROFILE_UNREGISTERED,
+                description="Reject contracts naming an unregistered runtime profile.",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+            ModelValidatorRule(
+                rule_id=RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE,
+                description="Reject subscribing reducer/effect naming no consumer lane.",
                 severity=EnumSeverity.ERROR,
                 enabled=True,
             ),
@@ -261,3 +275,277 @@ class TestValidatorRuntimeProfilesAllowlistFile:
                 f"allowlist entry {node_id!r} missing a non-empty 'reason' "
                 f"({ALLOWLIST_REASON_REQUIRED})"
             )
+
+
+@pytest.mark.unit
+class TestValidatorRuntimeProfileUnregistered:
+    """OMN-12957: declared profiles must be members of the canonical registry."""
+
+    def test_unregistered_profile_fails(self, tmp_path: Path) -> None:
+        # "compute" is a real bug observed in omnimarket: not a runtime profile.
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_compute",
+                "node_type": "compute",
+                "runtime_profiles": ["compute"],
+                "event_bus": {"subscribe_topics": ["onex.evt.demo.done.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        codes = {i.code for i in issues}
+        assert RULE_RUNTIME_PROFILE_UNREGISTERED in codes
+        unreg = next(i for i in issues if i.code == RULE_RUNTIME_PROFILE_UNREGISTERED)
+        assert "'compute'" in unreg.message
+        assert "unregistered" in unreg.message
+
+    def test_descriptor_unregistered_profile_fails(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "descriptor": {"runtime_profiles": ["does-not-exist"]},
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_UNREGISTERED in {i.code for i in issues}
+
+    def test_registered_profile_passes_unregistered_rule(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "runtime_profiles": ["effects", "workers"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_UNREGISTERED not in {i.code for i in issues}
+
+    def test_mixed_registered_and_unregistered_reports_only_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_orchestrator",
+                "node_type": "orchestrator",
+                "runtime_profiles": ["main", "bogus"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.start.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        unreg = [i for i in issues if i.code == RULE_RUNTIME_PROFILE_UNREGISTERED]
+        assert len(unreg) == 1
+        assert "'bogus'" in unreg[0].message
+        assert "'main'" not in unreg[0].message
+
+
+@pytest.mark.unit
+class TestValidatorRuntimeProfileNoConsumerLane:
+    """OMN-12957: subscribing REDUCER/EFFECT must name a consumer-attached lane.
+
+    The second class of silent orphaning: every named profile is registered but
+    none runs a standalone consumer, so the subscriptions are never drained.
+    """
+
+    def test_effect_with_only_non_consumer_profile_fails(self, tmp_path: Path) -> None:
+        # "canary" is registered but runs an isolated lane, not the effect
+        # consumer group an EFFECT needs.
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_effect",
+                "node_type": "effect",
+                "runtime_profiles": ["canary"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.do.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        codes = {i.code for i in issues}
+        assert RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE in codes
+        finding = next(
+            i for i in issues if i.code == RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE
+        )
+        assert "never drained" in finding.message
+
+    def test_reducer_generic_with_non_consumer_profile_fails(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_reducer",
+                "node_type": "REDUCER_GENERIC",
+                "runtime_profiles": ["projection-api"],
+                "event_bus": {"subscribe_topics": ["onex.evt.demo.happened.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE in {i.code for i in issues}
+
+    def test_effect_with_consumer_profile_passes(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_effect",
+                "node_type": "effect",
+                "runtime_profiles": ["effects"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.do.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE not in {i.code for i in issues}
+
+    def test_compute_with_non_consumer_profile_is_exempt(self, tmp_path: Path) -> None:
+        # COMPUTE nodes do not own a standalone consumer lane; rule does not fire.
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_compute",
+                "node_type": "compute",
+                "runtime_profiles": ["canary"],
+                "event_bus": {"subscribe_topics": ["onex.evt.demo.done.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE not in {i.code for i in issues}
+
+    def test_effect_without_subscriptions_is_exempt(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_effect",
+                "node_type": "effect",
+                "runtime_profiles": ["canary"],
+                "event_bus": {"publish_topics": ["onex.evt.demo.done.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract(), allowlist=set())
+        issues = validator._validate_file(path, _contract())
+        assert RULE_RUNTIME_PROFILE_NO_CONSUMER_LANE not in {i.code for i in issues}
+
+    def test_allowlisted_node_exempt_from_consumer_lane_rule(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_demo_effect",
+                "node_type": "effect",
+                "runtime_profiles": ["canary"],
+                "event_bus": {"subscribe_topics": ["onex.cmd.demo.do.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(
+            contract=_contract(), allowlist={"node_demo_effect"}
+        )
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+
+@pytest.mark.unit
+class TestAllowlistFreezesAllRules:
+    """A baselined (allowlisted) node is exempt from every runtime_profiles rule."""
+
+    def test_allowlisted_unregistered_profile_is_frozen(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            {
+                "name": "node_legacy_orphan",
+                "node_type": "compute",
+                "runtime_profiles": ["compute"],  # unregistered, but baselined
+                "event_bus": {"subscribe_topics": ["onex.cmd.legacy.do.v1"]},
+            },
+        )
+        validator = ValidatorRuntimeProfiles(
+            contract=_contract(), allowlist={"node_legacy_orphan"}
+        )
+        issues = validator._validate_file(path, _contract())
+        assert issues == ()
+
+
+@pytest.mark.unit
+class TestRegistryParity:
+    """The core registry is the single source of truth for profile names."""
+
+    def test_consumer_attached_is_subset_of_registered(self) -> None:
+        from omnibase_core.constants.constants_runtime_profiles import (
+            CONSUMER_ATTACHED_RUNTIME_PROFILES,
+            REGISTERED_RUNTIME_PROFILES,
+        )
+
+        assert CONSUMER_ATTACHED_RUNTIME_PROFILES <= REGISTERED_RUNTIME_PROFILES
+
+
+@pytest.mark.unit
+class TestRepoBaselineAllowlistDiscovery:
+    """OMN-12957: consumer repos vendor a frozen baseline discovered by path.
+
+    A repo's baseline at ``<repo>/validation/runtime_profiles_allowlist.yaml`` is
+    discovered by walking up from the scanned contract to the ``pyproject.toml``
+    root. No env var. The effective allowlist is the union of core_default and repo_baseline.
+    """
+
+    def _make_repo(self, tmp_path: Path, baseline_node_ids: list[str]) -> Path:
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname='fake'\n", encoding="utf-8"
+        )
+        validation_dir = tmp_path / "validation"
+        validation_dir.mkdir()
+        entries = "\n".join(
+            f"  - node_id: {nid}\n    reason: frozen baseline test entry"
+            for nid in baseline_node_ids
+        )
+        (validation_dir / "runtime_profiles_allowlist.yaml").write_text(
+            "allowlist:\n" + entries + "\n", encoding="utf-8"
+        )
+        node_dir = tmp_path / "src" / "nodes" / "node_demo"
+        node_dir.mkdir(parents=True)
+        return node_dir / "contract.yaml"
+
+    def test_baselined_node_is_exempt(self, tmp_path: Path) -> None:
+        contract_path = self._make_repo(tmp_path, ["node_demo_compute"])
+        contract_path.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "node_demo_compute",
+                    "node_type": "compute",
+                    "runtime_profiles": ["compute"],  # unregistered
+                    "event_bus": {"subscribe_topics": ["onex.evt.demo.done.v1"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        # No explicit allowlist arg → repo discovery is active.
+        validator = ValidatorRuntimeProfiles(contract=_contract())
+        issues = validator._validate_file(contract_path, _contract())
+        assert issues == ()
+
+    def test_new_orphan_not_in_baseline_still_blocked(self, tmp_path: Path) -> None:
+        contract_path = self._make_repo(tmp_path, ["some_other_node"])
+        contract_path.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "node_demo_compute",
+                    "node_type": "compute",
+                    "runtime_profiles": ["compute"],  # unregistered, NOT baselined
+                    "event_bus": {"subscribe_topics": ["onex.evt.demo.done.v1"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        validator = ValidatorRuntimeProfiles(contract=_contract())
+        issues = validator._validate_file(contract_path, _contract())
+        assert RULE_RUNTIME_PROFILE_UNREGISTERED in {i.code for i in issues}


### PR DESCRIPTION
## OMN-12957 — Runtime-profile contract validator (P1.1)

Generalizes OMN-12950. A contract could declare any `runtime_profiles` string; a nonexistent profile (e.g. `[compute]`) silently orphaned the node — the auto-wiring ownership filter assigned it to no running runtime, so zero consumer groups, zero errors, empty projection tables.

### What this PR adds (omnibase_core — the validator + ratchet)
- **`constants/constants_runtime_profiles.py`** — canonical registry: `REGISTERED_RUNTIME_PROFILES` (9 profile names the runtime can boot) and `CONSUMER_ATTACHED_RUNTIME_PROFILES` (`main`/`effects`/`workers`). Core owns the *names* so contract validation enforces membership without a core->infra dependency; infra owns the *behaviour* (`_PROFILES`) and carries a parity test.
- **`validation/validator_runtime_profiles.py`** — two new rules on top of OMN-9886's `runtime_profiles_missing`:
  - `runtime_profile_unregistered` — every declared profile must be in `REGISTERED_RUNTIME_PROFILES` (catches the OMN-12950 class; finds 16 real orphans in omnimarket).
  - `runtime_profile_no_consumer_lane` — a subscribing REDUCER/EFFECT must name a consumer-attached profile or its subscriptions are never drained.
- **Deterministic repo-baseline discovery** — consumer repos vendor a frozen baseline at `<repo>/validation/runtime_profiles_allowlist.yaml`, discovered by walking up to the `pyproject.toml` root. No env var (passes the no-new-os.environ gate). Gate blocks NEW orphans; pre-existing ones drained via OMN-12982.

### Enforcement
All three rules wire via the existing pre-commit hook + `validator-runtime-profiles.yml` CI. Core self-scan green. Consumer-repo wiring (omnibase_infra, omnimarket) lands in paired PRs once this core change is pinned.

### Tests
`tests/unit/validation/test_validator_runtime_profiles.py` — 24 tests pass. `mypy --strict` clean.

Evidence-Ticket: OMN-12957
Evidence-Source: OCC#2485