### PR TITLE
feat(OMN-13292): github-token env-read ban validator + remote hook export (W7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -854,6 +854,20 @@ repos:
         exclude: ^(tests/|archived/|archive/).*\.py$
         stages: [pre-commit]
 
+      # GitHub Token Env-Read Ban (OMN-13292; fleet port of OMN-12856).
+      # Bans raw GH_PAT/GH_TOKEN/GITHUB_TOKEN reads via os.environ/os.getenv in
+      # production source. A GitHub token is a contract-native secret: declare an
+      # api_key_ref in the contract and resolve at the effect boundary.
+      # Suppress boundary code with: # github-token-env-ok: <reason>
+      - id: check-github-token-env-reads
+        name: GitHub Token Env-Read Ban (OMN-13292)
+        entry: uv run python -m omnibase_core.validators.github_token_env_reads
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: ^(tests/|archived/|archive/).*\.py$
+        stages: [pre-commit]
+
       - id: validate-exception-handling
         name: ONEX Exception Handling Validation
         entry: uv run python scripts/validation/validate-exception-handling.py

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -162,3 +162,17 @@
   types: [python]
   pass_filenames: true
   stages: [pre-commit]
+
+- id: check-github-token-env-reads
+  name: GitHub Token Env-Read Ban (OMN-13292)
+  description: >
+    Ban raw GitHub-token env reads (GH_PAT/GH_TOKEN/GITHUB_TOKEN via os.environ/os.getenv) in production
+    source. Fleet port of omnimarket OMN-12856. A GitHub token is a contract-native secret: declare its
+    api_key_ref in the node/effect contract and resolve the value at the effect boundary via the secret
+    resolver — never read it directly from the environment. Test files are excluded. Suppression for
+    boundary code that must read the env: # github-token-env-ok: <reason> (or # ONEX_EXCLUDE) on the line.
+  language: python
+  entry: python -m omnibase_core.validators.github_token_env_reads
+  types: [python]
+  pass_filenames: true
+  stages: [pre-commit]

--- a/src/omnibase_core/validators/github_token_env_reads.py
+++ b/src/omnibase_core/validators/github_token_env_reads.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Enforcement gate: ban raw GitHub-token env reads in production source.
+
+Fleet-wide port (OMN-13292) of omnimarket's ``check_github_token_env_reads``
+(OMN-12856). Flags any ``os.environ["GITHUB_TOKEN"]``,
+``os.environ.get("GH_TOKEN")``, ``os.getenv("GH_PAT")``, or any equivalent
+access to ``GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GH_PAT`` that appears outside the
+test tree.
+
+Rationale (memory ``feedback_secrets_contract_ref_value_in_store``): a GitHub
+token is a contract-native secret. The contract declares the secret's reference
+*name* (``api_key_ref`` / ``contract_secret_ref``) and the value is resolved at
+the effect boundary via the secret resolver — never read directly from the
+environment inside handler / adapter / consumer source. A raw env subscript in
+production source is always a violation.
+
+Detection (AST, deterministic, no I/O on the analysed code):
+
+1. ``os.environ["GITHUB_TOKEN"]`` — ``ast.Subscript`` on ``os.environ``.
+2. ``os.environ.get("GITHUB_TOKEN")`` — ``ast.Call`` on ``os.environ.get``.
+3. ``os.getenv("GITHUB_TOKEN")`` — ``ast.Call`` on ``os.getenv``.
+
+Scope: Python files passed on the command line (pre-commit passes staged
+files) or, in ``--all`` mode, all ``*.py`` under the repo's source roots. Test
+files, ``conftest.py``, and inline-annotated lines are excluded.
+
+Suppression (boundary code that legitimately must read the env, e.g. a runtime
+secret-resolver effect): add ``# github-token-env-ok: <reason>`` or
+``# ONEX_EXCLUDE`` on the offending line (or any line of a multi-line call).
+
+Exit codes:
+    0 — no violations.
+    1 — violations found (enforce mode, default).
+    2 — usage / internal error.
+
+Usage:
+    # pre-commit (staged files)
+    python -m omnibase_core.validators.github_token_env_reads file1.py ...
+
+    # full-repo scan (CI)
+    python -m omnibase_core.validators.github_token_env_reads --all --repo-root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+# Secret-name literals that are GitHub-token env reads. Any os.environ /
+# os.getenv access to these names in production source is a violation — the
+# value must come from a contract api_key_ref resolved at the effect boundary.
+GITHUB_TOKEN_ENV_NAMES: frozenset[str] = frozenset(
+    {"GH_PAT", "GH_TOKEN", "GITHUB_TOKEN"}
+)
+
+# Inline skip annotations accepted on the read line or any line of a multi-line call.
+SUPPRESSION_TOKENS: tuple[str, ...] = ("# github-token-env-ok:", "# ONEX_EXCLUDE")
+
+# Path segments that exclude a file from the scan (tests / build artifacts).
+_EXCLUDED_PATH_SEGMENTS: tuple[str, ...] = (
+    "/tests/",
+    "conftest.py",
+    "/__pycache__/",
+    ".pyc",
+)
+
+# Default source roots scanned in --all mode (relative to repo root).
+_DEFAULT_SRC_ROOTS: tuple[str, ...] = ("src",)
+
+
+def _is_excluded(rel_path: str) -> bool:
+    norm = "/" + rel_path.replace("\\", "/").lstrip("/")
+    return any(seg in norm for seg in _EXCLUDED_PATH_SEGMENTS)
+
+
+def _key_literal(node: ast.expr) -> str:
+    """Best-effort string repr of an env-lookup key (only constants count)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return ""
+
+
+def _has_suppression(lines: list[str], start: int, end: int) -> bool:
+    """True if any line in [start-1, end] (0-based slice) carries a suppression token."""
+    for raw in lines[max(0, start - 1) : end]:
+        if any(token in raw for token in SUPPRESSION_TOKENS):
+            return True
+    return False
+
+
+def scan_source(source: str, display_path: str) -> list[str]:
+    """Return violation strings for raw GitHub-token env reads in *source*.
+
+    Pure function over the supplied text — performs no filesystem or network
+    I/O on the analysed code.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        lineno: int | None = None
+        end_lineno: int = 0
+        detail: str = ""
+
+        # os.environ["GITHUB_TOKEN"] — Subscript
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "environ"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "os"
+        ):
+            key = _key_literal(node.slice)
+            if key in GITHUB_TOKEN_ENV_NAMES:
+                lineno = node.lineno
+                end_lineno = getattr(node, "end_lineno", node.lineno) or node.lineno
+                detail = f"os.environ[{key!r}]"
+
+        elif isinstance(node, ast.Call):
+            func = node.func
+            is_getenv = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "getenv"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            )
+            is_environ_get = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "environ"
+                and isinstance(func.value.value, ast.Name)
+                and func.value.value.id == "os"
+            )
+            if (is_getenv or is_environ_get) and node.args:
+                key = _key_literal(node.args[0])
+                if key in GITHUB_TOKEN_ENV_NAMES:
+                    lineno = node.lineno
+                    end_lineno = getattr(node, "end_lineno", node.lineno) or node.lineno
+                    call_form = "os.getenv" if is_getenv else "os.environ.get"
+                    detail = f"{call_form}({key!r})"
+
+        if lineno is not None and not _has_suppression(lines, lineno, end_lineno):
+            line_text = lines[lineno - 1].strip() if lineno <= len(lines) else ""
+            violations.append(
+                f"{display_path}:{lineno}: raw GitHub-token env read {detail!r} — "
+                f"declare a contract api_key_ref and resolve at the effect boundary "
+                f"instead. ({line_text!r})"
+            )
+
+    return violations
+
+
+def scan_file(path: Path, display_path: str | None = None) -> list[str]:
+    """Read *path* and return its violations. The only filesystem read."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    return scan_source(source, display_path or str(path))
+
+
+def scan_tree(
+    repo_root: Path, src_roots: tuple[str, ...] = _DEFAULT_SRC_ROOTS
+) -> list[str]:
+    """Scan every non-excluded ``*.py`` under *repo_root*'s source roots."""
+    all_violations: list[str] = []
+    for root_name in src_roots:
+        src_root = repo_root / root_name
+        if not src_root.exists():
+            continue
+        for py_file in sorted(src_root.rglob("*.py")):
+            rel = str(py_file.relative_to(repo_root)).replace("\\", "/")
+            if _is_excluded(rel):
+                continue
+            all_violations.extend(scan_file(py_file, rel))
+    return all_violations
+
+
+_FIX_HELP = (
+    "\nFix: a GitHub token is a contract-native secret. Declare its reference "
+    "name in the node/effect contract (api_key_ref) and resolve the value at "
+    "the effect boundary via the secret resolver — do not read os.environ / "
+    "os.getenv directly in handler/adapter/consumer source.\n"
+    "Boundary code that must read the env may suppress with "
+    "'# github-token-env-ok: <reason>' on the offending line.\n"
+    "(OMN-12856 / OMN-13292; memory feedback_secrets_contract_ref_value_in_store)"
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-github-token-env-reads",
+        description=(
+            "Ban raw GitHub-token (GH_PAT/GH_TOKEN/GITHUB_TOKEN) env reads in "
+            "production source (OMN-13292; fleet port of OMN-12856)."
+        ),
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Explicit file paths to scan (pre-commit passes staged files).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan the full source tree under --repo-root instead of named files.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repo root for --all mode (default: cwd).",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    violations: list[str] = []
+
+    if args.all:
+        violations = scan_tree(Path(args.repo_root).resolve())
+    else:
+        paths = [Path(p) for p in args.files]
+        if not paths:
+            # No files supplied — pre-commit passes only staged files; nothing to do.
+            return 0
+        for path in paths:
+            rel = path.name
+            try:
+                rel = str(path.resolve().relative_to(Path.cwd()))
+            except ValueError:
+                rel = str(path)
+            if _is_excluded(rel) or path.suffix != ".py":
+                continue
+            violations.extend(scan_file(path, rel))
+
+    if violations:
+        sys.stderr.write(
+            f"[check-github-token-env-reads] FAIL — "
+            f"{len(violations)} raw GitHub-token env read(s) found:\n"
+        )
+        for v in violations:
+            sys.stderr.write(f"  {v}\n")
+        sys.stderr.write(_FIX_HELP + "\n")
+        return 1
+
+    if args.verbose:
+        sys.stdout.write("[check-github-token-env-reads] OK — no violations.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validators/test_github_token_env_reads.py
+++ b/tests/unit/validators/test_github_token_env_reads.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for omnibase_core.validators.github_token_env_reads (OMN-13292).
+
+Fleet port of omnimarket's check_github_token_env_reads (OMN-12856). Verifies:
+(a) Clean source (contract api_key_ref resolution) produces zero violations.
+(b) Each raw GitHub-token env-read form is detected (positive corpus).
+(c) Suppression tokens silence a violation.
+(d) Test files / excluded paths are skipped.
+(e) main() exits 1 on violations (enforce) and 0 on a clean tree.
+(f) Port-equivalence: the omnimarket origin's documented corpus yields the
+    same verdict (1 violation per snippet) here.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators import github_token_env_reads as gate
+
+# Each snippet is a single raw GitHub-token env read → exactly one violation.
+_VIOLATION_SNIPPETS: list[str] = [
+    'import os\ntoken = os.environ["GH_PAT"]\n',
+    'import os\ntoken = os.environ.get("GH_PAT", "")\n',
+    'import os\ntoken = os.getenv("GH_PAT")\n',
+    'import os\ntoken = os.environ["GITHUB_TOKEN"]\n',
+    'import os\ntoken = os.environ.get("GITHUB_TOKEN")\n',
+    'import os\ntoken = os.getenv("GITHUB_TOKEN")\n',
+    'import os\ntoken = os.environ["GH_TOKEN"]\n',
+    'import os\ntoken = os.getenv("GH_TOKEN")\n',
+]
+
+_CLEAN_SOURCE = textwrap.dedent(
+    """
+    from pathlib import Path
+
+    def get_token(resolver, contract_path: Path) -> str:
+        # Secret resolved at the effect boundary from a contract api_key_ref.
+        ref = contract_secret_ref(contract_path, "GITHUB_TOKEN")
+        secret = resolver.resolve_api_key(ref)
+        return secret.get_secret_value()
+
+    # An unrelated env read of a non-token name is fine.
+    import os
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    """
+)
+
+
+@pytest.mark.unit
+def test_clean_source_returns_empty() -> None:
+    assert gate.scan_source(_CLEAN_SOURCE, "handler.py") == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("snippet", _VIOLATION_SNIPPETS)
+def test_detects_each_raw_env_read(snippet: str) -> None:
+    violations = gate.scan_source(snippet, "bad.py")
+    assert len(violations) == 1, f"snippet {snippet!r} -> {violations}"
+    assert "raw GitHub-token env read" in violations[0]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "token",
+    ["# github-token-env-ok: boundary resolver", "# ONEX_EXCLUDE: runtime secret read"],
+)
+def test_suppression_token_silences_violation(token: str) -> None:
+    snippet = f'import os\ntoken = os.environ["GITHUB_TOKEN"]  {token}\n'
+    assert gate.scan_source(snippet, "boundary.py") == []
+
+
+@pytest.mark.unit
+def test_suppression_on_multiline_call() -> None:
+    snippet = (
+        "import os\n"
+        "token = os.environ.get(  # github-token-env-ok: boundary\n"
+        '    "GITHUB_TOKEN",\n'
+        '    "",\n'
+        ")\n"
+    )
+    assert gate.scan_source(snippet, "boundary.py") == []
+
+
+@pytest.mark.unit
+def test_non_token_env_name_is_legal() -> None:
+    snippet = 'import os\nx = os.environ["SOME_OTHER_TOKEN"]\ny = os.getenv("HOME")\n'
+    assert gate.scan_source(snippet, "ok.py") == []
+
+
+@pytest.mark.unit
+def test_syntax_error_source_is_skipped() -> None:
+    assert gate.scan_source("def (:\n", "broken.py") == []
+
+
+@pytest.mark.unit
+def test_scan_tree_excludes_tests(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "good.py").write_text("x = 1\n", encoding="utf-8")
+    (src / "bad.py").write_text(
+        'import os\ntoken = os.environ["GH_PAT"]\n', encoding="utf-8"
+    )
+    tests_dir = src / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_thing.py").write_text(
+        'import os\ntoken = os.environ["GH_PAT"]\n', encoding="utf-8"
+    )
+    violations = gate.scan_tree(tmp_path)
+    assert len(violations) == 1
+    assert "bad.py" in violations[0]
+    assert "test_thing.py" not in violations[0]
+
+
+@pytest.mark.unit
+def test_main_exits_1_on_violation_file(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text('import os\ntoken = os.environ["GITHUB_TOKEN"]\n', encoding="utf-8")
+    assert gate.main([str(bad)]) == 1
+
+
+@pytest.mark.unit
+def test_main_exits_0_on_clean_file(tmp_path: Path) -> None:
+    good = tmp_path / "good.py"
+    good.write_text("x = 1\n", encoding="utf-8")
+    assert gate.main([str(good)]) == 0
+
+
+@pytest.mark.unit
+def test_main_no_files_is_noop() -> None:
+    assert gate.main([]) == 0
+
+
+@pytest.mark.unit
+def test_main_all_mode_scans_tree(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "bad.py").write_text(
+        'import os\ntoken = os.getenv("GH_TOKEN")\n', encoding="utf-8"
+    )
+    assert gate.main(["--all", "--repo-root", str(tmp_path)]) == 1


### PR DESCRIPTION
## OMN-13292 — github-token env-read ban (W7, fleet port of OMN-12856)

Ports omnimarket's `check_github_token_env_reads` (OMN-12856, omnimarket-scoped) to a canonical `omnibase_core` validator and exposes it as a remote pre-commit hook so the fleet can consume one implementation. Plan: `docs/tracking/2026-06-18-validator-standardization-remediation-plan.md` §3 W7. Parent epic OMN-9048.

### What
- New validator module `src/omnibase_core/validators/github_token_env_reads.py`. Pure, deterministic AST scanner (no `ValidatorBase`, no `NodeValidator`, no `Plugin*` base — sibling-pattern to `transport_mock_lint.py`). Bans raw `GH_PAT`/`GH_TOKEN`/`GITHUB_TOKEN` reads via `os.environ[...]`, `os.environ.get(...)`, `os.getenv(...)` in production source.
- Remote hook `check-github-token-env-reads` exported in `.pre-commit-hooks.yaml`; wired into core's own `.pre-commit-config.yaml`.
- Suppression for legitimate boundary code: `# github-token-env-ok: <reason>` or `# ONEX_EXCLUDE`.
- Fix direction: declare a contract `api_key_ref` and resolve at the effect boundary (memory `feedback_secrets_contract_ref_value_in_store`).

### Tests
19 unit tests (positive corpus of 8 violation forms, clean source, suppression incl. multi-line, excluded test paths, `main()` exit codes, `--all` mode). `mypy --strict` clean, `ruff` clean.

### Port equivalence
Detection logic is a 1:1 port of the omnimarket origin's AST matchers (same three forms, same `{GH_PAT, GH_TOKEN, GITHUB_TOKEN}` name set). The origin's documented corpus (5 forms) is a subset of this PR's 8-form corpus; every origin snippet yields exactly 1 violation here (`test_detects_each_raw_env_read`). The core scanner generalizes the scan root (per-file `pass_filenames` for any repo) rather than hardcoding `src/omnimarket/`.

### Fail-closed proof (verifier ≠ runner)
Planted `os.environ["GITHUB_TOKEN"]` in a real core src file; ran the hook entrypoint directly:

```
===== PROBE 1: planted violation (expect exit 1) =====
[check-github-token-env-reads] FAIL — 1 raw GitHub-token env read(s) found:
  src/omnibase_core/_fail_closed_probe.py:5: raw GitHub-token env read "os.environ['GITHUB_TOKEN']" — declare a contract api_key_ref and resolve at the effect boundary instead. ('return os.environ["GITHUB_TOKEN"]')
EXIT=1
===== PROBE 2: revert -> clean (expect exit 0) =====
EXIT=0
```

### Fleet wiring (separate per-repo PRs under this ticket)
omniclaude / onex_change_control / omnibase_infra consume the remote hook in their own PRs (clde + occ are clean; infra carries 3 pre-existing reads handled per OMN-12856 boundary-resolution).

### dod_evidence
Central OCC evidence: onex_change_control contract `contracts/OMN-13292.yaml` + binding receipts (paired OCC PR). OMN-13292 cited; receipts bind this PR by number + commit sha.

Closes part of OMN-13292 (W7). Reconciles OMN-12856 (fleet extension; no duplicate omnimarket impl removed in this PR).
