### PR TITLE
OMN-13240: detect qualified BaseModel contracts

### DIFF
--- a/src/omnibase_core/services/service_contract_validator.py
+++ b/src/omnibase_core/services/service_contract_validator.py
@@ -82,6 +82,38 @@ _FORBIDDEN_IMPORT_PATTERNS = [
 ]
 
 
+def _is_basemodel_subclass(node: ast.ClassDef) -> bool:
+    """Return whether a class inherits from a BaseModel-like class."""
+    return any("BaseModel" in ast.unparse(base).split(".")[-1] for base in node.bases)
+
+
+def _extract_annotated_model_fields(
+    node: ast.ClassDef,
+) -> list[TypedDictModelFieldInfo]:
+    """Extract annotated field names and types from a model class."""
+    fields: list[TypedDictModelFieldInfo] = []
+    for item in node.body:
+        if not isinstance(item, ast.AnnAssign) or not isinstance(item.target, ast.Name):
+            continue
+
+        fields.append(
+            {
+                "name": item.target.id,
+                "type": ast.unparse(item.annotation) if item.annotation else "Any",
+            }
+        )
+    return fields
+
+
+def _build_model_class_info(node: ast.ClassDef) -> TypedDictModelClassInfo:
+    """Build validator metadata for a Pydantic model class."""
+    return {
+        "name": node.name,
+        "fields": _extract_annotated_model_fields(node),
+        "bases": [ast.unparse(base) for base in node.bases],
+    }
+
+
 @dataclass
 class _ComplianceRuleImpl:
     """Concrete implementation of ProtocolComplianceRule."""
@@ -661,35 +693,8 @@ class ServiceContractValidator:
         model_classes: list[TypedDictModelClassInfo] = []
 
         for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                # Check if it's a BaseModel subclass
-                for base in node.bases:
-                    if isinstance(base, ast.Name) and "BaseModel" in base.id:
-                        # Extract fields
-                        fields: list[TypedDictModelFieldInfo] = []
-                        for item in node.body:
-                            if isinstance(item, ast.AnnAssign) and isinstance(
-                                item.target, ast.Name
-                            ):
-                                field_name = item.target.id
-                                field_type = (
-                                    ast.unparse(item.annotation)
-                                    if item.annotation
-                                    else "Any"
-                                )
-                                field_info: TypedDictModelFieldInfo = {
-                                    "name": field_name,
-                                    "type": field_type,
-                                }
-                                fields.append(field_info)
-
-                        model_info: TypedDictModelClassInfo = {
-                            "name": node.name,
-                            "fields": fields,
-                            "bases": [ast.unparse(b) for b in node.bases],
-                        }
-                        model_classes.append(model_info)
-                        break
+            if isinstance(node, ast.ClassDef) and _is_basemodel_subclass(node):
+                model_classes.append(_build_model_class_info(node))
 
         return model_classes
 

--- a/tests/unit/services/test_service_contract_validator_coverage.py
+++ b/tests/unit/services/test_service_contract_validator_coverage.py
@@ -244,6 +244,21 @@ class TestValidateModelCompliance:
         result = v.validate_model_compliance(code, _VALID_EFFECT_YAML)
         assert any("Any" in w for w in result.warnings)
 
+    def test_qualified_pydantic_basemodel_is_detected(self) -> None:
+        v = ServiceContractValidator()
+        code = (
+            "import pydantic\n"
+            "class ModelFooInput(pydantic.BaseModel):\n"
+            "    value: str\n"
+            "class ModelFooOutput(pydantic.BaseModel):\n"
+            "    result: bool\n"
+        )
+        result = v.validate_model_compliance(code, _VALID_EFFECT_YAML)
+        assert not any(
+            "No Pydantic model classes" in violation for violation in result.violations
+        )
+        assert not any("not found" in violation for violation in result.violations)
+
     def test_non_model_class_naming_warns(self) -> None:
         v = ServiceContractValidator()
         code = (


### PR DESCRIPTION
## Summary
- Extract BaseModel class detection/field extraction helpers in ServiceContractValidator
- Detect qualified Pydantic inheritance such as pydantic.BaseModel
- Add coverage for qualified BaseModel input/output classes

Linear: OMN-13240

## Verification
- uv run ruff format src/omnibase_core/services/service_contract_validator.py tests/unit/services/test_service_contract_validator_coverage.py
- uv run ruff check --fix src/omnibase_core/services/service_contract_validator.py tests/unit/services/test_service_contract_validator_coverage.py
- uv run pytest tests/unit/services/test_service_contract_validator_coverage.py -q (36 passed)
- uv run mypy src/omnibase_core/services/service_contract_validator.py --strict
- git diff --check

## Pre-commit
- Commit hooks passed for the staged patch.
- pre-commit run --all-files was executed before commit and failed on existing repo-wide gate violations outside this patch, including string ID/version validation, manual YAML validation, fallback-pattern checks, error-raising checks, local-path checks, single-class-per-file, and deterministic skill routing. The hook also auto-formatted an unrelated OMN-13130 contract, which was excluded from this scoped PR.

Evidence-Source: OCC#2768
Evidence-Ticket: OMN-13240