### PR TITLE
refactor(OMN-13194): re-annotate envelope_validator.py to ModelEventEnvelope[Any] (B3, annotation-only)

### DIFF
--- a/src/omnibase_core/validation/envelope_validator.py
+++ b/src/omnibase_core/validation/envelope_validator.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from omnibase_core.models.validation.model_envelope_validation_config import (
     ModelEnvelopeValidationConfig,
@@ -69,7 +69,7 @@ from omnibase_core.validation.envelope_validation_error import EnvelopeValidatio
 from omnibase_core.validation.envelope_validation_result import EnvelopeValidationResult
 
 if TYPE_CHECKING:
-    from omnibase_core.models.core.model_onex_envelope import ModelOnexEnvelope
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 
 __all__ = ["EnvelopeValidator"]
 
@@ -106,7 +106,7 @@ class EnvelopeValidator:
     """
     Configurable envelope validator with strict and lenient modes.
 
-    Validates ModelOnexEnvelope instances before dispatch, performing:
+    Validates ModelEventEnvelope[Any] instances before dispatch, performing:
     1. Structural validation (required fields, correlation_id presence)
     2. Payload type validation (empty list rejection, known schema checks)
     3. Type coercion warnings (for mismatched but convertible types)
@@ -186,7 +186,7 @@ class EnvelopeValidator:
 
     def validate(
         self,
-        envelope: ModelOnexEnvelope,
+        envelope: ModelEventEnvelope[Any],
         *,
         config_override: ModelEnvelopeValidationConfig | None = None,
     ) -> EnvelopeValidationResult:
@@ -200,7 +200,7 @@ class EnvelopeValidator:
         In lenient mode: collects all issues, logs warnings, returns result.
 
         Args:
-            envelope: The ModelOnexEnvelope to validate.
+            envelope: The ModelEventEnvelope[Any] to validate.
             config_override: Optional per-call configuration override.
                 Useful for per-handler strictness differences.
 
@@ -253,7 +253,7 @@ class EnvelopeValidator:
 
     def _validate_structure(
         self,
-        envelope: ModelOnexEnvelope,
+        envelope: ModelEventEnvelope[Any],
         config: ModelEnvelopeValidationConfig,
         errors: list[str],
         warnings: list[str],
@@ -319,7 +319,7 @@ class EnvelopeValidator:
 
     def _validate_payload(
         self,
-        envelope: ModelOnexEnvelope,
+        envelope: ModelEventEnvelope[Any],
         config: ModelEnvelopeValidationConfig,
         errors: list[str],
         warnings: list[str],


### PR DESCRIPTION
## OMN-13194 — B3: re-annotate `envelope_validator.py` to `ModelEventEnvelope[Any]`

Evidence-Source: OCC#2683
Evidence-Ticket: OMN-13194

B3 of the platform-debt envelope-dedup plan (`docs/plans/2026-06-16-platform-debt-contract-topics-and-envelope-dedup-plan.md`, §B). Annotation-only.

### What changed
Re-annotates the 4 `ModelOnexEnvelope` sites in `src/omnibase_core/validation/envelope_validator.py` to `ModelEventEnvelope[Any]`:
- the `TYPE_CHECKING` import → `omnibase_core.models.events.model_event_envelope`
- the parameter annotations on `EnvelopeValidator.validate`, `_validate_structure`, `_validate_payload`

The 2 prose docstring mentions are updated to the same name so the module references **zero** `ModelOnexEnvelope`. `ModelEventEnvelope[T]` is a PEP 695 generic (`class ModelEventEnvelope[T]`), so `ModelEventEnvelope[Any]` is a valid parametrization. `Any` is a runtime import; `ModelEventEnvelope` stays under `TYPE_CHECKING` (annotations are stringized by `from __future__ import annotations`).

### Why this is safe (annotation-only)
The validator reads every envelope field via `getattr(envelope, ..., None)` — it never depends on the concrete type. Swapping the annotation changes **no** runtime code path. `git diff`: 1 file, 7 insertions / 7 deletions.

Does **not** delete `ModelOnexEnvelope` — that is B4 (OMN-13196).

### Predecessor
B2 (OMN-13192, PR #1245) is **MERGED** to `dev` — merge commit `a84bb24cfce8b91f25915c47b46a1599faa53e35`, which is the base of this branch.

### dod_evidence (OMN-13194)
```
# zero ModelOnexEnvelope in the validator
$ grep -n "ModelOnexEnvelope" src/omnibase_core/validation/envelope_validator.py
(zero matches)

# ModelEventEnvelope now referenced at the 4 sites + 2 docstrings
$ grep -n "ModelEventEnvelope" src/omnibase_core/validation/envelope_validator.py
72:    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
105:    Validates ModelEventEnvelope[Any] instances before dispatch, performing:
185:        envelope: ModelEventEnvelope[Any],
199:            envelope: The ModelEventEnvelope[Any] to validate.
252:        envelope: ModelEventEnvelope[Any],
318:        envelope: ModelEventEnvelope[Any],
```

Gates (all green):
- `ruff format` + `ruff check --fix`: clean (All checks passed)
- `mypy src/omnibase_core/validation/envelope_validator.py --strict`: **Success, no issues found**
- focused suite `tests/unit/validation/test_envelope_validator.py`: **40 passed, 4 skipped**
- full `uv run pytest tests/ -n auto` (no `-k`): **41739 passed**, 65 skipped, 12 xfailed, 43 xpassed. The single full-suite failure was the timing-sensitive perf benchmark `tests/performance/test_source_node_id_overhead.py::test_round_trip_overhead` (round-trip overhead spiked under 16-way parallel load, std-dev ±0.4764ms); it **passes in isolation** (1.39s, within threshold) and references neither `envelope_validator` nor `EnvelopeValidator`. Machine-contention flake, not a regression.
- `pre-commit run --all-files`: all hooks pass (`DETERMINISTIC_SKILL_ROOT` pinned to `omniclaude@main` per CI parity — known sibling-worktree false-positive, memory `feedback_omnibase_core_precommit_sibling_skill_scan`).

Pre-existing, out of scope (unchanged on `origin/dev`, not in this 1-file diff): the broad `mypy src/ --strict` CLI form reports 3 errors in `contract_loader.py` + `cli_install.py`; the merge-determining `mypy.ini` gate is clean.

Paired OCC receipt: `onex_change_control` `contracts/OMN-13194.yaml` + `drift/dod_receipts/OMN-13194/pr-omnibase_core/command.yaml` (Evidence-Source bound to this PR head sha).
