### PR TITLE
chore(OMN-13195): bump validate-boundaries action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1492,7 +1492,7 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
-      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@77fb1485c535202f7e6d298a7cd25023f844781c # main 2026-03-25
+      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@7b9ff965139d14416cf40e28d9ade254a08e6da1 # main
         with:
           checks: "boundary-parity"
           warn-only: "false"


### PR DESCRIPTION
Evidence-Source: OCC#2684
Evidence-Ticket: OMN-13195

Replaces Dependabot PR #1247 with a ticketed branch so Receipt Gate can bind evidence.

### What changed
- Bumps `.github/workflows/ci.yml` `OmniNode-ai/onex_change_control/.github/actions/validate-boundaries` from `77fb1485c535202f7e6d298a7cd25023f844781c` to `7b9ff965139d14416cf40e28d9ade254a08e6da1`.

### Verification
- `pre-commit run --files .github/workflows/ci.yml` attempted; failed before commit on local environment/workspace issues unrelated to this file:
  - PyPI timeout resolving `hatchling` during ruff-format environment setup.
  - Existing deterministic-skill-routing violations in `$OMNI_HOME/omniclaude/plugins/onex/skills/*` outside this repo/worktree.
- Normal `git commit` hooks passed for the staged workflow-file change.

Closes OMN-13195.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use pinned dependency version for improved build stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
