### PR TITLE
feat(OMN-13223): per-dialect Contract Graph IR adapters

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -35,8 +35,8 @@ allowed_files:
       structural fact — descriptor.agent_invocation — from the enclosing node contract.yaml. contract.yaml
       schemas vary by node_type (ModelContractCompute/Effect/Reducer/Orchestrator) and the gate must tolerate
       ANY contract shape while reading a single boolean; no single Pydantic model applies, so raw yaml.safe_load
-      extracts the flat fact (same architectural pattern as validator_banned_compose_vars.py and
-      mixin_contract_publisher.py). The result is coerced to a strict bool (descriptor.get(...) is True).
+      extracts the flat fact (same architectural pattern as validator_banned_compose_vars.py and mixin_contract_publisher.py).
+      The result is coerced to a strict bool (descriptor.get(...) is True).
     added: "2026-06-18"
     review: "2026-12-13"
 

--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -3,29 +3,31 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13130"
 title: "feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core"
 summary: >
-  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract
-  primitives to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract,
-  PermissionContract, EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason
-  (four values mirroring omnidash/shared/types/chart-config.ts exactly) and supporting enums
-  (EnumBindingOrderDirection, EnumEvidenceGateMoment, EnumRendererInteractionModel, EnumAccessibilityTier).
-  ActionContract COMPOSES the existing ModelGate approval primitive (no duplication, per the ADR);
-  EvidenceRequirementContract composes the OCC ModelEvidenceRequirement. ModelGate and ModelGateSpec
-  source are untouched. All six models registered in scripts/emit_ts_types.py for Stage 2 TS codegen.
-  Additive only — every existing omnidash manifest still validates and the dashboard export-surface test
-  was extended (not broken).
+  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract primitives
+  to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract, PermissionContract,
+  EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason (four values mirroring
+  omnidash/shared/types/chart-config.ts exactly) and supporting enums (EnumBindingOrderDirection, EnumEvidenceGateMoment,
+  EnumRendererInteractionModel, EnumAccessibilityTier). ActionContract COMPOSES the existing ModelGate
+  approval primitive (no duplication, per the ADR); EvidenceRequirementContract composes the OCC ModelEvidenceRequirement.
+  ModelGate and ModelGateSpec source are untouched. All six models registered in scripts/emit_ts_types.py
+  for Stage 2 TS codegen. Additive only — every existing omnidash manifest still validates and the dashboard
+  export-surface test was extended (not broken).
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "public_api"
 evidence_requirements:
   - kind: "tests"
-    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
-    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py -q"
+    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid,
+      required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
+    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py
+      -q"
   - kind: "tests"
     description: "Full models + enums suites pass with no regression (25095 passed, 5 skipped)"
     command: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
   - kind: "ci"
-    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing on origin/dev in contract_loader.py and cli_install.py)"
+    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing
+      on origin/dev in contract_loader.py and cli_install.py)"
     command: "uv run mypy src/ --strict"
   - kind: "ci"
     description: "ruff lint and format pass on src/ tests/"
@@ -39,7 +41,9 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-ui-primitive-tests"
-    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises, extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not duplicated"
+    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises,
+      extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not
+      duplicated"
     source: "manual"
     checks:
       - check_type: "command"
@@ -47,7 +51,9 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '36 passed'"
   - id: "dod-additive-no-regression"
-    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected, zero import errors)"
+    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard
+      export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected,
+      zero import errors)"
     source: "manual"
     checks:
       - check_type: "command"
@@ -55,19 +61,23 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '25095 passed, 5 skipped'"
   - id: "dod-mypy-strict"
-    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704, cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704,
+      cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py --strict"
+        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py
+          --strict"
   - id: "dod-emit-ts-registration"
-    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
+    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and
+      present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
       - check_type: "command"
-        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract, ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
+        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract,
+          ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
   - id: "dod-gate-disambiguation"
     description: >
       Per ADR docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md (D2): ActionContract composes
@@ -77,15 +87,16 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py src/omnibase_core/models/objective/model_gate_spec.py"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py
+          src/omnibase_core/models/objective/model_gate_spec.py"
       - check_type: "command"
         check_value: "echo 'no changes to ModelGate / ModelGateSpec source'"
   - id: "dod-deploy-gate"
     description: >
       Deploy-gate evidence: pure additive Pydantic model + enum additions in omnibase_core. No Kafka topic
       schema changes, no new topics, no node/handler, no Docker image rebuild, no runtime process restart,
-      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer and
-      topic are Phase 1.
+      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer
+      and topic are Phase 1.
     source: "manual"
     checks:
       - check_type: "command"

--- a/src/omnibase_core/contract_graph/adapter_node_contract.py
+++ b/src/omnibase_core/contract_graph/adapter_node_contract.py
@@ -3,14 +3,41 @@
 
 """Read-only dialect adapter: backend node contracts -> Contract Graph IR.
 
-Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129; plan
-docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §8 Phase 2).
+Phase 2 Contract Graph IR (OMN-13132, epic OMN-13129) extended in Phase 3
+(OMN-13223) to cover all four structural contract dialects in this repo.
 
-Imports an existing ONEX node contract (``node_type`` effect/compute/reducer/
-orchestrator, with ``publish_topics`` / ``subscribe_topics`` / ``descriptor`` /
-``handler_routing``) into one IR node plus its topic edges. STRICTLY READ-ONLY:
-the adapter parses a contract dict and produces frozen IR models; it never
-mutates the source, performs no I/O, and resolves no endpoints.
+**Four dialects handled by this single adapter (option b — single adapter
+proven lossless for all four):**
+
+- ``descriptor`` — contracts with a ``descriptor:`` section (node_archetype,
+  purity, idempotent, timeout_ms) and top-level ``publish_topics`` /
+  ``subscribe_topics``. The ``descriptor`` metadata is intentionally dropped
+  from the IR projection (it is operational metadata, not routing topology);
+  the round-trip is zero-diff because ``normalize_node_contract`` also drops it.
+
+- ``event_bus`` — contracts where publish/subscribe topics are nested inside an
+  ``event_bus:`` section (``event_bus.publish_topics`` /
+  ``event_bus.subscribe_topics``) rather than at the top level. Used by
+  orchestrator contracts (e.g. ``node_compliance_orchestrator/contract.yaml``).
+  This adapter reads both top-level AND ``event_bus:``-nested topics so they
+  appear as edges in the IR and survive the round-trip.
+
+- ``state_machine`` — contracts using ``REDUCER_GENERIC`` / ``EFFECT_GENERIC``
+  node_type tokens and a ``state_transitions:`` section (states, transitions,
+  FSM operations). The FSM internals are intentionally dropped from the IR
+  projection (too deep to be general routing topology); the adapter maps the
+  generic node_type to the canonical archetype role and captures any declared
+  topics. Zero-diff round-trip is proven against the normalized baseline which
+  also omits the state_transitions section.
+
+- ``workflow_coordination`` — contracts using ``ORCHESTRATOR_GENERIC`` node_type
+  with a ``workflow_coordination:`` section (workflow_definition, execution_graph,
+  sub-node wiring). Same treatment as state_machine: adapter maps the generic
+  node_type to ORCHESTRATOR role; workflow_coordination is dropped from the IR
+  projection intentionally; zero-diff round-trip proven.
+
+STRICTLY READ-ONLY: the adapter parses a contract dict and produces frozen IR
+models; it never mutates the source, performs no I/O, and resolves no endpoints.
 
 Dialect identity is ``node``. Its version hash covers the source bytes of the
 import + round-trip functions so any behavioral change is reflected in the IR's
@@ -55,13 +82,33 @@ __all__ = [
 
 DIALECT_NAME = "node"
 
-# node_type token -> IR node role. Closed mapping: an unknown node_type fails
-# fast in import_node_contract rather than defaulting silently.
+# node_type token -> IR node role. Covers both canonical lowercase tokens
+# (effect/compute/reducer/orchestrator, used by in-repo node contracts) and
+# UPPER_GENERIC variants (REDUCER_GENERIC / ORCHESTRATOR_GENERIC /
+# EFFECT_GENERIC / COMPUTE_GENERIC, used by contracts/runtime/ contracts that
+# carry state_machine or workflow_coordination dialect sections). An unknown
+# node_type still fails fast in import_node_contract.
 _NODE_TYPE_TO_ROLE: dict[str, EnumContractGraphNodeRole] = {
+    # canonical lowercase (descriptor + event_bus dialects)
     "effect": EnumContractGraphNodeRole.EFFECT,
     "compute": EnumContractGraphNodeRole.COMPUTE,
     "reducer": EnumContractGraphNodeRole.REDUCER,
     "orchestrator": EnumContractGraphNodeRole.ORCHESTRATOR,
+    # UPPER_GENERIC variants (state_machine + workflow_coordination dialects)
+    "EFFECT_GENERIC": EnumContractGraphNodeRole.EFFECT,
+    "COMPUTE_GENERIC": EnumContractGraphNodeRole.COMPUTE,
+    "REDUCER_GENERIC": EnumContractGraphNodeRole.REDUCER,
+    "ORCHESTRATOR_GENERIC": EnumContractGraphNodeRole.ORCHESTRATOR,
+}
+
+# Canonical round-trip node_type string per role: always the lowercase token.
+# Used by round_trip_node_node to emit a consistent normalized form regardless
+# of whether the source used "reducer" or "REDUCER_GENERIC".
+_ROLE_TO_CANONICAL_NODE_TYPE: dict[EnumContractGraphNodeRole, str] = {
+    EnumContractGraphNodeRole.EFFECT: "effect",
+    EnumContractGraphNodeRole.COMPUTE: "compute",
+    EnumContractGraphNodeRole.REDUCER: "reducer",
+    EnumContractGraphNodeRole.ORCHESTRATOR: "orchestrator",
 }
 
 
@@ -74,6 +121,8 @@ def node_contract_adapter_version() -> str:
             inspect.getsource(import_node_contract),
             inspect.getsource(round_trip_node_node),
             inspect.getsource(_topic_list),
+            inspect.getsource(_raw_topic_list),
+            inspect.getsource(_node_id_from_source_path),
         ),
     )
 
@@ -82,34 +131,81 @@ def supports_node_contract(data: dict[str, JsonType]) -> bool:
     """True if ``data`` is a backend node contract this adapter imports.
 
     A node contract is identified by a ``node_type`` whose token is one of the
-    four canonical archetypes. UI component contracts (no ``node_type``) are not
-    matched.
+    canonical archetype tokens (lowercase or UPPER_GENERIC). UI component
+    contracts (no ``node_type``) are not matched.
     """
     node_type = data.get("node_type")
     return isinstance(node_type, str) and node_type in _NODE_TYPE_TO_ROLE
 
 
-def _topic_list(data: dict[str, JsonType], key: str) -> tuple[str, ...]:
-    """Extract a tuple of topic strings from a contract list field.
+def _raw_topic_list(raw: object, label: str) -> tuple[str, ...]:
+    """Validate and extract a topic list from a raw value already extracted from the dict.
 
-    Raises ``ValueError`` if the field is present but not a list of strings —
-    fail fast rather than silently dropping malformed entries.
+    Raises ``ValueError`` if the value is not a list of strings — fail fast
+    rather than silently dropping malformed entries.
     """
-    raw = data.get(key)
     if raw is None:
         return ()
     if not isinstance(raw, list):
         raise ValueError(  # error-ok: input validation at the contract-import boundary
-            f"{key!r} must be a list of topic strings, got {type(raw).__name__}"
+            f"{label!r} must be a list of topic strings, got {type(raw).__name__}"
         )
     topics: list[str] = []
     for entry in raw:
         if not isinstance(entry, str):
             raise ValueError(  # error-ok: input validation at the contract-import boundary
-                f"{key!r} entries must be strings, got {type(entry).__name__}"
+                f"{label!r} entries must be strings, got {type(entry).__name__}"
             )
         topics.append(entry)
     return tuple(topics)
+
+
+def _topic_list(data: dict[str, JsonType], key: str) -> tuple[str, ...]:
+    """Extract a tuple of topic strings from a top-level contract field.
+
+    Checks the top-level ``key`` first; then checks inside the ``event_bus:``
+    nested section if present (``event_bus`` dialect). When a topic is declared
+    in both places the union is taken, de-duplicated, preserving order (top-level
+    first, then event_bus entries not already included).
+
+    Raises ``ValueError`` if either location has the field but it is not a list
+    of strings — fail fast rather than silently dropping malformed entries.
+    """
+    top_level = _raw_topic_list(data.get(key), key)
+
+    event_bus = data.get("event_bus")
+    if not isinstance(event_bus, dict):
+        return top_level
+
+    nested = _raw_topic_list(event_bus.get(key), f"event_bus.{key}")
+    if not nested:
+        return top_level
+
+    # Union: top-level entries first, then any event_bus entries not already seen.
+    seen: set[str] = set(top_level)
+    combined: list[str] = list(top_level)
+    for t in nested:
+        if t not in seen:
+            combined.append(t)
+            seen.add(t)
+    return tuple(combined)
+
+
+def _node_id_from_source_path(source_path: str) -> str:
+    """Derive a stable node_id from the source file path when no explicit id is declared.
+
+    Uses the filename stem (without extension) of the source path so contracts
+    in the ``state_machine`` / ``workflow_coordination`` dialects (which do not
+    declare ``handler_id`` or ``name``) still produce a stable, meaningful id.
+    """
+    from pathlib import Path  # import-local: avoids module-level Path import
+
+    stem = Path(source_path).stem
+    if not stem:
+        raise ValueError(  # error-ok: input validation at the contract-import boundary
+            f"{source_path}: cannot derive node_id — source path has no stem"
+        )
+    return stem
 
 
 def import_node_contract(
@@ -119,9 +215,14 @@ def import_node_contract(
     """Import one backend node contract into an IR node + its topic edges.
 
     Returns the node and a deterministically-ordered tuple of publish/subscribe
-    edges. ``node_id`` is the contract ``handler_id`` (a stable semantic id) or,
-    when absent, ``name``. Missing both raises ``ValueError`` (fail fast — no
-    synthesized id).
+    edges. ``node_id`` is resolved in priority order:
+
+    1. ``handler_id`` — canonical stable semantic id when declared.
+    2. ``name`` — human-readable name as fallback.
+    3. ``node_id`` — explicit node identity field (used by some compute contracts).
+    4. Filename stem of ``source_path`` — for state_machine / workflow_coordination
+       dialect contracts that declare no inline identity (e.g. REDUCER_GENERIC
+       contracts in ``contracts/runtime/``).
     """
     if not supports_node_contract(data):
         raise ValueError(  # error-ok: input validation at the contract-import boundary
@@ -133,12 +234,21 @@ def import_node_contract(
 
     handler_id = data.get("handler_id")
     name = data.get("name")
-    node_id_source = handler_id if isinstance(handler_id, str) else name
-    if not isinstance(node_id_source, str) or not node_id_source:
-        raise ValueError(  # error-ok: input validation at the contract-import boundary
-            f"{source_path}: node contract has no handler_id or name to use as node_id"
+    node_id_field = data.get("node_id")
+    node_id_source = (
+        handler_id
+        if isinstance(handler_id, str) and handler_id
+        else (
+            name
+            if isinstance(name, str) and name
+            else (
+                node_id_field
+                if isinstance(node_id_field, str) and node_id_field
+                else _node_id_from_source_path(source_path)
+            )
         )
-    node_id = node_id_source
+    )
+    node_id = str(node_id_source)
 
     title_raw = name if isinstance(name, str) and name else node_id
     title = title_raw
@@ -203,14 +313,17 @@ def round_trip_node_node(
 ) -> dict[str, JsonType]:
     """Round-trip one IR node + its edges back to canonical normalized node form.
 
-    The round-trip target is the canonical normalized contract shape this
-    adapter reads: ``node_type`` + ``handler_id`` + ``publish_topics`` /
-    ``subscribe_topics`` (sorted), plus ``input_model`` / ``output_model`` when
-    the node carries an IO protocol. A no-op round-trip of an imported contract
-    reproduces these semantic fields so ``cli_contract_diff`` reports zero diff.
+    The round-trip target is the canonical normalized contract shape: lowercase
+    ``node_type`` + ``handler_id`` + ``publish_topics`` / ``subscribe_topics``
+    (sorted), plus ``input_model`` / ``output_model`` when the node carries an
+    IO protocol.
+
+    The output always uses the canonical lowercase ``node_type`` token (e.g.
+    ``"reducer"``) regardless of whether the source used ``"REDUCER_GENERIC"``.
+    This is intentional: ``normalize_node_contract`` also normalizes to lowercase,
+    so the round-trip comparison is zero-diff for all four dialect variants.
     """
-    role_to_node_type = {v: k for k, v in _NODE_TYPE_TO_ROLE.items()}
-    if node.role not in role_to_node_type:
+    if node.role not in _ROLE_TO_CANONICAL_NODE_TYPE:
         raise ValueError(  # error-ok: caller passed a non-backend node to this adapter
             f"node role {node.role!r} is not a backend node role; cannot round-trip via this adapter"
         )
@@ -218,7 +331,7 @@ def round_trip_node_node(
     result: dict[str, JsonType] = {
         "handler_id": node.node_id,
         "name": node.title,
-        "node_type": role_to_node_type[node.role],
+        "node_type": _ROLE_TO_CANONICAL_NODE_TYPE[node.role],
     }
 
     publishes = sorted(

--- a/src/omnibase_core/contract_graph/importer.py
+++ b/src/omnibase_core/contract_graph/importer.py
@@ -32,6 +32,7 @@ from omnibase_core.cli.cli_contract_diff import (
     load_contract_yaml_file,
 )
 from omnibase_core.contract_graph.adapter_node_contract import (
+    _ROLE_TO_CANONICAL_NODE_TYPE,
     import_node_contract,
     round_trip_node_node,
 )
@@ -137,40 +138,102 @@ def _json_str_list(values: list[str]) -> list[JsonType]:
     return widened
 
 
-def normalize_node_contract(data: dict[str, JsonType]) -> dict[str, JsonType]:
+def normalize_node_contract(
+    data: dict[str, JsonType],
+    source_path: str | None = None,
+) -> dict[str, JsonType]:
     """Canonical normalized form of a backend node contract.
 
     The semantic projection a node-contract round-trip targets: handler_id,
-    name, node_type, sorted publish/subscribe topics, and input/output models.
+    name, node_type (always canonical lowercase), sorted publish/subscribe
+    topics (from both top-level and ``event_bus:`` section), and input/output
+    models.
+
     This is the baseline a no-op round-trip is diffed against — NOT the raw
-    source (which also carries descriptor/version/build noise the IR drops).
+    source (which also carries ``descriptor`` / ``state_transitions`` /
+    ``workflow_coordination`` / version/build noise the IR drops).
+
+    ``source_path`` is used as the node_id fallback when the contract declares
+    no ``handler_id``, ``name``, or ``node_id`` (state_machine /
+    workflow_coordination dialect contracts in ``contracts/runtime/``).
     """
+    from omnibase_core.contract_graph.adapter_node_contract import (
+        _NODE_TYPE_TO_ROLE,  # late import: avoids circular at module level
+        _node_id_from_source_path,  # late import: avoids circular at module level
+    )
+
     canonical = canonicalize_contract(data)
     handler_id = canonical.get("handler_id")
     name = canonical.get("name")
-    node_id = handler_id if isinstance(handler_id, str) and handler_id else name
-    if not isinstance(node_id, str) or not node_id:
-        raise ValueError(  # error-ok: input validation at the contract-import boundary
-            "node contract has no handler_id or name"
+    node_id_field = canonical.get("node_id")
+    node_id: str | None = (
+        handler_id
+        if isinstance(handler_id, str) and handler_id
+        else (
+            name
+            if isinstance(name, str) and name
+            else (
+                node_id_field
+                if isinstance(node_id_field, str) and node_id_field
+                else None
+            )
         )
-    node_type = canonical.get("node_type")
-    if not isinstance(node_type, str):
+    )
+    if node_id is None:
+        if source_path is not None:
+            node_id = _node_id_from_source_path(source_path)
+        else:
+            raise ValueError(  # error-ok: input validation at the contract-import boundary
+                "node contract has no handler_id, name, or node_id, and no source_path was provided"
+            )
+
+    node_type_raw = canonical.get("node_type")
+    if not isinstance(node_type_raw, str):
         raise ValueError(  # error-ok: input validation at the contract-import boundary
             "node contract has no string node_type"
         )
+    # Normalize UPPER_GENERIC tokens to canonical lowercase for the round-trip
+    # baseline so a REDUCER_GENERIC source round-trips to "reducer" — the same
+    # token round_trip_node_node emits.
+    if node_type_raw in _NODE_TYPE_TO_ROLE:
+        role = _NODE_TYPE_TO_ROLE[node_type_raw]
+        node_type_canonical: str = _ROLE_TO_CANONICAL_NODE_TYPE.get(role, node_type_raw)
+    else:
+        node_type_canonical = node_type_raw
 
     result: dict[str, JsonType] = {
         "handler_id": node_id,
         "name": name if isinstance(name, str) and name else node_id,
-        "node_type": node_type,
+        "node_type": node_type_canonical,
     }
 
-    publish = canonical.get("publish_topics")
-    if isinstance(publish, list) and publish:
-        result["publish_topics"] = _json_str_list(sorted(str(x) for x in publish))
-    subscribe = canonical.get("subscribe_topics")
-    if isinstance(subscribe, list) and subscribe:
-        result["subscribe_topics"] = _json_str_list(sorted(str(x) for x in subscribe))
+    # Extract topics from both top-level fields and nested event_bus: section
+    # (event_bus dialect). Union is taken when both are present.
+    def _collect_topics(key: str) -> list[str]:
+        top = canonical.get(key)
+        top_list: list[str] = (
+            [str(x) for x in top if isinstance(x, str)] if isinstance(top, list) else []
+        )
+        event_bus = canonical.get("event_bus")
+        nested_list: list[str] = []
+        if isinstance(event_bus, dict):
+            nested = event_bus.get(key)
+            if isinstance(nested, list):
+                nested_list = [str(x) for x in nested if isinstance(x, str)]
+        seen: set[str] = set(top_list)
+        combined: list[str] = list(top_list)
+        for t in nested_list:
+            if t not in seen:
+                combined.append(t)
+                seen.add(t)
+        return sorted(combined)
+
+    publish = _collect_topics("publish_topics")
+    if publish:
+        result["publish_topics"] = _json_str_list(publish)
+    subscribe = _collect_topics("subscribe_topics")
+    if subscribe:
+        result["subscribe_topics"] = _json_str_list(subscribe)
 
     input_model = canonical.get("input_model")
     if isinstance(input_model, str):
@@ -275,10 +338,16 @@ def round_trip_node_diff(
     Round-trips the IR node + its edges back to canonical normalized node form
     and compares it to ``normalize_node_contract(source)`` using the shipped
     semantic diff spine.
+
+    The IR node's ``source_ref.source_path`` is passed to
+    ``normalize_node_contract`` so that state_machine / workflow_coordination
+    dialect contracts (which declare no ``handler_id`` or ``name``) resolve
+    their node_id from the file path stem, matching what ``import_node_contract``
+    already does.
     """
     node = next(n for n in ir.nodes if n.node_id == node_id)
     round_tripped = round_trip_node_node(node, _edges_for(ir, node_id))
-    baseline = normalize_node_contract(source)
+    baseline = normalize_node_contract(source, source_path=node.source_ref.source_path)
     diffs = diff_contract_dicts(baseline, round_tripped)
     return categorize_diff_entries(diffs)
 

--- a/tests/unit/contract_graph/test_per_dialect_round_trip.py
+++ b/tests/unit/contract_graph/test_per_dialect_round_trip.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-dialect round-trip proof tests for the Contract Graph IR (OMN-13223).
+
+Proves that the single ``node`` adapter in
+``omnibase_core.contract_graph.adapter_node_contract`` losslessly imports
+a REAL contract of each of the four structural dialect variants found in
+this repository, and that a no-op round-trip produces zero semantic diff
+through the shipped ``cli_contract_diff`` spine.
+
+Four dialects, four proofs (option b — single adapter, not four separate
+adapters, per OMN-13223 acceptance criteria):
+
+1. ``descriptor``  — canonical lowercase node_type + top-level topics +
+   ``descriptor:`` metadata section (intentionally dropped by IR projection).
+   Contract: ``node_compliance_evidence_effect/contract.yaml`` (effect).
+
+2. ``event_bus``   — topics nested inside ``event_bus: { publish_topics: [...],
+   subscribe_topics: [...] }`` instead of at the top level.
+   Contract: ``node_compliance_orchestrator/contract.yaml`` (orchestrator).
+
+3. ``state_machine`` — ``REDUCER_GENERIC`` node_type + ``state_transitions:``
+   FSM section (dropped by IR projection; only the archetype role is captured).
+   Contract: ``contracts/runtime/contract_registry_reducer.yaml``.
+
+4. ``workflow_coordination`` — ``ORCHESTRATOR_GENERIC`` node_type +
+   ``workflow_coordination:`` section (dropped by IR projection).
+   Contract: ``contracts/runtime/runtime_orchestrator.yaml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.contract_graph.adapter_node_contract import (
+    supports_node_contract,
+)
+from omnibase_core.contract_graph.importer import (
+    _load_yaml,
+    import_paths,
+    normalize_node_contract,
+    round_trip_node_diff,
+    round_trip_zero_diff,
+)
+from omnibase_core.enums.enum_contract_graph_edge_kind import EnumContractGraphEdgeKind
+from omnibase_core.enums.enum_contract_graph_node_role import EnumContractGraphNodeRole
+from omnibase_core.models.contract_graph.model_contract_graph_ir import (
+    ModelContractGraphIr,
+)
+from omnibase_core.types.type_json import JsonType
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# --------------------------------------------------------------------------- #
+# Real per-dialect contract paths
+# --------------------------------------------------------------------------- #
+
+# 1. descriptor dialect: effect node with descriptor: section + top-level topics
+_DESCRIPTOR_CONTRACT = (
+    "src/omnibase_core/nodes/node_compliance_evidence_effect/contract.yaml"
+)
+
+# 2. event_bus dialect: orchestrator node with event_bus: { publish_topics, subscribe_topics }
+_EVENT_BUS_CONTRACT = (
+    "src/omnibase_core/nodes/node_compliance_orchestrator/contract.yaml"
+)
+
+# 3. state_machine dialect: REDUCER_GENERIC + state_transitions: FSM section
+_STATE_MACHINE_CONTRACT = "contracts/runtime/contract_registry_reducer.yaml"
+
+# 4. workflow_coordination dialect: ORCHESTRATOR_GENERIC + workflow_coordination: section
+_WORKFLOW_COORD_CONTRACT = "contracts/runtime/runtime_orchestrator.yaml"
+
+
+# --------------------------------------------------------------------------- #
+# Helper: import a single real contract into an IR
+# --------------------------------------------------------------------------- #
+
+
+def _import_single(
+    repo_relative: str,
+) -> tuple[ModelContractGraphIr, dict[str, JsonType]]:
+    """Load + import one real contract; return (ir, raw_data)."""
+    fs_path = _REPO_ROOT / repo_relative
+    data = _load_yaml(fs_path)
+    ir: ModelContractGraphIr = import_paths(
+        discovery_roots=(str(Path(repo_relative).parent),),
+        node_paths=((fs_path, repo_relative),),
+        ui_components=(),
+    )
+    return ir, data
+
+
+# --------------------------------------------------------------------------- #
+# Dialect 1: descriptor
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_descriptor_dialect_is_supported() -> None:
+    """descriptor dialect contract is detected by the node adapter."""
+    data = _load_yaml(_REPO_ROOT / _DESCRIPTOR_CONTRACT)
+    assert data.get("node_type") == "effect"
+    assert "descriptor" in data, "descriptor section must be present"
+    assert supports_node_contract(data) is True
+
+
+@pytest.mark.unit
+def test_descriptor_dialect_import_role_and_edges() -> None:
+    """descriptor dialect contract imports to EFFECT role with correct topic edges."""
+    ir, _ = _import_single(_DESCRIPTOR_CONTRACT)
+    assert len(ir.nodes) == 1
+    node = ir.nodes[0]
+    assert node.role is EnumContractGraphNodeRole.EFFECT
+    kinds = {e.kind for e in ir.edges}
+    assert EnumContractGraphEdgeKind.PUBLISHES in kinds
+    assert EnumContractGraphEdgeKind.SUBSCRIBES in kinds
+
+
+@pytest.mark.unit
+def test_descriptor_dialect_zero_diff_round_trip() -> None:
+    """descriptor dialect: no-op round-trip == zero semantic diff (descriptor section dropped)."""
+    ir, data = _import_single(_DESCRIPTOR_CONTRACT)
+    node_id = ir.nodes[0].node_id
+    result = round_trip_node_diff(ir, node_id, data)
+    assert round_trip_zero_diff(result) is True, (
+        f"descriptor dialect round-trip has semantic diff: {result}"
+    )
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_descriptor_dialect_deterministic_ir() -> None:
+    """descriptor dialect IR is deterministic across two identical imports."""
+    ir1, _ = _import_single(_DESCRIPTOR_CONTRACT)
+    ir2, _ = _import_single(_DESCRIPTOR_CONTRACT)
+    assert ir1.model_dump_json() == ir2.model_dump_json()
+
+
+# --------------------------------------------------------------------------- #
+# Dialect 2: event_bus
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_event_bus_dialect_is_supported() -> None:
+    """event_bus dialect contract is detected (orchestrator with event_bus: section)."""
+    data = _load_yaml(_REPO_ROOT / _EVENT_BUS_CONTRACT)
+    assert data.get("node_type") == "orchestrator"
+    event_bus = data.get("event_bus")
+    assert isinstance(event_bus, dict), "event_bus section must be present"
+    assert "publish_topics" in event_bus or "subscribe_topics" in event_bus
+    assert supports_node_contract(data) is True
+
+
+@pytest.mark.unit
+def test_event_bus_dialect_topics_extracted_from_nested_section() -> None:
+    """event_bus dialect: topics nested under event_bus: are extracted as IR edges."""
+    ir, data = _import_single(_EVENT_BUS_CONTRACT)
+    assert len(ir.nodes) == 1
+    node = ir.nodes[0]
+    assert node.role is EnumContractGraphNodeRole.ORCHESTRATOR
+
+    # Topics must appear as edges even though they live in event_bus:, not top-level
+    event_bus_raw = data.get("event_bus")
+    assert isinstance(event_bus_raw, dict), "event_bus section must be a dict"
+    pub_raw = event_bus_raw.get("publish_topics")
+    sub_raw = event_bus_raw.get("subscribe_topics")
+    expected_pub: set[str] = (
+        {str(t) for t in pub_raw} if isinstance(pub_raw, list) else set()
+    )
+    expected_sub: set[str] = (
+        {str(t) for t in sub_raw} if isinstance(sub_raw, list) else set()
+    )
+
+    actual_pub = {
+        e.topic for e in ir.edges if e.kind is EnumContractGraphEdgeKind.PUBLISHES
+    }
+    actual_sub = {
+        e.topic for e in ir.edges if e.kind is EnumContractGraphEdgeKind.SUBSCRIBES
+    }
+
+    assert expected_pub <= actual_pub, (
+        f"event_bus publish topics not in IR edges: missing {expected_pub - actual_pub}"
+    )
+    assert expected_sub <= actual_sub, (
+        f"event_bus subscribe topics not in IR edges: missing {expected_sub - actual_sub}"
+    )
+
+
+@pytest.mark.unit
+def test_event_bus_dialect_zero_diff_round_trip() -> None:
+    """event_bus dialect: no-op round-trip == zero semantic diff (topics from event_bus: survive)."""
+    ir, data = _import_single(_EVENT_BUS_CONTRACT)
+    node_id = ir.nodes[0].node_id
+    result = round_trip_node_diff(ir, node_id, data)
+    assert round_trip_zero_diff(result) is True, (
+        f"event_bus dialect round-trip has semantic diff: {result}"
+    )
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_event_bus_dialect_deterministic_ir() -> None:
+    """event_bus dialect IR is deterministic across two identical imports."""
+    ir1, _ = _import_single(_EVENT_BUS_CONTRACT)
+    ir2, _ = _import_single(_EVENT_BUS_CONTRACT)
+    assert ir1.model_dump_json() == ir2.model_dump_json()
+
+
+# --------------------------------------------------------------------------- #
+# Dialect 3: state_machine
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_state_machine_dialect_is_supported() -> None:
+    """state_machine dialect contract is detected (REDUCER_GENERIC + state_transitions:)."""
+    data = _load_yaml(_REPO_ROOT / _STATE_MACHINE_CONTRACT)
+    assert data.get("node_type") == "REDUCER_GENERIC"
+    assert "state_transitions" in data, "state_transitions section must be present"
+    assert supports_node_contract(data) is True
+
+
+@pytest.mark.unit
+def test_state_machine_dialect_maps_to_reducer_role() -> None:
+    """state_machine dialect: REDUCER_GENERIC maps to REDUCER role in the IR."""
+    ir, _ = _import_single(_STATE_MACHINE_CONTRACT)
+    assert len(ir.nodes) == 1
+    node = ir.nodes[0]
+    assert node.role is EnumContractGraphNodeRole.REDUCER
+    # node_id derived from source_path stem (no handler_id or name in this contract)
+    assert node.node_id == "contract_registry_reducer"
+
+
+@pytest.mark.unit
+def test_state_machine_dialect_zero_diff_round_trip() -> None:
+    """state_machine dialect: no-op round-trip == zero semantic diff (FSM section dropped)."""
+    ir, data = _import_single(_STATE_MACHINE_CONTRACT)
+    node_id = ir.nodes[0].node_id
+    result = round_trip_node_diff(ir, node_id, data)
+    assert round_trip_zero_diff(result) is True, (
+        f"state_machine dialect round-trip has semantic diff: {result}"
+    )
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_state_machine_dialect_normalize_uses_canonical_node_type() -> None:
+    """state_machine dialect: normalize_node_contract emits lowercase 'reducer' not 'REDUCER_GENERIC'."""
+    data = _load_yaml(_REPO_ROOT / _STATE_MACHINE_CONTRACT)
+    normalized = normalize_node_contract(data, source_path=_STATE_MACHINE_CONTRACT)
+    assert normalized["node_type"] == "reducer"
+    assert normalized["handler_id"] == "contract_registry_reducer"
+
+
+@pytest.mark.unit
+def test_state_machine_dialect_deterministic_ir() -> None:
+    """state_machine dialect IR is deterministic across two identical imports."""
+    ir1, _ = _import_single(_STATE_MACHINE_CONTRACT)
+    ir2, _ = _import_single(_STATE_MACHINE_CONTRACT)
+    assert ir1.model_dump_json() == ir2.model_dump_json()
+
+
+# --------------------------------------------------------------------------- #
+# Dialect 4: workflow_coordination
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_workflow_coordination_dialect_is_supported() -> None:
+    """workflow_coordination dialect is detected (ORCHESTRATOR_GENERIC + workflow_coordination:)."""
+    data = _load_yaml(_REPO_ROOT / _WORKFLOW_COORD_CONTRACT)
+    assert data.get("node_type") == "ORCHESTRATOR_GENERIC"
+    assert "workflow_coordination" in data, (
+        "workflow_coordination section must be present"
+    )
+    assert supports_node_contract(data) is True
+
+
+@pytest.mark.unit
+def test_workflow_coordination_dialect_maps_to_orchestrator_role() -> None:
+    """workflow_coordination dialect: ORCHESTRATOR_GENERIC maps to ORCHESTRATOR role."""
+    ir, _ = _import_single(_WORKFLOW_COORD_CONTRACT)
+    assert len(ir.nodes) == 1
+    node = ir.nodes[0]
+    assert node.role is EnumContractGraphNodeRole.ORCHESTRATOR
+    assert node.node_id == "runtime_orchestrator"
+
+
+@pytest.mark.unit
+def test_workflow_coordination_dialect_zero_diff_round_trip() -> None:
+    """workflow_coordination dialect: no-op round-trip == zero semantic diff (wf section dropped)."""
+    ir, data = _import_single(_WORKFLOW_COORD_CONTRACT)
+    node_id = ir.nodes[0].node_id
+    result = round_trip_node_diff(ir, node_id, data)
+    assert round_trip_zero_diff(result) is True, (
+        f"workflow_coordination dialect round-trip has semantic diff: {result}"
+    )
+    assert result.total_changes == 0
+
+
+@pytest.mark.unit
+def test_workflow_coordination_dialect_normalize_uses_canonical_node_type() -> None:
+    """workflow_coordination dialect: normalize_node_contract emits 'orchestrator' not 'ORCHESTRATOR_GENERIC'."""
+    data = _load_yaml(_REPO_ROOT / _WORKFLOW_COORD_CONTRACT)
+    normalized = normalize_node_contract(data, source_path=_WORKFLOW_COORD_CONTRACT)
+    assert normalized["node_type"] == "orchestrator"
+    assert normalized["handler_id"] == "runtime_orchestrator"
+
+
+@pytest.mark.unit
+def test_workflow_coordination_dialect_deterministic_ir() -> None:
+    """workflow_coordination dialect IR is deterministic across two identical imports."""
+    ir1, _ = _import_single(_WORKFLOW_COORD_CONTRACT)
+    ir2, _ = _import_single(_WORKFLOW_COORD_CONTRACT)
+    assert ir1.model_dump_json() == ir2.model_dump_json()
+
+
+# --------------------------------------------------------------------------- #
+# Cross-dialect: adapter version hash changes when implementation changes
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_all_four_dialects_share_single_adapter_version() -> None:
+    """All four dialects are handled by the single 'node' adapter (single adapter_version_sha256)."""
+    from omnibase_core.contract_graph.adapter_node_contract import (
+        node_contract_adapter_version,
+    )
+
+    v = node_contract_adapter_version()
+    assert v.startswith("sha256:"), "adapter version must be a sha256: prefixed hash"
+
+    # All four dialect contracts imported via the same adapter share one adapter version
+    for repo_relative in (
+        _DESCRIPTOR_CONTRACT,
+        _EVENT_BUS_CONTRACT,
+        _STATE_MACHINE_CONTRACT,
+        _WORKFLOW_COORD_CONTRACT,
+    ):
+        ir, _ = _import_single(repo_relative)
+        for ref in ir.source_set.refs:
+            if ref.dialect == "node":
+                assert ref.adapter_version_sha256 == v, (
+                    f"contract {repo_relative!r} has unexpected adapter version "
+                    f"{ref.adapter_version_sha256!r} (expected {v!r})"
+                )
+
+
+@pytest.mark.unit
+def test_all_four_dialect_source_hashes_differ() -> None:
+    """Each dialect contract has a distinct source_contract_sha256."""
+    hashes: dict[str, str] = {}
+    for repo_relative in (
+        _DESCRIPTOR_CONTRACT,
+        _EVENT_BUS_CONTRACT,
+        _STATE_MACHINE_CONTRACT,
+        _WORKFLOW_COORD_CONTRACT,
+    ):
+        ir, _ = _import_single(repo_relative)
+        for ref in ir.source_set.refs:
+            if ref.dialect == "node":
+                hashes[repo_relative] = ref.source_contract_sha256
+    # All four source hashes must differ (distinct contracts)
+    assert len(set(hashes.values())) == 4, (
+        f"Expected 4 distinct source hashes, got {len(set(hashes.values()))}: {hashes}"
+    )


### PR DESCRIPTION
## feat(OMN-13223): per-dialect Contract Graph IR adapters

Closes OMN-13223. Extends the Phase-2 (`OMN-13132`) Contract Graph IR `node` adapter to losslessly handle all four structural dialect variants found in omnibase_core contracts.

### What changed

**`src/omnibase_core/contract_graph/adapter_node_contract.py`**
- `_NODE_TYPE_TO_ROLE` extended with `UPPER_GENERIC` token variants (`REDUCER_GENERIC`, `ORCHESTRATOR_GENERIC`)
- `_ROLE_TO_CANONICAL_NODE_TYPE` added for consistent lowercase round-trip output
- `_raw_topic_list()` + `_topic_list()` extended to extract topics from nested `event_bus:` section (previously silently dropped)
- `_node_id_from_source_path()` fallback for contracts with no explicit identity field
- `import_node_contract()` updated with node_id priority chain; `round_trip_node_node()` uses `_ROLE_TO_CANONICAL_NODE_TYPE`

**`src/omnibase_core/contract_graph/importer.py`**
- `normalize_node_contract()` gains `source_path` param + `event_bus:` topic extraction + `UPPER_GENERIC` normalization
- `round_trip_node_diff()` passes `source_path`

**`tests/unit/contract_graph/test_per_dialect_round_trip.py` (NEW)**
- 20 tests using one real contract per dialect
- Proves: detection, role mapping, zero-diff round-trip, deterministic IR
- All four dialects: `descriptor`, `event_bus`, `state_machine`, `workflow_coordination`

### Four dialects proven

| Dialect | Example contract | Adapter behavior |
|---------|-----------------|-----------------|
| `descriptor` | effect/compute/reducer node with `descriptor:` + top-level topics | descriptor metadata dropped by IR projection; zero-diff proven |
| `event_bus` | orchestrator node with `event_bus: { publish_topics, subscribe_topics }` | topics extracted from both top-level AND nested `event_bus:` section |
| `state_machine` | REDUCER_GENERIC + `state_transitions:` FSM | UPPER_GENERIC token mapped to canonical archetype role; FSM section dropped by IR |
| `workflow_coordination` | ORCHESTRATOR_GENERIC + `workflow_coordination:` | same treatment; section dropped by IR projection |

### Evidence

- 35 unit tests pass (15 pre-existing Phase-2 + 20 new per-dialect): `tests/unit/contract_graph/`
- All 20 new tests: `tests/unit/contract_graph/test_per_dialect_round_trip.py` — all four dialects produce `zero_diff=True total_changes=0`
- `uv run ruff check src/ tests/` — All checks passed
- `uv run mypy src/omnibase_core/contract_graph/ --strict` — 3 errors in 2 pre-existing transitively-imported files (`contract_loader.py:570/704`, `cli_install.py:45`); zero errors in any new module; confirmed byte-identical to origin/dev by empty git diff
- Head SHA: `d433630bd0dbc52656e2897af10aecdb4d3393e9`

### Receipt Gate

Evidence-Source: c4e66a13489d926a5d03e6a302a3a83115ecf829
Evidence-Ticket: OMN-13223

OCC contract + paired receipts shipped in onex_change_control dev PR (see OCC PR link in ticket OMN-13223).


