### PR TITLE
fix(OMN-13061): hard-fail on contract_sha256=None in OCC eligibility validator

### DIFF
--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -28,6 +28,7 @@ from omnibase_core.models.validation.model_occ_eligibility_result import (
     ModelOccEligibilityResult,
 )
 from omnibase_core.validation.validator_receipt_gate import (
+    _CONTRACT_SHA256_REQUIRED_AFTER,
     _extract_ticket_ids,
     _iter_dod_evidence,
 )
@@ -181,9 +182,28 @@ def validate_occ_merge_eligibility(
                         f"expected {ticket_id}"
                     ),
                 )
+            # OMN-13061: hard-fail when contract_sha256 is None — mirrors
+            # validator_receipt_gate post-cutoff enforcement (OMN-10421).
+            # The migration window closed on _CONTRACT_SHA256_REQUIRED_AFTER
+            # (2026-04-30); all receipts authored after that date must bind
+            # a contract hash. Historical corpus scanners are ADVISORY only
+            # (OMN-13060 follow-through unchanged).
             if receipt.contract_sha256 is None:
-                pass
-            elif receipt.contract_sha256 != contract_hash:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    detail=(
+                        f"receipt {receipt_path} missing required contract_sha256 field "
+                        f"(OMN-10421 / OMN-13061): receipts produced after "
+                        f"{_CONTRACT_SHA256_REQUIRED_AFTER.date()} must record the "
+                        "contract hash. Rerun probes to produce a new receipt."
+                    ),
+                )
+            if receipt.contract_sha256 != contract_hash:
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -281,15 +281,21 @@ def test_contract_hash_mismatch_is_ineligible(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_missing_contract_hash_is_migration_compatible(tmp_path: Path) -> None:
-    contract_hash = _write_contract(tmp_path)
+def test_missing_contract_hash_is_ineligible_post_cutoff(tmp_path: Path) -> None:
+    """contract_sha256=None must hard-fail (OMN-13061 / OMN-10421 post-cutoff).
+
+    The migration window closed on 2026-04-30; receipts without a contract hash
+    no longer pass silently — this aligns with validator_receipt_gate behaviour.
+    """
+    _write_contract(tmp_path)
     _write_receipt(tmp_path, contract_sha256=None)
 
     result = validate_occ_merge_eligibility(_snapshot(tmp_path))
 
-    assert result.eligible is True
-    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
-    assert result.contract_hashes == {TICKET: contract_hash}
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert "contract_sha256" in (result.detail or "")
+    assert "OMN-10421" in (result.detail or "")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Evidence-Source: OCC#2559
Evidence-Ticket: OMN-13061

## Summary

Fix `validator_occ_merge_eligibility.py` lines 184-185: replace silent `pass`
on `contract_sha256=None` with a hard `CONTRACT_HASH_MISMATCH` failure.

The migration window for OMN-10421 closed on 2026-04-30. All post-cutoff
receipts must include `contract_sha256`. The eligibility validator was silently
bypassing this check (`if receipt.contract_sha256 is None: pass`), diverging
from `validator_receipt_gate._check_one_receipt`'s post-cutoff hard-fail.

### Changes

- `src/omnibase_core/validation/validator_occ_merge_eligibility.py`: import
  `_CONTRACT_SHA256_REQUIRED_AFTER` from receipt gate; replace silent `pass`
  with `CONTRACT_HASH_MISMATCH` return matching receipt gate enforcement.
- `tests/unit/validation/test_occ_merge_eligibility.py`: rename
  `test_missing_contract_hash_is_migration_compatible` →
  `test_missing_contract_hash_is_ineligible_post_cutoff` with inverted
  assertions confirming `eligible=False, reason=CONTRACT_HASH_MISMATCH`.

### Red-case proof

Synthetic post-cutoff receipt with `contract_sha256: None` produces:
- `eligible: False`
- `reason: contract_hash_mismatch`
- `detail: ... missing required contract_sha256 field (OMN-10421 / OMN-13061): receipts produced after 2026-04-30 must record the contract hash`

Evidence: `docs/evidence/2026-06-12-weekend-pass/process/8.1-occ-none-bypass/RED_CASE_PROOF.md`

### Scope note

Historical corpus ADVISORY scanners (OMN-13060 follow-through) are unchanged.
This fix only closes the blocking eligibility gate bypass.

### Test results

```
tests/unit/validation/test_occ_merge_eligibility.py — 13 passed
```
