### PR TITLE
feat(OMN-13093): minimal content-addressed ArtifactStore slice (Phase 1)

### DIFF
--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -65,6 +65,7 @@ adjacency:
   # that every src/omnibase_core/<dir> has an entry.
   adapters: {reverse_deps: []}
   agents: {reverse_deps: []}
+  artifacts: {reverse_deps: []}
   analysis: {reverse_deps: []}
   backends: {reverse_deps: []}
   cli: {reverse_deps: []}

--- a/src/omnibase_core/artifacts/__init__.py
+++ b/src/omnibase_core/artifacts/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Content-addressed artifact store (OMN-13093, minimal slice).
+
+Provides :class:`ArtifactStore`, the durable-capture blob store consumed by
+the skill-output suppression slice (OMN-13089) and extended in place by the
+parent durable-capture plan's Phase 1.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.artifacts.artifact_store import (
+    ARTIFACT_STORE_ROOT_ENV,
+    WRITER_VERSION,
+    ArtifactStore,
+)
+
+__all__ = [
+    "ARTIFACT_STORE_ROOT_ENV",
+    "WRITER_VERSION",
+    "ArtifactStore",
+]

--- a/src/omnibase_core/artifacts/artifact_store.py
+++ b/src/omnibase_core/artifacts/artifact_store.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# parent-plan: Phase 1 extends this — this is the MINIMAL slice of the
+# durable-capture artifact store (docs/plans/
+# 2026-06-12-durable-capture-ingestion-intelligence-plan.md, Phase 1),
+# built for the skill-output suppression slice (OMN-13089 / OMN-13093).
+# Explicitly deferred to parent Phase 1 (extend in place, same module):
+# retention/quota policy, redaction transforms, restricted-topic handling,
+# authorized read API. Do NOT mistake this for the finished store.
+
+"""Minimal content-addressed artifact store (OMN-13093).
+
+Blobs are stored under ``$ONEX_ARTIFACT_STORE_ROOT`` at the sharded path
+``<root>/<hh>/<full-hex>`` where ``<hh>`` is the first two hex chars of the
+blob's SHA-256 digest. Every blob carries a JSON metadata sidecar
+``<full-hex>.meta.json`` with the ``artifact-captured`` required fields.
+
+Design constraints (ticket spec):
+
+- stdlib + Pydantic only — no infra deps — so omniclaude hooks import this
+  module cleanly (layering rule 7 / F14)
+- store root from ``os.environ["ONEX_ARTIFACT_STORE_ROOT"]`` — required env,
+  ``KeyError`` on absence (fail-fast, Operating Rule 8); callers set it from
+  ``$OMNI_HOME/.onex_state/artifacts/``
+- atomic temp+rename writes, idempotent on existing hash
+- reads are hash-verified against the content address
+
+.. versionadded:: OMN-13093
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
+
+__all__ = [
+    "ARTIFACT_STORE_ROOT_ENV",
+    "WRITER_VERSION",
+    "ArtifactStore",
+]
+
+ARTIFACT_STORE_ROOT_ENV = "ONEX_ARTIFACT_STORE_ROOT"
+
+# Sidecar generation marker. Parent Phase 1 extensions (retention, redaction,
+# read-API hardening) bump this so they can distinguish sidecar generations.
+WRITER_VERSION = "omn-13093-minimal-1"
+
+# Crude byte-based token estimate (~4 bytes/token for English-ish text).
+# Good enough for projection previews and budget heuristics; NOT a tokenizer.
+_BYTES_PER_TOKEN_ESTIMATE = 4
+
+_META_SUFFIX = ".meta.json"
+
+
+class ArtifactStore:
+    """Content-addressed blob store with JSON metadata sidecars.
+
+    The blob's :class:`ModelArtifactRef` (``sha256:<hex>``) is both its
+    identity and its integrity proof: :meth:`read_blob` re-hashes the bytes
+    on retrieval and fails on mismatch.
+    """
+
+    def __init__(self) -> None:
+        # Fail-fast: KeyError when ONEX_ARTIFACT_STORE_ROOT is unset.
+        # No silent default — a wrong default is worse than a loud crash.
+        self._root = Path(os.environ[ARTIFACT_STORE_ROOT_ENV])
+
+    @property
+    def root(self) -> Path:
+        """The store root directory (from ``ONEX_ARTIFACT_STORE_ROOT``)."""
+        return self._root
+
+    def write_blob(
+        self,
+        data: bytes,
+        *,
+        media_type: str,
+        artifact_kind: str,
+        source_system: str,
+        scope_ref: str | None,
+        correlation_id: str | None,
+    ) -> ModelArtifactRef:
+        """Store ``data`` content-addressed and return its ref.
+
+        Writes are atomic (temp file + ``os.replace`` in the destination
+        directory) and idempotent: if a blob with the same hash already
+        exists, neither the blob nor its sidecar is rewritten (first writer
+        wins for metadata).
+        """
+        ref = ModelArtifactRef.from_bytes(data)
+        blob_path = self._blob_path(ref)
+        if blob_path.exists():
+            return ref
+
+        shard_dir = blob_path.parent
+        shard_dir.mkdir(parents=True, exist_ok=True)
+
+        meta = {
+            "artifact_hash": ref.hex_digest,
+            "artifact_size_bytes": len(data),
+            "artifact_media_type": media_type,
+            "artifact_kind": artifact_kind,
+            "source_system": source_system,
+            "scope_ref": scope_ref,
+            "correlation_id": correlation_id,
+            # Minimal slice always stores raw bytes; redaction transforms are
+            # a parent Phase 1 extension.
+            "redaction_state": "raw",
+            "token_estimate": len(data) // _BYTES_PER_TOKEN_ESTIMATE,
+            "created_at_utc": datetime.now(UTC).isoformat(),
+            "writer_version": WRITER_VERSION,
+        }
+
+        # Sidecar first, blob last: blob presence is the idempotency signal,
+        # so a crash between the two writes never yields a blob without meta.
+        self._atomic_write(self._meta_path(ref), json.dumps(meta, indent=2).encode())
+        self._atomic_write(blob_path, data)
+        return ref
+
+    def read_blob(self, ref: ModelArtifactRef) -> bytes:
+        """Return the blob bytes for ``ref``, hash-verified.
+
+        Raises:
+            FileNotFoundError: if no blob exists for ``ref``.
+            ValueError: if the stored bytes do not hash to ``ref``
+                (on-disk corruption or tampering).
+        """
+        data = self._blob_path(ref).read_bytes()
+        actual = ModelArtifactRef.from_bytes(data)
+        if actual != ref:
+            msg = (
+                f"artifact hash mismatch for {ref.ref}: stored bytes hash to "
+                f"{actual.ref} (on-disk corruption or tampering)"
+            )
+            raise ValueError(msg)
+        return data
+
+    def read_meta(self, ref: ModelArtifactRef) -> dict[str, object]:
+        """Return the JSON sidecar metadata for ``ref``.
+
+        Raises:
+            FileNotFoundError: if no sidecar exists for ``ref``.
+            ValueError: if the sidecar does not contain a JSON object.
+        """
+        raw = self._meta_path(ref).read_bytes()
+        meta: object = json.loads(raw)
+        if not isinstance(meta, dict):
+            msg = f"artifact sidecar for {ref.ref} is not a JSON object"
+            raise ValueError(msg)
+        return meta
+
+    def _blob_path(self, ref: ModelArtifactRef) -> Path:
+        hex_digest = ref.hex_digest
+        return self._root / hex_digest[:2] / hex_digest
+
+    def _meta_path(self, ref: ModelArtifactRef) -> Path:
+        hex_digest = ref.hex_digest
+        return self._root / hex_digest[:2] / f"{hex_digest}{_META_SUFFIX}"
+
+    @staticmethod
+    def _atomic_write(dest: Path, data: bytes) -> None:
+        """Write ``data`` to ``dest`` via temp file + atomic rename."""
+        fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=f".{dest.name}.tmp")
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+            tmp_path.replace(dest)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)  # cleanup-resilience-ok: remove temp file
+            raise

--- a/tests/unit/artifacts/__init__.py
+++ b/tests/unit/artifacts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/artifacts/test_artifact_store.py
+++ b/tests/unit/artifacts/test_artifact_store.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the minimal content-addressed ArtifactStore slice (OMN-13093).
+
+Covers write/read round-trips, content addressing, sharded layout, sidecar
+metadata, idempotency, hash verification on read, and fail-fast behavior on
+a missing ``ONEX_ARTIFACT_STORE_ROOT`` env var.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.artifacts.artifact_store import (
+    ARTIFACT_STORE_ROOT_ENV,
+    WRITER_VERSION,
+    ArtifactStore,
+)
+from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
+
+_PAYLOAD = b"runtime capture log line\n" * 100
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ArtifactStore:
+    """ArtifactStore rooted at a per-test temp directory."""
+    monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+    return ArtifactStore()
+
+
+def _write(store: ArtifactStore, data: bytes = _PAYLOAD) -> ModelArtifactRef:
+    return store.write_blob(
+        data,
+        media_type="text/plain",
+        artifact_kind="tool_stdout",
+        source_system="local_cli",
+        scope_ref="omnibase_core/OMN-13093",
+        correlation_id="11111111-2222-3333-4444-555555555555",
+    )
+
+
+@pytest.mark.unit
+class TestArtifactStoreEnv:
+    """Fail-fast store-root resolution (Operating Rule 8)."""
+
+    def test_missing_env_raises_keyerror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ARTIFACT_STORE_ROOT_ENV, raising=False)
+        with pytest.raises(KeyError):
+            ArtifactStore()
+
+    def test_root_created_lazily_on_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "not-yet-created" / "artifacts"
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(root))
+        store = ArtifactStore()
+        ref = _write(store)
+        assert (root / ref.hex_digest[:2] / ref.hex_digest).is_file()
+
+
+@pytest.mark.unit
+class TestArtifactStoreWrite:
+    """Content addressing, sharded layout, atomic writes."""
+
+    def test_write_returns_content_address(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        assert ref.ref == f"sha256:{hashlib.sha256(_PAYLOAD).hexdigest()}"
+
+    def test_blob_stored_at_sharded_path(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        blob_path = tmp_path / ref.hex_digest[:2] / ref.hex_digest
+        assert blob_path.is_file()
+        assert blob_path.read_bytes() == _PAYLOAD
+
+    def test_no_temp_files_left_behind(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        shard = tmp_path / ref.hex_digest[:2]
+        leftovers = [
+            p
+            for p in shard.iterdir()
+            if p.name not in {ref.hex_digest, f"{ref.hex_digest}.meta.json"}
+        ]
+        assert leftovers == []
+
+    def test_write_is_idempotent_on_existing_hash(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref_first = _write(store)
+        blob_path = tmp_path / ref_first.hex_digest[:2] / ref_first.hex_digest
+        first_stat = blob_path.stat()
+        ref_second = _write(store)
+        assert ref_second == ref_first
+        # The existing blob is not rewritten.
+        second_stat = blob_path.stat()
+        assert second_stat.st_mtime_ns == first_stat.st_mtime_ns
+        assert second_stat.st_ino == first_stat.st_ino
+
+    def test_distinct_payloads_get_distinct_refs(self, store: ArtifactStore) -> None:
+        ref_a = _write(store, b"a")
+        ref_b = _write(store, b"b")
+        assert ref_a != ref_b
+
+    def test_empty_payload_supported(self, store: ArtifactStore) -> None:
+        ref = _write(store, b"")
+        assert store.read_blob(ref) == b""
+
+
+@pytest.mark.unit
+class TestArtifactStoreSidecar:
+    """JSON metadata sidecar carries the artifact-captured required fields."""
+
+    def test_sidecar_written_next_to_blob(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        meta_path = tmp_path / ref.hex_digest[:2] / f"{ref.hex_digest}.meta.json"
+        assert meta_path.is_file()
+
+    def test_sidecar_required_fields(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        meta = store.read_meta(ref)
+        assert meta["artifact_hash"] == ref.hex_digest
+        assert meta["artifact_size_bytes"] == len(_PAYLOAD)
+        assert meta["artifact_media_type"] == "text/plain"
+        assert meta["artifact_kind"] == "tool_stdout"
+        assert meta["source_system"] == "local_cli"
+        assert meta["scope_ref"] == "omnibase_core/OMN-13093"
+        assert meta["correlation_id"] == "11111111-2222-3333-4444-555555555555"
+        assert meta["redaction_state"] == "raw"
+        assert isinstance(meta["token_estimate"], int)
+        assert meta["token_estimate"] > 0
+        assert isinstance(meta["created_at_utc"], str)
+        assert meta["created_at_utc"].endswith("+00:00")
+        assert meta["writer_version"] == WRITER_VERSION
+
+    def test_sidecar_none_fields_serialized_as_null(self, store: ArtifactStore) -> None:
+        ref = store.write_blob(
+            b"payload-with-no-scope",
+            media_type="application/json",
+            artifact_kind="tool_result_json",
+            source_system="onex_node",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        meta = store.read_meta(ref)
+        assert meta["scope_ref"] is None
+        assert meta["correlation_id"] is None
+
+    def test_sidecar_first_writer_wins(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        first_meta = store.read_meta(ref)
+        # Re-write same bytes with different metadata: blob is idempotent and
+        # the original sidecar is preserved.
+        store.write_blob(
+            _PAYLOAD,
+            media_type="text/x-diff",
+            artifact_kind="diff",
+            source_system="claude_code",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        assert store.read_meta(ref) == first_meta
+
+
+@pytest.mark.unit
+class TestArtifactStoreRead:
+    """Hash-verified retrieval."""
+
+    def test_read_blob_roundtrip(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        assert store.read_blob(ref) == _PAYLOAD
+
+    def test_read_blob_large_payload(self, store: ArtifactStore) -> None:
+        data = b"x" * 100_000
+        ref = _write(store, data)
+        assert store.read_blob(ref) == data
+
+    def test_read_blob_missing_raises(self, store: ArtifactStore) -> None:
+        ref = ModelArtifactRef.from_bytes(b"never written")
+        with pytest.raises(FileNotFoundError):
+            store.read_blob(ref)
+
+    def test_read_blob_detects_corruption(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        blob_path = tmp_path / ref.hex_digest[:2] / ref.hex_digest
+        blob_path.write_bytes(b"tampered bytes")
+        with pytest.raises(ValueError, match="hash mismatch"):
+            store.read_blob(ref)
+
+    def test_read_meta_missing_raises(self, store: ArtifactStore) -> None:
+        ref = ModelArtifactRef.from_bytes(b"never written")
+        with pytest.raises(FileNotFoundError):
+            store.read_meta(ref)
+
+
+@pytest.mark.unit
+class TestAcceptanceProbe:
+    """Mirror of the ticket's acceptance probe."""
+
+    def test_probe(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        assert os.environ[ARTIFACT_STORE_ROOT_ENV] == str(tmp_path)
+        store = ArtifactStore()
+        ref = store.write_blob(
+            b"x" * 100_000,
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        assert store.read_blob(ref) == b"x" * 100_000
+        assert ref.ref.startswith("sha256:")


### PR DESCRIPTION
## Summary

OMN-13093 — Phase 1 of the skill-output-suppression plan (epic OMN-13089, `docs/plans/2026-06-12-skill-output-suppression-plan.md` in omni_home): minimal content-addressed ArtifactStore slice in omnibase_core. This is the SAME store the parent durable-capture plan specifies (parent Phase 1 extends it in place — retention/quota, redaction, read-API hardening); NOT a parallel store. Marked with a `# parent-plan: Phase 1 extends this` comment.

### What was built

- `src/omnibase_core/artifacts/artifact_store.py`:
  - `write_blob(data, *, media_type, artifact_kind, source_system, scope_ref, correlation_id) -> ModelArtifactRef` — sha256 content addressing (reuses OMN-13091 `ModelArtifactRef.from_bytes`), sharded path `<root>/<hh>/<full-hex>`, atomic temp+rename writes, idempotent on existing hash (blob and sidecar are not rewritten; first writer wins for metadata).
  - JSON metadata sidecar `<full-hex>.meta.json` with the parent `artifact-captured` required fields (`artifact_hash`, `artifact_size_bytes`, `artifact_media_type`, `artifact_kind`, `source_system`, `scope_ref`, `correlation_id`, `redaction_state` (always `raw` in this slice), `token_estimate`, `created_at_utc`) plus `writer_version` for sidecar-generation tracking.
  - `read_blob(ref) -> bytes` — hash-verified against the content address; raises `ValueError` on corruption, `FileNotFoundError` on missing blob. `read_meta(ref) -> dict[str, object]`.
  - Store root from `os.environ["ONEX_ARTIFACT_STORE_ROOT"]` — required env, KeyError on absence (fail-fast, Operating Rule 8). No `/Users/` literal anywhere.
  - Stdlib + Pydantic only — no infra deps — so omniclaude hooks import it cleanly (layering rule 7 / F14).
- `scripts/ci/test_selection_adjacency.yaml`: registered the new `artifacts` module (required by `test_every_src_module_has_adjacency_entry`); no reverse deps yet — consumers land in Phase 2a/3.
- `tests/unit/artifacts/test_artifact_store.py`: 18 tests — write/read round-trip, content addressing, sharded layout, sidecar required fields, None-field serialization, idempotency (mtime/inode stable), first-writer-wins metadata, corruption detection, missing-blob/meta failure, missing-env KeyError, empty/100KB payloads, ticket acceptance probe mirror.

### Explicitly deferred to parent Phase 1 (extend in place)

Retention/quota policy, redaction transforms, restricted-topic handling, authorized read API.

## dod_evidence

- `uv run pytest tests/unit/artifacts/ -v` → 18 passed.
- Ticket acceptance probe → `ONEX_ARTIFACT_STORE_ROOT=$(mktemp -d) uv run python -c "...write 100000 bytes, read back, assert equal..."` → printed `sha256:d69e68988157833272305aaf21f453c800346e8a3640db6578e260215542e5d4`, exit 0.
- `uv run mypy src/omnibase_core` (CI-canonical strict config) → `Success: no issues found in 3863 source files`.
- `uv run ruff format` + `uv run ruff check --fix src/ tests/` → clean on changed files.
- Full suite `uv run pytest tests/ -v -n 4` → 41731 passed, 63 skipped, 12 xfailed, 43 xpassed; 10 failed pre-fix. 1 of 10 (`test_every_src_module_has_adjacency_entry`) was caused by the new module and is fixed in this PR (adjacency entry). The other 9 (test_model_cli_command_registry, test_validator_pydantic_conventions, test_validator_reserved_enum, test_workflow_validator) are pre-existing whole-suite xdist ordering artifacts — the identical set passes when run directly (189 passed) and none import the changed code (same artifact class documented on OMN-13091 / PR #1235).
- `pre-commit run --all-files` → failure set identical to origin/dev baseline (verified by diffing failure lists with the new files removed); the one finding in new code (PTH105) was fixed. Commit-time hooks passed on both commits.

Evidence-Source: OCC#2590
Evidence-Ticket: OMN-13093

