### PR TITLE
fix(OMN-12961): reject typing.Protocol handler targets in ServiceHandlerResolver

### DIFF
--- a/src/omnibase_core/services/service_handler_resolver.py
+++ b/src/omnibase_core/services/service_handler_resolver.py
@@ -4,6 +4,8 @@
 
 Precedence (first match wins):
     1. Local ownership skip — node not hosted here -> skip cleanly
+    1a. Protocol reject     — typing.Protocol handler_cls -> identifying TypeError
+                              (OMN-12961; non-instantiable interface, fail fast)
     2. Node registry        — materialized explicit dep map from create_registry
     3. Container DI         — container.get_service(handler_cls)
     4. Known-param injection — any combination of event_bus/container/ownership_query
@@ -99,6 +101,31 @@ class ServiceHandlerResolver:
                     skipped_handler=context.handler_name,
                     skipped_reason=(f"node {context.node_name!r} is not hosted here"),
                 )
+
+        # Step 1a - reject non-instantiable Protocol handler classes (OMN-12961).
+        # A `typing.Protocol` used as a `handler_routing` target is an interface,
+        # not a concrete implementation, and cannot be instantiated. Its synthetic
+        # `__init__ = _no_init_or_replace_init(*args, **kwargs)` exposes only
+        # VAR_POSITIONAL/VAR_KEYWORD params, which the required-param scan below
+        # excludes — so the Step 5 zero-arg path would call `handler_cls()` and let
+        # typing's anonymous `TypeError("Protocols cannot be instantiated")` escape
+        # from typing.py, crashing runtime bootstrap with no attribution to the
+        # offending contract/handler. Fail fast here with an identifying TypeError.
+        # `_is_protocol` is the marker typing sets on every Protocol subclass; we
+        # duck-type it (core must not import omnibase_spi) and mirror the infra
+        # OMN-12501 guard semantics, which catches this TypeError and quarantines
+        # the handler as PROTOCOL_HANDLER_DECLARATION. Placed AFTER Step 1 so a
+        # Protocol handler on a node not hosted here still skips cleanly.
+        if getattr(context.handler_cls, "_is_protocol", False):
+            # error-ok: HandlerResolver fail-fast on non-instantiable Protocol target.
+            raise TypeError(
+                f"Handler {context.handler_module}.{context.handler_name} "
+                f"declared by contract {context.contract_name!r} is a "
+                f"typing.Protocol, which is an interface and cannot be "
+                f"instantiated. A handler_routing entry must target a concrete "
+                f"implementation, not a Protocol — fix the contract to route to "
+                f"the concrete handler class."
+            )
 
         # Step 2 - explicit materialized dependency map from node registry.
         mat = context.materialized_explicit_dependencies

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -71,7 +71,8 @@ class _ProtocolHandler(Protocol):
     typing internals with the anonymous "Protocols cannot be instantiated".
     """
 
-    async def handle(self, envelope: object) -> None: ...
+    async def handle(self, envelope: object) -> None:
+        """Protocol method signature only; never executed."""
 
 
 @runtime_checkable
@@ -83,7 +84,8 @@ class _RuntimeCheckableProtocolHandler(Protocol):
     rather than any runtime_checkable-specific marker.
     """
 
-    async def handle(self, envelope: object) -> None: ...
+    async def handle(self, envelope: object) -> None:
+        """Protocol method signature only; never executed."""
 
 
 @pytest.mark.unit

--- a/tests/unit/services/test_service_handler_resolver.py
+++ b/tests/unit/services/test_service_handler_resolver.py
@@ -22,7 +22,7 @@ cases described in the plan:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 from unittest.mock import MagicMock
 
 import pytest
@@ -57,6 +57,33 @@ class _HandlerWithDeps:
 
     async def handle(self, envelope: object) -> None:
         return None
+
+
+class _ProtocolHandler(Protocol):
+    """A typing.Protocol used as a (mis-declared) handler routing target.
+
+    Mirrors the real-world OMN-12961 defect: a contract's handler_routing
+    points at an interface Protocol (e.g. EvidenceEvaluator) rather than a
+    concrete implementation. Protocol's synthetic
+    `__init__(*args, **kwargs)` exposes only VAR_POSITIONAL/VAR_KEYWORD
+    params, so the resolver's required-param scan sees zero required
+    params and (pre-fix) attempts a zero-arg instantiation that dies inside
+    typing internals with the anonymous "Protocols cannot be instantiated".
+    """
+
+    async def handle(self, envelope: object) -> None: ...
+
+
+@runtime_checkable
+class _RuntimeCheckableProtocolHandler(Protocol):
+    """A runtime_checkable Protocol handler target.
+
+    Same defect class as `_ProtocolHandler`; included to prove the guard
+    keys off `_is_protocol` (set by typing for any Protocol subclass)
+    rather than any runtime_checkable-specific marker.
+    """
+
+    async def handle(self, envelope: object) -> None: ...
 
 
 @pytest.mark.unit
@@ -384,6 +411,151 @@ def test_skip_precedes_node_registry() -> None:
         materialized_explicit_dependencies={
             "H": {"projection_reader": proj, "reducer": reducer},
         },
+    )
+
+    result = ServiceHandlerResolver().resolve(ctx)
+
+    assert (
+        result.outcome == EnumHandlerResolutionOutcome.RESOLVED_VIA_LOCAL_OWNERSHIP_SKIP
+    )
+    assert result.handler_instance is None
+
+
+# ---------------------------------------------------------------------------
+# OMN-12961 — Protocol handler rejection.
+#
+# A typing.Protocol used as a handler_routing target is non-instantiable by
+# design. Pre-fix, the resolver's required-param scan treated Protocol's
+# synthetic `__init__(*args, **kwargs)` as zero-arg and called `handler_cls()`,
+# letting typing's anonymous `TypeError("Protocols cannot be instantiated")`
+# escape from typing.py — taking down runtime bootstrap with no attribution to
+# the offending contract/handler. The resolver must fail fast BEFORE any
+# instantiation path with an identifying TypeError naming the handler and its
+# contract, so the infra OMN-12501 quarantine guard (and any other caller) gets
+# an attributable error instead of typing's anonymous one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_protocol_handler_rejected_with_identifying_type_error() -> None:
+    """Protocol handler_cls raises a TypeError naming handler + contract."""
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_ProtocolHandler,
+        handler_module="omnimarket.nodes.node_overseer_observer.handlers",
+        handler_name="_ProtocolHandler",
+        contract_name="node_overseer_observer",
+        node_name="node_overseer_observer",
+    )
+
+    with pytest.raises(TypeError) as exc:
+        ServiceHandlerResolver().resolve(ctx)
+
+    msg = str(exc.value)
+    # Attributable: names the handler module.name and the owning contract.
+    assert "_ProtocolHandler" in msg
+    assert "omnimarket.nodes.node_overseer_observer.handlers" in msg
+    assert "node_overseer_observer" in msg
+    assert "Protocol" in msg
+    # NOT typing's anonymous internal message.
+    assert msg != "Protocols cannot be instantiated"
+
+
+@pytest.mark.unit
+def test_runtime_checkable_protocol_handler_rejected() -> None:
+    """A runtime_checkable Protocol handler is rejected the same way."""
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_RuntimeCheckableProtocolHandler,
+        handler_module="x",
+        handler_name="_RuntimeCheckableProtocolHandler",
+        contract_name="node_foo",
+        node_name="node_foo",
+    )
+
+    with pytest.raises(TypeError) as exc:
+        ServiceHandlerResolver().resolve(ctx)
+
+    assert "_RuntimeCheckableProtocolHandler" in str(exc.value)
+    assert "Protocol" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_protocol_handler_rejected_even_with_container_present() -> None:
+    """Protocol rejection precedes container DI — the container is never probed."""
+    container = MagicMock()
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_ProtocolHandler,
+        handler_module="x",
+        handler_name="_ProtocolHandler",
+        contract_name="node_foo",
+        node_name="node_foo",
+        container=container,
+    )
+
+    with pytest.raises(TypeError) as exc:
+        ServiceHandlerResolver().resolve(ctx)
+
+    assert "Protocol" in str(exc.value)
+    # Guard runs before Step 3; the container must never be consulted for a
+    # non-instantiable Protocol target.
+    container.get_service.assert_not_called()
+
+
+@pytest.mark.unit
+def test_protocol_handler_rejected_even_with_event_bus_present() -> None:
+    """Protocol rejection precedes known-param injection (Step 4)."""
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_ProtocolHandler,
+        handler_module="x",
+        handler_name="_ProtocolHandler",
+        contract_name="node_foo",
+        node_name="node_foo",
+        event_bus=object(),
+    )
+
+    with pytest.raises(TypeError) as exc:
+        ServiceHandlerResolver().resolve(ctx)
+
+    assert "Protocol" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_protocol_handler_rejected_when_owned_here() -> None:
+    """When ownership says owned-here, the Protocol handler is rejected."""
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = True
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_ProtocolHandler,
+        handler_module="x",
+        handler_name="_ProtocolHandler",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
+    )
+
+    with pytest.raises(TypeError) as exc:
+        ServiceHandlerResolver().resolve(ctx)
+
+    assert "Protocol" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_protocol_handler_not_owned_here_still_skips_cleanly() -> None:
+    """Protocol rejection must NOT fire for a node not hosted here.
+
+    Ownership skip (Step 1) is a deliberate non-error path; a Protocol-typed
+    handler on a node this runtime does not host must skip cleanly rather than
+    raise, mirroring infra: only handlers this runtime would actually wire are
+    rejected/quarantined.
+    """
+    ownership = MagicMock()
+    ownership.is_owned_here.return_value = False
+    ctx = ModelHandlerResolverContext(
+        handler_cls=_ProtocolHandler,
+        handler_module="x",
+        handler_name="_ProtocolHandler",
+        contract_name="node_foo",
+        node_name="node_foo",
+        ownership_query=ownership,
     )
 
     result = ServiceHandlerResolver().resolve(ctx)


### PR DESCRIPTION
## OMN-12961 — omnibase_core resolver hardening: reject typing.Protocol handler targets

### Problem
`ServiceHandlerResolver.resolve` Step 5 called `handler_cls()` for any handler whose required-param scan came back empty. A `typing.Protocol`'s synthetic `__init__ = _no_init_or_replace_init(*args, **kwargs)` exposes only `VAR_POSITIONAL`/`VAR_KEYWORD` params, which the scan excludes — so a Protocol used as a `handler_routing` target looked zero-arg and was instantiated, raising the anonymous `TypeError("Protocols cannot be instantiated")` from `typing.py:1774`. Uncaught on any path not behind infra's OMN-12501 quarantine, this took down the **entire** runtime bootstrap for one bad contract, with no attribution to the offending contract/handler.

This is fault classification (b) from `docs/evidence/2026-06-11-full-feature-pass/03-buildout/materialization-gap/RESOLVER-CRASH-DIAGNOSIS.md` (companion primary fix: OMN-12956, omnimarket contract).

### Fix
Add **Step 1a** to `service_handler_resolver.py`: fail fast on a `_is_protocol` `handler_cls` **before any instantiation path** with an identifying `TypeError` naming the handler `module.name` and the owning contract. The marker is duck-typed (`getattr(handler_cls, "_is_protocol", False)`) because `omnibase_core` must not import `omnibase_spi`.

This mirrors the infra **OMN-12501** guard semantics (`omnibase_infra/.../auto_wiring/handler_wiring.py:2894-2904`): the wiring layer's `except TypeError` still catches the error and quarantines the handler as `PROTOCOL_HANDLER_DECLARATION`. The failure stays a `TypeError` (so the existing quarantine convention is preserved — no third behavior invented), but it is now **attributable** instead of typing's anonymous message. Placed after Step 1 so a Protocol handler on a node not hosted here still skips cleanly via local-ownership skip.

### TDD
6 unit tests in `tests/unit/services/test_service_handler_resolver.py`:
- `test_protocol_handler_rejected_with_identifying_type_error` — asserts the TypeError names handler module.name + contract and is NOT typing's anonymous `"Protocols cannot be instantiated"`. **Red without the fix** (reproduces the exact crash signature).
- `test_runtime_checkable_protocol_handler_rejected` — guard keys off `_is_protocol`, not a runtime_checkable-specific marker.
- `test_protocol_handler_rejected_even_with_container_present` — rejection precedes Step 3 (container never probed).
- `test_protocol_handler_rejected_even_with_event_bus_present` — rejection precedes Step 4.
- `test_protocol_handler_rejected_when_owned_here` — rejected when owned here.
- `test_protocol_handler_not_owned_here_still_skips_cleanly` — ownership skip (Step 1) wins; no false rejection for non-hosted nodes.

### Verification (local)
- `uv run pytest tests/unit/services/ tests/unit/models/resolver/ -q` → **950 passed, 42 skipped**.
- TDD red proof: stashing the source fix → the 3 attribution tests fail with `'Protocols cannot be instantiated'`; restoring → all 21 in the file pass.
- `uv run ruff format` / `ruff check` → clean.
- `uv run mypy src/omnibase_core/services/service_handler_resolver.py --strict` → 0 errors in the changed file (2 pre-existing errors in unrelated `contracts/contract_loader.py`, identical on base HEAD).
- `pre-commit run --files <changed>` → all hooks pass (incl. ONEX Deterministic Skill Routing with `DETERMINISTIC_SKILL_ROOT` at omniclaude@main snapshot).

Evidence-Ticket: OMN-12961
Evidence-Source: OCC#2486