### PR TITLE
feat(OMN-12843): add EnumSelectionReason for Context Authority Rule

### DIFF
--- a/src/omnibase_core/enums/enum_selection_reason.py
+++ b/src/omnibase_core/enums/enum_selection_reason.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Selection-reason enum for the Context Authority Rule (OMN-12843 / M3).
+
+Every context factor selected for per-run injection carries a typed reason so
+that injection is auditable: there is no "hidden authority". The reason answers
+*why this factor was chosen*, paired in the Authority 5-tuple with the factor,
+its stable source id, its measured effectiveness score, and the experiment
+cohort (if any).
+
+Semantics:
+
+* ``POLICY_EFFECTIVENESS`` — selected because its measured effectiveness score
+  (resolved from the M2 capsule store) ranked it in.
+* ``POLICY_REQUIRED_FACTOR`` — declared required by the profile; admitted by
+  policy and stamped (auditable, not silent).
+* ``EXPERIMENT_ASSIGNMENT`` — a forced/arm-fixed selection under an active
+  experiment cohort. Permitted ONLY when a cohort id is present.
+* ``EXPLORATION`` — cold-start / decay re-trial (the M4 explore path). The
+  reason is reserved here; the bandit logic lands in M4.
+* ``FALLBACK_NO_SCORE`` — the candidate has no M2 score yet. Explicit, not
+  silent: ``effectiveness_score`` is ``None`` only with this reason.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumSelectionReason(StrEnum):
+    """Typed authority reason stamped on each selected context factor."""
+
+    POLICY_EFFECTIVENESS = "policy_effectiveness"
+    POLICY_REQUIRED_FACTOR = "policy_required_factor"
+    EXPERIMENT_ASSIGNMENT = "experiment_assignment"
+    EXPLORATION = "exploration"
+    FALLBACK_NO_SCORE = "fallback_no_score"
+
+
+__all__ = [
+    "EnumSelectionReason",
+]

--- a/tests/unit/enums/test_enum_selection_reason.py
+++ b/tests/unit/enums/test_enum_selection_reason.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for EnumSelectionReason enum (OMN-12843 / M3 Context Authority Rule).
+
+EnumSelectionReason is the typed authority enum stamped on every selected
+context factor so that per-run injection is auditable. It encodes WHY a factor
+was selected: by measured effectiveness, by required-factor policy, by an
+experiment arm, by exploration, or as an explicit no-score fallback.
+"""
+
+import json
+from enum import Enum, StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_selection_reason import EnumSelectionReason
+
+
+@pytest.mark.unit
+class TestEnumSelectionReason:
+    """Test cases for EnumSelectionReason enum."""
+
+    def test_all_reasons_exist(self) -> None:
+        """Verify the exact set of selection reasons required by the plan."""
+        assert EnumSelectionReason.POLICY_EFFECTIVENESS == "policy_effectiveness"
+        assert EnumSelectionReason.POLICY_REQUIRED_FACTOR == "policy_required_factor"
+        assert EnumSelectionReason.EXPERIMENT_ASSIGNMENT == "experiment_assignment"
+        assert EnumSelectionReason.EXPLORATION == "exploration"
+        assert EnumSelectionReason.FALLBACK_NO_SCORE == "fallback_no_score"
+
+    def test_enum_inheritance(self) -> None:
+        """Test that enum inherits from StrEnum (and therefore str + Enum)."""
+        assert issubclass(EnumSelectionReason, StrEnum)
+        assert issubclass(EnumSelectionReason, str)
+        assert issubclass(EnumSelectionReason, Enum)
+
+    def test_exactly_five_members(self) -> None:
+        """Plan mandates exactly five reasons — no more, no fewer."""
+        values = {member.value for member in EnumSelectionReason}
+        assert values == {
+            "policy_effectiveness",
+            "policy_required_factor",
+            "experiment_assignment",
+            "exploration",
+            "fallback_no_score",
+        }
+        assert len(list(EnumSelectionReason)) == 5
+
+    def test_json_serialization(self) -> None:
+        """Test that enum values can be JSON serialized as their string value."""
+        assert json.dumps(EnumSelectionReason.POLICY_EFFECTIVENESS) == (
+            '"policy_effectiveness"'
+        )
+
+    def test_enum_creation_from_string(self) -> None:
+        """Test that enum can be constructed from its string value."""
+        assert (
+            EnumSelectionReason("experiment_assignment")
+            == EnumSelectionReason.EXPERIMENT_ASSIGNMENT
+        )
+
+    def test_invalid_value_raises_error(self) -> None:
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            EnumSelectionReason("not_a_reason")
+
+    def test_values_are_unique(self) -> None:
+        """Test that enum values are unique."""
+        values = [member.value for member in EnumSelectionReason]
+        assert len(values) == len(set(values))


### PR DESCRIPTION
## OMN-12843 — M3 Context Authority Rule (core enum slice)

Adds `EnumSelectionReason` (StrEnum) to `omnibase_core` — the typed authority field that makes per-run context injection auditable. Exactly five reasons, per the Behavior-Augmented Context research plan:

- `POLICY_EFFECTIVENESS` — selected by M2-resolved measured effectiveness
- `POLICY_REQUIRED_FACTOR` — profile-declared required factor (stamped, not silent)
- `EXPERIMENT_ASSIGNMENT` — forced/arm-fixed under an active experiment cohort
- `EXPLORATION` — reserved for the M4 explore path (cold-start / decay re-trial)
- `FALLBACK_NO_SCORE` — candidate has no M2 score yet (explicit, not silent)

The omnimarket COMPUTE node `node_context_selection_policy_compute` (separate PR) consumes this enum to stamp the Authority 5-tuple {factor, source, selection_reason, effectiveness_score, experiment_cohort} on every selected factor.

### TDD (RED -> GREEN)
`tests/unit/enums/test_enum_selection_reason.py` written RED first (ModuleNotFoundError on the missing module), GREEN after: 7 passed. Asserts the exact 5-member set, StrEnum inheritance, JSON round-trip, and ValueError on unknown values.

### Local proof
- `uv run pytest tests/unit/enums/test_enum_selection_reason.py` -> 7 passed
- `uv run mypy src/omnibase_core/enums/enum_selection_reason.py --strict` -> Success
- `ruff format` + `ruff check` -> clean
- `pre-commit run --files ...` (74 hooks) -> all Passed, 0 Failed (DETERMINISTIC_SKILL_ROOT set to the omniclaude plugin skills root per OMN-8765 hook)

Placed next to `enum_context_factor.py` (the sibling enum it pairs with in the Authority tuple).

Evidence-Source: OCC#2858
Evidence-Ticket: OMN-12843

Paired OCC receipt PR (contract + dod_evidence) opened in OmniNode-ai/onex_change_control; see linked PR for the dod-core / dod-omnimarket receipts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented internal framework for categorizing context factor selection reasons with five distinct classification types.

* **Tests**
  * Added comprehensive validation tests for selection reason handling, including serialization, uniqueness, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

