### PR TITLE
feat(OMN-13131): canonical risk/confidence home for action-gate fields (ADR D2)

### DIFF
--- a/src/omnibase_core/enums/ui/__init__.py
+++ b/src/omnibase_core/enums/ui/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract-Driven UI Platform enums (OMN-13129 / OMN-13131).
+
+UI-platform-scoped enums for the action-gate policy. These are intentionally
+distinct from the routing/overseer ``EnumRiskLevel`` definitions and are not
+re-exported from the top-level ``omnibase_core.enums`` package to avoid a name
+collision; import them from ``omnibase_core.enums.ui``.
+"""
+
+from omnibase_core.enums.ui.enum_commit_level import EnumCommitLevel
+from omnibase_core.enums.ui.enum_risk_level import EnumRiskLevel
+
+__all__: list[str] = [
+    "EnumCommitLevel",
+    "EnumRiskLevel",
+]

--- a/src/omnibase_core/enums/ui/enum_commit_level.py
+++ b/src/omnibase_core/enums/ui/enum_commit_level.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Commit level for UI action-gate policy decisions (OMN-13131, ADR D2).
+
+Classifies the durability of the effect a declared UI action commits when it
+emits its canonical command envelope onto the bus. Distinct from ``reversible``
+(a boolean fast-path) in that it expresses the commit axis as a typed ordinal —
+read-only actions never mutate truth, reversible actions can be undone, and
+irreversible actions cannot. Consumed by the action-gate policy to drive
+disabled states, confirmation requirements, and evidence requirements.
+"""
+
+from enum import StrEnum
+
+
+class EnumCommitLevel(StrEnum):
+    """Durability of the effect a UI action commits, lowest to highest."""
+
+    READ_ONLY = "read_only"
+    """Read-only — emits no truth-mutating command; no commit."""
+
+    REVERSIBLE = "reversible"
+    """Reversible — commits an effect that can be undone."""
+
+    IRREVERSIBLE = "irreversible"
+    """Irreversible — commits an effect that cannot be undone."""
+
+
+__all__: list[str] = ["EnumCommitLevel"]

--- a/src/omnibase_core/enums/ui/enum_risk_level.py
+++ b/src/omnibase_core/enums/ui/enum_risk_level.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Risk level for UI action-gate policy decisions (OMN-13131, ADR D2).
+
+Scoped to the Contract-Driven UI Platform action-gate policy. Distinct from the
+domain-scoped ``routing.EnumRiskLevel`` and ``overseer.EnumRiskLevel``: those
+classify routing/dispatch decisions, while this classifies the user-facing risk
+of executing a declared UI action (a button = an ``onex.cmd.*`` emitter). Kept
+separate so UI affordances and confirmation requirements do not couple to
+routing-policy semantics.
+"""
+
+from enum import StrEnum
+
+
+class EnumRiskLevel(StrEnum):
+    """Risk level of executing a UI action, lowest to highest."""
+
+    LOW = "low"
+    """Low risk — safe to surface without elevated affordances."""
+
+    MEDIUM = "medium"
+    """Medium risk — state-modifying; standard confirmation affordance."""
+
+    HIGH = "high"
+    """High risk — destructive or hard-to-undo; explicit confirmation."""
+
+    CRITICAL = "critical"
+    """Critical risk — irreversible/high-impact; mandatory confirmation."""
+
+
+__all__: list[str] = ["EnumRiskLevel"]

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -54,6 +54,9 @@ See Also:
 
 from omnibase_core.enums.enum_binding_order_direction import EnumBindingOrderDirection
 from omnibase_core.models.dashboard.model_action_contract import ModelActionContract
+from omnibase_core.models.dashboard.model_action_gate_policy import (
+    ModelActionGatePolicy,
+)
 from omnibase_core.models.dashboard.model_capability_view import ModelCapabilityView
 from omnibase_core.models.dashboard.model_chart_axis_config import ModelChartAxisConfig
 from omnibase_core.models.dashboard.model_chart_series_config import (
@@ -136,6 +139,7 @@ __all__: tuple[str, ...] = (
     # UI Contract Primitives (OMN-13130 — Phase 0)
     "ModelComponentContract",
     "ModelActionContract",
+    "ModelActionGatePolicy",
     "ModelDataBindingContract",
     "EnumBindingOrderDirection",
     "ModelPermissionContract",

--- a/src/omnibase_core/models/dashboard/model_action_contract.py
+++ b/src/omnibase_core/models/dashboard/model_action_contract.py
@@ -14,12 +14,20 @@ approval semantics. The ADR
 Gate-vs-GateSpec resolution: ActionContract composes ``ModelGate`` (approval);
 ``ModelGateSpec`` stays a distinct objective pass/fail primitive and is not
 touched.
-"""
 
-from __future__ import annotations
+The risk/confidence policy the rev-4 plan §6 attributes to the action contract
+(``confidence_threshold``, ``requires_user_confirmation``, ``risk_level``,
+``reversible``, commit level) is **composed** here as ``ModelActionGatePolicy``
+per the ADR D2 plan-vs-code note — those fields are NOT on ``ModelGate`` and are
+declared in their canonical home ``ModelActionGatePolicy`` rather than invented
+onto the approval gate.
+"""
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from omnibase_core.models.dashboard.model_action_gate_policy import (
+    ModelActionGatePolicy,
+)
 from omnibase_core.models.ticket.model_gate import ModelGate
 from omnibase_core.models.validation.model_topic_suffix_parts import TOPIC_KIND_CMD
 from omnibase_core.validation.validator_topic_suffix import validate_topic_suffix
@@ -57,6 +65,14 @@ class ModelActionContract(BaseModel):
     approval_gate: ModelGate | None = Field(
         default=None,
         description="Composed canonical approval gate; None means no approval required",
+    )
+    gate_policy: ModelActionGatePolicy | None = Field(
+        default=None,
+        description=(
+            "Composed risk/confidence policy (confidence_threshold, "
+            "requires_user_confirmation, risk_level, reversible, commit_level); "
+            "None means no policy-driven gating beyond the approval gate"
+        ),
     )
     correlation_required: bool = Field(
         default=True,

--- a/src/omnibase_core/models/dashboard/model_action_gate_policy.py
+++ b/src/omnibase_core/models/dashboard/model_action_gate_policy.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical risk/confidence policy for UI action gates (OMN-13131, ADR D2).
+
+This module is the single canonical home in ``omnibase_core`` for the
+action-gate risk/confidence fields the rev-4 Contract-Driven UI Platform plan
+(§6) attributes to the action contract: ``confidence_threshold``,
+``requires_user_confirmation``, ``risk_level``, ``reversible``, and a commit
+level.
+
+The ADR ``docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md``
+(decision D2 and its plan-vs-code note) establishes that:
+
+* these fields do **not** exist on ``ModelGate`` (approval/commit checkpoint:
+  ``id/kind/description/required/status/approver/decided_at``) and must not be
+  silently invented onto it; the implementing ticket must declare them in a real
+  canonical source. ``ModelActionGatePolicy`` is that source.
+* ``ModelGateSpec`` (objective-scoring hard gates, OMN-2537) is a **distinct**
+  concept and is neither merged, aliased, renamed, nor extended here.
+
+``ActionContract`` (a later wave) composes this policy as a strongly-typed
+member; the capability dispatcher, disabled-state derivation, confirmation
+requirements, UI affordances, and evidence requirements all read these fields
+from this one model rather than from a frontend-only convention.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.ui.enum_commit_level import EnumCommitLevel
+from omnibase_core.enums.ui.enum_risk_level import EnumRiskLevel
+
+__all__ = ["ModelActionGatePolicy"]
+
+
+class ModelActionGatePolicy(BaseModel):
+    """Risk/confidence policy a UI action gate enforces before committing.
+
+    A UI action is a declared ``onex.cmd.*`` command emitter (a button). Before
+    that command is emitted, the action gate consults this policy to decide
+    whether to require user confirmation, how to render affordances/disabled
+    states, and what evidence the action must carry. The policy is declarative
+    and platform-neutral; renderers derive behavior from it rather than encoding
+    risk semantics in frontend code.
+
+    Attributes:
+        confidence_threshold: Minimum upstream confidence (0.0-1.0) required for
+            the action to proceed without escalation. Below this, the gate
+            escalates (e.g. forces confirmation regardless of other fields).
+        requires_user_confirmation: Whether the action gate must obtain explicit
+            user confirmation before the command is emitted.
+        risk_level: Typed user-facing risk of executing the action.
+        reversible: Whether the committed effect can be undone. This is the
+            boolean fast-path; ``commit_level`` carries the full typed ordinal.
+        commit_level: Typed durability of the effect the action commits
+            (read-only, reversible, or irreversible).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    confidence_threshold: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum upstream confidence (0.0-1.0) for the action to proceed "
+            "without escalation"
+        ),
+    )
+    requires_user_confirmation: bool = Field(
+        ...,
+        description="Whether explicit user confirmation is required before emit",
+    )
+    risk_level: EnumRiskLevel = Field(
+        ...,
+        description="Typed user-facing risk of executing the action",
+    )
+    reversible: bool = Field(
+        ...,
+        description="Whether the committed effect can be undone",
+    )
+    commit_level: EnumCommitLevel = Field(
+        ...,
+        description="Typed durability of the effect the action commits",
+    )

--- a/tests/unit/enums/ui/__init__.py
+++ b/tests/unit/enums/ui/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for UI-platform action-gate enums."""

--- a/tests/unit/enums/ui/test_enum_risk_level_and_commit_level.py
+++ b/tests/unit/enums/ui/test_enum_risk_level_and_commit_level.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for UI action-gate risk/commit enums (OMN-13131, ADR D2).
+
+These enums give the UI-platform action-gate fields (risk_level, commit_level)
+a canonical, strongly-typed home in core. They are scoped to the UI platform
+under ``omnibase_core.enums.ui`` and are intentionally distinct from the
+domain-scoped routing/overseer ``EnumRiskLevel`` definitions.
+"""
+
+from enum import StrEnum
+
+import pytest
+
+
+@pytest.mark.unit
+class TestEnumRiskLevel:
+    """Tests for the UI action-gate EnumRiskLevel."""
+
+    def test_canonical_location(self) -> None:
+        """EnumRiskLevel must live under omnibase_core.enums.ui."""
+        from omnibase_core.enums.ui import EnumRiskLevel
+        from omnibase_core.enums.ui.enum_risk_level import (
+            EnumRiskLevel as EnumRiskLevelDirect,
+        )
+
+        assert EnumRiskLevel is EnumRiskLevelDirect
+
+    def test_is_str_enum(self) -> None:
+        """EnumRiskLevel is a StrEnum for cross-process wire safety."""
+        from omnibase_core.enums.ui import EnumRiskLevel
+
+        assert issubclass(EnumRiskLevel, StrEnum)
+
+    def test_members(self) -> None:
+        """EnumRiskLevel exposes the ordered low->critical risk axis."""
+        from omnibase_core.enums.ui import EnumRiskLevel
+
+        assert EnumRiskLevel.LOW.value == "low"
+        assert EnumRiskLevel.MEDIUM.value == "medium"
+        assert EnumRiskLevel.HIGH.value == "high"
+        assert EnumRiskLevel.CRITICAL.value == "critical"
+        assert {m.value for m in EnumRiskLevel} == {
+            "low",
+            "medium",
+            "high",
+            "critical",
+        }
+
+
+@pytest.mark.unit
+class TestEnumCommitLevel:
+    """Tests for the UI action-gate EnumCommitLevel."""
+
+    def test_canonical_location(self) -> None:
+        """EnumCommitLevel must live under omnibase_core.enums.ui."""
+        from omnibase_core.enums.ui import EnumCommitLevel
+        from omnibase_core.enums.ui.enum_commit_level import (
+            EnumCommitLevel as EnumCommitLevelDirect,
+        )
+
+        assert EnumCommitLevel is EnumCommitLevelDirect
+
+    def test_is_str_enum(self) -> None:
+        """EnumCommitLevel is a StrEnum for cross-process wire safety."""
+        from omnibase_core.enums.ui import EnumCommitLevel
+
+        assert issubclass(EnumCommitLevel, StrEnum)
+
+    def test_members(self) -> None:
+        """EnumCommitLevel exposes the read-only -> irreversible commit axis."""
+        from omnibase_core.enums.ui import EnumCommitLevel
+
+        assert EnumCommitLevel.READ_ONLY.value == "read_only"
+        assert EnumCommitLevel.REVERSIBLE.value == "reversible"
+        assert EnumCommitLevel.IRREVERSIBLE.value == "irreversible"
+        assert {m.value for m in EnumCommitLevel} == {
+            "read_only",
+            "reversible",
+            "irreversible",
+        }

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -29,6 +29,8 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     # UI Contract Primitives (OMN-13130 — Phase 0)
     "ModelComponentContract",
     "ModelActionContract",
+    # Action-gate risk/confidence policy (OMN-13131 — ADR D2)
+    "ModelActionGatePolicy",
     "ModelDataBindingContract",
     "EnumBindingOrderDirection",
     "ModelPermissionContract",

--- a/tests/unit/models/dashboard/test_model_action_gate_policy.py
+++ b/tests/unit/models/dashboard/test_model_action_gate_policy.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelActionGatePolicy (OMN-13131, ADR D2).
+
+ModelActionGatePolicy is the canonical home in core for the UI action-gate
+risk/confidence fields the rev-4 plan §6 attributes to the action contract:
+``confidence_threshold``, ``requires_user_confirmation``, ``risk_level``,
+``reversible``, and a commit level. The ADR
+``docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md`` (D2 note)
+requires these be declared in a real canonical source rather than assumed onto
+``ModelGate`` — this model is that source. ``ActionContract`` (a later wave)
+composes this policy; it does not fork ModelGate.
+
+ModelGateSpec (objective scoring, OMN-2537) MUST stay untouched and distinct.
+"""
+
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.ui import EnumCommitLevel, EnumRiskLevel
+from omnibase_core.models.dashboard import ModelActionGatePolicy
+
+
+@pytest.mark.unit
+class TestModelActionGatePolicyCanonicalLocation:
+    """The model lives in the UI-platform (dashboard) models package in core."""
+
+    def test_importable_from_dashboard_package(self) -> None:
+        from omnibase_core.models.dashboard import (
+            ModelActionGatePolicy as FromPackage,
+        )
+        from omnibase_core.models.dashboard.model_action_gate_policy import (
+            ModelActionGatePolicy as FromModule,
+        )
+
+        assert FromPackage is FromModule
+
+    def test_defined_in_core(self) -> None:
+        module = ModelActionGatePolicy.__module__
+        assert module.startswith("omnibase_core.")
+
+
+@pytest.mark.unit
+class TestModelActionGatePolicyFields:
+    """The strongly-typed risk/confidence fields exist with canonical types."""
+
+    def _valid(self) -> ModelActionGatePolicy:
+        return ModelActionGatePolicy(
+            confidence_threshold=0.8,
+            requires_user_confirmation=True,
+            risk_level=EnumRiskLevel.HIGH,
+            reversible=False,
+            commit_level=EnumCommitLevel.IRREVERSIBLE,
+        )
+
+    def test_all_canonical_fields_present(self) -> None:
+        policy = self._valid()
+        assert policy.confidence_threshold == 0.8
+        assert policy.requires_user_confirmation is True
+        assert policy.risk_level is EnumRiskLevel.HIGH
+        assert policy.reversible is False
+        assert policy.commit_level is EnumCommitLevel.IRREVERSIBLE
+
+    def test_confidence_threshold_is_float(self) -> None:
+        fields = ModelActionGatePolicy.model_fields
+        assert fields["confidence_threshold"].annotation is float
+
+    def test_risk_level_uses_enum_not_string(self) -> None:
+        fields = ModelActionGatePolicy.model_fields
+        assert fields["risk_level"].annotation is EnumRiskLevel
+
+    def test_commit_level_uses_enum_not_string(self) -> None:
+        fields = ModelActionGatePolicy.model_fields
+        assert fields["commit_level"].annotation is EnumCommitLevel
+
+    def test_requires_user_confirmation_is_bool(self) -> None:
+        fields = ModelActionGatePolicy.model_fields
+        assert fields["requires_user_confirmation"].annotation is bool
+
+    def test_reversible_is_bool(self) -> None:
+        fields = ModelActionGatePolicy.model_fields
+        assert fields["reversible"].annotation is bool
+
+    def test_confidence_threshold_rejects_below_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionGatePolicy(
+                confidence_threshold=-0.1,
+                requires_user_confirmation=False,
+                risk_level=EnumRiskLevel.LOW,
+                reversible=True,
+                commit_level=EnumCommitLevel.READ_ONLY,
+            )
+
+    def test_confidence_threshold_rejects_above_one(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionGatePolicy(
+                confidence_threshold=1.5,
+                requires_user_confirmation=False,
+                risk_level=EnumRiskLevel.LOW,
+                reversible=True,
+                commit_level=EnumCommitLevel.READ_ONLY,
+            )
+
+
+@pytest.mark.unit
+class TestModelActionGatePolicyConfig:
+    """Frozen, extra-forbid value model per core Pydantic standards."""
+
+    def test_is_frozen(self) -> None:
+        policy = ModelActionGatePolicy(
+            confidence_threshold=0.5,
+            requires_user_confirmation=False,
+            risk_level=EnumRiskLevel.LOW,
+            reversible=True,
+            commit_level=EnumCommitLevel.READ_ONLY,
+        )
+        with pytest.raises(ValidationError):
+            policy.risk_level = EnumRiskLevel.HIGH  # type: ignore[misc]
+
+    def test_extra_forbid(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelActionGatePolicy(
+                confidence_threshold=0.5,
+                requires_user_confirmation=False,
+                risk_level=EnumRiskLevel.LOW,
+                reversible=True,
+                commit_level=EnumCommitLevel.READ_ONLY,
+                bogus="x",  # type: ignore[call-arg]
+            )
+
+
+@pytest.mark.unit
+class TestModelGateSpecUntouched:
+    """ADR D2: ModelGateSpec (objective scoring) must NOT be merged/changed."""
+
+    def test_gate_spec_still_objective_scoring(self) -> None:
+        from omnibase_core.models.objective.model_gate_spec import ModelGateSpec
+
+        fields = set(ModelGateSpec.model_fields)
+        assert fields == {"id", "type", "threshold", "weight"}
+
+    def test_gate_spec_has_no_risk_fields(self) -> None:
+        from omnibase_core.models.objective.model_gate_spec import ModelGateSpec
+
+        fields = set(ModelGateSpec.model_fields)
+        assert "risk_level" not in fields
+        assert "confidence_threshold" not in fields
+        assert "commit_level" not in fields
+
+    def test_gate_spec_source_unchanged_signature(self) -> None:
+        """ModelGateSpec is a distinct concept; it does not compose the policy."""
+        from omnibase_core.models.objective.model_gate_spec import ModelGateSpec
+
+        src = inspect.getsource(ModelGateSpec)
+        assert "ModelActionGatePolicy" not in src
+
+
+@pytest.mark.unit
+class TestModelActionContractComposesPolicy:
+    """ADR D2: ModelActionContract composes the risk policy (not ModelGate)."""
+
+    def test_action_contract_has_gate_policy_field(self) -> None:
+        from omnibase_core.models.dashboard import ModelActionContract
+
+        assert "gate_policy" in ModelActionContract.model_fields
+
+    def test_gate_policy_field_typed_as_policy_or_none(self) -> None:
+        from omnibase_core.models.dashboard import ModelActionContract
+
+        annotation = ModelActionContract.model_fields["gate_policy"].annotation
+        assert annotation == (ModelActionGatePolicy | None)
+
+    def test_action_contract_consumes_policy(self) -> None:
+        from omnibase_core.models.dashboard import ModelActionContract
+
+        policy = ModelActionGatePolicy(
+            confidence_threshold=0.9,
+            requires_user_confirmation=True,
+            risk_level=EnumRiskLevel.CRITICAL,
+            reversible=False,
+            commit_level=EnumCommitLevel.IRREVERSIBLE,
+        )
+        contract = ModelActionContract(
+            action_id="delegate.trigger",
+            command_topic="onex.cmd.delegation.trigger.v1",
+            label="Delegate",
+            gate_policy=policy,
+        )
+        assert contract.gate_policy is policy
+        assert contract.gate_policy.risk_level is EnumRiskLevel.CRITICAL
+
+    def test_gate_policy_defaults_to_none(self) -> None:
+        from omnibase_core.models.dashboard import ModelActionContract
+
+        contract = ModelActionContract(
+            action_id="refresh.view",
+            command_topic="onex.cmd.dashboard.refresh.v1",
+            label="Refresh",
+        )
+        assert contract.gate_policy is None
+
+    def test_action_contract_does_not_put_risk_fields_on_gate(self) -> None:
+        """The risk fields live on the policy, never on the approval gate."""
+        from omnibase_core.models.ticket.model_gate import ModelGate
+
+        gate_fields = set(ModelGate.model_fields)
+        assert "risk_level" not in gate_fields
+        assert "confidence_threshold" not in gate_fields
+        assert "commit_level" not in gate_fields
+        assert "reversible" not in gate_fields


### PR DESCRIPTION
Evidence-Source: 8c1e5462916e22989e4b36b8bdbe659a5de065de
Evidence-Ticket: OMN-13131

## Summary

Item **W7** (plan §4.7 / ADR obligation): gives the UI action-gate risk/confidence fields a single canonical home in `omnibase_core`.

Per ADR `docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md` (decision **D2** and its plan-vs-code note), the fields the rev-4 Contract-Driven UI Platform plan §6 attributes to the action contract — `confidence_threshold`, `requires_user_confirmation`, `risk_level`, `reversible`, `commit_level` — do **not** exist on `ModelGate` and must not be invented onto it. They are declared net-new in a canonical core model and composed into `ModelActionContract`.

## Changes

- **`ModelActionGatePolicy`** (`models/dashboard/model_action_gate_policy.py`): frozen / `extra="forbid"` / `from_attributes` value model carrying the five fields. `confidence_threshold` bounded `ge=0.0, le=1.0`; risk/commit are enums, not strings.
- **`EnumRiskLevel`** + **`EnumCommitLevel`** under `enums/ui/` (StrEnum, cross-process safe). Scoped to the UI platform and intentionally distinct from the domain-scoped `routing.EnumRiskLevel` / `overseer.EnumRiskLevel`; not re-exported from the top-level `enums` package to avoid a name collision.
- **`ModelActionContract`** composes the policy as an optional `gate_policy: ModelActionGatePolicy | None` member, so the capability dispatcher, disabled-states, confirmation requirements, UI affordances, and evidence-requirements consume the fields from one canonical home rather than a frontend-only convention. Drops the unused `from __future__ import annotations` so the composed annotations resolve as concrete types at class-build time.
- **`ModelGateSpec`** (objective scoring, OMN-2537) left untouched and distinct, per ADR D2.

## Verification

- TDD: failing tests authored first (`tests/unit/enums/ui/`, `tests/unit/models/dashboard/test_model_action_gate_policy.py`) then implementation to green. 26 new tests + dashboard export-pin test updated.
- `ruff format` / `ruff check` clean; `mypy src/omnibase_core` (CI invocation) clean; `mypy --config-file=mypy.ini` clean on changed files.
- Targeted suites green: `enums/ui`, `models/dashboard` (incl. import-surface pin), `models/objective` (gate_spec untouched), CI adjacency loader, circular-import + naming-convention validators.

OCC pairing: `dod-core-pr-1261` evidence item + PASS receipt landed via OCC PR #2747 (merged `8c1e5462916e22989e4b36b8bdbe659a5de065de`). OCC merge-eligibility verified eligible=True locally for this PR.
