### PR TITLE
fix(OMN-13214): port hardened arm+update-branch+enqueue+verify auto-merge flow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,6 +23,21 @@
 # targets. The main job depends on pre-check and is skipped entirely when
 # skip=true. A concurrency group per PR cancels redundant queued runs so
 # only the most-recent check_suite completion for a given PR actually runs.
+#
+# OMN-13214: Arming auto-merge is NOT the same as enqueuing. During the
+# 2026-06-17 dev wave, CLEAN + all-required-green + armed PRs sat OUTSIDE the
+# merge queue for hours and each needed a manual enqueuePullRequest to land.
+# Two fixes here: (1) the "Enable auto-merge" step previously passed bare
+# `--auto --squash`, but dev is queue-controlled, so an explicit method is
+# REJECTED ("The merge strategy for dev is set by the merge queue") and the PR
+# is NEVER enqueued. Use bare `--auto` and let the queue pick the method.
+# (2) The old "Force enqueue" step did not verify the PR actually entered the
+# queue. This workflow now (a) arms bare --auto, (b) runs gh pr update-branch
+# first on strict-update repos when the PR is BEHIND, (c) explicitly calls
+# enqueuePullRequest, and (d) VERIFIES the PR actually entered the queue —
+# failing loudly if a green+armed PR is not enqueued, so the gap surfaces
+# instead of stalling silently. The classify/verify decision logic is
+# unit-tested in scripts/ci/merge_queue_enqueue.py.
 name: Auto-Merge
 
 on:
@@ -198,20 +213,23 @@ jobs:
           PR: ${{ needs.pre-check.outputs.pr }}
         run: |
           set -euo pipefail
-          # "already enqueued" race is benign — treat as success.
-          # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
+          # OMN-13138/13214: dev is queue-controlled — the merge method is set by
+          # the merge queue, so passing an explicit --squash is rejected ("The
+          # merge strategy for dev is set by the merge queue") and the PR is NEVER
+          # enqueued (sits CLEAN + auto-merge armed forever). Use bare --auto and
+          # let the queue pick the method.
+          # OMN-13214: arming alone does not enqueue — the explicit enqueue +
+          # verify step below closes that gap. Do NOT exit here on success.
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto 2>&1); then
             echo "auto-merge enabled: $output"
-            exit 0
-          fi
-          if echo "$output" | grep -qiE "already enqueued|already queued|auto-merge already enabled"; then
+          elif echo "$output" | grep -qiE "already enqueued|already queued|auto-merge already enabled"; then
             echo "auto-merge not newly enabled (expected): $output"
-            exit 0
+          else
+            echo "auto-merge failed: $output"
+            exit 1
           fi
-          echo "auto-merge failed: $output"
-          exit 1
 
-      - name: Force enqueue to merge queue
+      - name: Enqueue armed PR and verify it entered the queue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -220,18 +238,111 @@ jobs:
           set -euo pipefail
           OWNER="${GH_REPO%/*}"
           NAME="${GH_REPO#*/}"
-          PR_ID=$(gh api graphql -f query='{repository(owner:"'"$OWNER"'",name:"'"$NAME"'"){pullRequest(number:'"$PR"'){id}}}' --jq '.data.repository.pullRequest.id')
-          if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
-            echo "could not resolve PR id"; exit 0
-          fi
-          if output=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
-            echo "enqueued: $output"
-          else
-            # Tolerate only known benign states.
-            if echo "$output" | grep -qiE "already (in|enqueued|queued)|merge queue (is )?not enabled|not mergeable|required status check"; then
-              echo "enqueue attempt result (tolerated): $output"
+
+          classify() {
+            python3 scripts/ci/merge_queue_enqueue.py classify \
+              --pr-json "$1" --strict-update "$2"
+          }
+
+          # Is the target (default) branch strict-update? On strict repos a BEHIND
+          # PR cannot enqueue until its branch is updated.
+          DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+          STRICT="$(gh api "repos/${GH_REPO}/branches/${DEFAULT_BRANCH}/protection/required_status_checks" \
+            --jq '.strict' 2>/dev/null || echo "false")"
+          [ "$STRICT" = "true" ] || STRICT="false"
+          echo "strict-update on '${DEFAULT_BRANCH}': ${STRICT}"
+
+          fetch_pr() {
+            # isInMergeQueue is only on the GraphQL PullRequest object, NOT a
+            # `gh pr view --json` field, so fetch PR state via GraphQL.
+            # shellcheck disable=SC2016  # $owner/$name/$number are GraphQL vars, not shell vars
+            gh api graphql \
+              -f owner="$OWNER" \
+              -f name="$NAME" \
+              -F number="$PR" \
+              -f query='
+                query($owner:String!, $name:String!, $number:Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      isInMergeQueue
+                      mergeStateStatus
+                      mergeable
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }' \
+              --jq '.data.repository.pullRequest'
+          }
+
+          PR_JSON="$(fetch_pr)"
+          ACTION="$(classify "$PR_JSON" "$STRICT")"
+          echo "classified action: ${ACTION}"
+
+          case "$ACTION" in
+            already_queued)
+              echo "PR #${PR} already in the merge queue — nothing to do."
               exit 0
-            fi
-            echo "enqueue failed: $output"
+              ;;
+            wait)
+              echo "PR #${PR} is not enqueueable yet (BLOCKED/DIRTY/DRAFT/UNKNOWN); will re-fire on next event."
+              exit 0
+              ;;
+            blocked)
+              echo "::warning::PR #${PR} in an unrecognised merge state: $(printf '%s' "$PR_JSON" | jq -r '.mergeStateStatus'). Not enqueuing."
+              exit 0
+              ;;
+            update_branch_then_enqueue)
+              echo "PR #${PR} is BEHIND on a strict-update repo — updating branch before enqueue."
+              if ! gh pr update-branch "$PR" --repo "$GH_REPO" 2>&1; then
+                echo "::warning::update-branch reported no change or a benign error; continuing."
+              fi
+              echo "update-branch issued; the resulting check run re-fires this workflow when CI is green."
+              exit 0
+              ;;
+            enqueue)
+              : # fall through to enqueue below
+              ;;
+            *)
+              echo "::error::unexpected action '${ACTION}' from classifier"
+              exit 1
+              ;;
+          esac
+
+          PR_ID="$(gh api graphql -f query='{repository(owner:"'"$OWNER"'",name:"'"$NAME"'"){pullRequest(number:'"$PR"'){id}}}' --jq '.data.repository.pullRequest.id')"
+          if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
+            echo "::error::could not resolve PR node id for #${PR}"
             exit 1
           fi
+
+          # shellcheck disable=SC2016  # $prId is a GraphQL variable, not a shell var
+          if enq_out=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
+            echo "enqueue issued: ${enq_out}"
+          else
+            if echo "$enq_out" | grep -qiE "merge queue (is )?not enabled|does not have a merge queue|merge_queue_not_enabled"; then
+              echo "repo has no merge queue — arming auto-merge is sufficient: ${enq_out}"
+              exit 0
+            fi
+            if echo "$enq_out" | grep -qiE "already (in|enqueued|queued)|in the merge queue"; then
+              echo "benign enqueue race (already queued): ${enq_out}"
+            else
+              echo "::error::enqueuePullRequest failed for #${PR}: ${enq_out}"
+              exit 1
+            fi
+          fi
+
+          # OMN-13214 ENFORCEMENT: verify the PR actually entered the queue.
+          # Poll briefly — GitHub may take a few seconds to reflect the entry.
+          for attempt in 1 2 3 4 5; do
+            sleep 6
+            PR_AFTER="$(fetch_pr)"
+            if python3 scripts/ci/merge_queue_enqueue.py verify --pr-json "$PR_AFTER"; then
+              echo "VERIFIED: PR #${PR} is in the merge queue."
+              exit 0
+            fi
+            echo "not yet in queue (attempt ${attempt}/5); state=$(printf '%s' "$PR_AFTER" | jq -r '.mergeStateStatus')"
+          done
+
+          echo "::error::PR #${PR} is green + armed but did NOT enter the merge queue after enqueue (OMN-13214 armed-but-not-enqueued). Manual intervention required."
+          exit 1

--- a/scripts/ci/merge_queue_enqueue.py
+++ b/scripts/ci/merge_queue_enqueue.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Reliable merge-queue enqueue decision logic (OMN-13214).
+
+Root cause this module addresses
+--------------------------------
+During the 2026-06-17 dev merge wave, many PRs reached ``mergeStateStatus=CLEAN``
+with all required checks green AND auto-merge armed (by the "Enable Auto-Merge"
+GitHub Actions job), yet never entered the dev merge queue. Each one needed a
+manual ``enqueuePullRequest`` GraphQL mutation (or a disable+re-arm with bare
+``--auto``) to actually land.
+
+Arming auto-merge is **not** the same as enqueuing. On a queue-controlled repo a
+PR can sit CLEAN + armed indefinitely without GitHub ever placing it in the
+queue. The reliable path is an explicit ``enqueuePullRequest`` after arming,
+followed by a verification that the PR actually entered the queue. On
+strict-update (require-branches-up-to-date) repos a branch-behind PR silently
+blocks enqueue with no auto ``update-branch`` step.
+
+This module is the deterministic, unit-tested core of the workflow step. The
+``auto-merge.yml`` workflow shells out to it to decide what action to take and to
+verify the outcome; all the branching that is worth testing in isolation lives
+here rather than in untestable bash.
+
+The module performs **no** network I/O. The workflow is responsible for fetching
+PR JSON via ``gh`` and passing it in; this module only classifies and decides.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from enum import StrEnum
+
+
+class EnumEnqueueAction(StrEnum):
+    """The action the workflow should take for a PR, derived from its state."""
+
+    ALREADY_QUEUED = "already_queued"
+    UPDATE_BRANCH_THEN_ENQUEUE = "update_branch_then_enqueue"
+    ENQUEUE = "enqueue"
+    WAIT = "wait"
+    BLOCKED = "blocked"
+
+
+# mergeStateStatus values that mean "GitHub will not let this PR merge / enqueue
+# right now for a reason that is not a transient branch-behind". These are not
+# our bug to fix; the workflow waits and re-fires on the next event.
+_NON_ENQUEUEABLE_STATES = frozenset(
+    {
+        "BLOCKED",  # required checks pending/failing or required review missing
+        "DIRTY",  # merge conflict
+        "DRAFT",  # draft PR
+        "UNKNOWN",  # GitHub still computing mergeability
+    }
+)
+
+# gh / GraphQL error fragments that mean the repo simply has no merge queue.
+# Enqueue is a no-op there; arming auto-merge is sufficient.
+_NO_MERGE_QUEUE_MARKERS = (
+    "does not have a merge queue",
+    "merge queue is not enabled",
+    "merge_queue_not_enabled",
+    "merge queue not enabled",
+)
+
+# gh / GraphQL error fragments that are benign races — the PR is already on its
+# way into the queue, or a concurrent run already enqueued it.
+_BENIGN_ENQUEUE_MARKERS = (
+    "already enqueued",
+    "already queued",
+    "already in the merge queue",
+    "is already queued",
+    "pull request is in the merge queue",
+)
+
+
+def _truthy(value: object) -> bool:
+    """Coerce a JSON-ish value to bool without surprising falsy strings."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    return bool(value)
+
+
+def is_no_merge_queue_error(message: str) -> bool:
+    """True when an enqueue error means the repo has no merge queue (benign)."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _NO_MERGE_QUEUE_MARKERS)
+
+
+def is_benign_enqueue_error(message: str) -> bool:
+    """True when an enqueue error is a benign already-queued race (benign)."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _BENIGN_ENQUEUE_MARKERS)
+
+
+def is_armed(pr: dict[str, object]) -> bool:
+    """True when auto-merge is armed on the PR.
+
+    ``gh pr view --json autoMergeRequest`` returns ``null`` when not armed and an
+    object (with ``enabledBy``/``mergeMethod``) when armed.
+    """
+    return pr.get("autoMergeRequest") not in (None, {}, "")
+
+
+def is_in_queue(pr: dict[str, object]) -> bool:
+    """True when the PR is already in the merge queue."""
+    return _truthy(pr.get("isInMergeQueue"))
+
+
+def is_behind(pr: dict[str, object]) -> bool:
+    """True when the PR head is behind its base (strict-update would block it).
+
+    ``mergeStateStatus == BEHIND`` is the authoritative GitHub signal. We also
+    treat an explicit ``behind`` integer (from a compare API) as behind.
+    """
+    if str(pr.get("mergeStateStatus", "")).upper() == "BEHIND":
+        return True
+    behind = pr.get("behind")
+    return isinstance(behind, int) and behind > 0
+
+
+def classify_pr(pr: dict[str, object], *, strict_update: bool) -> EnumEnqueueAction:
+    """Decide what to do with a PR based on its current GitHub state.
+
+    Args:
+        pr: ``gh pr view --json ...`` payload (isInMergeQueue, mergeStateStatus,
+            autoMergeRequest, mergeable, behind).
+        strict_update: True when the target branch requires branches to be up to
+            date before merging (require_status_checks.strict). On such repos a
+            BEHIND PR must be updated before it can enqueue.
+
+    Returns:
+        The action the workflow should take.
+    """
+    if is_in_queue(pr):
+        return EnumEnqueueAction.ALREADY_QUEUED
+
+    state = str(pr.get("mergeStateStatus", "")).upper()
+
+    # A branch-behind PR on a strict-update repo cannot enqueue until updated.
+    # On a non-strict repo BEHIND does not block enqueue, so fall through.
+    if is_behind(pr) and strict_update:
+        return EnumEnqueueAction.UPDATE_BRANCH_THEN_ENQUEUE
+
+    # CLEAN / HAS_HOOKS / UNSTABLE-but-mergeable: ready to enqueue.
+    # (UNSTABLE = non-required checks failing; required checks still green.)
+    if state in {"CLEAN", "HAS_HOOKS", "UNSTABLE"}:
+        return EnumEnqueueAction.ENQUEUE
+
+    # BEHIND on a non-strict repo: GitHub allows the queue to merge it; enqueue.
+    if state == "BEHIND":
+        return EnumEnqueueAction.ENQUEUE
+
+    if state in _NON_ENQUEUEABLE_STATES:
+        # BLOCKED/DIRTY/DRAFT/UNKNOWN: not our bug — wait for the next event.
+        return EnumEnqueueAction.WAIT
+
+    # Unrecognised state: do not silently enqueue; surface as blocked so the
+    # workflow logs it rather than masking a new GitHub state.
+    return EnumEnqueueAction.BLOCKED
+
+
+def verify_enqueued(pr_after: dict[str, object]) -> bool:
+    """Confirm a PR actually entered the queue after an enqueue attempt.
+
+    This is the enforcement check that distinguishes "armed" from "actually
+    enqueued" — the exact gap OMN-13214 closes.
+    """
+    return is_in_queue(pr_after)
+
+
+def _load_pr(raw: str) -> dict[str, object]:
+    payload: object = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("PR JSON must be an object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI surface for the workflow.
+
+    Subcommands:
+        classify  --pr-json <json> --strict-update <true|false>
+            Prints the EnumEnqueueAction value to stdout.
+        verify    --pr-json <json>
+            Exit 0 if the PR is in the queue, exit 1 otherwise.
+    """
+    parser = argparse.ArgumentParser(description="Merge-queue enqueue decision logic")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_classify = sub.add_parser("classify", help="Classify a PR into an action")
+    p_classify.add_argument("--pr-json", required=True)
+    p_classify.add_argument("--strict-update", default="false")
+
+    p_verify = sub.add_parser("verify", help="Verify a PR actually entered the queue")
+    p_verify.add_argument("--pr-json", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "classify":
+        pr = _load_pr(args.pr_json)
+        action = classify_pr(pr, strict_update=_truthy(args.strict_update))
+        sys.stdout.write(action.value + "\n")
+        return 0
+
+    if args.command == "verify":
+        pr = _load_pr(args.pr_json)
+        if verify_enqueued(pr):
+            sys.stdout.write("in_queue\n")
+            return 0
+        sys.stdout.write("not_in_queue\n")
+        return 1
+
+    # argparse marks the subcommand required, so this is defensive only.
+    # parser.error() raises SystemExit (NoReturn), so no trailing return needed.
+    parser.error(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/merge_queue_enqueue.py
+++ b/scripts/ci/merge_queue_enqueue.py
@@ -207,18 +207,19 @@ def main(argv: list[str] | None = None) -> int:
         action = classify_pr(pr, strict_update=_truthy(args.strict_update))
         sys.stdout.write(action.value + "\n")
         return 0
-
-    if args.command == "verify":
+    elif args.command == "verify":
         pr = _load_pr(args.pr_json)
         if verify_enqueued(pr):
             sys.stdout.write("in_queue\n")
             return 0
         sys.stdout.write("not_in_queue\n")
         return 1
-
-    # argparse marks the subcommand required, so this is defensive only.
-    # parser.error() raises SystemExit (NoReturn), so no trailing return needed.
-    parser.error(f"unknown command: {args.command}")
+    else:
+        # argparse marks the subcommand required, so this is defensive only.
+        # parser.error() raises SystemExit; raising keeps every branch of this
+        # function terminating with an explicit return or raise (no implicit
+        # fall-through that would silently return None).
+        raise SystemExit(parser.error(f"unknown command: {args.command}"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/ci/test_merge_queue_enqueue.py
+++ b/tests/unit/scripts/ci/test_merge_queue_enqueue.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the merge-queue enqueue decision logic (OMN-13214).
+
+These tests pin the exact armed-but-not-enqueued failure modes observed in the
+2026-06-17 dev wave:
+
+* CLEAN + armed but isInMergeQueue=false  -> ENQUEUE (the core bug).
+* CLEAN + already in queue                -> ALREADY_QUEUED (no double-enqueue).
+* BEHIND on a strict-update repo          -> UPDATE_BRANCH_THEN_ENQUEUE.
+* BEHIND on a non-strict repo             -> ENQUEUE (GitHub queue updates it).
+* BLOCKED / DIRTY / DRAFT / UNKNOWN       -> WAIT (not our bug).
+* verify_enqueued reflects isInMergeQueue.
+* error-message classification (no-queue / benign race).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.ci.merge_queue_enqueue import (
+    EnumEnqueueAction,
+    classify_pr,
+    is_armed,
+    is_benign_enqueue_error,
+    is_no_merge_queue_error,
+    main,
+    verify_enqueued,
+)
+
+Action = EnumEnqueueAction
+
+
+def _pr(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "isInMergeQueue": False,
+        "mergeStateStatus": "CLEAN",
+        "autoMergeRequest": {"mergeMethod": "SQUASH", "enabledBy": {"login": "x"}},
+        "mergeable": "MERGEABLE",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestClassifyPr:
+    def test_clean_armed_not_in_queue_enqueues(self) -> None:
+        # The exact armed-but-not-enqueued state: CLEAN + armed + queue empty.
+        assert classify_pr(_pr(), strict_update=False) is Action.ENQUEUE
+
+    def test_clean_armed_not_in_queue_enqueues_strict(self) -> None:
+        assert classify_pr(_pr(), strict_update=True) is Action.ENQUEUE
+
+    def test_already_in_queue_is_noop(self) -> None:
+        pr = _pr(isInMergeQueue=True)
+        assert classify_pr(pr, strict_update=True) is Action.ALREADY_QUEUED
+
+    def test_in_queue_takes_priority_over_behind(self) -> None:
+        pr = _pr(isInMergeQueue=True, mergeStateStatus="BEHIND")
+        assert classify_pr(pr, strict_update=True) is Action.ALREADY_QUEUED
+
+    def test_behind_strict_update_requires_branch_update(self) -> None:
+        # The strict-update branch-behind case: behind:3 on a strict repo.
+        pr = _pr(mergeStateStatus="BEHIND", behind=3)
+        assert classify_pr(pr, strict_update=True) is Action.UPDATE_BRANCH_THEN_ENQUEUE
+
+    def test_behind_non_strict_enqueues_directly(self) -> None:
+        pr = _pr(mergeStateStatus="BEHIND", behind=3)
+        assert classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+    def test_behind_integer_signal_without_state(self) -> None:
+        pr = _pr(mergeStateStatus="CLEAN", behind=2)
+        assert classify_pr(pr, strict_update=True) is Action.UPDATE_BRANCH_THEN_ENQUEUE
+
+    @pytest.mark.parametrize("state", ["BLOCKED", "DIRTY", "DRAFT", "UNKNOWN"])
+    def test_non_enqueueable_states_wait(self, state: str) -> None:
+        pr = _pr(mergeStateStatus=state)
+        assert classify_pr(pr, strict_update=False) is Action.WAIT
+
+    @pytest.mark.parametrize("state", ["HAS_HOOKS", "UNSTABLE"])
+    def test_mergeable_states_enqueue(self, state: str) -> None:
+        pr = _pr(mergeStateStatus=state)
+        assert classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+    def test_unrecognised_state_is_blocked_not_silently_enqueued(self) -> None:
+        pr = _pr(mergeStateStatus="SOME_NEW_GITHUB_STATE")
+        assert classify_pr(pr, strict_update=False) is Action.BLOCKED
+
+    def test_unarmed_clean_pr_still_enqueues(self) -> None:
+        # Arming and enqueue are independent; the workflow arms first. classify
+        # only decides enqueue eligibility from merge state, not armed-ness.
+        pr = _pr(autoMergeRequest=None)
+        assert classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+
+class TestArmedHelpers:
+    def test_is_armed_true_for_object(self) -> None:
+        assert is_armed(_pr()) is True
+
+    def test_is_armed_false_for_null(self) -> None:
+        assert is_armed(_pr(autoMergeRequest=None)) is False
+
+    def test_is_armed_false_for_empty(self) -> None:
+        assert is_armed(_pr(autoMergeRequest={})) is False
+
+
+class TestVerifyEnqueued:
+    def test_verify_true_when_in_queue(self) -> None:
+        assert verify_enqueued({"isInMergeQueue": True}) is True
+
+    def test_verify_false_when_not_in_queue(self) -> None:
+        assert verify_enqueued({"isInMergeQueue": False}) is False
+
+    def test_verify_false_when_field_missing(self) -> None:
+        assert verify_enqueued({}) is False
+
+
+class TestErrorClassification:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Repository does not have a merge queue",
+            "merge queue is not enabled for this branch",
+            "MERGE_QUEUE_NOT_ENABLED",
+        ],
+    )
+    def test_no_queue_markers(self, msg: str) -> None:
+        assert is_no_merge_queue_error(msg) is True
+        assert is_benign_enqueue_error(msg) is False
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Pull request is already enqueued",
+            "PR is already queued",
+            "pull request is in the merge queue",
+        ],
+    )
+    def test_benign_markers(self, msg: str) -> None:
+        assert is_benign_enqueue_error(msg) is True
+        assert is_no_merge_queue_error(msg) is False
+
+    def test_unrelated_error_is_neither(self) -> None:
+        msg = "GraphQL: Something unexpected happened"
+        assert is_no_merge_queue_error(msg) is False
+        assert is_benign_enqueue_error(msg) is False
+
+
+class TestCli:
+    def test_classify_cli_prints_action(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = main(
+            ["classify", "--pr-json", json.dumps(_pr()), "--strict-update", "false"]
+        )
+        out = capsys.readouterr().out.strip()
+        assert rc == 0
+        assert out == Action.ENQUEUE.value
+
+    def test_classify_cli_strict_behind(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pr = _pr(mergeStateStatus="BEHIND", behind=1)
+        rc = main(["classify", "--pr-json", json.dumps(pr), "--strict-update", "true"])
+        out = capsys.readouterr().out.strip()
+        assert rc == 0
+        assert out == Action.UPDATE_BRANCH_THEN_ENQUEUE.value
+
+    def test_verify_cli_exit_zero_in_queue(self) -> None:
+        rc = main(["verify", "--pr-json", json.dumps({"isInMergeQueue": True})])
+        assert rc == 0
+
+    def test_verify_cli_exit_one_not_in_queue(self) -> None:
+        rc = main(["verify", "--pr-json", json.dumps({"isInMergeQueue": False})])
+        assert rc == 1

--- a/tests/unit/validation/test_auto_merge_workflow_shape.py
+++ b/tests/unit/validation/test_auto_merge_workflow_shape.py
@@ -45,7 +45,7 @@ def test_auto_merge_runs_occ_preflight_before_mutating_pr() -> None:
 
     assert names.index("OCC auto-merge preflight") < names.index("Enable auto-merge")
     assert names.index("OCC auto-merge preflight") < names.index(
-        "Force enqueue to merge queue"
+        "Enqueue armed PR and verify it entered the queue"
     )
 
 
@@ -57,3 +57,34 @@ def test_auto_merge_preflight_uses_single_pr_snapshot() -> None:
     assert "omnibase_core.validation.validator_occ_merge_eligibility" in script
     assert "--occ-commit-sha" in script
     assert "--pr-body-file /tmp/pr_body.txt" in script
+
+
+def test_enable_auto_merge_arms_bare_auto_not_squash() -> None:
+    # OMN-13214: dev is queue-controlled; an explicit --squash is rejected and
+    # the PR is never enqueued. The actual `gh pr merge` command must arm bare
+    # --auto (a comment may still explain why --squash is wrong).
+    script = _step("Enable auto-merge")["run"]
+    assert isinstance(script, str)
+
+    merge_lines = [
+        line
+        for line in script.splitlines()
+        if "gh pr merge" in line and not line.strip().startswith("#")
+    ]
+    assert merge_lines, "no `gh pr merge` command found in Enable auto-merge step"
+    for line in merge_lines:
+        assert "--auto" in line
+        assert "--squash" not in line
+
+
+def test_enqueue_step_classifies_enqueues_and_verifies() -> None:
+    # OMN-13214: arming != enqueuing. The enqueue step must classify via the
+    # unit-tested helper, explicitly enqueue, and VERIFY the PR entered the queue.
+    script = _step("Enqueue armed PR and verify it entered the queue")["run"]
+
+    assert "scripts/ci/merge_queue_enqueue.py classify" in script
+    assert "scripts/ci/merge_queue_enqueue.py verify" in script
+    assert "enqueuePullRequest" in script
+    assert "gh pr update-branch" in script
+    # Must fail loudly when a green + armed PR does not enter the queue.
+    assert "::error::" in script


### PR DESCRIPTION
## OMN-13214 — Port hardened arm+update-branch+enqueue+verify auto-merge flow to omnibase_core

### Problem
During the 2026-06-17 dev merge wave, multiple PRs reached `mergeStateStatus=CLEAN` with **all required checks green** AND **auto-merge armed**, yet **never entered the dev merge queue**. Each needed a manual `enqueuePullRequest` GraphQL mutation to land. Arming auto-merge is **not** the same as enqueuing.

This repo's `auto-merge.yml` had two specific defects:
1. The "Enable auto-merge" step passed `--auto --squash`. dev is queue-controlled, so an explicit method is **rejected** ("The merge strategy for dev is set by the merge queue") and the PR is **never enqueued** (sits CLEAN + armed forever).
2. The "Force enqueue" step issued `enqueuePullRequest` but **never verified** the PR actually entered the queue, so an armed-but-not-enqueued PR stalled silently.

### Fix (enforcement, not advisory)
Ported from omnimarket PR #1253 (merge commit `8fad5e11`).

`.github/workflows/auto-merge.yml`:
1. "Enable auto-merge" now arms bare `--auto` (queue picks the method) and **falls through** instead of exiting on success.
2. New "Enqueue armed PR and verify it entered the queue" step: `classify` → (on strict-update `BEHIND`, `gh pr update-branch` first) → `enqueuePullRequest` → poll-and-**VERIFY** `isInMergeQueue`, failing loudly (`::error::`) if a green+armed PR is not enqueued.
3. Preserves this repo's existing `pre-check` fanout guard, self-hosted runner selection, and OCC auto-merge preflight.

The classify/verify decision logic is a stdlib-only, no-network, unit-tested helper:
- `scripts/ci/merge_queue_enqueue.py`
- `tests/unit/scripts/ci/test_merge_queue_enqueue.py` (32 tests) — pins clean+armed+empty-queue → ENQUEUE, already-queued → noop, BEHIND strict → update-branch, BEHIND non-strict → enqueue, BLOCKED/DIRTY/DRAFT/UNKNOWN → wait, verify, and error-marker classification.

### Verification
- `uv run pytest tests/unit/scripts/ci/test_merge_queue_enqueue.py` → 32 passed.
- `mypy --strict` clean (explicit-`Any`-free via `dict[str, object]`); `ruff` clean.
- `actionlint` clean on the new workflow steps.
- Full omnibase_core pre-commit suite green (40 hooks). The single skipped local hook (`validate-deterministic-skill-routing`) scans omniclaude-owned SKILL.md files via a sibling clone; its violations pre-exist on omniclaude@dev, are unrelated to this PR (no SKILL.md touched), and the check is **not** a required status check on omnibase_core dev.

### Honest dogfood limitation
This bootstrap PR **cannot** auto-enqueue itself: the `check_suite` event runs the **default-branch** (pre-fix) version of `auto-merge.yml` until this PR merges. This PR was manually enqueued. After merge, the next green+armed PR in omnibase_core will auto-enqueue via the hardened flow.

OMN-13214

---
Evidence-Source: OCC#2723
Evidence-Ticket: OMN-13214
