### PR TITLE
feat(OMN-13132): Contract Graph IR + read-only import

### DIFF
--- a/.onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt
+++ b/.onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt
@@ -1,0 +1,19 @@
+=== DETERMINISTIC IR over >=2 REAL contracts (2 backend nodes + 1 UI component) ===
+nodes: [('compliance_status_grid', 'component'), ('node.compliance.evidence', 'effect'), ('node.compliance.report.reducer', 'reducer')]
+DETERMINISTIC (run1 JSON == run2 JSON): True
+
+=== HASH MANIFEST ===
+  ui_component  in-memory://compliance_status_grid
+      source_contract_sha256 = sha256:77b6cb763cc051afea434b84650c96958754794e727cba5b3bded1926f3f25e3
+      adapter_version_sha256 = sha256:aff0ebbd798f42325ea435bb681df7846916a47bdbbbd3268213b7389dc268f7
+  node          src/omnibase_core/nodes/node_compliance_evidence_effect/contract.yaml
+      source_contract_sha256 = sha256:5ff3915eec87f68f60d5bee4b8436eea78d42aa0485bdfa333934c9a7c995766
+      adapter_version_sha256 = sha256:a8dfea4e9625322db32399f108d10a0920aea2c11f0f645491b8e99ed2f47134
+  node          src/omnibase_core/nodes/node_compliance_report_reducer/contract.yaml
+      source_contract_sha256 = sha256:6bc01b5a506bed70de01db3738789f91ce4575fd96ece416307b2e81896c34c2
+      adapter_version_sha256 = sha256:a8dfea4e9625322db32399f108d10a0920aea2c11f0f645491b8e99ed2f47134
+
+=== NO-OP ROUND-TRIP == ZERO SEMANTIC DIFF (via cli_contract_diff) ===
+  effect node  : zero_diff=True total_changes=0
+  reducer node : zero_diff=True total_changes=0
+  ui component : zero_diff=True total_changes=0

--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -3,31 +3,29 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13130"
 title: "feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core"
 summary: >
-  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract primitives
-  to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract, PermissionContract,
-  EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason (four values mirroring
-  omnidash/shared/types/chart-config.ts exactly) and supporting enums (EnumBindingOrderDirection, EnumEvidenceGateMoment,
-  EnumRendererInteractionModel, EnumAccessibilityTier). ActionContract COMPOSES the existing ModelGate
-  approval primitive (no duplication, per the ADR); EvidenceRequirementContract composes the OCC ModelEvidenceRequirement.
-  ModelGate and ModelGateSpec source are untouched. All six models registered in scripts/emit_ts_types.py
-  for Stage 2 TS codegen. Additive only — every existing omnidash manifest still validates and the dashboard
-  export-surface test was extended (not broken).
+  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract
+  primitives to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract,
+  PermissionContract, EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason
+  (four values mirroring omnidash/shared/types/chart-config.ts exactly) and supporting enums
+  (EnumBindingOrderDirection, EnumEvidenceGateMoment, EnumRendererInteractionModel, EnumAccessibilityTier).
+  ActionContract COMPOSES the existing ModelGate approval primitive (no duplication, per the ADR);
+  EvidenceRequirementContract composes the OCC ModelEvidenceRequirement. ModelGate and ModelGateSpec
+  source are untouched. All six models registered in scripts/emit_ts_types.py for Stage 2 TS codegen.
+  Additive only — every existing omnidash manifest still validates and the dashboard export-surface test
+  was extended (not broken).
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "public_api"
 evidence_requirements:
   - kind: "tests"
-    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid,
-      required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
-    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py
-      -q"
+    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
+    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py -q"
   - kind: "tests"
     description: "Full models + enums suites pass with no regression (25095 passed, 5 skipped)"
     command: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
   - kind: "ci"
-    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing
-      on origin/dev in contract_loader.py and cli_install.py)"
+    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing on origin/dev in contract_loader.py and cli_install.py)"
     command: "uv run mypy src/ --strict"
   - kind: "ci"
     description: "ruff lint and format pass on src/ tests/"
@@ -41,9 +39,7 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-ui-primitive-tests"
-    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises,
-      extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not
-      duplicated"
+    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises, extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not duplicated"
     source: "manual"
     checks:
       - check_type: "command"
@@ -51,9 +47,7 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '36 passed'"
   - id: "dod-additive-no-regression"
-    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard
-      export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected,
-      zero import errors)"
+    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected, zero import errors)"
     source: "manual"
     checks:
       - check_type: "command"
@@ -61,23 +55,19 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '25095 passed, 5 skipped'"
   - id: "dod-mypy-strict"
-    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704,
-      cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704, cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py
-          --strict"
+        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py --strict"
   - id: "dod-emit-ts-registration"
-    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and
-      present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
+    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
       - check_type: "command"
-        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract,
-          ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
+        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract, ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
   - id: "dod-gate-disambiguation"
     description: >
       Per ADR docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md (D2): ActionContract composes
@@ -87,16 +77,15 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py
-          src/omnibase_core/models/objective/model_gate_spec.py"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py src/omnibase_core/models/objective/model_gate_spec.py"
       - check_type: "command"
         check_value: "echo 'no changes to ModelGate / ModelGateSpec source'"
   - id: "dod-deploy-gate"
     description: >
       Deploy-gate evidence: pure additive Pydantic model + enum additions in omnibase_core. No Kafka topic
       schema changes, no new topics, no node/handler, no Docker image rebuild, no runtime process restart,
-      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer
-      and topic are Phase 1.
+      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer and
+      topic are Phase 1.
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -3,29 +3,31 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13130"
 title: "feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core"
 summary: >
-  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract
-  primitives to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract,
-  PermissionContract, EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason
-  (four values mirroring omnidash/shared/types/chart-config.ts exactly) and supporting enums
-  (EnumBindingOrderDirection, EnumEvidenceGateMoment, EnumRendererInteractionModel, EnumAccessibilityTier).
-  ActionContract COMPOSES the existing ModelGate approval primitive (no duplication, per the ADR);
-  EvidenceRequirementContract composes the OCC ModelEvidenceRequirement. ModelGate and ModelGateSpec
-  source are untouched. All six models registered in scripts/emit_ts_types.py for Stage 2 TS codegen.
-  Additive only — every existing omnidash manifest still validates and the dashboard export-surface test
-  was extended (not broken).
+  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract primitives
+  to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract, PermissionContract,
+  EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason (four values mirroring
+  omnidash/shared/types/chart-config.ts exactly) and supporting enums (EnumBindingOrderDirection, EnumEvidenceGateMoment,
+  EnumRendererInteractionModel, EnumAccessibilityTier). ActionContract COMPOSES the existing ModelGate
+  approval primitive (no duplication, per the ADR); EvidenceRequirementContract composes the OCC ModelEvidenceRequirement.
+  ModelGate and ModelGateSpec source are untouched. All six models registered in scripts/emit_ts_types.py
+  for Stage 2 TS codegen. Additive only — every existing omnidash manifest still validates and the dashboard
+  export-surface test was extended (not broken).
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "public_api"
 evidence_requirements:
   - kind: "tests"
-    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
-    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py -q"
+    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid,
+      required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
+    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py
+      -q"
   - kind: "tests"
     description: "Full models + enums suites pass with no regression (25095 passed, 5 skipped)"
     command: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
   - kind: "ci"
-    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing on origin/dev in contract_loader.py and cli_install.py)"
+    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing
+      on origin/dev in contract_loader.py and cli_install.py)"
     command: "uv run mypy src/ --strict"
   - kind: "ci"
     description: "ruff lint and format pass on src/ tests/"
@@ -39,7 +41,9 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-ui-primitive-tests"
-    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises, extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not duplicated"
+    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises,
+      extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not
+      duplicated"
     source: "manual"
     checks:
       - check_type: "command"
@@ -47,7 +51,9 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '36 passed'"
   - id: "dod-additive-no-regression"
-    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected, zero import errors)"
+    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard
+      export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected,
+      zero import errors)"
     source: "manual"
     checks:
       - check_type: "command"
@@ -55,19 +61,23 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '25095 passed, 5 skipped'"
   - id: "dod-mypy-strict"
-    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704, cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704,
+      cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py --strict"
+        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py
+          --strict"
   - id: "dod-emit-ts-registration"
-    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
+    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and
+      present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
       - check_type: "command"
-        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract, ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
+        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract,
+          ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
   - id: "dod-gate-disambiguation"
     description: >
       Per ADR docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md (D2): ActionContract composes
@@ -77,15 +87,16 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py src/omnibase_core/models/objective/model_gate_spec.py"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py
+          src/omnibase_core/models/objective/model_gate_spec.py"
       - check_type: "command"
         check_value: "echo 'no changes to ModelGate / ModelGateSpec source'"
   - id: "dod-deploy-gate"
     description: >
       Deploy-gate evidence: pure additive Pydantic model + enum additions in omnibase_core. No Kafka topic
       schema changes, no new topics, no node/handler, no Docker image rebuild, no runtime process restart,
-      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer and
-      topic are Phase 1.
+      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer
+      and topic are Phase 1.
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13132.yaml
+++ b/contracts/OMN-13132.yaml
@@ -1,0 +1,139 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13132"
+title: "feat(OMN-13132): Contract Graph IR + read-only import"
+summary: >
+  Phase 2 of the Contract-Driven UI Platform (epic OMN-13129). Adds the canonical read-only Contract Graph
+  IR to omnibase_core: six frozen Pydantic IR models in a DISTINCT namespace (src/omnibase_core/models/contract_graph/)
+  with non-colliding names — ModelContractGraphIr, ModelContractGraphNode, ModelContractGraphEdge, ModelContractGraphProtocol,
+  ModelContractGraphContractRef, ModelContractGraphSourceSet — plus EnumContractGraphNodeRole (includes
+  'renderer') and EnumContractGraphEdgeKind (includes component_renders / action_emits / data_binds).
+  These are intentionally distinct from the pre-existing workflow-viz graph models (models/graph/ ModelGraphNode/ModelGraphEdge,
+  UUID-keyed) and the validation-event ModelContractRef (models/events/contract_validation/), per plan
+  §8 which states the IR models are "distinct from the workflow-viz graph models." Read-only dialect adapters
+  (src/omnibase_core/contract_graph/) import existing backend node contracts (event_bus publish/subscribe
+  topics, descriptor archetypes, handler I/O) AND Phase-0 UI ComponentContract instances into one IR via
+  manifest-driven discovery that EXCLUDES .venv, omni_worktrees, and generated surfaces. Each source contract
+  carries a stable sha256 over canonicalized bytes plus a stable per-adapter version hash, both embedded
+  in the IR so diff evidence cannot drift. A no-op round-trip back to canonical normalized contract form
+  produces ZERO semantic diff, verified through the shipped cli_contract_diff spine (reused, not rebuilt).
+  STRICTLY READ-ONLY: no authoring UI, no contract mutation.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - "public_api"
+evidence_requirements:
+  - kind: "tests"
+    description: "29 new unit tests: per-IR-model (frozen/extra-forbid/required-fields/strong-typing)
+      + per-adapter (detection, hashing, discovery exclusion, role/edge mapping) + deterministic-IR over
+      >=2 real contracts + no-op round-trip == zero-semantic-diff through cli_contract_diff"
+    command: "uv run pytest tests/unit/models/contract_graph/ tests/unit/contract_graph/ -q"
+  - kind: "tests"
+    description: "Changed-surface regression: new IR suites + dashboard models + cli_contract_diff + enums
+      pass with no regression (4859 passed, 1 skipped)"
+    command: "uv run pytest tests/unit/contract_graph/ tests/unit/models/contract_graph/ tests/unit/models/dashboard/
+      tests/unit/cli/ tests/unit/enums/ -q -n auto"
+  - kind: "ci"
+    description: "mypy --strict clean on all new modules; the only 3 src-wide errors (contract_loader.py:570/704,
+      cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    command: "uv run mypy src/omnibase_core/models/contract_graph/ src/omnibase_core/contract_graph/ --strict"
+  - kind: "ci"
+    description: "ruff lint and format pass on src/ tests/"
+    command: "uv run ruff check src/ tests/"
+  - kind: "ci"
+    description: "Full tests/ collection succeeds with zero import errors (41715 collected)"
+    command: "uv run pytest tests/ --collect-only -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-ir-model-tests"
+    description: >
+      29 new unit tests pass: per IR model (frozen mutation raises, extra=forbid rejects unknown keys,
+      required fields enforced, strong typing — role/kind enums + ModelSemVer ir_version not str) and
+      a test asserting the IR ModelContractGraphNode is a DIFFERENT class than the workflow-viz ModelGraphNode
+      (no collision). Role vocabulary includes 'renderer'; edge-kind vocabulary includes component_renders
+      / action_emits / data_binds.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/contract_graph/ tests/unit/contract_graph/ -q"
+      - check_type: "command"
+        check_value: "echo '29 passed'"
+  - id: "dod-deterministic-ir-two-real-contracts"
+    description: >
+      Deterministic-IR test imports >=2 REAL contracts (2 backend node contracts: node_compliance_evidence_effect
+      + node_compliance_report_reducer, plus 1 UI ComponentContract instance) and asserts byte-identical
+      IR JSON across two runs. The IR embeds per-source source_contract_sha256 + per-adapter adapter_version_sha256
+      (the two node sources share one adapter hash; the ui_component source has a distinct adapter hash;
+      all three source hashes differ).
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/contract_graph/test_contract_graph_adapters.py -k deterministic
+          -q"
+      - check_type: "command"
+        check_value: "echo 'deterministic IR True; hash manifest in .onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt'"
+  - id: "dod-no-op-round-trip-zero-diff"
+    description: >
+      No-op round-trip (import a contract into IR, round-trip the IR node + its edges back to canonical
+      normalized contract form) produces ZERO semantic diff, verified through the shipped omnibase_core.cli.cli_contract_diff
+      semantic-diff functions (diff_contract_dicts + categorize_diff_entries -> has_changes/total_changes).
+      Proven for an effect node, a reducer node, and a UI component (all total_changes == 0). Round-trip
+      target = canonical normalized contract form (NOT byte-identical raw source).
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/contract_graph/test_contract_graph_adapters.py -k round_trip
+          -q"
+      - check_type: "command"
+        check_value: "echo 'effect/reducer/ui round-trip zero_diff True total_changes 0'"
+  - id: "dod-manifest-discovery-excludes"
+    description: >
+      Manifest-driven discovery (discover_contract_paths) excludes .venv, omni_worktrees, and generated
+      surfaces; a tmp-tree test plants contract.yaml under good/, .venv/, omni_worktrees/, and generated/
+      and asserts only good/ is discovered. EXCLUDED_DISCOVERY_DIRS covers the required surfaces.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/contract_graph/test_contract_graph_adapters.py -k discovery
+          -q"
+      - check_type: "command"
+        check_value: "echo 'discovery excludes .venv/omni_worktrees/generated'"
+  - id: "dod-mypy-strict"
+    description: >
+      mypy --strict reports zero errors in any new contract_graph module. The only 3 src-wide errors (contracts/contract_loader.py:570/704
+      untyped dispose, cli/cli_install.py:45 any-return) are byte-identical to origin/dev (empty git diff)
+      — pre-existing, not introduced here.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/models/contract_graph/ src/omnibase_core/contract_graph/
+          --strict"
+      - check_type: "command"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/contracts/contract_loader.py
+          src/omnibase_core/cli/cli_install.py"
+  - id: "dod-no-collision-readonly"
+    description: >
+      Name-collision constraint satisfied: the new IR models live in the distinct models/contract_graph/
+      namespace with ModelContractGraph* names; the bare ModelGraphNode/ModelGraphEdge (models/graph/)
+      and ModelContractRef (models/events/contract_validation/) identifiers are NOT reused. The phase
+      is read-only: no authoring UI, no contract mutation, no node/handler/topic created (adapters are
+      pure import/round-trip functions).
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "grep -rln 'class ModelContractGraphNode' src/omnibase_core/models/contract_graph/"
+      - check_type: "command"
+        check_value: "echo 'distinct namespace + non-colliding names; read-only import + round-trip only'"
+  - id: "dod-deploy-gate"
+    description: >
+      Deploy-gate evidence: pure additive Pydantic models + enums + read-only import/round-trip functions
+      in omnibase_core. No Kafka topic schema changes, no new topics, no node/handler, no Docker image
+      rebuild, no runtime process restart, no database migration. The IR is a read-only intermediate;
+      no runtime surface is wired this phase.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'no deploy action required for additive core IR models + read-only import functions'"

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -71,6 +71,10 @@ adjacency:
   cli: {reverse_deps: []}
   constants: {reverse_deps: []}
   context: {reverse_deps: [nodes, runtime]}
+  # Contract Graph IR (OMN-13132): read-only leaf module — nothing imports it yet,
+  # so reverse_deps is empty. It imports models/enums/cli (already shared_modules =>
+  # full-suite escalation) and types (see types.reverse_deps below).
+  contract_graph: {reverse_deps: []}
   crypto: {reverse_deps: []}
   decorators: {reverse_deps: []}
   dispatch: {reverse_deps: []}
@@ -96,7 +100,7 @@ adjacency:
   scripts: {reverse_deps: []}
   services: {reverse_deps: [nodes]}
   tools: {reverse_deps: []}
-  types: {reverse_deps: [models]}
+  types: {reverse_deps: [models, contract_graph]}
   utils: {reverse_deps: []}
   validators: {reverse_deps: []}
   workflows: {reverse_deps: [nodes]}

--- a/src/omnibase_core/contract_graph/__init__.py
+++ b/src/omnibase_core/contract_graph/__init__.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract Graph IR import + round-trip (OMN-13132 — Phase 2, epic OMN-13129).
+
+Read-only import of heterogeneous source contracts (backend node contracts and
+UI component contracts) into the canonical Contract Graph IR
+(``omnibase_core.models.contract_graph``), plus a no-op round-trip back to
+canonical normalized contract form verified through the shipped semantic-diff
+spine (``omnibase_core.cli.cli_contract_diff``).
+
+This package holds pure import/round-trip functions and stable hashing only.
+STRICTLY READ-ONLY this phase: no authoring UI, no contract mutation.
+"""
+
+from omnibase_core.contract_graph.adapter_node_contract import (
+    import_node_contract,
+    node_contract_adapter_version,
+    round_trip_node_node,
+    supports_node_contract,
+)
+from omnibase_core.contract_graph.adapter_ui_component import (
+    import_ui_component,
+    round_trip_ui_component,
+    supports_ui_component,
+    ui_component_adapter_version,
+)
+from omnibase_core.contract_graph.canonical_hash import (
+    adapter_version_sha256,
+    canonical_contract_sha256,
+    canonicalize_contract,
+)
+from omnibase_core.contract_graph.importer import (
+    EXCLUDED_DISCOVERY_DIRS,
+    IR_SCHEMA_VERSION,
+    discover_contract_paths,
+    import_paths,
+    normalize_node_contract,
+    normalize_ui_component,
+    round_trip_node_diff,
+    round_trip_ui_component_diff,
+    round_trip_zero_diff,
+)
+
+__all__ = [
+    # canonical hashing
+    "canonicalize_contract",
+    "canonical_contract_sha256",
+    "adapter_version_sha256",
+    # node-contract dialect adapter
+    "supports_node_contract",
+    "import_node_contract",
+    "round_trip_node_node",
+    "node_contract_adapter_version",
+    # ui-component dialect adapter
+    "supports_ui_component",
+    "import_ui_component",
+    "round_trip_ui_component",
+    "ui_component_adapter_version",
+    # importer + round-trip
+    "IR_SCHEMA_VERSION",
+    "EXCLUDED_DISCOVERY_DIRS",
+    "discover_contract_paths",
+    "normalize_node_contract",
+    "normalize_ui_component",
+    "import_paths",
+    "round_trip_node_diff",
+    "round_trip_ui_component_diff",
+    "round_trip_zero_diff",
+]

--- a/src/omnibase_core/contract_graph/adapter_node_contract.py
+++ b/src/omnibase_core/contract_graph/adapter_node_contract.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Read-only dialect adapter: backend node contracts -> Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+Imports an existing ONEX node contract (``node_type`` effect/compute/reducer/
+orchestrator, with ``publish_topics`` / ``subscribe_topics`` / ``descriptor`` /
+``handler_routing``) into one IR node plus its topic edges. STRICTLY READ-ONLY:
+the adapter parses a contract dict and produces frozen IR models; it never
+mutates the source, performs no I/O, and resolves no endpoints.
+
+Dialect identity is ``node``. Its version hash covers the source bytes of the
+import + round-trip functions so any behavioral change is reflected in the IR's
+embedded ``adapter_version_sha256``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from omnibase_core.contract_graph.canonical_hash import (
+    adapter_version_sha256,
+    canonical_contract_sha256,
+)
+from omnibase_core.enums.enum_contract_graph_edge_kind import (
+    EnumContractGraphEdgeKind,
+)
+from omnibase_core.enums.enum_contract_graph_node_role import (
+    EnumContractGraphNodeRole,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_contract_ref import (
+    ModelContractGraphContractRef,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_edge import (
+    ModelContractGraphEdge,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_node import (
+    ModelContractGraphNode,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_protocol import (
+    ModelContractGraphProtocol,
+)
+from omnibase_core.types.type_json import JsonType
+
+__all__ = [
+    "DIALECT_NAME",
+    "node_contract_adapter_version",
+    "supports_node_contract",
+    "import_node_contract",
+    "round_trip_node_node",
+]
+
+DIALECT_NAME = "node"
+
+# node_type token -> IR node role. Closed mapping: an unknown node_type fails
+# fast in import_node_contract rather than defaulting silently.
+_NODE_TYPE_TO_ROLE: dict[str, EnumContractGraphNodeRole] = {
+    "effect": EnumContractGraphNodeRole.EFFECT,
+    "compute": EnumContractGraphNodeRole.COMPUTE,
+    "reducer": EnumContractGraphNodeRole.REDUCER,
+    "orchestrator": EnumContractGraphNodeRole.ORCHESTRATOR,
+}
+
+
+def node_contract_adapter_version() -> str:
+    """Stable version hash of this adapter (name + implementing function source)."""
+    return adapter_version_sha256(
+        DIALECT_NAME,
+        (
+            inspect.getsource(supports_node_contract),
+            inspect.getsource(import_node_contract),
+            inspect.getsource(round_trip_node_node),
+            inspect.getsource(_topic_list),
+        ),
+    )
+
+
+def supports_node_contract(data: dict[str, JsonType]) -> bool:
+    """True if ``data`` is a backend node contract this adapter imports.
+
+    A node contract is identified by a ``node_type`` whose token is one of the
+    four canonical archetypes. UI component contracts (no ``node_type``) are not
+    matched.
+    """
+    node_type = data.get("node_type")
+    return isinstance(node_type, str) and node_type in _NODE_TYPE_TO_ROLE
+
+
+def _topic_list(data: dict[str, JsonType], key: str) -> tuple[str, ...]:
+    """Extract a tuple of topic strings from a contract list field.
+
+    Raises ``ValueError`` if the field is present but not a list of strings —
+    fail fast rather than silently dropping malformed entries.
+    """
+    raw = data.get(key)
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            f"{key!r} must be a list of topic strings, got {type(raw).__name__}"
+        )
+    topics: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            raise ValueError(  # error-ok: input validation at the contract-import boundary
+                f"{key!r} entries must be strings, got {type(entry).__name__}"
+            )
+        topics.append(entry)
+    return tuple(topics)
+
+
+def import_node_contract(
+    data: dict[str, JsonType],
+    source_path: str,
+) -> tuple[ModelContractGraphNode, tuple[ModelContractGraphEdge, ...]]:
+    """Import one backend node contract into an IR node + its topic edges.
+
+    Returns the node and a deterministically-ordered tuple of publish/subscribe
+    edges. ``node_id`` is the contract ``handler_id`` (a stable semantic id) or,
+    when absent, ``name``. Missing both raises ``ValueError`` (fail fast — no
+    synthesized id).
+    """
+    if not supports_node_contract(data):
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            f"{source_path}: not a backend node contract (node_type must be one of "
+            f"{sorted(_NODE_TYPE_TO_ROLE)})"
+        )
+    node_type = data.get("node_type")
+    role = _NODE_TYPE_TO_ROLE[str(node_type)]
+
+    handler_id = data.get("handler_id")
+    name = data.get("name")
+    node_id_source = handler_id if isinstance(handler_id, str) else name
+    if not isinstance(node_id_source, str) or not node_id_source:
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            f"{source_path}: node contract has no handler_id or name to use as node_id"
+        )
+    node_id = node_id_source
+
+    title_raw = name if isinstance(name, str) and name else node_id
+    title = title_raw
+
+    protocols: tuple[ModelContractGraphProtocol, ...] = ()
+    input_model = data.get("input_model")
+    output_model = data.get("output_model")
+    if isinstance(input_model, str) or isinstance(output_model, str):
+        protocols = (
+            ModelContractGraphProtocol(
+                protocol_id=f"{node_id}::io",
+                qualified_name=f"{node_id}::handler_io",
+                input_model=input_model if isinstance(input_model, str) else None,
+                output_model=output_model if isinstance(output_model, str) else None,
+            ),
+        )
+
+    source_ref = ModelContractGraphContractRef(
+        ref_id=node_id,
+        source_path=source_path,
+        dialect=DIALECT_NAME,
+        source_contract_sha256=canonical_contract_sha256(data),
+        adapter_version_sha256=node_contract_adapter_version(),
+    )
+
+    node = ModelContractGraphNode(
+        node_id=node_id,
+        role=role,
+        title=title,
+        source_ref=source_ref,
+        protocols=protocols,
+    )
+
+    edges: list[ModelContractGraphEdge] = []
+    for topic in _topic_list(data, "publish_topics"):
+        edges.append(
+            ModelContractGraphEdge(
+                edge_id=f"{node_id}--publishes-->{topic}",
+                source_node_id=node_id,
+                target_node_id=topic,
+                kind=EnumContractGraphEdgeKind.PUBLISHES,
+                topic=topic,
+            )
+        )
+    for topic in _topic_list(data, "subscribe_topics"):
+        edges.append(
+            ModelContractGraphEdge(
+                edge_id=f"{node_id}--subscribes-->{topic}",
+                source_node_id=node_id,
+                target_node_id=topic,
+                kind=EnumContractGraphEdgeKind.SUBSCRIBES,
+                topic=topic,
+            )
+        )
+    edges.sort(key=lambda e: e.edge_id)
+    return node, tuple(edges)
+
+
+def round_trip_node_node(
+    node: ModelContractGraphNode,
+    edges: tuple[ModelContractGraphEdge, ...],
+) -> dict[str, JsonType]:
+    """Round-trip one IR node + its edges back to canonical normalized node form.
+
+    The round-trip target is the canonical normalized contract shape this
+    adapter reads: ``node_type`` + ``handler_id`` + ``publish_topics`` /
+    ``subscribe_topics`` (sorted), plus ``input_model`` / ``output_model`` when
+    the node carries an IO protocol. A no-op round-trip of an imported contract
+    reproduces these semantic fields so ``cli_contract_diff`` reports zero diff.
+    """
+    role_to_node_type = {v: k for k, v in _NODE_TYPE_TO_ROLE.items()}
+    if node.role not in role_to_node_type:
+        raise ValueError(  # error-ok: caller passed a non-backend node to this adapter
+            f"node role {node.role!r} is not a backend node role; cannot round-trip via this adapter"
+        )
+
+    result: dict[str, JsonType] = {
+        "handler_id": node.node_id,
+        "name": node.title,
+        "node_type": role_to_node_type[node.role],
+    }
+
+    publishes = sorted(
+        e.topic
+        for e in edges
+        if e.source_node_id == node.node_id
+        and e.kind is EnumContractGraphEdgeKind.PUBLISHES
+        and e.topic is not None
+    )
+    subscribes = sorted(
+        e.topic
+        for e in edges
+        if e.source_node_id == node.node_id
+        and e.kind is EnumContractGraphEdgeKind.SUBSCRIBES
+        and e.topic is not None
+    )
+    if publishes:
+        result["publish_topics"] = list(publishes)
+    if subscribes:
+        result["subscribe_topics"] = list(subscribes)
+
+    for protocol in node.protocols:
+        if protocol.input_model is not None:
+            result["input_model"] = protocol.input_model
+        if protocol.output_model is not None:
+            result["output_model"] = protocol.output_model
+
+    return result

--- a/src/omnibase_core/contract_graph/adapter_ui_component.py
+++ b/src/omnibase_core/contract_graph/adapter_ui_component.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Read-only dialect adapter: UI component contracts -> Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+Imports a Phase-0 ``ModelComponentContract`` instance (or its serialized dict)
+into one IR ``COMPONENT`` node, plus ``ACTION_EMITS`` edges (one per declared
+command-emitting action) and ``DATA_BINDS`` edges (one per projection binding).
+STRICTLY READ-ONLY: parses the component contract and produces frozen IR models;
+no mutation, no I/O.
+
+Dialect identity is ``ui_component``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from omnibase_core.contract_graph.canonical_hash import (
+    adapter_version_sha256,
+    canonical_contract_sha256,
+)
+from omnibase_core.enums.enum_contract_graph_edge_kind import (
+    EnumContractGraphEdgeKind,
+)
+from omnibase_core.enums.enum_contract_graph_node_role import (
+    EnumContractGraphNodeRole,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_contract_ref import (
+    ModelContractGraphContractRef,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_edge import (
+    ModelContractGraphEdge,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_node import (
+    ModelContractGraphNode,
+)
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.types.type_json import JsonType
+
+__all__ = [
+    "DIALECT_NAME",
+    "ui_component_adapter_version",
+    "supports_ui_component",
+    "import_ui_component",
+    "round_trip_ui_component",
+]
+
+DIALECT_NAME = "ui_component"
+
+
+def ui_component_adapter_version() -> str:
+    """Stable version hash of this adapter (name + implementing function source)."""
+    return adapter_version_sha256(
+        DIALECT_NAME,
+        (
+            inspect.getsource(supports_ui_component),
+            inspect.getsource(import_ui_component),
+            inspect.getsource(round_trip_ui_component),
+        ),
+    )
+
+
+def supports_ui_component(data: dict[str, JsonType]) -> bool:
+    """True if ``data`` is a serialized UI component contract.
+
+    Identified by the presence of a ``component_id`` and ``component_kind``
+    (the required ``ModelComponentContract`` discriminating fields) and the
+    absence of a backend ``node_type``.
+    """
+    return (
+        "component_id" in data and "component_kind" in data and "node_type" not in data
+    )
+
+
+def import_ui_component(
+    contract: ModelComponentContract,
+    source_path: str,
+) -> tuple[ModelContractGraphNode, tuple[ModelContractGraphEdge, ...]]:
+    """Import one UI component contract into a COMPONENT IR node + edges.
+
+    Produces one ``ACTION_EMITS`` edge per declared action (target = the action's
+    command topic) and one ``DATA_BINDS`` edge per data binding (target = the
+    binding's projection topic). Edges are deterministically ordered by id.
+    """
+    node_id = contract.component_id
+    source_ref = ModelContractGraphContractRef(
+        ref_id=node_id,
+        source_path=source_path,
+        dialect=DIALECT_NAME,
+        source_contract_sha256=canonical_contract_sha256(
+            contract.model_dump(mode="json")
+        ),
+        adapter_version_sha256=ui_component_adapter_version(),
+    )
+
+    node = ModelContractGraphNode(
+        node_id=node_id,
+        role=EnumContractGraphNodeRole.COMPONENT,
+        title=contract.title,
+        source_ref=source_ref,
+        protocols=(),
+    )
+
+    edges: list[ModelContractGraphEdge] = []
+    for action in contract.actions:
+        edges.append(
+            ModelContractGraphEdge(
+                edge_id=f"{node_id}--action_emits-->{action.command_topic}",
+                source_node_id=node_id,
+                target_node_id=action.command_topic,
+                kind=EnumContractGraphEdgeKind.ACTION_EMITS,
+                topic=action.command_topic,
+            )
+        )
+    for binding in contract.data_bindings:
+        edges.append(
+            ModelContractGraphEdge(
+                edge_id=f"{node_id}--data_binds-->{binding.projection_topic}",
+                source_node_id=node_id,
+                target_node_id=binding.projection_topic,
+                kind=EnumContractGraphEdgeKind.DATA_BINDS,
+                topic=binding.projection_topic,
+            )
+        )
+    edges.sort(key=lambda e: e.edge_id)
+    return node, tuple(edges)
+
+
+def round_trip_ui_component(
+    node: ModelContractGraphNode,
+    edges: tuple[ModelContractGraphEdge, ...],
+) -> dict[str, JsonType]:
+    """Round-trip a COMPONENT IR node + edges back to canonical normalized form.
+
+    The round-trip target is the canonical normalized component shape: the
+    component id, kind, title, plus the sorted command topics it emits and the
+    sorted projection topics it binds. A no-op round-trip reproduces these
+    semantic fields so ``cli_contract_diff`` reports zero diff against the
+    normalized source.
+    """
+    if node.role is not EnumContractGraphNodeRole.COMPONENT:
+        raise ValueError(  # error-ok: caller passed a non-component node to this adapter
+            f"node role {node.role!r} is not a UI component role; cannot round-trip via this adapter"
+        )
+
+    emits = sorted(
+        e.topic
+        for e in edges
+        if e.source_node_id == node.node_id
+        and e.kind is EnumContractGraphEdgeKind.ACTION_EMITS
+        and e.topic is not None
+    )
+    binds = sorted(
+        e.topic
+        for e in edges
+        if e.source_node_id == node.node_id
+        and e.kind is EnumContractGraphEdgeKind.DATA_BINDS
+        and e.topic is not None
+    )
+
+    result: dict[str, JsonType] = {
+        "component_id": node.node_id,
+        "title": node.title,
+    }
+    if emits:
+        result["action_command_topics"] = list(emits)
+    if binds:
+        result["data_binding_projection_topics"] = list(binds)
+    return result

--- a/src/omnibase_core/contract_graph/canonical_hash.py
+++ b/src/omnibase_core/contract_graph/canonical_hash.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonicalization + stable hashing for Contract Graph IR import.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+The IR embeds two stable hashes so diff evidence cannot drift between runs:
+
+1. ``canonical_contract_sha256`` — sha256 over the *canonicalized* contract
+   bytes (recursively key-sorted, ``_metadata`` excluded so build-time noise
+   never perturbs the hash). This is the per-source-contract hash.
+2. ``adapter_version_sha256`` — a stable hash of an adapter's identity + the
+   source bytes of the function objects that implement it, so a behavioral
+   change to an adapter changes its version hash deterministically.
+
+Both are pure functions of their inputs — no clock, no environment, no I/O.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from omnibase_core.types.type_json import JsonType
+
+__all__ = [
+    "canonicalize_contract",
+    "canonical_contract_sha256",
+    "adapter_version_sha256",
+]
+
+# Build-time / non-semantic keys excluded from canonicalization so the per-source
+# hash reflects only the functional contract (matches cli_contract_diff's
+# DEFAULT_EXCLUDE_PREFIXES intent of dropping the _metadata section).
+_CANONICAL_EXCLUDE_KEYS: frozenset[str] = frozenset({"_metadata"})
+
+
+def canonicalize_contract(data: dict[str, JsonType]) -> dict[str, JsonType]:
+    """Return a canonical, semantics-only view of a contract dict.
+
+    Recursively drops excluded top-level build-time keys. Ordering is not
+    applied to the dict structure itself (JSON serialization with
+    ``sort_keys=True`` handles deterministic ordering at hash time), but excluded
+    keys are removed so byte-noise in ``_metadata`` never perturbs the hash.
+    """
+    return {
+        key: value for key, value in data.items() if key not in _CANONICAL_EXCLUDE_KEYS
+    }
+
+
+def canonical_contract_sha256(data: dict[str, JsonType]) -> str:
+    """sha256 over the canonicalized contract bytes, as ``"sha256:<hex>"``.
+
+    The dict is canonicalized (excluded keys dropped) then serialized with
+    sorted keys and compact separators so the byte representation is
+    deterministic regardless of source key order or whitespace.
+    """
+    canonical = canonicalize_contract(data)
+    payload = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def adapter_version_sha256(
+    adapter_name: str,
+    implementation_sources: tuple[str, ...],
+) -> str:
+    """Stable version hash for a dialect adapter, as ``"sha256:<hex>"``.
+
+    Combines the adapter's declared name with the source bytes of the functions
+    that implement it (callers pass ``inspect.getsource(fn)`` for each). A
+    behavioral change to any implementing function changes its source and
+    therefore the version hash, so the IR's embedded ``adapter_version_sha256``
+    deterministically tracks adapter changes. Pure: no Any, no I/O of its own.
+    """
+    parts: list[str] = [f"adapter:{adapter_name}", *implementation_sources]
+    payload = "\n".join(parts).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()

--- a/src/omnibase_core/contract_graph/importer.py
+++ b/src/omnibase_core/contract_graph/importer.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Manifest-driven import + round-trip for the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+Read-only entry points:
+
+- ``discover_contract_paths`` — manifest-driven discovery of ``contract.yaml``
+  files under given roots, EXCLUDING ``.venv``, ``omni_worktrees``, and generated
+  surfaces. Deterministically ordered.
+- ``import_paths`` — import a set of node + UI component contracts into one
+  ``ModelContractGraphIr`` with embedded source hashes + adapter version hashes.
+- ``normalize_node_contract`` / ``normalize_ui_component`` — the canonical
+  normalized contract form a round-trip targets. The semantic baseline against
+  which a no-op round-trip is compared via ``cli_contract_diff``.
+- ``round_trip_zero_diff`` — proves a no-op IR round-trip produces zero semantic
+  diff for one imported source, using the shipped ``cli_contract_diff`` spine.
+
+STRICTLY READ-ONLY: no source mutation, no contract authoring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.cli.cli_contract_diff import (
+    categorize_diff_entries,
+    diff_contract_dicts,
+    load_contract_yaml_file,
+)
+from omnibase_core.contract_graph.adapter_node_contract import (
+    import_node_contract,
+    round_trip_node_node,
+)
+from omnibase_core.contract_graph.adapter_ui_component import (
+    import_ui_component,
+    round_trip_ui_component,
+)
+from omnibase_core.contract_graph.canonical_hash import canonicalize_contract
+from omnibase_core.models.cli.model_diff_result import ModelDiffResult
+from omnibase_core.models.contract_graph.model_contract_graph_edge import (
+    ModelContractGraphEdge,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_ir import (
+    ModelContractGraphIr,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_node import (
+    ModelContractGraphNode,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_source_set import (
+    ModelContractGraphSourceSet,
+)
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.types.type_json import JsonType
+
+__all__ = [
+    "IR_SCHEMA_VERSION",
+    "EXCLUDED_DISCOVERY_DIRS",
+    "discover_contract_paths",
+    "normalize_node_contract",
+    "normalize_ui_component",
+    "import_node_path",
+    "import_ui_component_instance",
+    "import_paths",
+    "round_trip_node_diff",
+    "round_trip_ui_component_diff",
+    "round_trip_zero_diff",
+]
+
+# Schema version of the Contract Graph IR this importer emits.
+IR_SCHEMA_VERSION = ModelSemVer(major=0, minor=1, patch=0)
+
+# Directory names excluded from manifest-driven discovery: virtualenvs, the
+# worktrees tree, build/generated surfaces, and VCS internals. Discovery must
+# not pick up vendored or generated contracts.
+EXCLUDED_DISCOVERY_DIRS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "venv",
+        "omni_worktrees",
+        ".git",
+        "__pycache__",
+        "node_modules",
+        "dist",
+        "build",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "generated",
+        "_generated",
+    }
+)
+
+
+def discover_contract_paths(roots: tuple[Path, ...]) -> tuple[Path, ...]:
+    """Discover ``contract.yaml`` files under ``roots``, deterministically ordered.
+
+    Any path containing an excluded directory component (``.venv``,
+    ``omni_worktrees``, generated surfaces, etc.) is skipped. The result is
+    sorted by string path so two scans over the same tree yield identical order.
+    """
+    found: list[Path] = []
+    for root in roots:
+        for candidate in root.rglob("contract.yaml"):
+            if any(part in EXCLUDED_DISCOVERY_DIRS for part in candidate.parts):
+                continue
+            found.append(candidate)
+    return tuple(sorted(found, key=str))
+
+
+def _load_yaml(path: Path) -> dict[str, JsonType]:
+    """Load a contract YAML file via the shipped cli_contract_diff loader.
+
+    Reuses ``load_contract_yaml_file`` from the contract-diff spine (path
+    security checks + dict-root validation) rather than calling ``yaml.safe_load``
+    directly — same loader the semantic-diff path uses, so import and diff read
+    contracts identically.
+    """
+    return load_contract_yaml_file(path)
+
+
+def _json_str_list(values: list[str]) -> list[JsonType]:
+    """Widen a list of strings to ``list[JsonType]`` (str is a JsonType primitive).
+
+    Per-element widening so a ``list[str]`` can be stored in a ``dict[str,
+    JsonType]`` without an invariance error and without ``cast``.
+    """
+    widened: list[JsonType] = []
+    for value in values:
+        widened.append(value)
+    return widened
+
+
+def normalize_node_contract(data: dict[str, JsonType]) -> dict[str, JsonType]:
+    """Canonical normalized form of a backend node contract.
+
+    The semantic projection a node-contract round-trip targets: handler_id,
+    name, node_type, sorted publish/subscribe topics, and input/output models.
+    This is the baseline a no-op round-trip is diffed against — NOT the raw
+    source (which also carries descriptor/version/build noise the IR drops).
+    """
+    canonical = canonicalize_contract(data)
+    handler_id = canonical.get("handler_id")
+    name = canonical.get("name")
+    node_id = handler_id if isinstance(handler_id, str) and handler_id else name
+    if not isinstance(node_id, str) or not node_id:
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            "node contract has no handler_id or name"
+        )
+    node_type = canonical.get("node_type")
+    if not isinstance(node_type, str):
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            "node contract has no string node_type"
+        )
+
+    result: dict[str, JsonType] = {
+        "handler_id": node_id,
+        "name": name if isinstance(name, str) and name else node_id,
+        "node_type": node_type,
+    }
+
+    publish = canonical.get("publish_topics")
+    if isinstance(publish, list) and publish:
+        result["publish_topics"] = _json_str_list(sorted(str(x) for x in publish))
+    subscribe = canonical.get("subscribe_topics")
+    if isinstance(subscribe, list) and subscribe:
+        result["subscribe_topics"] = _json_str_list(sorted(str(x) for x in subscribe))
+
+    input_model = canonical.get("input_model")
+    if isinstance(input_model, str):
+        result["input_model"] = input_model
+    output_model = canonical.get("output_model")
+    if isinstance(output_model, str):
+        result["output_model"] = output_model
+    return result
+
+
+def normalize_ui_component(contract: ModelComponentContract) -> dict[str, JsonType]:
+    """Canonical normalized form of a UI component contract.
+
+    The semantic projection a component round-trip targets: component id, title,
+    sorted command topics emitted, sorted projection topics bound.
+    """
+    result: dict[str, JsonType] = {
+        "component_id": contract.component_id,
+        "title": contract.title,
+    }
+    emits = _json_str_list(sorted(a.command_topic for a in contract.actions))
+    if emits:
+        result["action_command_topics"] = emits
+    binds = _json_str_list(sorted(b.projection_topic for b in contract.data_bindings))
+    if binds:
+        result["data_binding_projection_topics"] = binds
+    return result
+
+
+def import_node_path(
+    path: Path,
+    repo_relative: str,
+) -> tuple[ModelContractGraphNode, tuple[ModelContractGraphEdge, ...]]:
+    """Load + import one backend node contract file into IR node + edges."""
+    data = _load_yaml(path)
+    return import_node_contract(data, repo_relative)
+
+
+def import_ui_component_instance(
+    contract: ModelComponentContract,
+    source_path: str,
+) -> tuple[ModelContractGraphNode, tuple[ModelContractGraphEdge, ...]]:
+    """Import one UI component contract instance into IR node + edges."""
+    return import_ui_component(contract, source_path)
+
+
+def import_paths(
+    discovery_roots: tuple[str, ...],
+    node_paths: tuple[tuple[Path, str], ...],
+    ui_components: tuple[tuple[ModelComponentContract, str], ...],
+) -> ModelContractGraphIr:
+    """Import node-contract files + UI component contracts into one IR.
+
+    ``node_paths`` are ``(filesystem_path, repo_relative_path)`` pairs;
+    ``ui_components`` are ``(contract, source_path)`` pairs. Nodes, edges, and the
+    source set are deterministically ordered so two imports over identical inputs
+    yield identical IR.
+    """
+    nodes: list[ModelContractGraphNode] = []
+    edges: list[ModelContractGraphEdge] = []
+
+    for fs_path, repo_relative in node_paths:
+        node, node_edges = import_node_path(fs_path, repo_relative)
+        nodes.append(node)
+        edges.extend(node_edges)
+
+    for contract, source_path in ui_components:
+        node, node_edges = import_ui_component_instance(contract, source_path)
+        nodes.append(node)
+        edges.extend(node_edges)
+
+    nodes.sort(key=lambda n: n.node_id)
+    edges.sort(key=lambda e: e.edge_id)
+
+    refs = tuple(sorted((n.source_ref for n in nodes), key=lambda r: r.source_path))
+    source_set = ModelContractGraphSourceSet(
+        discovery_roots=discovery_roots,
+        refs=refs,
+    )
+    return ModelContractGraphIr(
+        ir_version=IR_SCHEMA_VERSION,
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        source_set=source_set,
+    )
+
+
+def _edges_for(
+    ir: ModelContractGraphIr, node_id: str
+) -> tuple[ModelContractGraphEdge, ...]:
+    """All IR edges sourced from ``node_id``."""
+    return tuple(e for e in ir.edges if e.source_node_id == node_id)
+
+
+def round_trip_node_diff(
+    ir: ModelContractGraphIr,
+    node_id: str,
+    source: dict[str, JsonType],
+) -> ModelDiffResult:
+    """Diff a node's no-op round-trip against its normalized source.
+
+    Round-trips the IR node + its edges back to canonical normalized node form
+    and compares it to ``normalize_node_contract(source)`` using the shipped
+    semantic diff spine.
+    """
+    node = next(n for n in ir.nodes if n.node_id == node_id)
+    round_tripped = round_trip_node_node(node, _edges_for(ir, node_id))
+    baseline = normalize_node_contract(source)
+    diffs = diff_contract_dicts(baseline, round_tripped)
+    return categorize_diff_entries(diffs)
+
+
+def round_trip_ui_component_diff(
+    ir: ModelContractGraphIr,
+    contract: ModelComponentContract,
+) -> ModelDiffResult:
+    """Diff a component's no-op round-trip against its normalized source."""
+    node = next(n for n in ir.nodes if n.node_id == contract.component_id)
+    round_tripped = round_trip_ui_component(node, _edges_for(ir, contract.component_id))
+    baseline = normalize_ui_component(contract)
+    diffs = diff_contract_dicts(baseline, round_tripped)
+    return categorize_diff_entries(diffs)
+
+
+def round_trip_zero_diff(diff_result: ModelDiffResult) -> bool:
+    """True if a round-trip diff result carries zero semantic changes."""
+    return not diff_result.has_changes

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -94,6 +94,8 @@ from .enum_contract_compliance import EnumContractCompliance
 
 # Contract diff change type enum (semantic contract diffing)
 from .enum_contract_diff_change_type import EnumContractDiffChangeType
+from .enum_contract_graph_edge_kind import EnumContractGraphEdgeKind
+from .enum_contract_graph_node_role import EnumContractGraphNodeRole
 from .enum_coordination_mode import EnumCoordinationMode
 from .enum_core_error_code import (
     CORE_ERROR_CODE_TO_EXIT_CODE,
@@ -601,6 +603,9 @@ __all__ = [
     "EnumEmptyStateReason",
     "EnumEvidenceGateMoment",
     "EnumRendererInteractionModel",
+    # Contract Graph IR vocabulary (OMN-13132 — Phase 2)
+    "EnumContractGraphNodeRole",
+    "EnumContractGraphEdgeKind",
     # Effect classification domain (OMN-1147)
     "EnumEffectCategory",
     "EnumEffectPolicyLevel",

--- a/src/omnibase_core/enums/enum_contract_graph_edge_kind.py
+++ b/src/omnibase_core/enums/enum_contract_graph_edge_kind.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Edge-kind vocabulary for the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+An edge kind names the typed relationship between two IR nodes. The plan
+requires the three UI-platform edge kinds (``component_renders`` /
+``action_emits`` / ``data_binds``) in addition to the backend topology edges
+(publish/subscribe/protocol-implements) so a single IR spans backend node
+contracts and UI component contracts.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+__all__ = ("EnumContractGraphEdgeKind",)
+
+
+@unique
+class EnumContractGraphEdgeKind(UtilStrValueHelper, str, Enum):
+    """Typed relationship between two Contract Graph IR nodes.
+
+    Attributes:
+        PUBLISHES: A node publishes onto a topic (source node -> topic node).
+        SUBSCRIBES: A node subscribes to a topic (source node -> topic node).
+        IMPLEMENTS_PROTOCOL: A node implements a protocol/interface reference.
+        COMPONENT_RENDERS: A renderer renders a UI component contract.
+        ACTION_EMITS: A component action emits a command onto a topic.
+        DATA_BINDS: A component binds to a projection topic for its truth.
+    """
+
+    PUBLISHES = "publishes"
+    SUBSCRIBES = "subscribes"
+    IMPLEMENTS_PROTOCOL = "implements_protocol"
+    COMPONENT_RENDERS = "component_renders"
+    ACTION_EMITS = "action_emits"
+    DATA_BINDS = "data_binds"

--- a/src/omnibase_core/enums/enum_contract_graph_node_role.py
+++ b/src/omnibase_core/enums/enum_contract_graph_node_role.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Node-role vocabulary for the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+The IR is a *platform-neutral* intermediate distinct from the runtime
+``EnumNodeType`` (which names runtime archetypes/categories). A role classifies
+what kind of contract surface a node in the IR represents. ``RENDERER`` is
+mandatory per the plan: a renderer is a first-class IR node role so UI component
+contracts and the renderers that draw them share one graph.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+__all__ = ("EnumContractGraphNodeRole",)
+
+
+@unique
+class EnumContractGraphNodeRole(UtilStrValueHelper, str, Enum):
+    """Role a node plays in the Contract Graph IR.
+
+    Distinct from runtime ``EnumNodeType``: these roles classify imported
+    contract surfaces (backend node contracts and UI component contracts) within
+    one canonical intermediate, not runtime dispatch archetypes.
+
+    Attributes:
+        EFFECT: A backend EFFECT node contract (side-effecting boundary).
+        COMPUTE: A backend COMPUTE node contract (pure, returns a result).
+        REDUCER: A backend REDUCER node contract (pure state delta).
+        ORCHESTRATOR: A backend ORCHESTRATOR node contract (emits, never returns).
+        COMPONENT: A UI component contract (what a component shows/binds/emits).
+        RENDERER: A renderer that draws component contracts (mandatory IR role).
+        PROTOCOL: A protocol/interface reference typing a node's boundary.
+    """
+
+    EFFECT = "effect"
+    COMPUTE = "compute"
+    REDUCER = "reducer"
+    ORCHESTRATOR = "orchestrator"
+    COMPONENT = "component"
+    RENDERER = "renderer"
+    PROTOCOL = "protocol"

--- a/src/omnibase_core/models/contract_graph/__init__.py
+++ b/src/omnibase_core/models/contract_graph/__init__.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract Graph IR models (OMN-13132 — Phase 2, epic OMN-13129).
+
+The canonical read-only intermediate the plan
+(docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2)
+calls the Contract Graph IR. Heterogeneous source contracts — backend node
+contracts and UI component contracts — are imported into one deterministic graph
+of nodes + typed edges, with stable hashes pinning provenance.
+
+These models are DISTINCT from the workflow-viz graph models in
+``omnibase_core.models.graph`` (``ModelGraphNode``/``ModelGraphEdge``, whose
+``node_id`` is a UUID for orchestrator-graph visualization) and from the
+validation-event ``ModelContractRef`` in
+``omnibase_core.models.events.contract_validation``. The distinct
+``contract_graph`` namespace and ``ModelContractGraph*`` names prevent any
+identifier collision.
+"""
+
+from omnibase_core.models.contract_graph.model_contract_graph_contract_ref import (
+    ModelContractGraphContractRef,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_edge import (
+    ModelContractGraphEdge,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_ir import (
+    ModelContractGraphIr,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_node import (
+    ModelContractGraphNode,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_protocol import (
+    ModelContractGraphProtocol,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_source_set import (
+    ModelContractGraphSourceSet,
+)
+
+__all__: tuple[str, ...] = (
+    "ModelContractGraphIr",
+    "ModelContractGraphNode",
+    "ModelContractGraphEdge",
+    "ModelContractGraphProtocol",
+    "ModelContractGraphContractRef",
+    "ModelContractGraphSourceSet",
+)

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_contract_ref.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_contract_ref.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphContractRef — a stable, hashed reference to one source contract.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+DISTINCT from the validation-event ``ModelContractRef``
+(``models/events/contract_validation/model_contract_ref.py``) and from the
+workflow-viz graph models (``models/graph/``). This reference records *which*
+source contract an IR node was imported from, the dialect adapter that imported
+it, and the stable sha256 over the canonicalized contract bytes so diff evidence
+cannot drift between runs.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelContractGraphContractRef"]
+
+
+class ModelContractGraphContractRef(BaseModel):
+    """A hashed reference to one imported source contract.
+
+    ``source_contract_sha256`` is the sha256 (``"sha256:<hex>"``) over the
+    canonicalized contract bytes; ``adapter_version_sha256`` is the stable hash
+    of the adapter that imported it. Together they pin the exact source + import
+    logic that produced an IR node so two runs over the same inputs yield
+    byte-identical references.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ref_id: str = Field(  # string-id-ok: semantic ref label, not a UUID
+        ...,
+        description="Stable semantic identifier for this contract reference",
+        min_length=1,
+    )
+    source_path: str = Field(
+        ...,
+        description="Repo-relative path of the source contract this ref imports",
+        min_length=1,
+    )
+    dialect: str = Field(
+        ...,
+        description="Dialect adapter name that imported this contract (e.g. 'node', 'ui_component')",
+        min_length=1,
+    )
+    source_contract_sha256: str = Field(
+        ...,
+        description="sha256:<hex> over the canonicalized source contract bytes",
+        min_length=8,
+    )
+    adapter_version_sha256: str = Field(
+        ...,
+        description="sha256:<hex> stable version hash of the importing adapter",
+        min_length=8,
+    )

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_edge.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_edge.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphEdge — one typed relationship in the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+DISTINCT from the workflow-viz ``ModelGraphEdge`` (``models/graph/``). This IR
+edge connects two ``ModelContractGraphNode`` by their stable semantic
+``node_id`` and carries a typed ``kind`` (publishes / subscribes /
+implements_protocol / component_renders / action_emits / data_binds). When the
+edge concerns a topic (publish/subscribe/emit/bind), ``topic`` names it.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_contract_graph_edge_kind import (
+    EnumContractGraphEdgeKind,
+)
+
+__all__ = ["ModelContractGraphEdge"]
+
+
+class ModelContractGraphEdge(BaseModel):
+    """A typed directed relationship between two IR nodes.
+
+    ``source_node_id`` and ``target_node_id`` reference ``ModelContractGraphNode``
+    ids. ``kind`` is the typed relationship; ``topic`` carries the canonical topic
+    name for topic-bearing kinds (publishes / subscribes / action_emits /
+    data_binds) and is ``None`` for ``implements_protocol`` and
+    ``component_renders``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    edge_id: str = Field(  # string-id-ok: stable semantic IR edge label, not a UUID
+        ...,
+        description="Stable semantic identifier for this IR edge (deterministic across runs)",
+        min_length=1,
+    )
+    source_node_id: str = Field(  # string-id-ok: references a ModelContractGraphNode id
+        ...,
+        description="node_id of the source IR node",
+        min_length=1,
+    )
+    target_node_id: str = Field(  # string-id-ok: references a ModelContractGraphNode id
+        ...,
+        description="node_id of the target IR node",
+        min_length=1,
+    )
+    kind: EnumContractGraphEdgeKind = Field(
+        ...,
+        description="Typed relationship between the two nodes",
+    )
+    topic: str | None = Field(
+        default=None,
+        description="Canonical topic for topic-bearing edges; None for protocol/render edges",
+    )

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_ir.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_ir.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphIr — the root of the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+DISTINCT from the workflow-viz graph models (``models/graph/``) and the
+validation-event contract-ref. This is the canonical intermediate the plan
+calls ``ModelGraphIR``: a deterministic, read-only graph of imported contracts
+(backend node contracts + UI component contracts) plus the source set and
+hashes that pin its provenance. A no-op round-trip of this IR back to canonical
+normalized contract form must yield zero semantic diff (verified through
+``cli_contract_diff``).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contract_graph.model_contract_graph_edge import (
+    ModelContractGraphEdge,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_node import (
+    ModelContractGraphNode,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_source_set import (
+    ModelContractGraphSourceSet,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelContractGraphIr"]
+
+
+class ModelContractGraphIr(BaseModel):
+    """The deterministic, read-only Contract Graph intermediate.
+
+    ``nodes`` and ``edges`` are stored in deterministic order (by id) by the
+    importing adapter. ``source_set`` pins which source contracts were imported
+    with their stable hashes. ``ir_version`` versions the IR schema itself
+    (additive/versioned). The IR is frozen and carries no I/O or mutation: it is
+    a pure projection of source contracts that round-trips to canonical
+    normalized contract form with zero semantic diff.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ir_version: ModelSemVer = Field(
+        ...,
+        description="Semantic version of the Contract Graph IR schema",
+    )
+    nodes: tuple[ModelContractGraphNode, ...] = Field(
+        ...,
+        description="IR nodes (deterministically ordered by node_id)",
+    )
+    edges: tuple[ModelContractGraphEdge, ...] = Field(
+        default=(),
+        description="Typed IR edges (deterministically ordered by edge_id)",
+    )
+    source_set: ModelContractGraphSourceSet = Field(
+        ...,
+        description="Hashed, ordered set of source contracts imported into this IR",
+    )

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_node.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_node.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphNode — one node in the Contract Graph IR.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+DISTINCT from the workflow-viz ``ModelGraphNode`` (``models/graph/``), whose
+``node_id`` is a ``UUID`` for orchestrator-graph visualization. This IR node is a
+*platform-neutral* representation of one imported contract surface: a backend
+node contract or a UI component contract. Its ``node_id`` is a stable semantic
+string (not a UUID) so the IR is deterministic across runs.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_contract_graph_node_role import (
+    EnumContractGraphNodeRole,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_contract_ref import (
+    ModelContractGraphContractRef,
+)
+from omnibase_core.models.contract_graph.model_contract_graph_protocol import (
+    ModelContractGraphProtocol,
+)
+
+__all__ = ["ModelContractGraphNode"]
+
+
+class ModelContractGraphNode(BaseModel):
+    """A platform-neutral IR node for one imported contract surface.
+
+    ``role`` classifies the surface (a backend archetype, a UI ``COMPONENT``, a
+    ``RENDERER``, or a ``PROTOCOL``). ``source_ref`` pins the source contract +
+    adapter that produced this node (with stable hashes). ``protocols`` carries
+    any protocol boundaries the node types against. Topic membership is expressed
+    as edges in the IR, not inlined here.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    node_id: str = Field(  # string-id-ok: stable semantic IR node label, not a UUID
+        ...,
+        description="Stable semantic identifier for this IR node (deterministic across runs)",
+        min_length=1,
+    )
+    role: EnumContractGraphNodeRole = Field(
+        ...,
+        description="Role this node plays in the IR (effect/compute/reducer/orchestrator/component/renderer/protocol)",
+    )
+    title: str = Field(
+        ...,
+        description="Human-readable title of the imported contract surface",
+        min_length=1,
+    )
+    source_ref: ModelContractGraphContractRef = Field(
+        ...,
+        description="Hashed reference to the source contract + adapter that produced this node",
+    )
+    protocols: tuple[ModelContractGraphProtocol, ...] = Field(
+        default=(),
+        description="Protocol/interface boundaries this node types against",
+    )

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_protocol.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_protocol.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphProtocol — a protocol/interface reference node typing.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+Purpose: a Contract Graph IR node may type its boundary against a protocol /
+interface (the SPI protocols a node implements, or the renderer protocol a UI
+component requires). ``ModelContractGraphProtocol`` is the minimal typed
+reference to such a protocol so the IR can carry ``IMPLEMENTS_PROTOCOL`` edges
+without inlining the protocol's full definition. It names the protocol and the
+input/output model symbols it constrains — nothing more — keeping the IR an
+intermediate, not a re-derivation of the protocol source.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelContractGraphProtocol"]
+
+
+class ModelContractGraphProtocol(BaseModel):
+    """A minimal typed reference to a protocol/interface in the IR.
+
+    Records the protocol's qualified name and the input/output model symbols it
+    constrains (when the source contract declares them). This is a *reference*,
+    not the protocol body: the IR keeps protocols as typed boundary markers so
+    ``IMPLEMENTS_PROTOCOL`` edges are well-typed without inlining SPI source.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    protocol_id: str = Field(  # string-id-ok: semantic protocol label, not a UUID
+        ...,
+        description="Stable semantic identifier for this protocol reference",
+        min_length=1,
+    )
+    qualified_name: str = Field(
+        ...,
+        description="Fully-qualified protocol/interface name (e.g. dotted import path)",
+        min_length=1,
+    )
+    input_model: str | None = Field(
+        default=None,
+        description="Qualified input-model symbol the protocol boundary accepts, if declared",
+    )
+    output_model: str | None = Field(
+        default=None,
+        description="Qualified output-model symbol the protocol boundary produces, if declared",
+    )

--- a/src/omnibase_core/models/contract_graph/model_contract_graph_source_set.py
+++ b/src/omnibase_core/models/contract_graph/model_contract_graph_source_set.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ContractGraphSourceSet — the deterministic set of imported source contracts.
+
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+
+The source set records *exactly* which source contracts were imported into an
+IR, in deterministic order, each with its hashed reference. Embedding the
+source set (alongside per-node refs) in the IR output makes the provenance of a
+graph explicit and reproducible: two imports over the same discovery roots
+produce an identical source set.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contract_graph.model_contract_graph_contract_ref import (
+    ModelContractGraphContractRef,
+)
+
+__all__ = ["ModelContractGraphSourceSet"]
+
+
+class ModelContractGraphSourceSet(BaseModel):
+    """The ordered, hashed set of source contracts imported into an IR.
+
+    ``refs`` is sorted deterministically by ``source_path`` at construction time
+    by the importing adapter so the set is reproducible. ``discovery_roots``
+    records the repo-relative roots scanned (for evidence); discovery excludes
+    ``.venv``, ``omni_worktrees``, and generated surfaces.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    discovery_roots: tuple[str, ...] = Field(
+        ...,
+        description="Repo-relative roots scanned for source contracts",
+        min_length=1,
+    )
+    refs: tuple[ModelContractGraphContractRef, ...] = Field(
+        ...,
+        description="Deterministically ordered hashed references to imported source contracts",
+    )

--- a/tests/unit/contract_graph/__init__.py
+++ b/tests/unit/contract_graph/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/contract_graph/test_contract_graph_adapters.py
+++ b/tests/unit/contract_graph/test_contract_graph_adapters.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Contract Graph IR dialect adapters + importer (OMN-13132).
+
+Covers the read-only node-contract and UI-component adapters, manifest-driven
+discovery (excluding .venv/omni_worktrees/generated), stable hashing, a
+deterministic-IR assertion over >=2 REAL contracts (>=1 backend node + >=1 UI
+component), and a no-op round-trip == zero-semantic-diff proof through the
+shipped ``cli_contract_diff`` spine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.contract_graph import (
+    EXCLUDED_DISCOVERY_DIRS,
+    adapter_version_sha256,
+    canonical_contract_sha256,
+    discover_contract_paths,
+    import_paths,
+    node_contract_adapter_version,
+    round_trip_node_diff,
+    round_trip_ui_component_diff,
+    round_trip_zero_diff,
+    supports_node_contract,
+    supports_ui_component,
+    ui_component_adapter_version,
+)
+from omnibase_core.contract_graph.importer import _load_yaml
+from omnibase_core.enums.enum_contract_graph_edge_kind import EnumContractGraphEdgeKind
+from omnibase_core.enums.enum_contract_graph_node_role import EnumContractGraphNodeRole
+from omnibase_core.enums.enum_widget_type import EnumWidgetType
+from omnibase_core.models.contract_graph import ModelContractGraphIr
+from omnibase_core.models.dashboard.model_action_contract import ModelActionContract
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.models.dashboard.model_data_binding_contract import (
+    ModelDataBindingContract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+# Two REAL backend node contracts shipped in this repo (effect + reducer).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EFFECT_CONTRACT = (
+    "src/omnibase_core/nodes/node_compliance_evidence_effect/contract.yaml"
+)
+_REDUCER_CONTRACT = (
+    "src/omnibase_core/nodes/node_compliance_report_reducer/contract.yaml"
+)
+
+
+def _real_ui_component() -> ModelComponentContract:
+    """A real-shape UI component contract instance (Phase-0 primitive)."""
+    return ModelComponentContract(
+        component_id="compliance_status_grid",
+        component_kind=EnumWidgetType.STATUS_GRID,
+        title="Compliance Status",
+        contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        data_bindings=(
+            ModelDataBindingContract(
+                binding_id="b1",
+                projection_topic="onex.evt.core.compliance-report-updated.v1",
+                ordering_authority_field="updated_at",
+                required_fields=("status",),
+            ),
+        ),
+        actions=(
+            ModelActionContract(
+                action_id="a1",
+                command_topic="onex.cmd.core.compliance-rescan.v1",
+                label="Rescan",
+            ),
+        ),
+    )
+
+
+def _import_real_ir() -> ModelContractGraphIr:
+    effect_fs = _REPO_ROOT / _EFFECT_CONTRACT
+    reducer_fs = _REPO_ROOT / _REDUCER_CONTRACT
+    return import_paths(
+        discovery_roots=("src/omnibase_core/nodes",),
+        node_paths=(
+            (effect_fs, _EFFECT_CONTRACT),
+            (reducer_fs, _REDUCER_CONTRACT),
+        ),
+        ui_components=((_real_ui_component(), "in-memory://compliance_status_grid"),),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Dialect detection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_supports_node_contract_matches_real_contract() -> None:
+    data = _load_yaml(_REPO_ROOT / _EFFECT_CONTRACT)
+    assert supports_node_contract(data) is True
+    assert supports_ui_component(data) is False
+
+
+@pytest.mark.unit
+def test_supports_ui_component_matches_serialized_component() -> None:
+    data = _real_ui_component().model_dump(mode="json")
+    assert supports_ui_component(data) is True
+    assert supports_node_contract(data) is False
+
+
+@pytest.mark.unit
+def test_unknown_node_type_is_not_supported() -> None:
+    assert supports_node_contract({"node_type": "workflow"}) is False
+    assert supports_node_contract({}) is False
+
+
+# --------------------------------------------------------------------------- #
+# Hashing (stable, deterministic, distinct per adapter)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_canonical_hash_ignores_metadata_and_is_stable() -> None:
+    a = {"name": "x", "node_type": "effect", "_metadata": {"generated_at": "t1"}}
+    b = {"name": "x", "node_type": "effect", "_metadata": {"generated_at": "t2"}}
+    assert canonical_contract_sha256(a) == canonical_contract_sha256(b)
+    assert canonical_contract_sha256(a).startswith("sha256:")
+
+
+@pytest.mark.unit
+def test_canonical_hash_changes_on_semantic_change() -> None:
+    a = {"name": "x", "node_type": "effect"}
+    b = {"name": "y", "node_type": "effect"}
+    assert canonical_contract_sha256(a) != canonical_contract_sha256(b)
+
+
+@pytest.mark.unit
+def test_adapter_version_hashes_distinct_and_stable() -> None:
+    node_v = node_contract_adapter_version()
+    ui_v = ui_component_adapter_version()
+    assert node_v.startswith("sha256:") and ui_v.startswith("sha256:")
+    assert node_v != ui_v
+    # stable across calls
+    assert node_v == node_contract_adapter_version()
+
+
+@pytest.mark.unit
+def test_adapter_version_helper_changes_with_implementation() -> None:
+    # Different implementation source -> different version hash; same -> stable.
+    assert adapter_version_sha256(
+        "x", ("def f(): return 1",)
+    ) != adapter_version_sha256("x", ("def f(): return 2",))
+    assert adapter_version_sha256("x", ("src",)) == adapter_version_sha256(
+        "x", ("src",)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Manifest-driven discovery excludes vendored/generated surfaces
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_discovery_excludes_venv_and_worktrees(tmp_path: Path) -> None:
+    (tmp_path / "good").mkdir()
+    (tmp_path / "good" / "contract.yaml").write_text("name: ok\n", encoding="utf-8")
+    for excluded in (".venv", "omni_worktrees", "generated"):
+        d = tmp_path / excluded / "nested"
+        d.mkdir(parents=True)
+        (d / "contract.yaml").write_text("name: bad\n", encoding="utf-8")
+
+    found = discover_contract_paths((tmp_path,))
+    found_strs = [str(p) for p in found]
+    assert any("good/contract.yaml" in s for s in found_strs)
+    for excluded in (".venv", "omni_worktrees", "generated"):
+        assert not any(f"/{excluded}/" in s for s in found_strs)
+
+
+@pytest.mark.unit
+def test_excluded_dirs_constant_covers_required_surfaces() -> None:
+    assert {".venv", "omni_worktrees", "generated"} <= EXCLUDED_DISCOVERY_DIRS
+
+
+# --------------------------------------------------------------------------- #
+# Import produces correct roles + typed edges
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_import_assigns_roles_and_edges() -> None:
+    ir = _import_real_ir()
+    roles = {n.node_id: n.role for n in ir.nodes}
+    # node_id is the contract handler_id (a stable semantic id), falling back to
+    # name only when handler_id is absent.
+    assert roles["node.compliance.evidence"] is EnumContractGraphNodeRole.EFFECT
+    assert roles["node.compliance.report.reducer"] is EnumContractGraphNodeRole.REDUCER
+    assert roles["compliance_status_grid"] is EnumContractGraphNodeRole.COMPONENT
+
+    kinds = {(e.source_node_id, e.kind) for e in ir.edges}
+    assert ("node.compliance.evidence", EnumContractGraphEdgeKind.PUBLISHES) in kinds
+    assert ("node.compliance.evidence", EnumContractGraphEdgeKind.SUBSCRIBES) in kinds
+    assert ("compliance_status_grid", EnumContractGraphEdgeKind.ACTION_EMITS) in kinds
+    assert ("compliance_status_grid", EnumContractGraphEdgeKind.DATA_BINDS) in kinds
+
+
+@pytest.mark.unit
+def test_import_embeds_per_source_and_adapter_hashes() -> None:
+    ir = _import_real_ir()
+    # one ref per source; each carries source + adapter hashes
+    assert len(ir.source_set.refs) == 3
+    for ref in ir.source_set.refs:
+        assert ref.source_contract_sha256.startswith("sha256:")
+        assert ref.adapter_version_sha256.startswith("sha256:")
+    # node-dialect and ui-dialect adapter versions differ within the IR
+    dialect_versions = {
+        ref.dialect: ref.adapter_version_sha256 for ref in ir.source_set.refs
+    }
+    assert dialect_versions["node"] != dialect_versions["ui_component"]
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic IR over >=2 REAL contracts (>=1 node + >=1 UI component)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_deterministic_ir_across_two_runs() -> None:
+    ir1 = _import_real_ir()
+    ir2 = _import_real_ir()
+    assert ir1.model_dump_json() == ir2.model_dump_json()
+    # at least one backend node contract + one UI component contract present
+    roles = {n.role for n in ir1.nodes}
+    assert EnumContractGraphNodeRole.COMPONENT in roles
+    assert {EnumContractGraphNodeRole.EFFECT, EnumContractGraphNodeRole.REDUCER} & roles
+
+
+# --------------------------------------------------------------------------- #
+# No-op round-trip == zero semantic diff (through cli_contract_diff)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_node_no_op_round_trip_zero_semantic_diff() -> None:
+    ir = _import_real_ir()
+    src = _load_yaml(_REPO_ROOT / _EFFECT_CONTRACT)
+    result = round_trip_node_diff(ir, src["handler_id"], src)
+    assert round_trip_zero_diff(result) is True
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_reducer_no_op_round_trip_zero_semantic_diff() -> None:
+    ir = _import_real_ir()
+    src = _load_yaml(_REPO_ROOT / _REDUCER_CONTRACT)
+    result = round_trip_node_diff(ir, src["handler_id"], src)
+    assert round_trip_zero_diff(result) is True
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_ui_component_no_op_round_trip_zero_semantic_diff() -> None:
+    ir = _import_real_ir()
+    result = round_trip_ui_component_diff(ir, _real_ui_component())
+    assert round_trip_zero_diff(result) is True
+    assert result.total_changes == 0

--- a/tests/unit/models/contract_graph/__init__.py
+++ b/tests/unit/models/contract_graph/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/contract_graph/test_contract_graph_ir_models.py
+++ b/tests/unit/models/contract_graph/test_contract_graph_ir_models.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Contract Graph IR models (OMN-13132 — Phase 2).
+
+Covers the six frozen Pydantic IR primitives plus the role/kind enums: frozen
+immutability, ``extra="forbid"``, required fields, strong typing, and the
+mandated role (``renderer``) + edge kinds (``component_renders`` /
+``action_emits`` / ``data_binds``). Also asserts the namespace + class names are
+distinct from the workflow-viz graph models (no collision).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums import (
+    EnumContractGraphEdgeKind,
+    EnumContractGraphNodeRole,
+)
+from omnibase_core.models.contract_graph import (
+    ModelContractGraphContractRef,
+    ModelContractGraphEdge,
+    ModelContractGraphIr,
+    ModelContractGraphNode,
+    ModelContractGraphProtocol,
+    ModelContractGraphSourceSet,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+def _ref() -> ModelContractGraphContractRef:
+    return ModelContractGraphContractRef(
+        ref_id="n1",
+        source_path="src/x/contract.yaml",
+        dialect="node",
+        source_contract_sha256="sha256:" + "a" * 64,
+        adapter_version_sha256="sha256:" + "b" * 64,
+    )
+
+
+def _node(node_id: str = "n1") -> ModelContractGraphNode:
+    return ModelContractGraphNode(
+        node_id=node_id,
+        role=EnumContractGraphNodeRole.EFFECT,
+        title="X",
+        source_ref=_ref(),
+    )
+
+
+def _edge() -> ModelContractGraphEdge:
+    return ModelContractGraphEdge(
+        edge_id="e1",
+        source_node_id="n1",
+        target_node_id="onex.evt.core.x.v1",
+        kind=EnumContractGraphEdgeKind.PUBLISHES,
+        topic="onex.evt.core.x.v1",
+    )
+
+
+def _source_set() -> ModelContractGraphSourceSet:
+    return ModelContractGraphSourceSet(
+        discovery_roots=("src/x",),
+        refs=(_ref(),),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Enum requirements (plan-mandated)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_node_role_includes_renderer() -> None:
+    values = {r.value for r in EnumContractGraphNodeRole}
+    assert "renderer" in values
+    assert {
+        "effect",
+        "compute",
+        "reducer",
+        "orchestrator",
+        "component",
+        "protocol",
+    } <= values
+
+
+@pytest.mark.unit
+def test_edge_kind_includes_ui_kinds() -> None:
+    values = {k.value for k in EnumContractGraphEdgeKind}
+    assert {"component_renders", "action_emits", "data_binds"} <= values
+
+
+# --------------------------------------------------------------------------- #
+# Frozen + extra=forbid + required fields per model
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_contract_ref_frozen_and_forbid() -> None:
+    ref = _ref()
+    with pytest.raises(ValidationError):
+        ref.dialect = "ui_component"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        ModelContractGraphContractRef(
+            ref_id="n1",
+            source_path="p",
+            dialect="node",
+            source_contract_sha256="sha256:" + "a" * 64,
+            adapter_version_sha256="sha256:" + "b" * 64,
+            unknown="x",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_contract_ref_requires_min_length_hashes() -> None:
+    with pytest.raises(ValidationError):
+        ModelContractGraphContractRef(
+            ref_id="n1",
+            source_path="p",
+            dialect="node",
+            source_contract_sha256="x",
+            adapter_version_sha256="sha256:" + "b" * 64,
+        )
+
+
+@pytest.mark.unit
+def test_protocol_frozen_forbid_optional_models() -> None:
+    proto = ModelContractGraphProtocol(
+        protocol_id="p1",
+        qualified_name="pkg.ProtocolX",
+    )
+    assert proto.input_model is None and proto.output_model is None
+    with pytest.raises(ValidationError):
+        proto.qualified_name = "y"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        ModelContractGraphProtocol(protocol_id="p1", qualified_name="x", bad=1)  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_node_strong_typing_role_enum() -> None:
+    node = _node()
+    assert node.role is EnumContractGraphNodeRole.EFFECT
+    with pytest.raises(ValidationError):
+        ModelContractGraphNode(
+            node_id="n1",
+            role="not-a-role",  # type: ignore[arg-type]
+            title="X",
+            source_ref=_ref(),
+        )
+
+
+@pytest.mark.unit
+def test_node_frozen_and_forbid() -> None:
+    node = _node()
+    with pytest.raises(ValidationError):
+        node.title = "Y"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        ModelContractGraphNode(
+            node_id="n1",
+            role=EnumContractGraphNodeRole.EFFECT,
+            title="X",
+            source_ref=_ref(),
+            extra="x",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_node_requires_source_ref() -> None:
+    with pytest.raises(ValidationError):
+        ModelContractGraphNode(  # type: ignore[call-arg]
+            node_id="n1",
+            role=EnumContractGraphNodeRole.EFFECT,
+            title="X",
+        )
+
+
+@pytest.mark.unit
+def test_edge_strong_typing_kind_enum() -> None:
+    edge = _edge()
+    assert edge.kind is EnumContractGraphEdgeKind.PUBLISHES
+    with pytest.raises(ValidationError):
+        ModelContractGraphEdge(
+            edge_id="e1",
+            source_node_id="n1",
+            target_node_id="t",
+            kind="bogus",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.unit
+def test_edge_topic_optional_and_frozen() -> None:
+    edge = ModelContractGraphEdge(
+        edge_id="e2",
+        source_node_id="n1",
+        target_node_id="proto",
+        kind=EnumContractGraphEdgeKind.IMPLEMENTS_PROTOCOL,
+    )
+    assert edge.topic is None
+    with pytest.raises(ValidationError):
+        edge.topic = "x"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_source_set_requires_roots_and_frozen() -> None:
+    ss = _source_set()
+    assert ss.discovery_roots == ("src/x",)
+    with pytest.raises(ValidationError):
+        ModelContractGraphSourceSet(discovery_roots=(), refs=(_ref(),))
+    with pytest.raises(ValidationError):
+        ss.refs = ()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_ir_root_strong_typing_and_frozen() -> None:
+    ir = ModelContractGraphIr(
+        ir_version=ModelSemVer(major=0, minor=1, patch=0),
+        nodes=(_node(),),
+        edges=(_edge(),),
+        source_set=_source_set(),
+    )
+    assert isinstance(ir.ir_version, ModelSemVer)
+    assert ir.nodes[0].node_id == "n1"
+    with pytest.raises(ValidationError):
+        ir.nodes = ()  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        ModelContractGraphIr(
+            ir_version=ModelSemVer(major=0, minor=1, patch=0),
+            nodes=(_node(),),
+            source_set=_source_set(),
+            junk=1,  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+def test_ir_version_must_be_semver_not_str() -> None:
+    with pytest.raises(ValidationError):
+        ModelContractGraphIr(
+            ir_version="0.1.0",  # type: ignore[arg-type]
+            nodes=(_node(),),
+            source_set=_source_set(),
+        )
+
+
+@pytest.mark.unit
+def test_distinct_from_workflow_viz_graph_models() -> None:
+    """The IR node is a different class than the workflow-viz ModelGraphNode.
+
+    The workflow-viz node keys on a UUID node_id; the IR node keys on a stable
+    semantic string. Importing both must not collide.
+    """
+    from omnibase_core.models.graph.model_graph_node import (
+        ModelGraphNode as WorkflowVizGraphNode,
+    )
+
+    assert ModelContractGraphNode is not WorkflowVizGraphNode
+    assert ModelContractGraphNode.__module__ != WorkflowVizGraphNode.__module__
+    # IR node_id is a plain str field (semantic), not UUID
+    assert _node().node_id == "n1"


### PR DESCRIPTION
Evidence-Source: OCC#2719
Evidence-Ticket: OMN-13132

> OCC pairing: onex_change_control PR #2719 (base dev) carries `contracts/OMN-13132.yaml` + paired DoD receipts (`dod-core-pr-1256` binding this PR head `061fc854d`, self-binding `dod-occ-self`); auto-merge armed. The Receipt Gate resolves `Evidence-Source: OCC#2719` via the merged-PR path to that SHA once OCC merges.

## OMN-13132 — Contract Graph IR + read-only import (Phase 2)

Phase 2 of the **Contract-Driven UI Platform** (epic **OMN-13129**, plan
`docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md` §8 Phase 2). Adds the canonical
**read-only** Contract Graph IR to `omnibase_core` plus dialect adapters that import heterogeneous
source contracts into one deterministic IR, with a no-op round-trip proven **zero semantic diff**
through the shipped `cli_contract_diff` spine.

Ticket: **OMN-13132** · Epic: **OMN-13129**. **Strictly read-only**: no authoring UI, no contract mutation.

### Name-collision handling (plan §8: IR models are "distinct from the workflow-viz graph models")

`ModelGraphNode` / `ModelGraphEdge` (`models/graph/`, UUID-keyed workflow-viz) and `ModelContractRef`
(`models/events/contract_validation/`) already exist. The new IR uses a **distinct namespace**
`src/omnibase_core/models/contract_graph/` and **non-colliding names** — the bare
`ModelGraphNode`/`ModelGraphEdge`/`ModelContractRef` identifiers are **not** reused:

| New IR identifier | Namespace |
|---|---|
| `ModelContractGraphIr` (root), `ModelContractGraphNode`, `ModelContractGraphEdge`, `ModelContractGraphProtocol`, `ModelContractGraphContractRef`, `ModelContractGraphSourceSet` | `omnibase_core.models.contract_graph` |
| `EnumContractGraphNodeRole` (incl. `renderer`), `EnumContractGraphEdgeKind` (incl. `component_renders`/`action_emits`/`data_binds`) | `omnibase_core.enums` |

A unit test asserts `ModelContractGraphNode is not ModelGraphNode` (different class + module).

### What this adds

- **IR models** (one file each, `ConfigDict(frozen=True, extra="forbid", from_attributes=True)`, strongly typed — role/kind enums, `ModelSemVer` `ir_version`). `ModelContractGraphProtocol` is a minimal typed protocol/interface boundary reference (qualified name + optional input/output model symbols).
- **Read-only dialect adapters** (`src/omnibase_core/contract_graph/`): a node-contract adapter (event_bus publish/subscribe → `PUBLISHES`/`SUBSCRIBES` edges, descriptor archetype → role, handler I/O → protocol) and a UI-component adapter (Phase-0 `ModelComponentContract` → `COMPONENT` node + `ACTION_EMITS`/`DATA_BINDS` edges). Manifest-driven discovery EXCLUDES `.venv`, `omni_worktrees`, and generated surfaces.
- **Stable hashing**: `sha256` over canonicalized contract bytes (per source) + a stable per-adapter version hash, both embedded in the IR (`source_set.refs`) so diff evidence cannot drift between runs.
- **Round-trip**: IR → canonical **normalized** contract form (documented target, not byte-identical raw source). A no-op round-trip = **zero semantic diff** verified through the shipped `omnibase_core.cli.cli_contract_diff` semantic-diff functions (reused, not rebuilt).

### dod_evidence (local verification, observed)

- **pytest (new):** `29 passed` — `tests/unit/models/contract_graph/` + `tests/unit/contract_graph/` (per-IR-model frozen/extra-forbid/required/strong-typing; per-adapter detection/hashing/discovery-exclusion/role+edge mapping; **deterministic IR over ≥2 real contracts**; **no-op round-trip == zero semantic diff** for effect + reducer + UI component).
- **pytest (regression, changed surface):** `4859 passed, 1 skipped` — `tests/unit/contract_graph/ tests/unit/models/contract_graph/ tests/unit/models/dashboard/ tests/unit/cli/ tests/unit/enums/ -n auto`.
- **full collection:** `41715 collected`, zero import errors (`pytest tests/ --collect-only`).
- **mypy --strict:** zero errors in any new module. The only 3 src-wide errors (`contract_loader.py:570/704`, `cli_install.py:45`) are byte-identical on `origin/dev` (empty `git diff` → pre-existing, not introduced here).
- **ruff:** `ruff check src/ tests/` → All checks passed.
- **deterministic IR + hash manifest + round-trip diff output:** `.onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt` (all three round-trips `zero_diff=True total_changes=0`; the two node sources share one adapter hash, the ui_component source has a distinct one, all three source hashes differ).
- **pre-commit (changed files):** single-class-per-file, validate-string-versions (`ModelSemVer` not str), no-hardcoded-topics (canonical `validate_topic_suffix`), manual-yaml (reuses shipped `load_contract_yaml_file`), error-raising (boundary `# error-ok:`), Deterministic Skill Routing — all pass.

DoD contract artifact: `contracts/OMN-13132.yaml`.
