### PR TITLE
refactor(OMN-13192): migrate sole live ModelOnexEnvelope constructor to ModelEventEnvelope[ModelEventPublishIntent]

### DIFF
--- a/src/omnibase_core/mixins/mixin_intent_publisher.py
+++ b/src/omnibase_core/mixins/mixin_intent_publisher.py
@@ -34,7 +34,7 @@ Subcontract:
 
 Dependencies:
     - kafka_client service (for intent publishing)
-    - ModelOnexEnvelope (from omnibase_core)
+    - ModelEventEnvelope (from omnibase_core)
 
 Part of omnibase_core framework - provides coordination I/O for all ONEX nodes
 """
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError as OnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.models.events.model_intent_events import (
     TOPIC_EVENT_PUBLISH_INTENT,
     ModelEventPublishIntent,
@@ -234,32 +235,21 @@ class MixinIntentPublisher:
             priority=priority,
         )
 
-        # Wrap in ModelOnexEnvelope for standard event format
-        try:
-            from omnibase_core.models.core import ModelOnexEnvelope
-            from omnibase_core.models.primitives.model_semver import ModelSemVer
+        # Wrap the typed intent in the canonical ModelEventEnvelope[T].
+        # The payload is the typed ModelEventPublishIntent (NOT a serialized dict),
+        # so the envelope preserves full type fidelity on the wire.
+        envelope: ModelEventEnvelope[ModelEventPublishIntent] = ModelEventEnvelope[
+            ModelEventPublishIntent
+        ](
+            payload=intent,
+            envelope_id=intent_id,
+            correlation_id=correlation_id,
+            source_tool=f"omnibase_core.{self.__class__.__name__}",
+            envelope_timestamp=published_at,
+            payload_type=ModelEventPublishIntent.__name__,
+        )
 
-            envelope = ModelOnexEnvelope(
-                envelope_id=intent_id,
-                envelope_version=ModelSemVer(major=1, minor=0, patch=0),
-                correlation_id=correlation_id,
-                source_node=f"omnibase_core.{self.__class__.__name__}",
-                operation="EVENT_PUBLISH_INTENT",
-                payload=intent.model_dump(),
-                timestamp=published_at,
-            )
-
-            envelope_json = envelope.model_dump_json()
-
-        except ImportError:
-            # Fallback if ModelOnexEnvelope not available (should not happen)
-            logger.warning(
-                "Failed to import ModelOnexEnvelope; falling back to raw intent JSON "
-                "without envelope wrapper. This changes the message format on the wire "
-                "and may cause downstream parsing issues. intent_id=%s",
-                intent_id,
-            )
-            envelope_json = intent.model_dump_json()
+        envelope_json = envelope.model_dump_json()
 
         # Publish to intent topic (coordination I/O)
         await self._intent_kafka_client.publish(

--- a/tests/integration/test_intent_publisher_integration.py
+++ b/tests/integration/test_intent_publisher_integration.py
@@ -30,6 +30,7 @@ from omnibase_core.enums.enum_node_kind import EnumNodeKind
 from omnibase_core.mixins.mixin_intent_publisher import MixinIntentPublisher
 from omnibase_core.models.container.model_onex_container import ModelONEXContainer
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.models.events.model_intent_events import (
     TOPIC_EVENT_PUBLISH_INTENT,
     ModelIntentExecutionResult,
@@ -165,10 +166,12 @@ class TestIntentPublisherIntegration:
     @staticmethod
     def extract_intent_from_message(message_value: str) -> dict[str, Any]:
         """
-        Extract intent from Kafka message, handling both wrapped and unwrapped formats.
+        Extract the typed intent payload from a published Kafka message.
 
-        The mixin tries to wrap intents in ModelOnexEnvelope, but falls back to raw JSON
-        if the envelope class is not available.
+        As of OMN-13192 the mixin wraps the typed ModelEventPublishIntent in a
+        ModelEventEnvelope[ModelEventPublishIntent]; the intent lives under the
+        envelope's "payload" key. (A raw-intent fallback is retained for any
+        message that is not envelope-wrapped.)
 
         Args:
             message_value: JSON string from Kafka message
@@ -178,7 +181,7 @@ class TestIntentPublisherIntegration:
         """
         data = json.loads(message_value)
 
-        # Check if wrapped in ModelOnexEnvelope
+        # Check if wrapped in ModelEventEnvelope (carries payload + envelope_version)
         if "payload" in data and "envelope_version" in data:
             return data["payload"]
 
@@ -262,6 +265,59 @@ class TestIntentPublisherIntegration:
         # Verify result includes intent_id
         assert "intent_id" in result
         assert UUID(result["intent_id"])
+
+    @pytest.mark.asyncio
+    async def test_published_envelope_round_trips_typed_intent(
+        self, container_with_kafka, mock_kafka_client
+    ):
+        """Serialize -> deserialize round-trip on the migrated envelope (OMN-13192).
+
+        Proves the publisher emits a ModelEventEnvelope wrapping the intent on
+        the wire and that re-parsing the published JSON yields an envelope equal
+        to a second serialize/parse cycle (lossless wire format), with the
+        envelope metadata and intent fields preserved.
+
+        Deserialization uses the generic ModelEventEnvelope (payload preserved as
+        a mapping): the strict ModelEventEnvelope[ModelEventPublishIntent]
+        parameterization cannot reconstruct from JSON because the inner
+        ModelEventPayloadUnion before-validator rejects the plain dict that JSON
+        decoding produces. That is a pre-existing property of
+        ModelEventPublishIntent, independent of this envelope migration.
+        """
+        reducer = MockReducerWithIntentPublisher(container_with_kafka)
+
+        node_id = uuid4()
+        correlation_id = uuid4()
+        node_event = ModelNodeRegisteredEvent(
+            node_id=node_id,
+            node_name="round-trip-node",
+            node_type=EnumNodeKind.COMPUTE,
+        )
+
+        await reducer.publish_event_intent(
+            target_topic="dev.omninode.registration.v1",
+            target_key=str(node_id),
+            event=node_event,
+            correlation_id=correlation_id,
+        )
+
+        published_value = mock_kafka_client.published_messages[0]["value"]
+
+        # Deserialize the published wire bytes into the generic envelope.
+        envelope = ModelEventEnvelope.model_validate_json(published_value)
+        assert isinstance(envelope, ModelEventEnvelope)
+        assert envelope.correlation_id == correlation_id
+        assert envelope.source_tool == "omnibase_core.MockReducerWithIntentPublisher"
+        assert envelope.payload_type == "ModelEventPublishIntent"
+        assert isinstance(envelope.payload, dict)
+        assert envelope.payload["target_topic"] == "dev.omninode.registration.v1"
+        assert envelope.payload["target_event_type"] == "ModelNodeRegisteredEvent"
+
+        # Re-serialize and re-parse; the second envelope must equal the first.
+        round_tripped = ModelEventEnvelope.model_validate_json(
+            envelope.model_dump_json()
+        )
+        assert round_tripped == envelope
 
     @pytest.mark.asyncio
     async def test_intent_publish_result_validation(

--- a/tests/unit/mixins/test_mixin_intent_publisher.py
+++ b/tests/unit/mixins/test_mixin_intent_publisher.py
@@ -11,7 +11,7 @@ Validates ONEX standards for coordination I/O and intent-based architecture.
 import asyncio
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 from uuid import UUID, uuid4
 
 import pytest
@@ -20,7 +20,10 @@ from pydantic import BaseModel, ValidationError
 from omnibase_core.enums.enum_node_kind import EnumNodeKind
 from omnibase_core.mixins.mixin_intent_publisher import MixinIntentPublisher
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
-from omnibase_core.models.events.model_intent_events import TOPIC_EVENT_PUBLISH_INTENT
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.events.model_intent_events import (
+    TOPIC_EVENT_PUBLISH_INTENT,
+)
 from omnibase_core.models.events.model_node_registered_event import (
     ModelNodeRegisteredEvent,
 )
@@ -330,8 +333,21 @@ class TestMixinIntentPublisher:
 
         envelope_data = json.loads(published_value)
 
-        # Verify envelope structure (should have ModelOnexEnvelope fields or fallback)
-        assert "payload" in envelope_data or "intent_id" in envelope_data
+        # Verify ModelEventEnvelope[ModelEventPublishIntent] wire shape: the typed
+        # intent lives under "payload" and the envelope carries its own metadata.
+        assert "payload" in envelope_data
+        assert "envelope_id" in envelope_data
+        assert "envelope_timestamp" in envelope_data
+        assert envelope_data["source_tool"] == (
+            f"omnibase_core.{test_node.__class__.__name__}"
+        )
+        assert envelope_data["payload_type"] == "ModelEventPublishIntent"
+        assert envelope_data["correlation_id"] == str(correlation_id)
+        # The payload is the typed intent (NOT a serialized dict double-wrap).
+        intent_payload = envelope_data["payload"]
+        assert intent_payload["target_topic"] == target_topic
+        assert intent_payload["target_key"] == target_key
+        assert intent_payload["priority"] == priority
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(90)  # Longer timeout for CI async tests
@@ -437,50 +453,91 @@ class TestMixinIntentPublisher:
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(90)  # Longer timeout for CI async tests
-    async def test_onex_envelope_success_path(self, test_node, test_event):
+    async def test_event_envelope_wraps_typed_intent(self, test_node, test_event):
         """
-        Test successful ModelOnexEnvelope wrapping.
+        Test that the publisher wraps the intent in ModelEventEnvelope[ModelEventPublishIntent].
 
-        Validates envelope creation when ModelOnexEnvelope is available.
+        Validates the migrated envelope type (OMN-13192): the published value
+        deserializes back into a ModelEventEnvelope whose payload carries the
+        intent fields, with the mapped envelope fields populated.
+
+        Note on deserialization: the envelope is re-parsed via the generic
+        ModelEventEnvelope (payload preserved as a mapping). The strict
+        ModelEventEnvelope[ModelEventPublishIntent] parameterization cannot
+        reconstruct from JSON because ModelEventPublishIntent.target_event_payload
+        is a ModelEventPayloadUnion whose own before-validator rejects the plain
+        dict that JSON decoding produces (the union stores no discriminator).
+        That is a pre-existing property of ModelEventPublishIntent, independent
+        of this envelope migration.
         """
-        # Mock ModelOnexEnvelope to be available
-        mock_envelope_class = Mock()
-        mock_envelope_instance = Mock()
-        mock_envelope_instance.model_dump_json.return_value = '{"envelope": "data"}'
-        mock_envelope_class.return_value = mock_envelope_instance
+        target_topic = "dev.omninode.test.v1"
+        target_key = "envelope-key"
+        correlation_id = uuid4()
 
-        with patch.dict(
-            "sys.modules",
-            {"omnibase_core.models.core": Mock(ModelOnexEnvelope=mock_envelope_class)},
-        ):
-            await test_node.publish_event_intent(
-                target_topic="dev.omninode.test.v1",
-                target_key="test-key",
-                event=test_event,
-            )
+        await test_node.publish_event_intent(
+            target_topic=target_topic,
+            target_key=target_key,
+            event=test_event,
+            correlation_id=correlation_id,
+        )
 
-            # Verify envelope was used
-            call_kwargs = test_node._intent_kafka_client.publish.call_args.kwargs
-            assert call_kwargs["value"] == '{"envelope": "data"}'
+        call_kwargs = test_node._intent_kafka_client.publish.call_args.kwargs
+        published_value = call_kwargs["value"]
+
+        # Deserialize the published wire bytes into the generic envelope.
+        envelope = ModelEventEnvelope.model_validate_json(published_value)
+
+        assert isinstance(envelope, ModelEventEnvelope)
+        assert envelope.correlation_id == correlation_id
+        assert envelope.source_tool == (f"omnibase_core.{test_node.__class__.__name__}")
+        assert envelope.payload_type == "ModelEventPublishIntent"
+        # envelope_timestamp is mapped from the publisher's published_at.
+        assert envelope.envelope_timestamp is not None
+        # The intent payload fields survive the wrap.
+        assert isinstance(envelope.payload, dict)
+        assert envelope.payload["target_topic"] == target_topic
+        assert envelope.payload["target_key"] == target_key
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(90)  # Longer timeout for CI async tests
-    async def test_onex_envelope_fallback_path(self, test_node, test_event):
+    async def test_envelope_serialize_deserialize_round_trip(
+        self, test_node, test_event
+    ):
         """
-        Test fallback when ModelOnexEnvelope is not available.
+        Test serialize -> deserialize round-trip on the new envelope (OMN-13192).
 
-        Validates graceful degradation without envelope wrapping.
+        Proves the envelope wire format is lossless: re-parsing the published
+        JSON yields an envelope equal to a second serialize/parse cycle, with
+        all envelope metadata and intent payload fields preserved.
         """
-        # The actual implementation handles ImportError gracefully
-        # Test that publishing still works
+        correlation_id = uuid4()
         result = await test_node.publish_event_intent(
             target_topic="dev.omninode.test.v1",
-            target_key="test-key",
+            target_key="round-trip-key",
             event=test_event,
+            correlation_id=correlation_id,
+            priority=4,
         )
 
-        # Should still succeed
         assert isinstance(result, ModelIntentPublishResult)
+
+        call_kwargs = test_node._intent_kafka_client.publish.call_args.kwargs
+        published_value = call_kwargs["value"]
+
+        # First deserialization from the published wire bytes (generic envelope).
+        envelope = ModelEventEnvelope.model_validate_json(published_value)
+        # Re-serialize and deserialize again; the second envelope must equal the first.
+        round_tripped = ModelEventEnvelope.model_validate_json(
+            envelope.model_dump_json()
+        )
+
+        assert round_tripped == envelope
+        assert isinstance(round_tripped.payload, dict)
+        assert round_tripped.payload["intent_id"] == str(result.intent_id)
+        assert round_tripped.correlation_id == correlation_id
+        assert (
+            round_tripped.payload["target_event_type"] == test_event.__class__.__name__
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(90)  # Longer timeout for CI async tests


### PR DESCRIPTION
## OMN-13192 — Migrate the sole live `ModelOnexEnvelope` constructor to `ModelEventEnvelope[ModelEventPublishIntent]`

Retargets the one production `ModelOnexEnvelope(...)` constructor at `src/omnibase_core/mixins/mixin_intent_publisher.py` to `ModelEventEnvelope[ModelEventPublishIntent](...)`, publishing the **typed** `ModelEventPublishIntent` as the envelope payload (not a serialized dict). This leaves **zero live `ModelOnexEnvelope` constructor calls** in `src/`, so B4 (OMN-13194 follow-on) can delete the class. `ModelOnexEnvelope` itself and its docstring examples in `model_onex_envelope.py` are untouched (B4 scope).

### Field remap (per ticket B2 scope)
- `source_node="omnibase_core.{class}"` → `source_tool=...`
- `timestamp=published_at` → `envelope_timestamp=published_at`
- `payload=intent.model_dump()` (SerializedDict) → `payload=intent` (typed `ModelEventPublishIntent`)
- `operation="EVENT_PUBLISH_INTENT"` → **dropped** (no `ModelEventEnvelope` equivalent)
- `envelope_version=ModelSemVer(1,0,0)` → dropped (the new envelope owns its schema version default); `payload_type="ModelEventPublishIntent"` added for routing fidelity.

The legacy `try/except ImportError` fallback that silently changed the wire format is removed — `ModelEventEnvelope` is a direct top-level import; a silent format-changing fallback violates the no-defensive-default rule.

### No Kafka consumers exist — this is a type-correctness + test change only

Verification **REFUTED** the original plan's "IntentExecutor consumers on that topic must be updated in the SAME PR" framing (see OMN-13192 ticket comment):

- `IntentExecutor` (`omnibase_infra/.../service_intent_executor.py`) is a **synchronous runtime service** whose `execute()` takes an in-memory `ModelIntent`; it is called synchronously from `ServiceDispatchResultApplier`, never deserialized from `onex.runtime.intents`. No `contract.yaml` subscribes to the topic.
- `MixinIntentPublisher` (the only publisher) has **zero production call sites**.

So "update the consumers in the same PR" reduces to: **there are no Kafka consumers to update.** There is no consumer-node diff in this PR, and inventing one would have no target. The topic is dead from both ends; this change only collapses the publisher-side type so B4 can delete the class.

### What changed (3 files)
- `src/omnibase_core/mixins/mixin_intent_publisher.py` — constructor swap + `ModelEventEnvelope` import; removed the inline `ModelOnexEnvelope`/`ModelSemVer` imports and the ImportError fallback.
- `tests/unit/mixins/test_mixin_intent_publisher.py` — replaced the two obsolete `ModelOnexEnvelope`-mock tests with `test_event_envelope_wraps_typed_intent` + `test_envelope_serialize_deserialize_round_trip`; tightened `test_intent_payload_structure` to the new envelope shape.
- `tests/integration/test_intent_publisher_integration.py` — added `test_published_envelope_round_trips_typed_intent`; updated the `extract_intent_from_message` docstring.

No source behavior change beyond the envelope type, no Kafka topic schema change, no DDL/migration, no runtime/deploy/.201 mutation.

### Round-trip finding (documented, not a regression)
The strict `ModelEventEnvelope[ModelEventPublishIntent].model_validate_json(...)` cannot reconstruct from JSON because `ModelEventPublishIntent.target_event_payload` is a `ModelEventPayloadUnion` whose own `mode="before"` validator rejects the plain dict that JSON decoding produces (the union stores no discriminator). This is a **pre-existing property of `ModelEventPublishIntent`**, independent of this envelope migration. The round-trip assertions therefore validate the **generic** `ModelEventEnvelope` (payload preserved as a mapping) and prove the wire format is lossless for the intent fields.

## dod_evidence

**Zero live `ModelOnexEnvelope` constructor calls in `src/` (the B4-unblock proof):**
```
$ grep -rn "ModelOnexEnvelope(" src/
src/omnibase_core/models/core/model_onex_envelope.py:23:        request = ModelOnexEnvelope(      # docstring example
src/omnibase_core/models/core/model_onex_envelope.py:35:        response = ModelOnexEnvelope(     # docstring example
src/omnibase_core/models/core/model_onex_envelope.py:72:class ModelOnexEnvelope(BaseModel):     # class def (B4)
src/omnibase_core/models/core/model_onex_envelope.py:159:           request = ModelOnexEnvelope(  # docstring example
src/omnibase_core/models/core/model_onex_envelope.py:218:           response = ModelOnexEnvelope( # docstring example
src/omnibase_core/models/core/model_onex_envelope.py:234:           response = ModelOnexEnvelope( # docstring example
src/omnibase_core/models/core/model_onex_envelope.py:314:               response = ModelOnexEnvelope( # docstring example
```
All 7 remaining matches are in the class-definition file `model_onex_envelope.py`: one is the `class ModelOnexEnvelope(BaseModel):` definition (line 72), the other six are usage examples **inside docstrings** (verified via Python `tokenize`: every one falls inside a STRING token). **No live constructor call remains** — the mixin (the sole live caller) now constructs `ModelEventEnvelope[ModelEventPublishIntent]`.

**Gate results (run in worktree `omni_worktrees/OMN-13192/omnibase_core`):**
- `uv run ruff format src/ tests/` → 5577 files left unchanged
- `uv run ruff check --fix src/ tests/` → All checks passed!
- `uv run mypy src/omnibase_core` (CI-equivalent, `mypy.ini`) → **Success: no issues found in 3865 source files**
- `uv run mypy src/omnibase_core/mixins/mixin_intent_publisher.py --strict` → Success: no issues found in 1 source file
- `uv run pytest tests/unit/mixins/test_mixin_intent_publisher.py tests/integration/test_intent_publisher_integration.py -v` → **44 passed**
- `uv run pytest tests/ -n auto` (FULL suite, no `-k` filter) → **41740 passed, 65 skipped, 12 xfailed, 43 xpassed, 0 failed** in 948.56s (0:15:48).

Note: `uv run mypy src/ --strict` (the broad CLI form, not the CI gate) reports 3 pre-existing `--strict` errors in `contracts/contract_loader.py` and `cli/cli_install.py` — both **unchanged on `origin/dev` and not in this 3-file diff**. The merge-determining gate is the `mypy.ini`-configured `uv run mypy src/omnibase_core`, which passes clean.

Evidence-Source: OCC#2680
Evidence-Ticket: OMN-13192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized intent message envelope structure for consistent publishing format.

* **Tests**
  * Updated tests to validate new intent envelope format and serialize/deserialize round-trip integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->