### PR TITLE
feat(OMN-13305): add backend secret discipline compute hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -880,6 +880,19 @@ repos:
         exclude: ^(tests/|archived/|archive/).*\.py$
         stages: [pre-commit]
 
+      # Backend Secret-Ref Discipline Gate (OMN-13305, ported from OMN-12971).
+      # Rejects literal PEM/SA-JSON/bearer credentials in committed routing-authority
+      # YAML. Requires every authenticated cloud backend to declare a logical
+      # secret ref (secret_ref/api_key_ref/api_key_env/credential_ref). ADC and
+      # API-key auth are mutually exclusive per backend. No warn-only mode.
+      - id: check-backend-secret-discipline
+        name: Backend Secret-Ref Discipline Gate (OMN-13305)
+        entry: uv run python -m omnibase_core.validation.validator_backend_secret_discipline
+        language: system
+        types_or: [yaml]
+        pass_filenames: true
+        stages: [pre-commit]
+
       # Canonical Inference Gate (OMN-13219).
       # Fails on non-canonical model-inference surfaces: shelled model CLIs
       # (codex/claude/gemini/opencode via subprocess/exec/shutil.which) and

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -252,6 +252,19 @@
   pass_filenames: true
   stages: [pre-commit]
 
+- id: check-backend-secret-discipline
+  name: Backend Secret-Ref Discipline Gate (OMN-13305)
+  description: >
+    Canonical COMPUTE hook for backend secret discipline. Rejects literal PEM, service-account JSON, bearer
+    tokens, sk-/AIza/ya29-style keys in committed routing-authority config, and requires every authenticated
+    cloud backend to declare a logical secret reference (secret_ref / api_key_ref / api_key_env / credential_ref).
+    ADC and API-key auth are mutually exclusive per backend.
+  language: python
+  entry: python -m omnibase_core.validation.validator_backend_secret_discipline
+  files: \.(ya?ml|json)$
+  pass_filenames: true
+  stages: [pre-commit]
+
 - id: check-enum-governance
   name: ONEX Enum Governance Validation (OMN-13287)
   description: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ node_compliance_evidence_effect = "omnibase_core.nodes.node_compliance_evidence_
 node_compliance_orchestrator = "omnibase_core.nodes.node_compliance_orchestrator"
 node_compliance_report_reducer = "omnibase_core.nodes.node_compliance_report_reducer"
 node_compliance_scan_compute = "omnibase_core.nodes.node_compliance_scan_compute"
+node_backend_secret_discipline_compute = "omnibase_core.nodes.node_backend_secret_discipline_compute"
 node_contract_resolve_compute = "omnibase_core.nodes.node_contract_resolve_compute"
 node_contract_verify_replay_compute = "omnibase_core.nodes.node_contract_verify_replay_compute"
 
@@ -331,6 +332,7 @@ ignore = [
 "src/omnibase_core/validation/scripts/validate_string_versions.py" = ["T201"]
 "src/omnibase_core/validation/scripts/validate_topic_names.py" = ["T201"]
 "src/omnibase_core/validation/validator_demo_path_topic_coherence.py" = ["T201"]  # CLI output for demo-path topic coherence gate (OMN-12777)
+"src/omnibase_core/validation/validator_backend_secret_discipline.py" = ["T201"]  # CLI output for backend secret-ref discipline gate (OMN-13305)
 "src/omnibase_core/scripts/validate_markdown_links.py" = ["T201"]
 "scripts/pin_bump.py" = ["T201"]  # CLI output for publish-downstream-pin-bump workflow [OMN-9050]
 "scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ node_compliance_evidence_effect = "omnibase_core.nodes.node_compliance_evidence_
 node_compliance_orchestrator = "omnibase_core.nodes.node_compliance_orchestrator"
 node_compliance_report_reducer = "omnibase_core.nodes.node_compliance_report_reducer"
 node_compliance_scan_compute = "omnibase_core.nodes.node_compliance_scan_compute"
-node_backend_secret_discipline_compute = "omnibase_core.nodes.node_backend_secret_discipline_compute"
+node_backend_secret_discipline_compute = "omnibase_core.nodes.node_backend_secret_discipline_compute" # pragma: allowlist secret
 node_contract_resolve_compute = "omnibase_core.nodes.node_contract_resolve_compute"
 node_contract_verify_replay_compute = "omnibase_core.nodes.node_contract_verify_replay_compute"
 

--- a/src/omnibase_core/models/validation/model_backend_ref_violation.py
+++ b/src/omnibase_core/models/validation/model_backend_ref_violation.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Backend reference violation model for backend-secret-discipline checks."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelBackendRefViolation(BaseModel):
+    """A single backend-ref or mutual-exclusion finding."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    file: str
+    message: str
+
+
+__all__ = ["ModelBackendRefViolation"]

--- a/src/omnibase_core/models/validation/model_backend_secret_discipline_input.py
+++ b/src/omnibase_core/models/validation/model_backend_secret_discipline_input.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for the backend-secret-discipline COMPUTE validator."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelBackendSecretDisciplineInput(BaseModel):
+    """Input payload for backend-secret-discipline COMPUTE checks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    config_contents: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Map of config-file relative path to raw text content. "
+            "The handler checks all entries. Empty means no files checked."
+        ),
+    )
+
+
+__all__ = ["ModelBackendSecretDisciplineInput"]

--- a/src/omnibase_core/models/validation/model_backend_secret_discipline_output.py
+++ b/src/omnibase_core/models/validation/model_backend_secret_discipline_output.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Output model for the backend-secret-discipline COMPUTE validator."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.validation.model_backend_ref_violation import (
+    ModelBackendRefViolation,
+)
+from omnibase_core.models.validation.model_credential_violation import (
+    ModelCredentialViolation,
+)
+
+
+class ModelBackendSecretDisciplineOutput(BaseModel):
+    """COMPUTE result from the backend-secret-discipline handler."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ticket: str = "OMN-13305"
+    gate: str = "backend-secret-discipline"
+    literal_credential_violations: list[ModelCredentialViolation] = Field(
+        default_factory=list
+    )
+    backend_ref_violations: list[ModelBackendRefViolation] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+    passed: bool = False
+
+
+__all__ = ["ModelBackendSecretDisciplineOutput"]

--- a/src/omnibase_core/models/validation/model_credential_violation.py
+++ b/src/omnibase_core/models/validation/model_credential_violation.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Literal credential violation model for backend-secret-discipline checks."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelCredentialViolation(BaseModel):
+    """A single literal-credential finding."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    file: str
+    line: int
+    kind: str
+    message: str
+
+
+__all__ = ["ModelCredentialViolation"]

--- a/src/omnibase_core/nodes/node_backend_secret_discipline_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_backend_secret_discipline_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/src/omnibase_core/nodes/node_backend_secret_discipline_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_backend_secret_discipline_compute/contract.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the backend_secret_discipline compute node.
+# Validates that committed routing-authority config contains no literal credentials
+# and that every cloud backend declares a logical secret reference.
+#
+# See: OMN-13305 — port check_backend_secret_discipline to core COMPUTE validator
+
+name: node_backend_secret_discipline_compute
+node_id: node_backend_secret_discipline_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  Backend secret-ref / credential-ref discipline gate (OMN-13305, ported from OMN-12971). Validates that
+  committed routing-authority config contains no literal PEM/SA-JSON/bearer credentials, and that every
+  authenticated cloud backend declares a logical secret reference (secret_ref / api_key_ref / api_key_env
+  / credential_ref). ADC and API-key auth are mutually exclusive. Returns a ModelBackendSecretDisciplineOutput
+  verdict. #magic___^_^___line
+handler_routing:
+  default_handler: handler:NodeBackendSecretDisciplineCompute
+
+input_model: omnibase_core.validation.validator_backend_secret_discipline.ModelBackendSecretDisciplineInput
+output_model: omnibase_core.validation.validator_backend_secret_discipline.ModelBackendSecretDisciplineOutput
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 10000

--- a/src/omnibase_core/nodes/node_backend_secret_discipline_compute/handler.py
+++ b/src/omnibase_core/nodes/node_backend_secret_discipline_compute/handler.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeBackendSecretDisciplineCompute — thin node shell.
+
+The handler logic lives in
+``omnibase_core.validation.validator_backend_secret_discipline`` and is
+importable directly as ``NodeBackendSecretDisciplineCompute``.  This module
+re-exports it under the node package for contract-router registration.
+
+ONEX node type: COMPUTE
+"""
+
+from __future__ import annotations
+
+from omnibase_core.validation.validator_backend_secret_discipline import (
+    HandlerBackendSecretDisciplineCompute,
+)
+
+# Re-export the canonical handler class under the node-package alias.
+NodeBackendSecretDisciplineCompute = HandlerBackendSecretDisciplineCompute
+
+__all__ = [
+    "HandlerBackendSecretDisciplineCompute",
+    "NodeBackendSecretDisciplineCompute",
+]

--- a/src/omnibase_core/validation/validator_backend_secret_discipline.py
+++ b/src/omnibase_core/validation/validator_backend_secret_discipline.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ValidatorBackendSecretDiscipline — reject literal credentials; require secret-refs.
+
+Ported from omnimarket/scripts/ci/check_backend_secret_discipline.py (OMN-12971)
+to a canonical COMPUTE handler (OMN-13305, parent OMN-9048 W8).
+
+ENFORCEMENT RATCHET, not detection. Wired as a pre-commit hook (remote, via
+omnibase_core/.pre-commit-hooks.yaml) and as a required CI gate.
+
+Why this exists
+---------------
+The Vertex runtime wiring (OMN-12971) added a credential-backed backend
+(``cloud-vertex-gemini``) whose ADC credential is a FILE resolved from the
+secret store at the effect boundary. The whole point of secret-ref discipline
+is that the *credential value never lands in committed config*. This gate makes
+that invariant mechanically enforced so a future edit cannot regress it by
+pasting a literal key / service-account JSON / bearer token into the routing
+authority.
+
+What it checks (over the scanned config files or supplied file paths)
+---------------------------------------------------------------------
+1. NO literal credential value appears anywhere in the scanned config:
+   - PEM private-key blocks (``-----BEGIN ... PRIVATE KEY-----``)
+   - service-account JSON markers (``"private_key"``, ``"client_email"``)
+   - bearer/api-key-shaped literals (``Bearer <...>``, ``sk-...``, ``AIza...``,
+     ``ya29.`` OAuth tokens, Google API keys)
+2. Every CLOUD backend that requires authentication declares a LOGICAL
+   reference (``secret_ref`` / ``api_key_ref`` / ``api_key_env`` for API-key
+   backends, or ``credential_ref`` for ADC backends) — not an inline value.
+3. ADC and API-key auth are mutually exclusive on a single backend
+   (``credential_ref`` must not coexist with ``secret_ref`` / ``api_key_ref`` /
+   ``api_key_env``).
+
+The gate FAILS (exit 1) on any violation. There is no warn-only mode: a literal
+credential in committed config is never acceptable.
+
+COMPUTE handler usage (envelope-based)
+--------------------------------------
+::
+
+    from omnibase_core.validation.validator_backend_secret_discipline import (
+        HandlerBackendSecretDisciplineCompute,
+        ModelBackendSecretDisciplineInput,
+    )
+
+    handler = HandlerBackendSecretDisciplineCompute()
+    # Drive via envelope.payload (pure, deterministic, no filesystem I/O in handler)
+
+CLI / pre-commit usage
+----------------------
+::
+
+    python -m omnibase_core.validation.validator_backend_secret_discipline
+    python -m omnibase_core.validation.validator_backend_secret_discipline --json
+    python -m omnibase_core.validation.validator_backend_secret_discipline file1.yaml file2.yaml
+
+Port equivalence
+----------------
+Pre-port source SHA-256:
+    e2344b5cf9d696b7160ac3cbb9eca9380da4addc854fa5ccf1fd12f5da901aab
+
+The scanning logic (patterns, backend checks, mutual-exclusion check) is
+preserved verbatim. The handler wraps these pure functions behind the
+canonical COMPUTE interface; the CLI ``main()`` entry-point preserves the
+original invocation contract. No behavioral change — only the invocation
+surface is extended.
+
+Schema Version:
+    v1.0.0 — OMN-13305
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+from uuid import UUID, uuid4
+
+from yaml import YAMLError, safe_load
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.validation.model_backend_ref_violation import (
+    ModelBackendRefViolation,
+)
+from omnibase_core.models.validation.model_backend_secret_discipline_input import (
+    ModelBackendSecretDisciplineInput,
+)
+from omnibase_core.models.validation.model_backend_secret_discipline_output import (
+    ModelBackendSecretDisciplineOutput,
+)
+from omnibase_core.models.validation.model_credential_violation import (
+    ModelCredentialViolation,
+)
+
+if TYPE_CHECKING:
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+__all__ = [
+    "HandlerBackendSecretDisciplineCompute",
+    "NodeBackendSecretDisciplineCompute",
+    "ModelBackendSecretDisciplineInput",
+    "ModelBackendSecretDisciplineOutput",
+    "scan_literal_credentials",
+    "scan_bifrost_backends",
+    "build_report_from_files",
+]
+
+# ---------------------------------------------------------------------------
+# Constants — identical to the ported script
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT_MARKER = ".git"
+
+# Literal-credential signatures. A match means a real secret value leaked into
+# committed config — always a hard failure.
+_CREDENTIAL_LITERAL_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("pem-private-key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("service-account-private-key", re.compile(r'"private_key"\s*:')),
+    ("service-account-client-email", re.compile(r'"client_email"\s*:')),
+    ("bearer-token", re.compile(r"Bearer\s+[A-Za-z0-9._\-]{16,}")),
+    ("openai-style-key", re.compile(r"\bsk-[A-Za-z0-9]{20,}")),
+    ("google-api-key", re.compile(r"\bAIza[0-9A-Za-z._\-]{30,}")),
+    ("gcp-oauth-token", re.compile(r"\bya29\.[0-9A-Za-z._\-]{20,}")),
+)
+
+# Local backends do not require cloud auth.
+_LOCAL_TIERS: frozenset[str] = frozenset({"local"})
+
+# Tiers whose backends route to a provider that requires authentication.
+_CLOUD_TIERS: frozenset[str] = frozenset(
+    {"cheap_cloud", "cheap_frontier", "frontier_api"}
+)
+
+# Backend ids dispatched via subprocess (CLI agents) or using OAuth with no
+# committed secret — no secret/credential ref required.
+_NO_SECRET_BACKEND_IDS: frozenset[str] = frozenset(
+    {"cli-claude", "cli-opencode", "cloud-sonnet", "cloud-haiku"}
+)
+
+_CONFIG_SUFFIXES: frozenset[str] = frozenset({".yaml", ".yml", ".json"})
+_SUPPRESSION_TOKEN = "# backend-secret-ok:"
+
+# ---------------------------------------------------------------------------
+# Pure scanning functions — identical logic to ported script
+# ---------------------------------------------------------------------------
+
+
+def scan_literal_credentials(rel: str, text: str) -> list[ModelCredentialViolation]:
+    """Return all literal-credential violations found in *text*.
+
+    Args:
+        rel: Relative path label (used in violation messages).
+        text: Raw file content to scan.
+
+    Returns:
+        List of ``ModelCredentialViolation`` instances, one per matching line.
+    """
+    violations: list[ModelCredentialViolation] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _SUPPRESSION_TOKEN in line:
+            continue
+        for label, pattern in _CREDENTIAL_LITERAL_PATTERNS:
+            if pattern.search(line):
+                violations.append(
+                    ModelCredentialViolation(
+                        file=rel,
+                        line=lineno,
+                        kind=label,
+                        message=(
+                            f"{rel}:{lineno}: literal credential ({label}) in committed "
+                            f"config — credentials must live in the secret store, never "
+                            f"in routing-authority config"
+                        ),
+                    )
+                )
+    return violations
+
+
+def _backend_has_logical_ref(backend: dict[str, object]) -> bool:
+    for key in ("secret_ref", "api_key_ref", "api_key_env", "credential_ref"):
+        value = backend.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def _backend_auth_is_exclusive(backend: dict[str, object]) -> bool:
+    credential = backend.get("credential_ref")
+    has_credential = isinstance(credential, str) and bool(credential.strip())
+    has_api_key = False
+    for key in ("secret_ref", "api_key_ref", "api_key_env"):
+        value = backend.get(key)
+        if isinstance(value, str) and value.strip():
+            has_api_key = True
+            break
+    return not (has_credential and has_api_key)
+
+
+def scan_bifrost_backends(
+    rel: str, data: dict[str, object]
+) -> list[ModelBackendRefViolation]:
+    """Scan bifrost_delegation YAML data for missing/conflicting secret refs.
+
+    Args:
+        rel: Relative path label.
+        data: Parsed YAML mapping (expected to contain a ``backends`` list).
+
+    Returns:
+        List of ``ModelBackendRefViolation`` instances.
+    """
+    violations: list[ModelBackendRefViolation] = []
+    backends = data.get("backends", [])
+    if not isinstance(backends, list):
+        return [
+            ModelBackendRefViolation(
+                file=rel, message=f"{rel}: backends must be a list"
+            )
+        ]
+    for backend in backends:
+        if not isinstance(backend, dict):
+            continue
+        backend_data = cast("dict[str, object]", backend)
+        backend_id = backend_data.get("backend_id", "<unknown>")
+        tier = backend_data.get("tier", "")
+        if backend_id in _NO_SECRET_BACKEND_IDS:
+            continue
+        if tier in _LOCAL_TIERS:
+            continue
+        if tier in _CLOUD_TIERS and not _backend_has_logical_ref(backend_data):
+            violations.append(
+                ModelBackendRefViolation(
+                    file=rel,
+                    message=(
+                        f"{rel}: cloud backend {backend_id!r} (tier={tier!r}) requires a "
+                        f"logical secret reference (secret_ref/api_key_ref/api_key_env for "
+                        f"API-key auth, or credential_ref for ADC) — none declared"
+                    ),
+                )
+            )
+        if not _backend_auth_is_exclusive(backend_data):
+            violations.append(
+                ModelBackendRefViolation(
+                    file=rel,
+                    message=(
+                        f"{rel}: backend {backend_id!r} declares both credential_ref (ADC) "
+                        f"and api-key auth — they are mutually exclusive"
+                    ),
+                )
+            )
+    return violations
+
+
+def build_report_from_files(
+    config_contents: dict[str, str],
+) -> ModelBackendSecretDisciplineOutput:
+    """Build a ``ModelBackendSecretDisciplineOutput`` from pre-loaded file contents.
+
+    This is the pure core of the validator — no filesystem I/O. The caller
+    (EFFECT boundary or CLI) supplies the file contents.
+
+    Args:
+        config_contents: Map of relative-path → raw text.
+
+    Returns:
+        ``ModelBackendSecretDisciplineOutput`` with verdict and all findings.
+    """
+    literal_violations: list[ModelCredentialViolation] = []
+    backend_violations: list[ModelBackendRefViolation] = []
+    errors: list[str] = []
+
+    for rel, text in config_contents.items():
+        literal_violations.extend(scan_literal_credentials(rel, text))
+        if "backends" in text:
+            try:
+                parsed = safe_load(text)
+            except YAMLError as exc:
+                errors.append(f"{rel}: YAML parse error — {exc}")
+                continue
+            if isinstance(parsed, dict) and "backends" in parsed:
+                backend_violations.extend(
+                    scan_bifrost_backends(rel, cast("dict[str, object]", parsed))
+                )
+            elif not isinstance(parsed, dict):
+                errors.append(f"{rel}: did not parse to a mapping")
+
+    all_violations = literal_violations + backend_violations
+    return ModelBackendSecretDisciplineOutput(
+        literal_credential_violations=literal_violations,
+        backend_ref_violations=backend_violations,
+        errors=errors,
+        passed=len(all_violations) == 0 and len(errors) == 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# COMPUTE handler — ProtocolMessageHandler implementation
+# ---------------------------------------------------------------------------
+
+
+class HandlerBackendSecretDisciplineCompute:
+    """Backend-secret-discipline validator as a canonical COMPUTE handler.
+
+    Implements ``ProtocolMessageHandler`` (structural protocol, not base-class
+    inheritance). The handler is pure and deterministic: all file-loading I/O
+    happens at the EFFECT boundary (CLI / runner); the handler receives only
+    pre-loaded content via the envelope payload.
+
+    Node archetype: COMPUTE (pure, idempotent, no side effects).
+    """
+
+    # --- ProtocolMessageHandler protocol ---
+
+    @property
+    def handler_id(self) -> str:
+        return "node.backend-secret-discipline.compute"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        return EnumMessageCategory.COMMAND
+
+    @property
+    def message_types(self) -> set[str]:
+        return {"BackendSecretDisciplineCheck"}
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        return EnumNodeKind.COMPUTE
+
+    async def handle(
+        self,
+        envelope: ModelEventEnvelope[ModelBackendSecretDisciplineInput],
+    ) -> ModelHandlerOutput[ModelBackendSecretDisciplineOutput]:
+        """Run the backend-secret-discipline check and return a typed verdict.
+
+        The envelope payload supplies all file contents to scan; the handler
+        performs no filesystem I/O.
+
+        Args:
+            envelope: Input envelope carrying a
+                ``ModelBackendSecretDisciplineInput`` payload.
+
+        Returns:
+            ``ModelHandlerOutput[ModelBackendSecretDisciplineOutput]`` with
+            the verdict in ``result``.
+        """
+        payload: ModelBackendSecretDisciplineInput = envelope.payload
+        output = build_report_from_files(payload.config_contents)
+        # correlation_id is UUID | None on the envelope; for_compute requires UUID.
+        correlation_id: UUID = envelope.correlation_id or uuid4()
+        return ModelHandlerOutput.for_compute(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=correlation_id,
+            handler_id=self.handler_id,
+            result=output,
+        )
+
+
+NodeBackendSecretDisciplineCompute = HandlerBackendSecretDisciplineCompute
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point — preserves original invocation contract
+# ---------------------------------------------------------------------------
+
+
+def _find_repo_root(start: Path) -> Path:
+    candidate = start
+    while candidate != candidate.parent:
+        if (candidate / _REPO_ROOT_MARKER).exists():
+            return candidate
+        candidate = candidate.parent
+    return start
+
+
+def _run_on_files(paths: list[Path]) -> ModelBackendSecretDisciplineOutput:
+    """Run the check on the explicitly supplied file paths."""
+    repo_root = _find_repo_root(paths[0] if paths else Path.cwd())
+    contents: dict[str, str] = {}
+    for path in paths:
+        try:
+            rel = str(path.relative_to(repo_root))
+        except ValueError:
+            rel = str(path)
+        contents[rel] = path.read_text(encoding="utf-8")
+    return build_report_from_files(contents)
+
+
+def _git_changed_files(base: str) -> list[Path]:
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(2)  # error-ok: CLI exit code at the git-hook boundary
+    return [Path(p) for p in proc.stdout.splitlines() if p.strip()]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry-point for pre-commit hook and standalone invocation.
+
+    Returns:
+        0 on PASS, 1 on FAIL.
+    """
+    parser = argparse.ArgumentParser(
+        description="Backend secret-ref / credential-ref discipline gate (OMN-13305)"
+    )
+    parser.add_argument("--json", action="store_true", help="Print the report as JSON")
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Git base ref to diff HEAD against (CI mode); scans changed config files.",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help="Files to check (pre-commit passes staged filenames here)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.base is not None:
+        paths = _git_changed_files(args.base)
+    else:
+        paths = [Path(f) for f in args.filenames]
+
+    config_paths = [p for p in paths if p.suffix in _CONFIG_SUFFIXES]
+    if not config_paths:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "gate": "backend-secret-discipline",
+                        "passed": True,
+                        "note": "no config files to check",
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print("[backend-secret-discipline] PASS - no config files to check.")
+        return 0
+
+    report = _run_on_files(config_paths)
+
+    if args.json:
+        # Convert Pydantic models to dicts for JSON output.
+        print(
+            json.dumps(
+                {
+                    "ticket": report.ticket,
+                    "gate": report.gate,
+                    "literal_credential_violations": [
+                        v.model_dump() for v in report.literal_credential_violations
+                    ],
+                    "backend_ref_violations": [
+                        v.model_dump() for v in report.backend_ref_violations
+                    ],
+                    "errors": report.errors,
+                    "passed": report.passed,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0 if report.passed else 1
+
+    if report.passed:
+        print(
+            "[backend-secret-discipline] PASS — no literal credentials; every "
+            "authenticated cloud backend declares a logical secret/credential ref."
+        )
+        return 0
+
+    print("[backend-secret-discipline] FAIL")
+    for err in report.errors:
+        print(f"  error: {err}")
+    for cred_v in report.literal_credential_violations:
+        print(f"  literal-credential: {cred_v.message}")
+    for ref_v in report.backend_ref_violations:
+        print(f"  backend-ref: {ref_v.message}")
+    print(
+        "\nFix: keep credential VALUES in the secret store; declare only logical "
+        "refs (secret_ref / credential_ref) in routing-authority config."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/validation/test_validator_backend_secret_discipline.py
+++ b/tests/unit/validation/test_validator_backend_secret_discipline.py
@@ -58,19 +58,19 @@ backends:
     endpoint_url: http://localhost:8080/v1/chat/completions
 """
 
-_LEAKED_PEM_YAML = """\
-backends:
-  - backend_id: cloud-bad
-    tier: cheap_cloud
-    private_key: "-----BEGIN PRIVATE KEY-----MIIABC"
-"""
+_LEAKED_PEM_YAML = (
+    "backends:\n"
+    "  - backend_id: cloud-bad\n"
+    "    tier: cheap_cloud\n"
+    '    private_key: "-----BEGIN PRIVATE KEY-----MIIABC"\n'  # pragma: allowlist secret
+)
 
-_LEAKED_SA_PRIVATE_KEY_YAML = """\
-backends:
-  - backend_id: cloud-bad
-    tier: cheap_cloud
-    config: '"private_key": "-----BEGIN PRIVATE KEY-----ABC"'
-"""
+_LEAKED_SA_PRIVATE_KEY_YAML = (
+    "backends:\n"
+    "  - backend_id: cloud-bad\n"
+    "    tier: cheap_cloud\n"
+    '    config: \'"private_key": "-----BEGIN PRIVATE KEY-----ABC"\'\n'  # pragma: allowlist secret
+)
 
 _LEAKED_CLIENT_EMAIL_YAML = """\
 value: '"client_email": "svc@proj.iam.gserviceaccount.com"'
@@ -81,13 +81,11 @@ config:
   auth_header: "Bearer ya29.LONG_TOKEN_HERE_ABCDEFGHIJKLMNOPQRSTU"
 """
 
-_LEAKED_OPENAI_KEY_YAML = """\
-api_key: "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst"
-"""
+_LEAKED_OPENAI_KEY_YAML = 'api_key: "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst"\n'  # pragma: allowlist secret
 
-_LEAKED_GOOGLE_KEY_YAML = """\
-api_key: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"
-"""
+_LEAKED_GOOGLE_KEY_YAML = (
+    'api_key: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"\n'  # pragma: allowlist secret
+)
 
 _LEAKED_GCP_OAUTH_YAML = """\
 token: "ya29.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst"
@@ -444,7 +442,7 @@ def test_cli_fails_on_leaked_credential(tmp_path: Path) -> None:
     """Fail-closed proof: planted literal private_key → CLI exits 1."""
     config = tmp_path / "leaked.yaml"
     config.write_text(
-        'service_account: \'"private_key": "-----BEGIN PRIVATE KEY-----MIIABC"\'\n',
+        'service_account: \'"private_key": "-----BEGIN PRIVATE KEY-----MIIABC"\'\n',  # pragma: allowlist secret
         encoding="utf-8",
     )
 
@@ -495,7 +493,7 @@ def test_cli_json_flag_clean(tmp_path: Path) -> None:
 def test_cli_json_flag_violation(tmp_path: Path) -> None:
     config = tmp_path / "bad.yaml"
     config.write_text(
-        'value: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"\n',
+        'value: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"\n',  # pragma: allowlist secret
         encoding="utf-8",
     )
 

--- a/tests/unit/validation/test_validator_backend_secret_discipline.py
+++ b/tests/unit/validation/test_validator_backend_secret_discipline.py
@@ -1,0 +1,541 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ValidatorBackendSecretDiscipline (OMN-13305, ported from OMN-12971).
+
+Covers:
+- scan_literal_credentials: detects all 7 literal-credential patterns
+- scan_bifrost_backends: detects missing secret-ref and mutual-exclusion violations
+- build_report_from_files: PASS on clean input, FAIL on violation
+- HandlerBackendSecretDisciplineCompute handler: correct protocol properties + async handle
+- ModelBackendSecretDisciplineInput / Output: frozen Pydantic models
+- CLI entry-point: --json flag, exit codes
+- Fail-closed proof: planted SA-JSON private_key → gate red; clean → green
+
+Port equivalence note
+---------------------
+Pre-port source SHA-256 (omnimarket/scripts/ci/check_backend_secret_discipline.py):
+    e2344b5cf9d696b7160ac3cbb9eca9380da4addc854fa5ccf1fd12f5da901aab
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.validation.validator_backend_secret_discipline import (
+    HandlerBackendSecretDisciplineCompute,
+    ModelBackendSecretDisciplineInput,
+    ModelBackendSecretDisciplineOutput,
+    build_report_from_files,
+    scan_bifrost_backends,
+    scan_literal_credentials,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CLEAN_BIFROST_YAML = """\
+backends:
+  - backend_id: cloud-gemini-flash
+    tier: cheap_cloud
+    secret_ref: llm.gemini.api_key
+    endpoint_url: null
+  - backend_id: cloud-vertex-gemini
+    tier: cheap_frontier
+    secret_ref: llm.vertex.access_token
+    endpoint_url: null
+  - backend_id: local-llm
+    tier: local
+    endpoint_url: http://localhost:8080/v1/chat/completions
+"""
+
+_LEAKED_PEM_YAML = """\
+backends:
+  - backend_id: cloud-bad
+    tier: cheap_cloud
+    private_key: "-----BEGIN PRIVATE KEY-----MIIABC"
+"""
+
+_LEAKED_SA_PRIVATE_KEY_YAML = """\
+backends:
+  - backend_id: cloud-bad
+    tier: cheap_cloud
+    config: '"private_key": "-----BEGIN PRIVATE KEY-----ABC"'
+"""
+
+_LEAKED_CLIENT_EMAIL_YAML = """\
+value: '"client_email": "svc@proj.iam.gserviceaccount.com"'
+"""
+
+_LEAKED_BEARER_YAML = """\
+config:
+  auth_header: "Bearer ya29.LONG_TOKEN_HERE_ABCDEFGHIJKLMNOPQRSTU"
+"""
+
+_LEAKED_OPENAI_KEY_YAML = """\
+api_key: "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst"
+"""
+
+_LEAKED_GOOGLE_KEY_YAML = """\
+api_key: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"
+"""
+
+_LEAKED_GCP_OAUTH_YAML = """\
+token: "ya29.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst"
+"""
+
+_MISSING_REF_BIFROST_YAML = """\
+backends:
+  - backend_id: cloud-rogue
+    tier: cheap_cloud
+    endpoint_url: https://example.com/v1/chat/completions
+"""
+
+_MUTUAL_EXCLUSION_BIFROST_YAML = """\
+backends:
+  - backend_id: cloud-both
+    tier: cheap_cloud
+    credential_ref: llm.vertex.adc
+    secret_ref: llm.gemini.api_key
+"""
+
+_NO_SECRET_BACKEND_YAML = """\
+backends:
+  - backend_id: cli-claude
+    tier: cheap_frontier
+"""
+
+_LOCAL_BACKEND_YAML = """\
+backends:
+  - backend_id: local-llm
+    tier: local
+    endpoint_url: http://localhost:8080/v1/chat/completions
+"""
+
+
+# ---------------------------------------------------------------------------
+# scan_literal_credentials — positive (violation) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_detects_pem_private_key() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_PEM_YAML)
+    assert any("pem-private-key" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_service_account_private_key() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_SA_PRIVATE_KEY_YAML)
+    assert any("service-account-private-key" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_service_account_client_email() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_CLIENT_EMAIL_YAML)
+    assert any("service-account-client-email" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_bearer_token() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_BEARER_YAML)
+    assert any("bearer-token" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_openai_style_key() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_OPENAI_KEY_YAML)
+    assert any("openai-style-key" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_google_api_key() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_GOOGLE_KEY_YAML)
+    assert any("google-api-key" in v.kind for v in violations)
+
+
+@pytest.mark.unit
+def test_detects_gcp_oauth_token() -> None:
+    violations = scan_literal_credentials("fake.yaml", _LEAKED_GCP_OAUTH_YAML)
+    assert any("gcp-oauth-token" in v.kind for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# scan_literal_credentials — negative (clean) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clean_yaml_no_literal_violations() -> None:
+    violations = scan_literal_credentials("clean.yaml", _CLEAN_BIFROST_YAML)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_secret_ref_names_not_flagged() -> None:
+    """A secret_ref NAME (not value) must not be detected as a credential."""
+    text = "secret_ref: llm.gemini.api_key\n"
+    violations = scan_literal_credentials("ok.yaml", text)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# scan_bifrost_backends — positive (violation) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cloud_backend_missing_ref_detected() -> None:
+    import yaml
+
+    data = yaml.safe_load(_MISSING_REF_BIFROST_YAML)
+    violations = scan_bifrost_backends("fake.yaml", data)
+    assert any("requires a logical secret reference" in v.message for v in violations)
+
+
+@pytest.mark.unit
+def test_mutual_exclusion_detected() -> None:
+    import yaml
+
+    data = yaml.safe_load(_MUTUAL_EXCLUSION_BIFROST_YAML)
+    violations = scan_bifrost_backends("fake.yaml", data)
+    assert any("mutually exclusive" in v.message for v in violations)
+
+
+@pytest.mark.unit
+def test_backends_not_list_error() -> None:
+    violations = scan_bifrost_backends("fake.yaml", {"backends": "not-a-list"})
+    assert len(violations) == 1
+    assert "must be a list" in violations[0].message
+
+
+# ---------------------------------------------------------------------------
+# scan_bifrost_backends — negative (clean) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clean_bifrost_no_backend_violations() -> None:
+    import yaml
+
+    data = yaml.safe_load(_CLEAN_BIFROST_YAML)
+    violations = scan_bifrost_backends("clean.yaml", data)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_no_secret_backend_ids_exempt() -> None:
+    """cli-claude / cli-opencode are exempt from the secret-ref requirement."""
+    import yaml
+
+    data = yaml.safe_load(_NO_SECRET_BACKEND_YAML)
+    violations = scan_bifrost_backends("ok.yaml", data)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_local_tier_exempt() -> None:
+    import yaml
+
+    data = yaml.safe_load(_LOCAL_BACKEND_YAML)
+    violations = scan_bifrost_backends("ok.yaml", data)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_api_key_env_counts_as_logical_ref() -> None:
+    import yaml
+
+    data = yaml.safe_load(
+        "backends:\n  - backend_id: cloud-x\n    tier: cheap_cloud\n    api_key_env: SOME_ENV_VAR\n"
+    )
+    violations = scan_bifrost_backends("ok.yaml", data)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_credential_ref_alone_counts_as_logical_ref() -> None:
+    import yaml
+
+    data = yaml.safe_load(
+        "backends:\n  - backend_id: cloud-x\n    tier: cheap_cloud\n    credential_ref: llm.vertex.adc\n"
+    )
+    violations = scan_bifrost_backends("ok.yaml", data)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# build_report_from_files — integration-level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_report_passes_on_clean_input() -> None:
+    report = build_report_from_files({"bifrost_delegation.yaml": _CLEAN_BIFROST_YAML})
+    assert report.passed is True
+    assert report.literal_credential_violations == []
+    assert report.backend_ref_violations == []
+    assert report.errors == []
+
+
+@pytest.mark.unit
+def test_report_fails_on_leaked_credential() -> None:
+    """Fail-closed proof: literal SA private_key → gate red."""
+    report = build_report_from_files(
+        {"routing_tiers.yaml": _LEAKED_SA_PRIVATE_KEY_YAML}
+    )
+    assert report.passed is False
+    assert len(report.literal_credential_violations) >= 1
+
+
+@pytest.mark.unit
+def test_report_fails_on_missing_backend_ref() -> None:
+    """Fail-closed proof: cloud backend without secret-ref → gate red."""
+    report = build_report_from_files(
+        {"bifrost_delegation.yaml": _MISSING_REF_BIFROST_YAML}
+    )
+    assert report.passed is False
+    assert len(report.backend_ref_violations) >= 1
+
+
+@pytest.mark.unit
+def test_report_fails_on_mutual_exclusion() -> None:
+    report = build_report_from_files(
+        {"bifrost_delegation.yaml": _MUTUAL_EXCLUSION_BIFROST_YAML}
+    )
+    assert report.passed is False
+    assert any("mutually exclusive" in v.message for v in report.backend_ref_violations)
+
+
+@pytest.mark.unit
+def test_report_empty_config_contents_passes() -> None:
+    """No files to check → trivially passed (no violations possible)."""
+    report = build_report_from_files({})
+    assert report.passed is True
+
+
+@pytest.mark.unit
+def test_report_yaml_parse_error_recorded() -> None:
+    report = build_report_from_files({"bifrost_delegation.yaml": "backends: ["})
+    assert report.passed is False
+    assert len(report.errors) >= 1
+
+
+# ---------------------------------------------------------------------------
+# COMPUTE handler — protocol properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_handler_protocol_properties() -> None:
+    handler = HandlerBackendSecretDisciplineCompute()
+    assert handler.handler_id == "node.backend-secret-discipline.compute"
+    assert handler.node_kind == EnumNodeKind.COMPUTE
+    assert "BackendSecretDisciplineCheck" in handler.message_types
+
+
+@pytest.mark.unit
+def test_handler_handle_returns_compute_output() -> None:
+    """Handler returns a ModelHandlerOutput with a ModelBackendSecretDisciplineOutput result."""
+    from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+
+    handler = HandlerBackendSecretDisciplineCompute()
+
+    payload = ModelBackendSecretDisciplineInput(
+        config_contents={"bifrost_delegation.yaml": _CLEAN_BIFROST_YAML}
+    )
+    envelope = MagicMock()
+    envelope.payload = payload
+    envelope.envelope_id = uuid4()
+    envelope.correlation_id = uuid4()
+
+    output: ModelHandlerOutput[ModelBackendSecretDisciplineOutput] = asyncio.run(
+        handler.handle(envelope)
+    )
+
+    assert output.node_kind == EnumNodeKind.COMPUTE
+    assert output.result is not None
+    assert isinstance(output.result, ModelBackendSecretDisciplineOutput)
+    assert output.result.passed is True
+
+
+@pytest.mark.unit
+def test_handler_handle_fail_closed_on_violation() -> None:
+    """Handler result.passed=False when payload contains a literal credential."""
+    from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+
+    handler = HandlerBackendSecretDisciplineCompute()
+    payload = ModelBackendSecretDisciplineInput(
+        config_contents={"routing.yaml": _LEAKED_SA_PRIVATE_KEY_YAML}
+    )
+    envelope = MagicMock()
+    envelope.payload = payload
+    envelope.envelope_id = uuid4()
+    envelope.correlation_id = uuid4()
+
+    output: ModelHandlerOutput[ModelBackendSecretDisciplineOutput] = asyncio.run(
+        handler.handle(envelope)
+    )
+    assert output.result is not None
+    assert output.result.passed is False
+    assert len(output.result.literal_credential_violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model — frozen / extra=forbid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_input_model_frozen() -> None:
+    inp = ModelBackendSecretDisciplineInput(config_contents={"a.yaml": "x: 1"})
+    with pytest.raises(Exception):
+        inp.config_contents = {}  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_output_model_is_json_ledger_safe() -> None:
+    from omnibase_core.models.dispatch.model_handler_output import _is_json_ledger_safe
+
+    output = ModelBackendSecretDisciplineOutput(passed=True)
+    assert _is_json_ledger_safe(output)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point — exit codes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_passes_on_clean_tree(tmp_path: Path) -> None:
+    """CLI exits 0 when no YAML violations in supplied files."""
+    config = tmp_path / "clean.yaml"
+    config.write_text("key: value\n", encoding="utf-8")
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_backend_secret_discipline",
+            str(config),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Expected 0, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_cli_fails_on_leaked_credential(tmp_path: Path) -> None:
+    """Fail-closed proof: planted literal private_key → CLI exits 1."""
+    config = tmp_path / "leaked.yaml"
+    config.write_text(
+        'service_account: \'"private_key": "-----BEGIN PRIVATE KEY-----MIIABC"\'\n',
+        encoding="utf-8",
+    )
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_backend_secret_discipline",
+            str(config),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, (
+        f"Expected 1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    assert "FAIL" in result.stdout or "literal-credential" in result.stdout
+
+
+@pytest.mark.unit
+def test_cli_json_flag_clean(tmp_path: Path) -> None:
+    config = tmp_path / "ok.yaml"
+    config.write_text("key: value\n", encoding="utf-8")
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_backend_secret_discipline",
+            "--json",
+            str(config),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["passed"] is True
+
+
+@pytest.mark.unit
+def test_cli_json_flag_violation(tmp_path: Path) -> None:
+    config = tmp_path / "bad.yaml"
+    config.write_text(
+        'value: "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"\n',
+        encoding="utf-8",
+    )
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_backend_secret_discipline",
+            "--json",
+            str(config),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["passed"] is False
+    assert len(data["literal_credential_violations"]) >= 1
+
+
+@pytest.mark.unit
+def test_cli_no_yaml_files_passes(tmp_path: Path) -> None:
+    """No YAML files in staged set → trivially PASS."""
+    py_file = tmp_path / "module.py"
+    py_file.write_text("x = 1\n", encoding="utf-8")
+
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validation.validator_backend_secret_discipline",
+            str(py_file),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0

--- a/tests/validation/test_remote_hook_exposure_omn13305.py
+++ b/tests/validation/test_remote_hook_exposure_omn13305.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Assert OMN-13305 backend-secret-discipline remote hook exposure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HOOKS_FILE = REPO_ROOT / ".pre-commit-hooks.yaml"
+
+
+@pytest.fixture(scope="module")
+def hooks() -> dict[str, dict[str, object]]:
+    raw = yaml.safe_load(HOOKS_FILE.read_text(encoding="utf-8"))
+    assert isinstance(raw, list), ".pre-commit-hooks.yaml must be a list of hooks"
+    by_id: dict[str, dict[str, object]] = {}
+    for entry in raw:
+        assert isinstance(entry, dict)
+        hook_id = entry.get("id")
+        assert isinstance(hook_id, str)
+        by_id[hook_id] = entry
+    return by_id
+
+
+@pytest.mark.unit
+def test_backend_secret_discipline_compute_hook_exported(
+    hooks: dict[str, dict[str, object]],
+) -> None:
+    hook = hooks["check-backend-secret-discipline"]
+    assert hook["language"] == "python"
+    assert (
+        hook["entry"]
+        == "python -m omnibase_core.validation.validator_backend_secret_discipline"
+    )
+    assert hook["files"] == r"\.(ya?ml|json)$"
+    assert hook["pass_filenames"] is True
+
+
+@pytest.mark.unit
+def test_existing_backend_secret_hook_alias_retained(
+    hooks: dict[str, dict[str, object]],
+) -> None:
+    hook = hooks["backend-secret-discipline"]
+    assert (
+        hook["entry"] == "python -m omnibase_core.validators.backend_secret_discipline"
+    )


### PR DESCRIPTION
## Summary
- add canonical `validator_backend_secret_discipline` COMPUTE handler with typed input/output/finding models
- add `node_backend_secret_discipline_compute` contract/handler export and onex node entry point
- expose remote hook `check-backend-secret-discipline` while retaining the existing `backend-secret-discipline` hook alias
- add unit and remote-hook exposure tests for the new core surface

Evidence-Ticket: OMN-13305
Evidence-Source: OCC#2821

## Verification
- `uv run pre-commit run` — PASS
- `uv run pytest tests/validation/test_remote_hook_exposure_omn13305.py tests/validation/test_remote_hook_exposure_omn13287.py tests/unit/validation/test_validator_backend_secret_discipline.py tests/unit/validators/test_backend_secret_discipline.py -q` — 61 passed
- `uv run pre-commit run check-backend-secret-discipline --files .pre-commit-config.yaml .pre-commit-hooks.yaml pyproject.toml` — PASS
- fail-closed probe: planted literal service-account private key exits 1
- clean probe: logical `secret_ref` backend config exits 0
- `uv run mypy src/ --strict --show-error-codes --no-error-summary` — fails on current-dev pre-existing errors in `contract_loader.py` and `cli_install.py`; no OMN-13305 files reported

## Notes
- Scope intentionally narrowed to the core validator + hook export. Downstream consumer wiring/deletion should follow after this core hook lands and can be pinned to a merge SHA.