### PR TITLE
feat(OMN-12818): url-authority ratchet gate — ValidatorUrlAuthority in omnibase_core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,7 +742,9 @@ jobs:
           #
           # Excludes: uv.lock (dependency hashes), .venv/, test fixtures,
           # .git/, .secrets.baseline (contains hashed values that self-trigger),
-          # workflow YAML (references "secret" in config context)
+          # workflow YAML (references "secret" in config context),
+          # url_authority_baseline.json (sha256 fingerprints of known violations,
+          #   not secrets — Hex High Entropy false-positive)
           set +e
           git ls-files -z | xargs -0 detect-secrets-hook \
             --baseline .secrets.baseline \
@@ -751,7 +753,8 @@ jobs:
             --exclude-files 'tests/fixtures/' \
             --exclude-files '\.git/' \
             --exclude-files '\.secrets\.baseline' \
-            --exclude-files '\.github/workflows/.*\.yml'
+            --exclude-files '\.github/workflows/.*\.yml' \
+            --exclude-files 'url_authority_baseline\.json'
           HOOK_EXIT=$?
           set -e
 

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -86,7 +86,17 @@ jobs:
                   if e["repo"] == "omnibase_core"
               }
           except subprocess.CalledProcessError:
-              prior_repo = set()  # new file on this PR — no prior to compare
+              # Baseline file does not exist on the base branch — this is the
+              # initial introduction of the baseline for this repo.  By definition
+              # nothing "grew" relative to a non-existent prior, so the check
+              # passes.  Any new violations that sneak in via the first commit are
+              # caught by the gate step above.
+              print(
+                  "URL-AUTHORITY BASELINE OK (initial): "
+                  f"baseline file is new on this PR ({len(head_repo)} grandfathered "
+                  "fingerprints); no prior to compare against."
+              )
+              sys.exit(0)
           grew = head_repo - prior_repo
           if grew:
               sys.stderr.write(

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-12818 (PR-2 of OMN-12803): url-authority ratchet gate — BLOCKING MODE.
+#
+# Every URL/endpoint must resolve from a contract (the routing authority for
+# model endpoints, the integration catalog for external/infra endpoints) — never
+# from a public-HTTPS source literal or a *_URL / *_ENDPOINT env read. API-key
+# env reads and config-PATH reads stay legal.
+#
+# This is a RATCHET: existing violations are grandfathered by the sha256 baseline
+# at src/omnibase_core/validation/baselines/url_authority_baseline.json.
+# Any NEW violation (fingerprint absent from the baseline) fails the job and blocks
+# merge. The baseline is burn-down only — a CI assertion rejects baseline growth.
+#
+# To permit a legitimate literal, annotate the line:
+#   # url-authority-ok: <concrete reason>
+#
+# Migration debt tickets:
+#   omnibase_core:  OMN-12806
+#   omnibase_infra: OMN-12807
+#   other repos:    OMN-12808
+#
+# This job is a REQUIRED STATUS CHECK. The job name "URL Authority Gate" must
+# match branch protection rules.
+
+name: URL Authority Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  url-authority-gate:
+    name: URL Authority Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run url-authority gate (full-repo, against frozen baseline)
+        run: |
+          uv run python -m omnibase_core.validation.validator_url_authority \
+            --all --repo omnibase_core --repo-root .
+
+      - name: Assert baseline did not grow (anti-gaming)
+        run: |
+          uv run python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          baseline = Path(
+              "src/omnibase_core/validation/baselines/url_authority_baseline.json"
+          )
+          head = json.loads(baseline.read_text())
+          head_repo = {
+              e["fingerprint"]
+              for e in head["violations"]
+              if e["repo"] == "omnibase_core"
+          }
+          # Compare against the baseline on the PR base branch.
+          base_ref = "origin/${{ github.base_ref || 'dev' }}"
+          try:
+              prior_text = subprocess.check_output(
+                  ["git", "show", f"{base_ref}:{baseline}"], text=True
+              )
+              prior = json.loads(prior_text)
+              prior_repo = {
+                  e["fingerprint"]
+                  for e in prior["violations"]
+                  if e["repo"] == "omnibase_core"
+              }
+          except subprocess.CalledProcessError:
+              prior_repo = set()  # new file on this PR — no prior to compare
+          grew = head_repo - prior_repo
+          if grew:
+              sys.stderr.write(
+                  "URL-AUTHORITY BASELINE GREW: "
+                  f"{len(grew)} new fingerprint(s) added to the baseline. The baseline "
+                  "is burn-down only — fix the violation or annotate with "
+                  "# url-authority-ok:, never grow the baseline.\n"
+              )
+              sys.exit(1)
+          print(
+              "URL-AUTHORITY BASELINE OK: "
+              f"omnibase_core subset {len(head_repo)} (<= prior {len(prior_repo)})."
+          )
+          PY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -823,6 +823,20 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # URL Authority Gate (OMN-12818, PR-2 of OMN-12803).
+      # Ratchet: NEW fingerprints fail; existing violations are grandfathered.
+      # Baseline is burn-down only. Migration debt: OMN-12806 (omnibase_core).
+      # Suppress with: # url-authority-ok: <reason>
+      - id: check-url-authority
+        name: URL Authority Gate (OMN-12818)
+        entry: uv run python -m omnibase_core.validation.validator_url_authority
+        args: [--repo, omnibase_core, --repo-root, .]
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: ^(tests/|archived/|archive/).*\.py$
+        stages: [pre-commit]
+
       - id: validate-exception-handling
         name: ONEX Exception Handling Validation
         entry: uv run python scripts/validation/validate-exception-handling.py

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -147,3 +147,18 @@
   files: (^|/)test_.*\.py$
   pass_filenames: true
   stages: [pre-commit]
+
+- id: check-url-authority
+  name: URL Authority Gate (OMN-12818)
+  description: >
+    Ratchet gate: reject NEW URL/endpoint literals outside contracts (PR-2 of OMN-12803). Every URL and
+    *_URL/*_ENDPOINT env read must resolve from a contract (routing authority / integration catalog).
+    Existing violations are grandfathered by sha256 fingerprint; only NEW fingerprints fail the gate.
+    Baseline is burn-down only — may shrink, never grow. Migration debt: OMN-12806 (omnibase_core), OMN-12807
+    (omnibase_infra), OMN-12808 (others). Suppression: # url-authority-ok: <reason>
+  language: python
+  entry: python -m omnibase_core.validation.validator_url_authority
+  args: [--repo, omnibase_core, --repo-root, .]
+  types: [python]
+  pass_filenames: true
+  stages: [pre-commit]

--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -348,10 +348,10 @@ allowed_files:
   - file: "src/omnibase_core/validators/breaking_schema_change.py"
     reason: >-
       Breaking-schema-change validator (OMN-12621) — must read adjacent *.topic-schema.yaml declarations
-      and *.migration.yaml contracts from the filesystem to diff baseline vs current bindings. Every
-      yaml.safe_load() result is immediately passed to ModelTopicSchemaBinding.model_validate() /
-      ModelTopicMigrationContract.model_validate(); the raw dict is never used unvalidated. Mirrors the
-      contract_config_compliance.py validator pattern it is modeled on.
+      and *.migration.yaml contracts from the filesystem to diff baseline vs current bindings. Every yaml.safe_load()
+      result is immediately passed to ModelTopicSchemaBinding.model_validate() / ModelTopicMigrationContract.model_validate();
+      the raw dict is never used unvalidated. Mirrors the contract_config_compliance.py validator pattern
+      it is modeled on.
     added: "2026-06-02"
     review: "2026-12-13"
 

--- a/contracts/OMN-12663.yaml
+++ b/contracts/OMN-12663.yaml
@@ -3,12 +3,11 @@ schema_version: "1.0.0"
 ticket_id: "OMN-12663"
 title: "feat(OMN-12663): widen ModelDelegationRequest.task_type to full 12-value compat set"
 summary: >
-  Parity fix: ModelDelegationRequest.task_type was narrowed to 3 values during graduation
-  (OMN-12126) when the compat set at sha 4d887307 defines 12 values. This broke omnimarket
-  validation (3 tests fail; OMN-12659 held at 208/211). This PR widens task_type to the
-  full 12-value compat set and adds parametrized tests proving all 12 values accept.
-  Full parity audit conducted across all delegation wire models — only task_type required
-  widening; all other str fields match compat intentionally.
+  Parity fix: ModelDelegationRequest.task_type was narrowed to 3 values during graduation (OMN-12126)
+  when the compat set at sha 4d887307 defines 12 values. This broke omnimarket validation (3 tests fail;
+  OMN-12659 held at 208/211). This PR widens task_type to the full 12-value compat set and adds parametrized
+  tests proving all 12 values accept. Full parity audit conducted across all delegation wire models —
+  only task_type required widening; all other str fields match compat intentionally.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -43,20 +42,18 @@ dod_evidence:
         check_value: "uv run mypy src/omnibase_core/models/delegation/ --strict"
   - id: "dod-parity-audit"
     description: >
-      Full parity audit against compat@4d887307: ModelDelegationRequest.task_type widened
-      3 to 12. All other task_type fields are str in both compat and core, correct.
-      ModelDelegationFallbackPolicy.action/on_exhaust and
-      ModelDelegationBackendConfig.tier are typed Literals in core (stricter than compat
-      str), intentional improvement per typed-models doctrine.
+      Full parity audit against compat@4d887307: ModelDelegationRequest.task_type widened 3 to 12. All
+      other task_type fields are str in both compat and core, correct. ModelDelegationFallbackPolicy.action/on_exhaust
+      and ModelDelegationBackendConfig.tier are typed Literals in core (stricter than compat str), intentional
+      improvement per typed-models doctrine.
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "echo 'only ModelDelegationRequest.task_type required widening'"
   - id: "dod-deploy-gate"
     description: >
-      Deploy-gate evidence: pure Pydantic Literal type widening in a wire DTO.
-      No Kafka topic schema changes, no new topics, no Docker image rebuild, no runtime
-      process restart, no database migration required.
+      Deploy-gate evidence: pure Pydantic Literal type widening in a wire DTO. No Kafka topic schema changes,
+      no new topics, no Docker image rebuild, no runtime process restart, no database migration required.
     source: "manual"
     checks:
       - check_type: "command"

--- a/src/omnibase_core/validation/baselines/url_authority_baseline.json
+++ b/src/omnibase_core/validation/baselines/url_authority_baseline.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "1.0.0",
+  "count": 13,
+  "violations": [
+    {
+      "repo": "omnibase_core",
+      "path": "examples/demo/handlers/support_assistant/handler_anthropic.py",
+      "rule": "url-const-assignment",
+      "fingerprint": "e1a289119d3d1358f6cdf3e76266f1f160213fff5aec9ae642cb19d5d1101899"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "examples/demo/handlers/support_assistant/handler_local.py",
+      "rule": "url-const-assignment",
+      "fingerprint": "7b0aeac4145d0b5421270aeae6cc022463f5f4406a5dd475ef4d43a7708a3855"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "examples/demo/handlers/support_assistant/handler_openai.py",
+      "rule": "url-const-assignment",
+      "fingerprint": "bf799835300f8665db12abb90ae9f5f4c6d1cdbdc0afcb942879d3d55f7eb753"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "examples/demo/handlers/support_assistant/handler_openai.py",
+      "rule": "public-https-literal",
+      "fingerprint": "f811f1e5a4df1d9c8042299fe2dad0a37cf281b8cd1eae9d51d0ec5399d16547"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "scripts/emit_ts_types.py",
+      "rule": "public-https-literal",
+      "fingerprint": "49517946e67a010743926613607e217192833a4419ede0952411600ad5c303d8"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/doctor/checks/check_linear.py",
+      "rule": "public-https-literal",
+      "fingerprint": "616575581e98efa2826fbfb74e5beaa38214fd40552905067cb655bbdcf34a2a"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/handlers/model_artifact_ref.py",
+      "rule": "public-https-literal",
+      "fingerprint": "0f57ee9e1b9920c058c7e4f119248f0164442f432043087ce6838691331e0026"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/handlers/model_packaging_metadata_ref.py",
+      "rule": "public-https-literal",
+      "fingerprint": "e581c5786f36a9a424cdea11f3afcffe4f5298fba722e67a0ef0c5599bebe612"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/operations/model_change_proposal.py",
+      "rule": "public-https-literal",
+      "fingerprint": "05ff38ee1c4cc26e350a487fb3f54b551cbba9b4e90059929dd0a8efd1a7e7d6"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/operations/model_change_proposal.py",
+      "rule": "public-https-literal",
+      "fingerprint": "bc7c34f657d5f7574faf4c84ee0e1daaa249b170f65cee97f347b21547ecefe1"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/reducer/payloads/model_extension_payloads.py",
+      "rule": "public-https-literal",
+      "fingerprint": "ff358f1228f2c46bce0dce88334a9661c27995a10c1685ca5812e052887617bc"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/reducer/payloads/model_payload_http.py",
+      "rule": "public-https-literal",
+      "fingerprint": "1d271e1c0ec30348f10b437b01be085442b77301f45a9c6b8d0b7e6809ceaad0"
+    },
+    {
+      "repo": "omnibase_core",
+      "path": "src/omnibase_core/models/vector/model_vector_connection_config.py",
+      "rule": "public-https-literal",
+      "fingerprint": "50e72ba0afdcfd2e8ff263e257daecbdf9157327d0f5d0066d29b8b1559205de"
+    }
+  ]
+}

--- a/src/omnibase_core/validation/contracts/url_authority.validation.yaml
+++ b/src/omnibase_core/validation/contracts/url_authority.validation.yaml
@@ -50,23 +50,22 @@ validation:
   rules:
     - rule_id: public-https-literal
       description: >-
-        Rejects quoted https:// URLs to public connection-target hosts outside authority
-        files. Migrate to the routing authority / integration catalog. Suppress with
-        # url-authority-ok: <reason>.
+        Rejects quoted https:// URLs to public connection-target hosts outside authority files. Migrate
+        to the routing authority / integration catalog. Suppress with # url-authority-ok: <reason>.
       severity: error
       enabled: true
 
     - rule_id: env-url-read
       description: >-
-        Rejects os.environ[*_URL] / os.environ.get(*_ENDPOINT) reads that bypass the
-        contract-driven routing authority. Resolve from contract model_routing instead.
+        Rejects os.environ[*_URL] / os.environ.get(*_ENDPOINT) reads that bypass the contract-driven routing
+        authority. Resolve from contract model_routing instead.
       severity: error
       enabled: true
 
     - rule_id: url-const-assignment
       description: >-
-        Rejects module-level *_URL / *_ENDPOINT constants assigned from os.environ or a
-        bare https:// literal. Declare in contract YAML and resolve via routing authority.
+        Rejects module-level *_URL / *_ENDPOINT constants assigned from os.environ or a bare https://
+        literal. Declare in contract YAML and resolve via routing authority.
       severity: error
       enabled: true
 

--- a/src/omnibase_core/validation/contracts/url_authority.validation.yaml
+++ b/src/omnibase_core/validation/contracts/url_authority.validation.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+contract_kind: validation_subcontract
+validation:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  validator_id: url_authority
+  validator_name: URL Authority Validator
+  validator_description: |
+    Rejects NEW URL/endpoint literals outside contracts (OMN-12818, PR-2 of OMN-12803).
+
+    Every URL and *_URL / *_ENDPOINT env read must resolve from a contract
+    (routing authority / integration catalog), not a bare literal or env var.
+
+    Three rules:
+    - public-https-literal: quoted https:// URLs to public hosts (connection targets only)
+    - env-url-read: os.environ[*_URL] / os.environ.get(*_ENDPOINT) reads
+    - url-const-assignment: module-constant assignments from os.environ or https:// literal
+
+    Existing violations are grandfathered by content fingerprint (ratchet baseline).
+    Only NEW fingerprints fail the gate. Baseline is burn-down only.
+
+    Migration debt tickets:
+      omnibase_core:        OMN-12806
+      omnibase_infra:       OMN-12807
+      other repos:          OMN-12808
+
+    Suppression: # url-authority-ok: <reason>
+
+  target_patterns:
+    - "**/*.py"
+
+  exclude_patterns:
+    - "**/tests/**"
+    - "**/test_*.py"
+    - "**/*_test.py"
+    - "**/__pycache__/**"
+    - "**/.git/**"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+    - "**/venv/**"
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/dod_receipts/**"
+    - "**/evidence/**"
+
+  rules:
+    - rule_id: public-https-literal
+      description: >-
+        Rejects quoted https:// URLs to public connection-target hosts outside authority
+        files. Migrate to the routing authority / integration catalog. Suppress with
+        # url-authority-ok: <reason>.
+      severity: error
+      enabled: true
+
+    - rule_id: env-url-read
+      description: >-
+        Rejects os.environ[*_URL] / os.environ.get(*_ENDPOINT) reads that bypass the
+        contract-driven routing authority. Resolve from contract model_routing instead.
+      severity: error
+      enabled: true
+
+    - rule_id: url-const-assignment
+      description: >-
+        Rejects module-level *_URL / *_ENDPOINT constants assigned from os.environ or a
+        bare https:// literal. Declare in contract YAML and resolve via routing authority.
+      severity: error
+      enabled: true
+
+  suppression_comments:
+    - "# url-authority-ok:"
+    - "# contract-config-ok:"
+
+  fail_on_error: true
+  fail_on_warning: false
+  max_violations: 0
+  severity_default: error
+  parallel_execution: true

--- a/src/omnibase_core/validation/validator_url_authority.py
+++ b/src/omnibase_core/validation/validator_url_authority.py
@@ -1,0 +1,663 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorUrlAuthority — reject new URL/endpoint literals outside contracts.
+
+Part of OMN-12803 (PR-2, the enforcement gate). Every URL and ``*_URL`` /
+``*_ENDPOINT`` env read must resolve from a contract (routing authority /
+integration catalog), not a literal string or a bare env read.
+
+Detects three classes of violations in Python source files:
+
+1. **public-https-literal** — a quoted ``https://`` URL targeting a public
+   host with a dotted TLD.  Excludes localhost/loopback, example placeholders,
+   VCS display permalinks, and JSON-schema refs (audit cosmetic-exclusion
+   class 1K).
+
+2. **env-url-read** — ``os.environ[...]`` subscript or ``os.environ.get(...)``
+   call whose variable NAME ends in ``_URL`` or ``_ENDPOINT``.  API-key /
+   token / secret variable names do NOT end in those suffixes and remain legal.
+
+3. **url-const-assignment** — module-level constant assignment whose name
+   ends in ``URL`` or ``ENDPOINT``, sourced from ``os.environ`` or a bare
+   ``https://`` literal.
+
+Ratchet (OMN-12818, mirrors OMN-12791 receipt-honesty gate): existing
+violations are grandfathered by content fingerprint (sha256 of {repo, path,
+normalized-snippet}).  Only NEW fingerprints fail the gate.  The baseline may
+only shrink — the ``--update-baseline`` / ``--seed`` modes enforce the
+burn-down invariant.
+
+Baseline per repo lives at:
+``src/omnibase_core/validation/baselines/url_authority_baseline.json``
+
+Usage Examples:
+    Programmatic usage::
+
+        from omnibase_core.validation import ValidatorUrlAuthority
+
+        v = ValidatorUrlAuthority()
+        result = v.validate(Path("src/"))
+        if not result.is_valid:
+            for issue in result.issues:
+                print(f"{issue.file_path}:{issue.line_number}: {issue.message}")
+
+    CLI — pre-commit (staged files)::
+
+        python -m omnibase_core.validation.validator_url_authority file1.py ...
+
+    CLI — full repo scan (CI)::
+
+        python -m omnibase_core.validation.validator_url_authority --all \\
+            --repo omnibase_core --repo-root .
+
+    CLI — seed / update baseline::
+
+        python -m omnibase_core.validation.validator_url_authority \\
+            --seed --repo omnibase_core --repo-root .
+
+Suppression:
+    Add ``# url-authority-ok: <reason>`` on the offending line.
+    Config-PATH env reads annotated with ``# contract-config-ok:`` are also exempt.
+
+Migration debt tickets:
+    - omnibase_core: OMN-12806
+    - omnibase_infra: OMN-12807
+    - other repos: OMN-12808
+
+Schema Version:
+    v1.0.0 - Initial version (OMN-12818)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import ClassVar, Final
+
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.validation.validator_base import ValidatorBase
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+# ---------------------------------------------------------------------------
+
+# 1. Public HTTPS endpoint literal.  Connection-target scope only: excludes
+#    localhost/loopback, example/placeholder hosts, VCS display permalinks,
+#    JSON-schema refs, and raw-content refs (audit cosmetic-exclusion class 1K).
+_PUBLIC_HTTPS_LITERAL: Final[re.Pattern[str]] = re.compile(
+    r"""["']https://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}(?:[/"':]|$)""",
+    re.IGNORECASE,
+)
+
+# Hosts/paths that are NOT connection targets (excluded from the public-https rule).
+_NON_ENDPOINT_MARKERS: Final[tuple[str, ...]] = (
+    "example.com",
+    "example.org",
+    ".invalid",
+    "://github.com/",  # display permalinks; api.github.com IS matched
+    "://gitlab.com/",
+    "raw.githubusercontent.com",
+    "$schema",
+    "schemastore.org",
+    "json-schema.org",
+    "w3.org",
+    "spdx.org",
+)
+
+# 2. ``*_URL`` / ``*_ENDPOINT`` env read.
+_ENV_URL_READ: Final[re.Pattern[str]] = re.compile(
+    r"""os\.environ(?:\.get\(\s*|\[\s*)["'][A-Z0-9_]*(?:_URL|_ENDPOINT)["']""",
+)
+
+# 3. ``*_URL`` / ``*_ENDPOINT`` module-constant assignment.
+_CONST_URL_FROM_ENV: Final[re.Pattern[str]] = re.compile(
+    r"""^[A-Z0-9_]*(?:URL|ENDPOINT)[A-Z0-9_]*\s*=\s*os\.environ""",
+)
+_CONST_URL_FROM_LITERAL: Final[re.Pattern[str]] = re.compile(
+    r"""^[A-Z0-9_]*(?:URL|ENDPOINT)[A-Z0-9_]*\s*=\s*["']https?://""",
+)
+
+# Suppression annotations.
+_SUPPRESS_ANNOTATION: Final[str] = "# url-authority-ok:"
+_CONFIG_PATH_ANNOTATION: Final[str] = "# contract-config-ok:"
+
+# Authority files: the URL literals inside them ARE canonical — skip.
+_AUTHORITY_PATH_SUFFIXES: Final[tuple[str, ...]] = (
+    "configs/bifrost_delegation.yaml",
+    "contracts/integrations/catalog.yaml",
+)
+
+# Rule identifiers (must match the validation contract).
+RULE_PUBLIC_HTTPS: Final[str] = "public-https-literal"
+RULE_ENV_URL_READ: Final[str] = "env-url-read"
+RULE_CONST_ASSIGNMENT: Final[str] = "url-const-assignment"
+
+# Directories excluded from full-tree scans.
+_EXCLUDED_PARTS: Final[frozenset[str]] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        "dist",
+        "build",
+        "dod_receipts",
+        "evidence",
+        ".onex_state",
+    }
+)
+
+# Default baseline path (relative to this file's parent → baselines/ subdir).
+_DEFAULT_BASELINE: Final[Path] = (
+    Path(__file__).parent / "baselines" / "url_authority_baseline.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class ModelUrlAuthorityViolation(BaseModel):
+    """A single url-authority finding with a content fingerprint for the ratchet."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str
+    path: str
+    line: int
+    rule: str
+    snippet: str
+    fingerprint: str
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(snippet: str) -> str:
+    """Normalize the offending snippet for a stable, line-number-independent hash."""
+    return re.sub(r"\s+", " ", snippet.strip())
+
+
+def make_fingerprint(repo: str, path: str, snippet: str) -> str:
+    """sha256({repo}\\0{path}\\0{normalized-snippet}) — survives unrelated edits."""
+    payload = f"{repo}\0{path}\0{_normalize(snippet)}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Per-line matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_authority_path(path: str) -> bool:
+    """True when the file IS a URL authority (its literals are canonical)."""
+    norm = path.replace("\\", "/")
+    return any(norm.endswith(suffix) for suffix in _AUTHORITY_PATH_SUFFIXES)
+
+
+def _is_test_path(path: str) -> bool:
+    lowered = path.lower()
+    return "test" in lowered or "conftest" in lowered
+
+
+def _is_connection_target(raw_line: str) -> bool:
+    """True when an https literal is a real connection endpoint, not a placeholder."""
+    lowered = raw_line.lower()
+    if any(marker in lowered for marker in _NON_ENDPOINT_MARKERS):
+        return False
+    # Heuristic: the line is (part of) a JSON-object literal, not an assignment.
+    stripped = raw_line.strip()
+    if stripped.startswith(("{", '{"')) or '":{"' in stripped:
+        return False
+    return True
+
+
+def _match_rule(raw_line: str, stripped: str) -> str | None:
+    """Return the first matching rule id for a line, or None."""
+    if _ENV_URL_READ.search(raw_line):
+        return RULE_ENV_URL_READ
+    if _CONST_URL_FROM_ENV.match(stripped) or _CONST_URL_FROM_LITERAL.match(stripped):
+        return RULE_CONST_ASSIGNMENT
+    if _PUBLIC_HTTPS_LITERAL.search(raw_line) and _is_connection_target(raw_line):
+        return RULE_PUBLIC_HTTPS
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Source scanner
+# ---------------------------------------------------------------------------
+
+
+def scan_source(repo: str, path: str, source: str) -> list[ModelUrlAuthorityViolation]:
+    """Scan one source file's text for url-authority violations.
+
+    Test files and authority files are skipped.  Lines carrying
+    ``# url-authority-ok:`` or (for env reads) ``# contract-config-ok:`` are
+    suppressed.  Returns at most one violation per line.
+
+    Args:
+        repo: Repo name used in fingerprints (e.g. ``"omnibase_core"``).
+        path: Repo-relative path for fingerprints (e.g. ``"src/pkg/file.py"``).
+        source: Full source text of the file.
+
+    Returns:
+        List of violations found in the file.
+    """
+    if _is_test_path(path) or _is_authority_path(path):
+        return []
+
+    violations: list[ModelUrlAuthorityViolation] = []
+    for index, raw_line in enumerate(source.splitlines(), start=1):
+        stripped = raw_line.strip()
+        # Skip blank, comment-only, and docstring lines (triple-quoted blocks
+        # holding URLs are documentation, not connection targets).
+        if not stripped or stripped.startswith(("#", '"""', "'''")):
+            continue
+        if _SUPPRESS_ANNOTATION in raw_line:
+            continue
+
+        rule = _match_rule(raw_line, stripped)
+        if rule is None:
+            continue
+        # Config-PATH env reads annotated with contract-config-ok are exempt.
+        if rule == RULE_ENV_URL_READ and _CONFIG_PATH_ANNOTATION in raw_line:
+            continue
+
+        snippet = stripped[:200]
+        violations.append(
+            ModelUrlAuthorityViolation(
+                repo=repo,
+                path=path,
+                line=index,
+                rule=rule,
+                snippet=snippet,
+                fingerprint=make_fingerprint(repo, path, snippet),
+            )
+        )
+    return violations
+
+
+def scan_tree(repo: str, repo_root: Path) -> list[ModelUrlAuthorityViolation]:
+    """Scan all ``*.py`` under ``repo_root`` for url-authority violations.
+
+    Paths in the returned violations are repo-relative so fingerprints are
+    machine-independent.  Excludes vendored, build, test, and evidence dirs.
+
+    Args:
+        repo: Repo name for fingerprints.
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        Sorted list of violations.
+    """
+    violations: list[ModelUrlAuthorityViolation] = []
+    for py in sorted(repo_root.rglob("*.py")):
+        if set(py.parts) & _EXCLUDED_PARTS:
+            continue
+        if _is_test_path(py.name):
+            continue
+        try:
+            source = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            rel = str(py.relative_to(repo_root))
+        except ValueError:
+            rel = str(py)
+        violations.extend(scan_source(repo, rel, source))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Ratchet baseline helpers
+# ---------------------------------------------------------------------------
+
+
+def load_baseline(baseline_path: Path) -> set[str]:
+    """Load the frozen fingerprint set from the baseline JSON.  Missing file = empty."""
+    if not baseline_path.exists():
+        return set()
+    data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    entries = data.get("violations", []) if isinstance(data, dict) else []
+    return {
+        str(e["fingerprint"])
+        for e in entries
+        if isinstance(e, dict) and "fingerprint" in e
+    }
+
+
+def partition_against_baseline(
+    violations: list[ModelUrlAuthorityViolation],
+    baseline_fingerprints: set[str],
+) -> tuple[list[ModelUrlAuthorityViolation], list[ModelUrlAuthorityViolation]]:
+    """Split violations into (new, grandfathered) by baseline membership.
+
+    Returns:
+        Tuple of (new_violations, grandfathered_violations).  New violations
+        fail the gate; grandfathered ones pass.
+    """
+    new: list[ModelUrlAuthorityViolation] = []
+    grandfathered: list[ModelUrlAuthorityViolation] = []
+    for v in violations:
+        if v.fingerprint in baseline_fingerprints:
+            grandfathered.append(v)
+        else:
+            new.append(v)
+    return new, grandfathered
+
+
+def assert_baseline_shrinks_only(before: set[str], after: set[str]) -> None:
+    """Anti-gaming: the baseline may shrink (burn-down) but never grow.
+
+    Raises:
+        ValueError: If ``after`` introduces fingerprints not present in ``before``.
+    """
+    added = after - before
+    if added:
+        raise ValueError(
+            "url-authority baseline grew: "
+            f"{len(added)} new fingerprint(s) added. The baseline is burn-down only "
+            "— fix the violation or annotate with # url-authority-ok:, never add it "
+            "to the baseline. Offending fingerprints: "
+            f"{sorted(added)[:5]}"
+        )
+
+
+def serialize_baseline(
+    violations: list[ModelUrlAuthorityViolation],
+) -> dict[str, object]:
+    """Build the on-disk baseline document — sorted, deterministic, fingerprint-keyed."""
+    entries: list[dict[str, str]] = sorted(
+        (
+            {
+                "repo": v.repo,
+                "path": v.path,
+                "rule": v.rule,
+                "fingerprint": v.fingerprint,
+            }
+            for v in violations
+        ),
+        key=lambda e: (e["repo"], e["path"], e["fingerprint"]),
+    )
+    seen: set[str] = set()
+    unique: list[dict[str, str]] = []
+    for e in entries:
+        fp = e["fingerprint"]
+        if fp in seen:
+            continue
+        seen.add(fp)
+        unique.append(e)
+    return {"schema_version": "1.0.0", "count": len(unique), "violations": unique}
+
+
+# ---------------------------------------------------------------------------
+# ValidatorBase subclass
+# ---------------------------------------------------------------------------
+
+
+class ValidatorUrlAuthority(ValidatorBase):
+    """Reject NEW URL/endpoint literals outside contracts.
+
+    Wraps the url-authority ratchet as a standard ValidatorBase subclass so it
+    participates in the ecosystem-wide validation pipeline (pre-commit hooks,
+    CI required checks, cross-repo wiring).
+
+    The validator ONLY reports violations that are NEW (not in the per-repo
+    baseline).  Existing (grandfathered) violations are silently skipped until
+    they are fixed and the baseline is shrunk.
+
+    See migration debt tickets OMN-12806 (omnibase_core), OMN-12807
+    (omnibase_infra), OMN-12808 (other repos).
+    """
+
+    validator_id: ClassVar[str] = "url_authority"
+
+    def __init__(
+        self,
+        contract: ModelValidatorSubcontract | None = None,
+        repo: str = "omnibase_core",
+        baseline_path: Path | None = None,
+        repo_root: Path | None = None,
+    ) -> None:
+        super().__init__(contract=contract)
+        self._repo = repo
+        self._baseline_path = baseline_path or _DEFAULT_BASELINE
+        self._baseline: set[str] | None = None
+        # repo_root anchors fingerprints to a stable repo-relative path.
+        # When None, the absolute path is used (consistent per machine run).
+        self._repo_root = repo_root
+
+    def _get_baseline(self) -> set[str]:
+        if self._baseline is None:
+            self._baseline = load_baseline(self._baseline_path)
+        return self._baseline
+
+    def _validate_file(
+        self,
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        if path.suffix not in {".py"}:
+            return ()
+
+        # Determine repo-relative path for stable fingerprints.
+        if self._repo_root is not None:
+            try:
+                rel = str(path.relative_to(self._repo_root))
+            except ValueError:
+                rel = path.name
+        else:
+            rel = path.name
+
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ()
+
+        raw_violations = scan_source(self._repo, rel, source)
+        baseline = self._get_baseline()
+        new, _ = partition_against_baseline(raw_violations, baseline)
+
+        issues: list[ModelValidationIssue] = []
+        for v in new:
+            enabled, severity = self._get_rule_config(v.rule, contract)
+            if not enabled:
+                continue
+            issues.append(
+                ModelValidationIssue(
+                    severity=severity,
+                    message=(
+                        f"url-authority violation [{v.rule}]: {v.snippet!r} — "
+                        "migrate to the routing authority/integration catalog, or "
+                        "annotate # url-authority-ok: <reason>"
+                    ),
+                    code=v.rule,
+                    file_path=path,
+                    line_number=v.line,
+                    rule_name=v.rule,
+                )
+            )
+        return tuple(issues)
+
+
+# ---------------------------------------------------------------------------
+# CLI — pre-commit hook + CI gate
+# ---------------------------------------------------------------------------
+
+
+def _err(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+
+
+def _out(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+
+
+def _update_baseline(
+    repo: str, repo_root: Path, baseline_path: Path, *, seed: bool
+) -> int:
+    """Regenerate this repo's baseline subset (burn-down only)."""
+    prior_entries: list[dict[str, str]] = []
+    if baseline_path.exists():
+        data = json.loads(baseline_path.read_text(encoding="utf-8"))
+        all_entries = data.get("violations", []) if isinstance(data, dict) else []
+        prior_entries = [
+            e for e in all_entries if isinstance(e, dict) and "fingerprint" in e
+        ]
+    repo_before = {e["fingerprint"] for e in prior_entries if e.get("repo") == repo}
+    other_entries = [e for e in prior_entries if e.get("repo") != repo]
+
+    fresh_violations = scan_tree(repo, repo_root)
+    fresh: list[dict[str, str]] = [
+        {
+            "repo": v.repo,
+            "path": v.path,
+            "rule": v.rule,
+            "fingerprint": v.fingerprint,
+        }
+        for v in fresh_violations
+    ]
+    repo_after = {e["fingerprint"] for e in fresh}
+
+    if not seed:
+        try:
+            assert_baseline_shrinks_only(repo_before, repo_after)
+        except ValueError as exc:
+            _err(f"URL-AUTHORITY BASELINE REJECTED: {exc}")
+            return 1
+
+    merged = sorted(
+        [*other_entries, *fresh],
+        key=lambda e: (e["repo"], e["path"], e["fingerprint"]),
+    )
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps(
+            {"schema_version": "1.0.0", "count": len(merged), "violations": merged},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    action = "seeded" if seed else f"burned down {len(repo_before) - len(repo_after)}"
+    _out(
+        f"URL-AUTHORITY BASELINE updated for {repo}: {len(repo_after)} violation(s) "
+        f"({action}). Total across repos: {len(merged)}."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Staged-files mode (pre-commit): pass file paths as positional args.
+    Full-repo mode (CI): pass ``--all --repo <name> --repo-root <path>``.
+    Baseline update: pass ``--seed`` or ``--update-baseline``.
+
+    Exit codes:
+        0 — no new violations (or grandfathered-only)
+        1 — new violation(s) found or baseline grew
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="check-url-authority",
+        description="url-authority ratchet gate (OMN-12818).",
+    )
+    parser.add_argument(
+        "paths", nargs="*", help="Explicit files to scan (staged set, pre-commit mode)."
+    )
+    parser.add_argument(
+        "--repo", default="omnibase_core", help="Repo name for fingerprints."
+    )
+    parser.add_argument(
+        "--repo-root", default=".", help="Repo root for repo-relative paths."
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Full-repo scan (CI mode) instead of explicit staged files.",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Regenerate this repo's baseline subset (burn-down only).",
+    )
+    parser.add_argument(
+        "--seed",
+        action="store_true",
+        help="One-time initialization of this repo's baseline subset (no shrink check).",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=str(_DEFAULT_BASELINE),
+        help="Path to the baseline JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    baseline_path = Path(args.baseline)
+
+    if args.update_baseline or args.seed:
+        return _update_baseline(args.repo, repo_root, baseline_path, seed=args.seed)
+
+    if args.all:
+        violations = scan_tree(args.repo, repo_root)
+    else:
+        if not args.paths:
+            _out("URL-AUTHORITY GATE: no files to scan.")
+            return 0
+        violations = []
+        for raw in args.paths:
+            p = Path(raw)
+            if not p.is_file() or p.suffix != ".py":
+                continue
+            try:
+                source = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            try:
+                rel = str(p.resolve().relative_to(repo_root.resolve()))
+            except ValueError:
+                rel = str(p)
+            violations.extend(scan_source(args.repo, rel, source))
+
+    baseline = load_baseline(baseline_path)
+    new, grandfathered = partition_against_baseline(violations, baseline)
+
+    if new:
+        _err(
+            f"URL-AUTHORITY GATE FAILED: {len(new)} NEW violation(s) — every URL must "
+            "resolve from a contract (routing authority / integration catalog), not a "
+            "literal or a *_URL/*_ENDPOINT env read.\n"
+        )
+        for v in new:
+            _err(f"  [{v.rule}] {v.repo}/{v.path}:{v.line}")
+            _err(f"    {v.snippet}")
+            _err(
+                "    -> migrate to the resolver, or annotate "
+                "# url-authority-ok: <reason>"
+            )
+        return 1
+
+    _out(
+        f"URL-AUTHORITY GATE PASSED: 0 new violations "
+        f"({len(grandfathered)} grandfathered)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validation/test_validator_url_authority.py
+++ b/tests/unit/validation/test_validator_url_authority.py
@@ -1,0 +1,528 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ValidatorUrlAuthority (OMN-12818).
+
+Covers:
+- Detection of all three violation classes (public-https-literal, env-url-read,
+  url-const-assignment)
+- Suppression annotations (# url-authority-ok:, # contract-config-ok:)
+- Authority-path and test-path exclusions
+- Ratchet: new fingerprints fail, grandfathered fingerprints pass
+- Baseline helpers: load_baseline, serialize_baseline, assert_baseline_shrinks_only
+- ValidatorBase integration (validate() returns ModelValidationResult)
+- CLI entry point: --all, staged-files, exit codes
+- Synthetic violation proves gate goes RED on new URL literal
+- Baselined tip proves gate stays GREEN when fingerprint is in baseline
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_severity import EnumSeverity
+from omnibase_core.models.contracts.subcontracts.model_validator_rule import (
+    ModelValidatorRule,
+)
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.validation.validator_url_authority import (
+    RULE_CONST_ASSIGNMENT,
+    RULE_ENV_URL_READ,
+    RULE_PUBLIC_HTTPS,
+    ValidatorUrlAuthority,
+    assert_baseline_shrinks_only,
+    load_baseline,
+    make_fingerprint,
+    partition_against_baseline,
+    scan_source,
+    scan_tree,
+    serialize_baseline,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, content: str, name: str = "mod.py") -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _baseline_with(fingerprints: set[str], tmp_path: Path) -> Path:
+    b = tmp_path / "baseline.json"
+    entries = [
+        {"repo": "r", "path": "p", "rule": "public-https-literal", "fingerprint": fp}
+        for fp in fingerprints
+    ]
+    b.write_text(
+        json.dumps(
+            {"schema_version": "1.0.0", "count": len(entries), "violations": entries}
+        ),
+        encoding="utf-8",
+    )
+    return b
+
+
+def _open_contract() -> ModelValidatorSubcontract:
+    """Minimal contract with all three url-authority rules enabled and no excludes.
+
+    Used in ValidatorBase integration tests to avoid the default contract's
+    exclude_patterns accidentally matching pytest temp directory names.
+    """
+    return ModelValidatorSubcontract(
+        version=ModelSemVer(major=1, minor=0, patch=0),
+        validator_id="url_authority",
+        validator_name="Test",
+        validator_description="Test",
+        target_patterns=["**/*.py"],
+        exclude_patterns=[],
+        suppression_comments=["# url-authority-ok:", "# contract-config-ok:"],
+        fail_on_error=True,
+        fail_on_warning=False,
+        severity_default=EnumSeverity.ERROR,
+        rules=[
+            ModelValidatorRule(
+                rule_id=RULE_PUBLIC_HTTPS,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+            ModelValidatorRule(
+                rule_id=RULE_ENV_URL_READ,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+            ModelValidatorRule(
+                rule_id=RULE_CONST_ASSIGNMENT,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: scan_source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScanSource:
+    def test_public_https_literal_detected(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_PUBLIC_HTTPS
+
+    def test_env_url_read_detected(self) -> None:
+        src = 'base = os.environ["MY_SERVICE_URL"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_ENV_URL_READ
+
+    def test_env_url_read_get_detected(self) -> None:
+        src = 'base = os.environ.get("DOWNSTREAM_ENDPOINT", "")\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_ENV_URL_READ
+
+    def test_const_url_from_env_detected(self) -> None:
+        # env-url-read fires before url-const-assignment when the line contains
+        # both an os.environ[...] read AND a *_URL variable name — only one
+        # violation per line is reported (the first matching rule wins).
+        src = 'BASE_URL = os.environ["BASE_URL"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule in (RULE_CONST_ASSIGNMENT, RULE_ENV_URL_READ)
+
+    def test_const_url_from_literal_detected(self) -> None:
+        src = 'API_ENDPOINT = "https://api.service.io/v2"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_CONST_ASSIGNMENT
+
+    def test_env_url_read_not_matched_for_api_key(self) -> None:
+        src = 'key = os.environ["LINEAR_API_KEY"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_env_url_read_not_matched_for_token(self) -> None:
+        src = 'tok = os.environ["GITHUB_TOKEN"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_comment_only_line_skipped(self) -> None:
+        src = "# https://api.example-service.com/v1\n"
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_suppression_annotation_clears(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"  # url-authority-ok: legacy\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_config_path_annotation_clears_env_read(self) -> None:
+        src = 'path = os.environ.get("CONTRACT_URL", "")  # contract-config-ok: path\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_example_host_excluded(self) -> None:
+        src = 'x = "https://example.com/api"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_github_permalink_excluded(self) -> None:
+        src = 'link = "https://github.com/OmniNode-ai/omnibase_core/pull/123"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_api_github_com_matched(self) -> None:
+        # api.github.com is a connection target; github.com display links are not
+        src = 'url = "https://api.github.com/repos"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_PUBLIC_HTTPS
+
+    def test_test_path_skipped(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs = scan_source("r", "tests/test_something.py", src)
+        assert vs == []
+
+    def test_authority_path_skipped(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs = scan_source("r", "configs/bifrost_delegation.yaml", src)
+        assert vs == []
+
+    def test_schema_ref_excluded(self) -> None:
+        src = 'schema = "https://json-schema.org/draft/2020-12/schema"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs1 = scan_source("r", "src/pkg/a.py", src)
+        vs2 = scan_source("r", "src/pkg/a.py", src)
+        assert vs1[0].fingerprint == vs2[0].fingerprint
+
+    def test_fingerprint_changes_with_snippet(self) -> None:
+        src1 = 'url = "https://api.example-service.com/v1"\n'
+        src2 = 'url = "https://api.different-host.com/v1"\n'
+        v1 = scan_source("r", "src/pkg/a.py", src1)[0]
+        v2 = scan_source("r", "src/pkg/a.py", src2)[0]
+        assert v1.fingerprint != v2.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Unit: ratchet helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRatchet:
+    def test_partition_new_vs_grandfathered(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        fp = vs[0].fingerprint
+
+        new, grand = partition_against_baseline(vs, {fp})
+        assert new == []
+        assert len(grand) == 1
+
+        new2, grand2 = partition_against_baseline(vs, set())
+        assert len(new2) == 1
+        assert grand2 == []
+
+    def test_assert_baseline_shrinks_only_pass(self) -> None:
+        # Shrinking is allowed
+        assert_baseline_shrinks_only({"a", "b"}, {"a"})
+
+    def test_assert_baseline_shrinks_only_same(self) -> None:
+        # Staying same is allowed
+        assert_baseline_shrinks_only({"a"}, {"a"})
+
+    def test_assert_baseline_shrinks_only_fails_on_growth(self) -> None:
+        with pytest.raises(ValueError, match="grew"):
+            assert_baseline_shrinks_only({"a"}, {"a", "b"})
+
+    def test_load_baseline_missing_file(self, tmp_path: Path) -> None:
+        result = load_baseline(tmp_path / "missing.json")
+        assert result == set()
+
+    def test_load_baseline_reads_fingerprints(self, tmp_path: Path) -> None:
+        b = _baseline_with({"abc123", "def456"}, tmp_path)
+        result = load_baseline(b)
+        assert result == {"abc123", "def456"}
+
+    def test_serialize_baseline_deduplicates(self) -> None:
+        src = 'url = "https://api.example-service.com/v1"\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        # Duplicate the same violation
+        doc = serialize_baseline(vs + vs)
+        assert doc["count"] == 1
+
+    def test_make_fingerprint_stable(self) -> None:
+        fp1 = make_fingerprint("repo", "path/to/file.py", 'url = "https://api.svc.com"')
+        fp2 = make_fingerprint("repo", "path/to/file.py", 'url = "https://api.svc.com"')
+        assert fp1 == fp2
+
+    def test_make_fingerprint_whitespace_normalized(self) -> None:
+        fp1 = make_fingerprint("r", "p", 'url  =  "https://api.svc.com"')
+        fp2 = make_fingerprint("r", "p", 'url = "https://api.svc.com"')
+        assert fp1 == fp2
+
+
+# ---------------------------------------------------------------------------
+# Integration: ValidatorUrlAuthority (ValidatorBase subclass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorUrlAuthorityIntegration:
+    def test_synthetic_violation_gate_red(self, tmp_path: Path) -> None:
+        """Synthetic URL env literal — gate must be RED (new fingerprint).
+
+        Uses an open contract (no exclude_patterns) so pytest temp dirs with
+        'test' in their name don't accidentally suppress the file.
+        """
+        f = _write(
+            tmp_path, 'BASE_URL = "https://api.totally-new-host.io/v1"\n', "src/m.py"
+        )
+        empty_baseline = tmp_path / "baseline.json"
+        empty_baseline.write_text(
+            json.dumps({"schema_version": "1.0.0", "count": 0, "violations": []}),
+            encoding="utf-8",
+        )
+
+        v = ValidatorUrlAuthority(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=empty_baseline,
+        )
+        result = v.validate_file(f)
+        assert not result.is_valid, f"Expected RED but got: {result.issues}"
+        assert len(result.issues) == 1
+        assert result.issues[0].code in (RULE_CONST_ASSIGNMENT, RULE_PUBLIC_HTTPS)
+
+    def test_baselined_violation_gate_green(self, tmp_path: Path) -> None:
+        """Baselined tip — gate must stay GREEN (fingerprint in baseline).
+
+        repo_root=tmp_path ensures the validator computes the same repo-relative
+        path ('src/m.py') that make_fingerprint uses here.
+        """
+        snippet = 'BASE_URL = "https://api.totally-new-host.io/v1"'
+        f = _write(tmp_path, snippet + "\n", "src/m.py")
+        fp = make_fingerprint("test_repo", "src/m.py", snippet)
+        baseline_path = _baseline_with({fp}, tmp_path)
+
+        v = ValidatorUrlAuthority(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=baseline_path,
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(f)
+        assert result.is_valid, f"Expected green but got: {result.issues}"
+
+    def test_suppressed_line_gate_green(self, tmp_path: Path) -> None:
+        """Suppressed line — gate stays GREEN regardless of baseline."""
+        f = _write(
+            tmp_path,
+            'BASE_URL = "https://api.service.com/v1"  # url-authority-ok: legacy-migration\n',
+            "src/m.py",
+        )
+        empty_baseline = tmp_path / "baseline.json"
+        empty_baseline.write_text(
+            json.dumps({"schema_version": "1.0.0", "count": 0, "violations": []}),
+            encoding="utf-8",
+        )
+
+        v = ValidatorUrlAuthority(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=empty_baseline,
+        )
+        result = v.validate_file(f)
+        assert result.is_valid
+
+    def test_validator_id(self) -> None:
+        assert ValidatorUrlAuthority.validator_id == "url_authority"
+
+    def test_multiple_rules_reported(self, tmp_path: Path) -> None:
+        """Multiple violation types in one file are all reported."""
+        src = textwrap.dedent(
+            """\
+            import os
+            API_URL = os.environ["REMOTE_URL"]
+            KEY = os.environ["API_KEY"]
+            PUBLIC_ENDPOINT = "https://api.service.io/v1"
+            """
+        )
+        f = _write(tmp_path, src, "src/m.py")
+        empty_baseline = tmp_path / "baseline.json"
+        empty_baseline.write_text(
+            json.dumps({"schema_version": "1.0.0", "count": 0, "violations": []}),
+            encoding="utf-8",
+        )
+        v = ValidatorUrlAuthority(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=empty_baseline,
+        )
+        result = v.validate_file(f)
+        assert not result.is_valid
+        # API_KEY read is NOT a violation; REMOTE_URL and PUBLIC_ENDPOINT are
+        codes = {i.code for i in result.issues}
+        assert RULE_ENV_URL_READ in codes or RULE_CONST_ASSIGNMENT in codes
+
+
+# ---------------------------------------------------------------------------
+# Integration: scan_tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScanTree:
+    def test_scan_tree_finds_violations(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        f = tmp_path / "src" / "module.py"
+        f.write_text('url = "https://api.example-service.com/v1"\n', encoding="utf-8")
+        vs = scan_tree("r", tmp_path)
+        assert any(v.path.endswith("module.py") for v in vs)
+
+    def test_scan_tree_excludes_tests(self, tmp_path: Path) -> None:
+        (tmp_path / "tests").mkdir()
+        f = tmp_path / "tests" / "test_m.py"
+        f.write_text('url = "https://api.example-service.com/v1"\n', encoding="utf-8")
+        vs = scan_tree("r", tmp_path)
+        assert vs == []
+
+    def test_scan_tree_uses_relative_paths(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        f = tmp_path / "src" / "pkg.py"
+        f.write_text('url = "https://api.example-service.com/v1"\n', encoding="utf-8")
+        vs = scan_tree("r", tmp_path)
+        # Paths must be relative (no absolute prefix)
+        for v in vs:
+            assert not v.path.startswith("/")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCLI:
+    def test_no_files_exit_0(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from omnibase_core.validation.validator_url_authority import main
+
+        rc = main([])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "no files" in captured.out.lower()
+
+    def test_new_violation_exit_1(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_url_authority import main
+
+        f = _write(tmp_path, 'BASE_URL = "https://api.new-host.io/v1"\n', "mod.py")
+        baseline = tmp_path / "baseline.json"
+        baseline.write_text(
+            json.dumps({"schema_version": "1.0.0", "count": 0, "violations": []}),
+            encoding="utf-8",
+        )
+        rc = main(
+            [
+                str(f),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(baseline),
+            ]
+        )
+        assert rc == 1
+
+    def test_grandfathered_violation_exit_0(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_url_authority import main
+
+        snippet = 'BASE_URL = "https://api.new-host.io/v1"'
+        f = _write(tmp_path, snippet + "\n", "mod.py")
+        fp = make_fingerprint("r", "mod.py", snippet)
+        baseline = _baseline_with({fp}, tmp_path)
+        rc = main(
+            [
+                str(f),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(baseline),
+            ]
+        )
+        assert rc == 0
+
+    def test_seed_creates_baseline(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_url_authority import main
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "m.py").write_text(
+            'url = "https://api.example-service.com/v1"\n', encoding="utf-8"
+        )
+        baseline = tmp_path / "baseline.json"
+        rc = main(
+            [
+                "--seed",
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(baseline),
+            ]
+        )
+        assert rc == 0
+        assert baseline.exists()
+        data = json.loads(baseline.read_text())
+        assert data["count"] >= 1
+
+    def test_update_baseline_rejects_growth(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_url_authority import main
+
+        # Baseline has one fingerprint; repo has a different one (growing the set)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "m.py").write_text(
+            'url = "https://api.example-service.com/v1"\n', encoding="utf-8"
+        )
+        # Pre-seed so baseline has a DIFFERENT fingerprint
+        pre_seed_fp = make_fingerprint(
+            "r", "src/fake.py", "FAKE_URL = os.environ['X_URL']"
+        )
+        baseline = _baseline_with({pre_seed_fp}, tmp_path)
+        rc = main(
+            [
+                "--update-baseline",
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(baseline),
+            ]
+        )
+        # Growth detected — must reject
+        assert rc == 1


### PR DESCRIPTION
feat(OMN-12818): url-authority ratchet gate — ValidatorUrlAuthority in omnibase_core

PR-2 of OMN-12803. Ships the canonical ValidatorBase subclass for the url-authority
gate so it participates in the ecosystem-wide validation pipeline.

## What

Adds `ValidatorUrlAuthority` (`src/omnibase_core/validation/validator_url_authority.py`),
a `ValidatorBase` subclass that detects NEW URL-hardcoding violations in Python source:

- `public-https-literal`: quoted `https://` URLs to real connection-target hosts
- `env-url-read`: `os.environ[*_URL]` / `os.environ.get(*_ENDPOINT)` reads
- `url-const-assignment`: module-level `*_URL`/`*_ENDPOINT` constants from env or literal

Ratchet (mirrors OMN-12791): sha256(repo+path+normalized-snippet) fingerprint; fails
only on NEW fingerprints; baseline is burn-down only (anti-gaming assertion).

Baseline = 13 frozen violations across omnibase_core. Migration debt:

- OMN-12806 (omnibase_core) — baselined, not resolved in this PR
- OMN-12807 (omnibase_infra) — baselined, cited
- OMN-12808 (other repos) — baselined, cited

## Gate proof

```
# RED on synthetic new violation:
$ uv run python -m omnibase_core.validation.validator_url_authority /tmp/synthetic_new_violation.py \
    --repo omnibase_core --repo-root /tmp
URL-AUTHORITY GATE FAILED: 1 NEW violation(s) — every URL must resolve from a contract ...
  [url-const-assignment] omnibase_core/synthetic_new_violation.py:2
    NEW_API_URL = "https://api.brand-new-host-not-in-baseline.io/v1"

# GREEN on full-repo baselined tip:
$ uv run python -m omnibase_core.validation.validator_url_authority --all --repo omnibase_core --repo-root .
URL-AUTHORITY GATE PASSED: 0 new violations (15 grandfathered).
```

## Files

- `src/omnibase_core/validation/validator_url_authority.py` — validator + CLI
- `src/omnibase_core/validation/contracts/url_authority.validation.yaml` — contract
- `src/omnibase_core/validation/baselines/url_authority_baseline.json` — 13 frozen fingerprints
- `tests/unit/validation/test_validator_url_authority.py` — 40 tests
- `.pre-commit-hooks.yaml` — exports `check-url-authority` hook
- `.pre-commit-config.yaml` — wires hook on omnibase_core
- `.github/workflows/url-authority-gate.yml` — required CI check

Evidence-Source: OCC#2572
Evidence-Ticket: OMN-12818

