### PR TITLE
feat(OMN-13209): promote runtime-deployment wire DTOs to core (A2 core slice)

### DIFF
--- a/src/omnibase_core/enums/enum_runtime_lane.py
+++ b/src/omnibase_core/enums/enum_runtime_lane.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime Lane Enum.
+
+Canonical runtime lane targeted by a deployment request or proof. Graduated from
+``omnibase_compat.contracts.runtime_deployment.wire.types`` (OMN-13209 / A2) now
+that >=2 repos import it. Values match the OCC-owned wire schema enum and the live
+``.201`` runtime lanes.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumRuntimeLane(UtilStrValueHelper, str, Enum):
+    """Runtime lane targeted by a deployment request or proof.
+
+    Values match the OCC wire schema enum and the live ``.201`` runtime lanes:
+    dev (8085/8086, omnibase-infra), stability-test (18085/18086,
+    omnibase-infra-stability-test), prod (28085/28086, omnibase-infra-prod).
+    """
+
+    DEV = "dev"
+    STABILITY_TEST = "stability-test"
+    PROD = "prod"
+
+
+__all__: list[str] = ["EnumRuntimeLane"]

--- a/src/omnibase_core/models/runtime_deployment/__init__.py
+++ b/src/omnibase_core/models/runtime_deployment/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime deployment wire DTOs (canonical, graduated from omnibase_compat).
+
+OMN-13209 (A2): the runtime-deployment lane enum and deployment-proof wire DTO
+graduate from the transient ``omnibase_compat.contracts.runtime_deployment.wire``
+mirror to this canonical core home now that >=2 repos import them. OCC remains the
+schema source of truth (``onex_change_control`` wire schemas); core owns the
+shared Python authority that downstream nodes import.
+"""

--- a/src/omnibase_core/models/runtime_deployment/wire/__init__.py
+++ b/src/omnibase_core/models/runtime_deployment/wire/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical runtime-deployment wire DTOs (graduated from omnibase_compat, OMN-13209).
+
+OCC owns the schema source of truth
+(``onex_change_control/src/onex_change_control/wire_schemas/``); core owns the
+shared Python authority for the lane enum and deployment-proof DTO that the
+deployment/OCC nodes import. ``EnumRuntimeLane`` is canonically defined in
+``omnibase_core.enums.enum_runtime_lane`` and re-exported here for the wire API.
+"""
+
+from omnibase_core.enums.enum_runtime_lane import EnumRuntimeLane
+from omnibase_core.models.runtime_deployment.wire.model_runtime_deployment_proof import (
+    DeploymentProofStatus,
+    ModelRuntimeDeploymentProof,
+    ProbeStatus,
+)
+
+__all__: list[str] = [
+    "DeploymentProofStatus",
+    "EnumRuntimeLane",
+    "ModelRuntimeDeploymentProof",
+    "ProbeStatus",
+]

--- a/src/omnibase_core/models/runtime_deployment/wire/model_runtime_deployment_proof.py
+++ b/src/omnibase_core/models/runtime_deployment/wire/model_runtime_deployment_proof.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRuntimeDeploymentProof — runtime deployment proof wire DTO (canonical core home).
+
+Graduated from ``omnibase_compat.contracts.runtime_deployment.wire`` (OMN-13209 /
+A2). Mirrors the OCC-owned wire schema
+(``onex_change_control/src/onex_change_control/wire_schemas/
+runtime_deployment_proof_v1.yaml``, topic
+``onex.evt.omnimarket.runtime-deployment-proof.v1``); OCC owns the schema source
+of truth, core owns the shared Python authority. The proof is assembled from the
+live runtime attestation surfaces plus the per-lane health/ready/digest probe.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_runtime_lane import EnumRuntimeLane
+
+type ProbeStatus = Literal["pass", "fail"]
+type DeploymentProofStatus = Literal["success", "failed"]
+
+
+class ModelRuntimeDeploymentProof(BaseModel):
+    """Per-lane runtime deployment proof consumed by the readiness gate.
+
+    ``image_digest`` is the prod-gate authority: production may deploy only the
+    digest proven READY in stability-test, so it is a required proof field.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(
+        ...,
+        description="Deployment run correlation ID shared by all deployment events.",
+    )
+    deployment_id: UUID = Field(
+        ...,
+        description="Stable identifier for the deployment attempt this proof covers.",
+    )
+    runtime_lane: EnumRuntimeLane = Field(
+        ..., description="Runtime lane that was probed."
+    )
+    source_sha: str = Field(
+        ...,
+        min_length=1,
+        description="Source commit SHA bound to the deployed artifact.",
+    )
+    image_digest: str = Field(
+        ...,
+        min_length=1,
+        description="Immutable digest of the running container image. Prod-gate authority.",
+    )
+    compose_project: str = Field(
+        ..., min_length=1, description="Compose project that owns the deployed lane."
+    )
+    health_status: ProbeStatus = Field(
+        ..., description="Per-lane /health probe result."
+    )
+    ready_status: ProbeStatus = Field(..., description="Per-lane /ready probe result.")
+    probed_at: datetime = Field(..., description="When the per-lane probe completed.")
+    status: DeploymentProofStatus = Field(..., description="Overall proof status.")
+    # string-id-ok: promotion_batch_id is a human-readable promotion batch label shared across OCC evidence, not a UUID.
+    promotion_batch_id: str | None = Field(
+        default=None, description="Promotion batch identifier shared with OCC evidence."
+    )
+    runtime_addresses: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Probed runtime addresses (main/effects ports) for the lane.",
+    )
+    topology_manifest_sha256: str | None = Field(
+        default=None,
+        description="Topology manifest hash from the runtime manifest reducer.",
+    )
+    package_versions: dict[str, str] = Field(
+        default_factory=dict,
+        description="Deployed package versions from runtime attestation.",
+    )
+    runtime_source_hash: str | None = Field(
+        default=None,
+        description="Runtime source hash from the runtime source attestor.",
+    )
+    consumer_groups: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Active consumer groups observed on the probed lane.",
+    )
+    runtime_sweep_input_ref: str | None = Field(
+        default=None,
+        description="Reference to the runtime sweep input used for classification.",
+    )
+
+
+__all__: list[str] = [
+    "DeploymentProofStatus",
+    "ModelRuntimeDeploymentProof",
+    "ProbeStatus",
+]

--- a/tests/unit/models/runtime_deployment/__init__.py
+++ b/tests/unit/models/runtime_deployment/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/runtime_deployment/test_runtime_deployment_wire.py
+++ b/tests/unit/models/runtime_deployment/test_runtime_deployment_wire.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for graduated runtime-deployment wire DTOs (OMN-13209 / A2).
+
+The lane enum and deployment-proof DTO graduated from
+``omnibase_compat.contracts.runtime_deployment.wire`` to this canonical core home.
+These tests pin the enum values and the proof DTO's required-field / immutability
+contract so downstream nodes can rely on a single authority.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.runtime_deployment.wire import (
+    EnumRuntimeLane,
+    ModelRuntimeDeploymentProof,
+)
+
+
+@pytest.mark.unit
+def test_enum_runtime_lane_values() -> None:
+    """Lane enum values match the OCC wire schema and live .201 lanes."""
+    assert EnumRuntimeLane.DEV == "dev"
+    assert EnumRuntimeLane.STABILITY_TEST == "stability-test"
+    assert EnumRuntimeLane.PROD == "prod"
+    assert {lane.value for lane in EnumRuntimeLane} == {
+        "dev",
+        "stability-test",
+        "prod",
+    }
+
+
+@pytest.mark.unit
+def test_deployment_proof_round_trip() -> None:
+    """A fully populated proof round-trips through model_validate(model_dump())."""
+    proof = ModelRuntimeDeploymentProof(
+        correlation_id=uuid.uuid4(),
+        deployment_id=uuid.uuid4(),
+        runtime_lane=EnumRuntimeLane.STABILITY_TEST,
+        source_sha="abc123",
+        image_digest="sha256:deadbeef",
+        compose_project="omnibase-infra-stability-test",
+        health_status="pass",
+        ready_status="pass",
+        probed_at=datetime.now(UTC),
+        status="success",
+    )
+    restored = ModelRuntimeDeploymentProof.model_validate(proof.model_dump())
+    assert restored == proof
+    assert restored.runtime_lane is EnumRuntimeLane.STABILITY_TEST
+
+
+@pytest.mark.unit
+def test_deployment_proof_is_frozen() -> None:
+    """The proof DTO is immutable (frozen)."""
+    proof = ModelRuntimeDeploymentProof(
+        correlation_id=uuid.uuid4(),
+        deployment_id=uuid.uuid4(),
+        runtime_lane=EnumRuntimeLane.PROD,
+        source_sha="abc123",
+        image_digest="sha256:deadbeef",
+        compose_project="omnibase-infra-prod",
+        health_status="pass",
+        ready_status="pass",
+        probed_at=datetime.now(UTC),
+        status="success",
+    )
+    with pytest.raises(ValidationError):
+        proof.source_sha = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_deployment_proof_rejects_extra_fields() -> None:
+    """The proof DTO forbids unknown fields (extra='forbid')."""
+    with pytest.raises(ValidationError):
+        ModelRuntimeDeploymentProof(
+            correlation_id=uuid.uuid4(),
+            deployment_id=uuid.uuid4(),
+            runtime_lane=EnumRuntimeLane.DEV,
+            source_sha="abc123",
+            image_digest="sha256:deadbeef",
+            compose_project="omnibase-infra",
+            health_status="pass",
+            ready_status="pass",
+            probed_at=datetime.now(UTC),
+            status="success",
+            unexpected="boom",  # type: ignore[call-arg]
+        )


### PR DESCRIPTION
## OMN-13209 — [A2] Re-home node_redeploy OCC + runtime models (core promotion slice)

Epic: OMN-13205 (canonical node migration). Plan: `docs/plans/2026-06-17-canonical-node-migration-noncanonical-cleanup.md` §3.3, §4 Phase A2. Consumes the A0 ledger (OMN-13206).

This is the **omnibase_core promotion slice** of A2: graduate the runtime-deployment lane enum and deployment-proof wire DTO from the transient `omnibase_compat` mirror to their canonical core home, per the compat copy's `COMPAT_MIGRATION_TARGET: omnibase_core.contracts.runtime_deployment.wire` header and the `>=2 repos import` graduation condition (the `node_redeploy` copy made it a 2nd-repo importer — A0 ledger rows for `EnumRuntimeLane` and `ModelRuntimeDeploymentProof`).

### What changed
- `omnibase_core.enums.enum_runtime_lane.EnumRuntimeLane` — `UtilStrValueHelper, str, Enum` (file-location validator requires `Enum*` classes in `enums/`).
- `omnibase_core.models.runtime_deployment.wire` — `ModelRuntimeDeploymentProof` + `ProbeStatus`/`DeploymentProofStatus` aliases; `__init__` re-exports the enum for the wire API.
- Unit tests: enum values, proof round-trip, frozen + extra=forbid contract.

### Provenance
Promoted from the **existing compat copy** (`omnibase_compat/.../contracts/runtime_deployment/wire/`), not authored fresh from the node files — exactly as the plan directs ("Do not author a fresh core copy from the node files").

### Path deviation from plan (documented)
The plan cited `omnibase_core.contracts.runtime_deployment.wire`. Any Pydantic `BaseModel` under a non-exempt core namespace trips core's `disallow_any_explicit` mypy gate (`mypy.ini` documents this for `pipeline.*`/`hooks.*`/`package.*`: "Pydantic BaseModel triggers [explicit-any] in class definitions ... NOT legacy tech debt"). The established graduated-wire home is `models.*` (cf. `models.delegation.wire`, OMN-12126). Wire DTOs therefore live under `models.runtime_deployment.wire`; the lane enum under `enums.*` per the file-location validator. Same substantive authority, lint-clean home.

### DoD evidence
- `uv run pytest tests/unit/models/runtime_deployment/ -q` → 4 passed (local).
- `uv run mypy src/omnibase_core/models/runtime_deployment/ src/omnibase_core/enums/enum_runtime_lane.py --strict` → clean.
- `uv run ruff format/check` → clean.
- `pre-commit run --files <staged>` → exit 0 (DETERMINISTIC_SKILL_ROOT aligned to omniclaude@main per memory `feedback_omnibase_core_precommit_sibling_skill_scan`).

OCC recipe:
Evidence-Source: OCC#2710
Evidence-Ticket: OMN-13209

Foundational slice — unblocks the omnimarket re-home (occ_evidence owner + consumer repoint) and the compat deploy-agent-events move.
