### PR TITLE
chore(OMN-13200): bump omnibase_core to v0.45.0 (B6 envelope-dedup pin propagation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.45.0 (2026-06-17)
+
+### Breaking Changes
+- refactor(OMN-13200): bump omnibase_core to v0.45.0 — removes ModelOnexEnvelope public API (deleted in #1250, B4). Canonical envelope is ModelEventEnvelope[T]. Minor bump per pre-1.0 semver convention for a breaking public-API deletion.
+
 ## v0.44.2 (2026-06-07)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.44.2"
+version = "0.45.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-13200 — B6: omnibase_core v0.45.0 bump + pin propagation

Final phase of the platform-debt envelope-dedup workstream. `ModelOnexEnvelope` was deleted from the public API in B4 (PR #1250, merged to dev at `e9bb51aacac98c6b9ae89f5aa26b2668e6508404`), collapsing the canonical envelope surface to `ModelEventEnvelope[T]`. This PR bumps the package version to propagate the breaking-deletion signal to dependents and trigger cross-repo pin-update bot PRs.

### Changes
- `pyproject.toml` version `0.44.2` -> `0.45.0` — minor bump under the repo's pre-1.0 semver convention for a breaking public-API deletion (CHANGELOG bump history: minor bumps carry breaking/feature changes, patch bumps are release-promotion chores). pyproject is the single source of truth; `__version__` reads dynamically via `version("omnibase-core")`, and `IMPORT_COMPATIBILITY_MATRIX.md` is historical v0.4.0, not version-derived, so no matrix hand-edit.
- `uv.lock` regenerated so its self-reference reads `0.45.0`.
- `CHANGELOG.md` Breaking Changes entry.

### Verification (origin/dev HEAD `e9bb51aac`)
- `grep -rniE 'ModelOnexEnvelope|model_onex_envelope' src/ tests/` -> **0 references** (class fully gone)
- `uv run mypy src/omnibase_core` (CI-canonical strict gate) -> **Success: no issues found in 3864 source files**
- `pytest tests/unit/validation/test_envelope_validator.py tests/unit/mixins/test_mixin_intent_publisher.py` -> **67 passed**
- `ruff check --fix src/ tests/` -> All checks passed
- `pre-commit run` (staged files) -> pass

### dod_evidence
- Evidence-Ticket: OMN-13200
- Evidence-Source: contracts/OMN-13200.yaml — paired OCC receipt PR OmniNode-ai/onex_change_control#2698 (verifier `receipt-gate-local` != runner `omn-13200-impl`, contract_sha256 bound to staged contract bytes, status PASS)

Predecessor B4 (OMN-13196, PR #1250) is MERGED to dev (`e9bb51aacac98c6b9ae89f5aa26b2668e6508404`, the base of this branch).

Evidence-Source: OCC#2698
Evidence-Ticket: OMN-13200