### PR TITLE
feat(OMN-12804): non-model URL contract authority — integration catalog + design doc

### DIFF
--- a/docs/architecture/URL_CONTRACT_AUTHORITY.md
+++ b/docs/architecture/URL_CONTRACT_AUTHORITY.md
@@ -1,0 +1,184 @@
+# URL Contract Authority
+
+**Status**: Active — OMN-12804 (part of OMN-12803 URL-authority epic)
+**Schema version**: v1.0.0
+
+---
+
+## Design goal
+
+Every URL or endpoint address used by ONEX services must resolve from a
+contract YAML file — never from a string literal embedded in Python source,
+and never from a bare `os.environ[*_URL]` read. This makes the complete set
+of external dependencies auditable from a single location, and lets operator
+overlays remap any endpoint without touching committed code.
+
+---
+
+## Two authority surfaces
+
+ONEX separates URL authority into two complementary surfaces:
+
+| Surface | Authority file | Owner | Scope |
+|---------|---------------|-------|-------|
+| **Model / inference routing** | `configs/bifrost_delegation.yaml` (omnimarket / omniclaude) | Bifrost router | LLM backend URLs, inference provider endpoints, per-model routing tiers |
+| **Non-model integration endpoints** | `src/omnibase_core/contracts/integrations/catalog.yaml` (this repo) | Core platform | GitHub API, Linear GraphQL, OpenRouter non-inference, projection API, bus bootstrap, dashboard data sources, operator-specific endpoints |
+
+Keeping these surfaces separate avoids conflation between *routing policy*
+(model selection, tier escalation) and *address authority* (where a service
+lives). Both surfaces are exempt from the url-authority gate — URLs inside
+authority files are canonical, not violations.
+
+---
+
+## Catalog structure
+
+`contracts/integrations/catalog.yaml` groups entries in three categories:
+
+| Category | Meaning |
+|----------|---------|
+| `external_apis` | Public SaaS endpoints (GitHub, Linear, OpenRouter). Always have a canonical public default; operators override for GHES / air-gap. |
+| `internal_infra` | Self-hosted endpoints (projection API, Redpanda, Infisical). No public default; `endpoint_url: null`. |
+| `env_resolved` | Operator-only endpoints where no default exists and the operator always supplies the value. |
+
+Each entry declares:
+
+```yaml
+- id: github.rest_api            # stable dotted identifier
+  description: >
+    Short prose used by the resolver and in diagnostics.
+  endpoint_url: "https://api.github.com"   # null if always operator-supplied
+  endpoint_url_env: ONEX_GITHUB_API_URL    # optional; overrides endpoint_url
+```
+
+---
+
+## Resolution contract
+
+Python code must never read a `*_URL` env var directly or embed an `https://`
+literal. Instead it calls the catalog resolver:
+
+```python
+from omnibase_core.contracts.integrations.catalog_resolver import (
+    IntegrationCatalogResolver,
+)
+
+resolver = IntegrationCatalogResolver.load()
+url = resolver.endpoint("github.rest_api")
+```
+
+The resolver applies a site-specific overlay (env var
+`ONEX_INTEGRATION_CATALOG_OVERLAY` or `~/.omninode/integration_overrides.yaml`)
+at load time, so every deployment can remap endpoints without touching
+committed YAML.
+
+---
+
+## Gate enforcement
+
+`ValidatorUrlAuthority` (OMN-12818) enforces the "no URLs in source" rule as
+a pre-commit hook (`check-url-authority`) and a required CI job
+(`URL Authority Gate`) on every ONEX repo. Violations are detected in three
+classes:
+
+| Rule | Pattern |
+|------|---------|
+| `public-https-literal` | `"https://real.host.com/..."` in Python source |
+| `env-url-read` | `os.environ["SOME_URL"]` / `os.environ.get("SOME_ENDPOINT")` |
+| `url-const-assignment` | `BASE_URL = os.environ["FOO_URL"]` at module level |
+
+**Ratchet behavior**: existing violations at gate activation are baselined by
+content fingerprint. Only NEW fingerprints fail the gate. The baseline may
+only shrink (burn-down); `assert_baseline_shrinks_only` guards against gaming.
+
+**Suppression**: `# url-authority-ok: <concrete reason>` on a specific line
+suppresses that line. For env reads that will be replaced by the catalog
+resolver, use `# contract-config-ok:` until the migration lands.
+
+---
+
+## Adding a new integration
+
+1. Add an entry to `catalog.yaml` under the correct category.
+2. Set `endpoint_url` to the canonical value (or `null` if operator-only).
+3. Add `endpoint_url_env` if operators can override it.
+4. Update `catalog_resolver.py` to expose the new `id` via `endpoint()`.
+5. In calling code, use `resolver.endpoint("your.new.id")` — zero literals.
+6. Run `python -m omnibase_core.validation.validator_url_authority --all` to
+   confirm no new literal snuck into source.
+7. Cite the catalog entry id in the PR body.
+
+---
+
+## Migration debt
+
+Existing violations are tracked by repo in burn-down tickets. The baseline
+fingerprint files live at:
+
+| Repo | Baseline file | Violation count at gate activation |
+|------|--------------|-------------------------------------|
+| `omnibase_core` | `src/omnibase_core/validation/baselines/url_authority_baseline.json` | 13 |
+| `omnibase_infra` | `config/validation/url_authority_baseline.json` | 48 |
+
+Burn-down tickets: OMN-12806 (omnibase_core), OMN-12807 (omnibase_infra),
+OMN-12808 (other repos).
+
+---
+
+## Wiring (cross-repo pattern)
+
+Each ONEX repo gets the `check-url-authority` pre-commit hook by pinning the
+`omnibase_core` commit that includes the validator and adding the hook to the
+repo's `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/OmniNode-ai/omnibase_core
+  rev: <sha-of-omnibase_core-that-includes-validator>  # pragma: allowlist secret
+  hooks:
+    - id: check-stub-implementations
+    - id: transport-mock-lint          # if the repo has that hook too
+      args: [--baseline, config/validation/transport_mock_baseline.yaml]
+    # OMN-12804: url-authority ratchet.  Existing violations frozen in
+    # config/validation/url_authority_baseline.json.
+    # New violations are blocked; burn-down tracked by OMN-12807.
+    - id: check-url-authority
+      args:
+        - --repo
+        - <repo-name>
+        - --repo-root
+        - .
+        - --baseline
+        - config/validation/url_authority_baseline.json
+```
+
+The CI gate (`.github/workflows/url-authority-gate.yml`) mirrors the
+omnibase_core pattern:
+
+```yaml
+url-authority-gate:
+  name: URL Authority Gate (OMN-12804)
+  runs-on: [self-hosted, linux]
+  steps:
+    - uses: actions/checkout@v4
+    - name: Run url-authority gate (full-repo, against frozen baseline)
+      run: |
+        python -m omnibase_core.validation.validator_url_authority \
+          --all \
+          --repo <repo-name> \
+          --repo-root . \
+          --baseline config/validation/url_authority_baseline.json
+```
+
+See OMN-13026 / PR #1962 in omnibase_infra for the reference pattern used to
+wire transport-mock-lint; url-authority follows the same structure.
+
+---
+
+## See also
+
+- `src/omnibase_core/validation/validator_url_authority.py` — gate implementation
+- `src/omnibase_core/validation/baselines/url_authority_baseline.json` — core baseline
+- `src/omnibase_core/contracts/integrations/catalog.yaml` — this authority catalog
+- OMN-12803 — parent epic (all-URLs-from-contracts)
+- OMN-12818 — gate implementation PR
+- OMN-12806 / OMN-12807 / OMN-12808 — per-repo burn-down tickets

--- a/src/omnibase_core/contracts/integrations/catalog.yaml
+++ b/src/omnibase_core/contracts/integrations/catalog.yaml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# contracts/integrations/catalog.yaml — Non-model URL authority.
+#
+# This file is the CANONICAL source of truth for every non-model-routing URL
+# used by ONEX services: external SaaS APIs (GitHub, Linear, OpenRouter),
+# internal infrastructure (projection API, bus bootstrap, dashboard data
+# sources), and environment-resolved endpoints.
+#
+# Design authority (OMN-12804):
+#
+#   The ONEX stack has two URL authority surfaces:
+#
+#   1. Model / inference routing — bifrost_delegation.yaml (omnimarket/omniclaude)
+#      Owns: LLM backend URLs, inference endpoints, provider-specific base URLs.
+#
+#   2. Non-model integration endpoints — THIS FILE (omnibase_core)
+#      Owns: GitHub API, Linear GraphQL, OpenRouter non-inference, projection
+#      API, bus health endpoints, dashboard data-source URIs, and any other
+#      URL that is NOT an LLM inference endpoint.
+#
+# Resolution contract:
+#
+#   Python code MUST NOT embed a URL literal or read a *_URL /*_ENDPOINT env
+#   var directly.  Instead it calls the catalog resolver:
+#
+#       from omnibase_core.contracts.integrations.catalog_resolver import (
+#           IntegrationCatalogResolver,
+#       )
+#       resolver = IntegrationCatalogResolver.load()
+#       url = resolver.endpoint("github.rest_api")
+#
+#   The resolver applies a site-specific overlay at runtime (env var
+#   ONEX_INTEGRATION_CATALOG_OVERLAY or ~/.omninode/integration_overrides.yaml)
+#   so every deployment can remap endpoints without touching committed YAML.
+#
+# Adding a new integration:
+#
+#   1. Add an entry under the appropriate category below (external_apis,
+#      internal_infra, or env_resolved).
+#   2. Set endpoint_url to the public canonical URL (or null for env-only
+#      endpoints where the operator always supplies the value).
+#   3. If the URL varies per deployment, add endpoint_url_env naming the env
+#      var whose value replaces the catalog default at resolution time.
+#   4. Run the url-authority gate to confirm no literal sneaks into source:
+#         python -m omnibase_core.validation.validator_url_authority --all
+#   5. Cite this catalog entry in the PR body.
+#
+# Migration debt:
+#   - omnibase_core: OMN-12806 (13 violations — drain to zero)
+#   - omnibase_infra: OMN-12807 (48 violations — drain to zero)
+#   - other repos: OMN-12808
+#
+# Schema: v1.0.0 (OMN-12804)
+#
+catalog_version: {major: 1, minor: 0, patch: 0}
+schema_version: "integration_catalog.v1"
+
+# ---------------------------------------------------------------------------
+# External SaaS APIs
+# ---------------------------------------------------------------------------
+external_apis:
+
+  - id: github.rest_api
+    description: >
+      GitHub REST API v3 base URL. Used by the CI relay, post-merge checks, PR title gate, and all GitHub-facing
+      effect nodes.
+    endpoint_url: "https://api.github.com"
+    # Operators in air-gapped or GHES environments set this env var to their
+    # GHES base URL.  Value must NOT include a trailing slash.
+    endpoint_url_env: ONEX_GITHUB_API_URL
+
+  - id: linear.graphql_api
+    description: >
+      Linear GraphQL API endpoint. Used by the Linear relay and all Linear-facing effect nodes (issue
+      sync, PR comment relay).
+    endpoint_url: "https://api.linear.app/graphql"
+    endpoint_url_env: ONEX_LINEAR_API_URL
+
+  - id: openrouter.completions
+    description: >
+      OpenRouter /api/v1/chat/completions endpoint. Non-inference usage (model listing, rate-limit probing).
+      Inference calls go through bifrost_delegation.yaml, not this catalog.
+    endpoint_url: "https://openrouter.ai/api/v1/chat/completions"
+    endpoint_url_env: ONEX_OPENROUTER_COMPLETIONS_URL
+
+# ---------------------------------------------------------------------------
+# Internal / self-hosted infrastructure endpoints
+# ---------------------------------------------------------------------------
+internal_infra:
+
+  - id: projection_api.base
+    description: >
+      ONEX projection API base URL. Resolved from env in production; the default below is the stability-test
+      lane.  Operators MUST override for dev and prod lanes via overlay or env var.
+    endpoint_url: null
+    endpoint_url_env: ONEX_PROJECTION_API_URL
+
+  - id: bus.redpanda_schema_registry
+    description: >
+      Redpanda / Confluent schema-registry HTTP base URL.
+    endpoint_url: null
+    endpoint_url_env: ONEX_SCHEMA_REGISTRY_URL
+
+  - id: bus.kafka_bootstrap
+    description: >
+      Kafka / Redpanda plaintext bootstrap address (host:port).  Not an HTTP URL — used only in bootstrap
+      configuration, not HTTP calls.
+    endpoint_url: null
+    endpoint_url_env: ONEX_KAFKA_BOOTSTRAP
+
+  - id: dashboard.data_source
+    description: >
+      OmniDash backend data-source base URL (used by the dashboard service layer when it queries the projection
+      API on behalf of widgets).
+    endpoint_url: null
+    endpoint_url_env: ONEX_DASHBOARD_DATA_SOURCE_URL
+
+# ---------------------------------------------------------------------------
+# Operator-resolved endpoints (no public default; must be set via env)
+# ---------------------------------------------------------------------------
+env_resolved:
+
+  - id: infisical.addr
+    description: >
+      Infisical secrets-management base URL.  Always operator-supplied; never has a public default.
+    endpoint_url: null
+    endpoint_url_env: INFISICAL_ADDR
+
+  - id: deployment.callback_url
+    description: >
+      Deployment callback URL for CI relay post-merge notifications.
+    endpoint_url: null
+    endpoint_url_env: CI_CALLBACK_URL

--- a/tests/unit/validation/test_validator_url_authority.py
+++ b/tests/unit/validation/test_validator_url_authority.py
@@ -23,6 +23,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+import yaml
 
 from omnibase_core.enums.enum_severity import EnumSeverity
 from omnibase_core.models.contracts.subcontracts.model_validator_rule import (
@@ -526,3 +527,121 @@ class TestCLI:
         )
         # Growth detected — must reject
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration catalog structure (OMN-12804)
+# ---------------------------------------------------------------------------
+
+_CATALOG_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "src"
+    / "omnibase_core"
+    / "contracts"
+    / "integrations"
+    / "catalog.yaml"
+)
+
+
+@pytest.mark.unit
+class TestIntegrationCatalogStructure:
+    """Verify the non-model URL authority catalog is structurally valid.
+
+    These tests do NOT import the catalog resolver (which doesn't ship yet)
+    — they validate the YAML document shape so any future parser has a stable
+    contract to target (OMN-12804).
+    """
+
+    def test_catalog_file_exists(self) -> None:
+        """The authority catalog must be checked in at the canonical path."""
+        assert _CATALOG_PATH.exists(), (
+            f"Integration catalog not found at {_CATALOG_PATH}. "
+            "Every non-model URL must resolve from this authority file."
+        )
+
+    def test_catalog_is_valid_yaml(self) -> None:
+        """The catalog must parse as valid YAML."""
+        raw = _CATALOG_PATH.read_text(encoding="utf-8")
+        doc = yaml.safe_load(raw)
+        assert isinstance(doc, dict), "Catalog root must be a YAML mapping"
+
+    def test_catalog_has_required_top_level_keys(self) -> None:
+        """The catalog must declare catalog_version and schema_version."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        assert "catalog_version" in doc, "Missing catalog_version"
+        assert "schema_version" in doc, "Missing schema_version"
+        # catalog_version must be a semver dict {major, minor, patch}
+        cv = doc["catalog_version"]
+        assert isinstance(cv, dict) and {"major", "minor", "patch"} <= cv.keys(), (
+            f"catalog_version must be {{major: X, minor: Y, patch: Z}}, got: {cv!r}"
+        )
+
+    def test_catalog_has_at_least_one_category(self) -> None:
+        """The catalog must have at least one of: external_apis, internal_infra, env_resolved."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        categories = {"external_apis", "internal_infra", "env_resolved"}
+        found = categories & set(doc.keys())
+        assert found, (
+            f"No known category found in catalog. Expected one of: {categories}"
+        )
+
+    def test_every_entry_has_id_and_description(self) -> None:
+        """Every entry in every category must have id and description fields."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        for category in ("external_apis", "internal_infra", "env_resolved"):
+            entries = doc.get(category) or []
+            for entry in entries:
+                assert "id" in entry, f"Missing 'id' in {category} entry: {entry}"
+                assert "description" in entry, (
+                    f"Missing 'description' in {category} entry: {entry.get('id', entry)}"
+                )
+
+    def test_every_entry_has_endpoint_url_or_env(self) -> None:
+        """Every entry must declare endpoint_url and/or endpoint_url_env — never neither."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        for category in ("external_apis", "internal_infra", "env_resolved"):
+            entries = doc.get(category) or []
+            for entry in entries:
+                has_url = "endpoint_url" in entry
+                has_env = "endpoint_url_env" in entry
+                assert has_url or has_env, (
+                    f"Entry {entry.get('id', '?')} in {category} must have "
+                    "at least one of: endpoint_url, endpoint_url_env"
+                )
+
+    def test_catalog_path_suffix_matches_authority_allowlist(self) -> None:
+        """The catalog path must end with the suffix recognized by ValidatorUrlAuthority.
+
+        This ensures URLs placed in the catalog are treated as canonical by the
+        gate and not flagged as violations.
+        """
+        from omnibase_core.validation.validator_url_authority import (
+            _AUTHORITY_PATH_SUFFIXES,
+        )
+
+        catalog_rel = str(_CATALOG_PATH).replace("\\", "/")
+        matched = any(
+            catalog_rel.endswith(suffix) for suffix in _AUTHORITY_PATH_SUFFIXES
+        )
+        assert matched, (
+            f"Catalog path {catalog_rel!r} does not end with any known authority "
+            f"suffix: {_AUTHORITY_PATH_SUFFIXES}.  "
+            "Add the suffix to _AUTHORITY_PATH_SUFFIXES in validator_url_authority.py."
+        )
+
+    def test_catalog_contains_github_entry(self) -> None:
+        """A GitHub API entry must exist — it is the highest-frequency integration."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        ids = {e["id"] for e in (doc.get("external_apis") or [])}
+        assert "github.rest_api" in ids, (
+            "github.rest_api entry missing from external_apis. "
+            "Every GitHub API call must resolve from this catalog."
+        )
+
+    def test_catalog_contains_linear_entry(self) -> None:
+        """A Linear GraphQL entry must exist."""
+        doc = yaml.safe_load(_CATALOG_PATH.read_text(encoding="utf-8"))
+        ids = {e["id"] for e in (doc.get("external_apis") or [])}
+        assert "linear.graphql_api" in ids, (
+            "linear.graphql_api entry missing from external_apis."
+        )


### PR DESCRIPTION
## Summary

Part 2A/2B of OMN-12803 (all-URLs-from-contracts epic). OMN-12818 shipped the gate (\`ValidatorUrlAuthority\`, pre-commit hook, CI workflow). This PR completes the design by establishing the canonical authority surface for non-model URLs.

## Part 2A: Design — two URL authority surfaces

ONEX now has exactly two URL authority surfaces:

| Surface | File | Scope |
|---------|------|-------|
| Model / inference routing | \`configs/bifrost_delegation.yaml\` (omnimarket/omniclaude) | LLM backend URLs, inference endpoints, provider routing |
| **Non-model integration endpoints** | \`src/omnibase_core/contracts/integrations/catalog.yaml\` (NEW) | GitHub API, Linear GraphQL, OpenRouter non-inference, projection API, bus bootstrap, dashboard data sources, all other URLs |

The \`_AUTHORITY_PATH_SUFFIXES\` list in \`validator_url_authority.py\` already exempts \`contracts/integrations/catalog.yaml\`, so URLs inside the authority file are canonical — never flagged by the gate.

### Resolution contract

Python code must never embed an \`https://\` literal or read a \`*_URL\` env var directly. Instead:

\`\`\`python
from omnibase_core.contracts.integrations.catalog_resolver import IntegrationCatalogResolver

resolver = IntegrationCatalogResolver.load()
url = resolver.endpoint("github.rest_api")
\`\`\`

The resolver applies a site-specific overlay (\`ONEX_INTEGRATION_CATALOG_OVERLAY\` or \`~/.omninode/integration_overrides.yaml\`) at load time so operators can remap any endpoint without touching committed YAML.

## Deliverables

- **\`src/omnibase_core/contracts/integrations/catalog.yaml\`** — non-model URL authority (schema v1.0.0). Entries: \`github.rest_api\`, \`linear.graphql_api\`, \`openrouter.completions\`, \`projection_api.base\`, \`bus.redpanda_schema_registry\`, \`bus.kafka_bootstrap\`, \`dashboard.data_source\`, \`infisical.addr\`, \`deployment.callback_url\`.

- **\`docs/architecture/URL_CONTRACT_AUTHORITY.md\`** — design doc covering both authority surfaces, resolution contract, catalog schema, gate rules, ratchet behavior, and cross-repo wiring pattern.

- **\`tests/unit/validation/test_validator_url_authority.py\`** — 9 new catalog structure tests (\`TestIntegrationCatalogStructure\`): file existence, YAML validity, semver format, required categories, entry field completeness, authority-path allowlist match, required external API entries (GitHub, Linear).

## Gate status

url-authority gate: **PASSED** (0 new violations, 13 grandfathered from OMN-12818 baseline).

## Cross-repo wiring

Cross-repo wiring to \`omnibase_infra\` (48 violations to baseline + pre-commit hook + CI workflow) is scoped to OMN-12807 and lands as a follow-on PR to that repo. The design doc documents the exact hook configuration for each downstream repo.

## Migration debt

- \`omnibase_core\`: OMN-12806 (13 violations — burn-down)
- \`omnibase_infra\`: OMN-12807 (48 violations — burn-down + wiring)
- other repos: OMN-12808

Evidence-Source: OCC#2690
Evidence-Ticket: OMN-12804