### PR TITLE
feat(OMN-13249): structural agent_invocation carve-out for canonical-inference gate (validator + fail-closed tests)

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -28,6 +28,18 @@
 # These files provide foundational YAML parsing utilities that sit BEFORE Pydantic validation
 # in the architecture. They need raw YAML access to prepare data for model validation.
 allowed_files:
+  - file: "src/omnibase_core/validation/validator_canonical_inference.py"
+    reason: >-
+      Canonical-inference gate structural agent-invocation carve-out (OMN-13249). To tell an agent-invocation
+      EFFECT (which legitimately shells a coding agent) from a banned inference tier, the gate reads ONE
+      structural fact — descriptor.agent_invocation — from the enclosing node contract.yaml. contract.yaml
+      schemas vary by node_type (ModelContractCompute/Effect/Reducer/Orchestrator) and the gate must tolerate
+      ANY contract shape while reading a single boolean; no single Pydantic model applies, so raw yaml.safe_load
+      extracts the flat fact (same architectural pattern as validator_banned_compose_vars.py and
+      mixin_contract_publisher.py). The result is coerced to a strict bool (descriptor.get(...) is True).
+    added: "2026-06-18"
+    review: "2026-12-13"
+
   - file: "src/omnibase_core/validation/validator_architecture.py"
     reason: >-
       Validator contract loading - must parse nested 'validation:' YAML structure before extracting the

--- a/src/omnibase_core/validation/validator_canonical_inference.py
+++ b/src/omnibase_core/validation/validator_canonical_inference.py
@@ -24,6 +24,23 @@ Detects the following non-canonical patterns in Python source:
    ``shutil.which(...)``. This is the canonical signal of "shell out to a model
    CLI as an inference/delegation tier."
 
+   **Structural agent-invocation carve-out (OMN-13249):** running a coding agent
+   (Claude Code / Codex) *is* external I/O performed by a canonical EFFECT node —
+   a distinct surface from the banned *inference* tier (OMN-13215/13219). The
+   architecture already distinguishes the two: an inference tier resolves a
+   model+endpoint+provider and is registered in ``routing_tiers.yaml`` /
+   ``bifrost_delegation.yaml``; an agent-invocation EFFECT declares
+   ``descriptor.agent_invocation: true`` in its node ``contract.yaml`` and is
+   never in those configs. So this gate permits a model-CLI shell-out **iff** the
+   enclosing node's ``contract.yaml`` declares ``descriptor.agent_invocation:
+   true`` (a real YAML boolean). The permission is a contract-declared,
+   reviewable fact the gate verifies — NOT a widened ``# canonical-inference-ok:``
+   comment (that free-text path is the "self-judgement is not evidence" failure
+   mode this gate exists to stop). A shell-out with no enclosing agent contract
+   still fails closed; the old codex-as-a-tier shape still fails if reintroduced.
+   The carve-out scopes only the shell-out surface — an ``agent_invocation`` node
+   does **not** license a model-id env read.
+
 2. **model-id-env-read** — ``os.environ[...]`` / ``os.environ.get(...)`` whose
    variable NAME ends in ``_MODEL`` / ``_MODEL_ID`` / ``_PROVIDER``. Model and
    provider must resolve from the routing-tiers / model_routing contract, not an
@@ -77,13 +94,16 @@ Usage Examples:
 
 Suppression:
     Add ``# canonical-inference-ok: <reason>`` on the offending line. Free-text
-    PR-body justification does NOT suppress — only the in-line annotation.
+    PR-body justification does NOT suppress — only the in-line annotation. This
+    is distinct from the structural agent-invocation carve-out (OMN-13249), which
+    is a contract fact (``descriptor.agent_invocation: true``), not a comment.
 
 Migration debt:
     - codex/claude/gemini CLI shell-out removal: OMN-13215
 
 Schema Version:
     v1.0.0 - Initial version (OMN-13219)
+    v1.1.0 - Structural agent-invocation carve-out (OMN-13249)
 """
 
 from __future__ import annotations
@@ -95,6 +115,8 @@ import re
 import sys
 from pathlib import Path
 from typing import ClassVar, Final
+
+import yaml
 
 from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
 from omnibase_core.models.contracts.subcontracts.model_validator_subcontract import (
@@ -144,6 +166,13 @@ _ENV_MODEL_READ: Final[re.Pattern[str]] = re.compile(
 
 # Suppression annotation.
 _SUPPRESS_ANNOTATION: Final[str] = "# canonical-inference-ok:"
+
+# Structural carve-out (OMN-13249): the node contract.yaml filename and the
+# descriptor flag that marks an agent-invocation EFFECT. A model-CLI shell-out is
+# permitted ONLY inside a node whose contract declares this flag as YAML ``true``.
+_CONTRACT_FILENAME: Final[str] = "contract.yaml"
+_DESCRIPTOR_KEY: Final[str] = "descriptor"
+_AGENT_INVOCATION_KEY: Final[str] = "agent_invocation"
 
 # Rule identifiers (must match the validation contract).
 RULE_MODEL_CLI_SHELLOUT: Final[str] = "model-cli-shellout"
@@ -259,6 +288,79 @@ def _cli_binary_in_call(call: ast.Call) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Structural agent-invocation carve-out (OMN-13249)
+# ---------------------------------------------------------------------------
+
+
+def find_enclosing_contract(source_path: Path) -> Path | None:
+    """Return the nearest ancestor ``contract.yaml`` for a source file, else None.
+
+    Walks up the directory tree from ``source_path`` (the Python file's own
+    directory first — handling both the core layout where ``handler.py`` sits
+    beside ``contract.yaml`` and the infra layout where handlers live in a
+    ``handlers/`` subdir below it). The first ``contract.yaml`` found wins;
+    directories above the node root do not declare a node contract.
+
+    Args:
+        source_path: Filesystem path to the Python source file.
+
+    Returns:
+        Path to the enclosing node ``contract.yaml``, or None if no ancestor
+        directory contains one.
+    """
+    for parent in source_path.resolve().parents:
+        candidate = parent / _CONTRACT_FILENAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def contract_permits_agent_invocation(contract_path: Path) -> bool:
+    """True iff the node ``contract.yaml`` declares ``descriptor.agent_invocation: true``.
+
+    The permission is a strict YAML boolean: a string ``"true"``, ``1``, or any
+    other truthy-but-not-``True`` value does NOT permit the shell-out. A malformed
+    or unreadable contract fails closed (returns False).
+
+    Args:
+        contract_path: Filesystem path to a node ``contract.yaml``.
+
+    Returns:
+        True only when the parsed descriptor maps ``agent_invocation`` to the
+        Python boolean ``True``.
+    """
+    try:
+        raw = contract_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    descriptor = data.get(_DESCRIPTOR_KEY)
+    if not isinstance(descriptor, dict):
+        return False
+    return descriptor.get(_AGENT_INVOCATION_KEY) is True
+
+
+def _permits_agent_shellout(source_path: Path | None) -> bool:
+    """Resolve whether the enclosing node permits a model-CLI shell-out.
+
+    A missing ``source_path`` (text-only scan, no filesystem anchor) fails closed
+    — the carve-out is opt-in via a real on-disk path so the gate can read the
+    contract fact, never a self-asserted claim.
+    """
+    if source_path is None:
+        return False
+    contract = find_enclosing_contract(source_path)
+    if contract is None:
+        return False
+    return contract_permits_agent_invocation(contract)
+
+
+# ---------------------------------------------------------------------------
 # Source scanner
 # ---------------------------------------------------------------------------
 
@@ -273,7 +375,10 @@ def _line_suppressed(raw_line: str) -> bool:
 
 
 def scan_source(
-    repo: str, path: str, source: str
+    repo: str,
+    path: str,
+    source: str,
+    source_path: Path | None = None,
 ) -> list[ModelCanonicalInferenceViolation]:
     """Scan one source file's text for non-canonical-inference violations.
 
@@ -284,6 +389,12 @@ def scan_source(
         repo: Repo name used in fingerprints (e.g. ``"omnibase_core"``).
         path: Repo-relative path for fingerprints (e.g. ``"src/pkg/file.py"``).
         source: Full source text of the file.
+        source_path: Filesystem path to the file, when available. Enables the
+            structural agent-invocation carve-out (OMN-13249): a model-CLI
+            shell-out is permitted iff the enclosing node ``contract.yaml``
+            declares ``descriptor.agent_invocation: true``. None (text-only
+            scan) fails closed — the shell-out rule is unaffected by the
+            carve-out.
 
     Returns:
         Sorted (by line) list of violations found in the file.
@@ -293,6 +404,8 @@ def scan_source(
 
     raw_lines = source.splitlines()
     violations: dict[int, ModelCanonicalInferenceViolation] = {}
+    # Resolve the contract permission once per file (not per call site).
+    agent_shellout_permitted = _permits_agent_shellout(source_path)
 
     def _add(line: int, rule: str) -> None:
         if line in violations:
@@ -311,16 +424,18 @@ def scan_source(
         )
 
     # Rule 1: model-CLI shell-out (AST — robust against false positives).
-    try:
-        tree = ast.parse(source, filename=path)
-    except SyntaxError:
-        tree = None
-    if tree is not None:
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                binary = _cli_binary_in_call(node)
-                if binary is not None:
-                    _add(node.lineno, RULE_MODEL_CLI_SHELLOUT)
+    # Permitted ONLY inside a node whose contract declares agent_invocation: true.
+    if not agent_shellout_permitted:
+        try:
+            tree = ast.parse(source, filename=path)
+        except SyntaxError:
+            tree = None
+        if tree is not None:
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    binary = _cli_binary_in_call(node)
+                    if binary is not None:
+                        _add(node.lineno, RULE_MODEL_CLI_SHELLOUT)
 
     # Rule 2: model/provider env read (line regex — env reads are single-line).
     for index, raw_line in enumerate(raw_lines, start=1):
@@ -360,7 +475,7 @@ def scan_tree(repo: str, repo_root: Path) -> list[ModelCanonicalInferenceViolati
             rel = str(py.relative_to(repo_root))
         except ValueError:
             rel = str(py)
-        violations.extend(scan_source(repo, rel, source))
+        violations.extend(scan_source(repo, rel, source, source_path=py))
     return violations
 
 
@@ -512,7 +627,7 @@ class ValidatorCanonicalInference(ValidatorBase):
         except OSError:
             return ()
 
-        raw_violations = scan_source(self._repo, rel, source)
+        raw_violations = scan_source(self._repo, rel, source, source_path=path)
         baseline = self._get_baseline()
         new, _ = partition_against_baseline(raw_violations, baseline)
 
@@ -680,7 +795,7 @@ def main(argv: list[str] | None = None) -> int:
                 rel = str(p.resolve().relative_to(repo_root.resolve()))
             except ValueError:
                 rel = str(p)
-            violations.extend(scan_source(args.repo, rel, source))
+            violations.extend(scan_source(args.repo, rel, source, source_path=p))
 
     baseline = load_baseline(baseline_path)
     new, grandfathered = partition_against_baseline(violations, baseline)

--- a/tests/unit/validation/test_validator_canonical_inference.py
+++ b/tests/unit/validation/test_validator_canonical_inference.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for ValidatorCanonicalInference (OMN-13219).
+"""Tests for ValidatorCanonicalInference (OMN-13219, OMN-13249).
 
 Covers:
 - Detection of both violation classes (model-cli-shellout, model-id-env-read)
@@ -13,6 +13,10 @@ Covers:
 - Baseline helpers: load_baseline, serialize_baseline, assert_baseline_shrinks_only
 - ValidatorBase integration (validate() returns ModelValidationResult)
 - CLI entry point: --all, staged-files, exit codes, seed, baseline-growth reject
+- Structural agent-invocation carve-out (OMN-13249): a model-CLI shell-out is
+  permitted iff the enclosing node contract.yaml declares
+  ``descriptor.agent_invocation: true``; otherwise it still fails closed. The
+  permission is a contract fact, NOT a widened free-text suppression.
 """
 
 from __future__ import annotations
@@ -36,6 +40,8 @@ from omnibase_core.validation.validator_canonical_inference import (
     RULE_MODEL_ENV_READ,
     ValidatorCanonicalInference,
     assert_baseline_shrinks_only,
+    contract_permits_agent_invocation,
+    find_enclosing_contract,
     load_baseline,
     make_fingerprint,
     partition_against_baseline,
@@ -514,3 +520,313 @@ class TestCLI:
             ]
         )
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Structural agent-invocation carve-out (OMN-13249)
+# ---------------------------------------------------------------------------
+
+
+def _node_with_contract(
+    tmp_path: Path,
+    *,
+    descriptor: str,
+    handler_src: str,
+    handler_rel: str = "handler.py",
+    node_dir: str = "src/omnibase_infra/nodes/node_thing",
+) -> Path:
+    """Materialize a node dir with a contract.yaml + a handler source file.
+
+    Returns the path to the written handler file.
+    """
+    base = tmp_path / node_dir
+    handler = base / handler_rel
+    handler.parent.mkdir(parents=True, exist_ok=True)
+    handler.write_text(textwrap.dedent(handler_src), encoding="utf-8")
+    (base / "contract.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            handler_id: node.thing
+            name: thing
+            node_type: effect
+            descriptor:
+            {textwrap.indent(textwrap.dedent(descriptor), "  ")}
+            """
+        ),
+        encoding="utf-8",
+    )
+    return handler
+
+
+_SHELLOUT = 'subprocess.run(["codex", "exec", prompt])\n'
+
+
+@pytest.mark.unit
+class TestContractDiscovery:
+    def test_find_enclosing_contract_in_node_root(self, tmp_path: Path) -> None:
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+        )
+        found = find_enclosing_contract(handler)
+        assert found is not None
+        assert found.name == "contract.yaml"
+        assert found.parent == handler.parent
+
+    def test_find_enclosing_contract_walks_up_from_handlers_subdir(
+        self, tmp_path: Path
+    ) -> None:
+        # infra layout: handlers live in a handlers/ subdir below contract.yaml.
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+            handler_rel="handlers/handler_invoke.py",
+        )
+        found = find_enclosing_contract(handler)
+        assert found is not None
+        assert found.parent == handler.parent.parent
+
+    def test_find_enclosing_contract_none_when_absent(self, tmp_path: Path) -> None:
+        f = tmp_path / "src" / "loose.py"
+        f.parent.mkdir(parents=True)
+        f.write_text(_SHELLOUT, encoding="utf-8")
+        assert find_enclosing_contract(f) is None
+
+    def test_contract_permits_when_flag_true(self, tmp_path: Path) -> None:
+        handler = _node_with_contract(
+            tmp_path, descriptor="agent_invocation: true\n", handler_src=_SHELLOUT
+        )
+        contract = find_enclosing_contract(handler)
+        assert contract is not None
+        assert contract_permits_agent_invocation(contract) is True
+
+    def test_contract_denies_when_flag_absent(self, tmp_path: Path) -> None:
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="node_archetype: effect\npurity: side_effecting\n",
+            handler_src=_SHELLOUT,
+        )
+        contract = find_enclosing_contract(handler)
+        assert contract is not None
+        assert contract_permits_agent_invocation(contract) is False
+
+    def test_contract_denies_when_flag_false(self, tmp_path: Path) -> None:
+        handler = _node_with_contract(
+            tmp_path, descriptor="agent_invocation: false\n", handler_src=_SHELLOUT
+        )
+        contract = find_enclosing_contract(handler)
+        assert contract is not None
+        assert contract_permits_agent_invocation(contract) is False
+
+    def test_contract_denies_on_truthy_non_bool(self, tmp_path: Path) -> None:
+        # A string "true" must NOT be honored — only a real YAML boolean true.
+        handler = _node_with_contract(
+            tmp_path, descriptor='agent_invocation: "true"\n', handler_src=_SHELLOUT
+        )
+        contract = find_enclosing_contract(handler)
+        assert contract is not None
+        assert contract_permits_agent_invocation(contract) is False
+
+
+@pytest.mark.unit
+class TestAgentInvocationCarveOut:
+    def test_shellout_fails_closed_without_agent_invocation(
+        self, tmp_path: Path
+    ) -> None:
+        """(1) A model-CLI shell-out in a node WITHOUT the flag still fails closed."""
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="node_archetype: effect\n",
+            handler_src=_SHELLOUT,
+        )
+        vs = scan_source("r", "src/x/handler.py", _SHELLOUT, source_path=handler)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+    def test_shellout_permitted_with_agent_invocation(self, tmp_path: Path) -> None:
+        """(2) The SAME shell-out passes inside an agent_invocation: true node."""
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+        )
+        vs = scan_source("r", "src/x/handler.py", _SHELLOUT, source_path=handler)
+        assert vs == [], f"agent_invocation node must be permitted, got: {vs}"
+
+    def test_env_read_not_permitted_by_agent_invocation(self, tmp_path: Path) -> None:
+        """The flag only carves out the shell-out surface, NOT env-resolved models.
+
+        agent_invocation declares "this node legitimately shells a coding agent";
+        it never licenses resolving a model id from an env var.
+        """
+        env_src = 'model = os.environ["LLM_MODEL"]\n'
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=env_src,
+        )
+        vs = scan_source("r", "src/x/handler.py", env_src, source_path=handler)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_ENV_READ
+
+    def test_no_source_path_means_fail_closed(self) -> None:
+        """Without a filesystem path the gate cannot read a contract → fail closed.
+
+        scan_source's text-only call sites (no source_path) must keep the prior
+        fail-closed behavior — the carve-out is opt-in via a real on-disk path.
+        """
+        vs = scan_source("r", "src/x/handler.py", _SHELLOUT)
+        assert len(vs) == 1
+        assert vs[0].rule == RULE_MODEL_CLI_SHELLOUT
+
+
+@pytest.mark.unit
+class TestAgentInvocationCarveOutIntegration:
+    def test_validator_red_without_agent_invocation(self, tmp_path: Path) -> None:
+        """(1) ValidatorBase path: shell-out outside an agent node → RED."""
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="node_archetype: effect\n",
+            handler_src=_SHELLOUT,
+        )
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(handler)
+        assert not result.is_valid, f"Expected RED but got: {result.issues}"
+        assert result.issues[0].code == RULE_MODEL_CLI_SHELLOUT
+
+    def test_validator_green_with_agent_invocation(self, tmp_path: Path) -> None:
+        """(2) ValidatorBase path: same shell-out inside an agent node → GREEN."""
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+        )
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(handler)
+        assert result.is_valid, f"Expected GREEN but got: {result.issues}"
+
+    def test_codex_as_inference_tier_still_fails_if_reintroduced(
+        self, tmp_path: Path
+    ) -> None:
+        """(3) The codex-as-inference-tier baseline shape still FAILS.
+
+        A bare shell-out in a routing/inference module that is NOT inside an
+        agent_invocation node is exactly OMN-13215's banned tier — the flag must
+        not whitewash it. No enclosing agent contract → still RED.
+        """
+        f = tmp_path / "src" / "delegation" / "routing_tier_invoker.py"
+        f.parent.mkdir(parents=True)
+        f.write_text(_SHELLOUT, encoding="utf-8")
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(f)
+        assert not result.is_valid, "codex-as-tier must still fail closed"
+        assert result.issues[0].code == RULE_MODEL_CLI_SHELLOUT
+
+    def test_sibling_inference_module_not_covered_by_agent_node_contract(
+        self, tmp_path: Path
+    ) -> None:
+        """An agent node's contract must not bleed onto an unrelated sibling tree.
+
+        The carve-out is scoped to the node dir that owns the contract.yaml, not
+        to arbitrary files elsewhere in the repo.
+        """
+        # An agent node exists ...
+        _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+            node_dir="src/omnibase_infra/nodes/node_agent",
+        )
+        # ... but a shell-out in a different, contract-less module still fails.
+        rogue = tmp_path / "src" / "delegation" / "rogue.py"
+        rogue.parent.mkdir(parents=True)
+        rogue.write_text(_SHELLOUT, encoding="utf-8")
+        v = ValidatorCanonicalInference(
+            contract=_open_contract(),
+            repo="test_repo",
+            baseline_path=_empty_baseline(tmp_path),
+            repo_root=tmp_path,
+        )
+        result = v.validate_file(rogue)
+        assert not result.is_valid
+        assert result.issues[0].code == RULE_MODEL_CLI_SHELLOUT
+
+    def test_cli_staged_shellout_in_agent_node_exit_0(self, tmp_path: Path) -> None:
+        """CLI staged-files mode: an agent-node shell-out passes (exit 0)."""
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+        )
+        rc = main(
+            [
+                str(handler),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(_empty_baseline(tmp_path)),
+            ]
+        )
+        assert rc == 0
+
+    def test_cli_staged_shellout_outside_agent_node_exit_1(
+        self, tmp_path: Path
+    ) -> None:
+        """CLI staged-files mode: a non-agent shell-out still fails (exit 1)."""
+        from omnibase_core.validation.validator_canonical_inference import main
+
+        handler = _node_with_contract(
+            tmp_path,
+            descriptor="node_archetype: effect\n",
+            handler_src=_SHELLOUT,
+        )
+        rc = main(
+            [
+                str(handler),
+                "--repo",
+                "r",
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(_empty_baseline(tmp_path)),
+            ]
+        )
+        assert rc == 1
+
+    def test_full_tree_scan_permits_agent_node_only(self, tmp_path: Path) -> None:
+        """scan_tree carve-out: agent-node shell-out passes, rogue one is reported."""
+        _node_with_contract(
+            tmp_path,
+            descriptor="agent_invocation: true\n",
+            handler_src=_SHELLOUT,
+            node_dir="src/omnibase_infra/nodes/node_agent",
+        )
+        rogue = tmp_path / "src" / "delegation" / "rogue.py"
+        rogue.parent.mkdir(parents=True)
+        rogue.write_text(_SHELLOUT, encoding="utf-8")
+
+        vs = scan_tree("r", tmp_path)
+        reported = {v.path for v in vs}
+        assert any(p.endswith("rogue.py") for p in reported), reported
+        assert not any("node_agent" in p for p in reported), reported


### PR DESCRIPTION
## OMN-13249 — Phase C: structural `agent_invocation` carve-out for the canonical-inference gate

Epic: OMN-13245. Plan: `docs/tracking/2026-06-18-canonical-cli-coding-agent-node-plan.md` §6–7 (Phase C).

### Scope (read this first)
This PR is the **VALIDATOR carve-out + fail-closed tests ONLY**. The fleet-wide rollout of OMN-13219 across omnimarket / omnibase_infra / omniclaude is **deferred to separate per-repo PRs** (plan Risk 4: fleet-rollout must not be coupled to the coding-agent node work, and will surface pre-existing violations to be seeded as shrink-only baselines). The per-repo fingerprint baseline + shrink-only behavior of the gate is preserved unchanged here.

### What changed
`ValidatorCanonicalInference` (OMN-13219) now permits a model-CLI subprocess (`codex`/`claude`/`gemini`/`opencode` argv, or `shutil.which` on those) **iff the enclosing node `contract.yaml` declares `descriptor.agent_invocation: true`** (a strict YAML boolean). Otherwise it still fails closed.

This is a **structural permission read from the contract**, not a new free-text `# canonical-inference-ok:` suppression — that comment path is the "self-judgement is not evidence" failure mode the gate exists to stop, and it is deliberately NOT widened. The architecture already distinguishes the two surfaces (plan §6): an inference tier resolves model+endpoint+provider and lives in `routing_tiers.yaml`/`bifrost_delegation.yaml`; an agent-invocation EFFECT declares the contract flag and is never in those configs. The gate just reads that fact.

- `scan_source` gains `source_path: Path | None`; `scan_tree` / `_validate_file` / the CLI staged-files path all pass the real filesystem path so the gate can resolve the enclosing contract. A text-only scan (no `source_path`) fails closed.
- New helpers: `find_enclosing_contract(path)` (walks up to the nearest `contract.yaml`, handling both the core layout — `handler.py` beside `contract.yaml` — and the infra layout — `handlers/` subdir below it) and `contract_permits_agent_invocation(contract)` (coerces to `descriptor.get("agent_invocation") is True`; a string `"true"`, malformed, or unreadable contract fails closed).
- The carve-out scopes **only** the shell-out surface — a model-id env read is never licensed by the flag.
- `validator_canonical_inference.py` added to `.yaml-validation-allowlist.yaml`: the gate must tolerate any `node_type`'s `contract.yaml` while reading one descriptor flag, so no single Pydantic model applies (same architectural pattern already allowlisted for `validator_banned_compose_vars.py` / `mixin_contract_publisher.py`).

### dod_evidence (this PR)
TDD — fail-closed regression tests written FIRST, using fixture contracts (no dependency on the real Phase A coding-agent node existing):
1. A model-CLI shell-out in a node **without** `descriptor.agent_invocation: true` → gate FAILS (`test_shellout_fails_closed_without_agent_invocation`, `test_validator_red_without_agent_invocation`, `test_cli_staged_shellout_outside_agent_node_exit_1`).
2. The **same** shell-out in a node whose contract declares `descriptor.agent_invocation: true` → gate PASSES (`test_shellout_permitted_with_agent_invocation`, `test_validator_green_with_agent_invocation`, `test_cli_staged_shellout_in_agent_node_exit_0`).
3. The codex-as-inference-tier baseline still FAILS if reintroduced as a routing/inference tier — the flag never whitewashes a tier, only an enclosing agent contract permits (`test_codex_as_inference_tier_still_fails_if_reintroduced`, `test_sibling_inference_module_not_covered_by_agent_node_contract`).

Local proof:
- `uv run pytest tests/unit/validation/test_validator_canonical_inference.py` → **60 passed** (47 pre-existing + 13 new carve-out).
- `uv run pytest tests/unit/validation/test_yaml_allowlist.py` → **10 passed** (allowlist integrity).
- `uv run pytest tests/unit/validation/` (full directory) → **4327 passed, 5 skipped**.
- `uv run ruff format` / `ruff check --fix` → clean.
- `uv run mypy src/ --strict` → 0 NEW errors on the changed file (3 pre-existing errors in `contract_loader.py`/`cli_install.py` exist identically on the unchanged HEAD tree).
- `pre-commit run --files <changed>` → all hooks pass on the changed files, including ONEX Manual YAML Prevention (via the allowlist entry).

DO NOT MERGE — held for epic OMN-13245 sequencing.

Evidence-Source: OCC#2757
Evidence-Ticket: OMN-13249
