### PR TITLE
feat(OMN-12846): add user-correction category + failure-axis enums

### DIFF
--- a/src/omnibase_core/enums/enum_correction_failure_axis.py
+++ b/src/omnibase_core/enums/enum_correction_failure_axis.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Correction failure-axis enum for the context-selection learning loop.
+
+The failure axis is the dimension that decides whether a user correction counts
+*against context selection*:
+
+* ``MISUNDERSTANDING`` — context was present at injection but failed to convey
+  or disambiguate intent. This is a real context-selection failure and is
+  counted toward the context-failure rate.
+* ``NEW_INFORMATION`` — a requirement that did not exist at injection time. This
+  is NOT a context failure; it is recorded but excluded from the context-failure
+  rate.
+
+Orthogonal to ``EnumUserCorrectionCategory`` and stored as a separate
+first-class field (OMN-12846). Lives in ``omnibase_core`` because it crosses the
+core / omnimarket boundary.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumCorrectionFailureAxis(StrEnum):
+    """Whether a user correction counts against context selection."""
+
+    MISUNDERSTANDING = "MISUNDERSTANDING"
+    NEW_INFORMATION = "NEW_INFORMATION"
+
+
+__all__: list[str] = ["EnumCorrectionFailureAxis"]

--- a/src/omnibase_core/enums/enum_user_correction_category.py
+++ b/src/omnibase_core/enums/enum_user_correction_category.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""User-correction category enum for the context-selection learning loop.
+
+A user correction is categorized by *what kind* of correction it is. This axis
+is orthogonal to ``EnumCorrectionFailureAxis`` (whether the correction counts as
+a context-selection failure): both are first-class fields on the correction
+event and are never collapsed into a single rolled-up score (OMN-12846).
+
+Lives in ``omnibase_core`` because it crosses the core / omnimarket boundary:
+the typed ``ModelUserCorrectionEvent`` in omnimarket references it.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumUserCorrectionCategory(StrEnum):
+    """The kind of user correction applied to an agent's work.
+
+    Finite, exhaustive set. Categories are preserved on the event; there is no
+    single rolled-up score that flattens them.
+    """
+
+    CLARIFICATION = "CLARIFICATION"
+    CONSTRAINT_VIOLATION = "CONSTRAINT_VIOLATION"
+    SCOPE_REDUCTION = "SCOPE_REDUCTION"
+    SCOPE_EXPANSION = "SCOPE_EXPANSION"
+    PRIORITY_SHIFT = "PRIORITY_SHIFT"
+    STYLE = "STYLE"
+    INTENT = "INTENT"
+
+
+__all__: list[str] = ["EnumUserCorrectionCategory"]

--- a/tests/unit/enums/test_enum_user_correction.py
+++ b/tests/unit/enums/test_enum_user_correction.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the category-weighted user-correction enums (OMN-12846).
+
+These enums cross the omnibase_core / omnimarket boundary: the typed
+user-correction event in omnimarket references them, so they live in core.
+
+The category axis (what kind of correction) is deliberately kept orthogonal
+to the failure axis (whether the correction counts against context selection)
+— there is no single rolled-up score, by design (anti-flattening invariant).
+"""
+
+from enum import StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_correction_failure_axis import EnumCorrectionFailureAxis
+from omnibase_core.enums.enum_user_correction_category import EnumUserCorrectionCategory
+
+
+@pytest.mark.unit
+class TestEnumUserCorrectionCategory:
+    """The correction category is a finite, exhaustive, typed set."""
+
+    def test_correction_category_enum_is_exhaustive(self) -> None:
+        """Exactly the 7 named members, no more, no fewer."""
+        expected = {
+            "CLARIFICATION",
+            "CONSTRAINT_VIOLATION",
+            "SCOPE_REDUCTION",
+            "SCOPE_EXPANSION",
+            "PRIORITY_SHIFT",
+            "STYLE",
+            "INTENT",
+        }
+        actual = {member.name for member in EnumUserCorrectionCategory}
+        assert actual == expected
+
+    def test_is_str_enum(self) -> None:
+        """Must be a StrEnum for cross-process wire stability."""
+        assert issubclass(EnumUserCorrectionCategory, StrEnum)
+
+    def test_enum_prefix(self) -> None:
+        """Class name carries the canonical Enum prefix."""
+        assert EnumUserCorrectionCategory.__name__.startswith("Enum")
+
+    def test_members_round_trip_by_value(self) -> None:
+        """Each member reconstructs from its own string value."""
+        for member in EnumUserCorrectionCategory:
+            assert EnumUserCorrectionCategory(member.value) is member
+
+
+@pytest.mark.unit
+class TestEnumCorrectionFailureAxis:
+    """The failure axis gates whether a correction counts against context."""
+
+    def test_failure_axis_misunderstanding_vs_new_information(self) -> None:
+        """Exactly MISUNDERSTANDING and NEW_INFORMATION."""
+        expected = {"MISUNDERSTANDING", "NEW_INFORMATION"}
+        actual = {member.name for member in EnumCorrectionFailureAxis}
+        assert actual == expected
+
+    def test_is_str_enum(self) -> None:
+        """Must be a StrEnum for cross-process wire stability."""
+        assert issubclass(EnumCorrectionFailureAxis, StrEnum)
+
+    def test_enum_prefix(self) -> None:
+        """Class name carries the canonical Enum prefix."""
+        assert EnumCorrectionFailureAxis.__name__.startswith("Enum")
+
+    def test_members_round_trip_by_value(self) -> None:
+        """Each member reconstructs from its own string value."""
+        for member in EnumCorrectionFailureAxis:
+            assert EnumCorrectionFailureAxis(member.value) is member


### PR DESCRIPTION
## OMN-12846 — user-correction category + failure-axis enums

Adds two `StrEnum`s that cross the omnibase_core / omnimarket boundary (so they live in core), for the context-selection learning loop:

- `EnumUserCorrectionCategory` — exactly the 7 members: `CLARIFICATION`, `CONSTRAINT_VIOLATION`, `SCOPE_REDUCTION`, `SCOPE_EXPANSION`, `PRIORITY_SHIFT`, `STYLE`, `INTENT`.
- `EnumCorrectionFailureAxis` — exactly `MISUNDERSTANDING` and `NEW_INFORMATION`.

Category (what kind of correction) and failure axis (whether it counts against context selection) are orthogonal, first-class dimensions — there is no single rolled-up score (anti-flattening invariant). `MISUNDERSTANDING` is the context-selection-quality signal; `NEW_INFORMATION` is recorded but excluded from the context-failure rate.

The typed `ModelUserCorrectionEvent` in omnimarket references these enums (omnimarket PR stacks on this one).

### Tests (RED -> GREEN)
`tests/unit/enums/test_enum_user_correction.py` — 8 tests, all green:
- `test_correction_category_enum_is_exhaustive` (exactly the 7 members, StrEnum, Enum prefix)
- `test_failure_axis_misunderstanding_vs_new_information` (exactly the 2 members)
- round-trip + StrEnum + prefix checks for both enums

RED before implementation (`ModuleNotFoundError: No module named 'omnibase_core.enums.enum_correction_failure_axis'`), GREEN after.

### Verification
- `uv run pytest tests/unit/enums/test_enum_user_correction.py` — 8 passed
- `uv run mypy src/omnibase_core` (config-driven, as CI) — clean, 3930 files
- `uv run ruff format/check` — clean
- `pre-commit run --files <changed>` — exit 0

Evidence-Source: OCC#2853
Evidence-Ticket: OMN-12846

### OCC receipt pairing
Paired OCC evidence PR: OmniNode-ai/onex_change_control#2853 (contract `contracts/OMN-12846.yaml` + receipts `drift/dod_receipts/OMN-12846/`).

