### PR TITLE
docs(OMN-13172): refresh omnibase_core documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v0.44.2 (2026-06-07)
+
+### Changes
+- chore(release)(OMN-12765): bump omnibase_core to v0.44.2 (#1217)
+- release(OMN-12765): promote dev integration to main (#1216)
+
+## v0.44.1 (2026-06-07)
+
+### Changes
+- chore(release)(OMN-12765): bump omnibase_core to v0.44.1 (#1213)
+- release(OMN-12765): promote core dev lane to main (#1211)
+
+## v0.44.0 (2026-06-06)
+
+### Features
+- feat(OMN-13098): skill-dispatch receipt-mode validator (Phase 4b) (#1237)
+- feat(OMN-13093): minimal content-addressed ArtifactStore slice (Phase 1) (#1236)
+- feat(OMN-13091): ModelArtifactRef + ModelSkillResult[T] typed receipt models (#1235)
+- feat(OMN-12818): url-authority ratchet gate — ValidatorUrlAuthority (#1232)
+- feat(OMN-13026): transport-mock lint validator — bare AsyncMock/MagicMock on EventBus/transport surfaces (#1231)
+- feat(OMN-13026): protocol-conformance tests per Protocol + portable _rel_path baseline fix (#1234)
+- feat(OMN-12957): runtime-profile registry + unregistered/no-consumer-lane validator rules (#1229)
+- feat(OMN-12960): single transport-envelope unwrap predicate + dispatch-surface test gate (#1228)
+- feat(OMN-12857): add Bifrost logical secret refs (#1223)
+- feat(OMN-12791): receipt-honesty validator — fail gamed DoD receipts (#1219)
+- feat(OMN-12777): add demo-path topic coherence gate as pre-commit + required CI (#1218)
+
+### Bug Fixes
+- fix(OMN-13061): hard-fail on contract_sha256=None in OCC eligibility validator (#1233)
+- fix(OMN-12961): reject typing.Protocol handler targets in ServiceHandlerResolver (#1230)
+- fix(OMN-12816): raise generation retry budget (#1221)
+
+### CI
+- ci(OMN-12825): wire receipt-honesty CI + pre-commit gate (queue-safe prep) (#1222)
+
 ## v0.43.0 (2026-05-31)
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,11 @@ failure would be worse than a documented failure event.
 | Replay/Corpus System | `src/omnibase_core/models/replay/`, `services/replay/`, `protocols/replay/` |
 | DB Validation | `src/omnibase_core/validation/db/` |
 | Claude Code Hooks | `src/omnibase_core/models/hooks/`, `enums/hooks/` |
+| ArtifactStore | `src/omnibase_core/artifacts/artifact_store.py` — content-addressed artifact storage (OMN-13093) |
+| Dispatch Bus Client | `src/omnibase_core/dispatch/dispatch_bus_client.py` — typed dispatch surface over the event bus |
+| Doctor Health Checks | `src/omnibase_core/doctor/` — extensible health-check registry; checks registered in `onex.doctor` entry-point group |
+| In-Memory Event Bus | `src/omnibase_core/event_bus/event_bus_inmemory.py` — registered in `onex.backends` entry-point group |
+| OmniGate | `src/omnibase_core/gate/` — config loader, diff hash, receipt canonical (OMN-11137/11139/11140) |
 
 ### File Naming Conventions
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -307,7 +307,7 @@ All behavior is declared in YAML contracts:
 | Use protocol names for DI | `container.get_service("ProtocolLogger")` not `"LoggerService"` |
 | No `dict[str, Any]` | Use TypedDict or Pydantic models for type safety |
 | ORCHESTRATOR cannot return results | Only COMPUTE nodes return typed results |
-| Always use Poetry | `uv run pytest`, never `python -m pytest` |
+| Always use uv | `uv run pytest`, never `python -m pytest` directly |
 
 ---
 
@@ -315,6 +315,10 @@ All behavior is declared in YAML contracts:
 
 ```text
 src/omnibase_core/
+├── adapters/               # Adapter utilities
+├── agents/                 # Agent support models
+├── analysis/               # Analysis helpers
+├── artifacts/              # Content-addressed ArtifactStore (OMN-13093)
 ├── backends/               # Cache (Redis) and metrics (Prometheus, in-memory)
 ├── cli/                    # CLI commands
 ├── constants/              # Project constants
@@ -323,27 +327,37 @@ src/omnibase_core/
 ├── contracts/              # Contract management
 ├── crypto/                 # Blake3 hashing, Ed25519 signing
 ├── decorators/             # Utility decorators (@standard_error_handling)
+├── discovery/              # Node discovery utilities
+├── dispatch/               # Dispatch bus client (OMN-12960)
+├── doctor/                 # onex doctor health-check registry and checks
 ├── enums/                  # Core enumerations (300+ enums, 6 subdirectories)
 ├── errors/                 # Error handling (ModelOnexError)
+├── event_bus/              # In-memory event bus (registered in onex.backends)
 ├── factories/              # Contract and profile factories
+├── gate/                   # OmniGate config loader, diff hash, receipt canonical
 ├── infrastructure/         # Base node classes
 ├── integrations/           # External integrations
 ├── logging/                # Structured logging
 ├── merge/                  # Contract merge engine, conflict classifier
 ├── mixins/                 # Reusable behavior mixins (40+)
 ├── models/                 # Pydantic models (80+ subdirectories)
+├── navigation/             # Navigation helpers
 ├── nodes/                  # EFFECT, COMPUTE, REDUCER, ORCHESTRATOR
+├── normalization/          # Normalization pipeline
+├── overlays/               # Contract overlay support
 ├── pipeline/               # Execution plan builders, runners
 ├── protocols/              # Protocol definitions
 ├── rendering/              # Report renderers (CLI, HTML, JSON, Markdown, Diff)
 ├── resolution/             # Execution, handler, protocol dependency resolvers
-├── runtime/                # Runtime components (FileRegistry)
+├── runtime/                # Runtime components (handler registry, message dispatch)
 ├── schemas/                # JSON Schema definitions
 ├── services/               # Service implementations
 ├── tools/                  # Mypy plugins
 ├── types/                  # TypedDict definitions
 ├── utils/                  # Utility functions
-└── validation/             # Validation framework + cross-repo validators + DB validators
+├── validators/             # Standalone validator modules
+├── validation/             # Validation framework + cross-repo validators + DB validators
+└── workflows/              # Workflow support models
 ```
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,87 +14,65 @@ This guide walks you through setting up your development environment for buildin
 ## Prerequisites
 
 - **Python 3.12+** (required for modern async features)
-- **Poetry** (recommended package manager)
+- **uv** (required package manager)
 - **Git** (for version control)
 
 ## Installation Methods
 
-### Method 1: Poetry (Recommended)
+### Method 1: uv (Recommended)
 
-Poetry provides better dependency management and virtual environment handling.
+uv is the required package manager for this project. All Python commands must be run via `uv run`.
 
-#### 1. Install Poetry
+#### 1. Install uv
 
-```
-# Install Poetry
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Add to PATH (add to your shell profile)
-export PATH="$HOME/.local/bin:$PATH"
+```bash
+# Install uv (see https://docs.astral.sh/uv/getting-started/installation/)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Verify installation
-poetry --version
+uv --version
 ```
 
 #### 2. Install omnibase_core
 
 **Option A: As a dependency in your project**
-```
+
+```bash
 # In your project directory
-poetry add omnibase_core
+uv add omnibase_core
 ```
 
 **Option B: For development**
-```
+
+```bash
 # Clone the repository
 git clone https://github.com/OmniNode-ai/omnibase_core.git
 cd omnibase_core
 
-# Install dependencies
-poetry install
+# Install all dependencies (including dev extras)
+uv sync --all-extras
 
-# Activate virtual environment
-poetry shell
-```
-
-### Method 2: pip (Alternative)
-
-If you prefer pip, you can install directly:
-
-```
-# Clone the repository
-git clone https://github.com/OmniNode-ai/omnibase_core.git
-cd omnibase_core
-
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install dependencies
-pip install -e .
+# Install pre-commit hooks
+pre-commit install
 ```
 
 ## Verification
 
 ### 1. Basic Import Test
 
-```
-# With Poetry
-uv run python -c "from omnibase_core.nodes.node_compute import NodeCompute; print('✅ Installation successful!')"
-
-# With pip
-python -c "from omnibase_core.nodes.node_compute import NodeCompute; print('✅ Installation successful!')"
+```bash
+uv run python -c "from omnibase_core.nodes.node_compute import NodeCompute; print('Installation successful!')"
 ```
 
 ### 2. All Node Types Test
 
-```
+```bash
 uv run python -c "
 from omnibase_core.nodes.node_compute import NodeCompute
 from omnibase_core.nodes.node_effect import NodeEffect
 from omnibase_core.nodes.node_reducer import NodeReducer
 from omnibase_core.nodes.node_orchestrator import NodeOrchestrator
-print('✅ All node types imported successfully!')
+print('All node types imported successfully!')
 "
 ```
 
@@ -102,34 +80,21 @@ print('✅ All node types imported successfully!')
 
 ### 1. Install Development Dependencies
 
-```
-# With Poetry
-poetry install --with dev
-
-# With pip
-pip install -e ".[dev]"
+```bash
+uv sync --all-extras
 ```
 
 ### 2. Run Tests
 
-```
-# With Poetry
-uv run pytest
-
-# With pip
-pytest
+```bash
+uv run pytest tests/
 ```
 
 ### 3. Run Linting
 
-```
-# With Poetry
-uv run ruff check .
-uv run mypy .
-
-# With pip
-ruff check .
-mypy .
+```bash
+uv run ruff check src/ tests/
+uv run mypy src/omnibase_core/
 ```
 
 ## IDE Setup
@@ -143,7 +108,7 @@ mypy .
 
 ```json
 {
-    "python.defaultInterpreterPath": "./venv/bin/python",
+    "python.defaultInterpreterPath": ".venv/bin/python",
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,
@@ -159,7 +124,7 @@ mypy .
 ### PyCharm
 
 1. Open the project
-2. Configure Python interpreter to use the virtual environment
+2. Configure Python interpreter to use `.venv/bin/python` (created by `uv sync`)
 3. Enable type checking in Settings → Editor → Inspections → Python → Type checker
 
 ## Troubleshooting
@@ -168,17 +133,17 @@ mypy .
 
 #### Import Errors
 
-```
-# If you see import errors, ensure you're in the virtual environment
-poetry shell  # or source venv/bin/activate
+```bash
+# Ensure uv sync has been run
+uv sync --all-extras
 
-# Reinstall if needed
-poetry install --force
+# Confirm the venv is active or prefix commands with uv run
+uv run python -c "import omnibase_core"
 ```
 
 #### Python Version Issues
 
-```
+```bash
 # Check Python version
 python --version  # Should be 3.12+
 
@@ -187,26 +152,16 @@ pyenv install 3.12.0
 pyenv local 3.12.0
 ```
 
-#### Poetry Issues
-
-```
-# Clear Poetry cache
-poetry cache clear --all pypi
-
-# Reinstall Poetry
-curl -sSL https://install.python-poetry.org | python3 -
-```
-
 ### Verification Commands
 
-```
+```bash
 # Check installation
 uv run python -c "
 from omnibase_core.nodes.node_compute import NodeCompute
 from omnibase_core.nodes.node_effect import NodeEffect
 from omnibase_core.nodes.node_reducer import NodeReducer
 from omnibase_core.nodes.node_orchestrator import NodeOrchestrator
-print('✅ All node types imported successfully!')
+print('All node types imported successfully!')
 "
 
 # Check version
@@ -225,7 +180,7 @@ If you encounter issues:
 
 1. Check the [troubleshooting section](#troubleshooting) above
 2. Search [existing issues](https://github.com/OmniNode-ai/omnibase_core/issues)
-4. Create a [new issue](https://github.com/OmniNode-ai/omnibase_core/issues/new) with:
+3. Create a [new issue](https://github.com/OmniNode-ai/omnibase_core/issues/new) with:
    - Python version
    - Installation method used
    - Full error message
@@ -234,5 +189,5 @@ If you encounter issues:
 ---
 
 **Related Documentation**:
-- [Poetry Documentation](https://python-poetry.org/docs/)
+- [uv Documentation](https://docs.astral.sh/uv/)
 - [Node Building Guide](../guides/node-building/README.md)

--- a/docs/reference/VALIDATION_OWNERSHIP.md
+++ b/docs/reference/VALIDATION_OWNERSHIP.md
@@ -1,7 +1,7 @@
 # Validation Ownership
 
 **Owner:** `omnibase_core`
-**Last verified:** 2026-04-24
+**Last verified:** 2026-06-16
 **Verification:** `pyproject.toml`, validation scripts, OMN-9599 docs pass
 
 This page defines which validation surfaces Core owns and how downstream repos
@@ -29,6 +29,22 @@ Core publishes these validator entrypoints in `pyproject.toml`.
 | `check-local-paths` | `omnibase_core` | Detect machine-specific absolute paths in text files. | `uv run check-local-paths docs src scripts` |
 | `validate-string-versions` | `omnibase_core` | Detect string version literals that should use version models or constants. | `uv run validate-string-versions src` |
 | `onex` | `omnibase_core` | Core CLI command group. | `uv run onex --help` |
+| `onex-demo-path-topic-gate` | `omnibase_core` | Enforce topic coherence on demo-path contracts; fails on mismatched topics. | `uv run onex-demo-path-topic-gate` (OMN-12777) |
+
+## Pre-Commit and CI Gate Validators (no standalone CLI entrypoint)
+
+The following validators ship as pre-commit hooks and required CI gates but are
+not exposed as standalone `[project.scripts]` entrypoints. They run automatically
+on every commit and in every CI run.
+
+| Validator | Ticket | Purpose |
+|-----------|--------|---------|
+| `ValidatorUrlAuthority` | OMN-12818 | URL-authority ratchet gate: rejects new commits that introduce bare or unauthorized base URLs. |
+| `ValidatorReceiptHonesty` | OMN-12791 | Fails gamed DoD receipts where PASS status is claimed while probe_stdout reads PENDING or a fake verifier is used. |
+| `ValidatorRuntimeProfiles` | OMN-12957 | Enforces runtime-profile registry rules; rejects unregistered profiles and no-consumer-lane mismatches. |
+| `gitignore_baseline` validator | OMN-12452/12453 | Baseline gitignore validator: ensures `.gitignore` files match the propagated baseline. |
+| Transport-mock lint validator | OMN-13026 | Rejects bare `AsyncMock`/`MagicMock` on `EventBus` or transport surfaces in tests. |
+| Skill-dispatch receipt-mode validator | OMN-13098 | Enforces correct receipt mode on skill-dispatch paths (Phase 4b). |
 
 ## Markdown Link Validation
 

--- a/docs/standards/onex_terminology.md
+++ b/docs/standards/onex_terminology.md
@@ -67,8 +67,8 @@ The ONEX (OmniNode eXecution) framework defines a structured vocabulary for buil
     +---------------------------------------------------------------------------+
     |                              RUNTIME HOST                                  |
     |  +-------------+  +-------------+  +---------------+  +-----------------+ |
-    |  |  Handler    |  |  Handler    |  |   Envelope    |  |    Projection   | |
-    |  |  (HTTP)     |  |  (Kafka)    |  |    Router     |  |      Store      | |
+    |  |  Handler    |  |  Handler    |  |   Message     |  |    Projection   | |
+    |  |  (HTTP)     |  |  (Kafka)    |  |   Dispatch    |  |      Store      | |
     |  +-------------+  +-------------+  +---------------+  +-----------------+ |
     +---------------------------------------------------------------------------+
 
@@ -414,7 +414,7 @@ class NodeDatabaseWriterEffect(NodeEffect):
 
 **File Location**: `src/omnibase_core/protocols/runtime/protocol_handler.py`
 
-**Role in Architecture**: Handlers are execution units within the Runtime that process `ModelOnexEnvelope` instances. The `EnvelopeRouter` routes envelopes to handlers based on `handler_type`.
+**Role in Architecture**: Handlers are execution units within the Runtime that process `ModelOnexEnvelope` instances. The `RuntimeMessageDispatch` routes envelopes to registered handlers based on `handler_type`.
 
 **Three Handler Sub-Patterns**:
 
@@ -546,7 +546,8 @@ if projection is None:
 
 | Component | Description | Location |
 |-----------|-------------|----------|
-| `EnvelopeRouter` | Transport-agnostic orchestrator | `src/omnibase_core/runtime/runtime_envelope_router.py` |
+| `RuntimeMessageDispatch` | Transport-agnostic message dispatcher | `src/omnibase_core/runtime/runtime_message_dispatch.py` |
+| `RuntimeHandlerRegistry` | Handler registration and lookup | `src/omnibase_core/runtime/runtime_handler_registry.py` |
 | `ModelRuntimeNodeInstance` | Node instance wrapper | `src/omnibase_core/models/runtime/model_runtime_node_instance.py` |
 | `ModelONEXContainer` | DI container for services | `src/omnibase_core/models/container/model_onex_container.py` |
 
@@ -560,7 +561,8 @@ if projection is None:
 **Code Example**:
 
 ```python
-from omnibase_core.runtime.runtime_envelope_router import EnvelopeRouter
+from omnibase_core.runtime.runtime_handler_registry import RuntimeHandlerRegistry
+from omnibase_core.runtime.runtime_message_dispatch import RuntimeMessageDispatch
 from omnibase_core.models.container.model_onex_container import ModelONEXContainer
 
 # Initialize DI container
@@ -568,16 +570,15 @@ container = ModelONEXContainer()
 container.register_service("ProtocolLogger", logger_instance)
 container.register_service("ProtocolEventBus", event_bus_instance)
 
-# Create envelope router
-router = EnvelopeRouter(container)
+# Register handlers via the handler registry
+registry = RuntimeHandlerRegistry()
+registry.register(HttpHandler())
+registry.register(DatabaseHandler())
+registry.register(KafkaHandler())
 
-# Register handlers
-router.register_handler(HttpHandler())
-router.register_handler(DatabaseHandler())
-router.register_handler(KafkaHandler())
-
-# Route envelope to appropriate handler
-response = await router.route(incoming_envelope)
+# Dispatch envelope to appropriate handler via RuntimeMessageDispatch
+dispatch = RuntimeMessageDispatch(container, registry)
+response = await dispatch.route(incoming_envelope)
 ```
 
 ---
@@ -594,7 +595,7 @@ response = await router.route(incoming_envelope)
 | **EFFECT** | `NodeEffect` | `nodes/node_effect.py` | Position 1 |
 | **HANDLER** | `ProtocolHandler` | `protocols/runtime/protocol_handler.py` | Runtime layer |
 | **PROJECTION** | `ModelProjectionBase` | `models/projection/model_projection_base.py` | CQRS read side |
-| **RUNTIME** | `EnvelopeRouter` | `runtime/runtime_envelope_router.py` | Infrastructure |
+| **RUNTIME** | `RuntimeMessageDispatch` | `runtime/runtime_message_dispatch.py` | Infrastructure |
 
 ---
 
@@ -676,7 +677,7 @@ Start
             v
     +---------------+
     |   RUNTIME     |
-    | (EnvelopeRouter|
+    | (MsgDispatch  |
     |  + Handlers)  |
     +---------------+
             |


### PR DESCRIPTION
## Summary

Refresh omnibase_core documentation as part of the parent repository documentation refresh wave.

The PR updates stale repository documentation only. Source behavior is unchanged.

## dod_evidence

- Documentation changes were verified against the repository state before editing.
- The doc diff is the proof for this docs-only refresh.
- Central parent evidence is carried in onex_change_control PR #2657.

Evidence-Source: OCC#2661
Evidence-Ticket: OMN-13172


