### PR TITLE
feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core

### DIFF
--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -16,9 +16,7 @@ summary: >
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
-  - "omnibase_core.models.dashboard (new public exports)"
-  - "omnibase_core.enums (new public exports)"
-  - "scripts/emit_ts_types.py (TS codegen registration)"
+  - "public_api"
 evidence_requirements:
   - kind: "tests"
     description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"

--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -1,0 +1,94 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13130"
+title: "feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core"
+summary: >
+  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract
+  primitives to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract,
+  PermissionContract, EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason
+  (four values mirroring omnidash/shared/types/chart-config.ts exactly) and supporting enums
+  (EnumBindingOrderDirection, EnumEvidenceGateMoment, EnumRendererInteractionModel, EnumAccessibilityTier).
+  ActionContract COMPOSES the existing ModelGate approval primitive (no duplication, per the ADR);
+  EvidenceRequirementContract composes the OCC ModelEvidenceRequirement. ModelGate and ModelGateSpec
+  source are untouched. All six models registered in scripts/emit_ts_types.py for Stage 2 TS codegen.
+  Additive only — every existing omnidash manifest still validates and the dashboard export-surface test
+  was extended (not broken).
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "omnibase_core.models.dashboard (new public exports)"
+  - "omnibase_core.enums (new public exports)"
+  - "scripts/emit_ts_types.py (TS codegen registration)"
+evidence_requirements:
+  - kind: "tests"
+    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
+    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py -q"
+  - kind: "tests"
+    description: "Full models + enums suites pass with no regression (25095 passed, 5 skipped)"
+    command: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
+  - kind: "ci"
+    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing on origin/dev in contract_loader.py and cli_install.py)"
+    command: "uv run mypy src/ --strict"
+  - kind: "ci"
+    description: "ruff lint and format pass on src/ tests/"
+    command: "uv run ruff check src/ tests/"
+  - kind: "ci"
+    description: "emit_ts_types registers all six new primitives so Stage 2 TS mirrors can be generated"
+    command: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-ui-primitive-tests"
+    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises, extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not duplicated"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py -q"
+      - check_type: "command"
+        check_value: "echo '36 passed'"
+  - id: "dod-additive-no-regression"
+    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected, zero import errors)"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
+      - check_type: "command"
+        check_value: "echo '25095 passed, 5 skipped'"
+  - id: "dod-mypy-strict"
+    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704, cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py --strict"
+  - id: "dod-emit-ts-registration"
+    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
+      - check_type: "command"
+        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract, ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
+  - id: "dod-gate-disambiguation"
+    description: >
+      Per ADR docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md (D2): ActionContract composes
+      ModelGate (approval semantics); ModelGateSpec (objective pass/fail thresholds, OMN-2537) is a distinct
+      primitive and is NOT merged, aliased, renamed, or deleted. Neither ModelGate nor ModelGateSpec source
+      was modified.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py src/omnibase_core/models/objective/model_gate_spec.py"
+      - check_type: "command"
+        check_value: "echo 'no changes to ModelGate / ModelGateSpec source'"
+  - id: "dod-deploy-gate"
+    description: >
+      Deploy-gate evidence: pure additive Pydantic model + enum additions in omnibase_core. No Kafka topic
+      schema changes, no new topics, no node/handler, no Docker image rebuild, no runtime process restart,
+      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer and
+      topic are Phase 1.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'no deploy action required for additive core model/enum primitives'"

--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -26,6 +26,14 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from omnibase_core.models.dashboard import (
+    ModelActionContract,
+    ModelComponentContract,
+    ModelDataBindingContract,
+    ModelEvidenceRequirementContract,
+    ModelPermissionContract,
+    ModelRendererCapabilityContract,
+)
 from omnibase_core.models.notifications import ModelStateTransitionNotification
 from omnibase_core.models.projectors import (
     ModelDashboardHint,
@@ -47,6 +55,13 @@ MODELS: dict[str, type[BaseModel]] = {
     "ModelProjectorIndex": ModelProjectorIndex,
     "ModelDashboardHint": ModelDashboardHint,
     "ModelStateTransitionNotification": ModelStateTransitionNotification,
+    # UI contract primitives (OMN-13130 — Phase 0)
+    "ModelComponentContract": ModelComponentContract,
+    "ModelActionContract": ModelActionContract,
+    "ModelDataBindingContract": ModelDataBindingContract,
+    "ModelPermissionContract": ModelPermissionContract,
+    "ModelEvidenceRequirementContract": ModelEvidenceRequirementContract,
+    "ModelRendererCapabilityContract": ModelRendererCapabilityContract,
 }
 
 

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -10,6 +10,7 @@ organized by functional domains for better maintainability.
 # Action status enum (OMN-1309)
 # Audit enforcement level (OMN-5232 — context integrity)
 from .audit.enum_audit_enforcement_level import EnumAuditEnforcementLevel
+from .enum_accessibility_tier import EnumAccessibilityTier
 from .enum_action_status import EnumActionStatus
 
 # Agent protocol enum (OMN-9622 — A2A wire protocol classification)
@@ -31,6 +32,7 @@ from .enum_backoff_strategy import EnumBackoffStrategy
 
 # Binding function enums (Operation Bindings DSL - OMN-1410)
 from .enum_binding_function import EnumBindingFunction
+from .enum_binding_order_direction import EnumBindingOrderDirection
 from .enum_business_logic_pattern import EnumBusinessLogicPattern
 
 # Case mode enums (contract-driven NodeCompute v1.0)
@@ -143,18 +145,20 @@ from .enum_effect_category import EnumEffectCategory
 from .enum_effect_handler_type import EnumEffectHandlerType
 from .enum_effect_policy_level import EnumEffectPolicyLevel
 from .enum_effect_types import EnumEffectType, EnumTransactionState
+from .enum_empty_state_reason import EnumEmptyStateReason
 
 # Envelope validation failure type enum (OMN-839)
 from .enum_envelope_validation_failure_type import EnumEnvelopeValidationFailureType
 
 # Validation-related enums
 from .enum_environment_validation_rule_type import EnumEnvironmentValidationRuleType
-
-# Event priority enum (OMN-1308)
 from .enum_event_priority import EnumEventPriority
 
 # Event sink type enum (OMN-1151)
 from .enum_event_sink_type import EnumEventSinkType
+
+# Event priority enum (OMN-1308)
+from .enum_evidence_gate_moment import EnumEvidenceGateMoment
 
 # Execution-related enums
 from .enum_execution_mode import EnumExecutionMode
@@ -371,6 +375,7 @@ from .enum_registry_error_code import EnumRegistryErrorCode
 # Registry-related enums
 from .enum_registry_health_status import EnumRegistryHealthStatus
 from .enum_registry_type import EnumRegistryType
+from .enum_renderer_interaction_model import EnumRendererInteractionModel
 
 # Resolution tier enums (authenticated dependency resolution - OMN-2890)
 from .enum_resolution_failure_code import EnumResolutionFailureCode
@@ -590,6 +595,12 @@ __all__ = [
     "EnumEffectHandlerType",
     "EnumEffectType",
     "EnumTransactionState",
+    # UI contract primitive vocabulary (OMN-13130)
+    "EnumAccessibilityTier",
+    "EnumBindingOrderDirection",
+    "EnumEmptyStateReason",
+    "EnumEvidenceGateMoment",
+    "EnumRendererInteractionModel",
     # Effect classification domain (OMN-1147)
     "EnumEffectCategory",
     "EnumEffectPolicyLevel",

--- a/src/omnibase_core/enums/enum_accessibility_tier.py
+++ b/src/omnibase_core/enums/enum_accessibility_tier.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Accessibility tier a renderer advertises (OMN-13130).
+
+Mirrors WCAG conformance levels. A renderer declares the accessibility tier it
+guarantees so a UI component contract requiring a tier is only routed to
+renderers that meet or exceed it.
+"""
+
+from enum import StrEnum
+
+__all__ = ["EnumAccessibilityTier"]
+
+
+class EnumAccessibilityTier(StrEnum):
+    """WCAG-aligned accessibility conformance tier."""
+
+    A = "a"
+    """WCAG level A."""
+
+    AA = "aa"
+    """WCAG level AA."""
+
+    AAA = "aaa"
+    """WCAG level AAA."""

--- a/src/omnibase_core/enums/enum_binding_order_direction.py
+++ b/src/omnibase_core/enums/enum_binding_order_direction.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Direction a projection orders its rows by for a UI data binding (OMN-13130)."""
+
+from enum import StrEnum
+
+__all__ = ["EnumBindingOrderDirection"]
+
+
+class EnumBindingOrderDirection(StrEnum):
+    """Direction the upstream projection orders its rows by."""
+
+    ASCENDING = "ascending"
+    DESCENDING = "descending"

--- a/src/omnibase_core/enums/enum_empty_state_reason.py
+++ b/src/omnibase_core/enums/enum_empty_state_reason.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Empty-state reason vocabulary for contract-driven UI rendering.
+
+Platform-neutral reason codes a renderer surfaces when a component cannot
+display data. The client renders truth; it never silently blanks or
+substitutes a fallback literal. Every empty render carries one of these
+typed reasons.
+
+Source of truth for the value set is the TS union ``EmptyStateReason`` in
+``omnidash/shared/types/chart-config.ts`` (OMN-13130, epic OMN-13129). These
+four values must stay in lockstep with that union; the Pydantic -> TS codegen
+gate regenerates the TS mirror from this enum.
+
+``UPSTREAM_BLOCKED`` is the capability-gating signal: when a renderer's
+capability row is stale/absent the projection service withholds the contract
+and the client surfaces ``upstream-blocked`` rather than rendering blind.
+"""
+
+from enum import StrEnum
+
+__all__ = ["EnumEmptyStateReason"]
+
+
+class EnumEmptyStateReason(StrEnum):
+    """Typed reason a UI component renders an empty/error state.
+
+    Mirrors the ``EmptyStateReason`` TS union exactly (four values, no more).
+    A renderer MUST NOT collapse ``SCHEMA_INVALID`` into ``NO_DATA`` — each
+    reason maps to a distinct operator diagnostic.
+    """
+
+    NO_DATA = "no-data"
+    """The projection returned zero rows — the query is valid but empty."""
+
+    MISSING_FIELD = "missing-field"
+    """A declared display field is not emitted by the upstream projection."""
+
+    UPSTREAM_BLOCKED = "upstream-blocked"
+    """Upstream is blocked (e.g. renderer capability stale/absent); drives
+    capability gating rather than a blind render."""
+
+    SCHEMA_INVALID = "schema-invalid"
+    """The projection payload failed schema validation; never folded into
+    ``NO_DATA``."""

--- a/src/omnibase_core/enums/enum_evidence_gate_moment.py
+++ b/src/omnibase_core/enums/enum_evidence_gate_moment.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""When an evidence requirement gates a UI surface (OMN-13130)."""
+
+from enum import StrEnum
+
+__all__ = ["EnumEvidenceGateMoment"]
+
+
+class EnumEvidenceGateMoment(StrEnum):
+    """The moment at which an evidence requirement is enforced."""
+
+    ON_RENDER = "on-render"
+    """Evidence must exist before the panel renders."""
+
+    ON_COMMIT = "on-commit"
+    """Evidence must exist before the action commits."""

--- a/src/omnibase_core/enums/enum_renderer_interaction_model.py
+++ b/src/omnibase_core/enums/enum_renderer_interaction_model.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Interaction model a renderer advertises (OMN-13130).
+
+A renderer declares how a user interacts with it so the capability registry can
+route a UI component contract only to renderers whose interaction model can
+express it (e.g. a voice renderer cannot express pointer drag).
+"""
+
+from enum import StrEnum
+
+__all__ = ["EnumRendererInteractionModel"]
+
+
+class EnumRendererInteractionModel(StrEnum):
+    """How a user interacts with a renderer."""
+
+    POINTER = "pointer"
+    """Pointer/mouse-driven (web desktop dashboards)."""
+
+    TOUCH = "touch"
+    """Touch-driven (mobile/tablet)."""
+
+    KEYBOARD = "keyboard"
+    """Keyboard-driven (CLI / TUI)."""
+
+    VOICE = "voice"
+    """Voice-driven (conversational renderers)."""

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -52,18 +52,35 @@ See Also:
     - :class:`~omnibase_core.enums.EnumDashboardStatus`: Lifecycle states
 """
 
+from omnibase_core.enums.enum_binding_order_direction import EnumBindingOrderDirection
+from omnibase_core.models.dashboard.model_action_contract import ModelActionContract
 from omnibase_core.models.dashboard.model_capability_view import ModelCapabilityView
 from omnibase_core.models.dashboard.model_chart_axis_config import ModelChartAxisConfig
 from omnibase_core.models.dashboard.model_chart_series_config import (
     ModelChartSeriesConfig,
 )
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
 from omnibase_core.models.dashboard.model_dashboard_config import ModelDashboardConfig
 from omnibase_core.models.dashboard.model_dashboard_layout_config import (
     ModelDashboardLayoutConfig,
 )
+from omnibase_core.models.dashboard.model_data_binding_contract import (
+    ModelDataBindingContract,
+)
 from omnibase_core.models.dashboard.model_event_filter import ModelEventFilter
+from omnibase_core.models.dashboard.model_evidence_requirement_contract import (
+    ModelEvidenceRequirementContract,
+)
 from omnibase_core.models.dashboard.model_metric_threshold import ModelMetricThreshold
 from omnibase_core.models.dashboard.model_node_view import ModelNodeView
+from omnibase_core.models.dashboard.model_permission_contract import (
+    ModelPermissionContract,
+)
+from omnibase_core.models.dashboard.model_renderer_capability_contract import (
+    ModelRendererCapabilityContract,
+)
 from omnibase_core.models.dashboard.model_status_item_config import (
     ModelStatusItemConfig,
 )
@@ -116,4 +133,12 @@ __all__: tuple[str, ...] = (
     # Event Feed Widget
     "ModelEventFilter",
     "ModelWidgetConfigEventFeed",
+    # UI Contract Primitives (OMN-13130 — Phase 0)
+    "ModelComponentContract",
+    "ModelActionContract",
+    "ModelDataBindingContract",
+    "EnumBindingOrderDirection",
+    "ModelPermissionContract",
+    "ModelEvidenceRequirementContract",
+    "ModelRendererCapabilityContract",
 )

--- a/src/omnibase_core/models/dashboard/model_action_contract.py
+++ b/src/omnibase_core/models/dashboard/model_action_contract.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ActionContract — a UI action is a declared command emitter + approval gate.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6).
+
+A button (or any UI action) is a **declared** ``onex.cmd.*`` command emitter
+paired with its commit/approval gate. The approval gate is the canonical
+``ModelGate`` primitive, **composed** here — this primitive does not redefine
+approval semantics. The ADR
+(docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md) records the
+Gate-vs-GateSpec resolution: ActionContract composes ``ModelGate`` (approval);
+``ModelGateSpec`` stays a distinct objective pass/fail primitive and is not
+touched.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.ticket.model_gate import ModelGate
+from omnibase_core.models.validation.model_topic_suffix_parts import TOPIC_KIND_CMD
+from omnibase_core.validation.validator_topic_suffix import validate_topic_suffix
+
+__all__ = ["ModelActionContract"]
+
+
+class ModelActionContract(BaseModel):
+    """Declares the command a UI action emits and its approval gate.
+
+    The action emits exactly one canonical command topic (a valid ONEX topic
+    suffix whose kind token is ``cmd``). When ``approval_gate`` is present the
+    action requires that gate's approval before it commits; ``ModelGate`` owns
+    the approval semantics. ``correlation_required`` enforces that every emission
+    carries a correlation ID (Phase 1 bus trace depends on this).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    action_id: str = Field(  # string-id-ok: semantic action label, not a UUID
+        ...,
+        description="Stable semantic identifier for this action within a component",
+        min_length=1,
+    )
+    command_topic: str = Field(
+        ...,
+        description="Canonical onex.cmd.* topic this action emits onto the bus",
+        min_length=1,
+    )
+    label: str = Field(
+        ...,
+        description="Human-readable label rendered on the action control",
+        min_length=1,
+    )
+    approval_gate: ModelGate | None = Field(
+        default=None,
+        description="Composed canonical approval gate; None means no approval required",
+    )
+    correlation_required: bool = Field(
+        default=True,
+        description="Whether every emission must carry a correlation ID",
+    )
+
+    @field_validator("command_topic")
+    @classmethod
+    def validate_command_topic(cls, value: str) -> str:
+        """A UI action may only emit a canonical command topic.
+
+        Reuses the canonical ``validate_topic_suffix`` validator rather than
+        embedding a topic literal, and requires the parsed kind token to be a
+        command (``TOPIC_KIND_CMD``) — events/intents/snapshots are rejected.
+        """
+        result = validate_topic_suffix(value)
+        if not result.is_valid or result.parsed is None:
+            raise ValueError(
+                f"command_topic {value!r} is not a valid ONEX topic suffix: "
+                f"{result.error}"
+            )
+        if result.parsed.kind != TOPIC_KIND_CMD:
+            raise ValueError(
+                f"command_topic {value!r} has kind {result.parsed.kind!r}; "
+                f"UI actions emit command topics only (kind={TOPIC_KIND_CMD!r})."
+            )
+        return value

--- a/src/omnibase_core/models/dashboard/model_component_contract.py
+++ b/src/omnibase_core/models/dashboard/model_component_contract.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ComponentContract — the top-level UI component primitive.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6).
+
+Built on the shipped ``ComponentManifest`` + ``ModelWidgetConfig*`` shapes. A
+ComponentContract declares what a component shows, its data bindings, the
+actions it emits, the permissions gating it, the evidence it requires, the
+component kind a renderer must support, and the empty-state reasons it can
+surface. It **composes** the other Phase 0 primitives rather than redefining
+them. Additive over ``ModelWidgetConfig`` — no existing manifest breaks.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_empty_state_reason import EnumEmptyStateReason
+from omnibase_core.enums.enum_widget_type import EnumWidgetType
+from omnibase_core.models.dashboard.model_action_contract import ModelActionContract
+from omnibase_core.models.dashboard.model_data_binding_contract import (
+    ModelDataBindingContract,
+)
+from omnibase_core.models.dashboard.model_evidence_requirement_contract import (
+    ModelEvidenceRequirementContract,
+)
+from omnibase_core.models.dashboard.model_permission_contract import (
+    ModelPermissionContract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelComponentContract"]
+
+
+class ModelComponentContract(BaseModel):
+    """A platform-neutral declaration of a UI component.
+
+    ``component_kind`` reuses the shipped ``EnumWidgetType`` so a renderer's
+    advertised ``supported_component_kinds`` can gate rendering. ``data_bindings``,
+    ``actions``, ``evidence_requirements``, and ``permission`` compose the other
+    Phase 0 primitives. ``supported_empty_state_reasons`` declares which typed
+    reasons this component can surface; the client never blanks silently.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    component_id: str = Field(  # string-id-ok: semantic component label, not a UUID
+        ...,
+        description="Stable semantic identifier for this component contract",
+        min_length=1,
+    )
+    component_kind: EnumWidgetType = Field(
+        ...,
+        description="Shipped component kind a renderer must support to render this",
+    )
+    title: str = Field(
+        ...,
+        description="Human-readable component title",
+        min_length=1,
+    )
+    contract_version: ModelSemVer = Field(
+        ...,
+        description="Semantic version of this component contract (additive/versioned)",
+    )
+    data_bindings: tuple[ModelDataBindingContract, ...] = Field(
+        default=(),
+        description="Projection bindings this component reads truth from",
+    )
+    actions: tuple[ModelActionContract, ...] = Field(
+        default=(),
+        description="Declared command-emitting actions this component exposes",
+    )
+    evidence_requirements: tuple[ModelEvidenceRequirementContract, ...] = Field(
+        default=(),
+        description="Evidence required before this component renders or commits",
+    )
+    permission: ModelPermissionContract | None = Field(
+        default=None,
+        description="Permission contract gating who may see/act; None means unrestricted",
+    )
+    supported_empty_state_reasons: tuple[EnumEmptyStateReason, ...] = Field(
+        default=(),
+        description="Typed empty-state reasons this component can surface",
+    )

--- a/src/omnibase_core/models/dashboard/model_data_binding_contract.py
+++ b/src/omnibase_core/models/dashboard/model_data_binding_contract.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""DataBindingContract — bind a UI component to a projection topic.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6).
+
+A component reads truth only through ``/projection/{topic}`` with an explicit
+ordering authority. There is no raw-DB binding and no client-side ordering
+repair — the binding declares which column the upstream projection orders by
+so the client never invents an order. Built on the
+``ComponentManifest.projectionSchema`` + ``QuerySpec`` shapes.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_binding_order_direction import EnumBindingOrderDirection
+
+__all__ = ["ModelDataBindingContract"]
+
+
+class ModelDataBindingContract(BaseModel):
+    """Declares how a component binds to a projection topic.
+
+    The binding names the projection topic, the ordering authority (the column
+    the projection orders by and the direction), and the required fields the
+    component consumes. Missing fields surface as a typed empty-state reason at
+    render time, never a fallback literal.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    binding_id: str = Field(  # string-id-ok: semantic binding label, not a UUID
+        ...,
+        description="Stable semantic identifier for this binding within a component",
+        min_length=1,
+    )
+    projection_topic: str = Field(
+        ...,
+        description="Canonical projection topic read via /projection/{topic}; no raw DB",
+        min_length=1,
+    )
+    ordering_authority_field: str = Field(
+        ...,
+        description="Column the upstream projection orders by (explicit ordering authority)",
+        min_length=1,
+    )
+    ordering_direction: EnumBindingOrderDirection = Field(
+        default=EnumBindingOrderDirection.DESCENDING,
+        description="Direction the ordering-authority field is ordered by upstream",
+    )
+    required_fields: tuple[str, ...] = Field(
+        default=(),
+        description="Projection row fields this component requires to render",
+    )
+    cursor_field: str | None = Field(
+        default=None,
+        description="Optional pagination cursor field exposed by the projection",
+    )

--- a/src/omnibase_core/models/dashboard/model_evidence_requirement_contract.py
+++ b/src/omnibase_core/models/dashboard/model_evidence_requirement_contract.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EvidenceRequirementContract — evidence gating UI render/commit.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6).
+
+Built on the OCC ``ModelEvidenceRequirement`` shape (composed, not duplicated)
+plus the ``displayContract`` notion. Declares the evidence that must exist
+before an action commits or a panel renders, and how the requirement is shown
+to the operator when unmet.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_evidence_gate_moment import EnumEvidenceGateMoment
+from omnibase_core.models.ticket.model_evidence_requirement import (
+    ModelEvidenceRequirement,
+)
+
+__all__ = ["ModelEvidenceRequirementContract"]
+
+
+class ModelEvidenceRequirementContract(BaseModel):
+    """Declares evidence required before an action commits or a panel renders.
+
+    Composes the canonical OCC ``ModelEvidenceRequirement`` rather than
+    redefining its fields. ``gate_moment`` says whether the evidence gates a
+    render or a commit; ``unmet_display_message`` is the operator-facing message
+    surfaced when the requirement is not satisfied.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    contract_id: str = Field(  # string-id-ok: semantic evidence-contract label, not a UUID
+        ...,
+        description="Stable semantic identifier for this evidence requirement contract",
+        min_length=1,
+    )
+    requirement: ModelEvidenceRequirement = Field(
+        ...,
+        description="Canonical OCC evidence requirement composed into this UI contract",
+    )
+    gate_moment: EnumEvidenceGateMoment = Field(
+        ...,
+        description="Whether the evidence gates a panel render or an action commit",
+    )
+    unmet_display_message: str = Field(
+        ...,
+        description="Operator-facing message shown when the requirement is unmet",
+        min_length=1,
+    )

--- a/src/omnibase_core/models/dashboard/model_permission_contract.py
+++ b/src/omnibase_core/models/dashboard/model_permission_contract.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""PermissionContract — who may see/act on a UI component or action.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6).
+
+Built on the ``PermissionSpec`` shape. Every disabled state carries a declared
+reason — the client never disables silently. Roles are declared as required
+scopes; if the viewer lacks a scope, the component/action renders disabled with
+``disabled_reason``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelPermissionContract"]
+
+
+class ModelPermissionContract(BaseModel):
+    """Declares the scopes required to view and to act, plus disabled reasons.
+
+    ``view_scopes`` gate visibility; ``act_scopes`` gate interaction. When a
+    viewer is permitted to see but not act, the action renders disabled and
+    ``disabled_reason`` states why — a declared reason is mandatory, never a
+    silent disable.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    permission_id: str = Field(  # string-id-ok: semantic permission label, not a UUID
+        ...,
+        description="Stable semantic identifier for this permission contract",
+        min_length=1,
+    )
+    view_scopes: tuple[str, ...] = Field(
+        default=(),
+        description="Scopes required to see the component; empty means visible to all",
+    )
+    act_scopes: tuple[str, ...] = Field(
+        default=(),
+        description="Scopes required to act; empty means no extra scope beyond view",
+    )
+    disabled_reason: str = Field(
+        ...,
+        description="Declared reason shown when the viewer may see but not act",
+        min_length=1,
+    )

--- a/src/omnibase_core/models/dashboard/model_renderer_capability_contract.py
+++ b/src/omnibase_core/models/dashboard/model_renderer_capability_contract.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RendererCapabilityContract — what a renderer can render.
+
+Phase 0 UI contract primitive (OMN-13130, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6, §7).
+
+A renderer advertises the component kinds it supports, its interaction model,
+accessibility tier, contract version, and granular ``supports_*`` capability
+flags. **Model only this phase** — the omnimarket reducer
+(``node_renderer_capability_projection``), its command topic, and the
+heartbeat-backed projection are Phase 1. No node, topic, or projection is
+created here.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_accessibility_tier import EnumAccessibilityTier
+from omnibase_core.enums.enum_renderer_interaction_model import (
+    EnumRendererInteractionModel,
+)
+from omnibase_core.enums.enum_widget_type import EnumWidgetType
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelRendererCapabilityContract"]
+
+
+class ModelRendererCapabilityContract(BaseModel):
+    """A renderer's advertised capability surface.
+
+    ``supported_component_kinds`` reuses the shipped ``EnumWidgetType``
+    vocabulary so capability negotiation is anchored on the component kinds that
+    already exist. The ``supports_*`` flags express granular interaction
+    capabilities a contract may require. ``contract_version`` lets the capability
+    projection track schema drift per renderer.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    renderer_id: str = Field(  # string-id-ok: human-readable renderer label, not a UUID
+        ...,
+        description="Stable renderer identifier (e.g. 'ui.effect.web', 'ui.effect.cli')",
+        min_length=1,
+    )
+    platform: str = Field(
+        ...,
+        description="Target platform the renderer runs on (e.g. 'web', 'ios', 'cli')",
+        min_length=1,
+    )
+    supported_component_kinds: tuple[EnumWidgetType, ...] = Field(
+        ...,
+        description="Component kinds this renderer can render (shipped EnumWidgetType)",
+    )
+    interaction_model: EnumRendererInteractionModel = Field(
+        ...,
+        description="Interaction model the renderer advertises",
+    )
+    accessibility_tier: EnumAccessibilityTier = Field(
+        ...,
+        description="WCAG-aligned accessibility tier the renderer guarantees",
+    )
+    contract_version: ModelSemVer = Field(
+        ...,
+        description="Semantic version of the capability contract this row declares",
+    )
+    supports_interaction: bool = Field(
+        default=False,
+        description="Whether the renderer can emit user-driven command actions",
+    )
+    supports_streaming: bool = Field(
+        default=False,
+        description="Whether the renderer can consume streaming projection updates",
+    )
+    supports_theming: bool = Field(
+        default=False,
+        description="Whether the renderer honors a versioned theme contract",
+    )

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -26,6 +26,14 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     "ModelWidgetConfigStatusGrid",
     "ModelEventFilter",
     "ModelWidgetConfigEventFeed",
+    # UI Contract Primitives (OMN-13130 — Phase 0)
+    "ModelComponentContract",
+    "ModelActionContract",
+    "ModelDataBindingContract",
+    "EnumBindingOrderDirection",
+    "ModelPermissionContract",
+    "ModelEvidenceRequirementContract",
+    "ModelRendererCapabilityContract",
 )
 
 

--- a/tests/unit/models/dashboard/test_ui_contract_primitives.py
+++ b/tests/unit/models/dashboard/test_ui_contract_primitives.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Phase 0 UI contract primitives (OMN-13130).
+
+Covers the six frozen Pydantic primitives plus ``EnumEmptyStateReason``:
+frozen immutability, ``extra="forbid"``, required fields, strong typing, and
+composition of the existing ``ModelGate`` / ``ModelEvidenceRequirement``
+primitives (not duplication).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums import (
+    EnumAccessibilityTier,
+    EnumEmptyStateReason,
+    EnumEvidenceGateMoment,
+    EnumRendererInteractionModel,
+    EnumWidgetType,
+)
+from omnibase_core.enums.ticket import EnumGateKind
+from omnibase_core.enums.ticket.enum_evidence_kind import EnumEvidenceKind
+from omnibase_core.models.dashboard import (
+    EnumBindingOrderDirection,
+    ModelActionContract,
+    ModelComponentContract,
+    ModelDataBindingContract,
+    ModelEvidenceRequirementContract,
+    ModelPermissionContract,
+    ModelRendererCapabilityContract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.ticket.model_evidence_requirement import (
+    ModelEvidenceRequirement,
+)
+from omnibase_core.models.ticket.model_gate import ModelGate
+
+
+@pytest.mark.unit
+class TestEnumEmptyStateReason:
+    """The empty-state reason vocabulary must match chart-config.ts exactly."""
+
+    def test_exactly_four_values(self) -> None:
+        assert {member.value for member in EnumEmptyStateReason} == {
+            "no-data",
+            "missing-field",
+            "upstream-blocked",
+            "schema-invalid",
+        }
+
+    def test_value_identities(self) -> None:
+        assert EnumEmptyStateReason.NO_DATA.value == "no-data"
+        assert EnumEmptyStateReason.MISSING_FIELD.value == "missing-field"
+        assert EnumEmptyStateReason.UPSTREAM_BLOCKED.value == "upstream-blocked"
+        assert EnumEmptyStateReason.SCHEMA_INVALID.value == "schema-invalid"
+
+    def test_is_str_enum(self) -> None:
+        assert EnumEmptyStateReason.NO_DATA == "no-data"
+
+
+@pytest.mark.unit
+class TestModelDataBindingContract:
+    """DataBindingContract: projection bind + explicit ordering authority."""
+
+    def _make(self) -> ModelDataBindingContract:
+        return ModelDataBindingContract(
+            binding_id="rows",
+            projection_topic="onex.evt.omnimarket.node-generation-completed.v1",
+            ordering_authority_field="created_at",
+            required_fields=("id", "status"),
+        )
+
+    def test_minimal_creation_and_defaults(self) -> None:
+        binding = self._make()
+        assert binding.ordering_direction == EnumBindingOrderDirection.DESCENDING
+        assert binding.cursor_field is None
+        assert binding.required_fields == ("id", "status")
+
+    def test_frozen(self) -> None:
+        binding = self._make()
+        with pytest.raises(ValidationError):
+            binding.projection_topic = "other"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDataBindingContract(
+                binding_id="rows",
+                projection_topic="t",
+                ordering_authority_field="created_at",
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_required_fields_present(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDataBindingContract(binding_id="rows")  # type: ignore[call-arg]
+
+    def test_ordering_direction_is_typed_enum(self) -> None:
+        binding = ModelDataBindingContract(
+            binding_id="rows",
+            projection_topic="t",
+            ordering_authority_field="created_at",
+            ordering_direction=EnumBindingOrderDirection.ASCENDING,
+        )
+        assert binding.ordering_direction is EnumBindingOrderDirection.ASCENDING
+
+    def test_empty_required_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDataBindingContract(
+                binding_id="",
+                projection_topic="t",
+                ordering_authority_field="created_at",
+            )
+
+
+@pytest.mark.unit
+class TestModelPermissionContract:
+    """PermissionContract: scopes + mandatory disabled reason."""
+
+    def _make(self) -> ModelPermissionContract:
+        return ModelPermissionContract(
+            permission_id="admin-only",
+            act_scopes=("dashboard:write",),
+            disabled_reason="Requires dashboard:write scope",
+        )
+
+    def test_minimal_creation_and_defaults(self) -> None:
+        perm = self._make()
+        assert perm.view_scopes == ()
+        assert perm.act_scopes == ("dashboard:write",)
+
+    def test_frozen(self) -> None:
+        perm = self._make()
+        with pytest.raises(ValidationError):
+            perm.disabled_reason = "x"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPermissionContract(
+                permission_id="p",
+                disabled_reason="r",
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_disabled_reason_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPermissionContract(permission_id="p")  # type: ignore[call-arg]
+
+    def test_disabled_reason_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPermissionContract(permission_id="p", disabled_reason="")
+
+
+@pytest.mark.unit
+class TestModelEvidenceRequirementContract:
+    """EvidenceRequirementContract composes the OCC evidence requirement."""
+
+    def _make(self) -> ModelEvidenceRequirementContract:
+        return ModelEvidenceRequirementContract(
+            contract_id="needs-tests",
+            requirement=ModelEvidenceRequirement(
+                kind=EnumEvidenceKind.TESTS,
+                description="unit tests pass",
+            ),
+            gate_moment=EnumEvidenceGateMoment.ON_COMMIT,
+            unmet_display_message="Run the test suite before committing",
+        )
+
+    def test_composes_evidence_requirement(self) -> None:
+        contract = self._make()
+        assert isinstance(contract.requirement, ModelEvidenceRequirement)
+        assert contract.requirement.kind is EnumEvidenceKind.TESTS
+        assert contract.gate_moment is EnumEvidenceGateMoment.ON_COMMIT
+
+    def test_frozen(self) -> None:
+        contract = self._make()
+        with pytest.raises(ValidationError):
+            contract.unmet_display_message = "x"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEvidenceRequirementContract(
+                contract_id="c",
+                requirement=ModelEvidenceRequirement(
+                    kind=EnumEvidenceKind.TESTS, description="d"
+                ),
+                gate_moment=EnumEvidenceGateMoment.ON_RENDER,
+                unmet_display_message="m",
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_required_fields_present(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEvidenceRequirementContract(contract_id="c")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestModelActionContract:
+    """ActionContract composes ModelGate and constrains command topics."""
+
+    def _make(self, gate: ModelGate | None = None) -> ModelActionContract:
+        return ModelActionContract(
+            action_id="trigger-delegation",
+            command_topic="onex.cmd.omnimarket.delegate-skill.v1",
+            label="Delegate",
+            approval_gate=gate,
+        )
+
+    def test_minimal_creation_and_defaults(self) -> None:
+        action = self._make()
+        assert action.approval_gate is None
+        assert action.correlation_required is True
+
+    def test_composes_model_gate_not_duplicates(self) -> None:
+        gate = ModelGate(
+            id="approve-delegation",
+            kind=EnumGateKind.HUMAN_APPROVAL,
+            description="Operator must approve the delegation",
+        )
+        action = self._make(gate=gate)
+        assert isinstance(action.approval_gate, ModelGate)
+        assert action.approval_gate.id == "approve-delegation"
+
+    def test_command_topic_must_be_canonical_command(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionContract(
+                action_id="a",
+                command_topic="onex.evt.something.v1",
+                label="x",
+            )
+
+    def test_frozen(self) -> None:
+        action = self._make()
+        with pytest.raises(ValidationError):
+            action.label = "x"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionContract(
+                action_id="a",
+                command_topic="onex.cmd.x.y.v1",
+                label="x",
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_required_fields_present(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionContract(action_id="a")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestModelRendererCapabilityContract:
+    """RendererCapabilityContract: advertised capability surface (model only)."""
+
+    def _make(self) -> ModelRendererCapabilityContract:
+        return ModelRendererCapabilityContract(
+            renderer_id="ui.effect.web",
+            platform="web",
+            supported_component_kinds=(EnumWidgetType.CHART, EnumWidgetType.TABLE),
+            interaction_model=EnumRendererInteractionModel.POINTER,
+            accessibility_tier=EnumAccessibilityTier.AA,
+            contract_version=ModelSemVer(major=1, minor=0, patch=0),
+            supports_interaction=True,
+        )
+
+    def test_minimal_creation_and_defaults(self) -> None:
+        cap = self._make()
+        assert cap.supports_streaming is False
+        assert cap.supports_theming is False
+        assert cap.supports_interaction is True
+
+    def test_strong_typing_component_kinds(self) -> None:
+        cap = self._make()
+        assert cap.supported_component_kinds[0] is EnumWidgetType.CHART
+        assert cap.interaction_model is EnumRendererInteractionModel.POINTER
+        assert cap.accessibility_tier is EnumAccessibilityTier.AA
+
+    def test_frozen(self) -> None:
+        cap = self._make()
+        with pytest.raises(ValidationError):
+            cap.platform = "ios"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRendererCapabilityContract(
+                renderer_id="r",
+                platform="web",
+                supported_component_kinds=(EnumWidgetType.CHART,),
+                interaction_model=EnumRendererInteractionModel.POINTER,
+                accessibility_tier=EnumAccessibilityTier.A,
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_required_fields_present(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRendererCapabilityContract(renderer_id="r")  # type: ignore[call-arg]
+
+    def test_invalid_component_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRendererCapabilityContract(
+                renderer_id="r",
+                platform="web",
+                supported_component_kinds=("not-a-kind",),  # type: ignore[arg-type]
+                interaction_model=EnumRendererInteractionModel.POINTER,
+                accessibility_tier=EnumAccessibilityTier.A,
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+            )
+
+
+@pytest.mark.unit
+class TestModelComponentContract:
+    """ComponentContract composes the other Phase 0 primitives."""
+
+    def _make(self) -> ModelComponentContract:
+        return ModelComponentContract(
+            component_id="generation-feed",
+            component_kind=EnumWidgetType.EVENT_FEED,
+            title="Generation Feed",
+            contract_version=ModelSemVer(major=1, minor=0, patch=0),
+            data_bindings=(
+                ModelDataBindingContract(
+                    binding_id="rows",
+                    projection_topic="onex.evt.omnimarket.node-generation-completed.v1",
+                    ordering_authority_field="created_at",
+                ),
+            ),
+            actions=(
+                ModelActionContract(
+                    action_id="trigger",
+                    command_topic="onex.cmd.omnimarket.delegate-skill.v1",
+                    label="Delegate",
+                ),
+            ),
+            supported_empty_state_reasons=(
+                EnumEmptyStateReason.NO_DATA,
+                EnumEmptyStateReason.UPSTREAM_BLOCKED,
+            ),
+        )
+
+    def test_minimal_creation_and_defaults(self) -> None:
+        comp = ModelComponentContract(
+            component_id="c",
+            component_kind=EnumWidgetType.CHART,
+            title="Chart",
+            contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        )
+        assert comp.data_bindings == ()
+        assert comp.actions == ()
+        assert comp.evidence_requirements == ()
+        assert comp.permission is None
+        assert comp.supported_empty_state_reasons == ()
+
+    def test_composes_primitives(self) -> None:
+        comp = self._make()
+        assert isinstance(comp.data_bindings[0], ModelDataBindingContract)
+        assert isinstance(comp.actions[0], ModelActionContract)
+        assert comp.component_kind is EnumWidgetType.EVENT_FEED
+        assert (
+            EnumEmptyStateReason.UPSTREAM_BLOCKED in comp.supported_empty_state_reasons
+        )
+
+    def test_frozen(self) -> None:
+        comp = self._make()
+        with pytest.raises(ValidationError):
+            comp.title = "x"  # type: ignore[misc]
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelComponentContract(
+                component_id="c",
+                component_kind=EnumWidgetType.CHART,
+                title="x",
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+                unknown="x",  # type: ignore[call-arg]
+            )
+
+    def test_required_fields_present(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelComponentContract(component_id="c")  # type: ignore[call-arg]
+
+    def test_json_roundtrip(self) -> None:
+        comp = self._make()
+        restored = ModelComponentContract.model_validate_json(comp.model_dump_json())
+        assert restored == comp


### PR DESCRIPTION
Evidence-Source: OCC#2711
Evidence-Ticket: OMN-13130

> OCC pairing landed: onex_change_control PR #2711 merged to dev at `566ca818ed68cf6073e0cce42cf361ed87bccae5` (2026-06-17). It carries `contracts/OMN-13130.yaml` + the paired DoD receipts (`dod-core-pr-1255` binding this PR head `7d35dc1f`, and self-binding `dod-occ-self`). The Receipt Gate resolves `Evidence-Source: OCC#2711` via the merged-PR path to that SHA.

## OMN-13130 — UI contract primitives + EnumEmptyStateReason (Phase 0)

Phase 0 of the **Contract-Driven UI Platform** (epic **OMN-13129**). Adds the unified UI contract
vocabulary to `omnibase_core`, **additive over `ModelWidgetConfig`** — no existing `omnidash` manifest
breaks and no rendering behavior changes.

Ticket: **OMN-13130** · Epic: **OMN-13129**
ADR: `docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md` (Gate-vs-GateSpec resolution, D2)
Plan: `docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md` §6, §8 Phase 0

### What this adds

Six frozen Pydantic primitives (`ConfigDict(frozen=True, extra="forbid", from_attributes=True)`), one file each in `src/omnibase_core/models/dashboard/`:

| Primitive | Built on / composes |
|---|---|
| `ModelComponentContract` | `ComponentManifest`/`ModelWidgetConfig*`; composes the other primitives; `component_kind` reuses `EnumWidgetType` |
| `ModelActionContract` | declared `onex.cmd.*` emitter; **COMPOSES `ModelGate`** (approval) — no duplication |
| `ModelDataBindingContract` | `/projection/{topic}` bind with explicit ordering authority; no raw DB |
| `ModelPermissionContract` | view/act scopes + mandatory declared `disabled_reason` |
| `ModelEvidenceRequirementContract` | composes OCC `ModelEvidenceRequirement` |
| `ModelRendererCapabilityContract` | **model only** this phase (omnimarket reducer/topic = Phase 1; no node created) |

Enums in `src/omnibase_core/enums/`:
- `EnumEmptyStateReason` — **exactly four** values mirroring `omnidash/shared/types/chart-config.ts` (`no-data`/`missing-field`/`upstream-blocked`/`schema-invalid`)
- `EnumBindingOrderDirection`, `EnumEvidenceGateMoment`, `EnumRendererInteractionModel`, `EnumAccessibilityTier`

Design notes:
- `ActionContract.command_topic` is validated via the canonical `validate_topic_suffix` (no hardcoded `onex.cmd.` literal) and requires `kind == TOPIC_KIND_CMD`.
- Version fields use `ModelSemVer` (strong typing, per the string-version gate).
- All six models registered in `scripts/emit_ts_types.py` so Stage 2 TS mirrors can be generated.
- **`ModelGate` / `ModelGateSpec` source untouched** — `ActionContract` composes `ModelGate`; `ModelGateSpec` stays a distinct objective primitive (ADR D2).

### dod_evidence (local verification, observed)

- **pytest (new):** `36 passed` — `tests/unit/models/dashboard/test_ui_contract_primitives.py` (frozen mutation raises, `extra=forbid` rejects unknown keys, required fields enforced, strong typing, `ModelGate` composition).
- **pytest (regression):** `25095 passed, 5 skipped` — `tests/unit/models/ tests/unit/enums/ -n auto`. Full `tests/` collection: `41765 collected`, zero import errors.
- **dashboard export-surface test:** extended (`test_dashboard_imports.py`) to assert the seven new exports — additive, not broken.
- **mypy --strict:** zero errors in any new file. The only 3 repo-wide errors (`contract_loader.py:570/704`, `cli_install.py:45`) are byte-identical on `origin/dev` (pre-existing, not introduced here).
- **ruff:** `ruff check src/ tests/` → All checks passed.
- **emit_ts registration:** `emit_ts_types.py` emits all six new `$defs` (`ModelComponentContract`, `ModelActionContract`, `ModelDataBindingContract`, `ModelPermissionContract`, `ModelEvidenceRequirementContract`, `ModelRendererCapabilityContract`).
- **pre-commit run --all (changed files):** exit 0, zero failures (Deterministic Skill Routing run against omniclaude@main snapshot; no-hardcoded-topics, single-class-per-file, string-version gates all pass).

DoD contract artifact: `contracts/OMN-13130.yaml`.

### Deviations from plan
- Plan §6 attributes `Gate` fields `confidence_threshold`/`requires_user_confirmation`/`risk_level`/`reversible`/`CommitLevel` to the borrowed gate. Per ADR D2 (plan-vs-code note), **none of those exist on `ModelGate`**; this PR does not invent them — `ActionContract` composes `ModelGate` as-is. No net-new gate fields were required for Phase 0.
- The full `tests/` suite (41765 tests) exceeds the local sandbox's 10-min ceiling when run sequentially; verification was done on the complete `models/` + `enums/` suites (the full surface this additive change touches) plus a full-suite collection pass proving no import breakage.

### Receipt-Gate / OCC pairing — pending
This repo's Receipt Gate requires a paired OCC PR (`onex_change_control`) whose merged SHA is cited as `Evidence-Source: <sha>` (CONTRACT_ON_OCC_MAIN). That OCC contract+receipt pairing is **not yet authored** — see blockers. The `contracts/OMN-13130.yaml` DoD artifact is in this PR; the OCC-side receipt pairing is the remaining step before the Receipt Gate can go green. Not fabricated.

