### PR TITLE
feat(OMN-13338): tiered proof-packet (L0-L3) in ModelDodReceipt schema

### DIFF
--- a/src/omnibase_core/enums/ticket/__init__.py
+++ b/src/omnibase_core/enums/ticket/__init__.py
@@ -27,6 +27,8 @@ from omnibase_core.enums.ticket.enum_mock_strategy import (
     EnumMockStrategy,
     MockStrategy,
 )
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.enums.ticket.enum_ticket_class import EnumTicketClass
 from omnibase_core.enums.ticket.enum_ticket_types import (
     PHASE_ALLOWED_ACTIONS,
     Action,
@@ -71,4 +73,7 @@ __all__ = [
     "EnumContractInterfaceSurface",
     # OMN-10241: DoD evidence check types
     "EnumDodCheckType",
+    # OMN-13338: tiered proof-packet enums
+    "EnumProofTier",
+    "EnumTicketClass",
 ]

--- a/src/omnibase_core/enums/ticket/enum_proof_tier.py
+++ b/src/omnibase_core/enums/ticket/enum_proof_tier.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumProofTier — graded evidence depth (L0-L3) for a DoD proof packet.
+
+A receipt without a graded tier makes a weak proof indistinguishable from a
+strong one. ``EnumProofTier`` ranks evidence depth so the receipt gate can
+reject a receipt whose tier is below the tier required for its ticket class
+(see :class:`omnibase_core.enums.ticket.enum_ticket_class.EnumTicketClass`).
+
+Tiers are cumulative — each higher tier requires every field of the tier(s)
+below it, plus its own additional fields. The ordering is what lets the gate
+compare two tiers with ``>=``; do not reorder members without updating
+``rank``.
+
+Members
+-------
+L0
+    Docs class. Required fields: pr_url, ci_status. Proves a PR exists and CI
+    reached a terminal state — the floor for any change.
+L1
+    Code class. L0 + merged_pr_url, test_evidence. Proves the change merged
+    and a test exercised the changed behavior.
+L2
+    Runtime class. L1 + runtime_sha, image_digest, correlation_id,
+    terminal_event, projection_ref. Proves the change is live and a workflow
+    transited the bus to a terminal state with a materialized projection.
+L3
+    Customer class. L2 + dashboard_ref, network_evidence, replay_class.
+    Proves a customer-visible surface rendered the change and the run is
+    replayable.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumProofTier(StrEnum):
+    """Graded evidence-depth tier for a DoD proof packet (L0 lowest, L3 highest)."""
+
+    L0 = "L0"
+    L1 = "L1"
+    L2 = "L2"
+    L3 = "L3"
+
+    @property
+    def rank(self) -> int:
+        """Return the numeric rank (0-3) so tiers can be compared by depth.
+
+        ``EnumProofTier.L2.rank >= EnumProofTier.L1.rank`` is the canonical
+        "is this packet at least the required tier" comparison. Implemented as
+        an int extracted from the member name rather than a hand-maintained
+        map so a new tier (e.g. ``L4``) ranks correctly without a second edit.
+        """
+        return int(self.value[1:])
+
+    def satisfies(self, required: EnumProofTier) -> bool:
+        """Return True when this tier is at or above ``required``."""
+        return self.rank >= required.rank
+
+
+__all__ = ["EnumProofTier"]

--- a/src/omnibase_core/enums/ticket/enum_ticket_class.py
+++ b/src/omnibase_core/enums/ticket/enum_ticket_class.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumTicketClass — the kind of change a ticket represents, with its minimum proof tier.
+
+The receipt gate compares a receipt's :class:`EnumProofTier` against the
+minimum tier required for the ticket's class. A docs-only change need only
+prove L0 (PR + CI); a customer-facing change must prove L3 (dashboard +
+network + replay). Mapping the class to a *minimum* (not exact) tier keeps the
+gate from forcing an over-heavyweight packet on a small change while still
+rejecting an under-evidenced one.
+
+Members
+-------
+DOCS
+    Documentation / non-code change. Minimum tier L0.
+CODE
+    Source change with tests but no runtime/deploy surface. Minimum tier L1.
+RUNTIME
+    Change that alters deployed runtime behavior. Minimum tier L2.
+CUSTOMER
+    Change with a customer-visible surface (dashboard / network). Minimum
+    tier L3.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+
+
+class EnumTicketClass(StrEnum):
+    """Class of change a ticket represents; determines the minimum proof tier."""
+
+    DOCS = "docs"
+    CODE = "code"
+    RUNTIME = "runtime"
+    CUSTOMER = "customer"
+
+    @property
+    def required_tier(self) -> EnumProofTier:
+        """Return the minimum :class:`EnumProofTier` a receipt for this class must reach."""
+        return _CLASS_REQUIRED_TIER[self]
+
+
+# Single source of truth for class -> minimum required tier. Kept as a
+# module-level frozen mapping (not a method body) so the policy is grep-able
+# and a static check can assert every class has an entry.
+_CLASS_REQUIRED_TIER: dict[EnumTicketClass, EnumProofTier] = {
+    EnumTicketClass.DOCS: EnumProofTier.L0,
+    EnumTicketClass.CODE: EnumProofTier.L1,
+    EnumTicketClass.RUNTIME: EnumProofTier.L2,
+    EnumTicketClass.CUSTOMER: EnumProofTier.L3,
+}
+
+
+__all__ = ["EnumTicketClass"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -55,6 +55,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.contracts.ticket.model_proof_packet import ModelProofPacket
 
 _TICKET_ID_RE = re.compile(r"^OMN-\d+$")
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
@@ -236,6 +237,18 @@ class ModelDodReceipt(BaseModel):
         description=(
             "Absolute path to the working directory where the check ran. Migrated "
             "from EvidenceReceipt (OMN-9792). None when not applicable."
+        ),
+    )
+    proof_packet: ModelProofPacket | None = Field(
+        default=None,
+        description=(
+            "Tiered (L0-L3) evidence-depth packet (OMN-13338). When present, the "
+            "receipt gate rejects a receipt whose packet tier is below the tier "
+            "required for its ticket class. Optional here so legacy receipts and "
+            "receipts whose ticket class carries no tier requirement remain valid; "
+            "the per-class tier requirement is enforced at the gate, not on every "
+            "receipt unconditionally. F1 autobind (OMN-13317) fills the packet's "
+            "source fields (evidence_source_sha, evidence_ticket, verifier)."
         ),
     )
 

--- a/src/omnibase_core/models/contracts/ticket/model_proof_packet.py
+++ b/src/omnibase_core/models/contracts/ticket/model_proof_packet.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelProofPacket — tiered (L0-L3) evidence-depth packet for a DoD receipt.
+
+A proof packet attaches a *graded* evidence claim to a :class:`ModelDodReceipt`
+so a weak receipt and a strong one are no longer indistinguishable. The packet
+declares a :class:`EnumProofTier` and carries the fields that tier requires;
+the model validator rejects a packet whose tier claims more depth than its
+populated fields support (e.g. ``tier=L2`` with no ``runtime_sha``).
+
+Tier field requirements (cumulative — each tier requires all lower-tier fields)
+-------------------------------------------------------------------------------
+L0 (docs)     : pr_url, ci_status
+L1 (code)     : + merged_pr_url, test_evidence
+L2 (runtime)  : + runtime_sha, image_digest, correlation_id, terminal_event,
+                projection_ref
+L3 (customer) : + dashboard_ref, network_evidence, replay_class
+
+Source fields (``evidence_source_sha``, ``evidence_ticket``, ``verifier``) are
+filled by F1 autobind (OMN-13317) from the Evidence-Source line; they are
+optional on the model so a packet can be constructed before autobind runs, but
+the validator requires ``verifier`` from L1 upward (anything beyond a docs PR
+needs an attributed verifier).
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+_TICKET_ID_RE = re.compile(r"^OMN-\d+$")
+
+# Per-tier *additional* required field names (the fields that tier introduces).
+# Cumulative requirement is computed by unioning this tier's set with every
+# lower tier's set, so the policy stays single-sourced and a new tier only
+# needs one entry here. Listed as a module constant (not inline in the
+# validator) so the required-field policy is grep-able and testable.
+_TIER_ADDED_FIELDS: dict[EnumProofTier, tuple[str, ...]] = {
+    EnumProofTier.L0: ("pr_url", "ci_status"),
+    EnumProofTier.L1: ("merged_pr_url", "test_evidence"),
+    EnumProofTier.L2: (
+        "runtime_sha",
+        "image_digest",
+        "correlation_id",
+        "terminal_event",
+        "projection_ref",
+    ),
+    EnumProofTier.L3: ("dashboard_ref", "network_evidence", "replay_class"),
+}
+
+
+def required_fields_for_tier(tier: EnumProofTier) -> tuple[str, ...]:
+    """Return the cumulative set of fields required at ``tier`` (this tier + all below)."""
+    fields: list[str] = []
+    for candidate in (
+        EnumProofTier.L0,
+        EnumProofTier.L1,
+        EnumProofTier.L2,
+        EnumProofTier.L3,
+    ):
+        fields.extend(_TIER_ADDED_FIELDS[candidate])
+        if candidate is tier:
+            break
+    return tuple(fields)
+
+
+class ModelProofPacket(BaseModel):
+    """Graded L0-L3 evidence packet attached to a :class:`ModelDodReceipt`.
+
+    Frozen. The declared ``tier`` is a claim; the model validator enforces
+    that every field the tier requires is populated, so a packet cannot claim
+    a higher tier than its evidence supports.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    tier: EnumProofTier = Field(
+        ...,
+        description=(
+            "Declared evidence-depth tier (L0-L3). The validator rejects a "
+            "tier whose required fields are not all populated."
+        ),
+    )
+
+    # --- L0: docs floor -----------------------------------------------------
+    pr_url: str | None = Field(
+        default=None, description="URL of the PR carrying the change (L0+)."
+    )
+    ci_status: str | None = Field(
+        default=None,
+        description="Terminal CI status string for the PR (e.g. 'success') (L0+).",
+    )
+
+    # --- L1: merged code + test --------------------------------------------
+    merged_pr_url: str | None = Field(
+        default=None, description="URL of the merged PR (L1+)."
+    )
+    test_evidence: str | None = Field(
+        default=None,
+        description="Reference to the test that exercised the change (L1+).",
+    )
+
+    # --- L2: runtime --------------------------------------------------------
+    runtime_sha: str | None = Field(
+        default=None,
+        description="Git SHA of the running binary (7-40 hex) (L2+).",
+    )
+    image_digest: str | None = Field(
+        default=None,
+        description="Container image digest of the deployed image (L2+).",
+    )
+    correlation_id: str | None = Field(
+        default=None,
+        description="Correlation id of the proving workflow run (L2+).",
+    )
+    terminal_event: str | None = Field(
+        default=None,
+        description="Terminal bus event topic/id proving transit (L2+).",
+    )
+    projection_ref: str | None = Field(
+        default=None,
+        description="Reference to the materialized projection row (L2+).",
+    )
+
+    # --- L3: customer-visible ----------------------------------------------
+    dashboard_ref: str | None = Field(
+        default=None,
+        description="Reference to the customer-visible dashboard surface (L3).",
+    )
+    network_evidence: str | None = Field(
+        default=None,
+        description="Captured network request/response proving render (L3).",
+    )
+    replay_class: str | None = Field(
+        default=None,
+        description="Replay class / fixture id making the run replayable (L3).",
+    )
+
+    # --- Source fields (F1 autobind, OMN-13317) ----------------------------
+    evidence_source_sha: str | None = Field(
+        default=None,
+        description=(
+            "Evidence-Source commit SHA, filled by F1 autobind from the "
+            "Evidence-Source PR-body line (OMN-13317)."
+        ),
+    )
+    evidence_ticket: str | None = Field(
+        default=None,
+        description="Evidence-Ticket id (OMN-XXXX), filled by F1 autobind.",
+    )
+    verifier: str | None = Field(
+        default=None,
+        description=(
+            "Identity that verified the proof, filled by F1 autobind. Required "
+            "from tier L1 upward — only a docs (L0) packet may omit it."
+        ),
+    )
+
+    @field_validator("evidence_source_sha", "runtime_sha")
+    @classmethod
+    def _validate_sha(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not _SHA_RE.match(v):
+            raise ValueError(f"must be a 7-40 char hex git SHA, got: {v!r}")
+        return v
+
+    @field_validator("evidence_ticket")
+    @classmethod
+    def _validate_ticket(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not _TICKET_ID_RE.match(v):
+            raise ValueError(f"evidence_ticket must match OMN-\\d+, got: {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def enforce_tier_required_fields(self) -> ModelProofPacket:
+        """Reject a packet whose declared tier has unpopulated required fields.
+
+        A "required" field here means non-None and, for strings, non-blank
+        after stripping. This is what prevents a packet from claiming ``L2``
+        while carrying only the L0 docs fields — the claim of depth must be
+        backed by the fields that depth requires.
+
+        ``verifier`` is required from L1 upward: anything past a docs PR needs
+        an attributed verifier so the receipt is not self-anonymous.
+        """
+        missing: list[str] = []
+        for name in required_fields_for_tier(self.tier):
+            value = getattr(self, name)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                missing.append(name)
+
+        if self.tier.rank >= EnumProofTier.L1.rank:
+            verifier = self.verifier
+            if verifier is None or not verifier.strip():
+                missing.append("verifier")
+
+        if missing:
+            raise ValueError(
+                f"proof_packet declares tier {self.tier.value} but is missing "
+                f"required field(s): {', '.join(missing)}. A tier is a claim of "
+                "evidence depth; every field that tier requires must be populated."
+            )
+        return self
+
+
+__all__ = ["ModelProofPacket", "required_fields_for_tier"]

--- a/src/omnibase_core/models/contracts/ticket/model_proof_tier_gate_result.py
+++ b/src/omnibase_core/models/contracts/ticket/model_proof_tier_gate_result.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelProofTierGateResult — outcome of evaluating a receipt against its required tier.
+
+Returned by
+:func:`omnibase_core.validation.validator_proof_tier_gate.evaluate_proof_tier`.
+Records the ticket class, the tier its class required, the tier the receipt's
+proof packet actually reached (``None`` when no packet was attached), and the
+pass/fail decision with a human-readable reason (OMN-13338).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.enums.ticket.enum_ticket_class import EnumTicketClass
+
+
+class ModelProofTierGateResult(BaseModel):
+    """Outcome of comparing a receipt's proof tier to its ticket-class minimum."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    passed: bool = Field(
+        ..., description="True when the receipt meets the required tier."
+    )
+    ticket_class: EnumTicketClass = Field(
+        ..., description="Class of the ticket the receipt proves."
+    )
+    required_tier: EnumProofTier = Field(
+        ..., description="Minimum tier the ticket class requires."
+    )
+    actual_tier: EnumProofTier | None = Field(
+        default=None,
+        description="Tier the receipt's proof_packet declared; None when absent.",
+    )
+    reason: str = Field(
+        ..., min_length=1, description="Human-readable explanation of the decision."
+    )
+
+
+__all__ = ["ModelProofTierGateResult"]

--- a/src/omnibase_core/validation/validator_proof_tier_gate.py
+++ b/src/omnibase_core/validation/validator_proof_tier_gate.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Proof-tier gate — reject a receipt below the tier required for its ticket class.
+
+Companion to :mod:`omnibase_core.validation.validator_receipt_gate` (OMN-13338).
+A ticket's :class:`EnumTicketClass` declares the minimum
+:class:`EnumProofTier` a receipt must reach. This module evaluates a single
+receipt's :class:`ModelProofPacket` against that minimum and returns a typed
+result the receipt gate folds into its decision.
+
+Policy
+------
+- ticket class has a required tier (every class does — see ``EnumTicketClass``)
+- receipt with no ``proof_packet`` AND a required tier above L0 → REJECT
+  (absence of a packet cannot satisfy a non-floor requirement)
+- receipt whose packet tier ``satisfies`` the required tier → PASS
+- receipt whose packet tier is below the required tier → REJECT
+
+The function is pure (no I/O) so the gate, ``node_dod_verify``, and unit tests
+all exercise the identical decision path.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.enums.ticket.enum_ticket_class import EnumTicketClass
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.models.contracts.ticket.model_proof_tier_gate_result import (
+    ModelProofTierGateResult,
+)
+
+
+def evaluate_proof_tier(
+    receipt: ModelDodReceipt,
+    ticket_class: EnumTicketClass,
+) -> ModelProofTierGateResult:
+    """Return whether ``receipt`` meets the minimum proof tier for ``ticket_class``.
+
+    Args:
+        receipt: The receipt under test.
+        ticket_class: The class of the ticket the receipt proves.
+
+    Returns:
+        :class:`ModelProofTierGateResult` with ``passed`` and a reason string.
+    """
+    required = ticket_class.required_tier
+
+    packet = receipt.proof_packet
+    if packet is None:
+        # An absent packet only satisfies the floor (L0). Any higher requirement
+        # cannot be met without a packet declaring the depth.
+        if required is EnumProofTier.L0:
+            return ModelProofTierGateResult(
+                passed=True,
+                ticket_class=ticket_class,
+                required_tier=required,
+                actual_tier=None,
+                reason=(
+                    f"ticket class {ticket_class.value} requires tier "
+                    f"{required.value} (floor); receipt without a proof_packet "
+                    "is accepted at the floor."
+                ),
+            )
+        return ModelProofTierGateResult(
+            passed=False,
+            ticket_class=ticket_class,
+            required_tier=required,
+            actual_tier=None,
+            reason=(
+                f"PROOF TIER GATE FAILED: ticket class {ticket_class.value} "
+                f"requires tier {required.value} but the receipt has no "
+                "proof_packet. Attach a ModelProofPacket at or above the "
+                "required tier."
+            ),
+        )
+
+    if packet.tier.satisfies(required):
+        return ModelProofTierGateResult(
+            passed=True,
+            ticket_class=ticket_class,
+            required_tier=required,
+            actual_tier=packet.tier,
+            reason=(
+                f"proof_packet tier {packet.tier.value} satisfies the "
+                f"{required.value} required for ticket class {ticket_class.value}."
+            ),
+        )
+
+    return ModelProofTierGateResult(
+        passed=False,
+        ticket_class=ticket_class,
+        required_tier=required,
+        actual_tier=packet.tier,
+        reason=(
+            f"PROOF TIER GATE FAILED: ticket class {ticket_class.value} requires "
+            f"tier {required.value} but the receipt's proof_packet is only "
+            f"{packet.tier.value}. Produce a higher-tier packet with the fields "
+            "that tier requires."
+        ),
+    )
+
+
+__all__ = ["evaluate_proof_tier"]

--- a/tests/unit/enums/test_enum_proof_tier_and_ticket_class.py
+++ b/tests/unit/enums/test_enum_proof_tier_and_ticket_class.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumProofTier ordering and EnumTicketClass mapping (OMN-13338)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.enums.ticket.enum_ticket_class import EnumTicketClass
+
+
+@pytest.mark.unit
+class TestProofTierRanking:
+    def test_ranks_are_monotonic(self) -> None:
+        assert (
+            EnumProofTier.L0.rank
+            < EnumProofTier.L1.rank
+            < EnumProofTier.L2.rank
+            < EnumProofTier.L3.rank
+        )
+
+    def test_satisfies_at_or_above(self) -> None:
+        assert EnumProofTier.L2.satisfies(EnumProofTier.L1)
+        assert EnumProofTier.L2.satisfies(EnumProofTier.L2)
+
+    def test_does_not_satisfy_below(self) -> None:
+        assert not EnumProofTier.L1.satisfies(EnumProofTier.L2)
+        assert not EnumProofTier.L0.satisfies(EnumProofTier.L3)
+
+
+@pytest.mark.unit
+class TestTicketClassRequiredTier:
+    @pytest.mark.parametrize(
+        ("ticket_class", "expected"),
+        [
+            (EnumTicketClass.DOCS, EnumProofTier.L0),
+            (EnumTicketClass.CODE, EnumProofTier.L1),
+            (EnumTicketClass.RUNTIME, EnumProofTier.L2),
+            (EnumTicketClass.CUSTOMER, EnumProofTier.L3),
+        ],
+    )
+    def test_required_tier_mapping(
+        self, ticket_class: EnumTicketClass, expected: EnumProofTier
+    ) -> None:
+        assert ticket_class.required_tier is expected
+
+    def test_every_class_has_a_required_tier(self) -> None:
+        for ticket_class in EnumTicketClass:
+            # Must not raise KeyError — every member is mapped.
+            assert isinstance(ticket_class.required_tier, EnumProofTier)

--- a/tests/unit/models/contracts/test_model_proof_packet.py
+++ b/tests/unit/models/contracts/test_model_proof_packet.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelProofPacket — per-tier required-field enforcement (OMN-13338)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.models.contracts.ticket.model_proof_packet import (
+    ModelProofPacket,
+    required_fields_for_tier,
+)
+
+
+def _l0_fields() -> dict[str, Any]:
+    return {"pr_url": "https://github.com/o/r/pull/1", "ci_status": "success"}
+
+
+def _l1_fields() -> dict[str, Any]:
+    return {
+        **_l0_fields(),
+        "merged_pr_url": "https://github.com/o/r/pull/1",
+        "test_evidence": "tests/unit/test_x.py::test_y PASSED",
+        "verifier": "ci-reviewer-2026-06-19",
+    }
+
+
+def _l2_fields() -> dict[str, Any]:
+    return {
+        **_l1_fields(),
+        "runtime_sha": "a1b2c3d",
+        "image_digest": "sha256:" + "a" * 64,
+        "correlation_id": "11880229-aaaa-bbbb-cccc-ddddeeeeffff",
+        "terminal_event": "onex.evt.x.completed.v1",
+        "projection_ref": "projection_x:row-42",
+    }
+
+
+def _l3_fields() -> dict[str, Any]:
+    return {
+        **_l2_fields(),
+        "dashboard_ref": "omnidash/widget/x",
+        "network_evidence": "GET /projection/x -> 200",
+        "replay_class": "golden-chain-x",
+    }
+
+
+@pytest.mark.unit
+class TestProofPacketPerTierConstruction:
+    """Each tier constructs when all its cumulative required fields are present."""
+
+    def test_l0_constructs(self) -> None:
+        packet = ModelProofPacket(tier=EnumProofTier.L0, **_l0_fields())
+        assert packet.tier is EnumProofTier.L0
+
+    def test_l1_constructs(self) -> None:
+        packet = ModelProofPacket(tier=EnumProofTier.L1, **_l1_fields())
+        assert packet.tier is EnumProofTier.L1
+
+    def test_l2_constructs(self) -> None:
+        packet = ModelProofPacket(tier=EnumProofTier.L2, **_l2_fields())
+        assert packet.tier is EnumProofTier.L2
+
+    def test_l3_constructs(self) -> None:
+        packet = ModelProofPacket(tier=EnumProofTier.L3, **_l3_fields())
+        assert packet.tier is EnumProofTier.L3
+
+
+@pytest.mark.unit
+class TestProofPacketTierUnderEvidenced:
+    """A tier claim with a missing required field is rejected."""
+
+    def test_l0_missing_ci_status_rejected(self) -> None:
+        fields = _l0_fields()
+        del fields["ci_status"]
+        with pytest.raises(ValidationError, match="ci_status"):
+            ModelProofPacket(tier=EnumProofTier.L0, **fields)
+
+    def test_l1_missing_test_evidence_rejected(self) -> None:
+        fields = _l1_fields()
+        del fields["test_evidence"]
+        with pytest.raises(ValidationError, match="test_evidence"):
+            ModelProofPacket(tier=EnumProofTier.L1, **fields)
+
+    def test_l1_missing_verifier_rejected(self) -> None:
+        fields = _l1_fields()
+        del fields["verifier"]
+        with pytest.raises(ValidationError, match="verifier"):
+            ModelProofPacket(tier=EnumProofTier.L1, **fields)
+
+    def test_l2_claim_with_only_l0_fields_rejected(self) -> None:
+        # The discriminating case: claiming L2 while carrying L0-only evidence.
+        with pytest.raises(ValidationError, match="runtime_sha"):
+            ModelProofPacket(tier=EnumProofTier.L2, **_l0_fields())
+
+    def test_l3_missing_replay_class_rejected(self) -> None:
+        fields = _l3_fields()
+        del fields["replay_class"]
+        with pytest.raises(ValidationError, match="replay_class"):
+            ModelProofPacket(tier=EnumProofTier.L3, **fields)
+
+    def test_blank_string_treated_as_missing(self) -> None:
+        fields = _l0_fields()
+        fields["ci_status"] = "   "
+        with pytest.raises(ValidationError, match="ci_status"):
+            ModelProofPacket(tier=EnumProofTier.L0, **fields)
+
+
+@pytest.mark.unit
+class TestProofPacketFieldValidators:
+    def test_bad_runtime_sha_rejected(self) -> None:
+        fields = _l2_fields()
+        fields["runtime_sha"] = "zzz"
+        with pytest.raises(ValidationError, match="hex git SHA"):
+            ModelProofPacket(tier=EnumProofTier.L2, **fields)
+
+    def test_bad_evidence_ticket_rejected(self) -> None:
+        fields = _l1_fields()
+        fields["evidence_ticket"] = "PROJ-1"
+        with pytest.raises(ValidationError, match="evidence_ticket"):
+            ModelProofPacket(tier=EnumProofTier.L1, **fields)
+
+    def test_valid_source_fields_accepted(self) -> None:
+        fields = _l1_fields()
+        fields["evidence_ticket"] = "OMN-13338"
+        fields["evidence_source_sha"] = "deadbeef"
+        packet = ModelProofPacket(tier=EnumProofTier.L1, **fields)
+        assert packet.evidence_ticket == "OMN-13338"
+
+    def test_packet_is_frozen(self) -> None:
+        packet = ModelProofPacket(tier=EnumProofTier.L0, **_l0_fields())
+        with pytest.raises(ValidationError):
+            packet.tier = EnumProofTier.L1  # type: ignore[misc]
+
+    def test_extra_field_rejected(self) -> None:
+        fields = _l0_fields()
+        fields["rogue"] = "x"
+        with pytest.raises(ValidationError):
+            ModelProofPacket(tier=EnumProofTier.L0, **fields)
+
+
+@pytest.mark.unit
+class TestRequiredFieldsForTier:
+    def test_l0_required_fields(self) -> None:
+        assert required_fields_for_tier(EnumProofTier.L0) == ("pr_url", "ci_status")
+
+    def test_cumulative_growth(self) -> None:
+        l0 = set(required_fields_for_tier(EnumProofTier.L0))
+        l1 = set(required_fields_for_tier(EnumProofTier.L1))
+        l2 = set(required_fields_for_tier(EnumProofTier.L2))
+        l3 = set(required_fields_for_tier(EnumProofTier.L3))
+        assert l0 < l1 < l2 < l3
+
+    def test_l3_includes_customer_fields(self) -> None:
+        l3 = required_fields_for_tier(EnumProofTier.L3)
+        assert {"dashboard_ref", "network_evidence", "replay_class"} <= set(l3)

--- a/tests/unit/validation/test_validator_proof_tier_gate.py
+++ b/tests/unit/validation/test_validator_proof_tier_gate.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the proof-tier gate — reject receipts below required tier (OMN-13338)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from omnibase_core.enums.ticket.enum_proof_tier import EnumProofTier
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.enums.ticket.enum_ticket_class import EnumTicketClass
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.models.contracts.ticket.model_proof_packet import ModelProofPacket
+from omnibase_core.validation.validator_proof_tier_gate import evaluate_proof_tier
+
+
+def _receipt(packet: ModelProofPacket | None) -> ModelDodReceipt:
+    fields: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-13338",
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "gh pr view --json state -q .state",
+        "status": EnumReceiptStatus.PASS,
+        "run_timestamp": datetime.now(tz=UTC),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "ci-receipt-gate",
+        "verifier": "foreground-receipt-gate-2026-06-19",
+        "probe_command": "gh pr view --json state -q .state",
+        "probe_stdout": "OPEN\n",
+        "proof_packet": packet,
+    }
+    return ModelDodReceipt(**fields)
+
+
+def _packet(tier: EnumProofTier) -> ModelProofPacket:
+    base: dict[str, Any] = {
+        "pr_url": "https://github.com/o/r/pull/1",
+        "ci_status": "success",
+    }
+    if tier.rank >= EnumProofTier.L1.rank:
+        base |= {
+            "merged_pr_url": "https://github.com/o/r/pull/1",
+            "test_evidence": "tests/x.py::test PASSED",
+            "verifier": "ci-reviewer",
+        }
+    if tier.rank >= EnumProofTier.L2.rank:
+        base |= {
+            "runtime_sha": "a1b2c3d",
+            "image_digest": "sha256:" + "a" * 64,
+            "correlation_id": "11880229-aaaa-bbbb-cccc-ddddeeeeffff",
+            "terminal_event": "onex.evt.x.completed.v1",
+            "projection_ref": "projection_x:row-42",
+        }
+    if tier.rank >= EnumProofTier.L3.rank:
+        base |= {
+            "dashboard_ref": "omnidash/widget/x",
+            "network_evidence": "GET /projection/x -> 200",
+            "replay_class": "golden-chain-x",
+        }
+    return ModelProofPacket(tier=tier, **base)
+
+
+@pytest.mark.unit
+class TestProofTierGatePassesAtOrAbove:
+    @pytest.mark.parametrize(
+        ("ticket_class", "tier"),
+        [
+            (EnumTicketClass.DOCS, EnumProofTier.L0),
+            (EnumTicketClass.CODE, EnumProofTier.L1),
+            (EnumTicketClass.RUNTIME, EnumProofTier.L2),
+            (EnumTicketClass.CUSTOMER, EnumProofTier.L3),
+        ],
+    )
+    def test_exact_tier_passes(
+        self, ticket_class: EnumTicketClass, tier: EnumProofTier
+    ) -> None:
+        result = evaluate_proof_tier(_receipt(_packet(tier)), ticket_class)
+        assert result.passed
+        assert result.actual_tier is tier
+
+    def test_higher_tier_passes(self) -> None:
+        # An L3 packet satisfies a RUNTIME (L2) requirement.
+        result = evaluate_proof_tier(
+            _receipt(_packet(EnumProofTier.L3)), EnumTicketClass.RUNTIME
+        )
+        assert result.passed
+
+
+@pytest.mark.unit
+class TestProofTierGateRejectsBelow:
+    @pytest.mark.parametrize(
+        ("ticket_class", "tier"),
+        [
+            (EnumTicketClass.CODE, EnumProofTier.L0),
+            (EnumTicketClass.RUNTIME, EnumProofTier.L1),
+            (EnumTicketClass.CUSTOMER, EnumProofTier.L2),
+        ],
+    )
+    def test_below_required_rejected(
+        self, ticket_class: EnumTicketClass, tier: EnumProofTier
+    ) -> None:
+        result = evaluate_proof_tier(_receipt(_packet(tier)), ticket_class)
+        assert not result.passed
+        assert "PROOF TIER GATE FAILED" in result.reason
+        assert result.required_tier is ticket_class.required_tier
+        assert result.actual_tier is tier
+
+
+@pytest.mark.unit
+class TestProofTierGateMissingPacket:
+    def test_missing_packet_docs_passes_at_floor(self) -> None:
+        result = evaluate_proof_tier(_receipt(None), EnumTicketClass.DOCS)
+        assert result.passed
+        assert result.actual_tier is None
+
+    @pytest.mark.parametrize(
+        "ticket_class",
+        [EnumTicketClass.CODE, EnumTicketClass.RUNTIME, EnumTicketClass.CUSTOMER],
+    )
+    def test_missing_packet_above_floor_rejected(
+        self, ticket_class: EnumTicketClass
+    ) -> None:
+        result = evaluate_proof_tier(_receipt(None), ticket_class)
+        assert not result.passed
+        assert "no proof_packet" in result.reason
+        assert result.actual_tier is None


### PR DESCRIPTION
## Summary

Implements **OMN-13338** (R3: Tiered proof-packet L0-L3 in ModelDodReceipt) — net-new schema, no runtime needed.

Receipts vary in evidence depth with no graded standard, so a weak and a strong receipt look alike. This adds a tiered `proof_packet` (L0 docs: PR+CI · L1 code: +merged-PR+test · L2 runtime: +runtime SHA/image digest/correlation/terminal/projection · L3 customer: +dashboard/network+replay) so evidence depth is machine-comparable, and a gate that rejects a receipt below the tier required for its ticket class.

## Changes

- `EnumProofTier` (L0-L3) with `rank` / `satisfies` depth ordering.
- `EnumTicketClass` (docs/code/runtime/customer) -> minimum required tier.
- `ModelProofPacket`: declared `tier` + per-tier required fields enforced by a model validator (a tier claim with an unpopulated required field is rejected — e.g. `tier=L2` with no `runtime_sha`). Source fields (`evidence_source_sha`, `evidence_ticket`, `verifier`) are the slots **F1 autobind (OMN-13317)** fills.
- `ModelDodReceipt` gains an optional `proof_packet` field.
- `validator_proof_tier_gate.evaluate_proof_tier`: pure (no-I/O) gate decision rejecting a receipt whose packet tier is below the ticket-class minimum, and a missing packet above the L0 floor. Returns typed `ModelProofTierGateResult`.
- 38 new per-tier tests (packet construction + under-evidenced rejection; enum ordering + class mapping; gate pass-at-or-above / reject-below / missing-packet).

## Verification (dod_evidence)

- `uv run pytest` on the 3 new test files: **38 passed**.
- Full `tests/unit/models/contracts/ + tests/unit/enums/` suite: **7159 passed** (no regression from the new `proof_packet` field).
- Existing receipt-gate/dod_receipt suites: **113 passed**.
- `mypy --strict`: **0 errors** on all 6 new/changed modules (the 6 strict errors that remain in the tree are pre-existing on `origin/dev` in `contract_loader.py` / `cli_install.py` / `model_onex_container.py`, confirmed by stash-and-recheck; none introduced by this PR).
- `ruff format` + `ruff check`: clean.

Evidence-Ticket: OMN-13338
Evidence-Source: OCC#2817

Closes OMN-13338
