### PR TITLE
feat(OMN-13355): add ModelPremiumCounterfactual wire DTO + task-delegated event field

### DIFF
--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -37,6 +37,9 @@ from omnibase_core.models.delegation.wire.model_orchestrator_intents import (
     ModelQualityGateIntent,
     ModelRoutingIntent,
 )
+from omnibase_core.models.delegation.wire.model_premium_counterfactual import (
+    ModelPremiumCounterfactual,
+)
 from omnibase_core.models.delegation.wire.model_quality_gate import (
     EnumQualityGateCategory,
     ModelQualityGateInput,
@@ -75,6 +78,7 @@ __all__: list[str] = [
     "ModelDelegationShadowConfig",
     "ModelInferenceIntent",
     "ModelInferenceResponseData",
+    "ModelPremiumCounterfactual",
     "ModelQualityGateInput",
     "ModelQualityGateIntent",
     "ModelQualityGateResult",

--- a/src/omnibase_core/models/delegation/wire/model_premium_counterfactual.py
+++ b/src/omnibase_core/models/delegation/wire/model_premium_counterfactual.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pinned premium counterfactual for auditable delegation savings (OMN-13355).
+
+When a cheaper tier serves a delegated task the premium (frontier) model never
+runs, so the saving is a *modeled counterfactual*, not a measurement of a real
+premium call. This DTO pins the counterfactual to an auditable pricing-manifest
+value so the saving can be defended:
+
+    savings_usd = counterfactual_cost_usd - actual_cost_usd
+
+``counterfactual_cost_usd`` is a PINNED price-table value (USD per 1,000 tokens,
+from the canonical pricing manifest) multiplied by the measured token counts.
+There is NO live premium API call — the organisation holds no Anthropic/OpenAI
+key and provisions none. The pinned model identifier, per-1k input/output price,
+and the manifest ``effective_date`` are all carried so a verifier can recompute
+the number from the persisted provenance.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelPremiumCounterfactual(BaseModel):
+    """Pinned premium-model counterfactual for one delegated task.
+
+    Every field is provenance: the model whose price was pinned, the two per-1k
+    token prices read from the pricing manifest, the manifest ``as_of``
+    (effective_date) the price was pinned to, the measured token counts, and the
+    derived counterfactual cost. ``counterfactual_cost_usd`` always equals
+    ``price_in_per_1k * tokens_in/1000 + price_out_per_1k * tokens_out/1000`` and
+    is recomputable from the other fields. No field is defaulted to a placeholder
+    — a counterfactual either carries its full pinned provenance or is ``None``
+    on the carrying model.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    model: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Premium model identifier whose price was pinned for the "
+            "counterfactual (e.g. 'claude-opus-4-6')."
+        ),
+    )
+    price_in_per_1k: Decimal = Field(
+        ...,
+        ge=Decimal("0"),
+        description="Pinned input-token price in USD per 1,000 tokens.",
+    )
+    price_out_per_1k: Decimal = Field(
+        ...,
+        ge=Decimal("0"),
+        description="Pinned output-token price in USD per 1,000 tokens.",
+    )
+    as_of: str = Field(
+        ...,
+        min_length=10,
+        max_length=10,
+        description=(
+            "ISO-8601 date (YYYY-MM-DD) the pinned price was effective, carried "
+            "verbatim from the pricing manifest entry's effective_date."
+        ),
+    )
+    tokens_in: int = Field(
+        ...,
+        ge=0,
+        description="Measured input (prompt) tokens used to compute the counterfactual.",
+    )
+    tokens_out: int = Field(
+        ...,
+        ge=0,
+        description="Measured output (completion) tokens used to compute the counterfactual.",
+    )
+    counterfactual_cost_usd: Decimal = Field(
+        ...,
+        ge=Decimal("0"),
+        description=(
+            "Pinned counterfactual cost = price_in_per_1k * tokens_in/1000 + "
+            "price_out_per_1k * tokens_out/1000. Recomputable from the other fields."
+        ),
+    )
+    pricing_source: str = Field(
+        default="pricing_manifest",
+        min_length=1,
+        description=(
+            "Provenance of the pinned price (e.g. 'pricing_manifest' for the "
+            "canonical manifest, 'calibration' for a measured real-premium run)."
+        ),
+    )
+    measured: bool = Field(
+        default=False,
+        description=(
+            "True only when tokens_in/tokens_out were measured from a real premium "
+            "run (the OMN-13355 calibration hook); False for the pinned-price "
+            "counterfactual computed from the delegated model's own token counts."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_cost_recomputable(self) -> ModelPremiumCounterfactual:
+        """Reject rows whose stored cost does not match the pinned price * tokens.
+
+        Guards the audit invariant: a verifier recomputing the cost from the
+        pinned prices and measured tokens must reproduce ``counterfactual_cost_usd``
+        exactly. A tiny tolerance absorbs Decimal rounding at the recorded scale.
+        """
+        recomputed = (
+            self.price_in_per_1k * Decimal(self.tokens_in)
+            + self.price_out_per_1k * Decimal(self.tokens_out)
+        ) / Decimal("1000")
+        if abs(recomputed - self.counterfactual_cost_usd) > Decimal("0.000001"):
+            raise ValueError(
+                "counterfactual_cost_usd must equal "
+                "price_in_per_1k * tokens_in/1000 + price_out_per_1k * tokens_out/1000 "
+                f"(recomputed={recomputed}, stored={self.counterfactual_cost_usd})"
+            )
+        return self
+
+
+__all__: list[str] = ["ModelPremiumCounterfactual"]

--- a/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
+++ b/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
@@ -9,6 +9,9 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.models.delegation.wire.model_premium_counterfactual import (
+    ModelPremiumCounterfactual,
+)
 from omnibase_core.topics import TopicBase
 
 TASK_DELEGATED_TOPIC_V1 = TopicBase.TASK_DELEGATED
@@ -118,6 +121,20 @@ class ModelTaskDelegatedEvent(BaseModel):
         ge=0.0,
         description="Total estimated cost across all attempts.",
     )
+    premium_counterfactual: ModelPremiumCounterfactual | None = Field(
+        default=None,
+        description=(
+            "Pinned premium-model counterfactual for this task (OMN-13355). Carries "
+            "{model, price_in_per_1k, price_out_per_1k, as_of, tokens, "
+            "counterfactual_cost_usd} so cost_savings_usd (= counterfactual_cost_usd - "
+            "cost_usd) is auditable rather than an opaque estimate. None when no "
+            "pinned premium price could be resolved for the run."
+        ),
+    )
 
 
-__all__: list[str] = ["TASK_DELEGATED_TOPIC_V1", "ModelTaskDelegatedEvent"]
+__all__: list[str] = [
+    "TASK_DELEGATED_TOPIC_V1",
+    "ModelPremiumCounterfactual",
+    "ModelTaskDelegatedEvent",
+]

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import pytest
 from pydantic import ValidationError
@@ -28,6 +29,7 @@ from omnibase_core.models.delegation.wire import (
     ModelDelegationShadowConfig,
     ModelInferenceIntent,
     ModelInferenceResponseData,
+    ModelPremiumCounterfactual,
     ModelQualityGateInput,
     ModelQualityGateIntent,
     ModelQualityGateResult,
@@ -548,6 +550,96 @@ class TestModelTaskDelegatedEvent:
 
     def test_topic_constant(self) -> None:
         assert TASK_DELEGATED_TOPIC_V1 == "onex.evt.omniclaude.task-delegated.v1"
+
+    def test_premium_counterfactual_default_none(self) -> None:
+        event = ModelTaskDelegatedEvent(
+            timestamp="2026-05-26T00:00:00Z",
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            delegated_to="local_qwen3",
+            quality_gate_passed=True,
+        )
+        assert event.premium_counterfactual is None
+
+    def test_carries_premium_counterfactual(self) -> None:
+        counterfactual = ModelPremiumCounterfactual(
+            model="claude-opus-4-6",
+            price_in_per_1k=Decimal("0.015"),
+            price_out_per_1k=Decimal("0.075"),
+            as_of="2026-02-01",
+            tokens_in=1000,
+            tokens_out=500,
+            counterfactual_cost_usd=Decimal("0.0525"),
+        )
+        event = ModelTaskDelegatedEvent(
+            timestamp="2026-05-26T00:00:00Z",
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            delegated_to="local_qwen3",
+            quality_gate_passed=True,
+            cost_usd=0.0,
+            cost_savings_usd=0.0525,
+            premium_counterfactual=counterfactual,
+        )
+        assert event.premium_counterfactual is not None
+        assert event.premium_counterfactual.model == "claude-opus-4-6"
+        assert event.premium_counterfactual.as_of == "2026-02-01"
+        # cost_savings_usd is the auditable counterfactual - actual.
+        assert event.premium_counterfactual.counterfactual_cost_usd - Decimal(
+            str(event.cost_usd)
+        ) == Decimal(str(event.cost_savings_usd))
+
+
+@pytest.mark.unit
+class TestModelPremiumCounterfactual:
+    """Auditable pinned premium counterfactual provenance (OMN-13355)."""
+
+    def _make(self, **overrides: object) -> ModelPremiumCounterfactual:
+        kwargs: dict[str, object] = {
+            "model": "claude-opus-4-6",
+            "price_in_per_1k": Decimal("0.015"),
+            "price_out_per_1k": Decimal("0.075"),
+            "as_of": "2026-02-01",
+            "tokens_in": 1000,
+            "tokens_out": 500,
+            "counterfactual_cost_usd": Decimal("0.0525"),
+        }
+        kwargs.update(overrides)
+        return ModelPremiumCounterfactual(**kwargs)  # type: ignore[arg-type]
+
+    def test_provenance_fields_present(self) -> None:
+        cf = self._make()
+        assert cf.model == "claude-opus-4-6"
+        assert cf.price_in_per_1k == Decimal("0.015")
+        assert cf.price_out_per_1k == Decimal("0.075")
+        assert cf.as_of == "2026-02-01"
+        assert cf.tokens_in == 1000
+        assert cf.tokens_out == 500
+        assert cf.counterfactual_cost_usd == Decimal("0.0525")
+        assert cf.pricing_source == "pricing_manifest"
+        assert cf.measured is False
+
+    def test_cost_is_recomputable(self) -> None:
+        cf = self._make()
+        recomputed = (
+            cf.price_in_per_1k * Decimal(cf.tokens_in)
+            + cf.price_out_per_1k * Decimal(cf.tokens_out)
+        ) / Decimal("1000")
+        assert recomputed == cf.counterfactual_cost_usd
+
+    def test_rejects_inconsistent_cost(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make(counterfactual_cost_usd=Decimal("99.0"))
+
+    def test_frozen(self) -> None:
+        cf = self._make()
+        with pytest.raises(ValidationError):
+            cf.model = "gpt-4o"  # type: ignore[misc]
+
+    def test_calibration_measured_flag(self) -> None:
+        cf = self._make(pricing_source="calibration", measured=True)
+        assert cf.measured is True
+        assert cf.pricing_source == "calibration"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## OMN-13355 — Auditable premium counterfactual (core wire DTO)

Evidence-Source: OCC#2845
Evidence-Ticket: OMN-13355

Part 1 of 4 (omnibase_core) for the auditable premium-counterfactual carry path.

### What

Adds `ModelPremiumCounterfactual` to the canonical delegation wire package and a
`premium_counterfactual: ModelPremiumCounterfactual | None` field on the durable
`ModelTaskDelegatedEvent` (the event named in the OMN-13355 DoD).

The counterfactual pins `{model, price_in_per_1k, price_out_per_1k, as_of,
tokens_in, tokens_out, counterfactual_cost_usd}` so the delegation saving
(`cost_savings_usd = counterfactual_cost_usd - cost_usd`) is **auditable** rather
than an opaque estimate. A frozen model-validator rejects any row whose stored
cost does not equal `price_in_per_1k * tokens_in/1000 + price_out_per_1k *
tokens_out/1000`, so a verifier can recompute the number from the persisted
provenance.

No live premium API call is made — the price/`as_of` come from the canonical
pricing manifest (key-free, OAuth-only org). `pricing_source` / `measured`
distinguish the pinned-price counterfactual from a calibrated real-premium run.

### Carry path

This is the upstream model. Downstream PRs (omnimarket build+persist,
omnibase_infra 0017 migration, omnidash reader) cite the same ticket.

### Tests

`tests/unit/models/delegation/wire/test_delegation_wire_models.py`:
`TestModelPremiumCounterfactual` (provenance non-null, cost recomputable,
rejects inconsistent cost, frozen, calibration flag) +
`TestModelTaskDelegatedEvent` (default None, carries counterfactual, saving =
counterfactual - actual). 69 passed locally; `mypy --strict` clean.

PRs are no-merge — left green for the merge sweep.

