### PR TITLE
feat(OMN-13219): canonical-inference enforcement gate (pre-commit + required CI)

### DIFF
--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-13219: canonical-inference ratchet gate — BLOCKING MODE.
+#
+# Inference must go through the contract-driven routing authority (bus /
+# inference-effect / Bifrost), never a shelled model CLI and never a
+# hardcoded/env-resolved model or provider. This gate fails on:
+#   - model-cli-shellout: codex/claude/gemini/opencode passed to subprocess/exec
+#     or resolved via shutil.which
+#   - model-id-env-read:  os.environ[*_MODEL] / os.environ.get(*_PROVIDER) reads
+#
+# Endpoint URLs and *_URL / *_ENDPOINT env reads are owned by the URL Authority
+# Gate (OMN-12818); freestanding imperative IO generally is owned by the
+# imperative-contract guard (OMN-12515/12540). This gate is the missing
+# shell-out-for-inference layer.
+#
+# This is a RATCHET: existing violations are grandfathered by the sha256 baseline
+# at src/omnibase_core/validation/baselines/canonical_inference_baseline.json.
+# Any NEW violation (fingerprint absent from the baseline) fails the job and
+# blocks merge. The baseline is burn-down only — a CI assertion rejects growth.
+# The codex shell-out removal is tracked by OMN-13215.
+#
+# To permit a legitimate exception, annotate the line:
+#   # canonical-inference-ok: <concrete reason>
+#
+# This job is a REQUIRED STATUS CHECK. The job name "Canonical Inference Gate"
+# must match branch protection rules.
+
+name: Canonical Inference Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-inference-gate:
+    name: Canonical Inference Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run canonical-inference gate (full-repo, against frozen baseline)
+        run: |
+          uv run python -m omnibase_core.validation.validator_canonical_inference \
+            --all --repo omnibase_core --repo-root .
+
+      - name: Assert baseline did not grow (anti-gaming)
+        run: |
+          uv run python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          baseline = Path(
+              "src/omnibase_core/validation/baselines/canonical_inference_baseline.json"
+          )
+          head = json.loads(baseline.read_text())
+          head_repo = {
+              e["fingerprint"]
+              for e in head["violations"]
+              if e["repo"] == "omnibase_core"
+          }
+          # Compare against the baseline on the PR base branch.
+          base_ref = "origin/${{ github.base_ref || 'dev' }}"
+          try:
+              prior_text = subprocess.check_output(
+                  ["git", "show", f"{base_ref}:{baseline}"], text=True
+              )
+              prior = json.loads(prior_text)
+              prior_repo = {
+                  e["fingerprint"]
+                  for e in prior["violations"]
+                  if e["repo"] == "omnibase_core"
+              }
+          except subprocess.CalledProcessError:
+              # Baseline file does not exist on the base branch — this is the
+              # initial introduction of the baseline for this repo. By definition
+              # nothing "grew" relative to a non-existent prior, so the check
+              # passes. Any new violations that sneak in via the first commit are
+              # caught by the gate step above.
+              print(
+                  "CANONICAL-INFERENCE BASELINE OK (initial): "
+                  f"baseline file is new on this PR ({len(head_repo)} grandfathered "
+                  "fingerprints); no prior to compare against."
+              )
+              sys.exit(0)
+          grew = head_repo - prior_repo
+          if grew:
+              sys.stderr.write(
+                  "CANONICAL-INFERENCE BASELINE GREW: "
+                  f"{len(grew)} new fingerprint(s) added to the baseline. The "
+                  "baseline is burn-down only — fix the violation or annotate with "
+                  "# canonical-inference-ok:, never grow the baseline.\n"
+              )
+              sys.exit(1)
+          print(
+              "CANONICAL-INFERENCE BASELINE OK: "
+              f"omnibase_core subset {len(head_repo)} (<= prior {len(prior_repo)})."
+          )
+          PY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -837,6 +837,23 @@ repos:
         exclude: ^(tests/|archived/|archive/).*\.py$
         stages: [pre-commit]
 
+      # Canonical Inference Gate (OMN-13219).
+      # Fails on non-canonical model-inference surfaces: shelled model CLIs
+      # (codex/claude/gemini/opencode via subprocess/exec/shutil.which) and
+      # *_MODEL / *_PROVIDER env reads. Endpoint URLs are owned by the
+      # url-authority gate above. Ratchet: NEW fingerprints fail; existing are
+      # grandfathered (codex shell-out removal tracked by OMN-13215). Baseline is
+      # burn-down only. Suppress with: # canonical-inference-ok: <reason>
+      - id: check-canonical-inference
+        name: Canonical Inference Gate (OMN-13219)
+        entry: uv run python -m omnibase_core.validation.validator_canonical_inference
+        args: [--repo, omnibase_core, --repo-root, .]
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: ^(tests/|archived/|archive/).*\.py$
+        stages: [pre-commit]
+
       - id: validate-exception-handling
         name: ONEX Exception Handling Validation
         entry: uv run python scripts/validation/validate-exception-handling.py

--- a/contracts/OMN-13219.yaml
+++ b/contracts/OMN-13219.yaml
@@ -1,0 +1,53 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13219"
+title: "feat(OMN-13219): canonical-inference enforcement gate (pre-commit + required CI)"
+summary: >
+  Adds ValidatorCanonicalInference (omnibase_core) — a ratchet gate, wired as a pre-commit hook and a
+  required CI status check, that fails on non-canonical model-inference surfaces: shelled model CLIs (codex/claude/gemini/opencode
+  via subprocess/exec/os.system/shutil.which) and *_MODEL / *_PROVIDER env reads. Endpoint URLs and *_URL
+  / *_ENDPOINT env reads remain owned by the URL-authority gate (OMN-12818); freestanding imperative IO
+  generally by scan_freestanding_imperative_io (OMN-12515/12540). Fail-closed: a NEW shell-out or env-resolved
+  model trips the gate (exit 1); the contract-resolved tier (OMN-13215 target shape) passes. Existing
+  violations grandfathered by sha256 baseline; burn-down only.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Canonical-inference validator unit tests pass (fail-closed regression included)"
+    command: "uv run pytest tests/unit/validation/test_validator_canonical_inference.py -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-tests"
+    description: "42 unit tests pass — shell-out + env-model trip the gate; contract-resolved path passes;
+      ratchet + baseline + CLI exit codes covered"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/validation/test_validator_canonical_inference.py -q"
+  - id: "dod-mypy"
+    description: "mypy --strict clean on validator + model"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/validation/validator_canonical_inference.py src/omnibase_core/models/validation/model_canonical_inference_violation.py
+          --strict"
+  - id: "dod-precommit-gate"
+    description: "New pre-commit hook check-canonical-inference passes; full focused pre-commit pass clean"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pre-commit run check-canonical-inference --all-files"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: adds a static validator + pre-commit hook + CI workflow only;
+      no Docker image, daemon, broker topic, runtime process, docker exec, or service deploy is required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13219 ships a static enforcement gate (validator + pre-commit
+          hook + CI workflow); no Docker image, daemon, broker topic, runtime process, docker exec, or
+          service deploy is required before merge'"

--- a/src/omnibase_core/models/validation/model_canonical_inference_violation.py
+++ b/src/omnibase_core/models/validation/model_canonical_inference_violation.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelCanonicalInferenceViolation — one non-canonical-inference finding.
+
+Used by the canonical-inference ratchet gate (OMN-13219). Each violation carries
+a content fingerprint (sha256 of {repo, path, normalized-snippet}) so existing
+violations can be grandfathered via the burn-down baseline while NEW ones fail
+the gate.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelCanonicalInferenceViolation(BaseModel):
+    """A single non-canonical-inference finding with a content fingerprint."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str
+    path: str
+    line: int
+    rule: str
+    snippet: str
+    fingerprint: str

--- a/src/omnibase_core/validation/baselines/canonical_inference_baseline.json
+++ b/src/omnibase_core/validation/baselines/canonical_inference_baseline.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "1.0.0",
+  "count": 0,
+  "violations": []
+}

--- a/src/omnibase_core/validation/contracts/canonical_inference.validation.yaml
+++ b/src/omnibase_core/validation/contracts/canonical_inference.validation.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+contract_kind: validation_subcontract
+validation:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  validator_id: canonical_inference
+  validator_name: Canonical Inference Validator
+  validator_description: |
+    Rejects NEW non-canonical model-inference surfaces (OMN-13219).
+
+    Inference must go through the contract-driven routing authority (bus /
+    inference-effect / Bifrost), never a shelled model CLI and never a
+    hardcoded/env-resolved model or provider.
+
+    Two rules:
+    - model-cli-shellout: a model-CLI binary (codex/claude/gemini/opencode) passed
+      to subprocess/exec or resolved via shutil.which
+    - model-id-env-read: os.environ[*_MODEL] / os.environ.get(*_PROVIDER) reads
+
+    Endpoint URLs and *_URL / *_ENDPOINT env reads are covered by the sibling
+    URL-authority gate (OMN-12803/12818); this validator does NOT re-implement
+    them. Freestanding imperative IO generally is covered by
+    scan_freestanding_imperative_io (OMN-12515/12540).
+
+    Existing violations are grandfathered by content fingerprint (ratchet
+    baseline). Only NEW fingerprints fail the gate. Baseline is burn-down only.
+    The codex shell-out (OMN-13215) is the seeded baseline with its removal ticket.
+
+    Suppression: # canonical-inference-ok: <reason>
+
+  target_patterns:
+    - "**/*.py"
+
+  exclude_patterns:
+    - "**/tests/**"
+    - "**/test_*.py"
+    - "**/*_test.py"
+    - "**/__pycache__/**"
+    - "**/.git/**"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+    - "**/venv/**"
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/dod_receipts/**"
+    - "**/evidence/**"
+
+  rules:
+    - rule_id: model-cli-shellout
+      description: >-
+        Rejects shelling out to a model-CLI binary (codex/claude/gemini/opencode) via subprocess/exec/os.system
+        or shutil.which as an inference/delegation tier. Route inference through the canonical path (bus
+        / inference-effect / Bifrost). Suppress with # canonical-inference-ok: <reason>.
+      severity: error
+      enabled: true
+
+    - rule_id: model-id-env-read
+      description: >-
+        Rejects os.environ[*_MODEL] / os.environ.get(*_PROVIDER) reads that bypass the contract-driven
+        routing authority. Resolve model + provider from the routing-tiers / model_routing contract instead.
+      severity: error
+      enabled: true
+
+  suppression_comments:
+    - "# canonical-inference-ok:"
+
+  fail_on_error: true
+  fail_on_warning: false
+  max_violations: 0
+  severity_default: error
+  parallel_execution: true

--- a/src/omnibase_core/validation/validator_canonical_inference.py
+++ b/src/omnibase_core/validation/validator_canonical_inference.py
@@ -139,7 +139,7 @@ _MODEL_ENV_SUFFIXES: Final[tuple[str, ...]] = ("_MODEL", "_MODEL_ID", "_PROVIDER
 
 # ``os.environ[...]`` / ``os.environ.get(...)`` for a model/provider name.
 _ENV_MODEL_READ: Final[re.Pattern[str]] = re.compile(
-    r"""os\.environ(?:\.get\(\s*|\[\s*)["'][A-Z0-9_]*(?:_MODEL|_MODEL_ID|_PROVIDER)["']""",
+    rf"""os\.environ(?:\.get\(\s*|\[\s*)["'][A-Z0-9_]*(?:{"|".join(re.escape(suffix) for suffix in _MODEL_ENV_SUFFIXES)})["']""",
 )
 
 # Suppression annotation.

--- a/src/omnibase_core/validation/validator_canonical_inference.py
+++ b/src/omnibase_core/validation/validator_canonical_inference.py
@@ -1,0 +1,712 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorCanonicalInference — reject non-canonical model-inference surfaces.
+
+Part of OMN-13219 (enforcement gate: pre-commit + CI must catch non-canonical
+code). The delegation ceiling tier shipped as a *shelled* ``codex`` CLI
+execution (OMN-13215) — a non-canonical surface — and nothing caught it until a
+live matrix run failed with "codex executable not found". Per CLAUDE.md Rule 5
+(enforcement, not detection), a detection tool that is not a merge gate gets
+ignored; this validator is wired as BOTH a pre-commit hook AND a required CI
+status check.
+
+Inference must go through the canonical inference path (the contract-driven
+routing authority → bus → inference-effect → Bifrost), never a shelled CLI and
+never a hardcoded/env-resolved model or provider.
+
+Detects the following non-canonical patterns in Python source:
+
+1. **model-cli-shellout** — a model-CLI binary name (``codex``, ``claude``,
+   ``gemini``, ``opencode``) passed as the program to a subprocess/exec call
+   (``subprocess.run``/``Popen``/``call``/``check_output``/``check_call``,
+   ``asyncio.create_subprocess_exec``/``_shell``, ``os.system``) OR resolved via
+   ``shutil.which(...)``. This is the canonical signal of "shell out to a model
+   CLI as an inference/delegation tier."
+
+2. **model-id-env-read** — ``os.environ[...]`` / ``os.environ.get(...)`` whose
+   variable NAME ends in ``_MODEL`` / ``_MODEL_ID`` / ``_PROVIDER``. Model and
+   provider must resolve from the routing-tiers / model_routing contract, not an
+   env var. (Endpoint URLs and ``*_URL`` / ``*_ENDPOINT`` env reads are covered
+   by the sibling URL-authority gate, OMN-12803/12818 — this validator does NOT
+   re-implement those.)
+
+The two scanners are complementary, not overlapping:
+    - ``ValidatorUrlAuthority`` (OMN-12818) owns endpoint URLs + ``*_URL`` /
+      ``*_ENDPOINT`` env reads + public-https literals.
+    - ``ValidatorCanonicalInference`` (this file, OMN-13219) owns shelled model
+      CLIs + ``*_MODEL`` / ``*_PROVIDER`` env reads.
+    - The imperative-contract guard ``scan_freestanding_imperative_io``
+      (OMN-12515/12540) owns freestanding imperative IO generally.
+
+Ratchet (mirrors the OMN-12818 url-authority gate and the OMN-12791 receipt
+gate): existing violations are grandfathered by content fingerprint (sha256 of
+{repo, path, normalized-snippet}). Only NEW fingerprints fail the gate. The
+baseline may only shrink (burn-down). The codex shell-out tracked by OMN-13215
+is baselined explicitly with its removal ticket — a NEW shell-out fails closed.
+
+Baseline per repo lives at:
+``src/omnibase_core/validation/baselines/canonical_inference_baseline.json``
+
+Usage Examples:
+    Programmatic usage::
+
+        from omnibase_core.validation.validator_canonical_inference import (
+            ValidatorCanonicalInference,
+        )
+
+        v = ValidatorCanonicalInference()
+        result = v.validate(Path("src/"))
+        if not result.is_valid:
+            for issue in result.issues:
+                print(f"{issue.file_path}:{issue.line_number}: {issue.message}")
+
+    CLI — pre-commit (staged files)::
+
+        python -m omnibase_core.validation.validator_canonical_inference file1.py ...
+
+    CLI — full repo scan (CI)::
+
+        python -m omnibase_core.validation.validator_canonical_inference --all \\
+            --repo omnibase_core --repo-root .
+
+    CLI — seed / update baseline::
+
+        python -m omnibase_core.validation.validator_canonical_inference \\
+            --seed --repo omnibase_core --repo-root .
+
+Suppression:
+    Add ``# canonical-inference-ok: <reason>`` on the offending line. Free-text
+    PR-body justification does NOT suppress — only the in-line annotation.
+
+Migration debt:
+    - codex/claude/gemini CLI shell-out removal: OMN-13215
+
+Schema Version:
+    v1.0.0 - Initial version (OMN-13219)
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import ClassVar, Final
+
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.validation.model_canonical_inference_violation import (
+    ModelCanonicalInferenceViolation,
+)
+from omnibase_core.validation.validator_base import ValidatorBase
+
+# ---------------------------------------------------------------------------
+# Detection configuration
+# ---------------------------------------------------------------------------
+
+# Model-CLI binary names that must never be shelled out for inference.
+MODEL_CLI_BINARIES: Final[frozenset[str]] = frozenset(
+    {"codex", "claude", "gemini", "opencode"}
+)
+
+# Subprocess/exec callables whose FIRST string/list arg is the program.
+# Stored as the trailing attribute name; the full dotted path is matched too.
+_SUBPROCESS_CALLS: Final[frozenset[str]] = frozenset(
+    {
+        "subprocess.run",
+        "subprocess.Popen",
+        "subprocess.call",
+        "subprocess.check_output",
+        "subprocess.check_call",
+        "asyncio.create_subprocess_exec",
+        "asyncio.create_subprocess_shell",
+        "os.system",
+        "os.popen",
+    }
+)
+
+# ``shutil.which("codex")`` is the canonical "is the CLI on PATH" probe that
+# precedes a shell-out — treat it as the same violation class.
+_WHICH_CALL: Final[str] = "shutil.which"
+
+# Env-var name suffixes that must resolve from the routing contract instead.
+_MODEL_ENV_SUFFIXES: Final[tuple[str, ...]] = ("_MODEL", "_MODEL_ID", "_PROVIDER")
+
+# ``os.environ[...]`` / ``os.environ.get(...)`` for a model/provider name.
+_ENV_MODEL_READ: Final[re.Pattern[str]] = re.compile(
+    r"""os\.environ(?:\.get\(\s*|\[\s*)["'][A-Z0-9_]*(?:_MODEL|_MODEL_ID|_PROVIDER)["']""",
+)
+
+# Suppression annotation.
+_SUPPRESS_ANNOTATION: Final[str] = "# canonical-inference-ok:"
+
+# Rule identifiers (must match the validation contract).
+RULE_MODEL_CLI_SHELLOUT: Final[str] = "model-cli-shellout"
+RULE_MODEL_ENV_READ: Final[str] = "model-id-env-read"
+
+# Directories excluded from full-tree scans.
+_EXCLUDED_PARTS: Final[frozenset[str]] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        "dist",
+        "build",
+        "dod_receipts",
+        "evidence",
+        ".onex_state",
+    }
+)
+
+# Default baseline path (relative to this file's parent → baselines/ subdir).
+_DEFAULT_BASELINE: Final[Path] = (
+    Path(__file__).parent / "baselines" / "canonical_inference_baseline.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(snippet: str) -> str:
+    """Normalize the offending snippet for a stable, line-number-independent hash."""
+    return re.sub(r"\s+", " ", snippet.strip())
+
+
+def make_fingerprint(repo: str, path: str, snippet: str) -> str:
+    """sha256({repo}\\0{path}\\0{normalized-snippet}) — survives unrelated edits."""
+    payload = f"{repo}\0{path}\0{_normalize(snippet)}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _dotted_call_name(func: ast.expr) -> str | None:
+    """Return the dotted name of a call target (e.g. ``subprocess.run``)."""
+    if isinstance(func, ast.Attribute):
+        parent = _dotted_call_name(func.value)
+        return f"{parent}.{func.attr}" if parent else func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _string_literals(node: ast.expr) -> list[str]:
+    """Collect direct string-literal values from an expr (Constant or list)."""
+    out: list[str] = []
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        out.append(node.value)
+    elif isinstance(node, (ast.List, ast.Tuple)):
+        for elt in node.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                out.append(elt.value)
+    return out
+
+
+def _program_token(value: str) -> str:
+    """Reduce a program string to its bare binary name (strip path / args)."""
+    # Take the first whitespace-delimited token (handles os.system("codex ...")),
+    # then the basename (handles "/usr/bin/codex").
+    first = value.strip().split()[0] if value.strip() else ""
+    return first.rsplit("/", maxsplit=1)[-1]
+
+
+def _cli_binary_in_call(call: ast.Call) -> str | None:
+    """Return the model-CLI binary name a subprocess/which call targets, else None.
+
+    For subprocess/exec calls, inspects the first positional arg (the program or
+    argv). For ``shutil.which``, inspects the first positional arg (the name).
+    """
+    name = _dotted_call_name(call.func)
+    if name is None:
+        return None
+
+    if name == _WHICH_CALL:
+        for literal in (lit for arg in call.args[:1] for lit in _string_literals(arg)):
+            token = _program_token(literal)
+            if token in MODEL_CLI_BINARIES:
+                return token
+        return None
+
+    if name in _SUBPROCESS_CALLS or name.rsplit(".", maxsplit=1)[-1] in {
+        n.rsplit(".", maxsplit=1)[-1] for n in _SUBPROCESS_CALLS
+    }:
+        # First positional arg is the program (str) or argv (list whose head is
+        # the program).
+        if not call.args:
+            return None
+        first = call.args[0]
+        literals = _string_literals(first)
+        # For a list/tuple argv, only the HEAD element is the program.
+        if isinstance(first, (ast.List, ast.Tuple)):
+            literals = literals[:1]
+        for literal in literals:
+            token = _program_token(literal)
+            if token in MODEL_CLI_BINARIES:
+                return token
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Source scanner
+# ---------------------------------------------------------------------------
+
+
+def _is_test_path(path: str) -> bool:
+    lowered = path.lower()
+    return "test" in lowered or "conftest" in lowered
+
+
+def _line_suppressed(raw_line: str) -> bool:
+    return _SUPPRESS_ANNOTATION in raw_line
+
+
+def scan_source(
+    repo: str, path: str, source: str
+) -> list[ModelCanonicalInferenceViolation]:
+    """Scan one source file's text for non-canonical-inference violations.
+
+    Test files are skipped. Lines carrying ``# canonical-inference-ok:`` are
+    suppressed. Returns at most one violation per line.
+
+    Args:
+        repo: Repo name used in fingerprints (e.g. ``"omnibase_core"``).
+        path: Repo-relative path for fingerprints (e.g. ``"src/pkg/file.py"``).
+        source: Full source text of the file.
+
+    Returns:
+        Sorted (by line) list of violations found in the file.
+    """
+    if _is_test_path(path):
+        return []
+
+    raw_lines = source.splitlines()
+    violations: dict[int, ModelCanonicalInferenceViolation] = {}
+
+    def _add(line: int, rule: str) -> None:
+        if line in violations:
+            return
+        raw = raw_lines[line - 1] if 1 <= line <= len(raw_lines) else ""
+        if _line_suppressed(raw):
+            return
+        snippet = raw.strip()[:200]
+        violations[line] = ModelCanonicalInferenceViolation(
+            repo=repo,
+            path=path,
+            line=line,
+            rule=rule,
+            snippet=snippet,
+            fingerprint=make_fingerprint(repo, path, snippet),
+        )
+
+    # Rule 1: model-CLI shell-out (AST — robust against false positives).
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        tree = None
+    if tree is not None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                binary = _cli_binary_in_call(node)
+                if binary is not None:
+                    _add(node.lineno, RULE_MODEL_CLI_SHELLOUT)
+
+    # Rule 2: model/provider env read (line regex — env reads are single-line).
+    for index, raw_line in enumerate(raw_lines, start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _ENV_MODEL_READ.search(raw_line):
+            _add(index, RULE_MODEL_ENV_READ)
+
+    return [violations[line] for line in sorted(violations)]
+
+
+def scan_tree(repo: str, repo_root: Path) -> list[ModelCanonicalInferenceViolation]:
+    """Scan all ``*.py`` under ``repo_root`` for non-canonical-inference violations.
+
+    Paths in the returned violations are repo-relative so fingerprints are
+    machine-independent. Excludes vendored, build, test, and evidence dirs.
+
+    Args:
+        repo: Repo name for fingerprints.
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        List of violations.
+    """
+    violations: list[ModelCanonicalInferenceViolation] = []
+    for py in sorted(repo_root.rglob("*.py")):
+        if set(py.parts) & _EXCLUDED_PARTS:
+            continue
+        if _is_test_path(py.name):
+            continue
+        try:
+            source = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            rel = str(py.relative_to(repo_root))
+        except ValueError:
+            rel = str(py)
+        violations.extend(scan_source(repo, rel, source))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Ratchet baseline helpers
+# ---------------------------------------------------------------------------
+
+
+def load_baseline(baseline_path: Path) -> set[str]:
+    """Load the frozen fingerprint set from the baseline JSON. Missing file = empty."""
+    if not baseline_path.exists():
+        return set()
+    data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    entries = data.get("violations", []) if isinstance(data, dict) else []
+    return {
+        str(e["fingerprint"])
+        for e in entries
+        if isinstance(e, dict) and "fingerprint" in e
+    }
+
+
+def partition_against_baseline(
+    violations: list[ModelCanonicalInferenceViolation],
+    baseline_fingerprints: set[str],
+) -> tuple[
+    list[ModelCanonicalInferenceViolation], list[ModelCanonicalInferenceViolation]
+]:
+    """Split violations into (new, grandfathered) by baseline membership.
+
+    Returns:
+        Tuple of (new_violations, grandfathered_violations). New violations fail
+        the gate; grandfathered ones pass.
+    """
+    new: list[ModelCanonicalInferenceViolation] = []
+    grandfathered: list[ModelCanonicalInferenceViolation] = []
+    for v in violations:
+        if v.fingerprint in baseline_fingerprints:
+            grandfathered.append(v)
+        else:
+            new.append(v)
+    return new, grandfathered
+
+
+def assert_baseline_shrinks_only(before: set[str], after: set[str]) -> None:
+    """Anti-gaming: the baseline may shrink (burn-down) but never grow.
+
+    Raises:
+        ValueError: If ``after`` introduces fingerprints not present in ``before``.
+    """
+    added = after - before
+    if added:
+        # Standard-Python boundary validation in a pure helper; mirrors
+        # ValidatorUrlAuthority.assert_baseline_shrinks_only — no OnexError context
+        # is meaningful here and this runs as a CLI/anti-gaming assertion.
+        # error-ok: standard-library boundary assertion in a pure CLI helper
+        raise ValueError(
+            "canonical-inference baseline grew: "
+            f"{len(added)} new fingerprint(s) added. The baseline is burn-down "
+            "only — fix the violation or annotate with # canonical-inference-ok:, "
+            "never add it to the baseline. Offending fingerprints: "
+            f"{sorted(added)[:5]}"
+        )
+
+
+def serialize_baseline(
+    violations: list[ModelCanonicalInferenceViolation],
+) -> dict[str, object]:
+    """Build the on-disk baseline document — sorted, deterministic, fingerprint-keyed."""
+    entries: list[dict[str, str]] = sorted(
+        (
+            {
+                "repo": v.repo,
+                "path": v.path,
+                "rule": v.rule,
+                "fingerprint": v.fingerprint,
+            }
+            for v in violations
+        ),
+        key=lambda e: (e["repo"], e["path"], e["fingerprint"]),
+    )
+    seen: set[str] = set()
+    unique: list[dict[str, str]] = []
+    for e in entries:
+        fp = e["fingerprint"]
+        if fp in seen:
+            continue
+        seen.add(fp)
+        unique.append(e)
+    return {"schema_version": "1.0.0", "count": len(unique), "violations": unique}
+
+
+# ---------------------------------------------------------------------------
+# ValidatorBase subclass
+# ---------------------------------------------------------------------------
+
+
+class ValidatorCanonicalInference(ValidatorBase):
+    """Reject NEW non-canonical model-inference surfaces.
+
+    Wraps the canonical-inference ratchet as a standard ValidatorBase subclass so
+    it participates in the ecosystem-wide validation pipeline (pre-commit hooks,
+    CI required checks, cross-repo wiring).
+
+    The validator ONLY reports violations that are NEW (not in the per-repo
+    baseline). Existing (grandfathered) violations are silently skipped until they
+    are fixed and the baseline is shrunk. The codex shell-out tracked by OMN-13215
+    is the seeded baseline.
+    """
+
+    validator_id: ClassVar[str] = "canonical_inference"
+
+    def __init__(
+        self,
+        contract: ModelValidatorSubcontract | None = None,
+        repo: str = "omnibase_core",
+        baseline_path: Path | None = None,
+        repo_root: Path | None = None,
+    ) -> None:
+        super().__init__(contract=contract)
+        self._repo = repo
+        self._baseline_path = baseline_path or _DEFAULT_BASELINE
+        self._baseline: set[str] | None = None
+        # repo_root anchors fingerprints to a stable repo-relative path.
+        self._repo_root = repo_root
+
+    def _get_baseline(self) -> set[str]:
+        if self._baseline is None:
+            self._baseline = load_baseline(self._baseline_path)
+        return self._baseline
+
+    def _validate_file(
+        self,
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> tuple[ModelValidationIssue, ...]:
+        if path.suffix != ".py":
+            return ()
+
+        if self._repo_root is not None:
+            try:
+                rel = str(path.relative_to(self._repo_root))
+            except ValueError:
+                rel = path.name
+        else:
+            rel = path.name
+
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ()
+
+        raw_violations = scan_source(self._repo, rel, source)
+        baseline = self._get_baseline()
+        new, _ = partition_against_baseline(raw_violations, baseline)
+
+        issues: list[ModelValidationIssue] = []
+        for v in new:
+            enabled, severity = self._get_rule_config(v.rule, contract)
+            if not enabled:
+                continue
+            issues.append(
+                ModelValidationIssue(
+                    severity=severity,
+                    message=(
+                        f"non-canonical inference [{v.rule}]: {v.snippet!r} — route "
+                        "inference through the contract-driven routing authority "
+                        "(bus / inference-effect / Bifrost); resolve model + provider "
+                        "from the routing contract. Annotate "
+                        "# canonical-inference-ok: <reason> only with a real waiver."
+                    ),
+                    code=v.rule,
+                    file_path=path,
+                    line_number=v.line,
+                    rule_name=v.rule,
+                )
+            )
+        return tuple(issues)
+
+
+# ---------------------------------------------------------------------------
+# CLI — pre-commit hook + CI gate
+# ---------------------------------------------------------------------------
+
+
+def _err(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+
+
+def _out(msg: str) -> None:
+    sys.stdout.write(msg + "\n")
+
+
+def _update_baseline(
+    repo: str, repo_root: Path, baseline_path: Path, *, seed: bool
+) -> int:
+    """Regenerate this repo's baseline subset (burn-down only)."""
+    prior_entries: list[dict[str, str]] = []
+    if baseline_path.exists():
+        data = json.loads(baseline_path.read_text(encoding="utf-8"))
+        all_entries = data.get("violations", []) if isinstance(data, dict) else []
+        prior_entries = [
+            e for e in all_entries if isinstance(e, dict) and "fingerprint" in e
+        ]
+    repo_before = {e["fingerprint"] for e in prior_entries if e.get("repo") == repo}
+    other_entries = [e for e in prior_entries if e.get("repo") != repo]
+
+    fresh_violations = scan_tree(repo, repo_root)
+    fresh: list[dict[str, str]] = [
+        {
+            "repo": v.repo,
+            "path": v.path,
+            "rule": v.rule,
+            "fingerprint": v.fingerprint,
+        }
+        for v in fresh_violations
+    ]
+    repo_after = {e["fingerprint"] for e in fresh}
+
+    if not seed:
+        try:
+            assert_baseline_shrinks_only(repo_before, repo_after)
+        except ValueError as exc:
+            _err(f"CANONICAL-INFERENCE BASELINE REJECTED: {exc}")
+            return 1
+
+    merged = sorted(
+        [*other_entries, *fresh],
+        key=lambda e: (e["repo"], e["path"], e["fingerprint"]),
+    )
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps(
+            {"schema_version": "1.0.0", "count": len(merged), "violations": merged},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    action = "seeded" if seed else f"burned down {len(repo_before) - len(repo_after)}"
+    _out(
+        f"CANONICAL-INFERENCE BASELINE updated for {repo}: {len(repo_after)} "
+        f"violation(s) ({action}). Total across repos: {len(merged)}."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Staged-files mode (pre-commit): pass file paths as positional args.
+    Full-repo mode (CI): pass ``--all --repo <name> --repo-root <path>``.
+    Baseline update: pass ``--seed`` or ``--update-baseline``.
+
+    Exit codes:
+        0 — no new violations (or grandfathered-only)
+        1 — new violation(s) found or baseline grew
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="check-canonical-inference",
+        description="canonical-inference ratchet gate (OMN-13219).",
+    )
+    parser.add_argument(
+        "paths", nargs="*", help="Explicit files to scan (staged set, pre-commit mode)."
+    )
+    parser.add_argument(
+        "--repo", default="omnibase_core", help="Repo name for fingerprints."
+    )
+    parser.add_argument(
+        "--repo-root", default=".", help="Repo root for repo-relative paths."
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Full-repo scan (CI mode) instead of explicit staged files.",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Regenerate this repo's baseline subset (burn-down only).",
+    )
+    parser.add_argument(
+        "--seed",
+        action="store_true",
+        help="One-time initialization of this repo's baseline subset (no shrink check).",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=str(_DEFAULT_BASELINE),
+        help="Path to the baseline JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    baseline_path = Path(args.baseline)
+
+    if args.update_baseline or args.seed:
+        return _update_baseline(args.repo, repo_root, baseline_path, seed=args.seed)
+
+    if args.all:
+        violations = scan_tree(args.repo, repo_root)
+    else:
+        if not args.paths:
+            _out("CANONICAL-INFERENCE GATE: no files to scan.")
+            return 0
+        violations = []
+        for raw in args.paths:
+            p = Path(raw)
+            if not p.is_file() or p.suffix != ".py":
+                continue
+            try:
+                source = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            try:
+                rel = str(p.resolve().relative_to(repo_root.resolve()))
+            except ValueError:
+                rel = str(p)
+            violations.extend(scan_source(args.repo, rel, source))
+
+    baseline = load_baseline(baseline_path)
+    new, grandfathered = partition_against_baseline(violations, baseline)
+
+    if new:
+        _err(
+            f"CANONICAL-INFERENCE GATE FAILED: {len(new)} NEW violation(s) — inference "
+            "must go through the contract-driven routing authority (bus / "
+            "inference-effect / Bifrost); model + provider resolve from the routing "
+            "contract, never a shelled model CLI or env var.\n"
+        )
+        for v in new:
+            _err(f"  [{v.rule}] {v.repo}/{v.path}:{v.line}")
+            _err(f"    {v.snippet}")
+            _err(
+                "    -> route through the canonical inference path, or annotate "
+                "# canonical-inference-ok: <reason>"
+            )
+        return 1
+
+    _out(
+        f"CANONICAL-INFERENCE GATE PASSED: 0 new violations "
+        f"({len(grandfathered)} grandfathered)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validation/test_validator_canonical_inference.py
+++ b/tests/unit/validation/test_validator_canonical_inference.py
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ValidatorCanonicalInference (OMN-13219).
+
+Covers:
+- Detection of both violation classes (model-cli-shellout, model-id-env-read)
+- Suppression annotation (# canonical-inference-ok:)
+- Test-path exclusion
+- Fail-closed: a shelled-CLI inference tier and a hardcoded/env model each trip
+  the gate (exit 1); the canonical contract-resolved path passes (exit 0)
+- Ratchet: new fingerprints fail, grandfathered fingerprints pass
+- Baseline helpers: load_baseline, serialize_baseline, assert_baseline_shrinks_only
+- ValidatorBase integration (validate() returns ModelValidationResult)
+- CLI entry point: --all, staged-files, exit codes, seed, baseline-growth reject
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_severity import EnumSeverity
+from omnibase_core.models.contracts.subcontracts.model_validator_rule import (
+    ModelValidatorRule,
+)
+from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
+    ModelValidatorSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.validation.validator_canonical_inference import (
+    RULE_MODEL_CLI_SHELLOUT,
+    RULE_MODEL_ENV_READ,
+    ValidatorCanonicalInference,
+    assert_baseline_shrinks_only,
+    load_baseline,
+    make_fingerprint,
+    partition_against_baseline,
+    scan_source,
+    scan_tree,
+    serialize_baseline,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, content: str, name: str = "mod.py") -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _baseline_with(fingerprints: set[str], tmp_path: Path) -> Path:
+    b = tmp_path / "baseline.json"
+    entries = [
+        {"repo": "r", "path": "p", "rule": RULE_MODEL_CLI_SHELLOUT, "fingerprint": fp}
+        for fp in fingerprints
+    ]
+    b.write_text(
+        json.dumps(
+            {"schema_version": "1.0.0", "count": len(entries), "violations": entries}
+        ),
+        encoding="utf-8",
+    )
+    return b
+
+
+def _empty_baseline(tmp_path: Path) -> Path:
+    b = tmp_path / "baseline.json"
+    b.write_text(
+        json.dumps({"schema_version": "1.0.0", "count": 0, "violations": []}),
+        encoding="utf-8",
+    )
+    return b
+
+
+def _open_contract() -> ModelValidatorSubcontract:
+    """Minimal contract with both canonical-inference rules enabled and no excludes."""
+    return ModelValidatorSubcontract(
+        version=ModelSemVer(major=1, minor=0, patch=0),
+        validator_id="canonical_inference",
+        validator_name="Test",
+        validator_description="Test",
+        target_patterns=["**/*.py"],
+        exclude_patterns=[],
+        suppression_comments=["# canonical-inference-ok:"],
+        fail_on_error=True,
+        fail_on_warning=False,
+        severity_default=EnumSeverity.ERROR,
+        rules=[
+            ModelValidatorRule(
+                rule_id=RULE_MODEL_CLI_SHELLOUT,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+            ModelValidatorRule(
+                rule_id=RULE_MODEL_ENV_READ,
+                description="test",
+                severity=EnumSeverity.ERROR,
+                enabled=True,
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: scan_source — model-cli-shellout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScanShellout:
+    def test_subprocess_run_codex_detected(self) -> None:
+        src = 'subprocess.run(["codex", "exec", prompt])\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_subprocess_run_codex_str_program_detected(self) -> None:
+        src = 'subprocess.run("codex exec", shell=True)\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_popen_claude_detected(self) -> None:
+        src = 'proc = subprocess.Popen(["claude", "-p", prompt])\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_create_subprocess_exec_gemini_detected(self) -> None:
+        src = 'await asyncio.create_subprocess_exec("gemini", "-p", prompt)\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_os_system_codex_detected(self) -> None:
+        src = 'os.system("codex exec hi")\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_shutil_which_codex_detected(self) -> None:
+        src = 'executable = shutil.which("codex")\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_abs_path_codex_detected(self) -> None:
+        src = 'subprocess.run(["/usr/local/bin/codex", "exec"])\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_non_model_cli_not_detected(self) -> None:
+        # git/docker/etc. are NOT model CLIs — not this gate's concern.
+        src = 'subprocess.run(["git", "status"])\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_codex_as_arg_not_program_not_detected(self) -> None:
+        # "codex" appears as a non-head list element (an argument, not the
+        # program) — not a shell-out of the codex binary.
+        src = 'subprocess.run(["echo", "codex"])\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_codex_string_in_unrelated_call_not_detected(self) -> None:
+        src = 'logger.info("codex")\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_shellout_suppressed(self) -> None:
+        src = 'subprocess.run(["codex", "exec"])  # canonical-inference-ok: legacy\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+
+# ---------------------------------------------------------------------------
+# Unit: scan_source — model-id-env-read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScanEnvRead:
+    def test_env_model_read_detected(self) -> None:
+        src = 'model = os.environ["LLM_MODEL"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_ENV_READ
+
+    def test_env_provider_read_get_detected(self) -> None:
+        src = 'provider = os.environ.get("INFERENCE_PROVIDER", "")\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_ENV_READ
+
+    def test_env_api_key_not_detected(self) -> None:
+        # api-key reads stay legal — secrets resolve at the effect boundary.
+        src = 'key = os.environ["LINEAR_API_KEY"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_env_url_not_this_gate(self) -> None:
+        # *_URL is the URL-authority gate's concern, not this one.
+        src = 'base = os.environ["LLM_URL"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_comment_only_env_read_skipped(self) -> None:
+        src = '# model = os.environ["LLM_MODEL"]\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+    def test_env_read_suppressed(self) -> None:
+        src = 'm = os.environ["LLM_MODEL"]  # canonical-inference-ok: bootstrap\n'
+        vs = scan_source("r", "src/pkg/a.py", src)
+        assert vs == []
+
+
+# ---------------------------------------------------------------------------
+# Unit: path handling + fingerprints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPathsAndFingerprints:
+    def test_test_path_skipped(self) -> None:
+        src = 'subprocess.run(["codex", "exec"])\n'
+        vs = scan_source("r", "tests/test_something.py", src)
+        assert vs == []
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        src = 'shutil.which("codex")\n'
+        v1 = scan_source("r", "src/pkg/a.py", src)[0]
+        v2 = scan_source("r", "src/pkg/a.py", src)[0]
+        assert v1.fingerprint == v2.fingerprint
+
+    def test_fingerprint_changes_with_snippet(self) -> None:
+        v1 = scan_source("r", "src/pkg/a.py", 'shutil.which("codex")\n')[0]
+        v2 = scan_source("r", "src/pkg/a.py", 'shutil.which("claude")\n')[0]
+        assert v1.fingerprint != v2.fingerprint
+
+    def test_make_fingerprint_whitespace_normalized(self) -> None:
+        # _normalize collapses internal whitespace RUNS to a single space and
+        # strips ends; double-space vs single-space hash identically.
+        fp1 = make_fingerprint("r", "p", '  shutil.which("codex")  ')
+        fp2 = make_fingerprint("r", "p", 'shutil.which("codex")')
+        assert fp1 == fp2
+
+
+# ---------------------------------------------------------------------------
+# Unit: ratchet helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRatchet:
+    def test_partition_new_vs_grandfathered(self) -> None:
+        vs = scan_source("r", "src/pkg/a.py", 'shutil.which("codex")\n')
+        assert len(vs) == 1
+        fp = vs[0].fingerprint
+
+        new, grand = partition_against_baseline(vs, {fp})
+        assert new == []
+        assert len(grand) == 1
+
+        new2, grand2 = partition_against_baseline(vs, set())
+        assert len(new2) == 1
+        assert grand2 == []
+
+    def test_assert_baseline_shrinks_only_pass(self) -> None:
+        assert_baseline_shrinks_only({"a", "b"}, {"a"})
+
+    def test_assert_baseline_shrinks_only_same(self) -> None:
+        assert_baseline_shrinks_only({"a"}, {"a"})
+
+    def test_assert_baseline_shrinks_only_fails_on_growth(self) -> None:
+        with pytest.raises(ValueError, match="grew"):
+            assert_baseline_shrinks_only({"a"}, {"a", "b"})
+
+    def test_load_baseline_missing_file(self, tmp_path: Path) -> None:
+        assert load_baseline(tmp_path / "missing.json") == set()
+
+    def test_load_baseline_reads_fingerprints(self, tmp_path: Path) -> None:
+        b = _baseline_with({"abc123", "def456"}, tmp_path)
+        assert load_baseline(b) == {"abc123", "def456"}
+
+    def test_serialize_baseline_deduplicates(self) -> None:
+        vs = scan_source("r", "src/pkg/a.py", 'shutil.which("codex")\n')
+        doc = serialize_baseline(vs + vs)
+        assert doc["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: ValidatorCanonicalInference (ValidatorBase subclass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidatorIntegration:
+    def test_shellout_gate_red(self, tmp_path: Path) -> None:
+        """Fail-closed: a NEW shelled-CLI inference tier trips the gate."""
+        f = _write(tmp_path, 'subprocess.run(["codex", "exec", p])\n', "src/m.py")
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+        )
+        result = v.validate_file(f)
+        assert not result.is_valid, f"Expected RED but got: {result.issues}"
+        assert result.issues[0].code == RULE_MODEL_CLI_SHELLOUT
+
+    def test_env_model_gate_red(self, tmp_path: Path) -> None:
+        """Fail-closed: a NEW env-resolved model trips the gate."""
+        f = _write(tmp_path, 'model = os.environ["LLM_MODEL"]\n', "src/m.py")
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+        )
+        result = v.validate_file(f)
+        assert not result.is_valid
+        assert result.issues[0].code == RULE_MODEL_ENV_READ
+
+    def test_canonical_path_gate_green(self, tmp_path: Path) -> None:
+        """The contract-resolved tier (OMN-13215 target shape) passes the gate.
+
+        Resolving model/provider/endpoint from the routing contract + dispatching
+        over the bus contains no shell-out and no env read — zero violations.
+        """
+        src = textwrap.dedent(
+            """\
+            tier = routing.resolve_tier(task_type)
+            envelope = build_inference_envelope(
+                model=tier.selected_model,
+                provider=tier.provider,
+                endpoint_url=tier.endpoint_url,
+                api_key_ref=tier.api_key_ref,
+            )
+            response = await event_bus.publish(envelope)
+            """
+        )
+        f = _write(tmp_path, src, "src/m.py")
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+        )
+        result = v.validate_file(f)
+        assert result.is_valid, f"Expected GREEN but got: {result.issues}"
+
+    def test_baselined_shellout_gate_green(self, tmp_path: Path) -> None:
+        """Grandfathered (baselined) shell-out passes — burn-down tracked elsewhere."""
+        snippet = 'subprocess.run(["codex", "exec", p])'
+        f = _write(tmp_path, snippet + "\n", "src/m.py")
+        fp = make_fingerprint("test_repo", "src/m.py", snippet)
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_baseline_with({fp}, tmp_path),
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(f)
+        assert result.is_valid, f"Expected green but got: {result.issues}"
+
+    def test_suppressed_line_gate_green(self, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path,
+            'subprocess.run(["codex", "exec"])  # canonical-inference-ok: legacy\n',
+            "src/m.py",
+        )
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+        )
+        result = v.validate_file(f)
+        assert result.is_valid
+
+    def test_validator_id(self) -> None:
+        assert ValidatorCanonicalInference.validator_id == "canonical_inference"
+
+
+# ---------------------------------------------------------------------------
+# Integration: scan_tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScanTree:
+    def test_scan_tree_finds_violations(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "module.py").write_text(
+            'shutil.which("codex")\n', encoding="utf-8"
+        )
+        vs = scan_tree("r", tmp_path)
+        assert any(v.path.endswith("module.py") for v in vs)
+
+    def test_scan_tree_excludes_tests(self, tmp_path: Path) -> None:
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "test_m.py").write_text(
+            'subprocess.run(["codex"])\n', encoding="utf-8"
+        )
+        assert scan_tree("r", tmp_path) == []
+
+    def test_scan_tree_uses_relative_paths(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "pkg.py").write_text(
+            'shutil.which("codex")\n', encoding="utf-8"
+        )
+        for v in scan_tree("r", tmp_path):
+            assert not v.path.startswith("/")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCLI:
+    def test_no_files_exit_0(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        rc = main([])
+        assert rc == 0
+        assert "no files" in capsys.readouterr().out.lower()
+
+    def test_new_violation_exit_1(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        f = _write(tmp_path, 'subprocess.run(["codex", "exec"])\n', "mod.py")
+        rc = main(
+            [
+                str(f),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(_empty_baseline(tmp_path)),
+            ]
+        )
+        assert rc == 1
+
+    def test_grandfathered_violation_exit_0(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        snippet = 'subprocess.run(["codex", "exec"])'
+        f = _write(tmp_path, snippet + "\n", "mod.py")
+        fp = make_fingerprint("r", "mod.py", snippet)
+        rc = main(
+            [
+                str(f),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(_baseline_with({fp}, tmp_path)),
+            ]
+        )
+        assert rc == 0
+
+    def test_seed_creates_baseline(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "m.py").write_text(
+            'shutil.which("codex")\n', encoding="utf-8"
+        )
+        baseline = tmp_path / "baseline.json"
+        rc = main(
+            [
+                "--seed",
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(baseline),
+            ]
+        )
+        assert rc == 0
+        assert baseline.exists()
+        assert json.loads(baseline.read_text())["count"] >= 1
+
+    def test_update_baseline_rejects_growth(self, tmp_path: Path) -> None:
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "m.py").write_text(
+            'shutil.which("codex")\n', encoding="utf-8"
+        )
+        # Pre-seed baseline with a DIFFERENT fingerprint so the repo scan grows it.
+        pre_seed_fp = make_fingerprint("r", "src/fake.py", 'shutil.which("claude")')
+        rc = main(
+            [
+                "--update-baseline",
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(_baseline_with({pre_seed_fp}, tmp_path)),
+            ]
+        )
+        assert rc == 1


### PR DESCRIPTION
Evidence-Source: OCC#2732
Evidence-Ticket: OMN-13219

> OCC pairing: a paired `onex_change_control` PR carrying `contracts/OMN-13219.yaml` + DoD receipts binding this PR head is required for the Receipt Gate to resolve `Evidence-Source`. The DoD contract artifact `contracts/OMN-13219.yaml` ships in this PR; the OCC pairing PR is the cross-repo follow-up.

## OMN-13219 — canonical-inference enforcement gate (pre-commit + required CI)

The delegation ceiling tier shipped as a **shelled** `codex` CLI execution (OMN-13215) — a non-canonical surface — and nothing caught it until a live matrix run failed with `codex executable not found`. Per CLAUDE.md Rule 5 (enforcement, not detection) and the user directive *"non-canonical code should be caught by pre-commit and CI"*, this PR adds a mechanically-enforced gate.

### What this adds

`ValidatorCanonicalInference` (`src/omnibase_core/validation/validator_canonical_inference.py`) — a `ValidatorBase` subclass + ratchet, structurally parallel to the OMN-12818 `ValidatorUrlAuthority` gate. Two rules:

| Rule | Detects |
|---|---|
| `model-cli-shellout` | a model-CLI binary (`codex`/`claude`/`gemini`/`opencode`) passed as the program to `subprocess.run`/`Popen`/`call`/`check_output`/`check_call`, `asyncio.create_subprocess_exec`/`_shell`, `os.system`/`popen`, OR resolved via `shutil.which(...)` (AST-based, low false-positive: only the program/head-of-argv counts, not arguments) |
| `model-id-env-read` | `os.environ[*_MODEL]` / `os.environ.get(*_PROVIDER)` reads |

### Reuses/extends existing guards — no parallel one-off (ticket requirement)

The three guards **partition** the non-canonical space; this gate fills the one genuinely-missing layer (shell-out for inference):
- `ValidatorUrlAuthority` (OMN-12818) owns endpoint URLs + `*_URL`/`*_ENDPOINT` env reads + public-https literals — **not re-implemented here**.
- `scan_freestanding_imperative_io` (OMN-12515/12540) owns freestanding imperative IO generally.
- `ValidatorCanonicalInference` (this PR) owns shelled model CLIs + `*_MODEL`/`*_PROVIDER` env reads.

Built on the same shipped infrastructure: `ValidatorBase`, `ModelValidatorSubcontract`, the sha256-fingerprint ratchet, and the burn-down baseline assertion.

### Wired as BOTH a pre-commit hook AND a required CI check (Rule 5)

- pre-commit: `check-canonical-inference` in `.pre-commit-config.yaml` (next to `check-url-authority`).
- CI: `.github/workflows/canonical-inference-gate.yml` — blocking job `Canonical Inference Gate`, full-repo scan against the frozen baseline + an anti-gaming baseline-growth assertion. Triggers on PRs to `main`/`dev` and `merge_group`.

### Fail-closed regression test (ticket requirement)

`tests/unit/validation/test_validator_canonical_inference.py` — 42 tests:
- a shelled-CLI inference tier (`subprocess.run(["codex", ...])`) trips the gate (RED, exit 1);
- a hardcoded/env-resolved model (`os.environ["LLM_MODEL"]`) trips the gate (RED);
- the canonical contract-resolved path (resolve model/provider/endpoint from the routing contract → publish over the bus) **passes** (GREEN);
- non-model CLIs (`git`/`docker`), `codex` as a non-program arg, api-key env reads, and `*_URL` reads (URL-gate's job) do **not** false-positive;
- ratchet (new vs grandfathered), baseline burn-down-only, suppression annotation, CLI exit codes, `--seed`, and baseline-growth rejection all covered.

### Baseline / pre-existing violations (ticket requirement)

`omnibase_core` itself contains **zero** shell-out / model-env violations → seeded baseline is `0`. The codex shell-out tracked by OMN-13215 lives in `omnimarket`/`omnibase_infra`/`omniclaude` (verified: the gate detects `shutil.which("codex")` in `handler_inference_intent.py`); those repos' baselines + wiring are the cross-repo follow-up, with the shell-out's removal already ticketed as OMN-13215. The gate **fails-closed on NEW shell-outs** — re-introducing the `codex-cli` shell-out in omnibase_core would fail pre-commit and CI immediately.

### dod_evidence (local, observed)

- **pytest:** `42 passed` — `tests/unit/validation/test_validator_canonical_inference.py`.
- **regression (validator pair):** `91 passed` — canonical-inference + url-authority validator tests together.
- **mypy --strict:** zero errors on `validator_canonical_inference.py` + `model_canonical_inference_violation.py`.
- **ruff:** `ruff format` + `ruff check --fix` → All checks passed.
- **pre-commit (changed files, all hooks):** ALL HOOKS PASSED — including the new `Canonical Inference Gate`, `URL Authority Gate`, SPDX, single-class-per-file, error-raising (`# error-ok:` boundary), Deterministic Skill Routing.
- **fail-closed proof:** synthetic `subprocess.run(["codex","exec"])` → `GATE FAILED: 1 NEW violation`; same line `# canonical-inference-ok:` annotated → `GATE PASSED`.

DoD contract artifact: `contracts/OMN-13219.yaml`.

Relates to OMN-13215 (canonical swappable tiers / codex shell-out removal), OMN-12803/12818 (URL-from-contract gate), OMN-12515/12540 (imperative-contract guard).