### PR TITLE
feat(OMN-13234): typed tier cost model (free_local/metered/budgeted) on delegation wire DTOs

### DIFF
--- a/contracts/OMN-13234.yaml
+++ b/contracts/OMN-13234.yaml
@@ -1,0 +1,51 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13234"
+title: "Typed tier cost model on ModelRoutingTier (free_local / metered / budgeted)"
+summary: >
+  Add the canonical typed per-tier cost model to the delegation routing wire DTOs: EnumTierCostType (free_local
+  | metered | budgeted), ModelTierCost (rate/cap/overage with regime-aware validation), a `cost` field
+  on ModelRoutingTier, and cost-measurement carrier fields on ModelTaskDelegatedEvent (cost_tier_type,
+  cost_tier_name, cost_measurement_source, budget_headroom_consumed_usd). These are the shared cross-repo
+  models the omnimarket routing parser, pricing computation, and delegation_events projection consume
+  (OMN-13234).
+is_seam_ticket: true
+interface_change: true
+interfaces_touched:
+  - "public_api"
+  - "events"
+evidence_requirements:
+  - kind: "tests"
+    description: "Delegation wire model unit tests green incl. ModelTierCost regime validation (free_local zero-rate, metered positive-rate, budgeted cap+overage) and ModelRoutingTier typed-cost acceptance."
+    command: "uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q"
+  - kind: "ci"
+    description: "mypy --strict green on the changed wire model module."
+    command: "uv run mypy src/omnibase_core/models/delegation/wire/model_routing_config.py --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Delegation wire model unit tests green incl. ModelTierCost regime validation (free_local
+      zero-rate, metered positive-rate, budgeted cap+overage) and ModelRoutingTier typed-cost acceptance."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q"
+  - id: "dod-002"
+    description: "mypy --strict green on the changed wire model module."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/models/delegation/wire/model_routing_config.py --strict"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: pure typed-model addition (Pydantic DTOs + enum) with no runtime
+      process, broker topic, or service deploy. Downstream consumers (omnimarket) pick the symbols up
+      on the next core pin bump."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13234 adds typed delegation-wire DTOs (EnumTierCostType /
+          ModelTierCost / ModelRoutingTier.cost); no Docker image, daemon, broker topic, or service deploy
+          required'"

--- a/src/omnibase_core/enums/enum_correction_failure_axis.py
+++ b/src/omnibase_core/enums/enum_correction_failure_axis.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Correction failure-axis enum for the context-selection learning loop.
+
+The failure axis is the dimension that decides whether a user correction counts
+*against context selection*:
+
+* ``MISUNDERSTANDING`` — context was present at injection but failed to convey
+  or disambiguate intent. This is a real context-selection failure and is
+  counted toward the context-failure rate.
+* ``NEW_INFORMATION`` — a requirement that did not exist at injection time. This
+  is NOT a context failure; it is recorded but excluded from the context-failure
+  rate.
+
+Orthogonal to ``EnumUserCorrectionCategory`` and stored as a separate
+first-class field (OMN-12846). Lives in ``omnibase_core`` because it crosses the
+core / omnimarket boundary.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumCorrectionFailureAxis(StrEnum):
+    """Whether a user correction counts against context selection."""
+
+    MISUNDERSTANDING = "MISUNDERSTANDING"
+    NEW_INFORMATION = "NEW_INFORMATION"
+
+
+__all__: list[str] = ["EnumCorrectionFailureAxis"]

--- a/src/omnibase_core/enums/enum_selection_reason.py
+++ b/src/omnibase_core/enums/enum_selection_reason.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Selection-reason enum for the Context Authority Rule (OMN-12843 / M3).
+
+Every context factor selected for per-run injection carries a typed reason so
+that injection is auditable: there is no "hidden authority". The reason answers
+*why this factor was chosen*, paired in the Authority 5-tuple with the factor,
+its stable source id, its measured effectiveness score, and the experiment
+cohort (if any).
+
+Semantics:
+
+* ``POLICY_EFFECTIVENESS`` — selected because its measured effectiveness score
+  (resolved from the M2 capsule store) ranked it in.
+* ``POLICY_REQUIRED_FACTOR`` — declared required by the profile; admitted by
+  policy and stamped (auditable, not silent).
+* ``EXPERIMENT_ASSIGNMENT`` — a forced/arm-fixed selection under an active
+  experiment cohort. Permitted ONLY when a cohort id is present.
+* ``EXPLORATION`` — cold-start / decay re-trial (the M4 explore path). The
+  reason is reserved here; the bandit logic lands in M4.
+* ``FALLBACK_NO_SCORE`` — the candidate has no M2 score yet. Explicit, not
+  silent: ``effectiveness_score`` is ``None`` only with this reason.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumSelectionReason(StrEnum):
+    """Typed authority reason stamped on each selected context factor."""
+
+    POLICY_EFFECTIVENESS = "policy_effectiveness"
+    POLICY_REQUIRED_FACTOR = "policy_required_factor"
+    EXPERIMENT_ASSIGNMENT = "experiment_assignment"
+    EXPLORATION = "exploration"
+    FALLBACK_NO_SCORE = "fallback_no_score"
+
+
+__all__ = [
+    "EnumSelectionReason",
+]

--- a/src/omnibase_core/enums/enum_tier_cost_type.py
+++ b/src/omnibase_core/enums/enum_tier_cost_type.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed cost-measurement regime for a delegation routing tier (OMN-13234)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumTierCostType(StrEnum):
+    """How a routing tier's actual dollar cost is measured (OMN-13234).
+
+    The flat ``cost_per_1k_tokens`` field models every tier as one per-token
+    rate, which cannot express a locally-served tier (zero API cost) or a tier
+    with a monthly spend cap and overage rate. This enum names the three
+    measurement regimes the delegation ladder actually runs:
+
+    - ``FREE_LOCAL`` — served on owned hardware (local GPU / Mac). No marginal
+      API cost; the dollar figure, when needed, comes from the pricing
+      manifest's GPU ``compute_cost`` (electricity + amortization), not a
+      per-1k token rate. Token-rate cost is always 0.
+    - ``METERED`` — billed per token at a fixed ``rate_per_1k_usd`` with no cap
+      (e.g. a direct provider key). cost = rate * tokens / 1000.
+    - ``BUDGETED`` — billed per token but covered by a monthly spend cap
+      (``monthly_cap_usd``). Tokens served while headroom remains cost 0 cash
+      (the cap is already paid); tokens served past the cap are billed at
+      ``overage_rate_per_1k_usd``.
+    """
+
+    FREE_LOCAL = "free_local"
+    METERED = "metered"
+    BUDGETED = "budgeted"
+
+
+__all__: list[str] = ["EnumTierCostType"]

--- a/src/omnibase_core/enums/enum_user_correction_category.py
+++ b/src/omnibase_core/enums/enum_user_correction_category.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""User-correction category enum for the context-selection learning loop.
+
+A user correction is categorized by *what kind* of correction it is. This axis
+is orthogonal to ``EnumCorrectionFailureAxis`` (whether the correction counts as
+a context-selection failure): both are first-class fields on the correction
+event and are never collapsed into a single rolled-up score (OMN-12846).
+
+Lives in ``omnibase_core`` because it crosses the core / omnimarket boundary:
+the typed ``ModelUserCorrectionEvent`` in omnimarket references it.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumUserCorrectionCategory(StrEnum):
+    """The kind of user correction applied to an agent's work.
+
+    Finite, exhaustive set. Categories are preserved on the event; there is no
+    single rolled-up score that flattens them.
+    """
+
+    CLARIFICATION = "CLARIFICATION"
+    CONSTRAINT_VIOLATION = "CONSTRAINT_VIOLATION"
+    SCOPE_REDUCTION = "SCOPE_REDUCTION"
+    SCOPE_EXPANSION = "SCOPE_EXPANSION"
+    PRIORITY_SHIFT = "PRIORITY_SHIFT"
+    STYLE = "STYLE"
+    INTENT = "INTENT"
+
+
+__all__: list[str] = ["EnumUserCorrectionCategory"]

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -46,8 +46,10 @@ from omnibase_core.models.delegation.wire.model_quality_gate import (
     ModelQualityGateResult,
 )
 from omnibase_core.models.delegation.wire.model_routing_config import (
+    EnumTierCostType,
     ModelDelegationConfig,
     ModelRoutingTier,
+    ModelTierCost,
     ModelTierModel,
 )
 from omnibase_core.models.delegation.wire.model_task_delegated_event import (
@@ -62,6 +64,7 @@ __all__: list[str] = [
     "EnumBudgetAction",
     "EnumQualityContractMode",
     "EnumQualityGateCategory",
+    "EnumTierCostType",
     "ModelBaselineIntent",
     "ModelBifrostDelegationConfig",
     "ModelBudgetLimits",
@@ -85,6 +88,7 @@ __all__: list[str] = [
     "ModelRoutingIntent",
     "ModelRoutingTier",
     "ModelTaskDelegatedEvent",
+    "ModelTierCost",
     "ModelTierModel",
     "validate_acceptance_criteria",
 ]

--- a/src/omnibase_core/models/delegation/wire/model_routing_config.py
+++ b/src/omnibase_core/models/delegation/wire/model_routing_config.py
@@ -8,7 +8,82 @@ OMN-8596 owns ModelRoutingDecision; this module only carries routing config.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_tier_cost_type import EnumTierCostType
+
+
+class ModelTierCost(BaseModel):
+    """Typed per-tier cost model (OMN-13234).
+
+    Declares HOW a tier is billed (``cost_type``) plus the rate/cap fields that
+    measurement regime requires. Validated so each regime carries exactly the
+    fields it needs and nothing it does not:
+
+    - ``free_local`` — no rate, no cap.
+    - ``metered`` — ``rate_per_1k_usd`` required (> 0); no cap.
+    - ``budgeted`` — ``monthly_cap_usd`` and ``overage_rate_per_1k_usd``
+      required; ``rate_per_1k_usd`` is the in-budget per-1k accounting rate
+      used to draw down headroom.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    cost_type: EnumTierCostType = Field(
+        ...,
+        description="Measurement regime for this tier's actual dollar cost.",
+    )
+    rate_per_1k_usd: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Per-1,000-token USD rate. For 'metered' this is the billed rate. "
+            "For 'budgeted' this is the in-budget accounting rate that draws "
+            "down monthly headroom. For 'free_local' it must be 0."
+        ),
+    )
+    monthly_cap_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Monthly spend cap for 'budgeted' tiers. Tokens served while "
+            "headroom remains cost 0 cash; tokens past the cap bill at "
+            "overage_rate_per_1k_usd. Must be None for free_local/metered."
+        ),
+    )
+    overage_rate_per_1k_usd: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Per-1,000-token USD rate charged for 'budgeted' tokens served "
+            "after the monthly cap is exhausted. Ignored for other types."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_regime_fields(self) -> ModelTierCost:
+        if self.cost_type is EnumTierCostType.FREE_LOCAL:
+            if self.rate_per_1k_usd != 0.0:
+                raise ValueError("free_local cost must have rate_per_1k_usd == 0")
+            if self.monthly_cap_usd is not None:
+                raise ValueError("free_local cost must not declare monthly_cap_usd")
+            if self.overage_rate_per_1k_usd != 0.0:
+                raise ValueError(
+                    "free_local cost must have overage_rate_per_1k_usd == 0"
+                )
+        elif self.cost_type is EnumTierCostType.METERED:
+            if self.rate_per_1k_usd <= 0.0:
+                raise ValueError("metered cost requires rate_per_1k_usd > 0")
+            if self.monthly_cap_usd is not None:
+                raise ValueError(
+                    "metered cost must not declare monthly_cap_usd; use 'budgeted'"
+                )
+        elif self.cost_type is EnumTierCostType.BUDGETED:
+            if self.monthly_cap_usd is None:
+                raise ValueError("budgeted cost requires monthly_cap_usd")
+            if self.overage_rate_per_1k_usd <= 0.0:
+                raise ValueError("budgeted cost requires overage_rate_per_1k_usd > 0")
+        return self
 
 
 class ModelTierModel(BaseModel):
@@ -56,7 +131,20 @@ class ModelRoutingTier(BaseModel):
     cost_per_1k_tokens: float = Field(
         default=0.0,
         ge=0.0,
-        description="Estimated tier cost per 1,000 tokens.",
+        description=(
+            "Legacy flat per-1,000-token estimate used by the ceiling-comparison "
+            "routing check. Superseded for actual-cost measurement by the typed "
+            "`cost` model (OMN-13234); kept for the routing policy comparison."
+        ),
+    )
+    cost: ModelTierCost | None = Field(
+        default=None,
+        description=(
+            "Typed per-tier cost model (OMN-13234): free_local | metered | "
+            "budgeted with rate/cap/overage. When present, the projection cost "
+            "computation uses this instead of the flat cost_per_1k_tokens. "
+            "None means the tier has not been migrated to the typed model."
+        ),
     )
     max_retries: int = Field(
         default=0,
@@ -76,4 +164,10 @@ class ModelDelegationConfig(BaseModel):
     )
 
 
-__all__: list[str] = ["ModelDelegationConfig", "ModelRoutingTier", "ModelTierModel"]
+__all__: list[str] = [
+    "EnumTierCostType",
+    "ModelDelegationConfig",
+    "ModelRoutingTier",
+    "ModelTierCost",
+    "ModelTierModel",
+]

--- a/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
+++ b/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
@@ -131,6 +131,38 @@ class ModelTaskDelegatedEvent(BaseModel):
             "pinned premium price could be resolved for the run."
         ),
     )
+    cost_tier_type: str = Field(
+        default="",
+        description=(
+            "Typed tier cost regime that priced this call (OMN-13234): "
+            "free_local | metered | budgeted. Empty when the serving tier had no "
+            "typed cost model (legacy flat-rate path)."
+        ),
+    )
+    cost_tier_name: str = Field(
+        default="",
+        description=(
+            "Routing tier name that served this task (OMN-13234): "
+            "local | cheap_cloud | cheap_frontier | claude."
+        ),
+    )
+    cost_measurement_source: str = Field(
+        default="",
+        description=(
+            "How cost_usd was measured (OMN-13234): free_local | metered | "
+            "budgeted_in_budget | budgeted_overage | budgeted_split | "
+            "manifest_compute | no_cost_model."
+        ),
+    )
+    budget_headroom_consumed_usd: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Monthly-budget drawdown for budgeted tiers (OMN-13234): the "
+            "accounting cost of in-budget tokens served at 0 cash. 0 for "
+            "free_local / metered / overage tokens."
+        ),
+    )
 
 
 __all__: list[str] = [

--- a/tests/unit/enums/test_enum_selection_reason.py
+++ b/tests/unit/enums/test_enum_selection_reason.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for EnumSelectionReason enum (OMN-12843 / M3 Context Authority Rule).
+
+EnumSelectionReason is the typed authority enum stamped on every selected
+context factor so that per-run injection is auditable. It encodes WHY a factor
+was selected: by measured effectiveness, by required-factor policy, by an
+experiment arm, by exploration, or as an explicit no-score fallback.
+"""
+
+import json
+from enum import Enum, StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_selection_reason import EnumSelectionReason
+
+
+@pytest.mark.unit
+class TestEnumSelectionReason:
+    """Test cases for EnumSelectionReason enum."""
+
+    def test_all_reasons_exist(self) -> None:
+        """Verify the exact set of selection reasons required by the plan."""
+        assert EnumSelectionReason.POLICY_EFFECTIVENESS == "policy_effectiveness"
+        assert EnumSelectionReason.POLICY_REQUIRED_FACTOR == "policy_required_factor"
+        assert EnumSelectionReason.EXPERIMENT_ASSIGNMENT == "experiment_assignment"
+        assert EnumSelectionReason.EXPLORATION == "exploration"
+        assert EnumSelectionReason.FALLBACK_NO_SCORE == "fallback_no_score"
+
+    def test_enum_inheritance(self) -> None:
+        """Test that enum inherits from StrEnum (and therefore str + Enum)."""
+        assert issubclass(EnumSelectionReason, StrEnum)
+        assert issubclass(EnumSelectionReason, str)
+        assert issubclass(EnumSelectionReason, Enum)
+
+    def test_exactly_five_members(self) -> None:
+        """Plan mandates exactly five reasons — no more, no fewer."""
+        values = {member.value for member in EnumSelectionReason}
+        assert values == {
+            "policy_effectiveness",
+            "policy_required_factor",
+            "experiment_assignment",
+            "exploration",
+            "fallback_no_score",
+        }
+        assert len(list(EnumSelectionReason)) == 5
+
+    def test_json_serialization(self) -> None:
+        """Test that enum values can be JSON serialized as their string value."""
+        assert json.dumps(EnumSelectionReason.POLICY_EFFECTIVENESS) == (
+            '"policy_effectiveness"'
+        )
+
+    def test_enum_creation_from_string(self) -> None:
+        """Test that enum can be constructed from its string value."""
+        assert (
+            EnumSelectionReason("experiment_assignment")
+            == EnumSelectionReason.EXPERIMENT_ASSIGNMENT
+        )
+
+    def test_invalid_value_raises_error(self) -> None:
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            EnumSelectionReason("not_a_reason")
+
+    def test_values_are_unique(self) -> None:
+        """Test that enum values are unique."""
+        values = [member.value for member in EnumSelectionReason]
+        assert len(values) == len(set(values))

--- a/tests/unit/enums/test_enum_user_correction.py
+++ b/tests/unit/enums/test_enum_user_correction.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the category-weighted user-correction enums (OMN-12846).
+
+These enums cross the omnibase_core / omnimarket boundary: the typed
+user-correction event in omnimarket references them, so they live in core.
+
+The category axis (what kind of correction) is deliberately kept orthogonal
+to the failure axis (whether the correction counts against context selection)
+— there is no single rolled-up score, by design (anti-flattening invariant).
+"""
+
+from enum import StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_correction_failure_axis import EnumCorrectionFailureAxis
+from omnibase_core.enums.enum_user_correction_category import EnumUserCorrectionCategory
+
+
+@pytest.mark.unit
+class TestEnumUserCorrectionCategory:
+    """The correction category is a finite, exhaustive, typed set."""
+
+    def test_correction_category_enum_is_exhaustive(self) -> None:
+        """Exactly the 7 named members, no more, no fewer."""
+        expected = {
+            "CLARIFICATION",
+            "CONSTRAINT_VIOLATION",
+            "SCOPE_REDUCTION",
+            "SCOPE_EXPANSION",
+            "PRIORITY_SHIFT",
+            "STYLE",
+            "INTENT",
+        }
+        actual = {member.name for member in EnumUserCorrectionCategory}
+        assert actual == expected
+
+    def test_is_str_enum(self) -> None:
+        """Must be a StrEnum for cross-process wire stability."""
+        assert issubclass(EnumUserCorrectionCategory, StrEnum)
+
+    def test_enum_prefix(self) -> None:
+        """Class name carries the canonical Enum prefix."""
+        assert EnumUserCorrectionCategory.__name__.startswith("Enum")
+
+    def test_members_round_trip_by_value(self) -> None:
+        """Each member reconstructs from its own string value."""
+        for member in EnumUserCorrectionCategory:
+            assert EnumUserCorrectionCategory(member.value) is member
+
+
+@pytest.mark.unit
+class TestEnumCorrectionFailureAxis:
+    """The failure axis gates whether a correction counts against context."""
+
+    def test_failure_axis_misunderstanding_vs_new_information(self) -> None:
+        """Exactly MISUNDERSTANDING and NEW_INFORMATION."""
+        expected = {"MISUNDERSTANDING", "NEW_INFORMATION"}
+        actual = {member.name for member in EnumCorrectionFailureAxis}
+        assert actual == expected
+
+    def test_is_str_enum(self) -> None:
+        """Must be a StrEnum for cross-process wire stability."""
+        assert issubclass(EnumCorrectionFailureAxis, StrEnum)
+
+    def test_enum_prefix(self) -> None:
+        """Class name carries the canonical Enum prefix."""
+        assert EnumCorrectionFailureAxis.__name__.startswith("Enum")
+
+    def test_members_round_trip_by_value(self) -> None:
+        """Each member reconstructs from its own string value."""
+        for member in EnumCorrectionFailureAxis:
+            assert EnumCorrectionFailureAxis(member.value) is member

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from omnibase_core.models.delegation.wire import (
     TASK_DELEGATED_TOPIC_V1,
     EnumBudgetAction,
+    EnumTierCostType,
     ModelBaselineIntent,
     ModelBifrostDelegationConfig,
     ModelBudgetLimits,
@@ -36,6 +37,7 @@ from omnibase_core.models.delegation.wire import (
     ModelRoutingIntent,
     ModelRoutingTier,
     ModelTaskDelegatedEvent,
+    ModelTierCost,
     ModelTierModel,
     validate_acceptance_criteria,
 )
@@ -350,6 +352,85 @@ class TestModelRoutingTier:
 
         with pytest.raises(ValidationError):
             ModelRoutingTier(name="local", max_retries=-1)
+
+    def test_accepts_typed_cost_model(self) -> None:
+        """OMN-13234: ModelRoutingTier carries the typed cost model."""
+        tier = ModelRoutingTier(
+            name="cheap_cloud",
+            cost=ModelTierCost(
+                cost_type=EnumTierCostType.METERED,
+                rate_per_1k_usd=0.002,
+            ),
+        )
+        assert tier.cost is not None
+        assert tier.cost.cost_type is EnumTierCostType.METERED
+
+    def test_cost_defaults_none(self) -> None:
+        """A tier not yet migrated to the typed model has cost=None."""
+        tier = ModelRoutingTier(name="local")
+        assert tier.cost is None
+
+
+@pytest.mark.unit
+class TestModelTierCost:
+    def test_free_local_zero_rate(self) -> None:
+        cost = ModelTierCost(cost_type=EnumTierCostType.FREE_LOCAL)
+        assert cost.rate_per_1k_usd == 0.0
+        assert cost.monthly_cap_usd is None
+
+    def test_free_local_rejects_nonzero_rate(self) -> None:
+        with pytest.raises(ValidationError, match="rate_per_1k_usd == 0"):
+            ModelTierCost(
+                cost_type=EnumTierCostType.FREE_LOCAL,
+                rate_per_1k_usd=0.002,
+            )
+
+    def test_free_local_rejects_cap(self) -> None:
+        with pytest.raises(ValidationError, match="must not declare monthly_cap_usd"):
+            ModelTierCost(
+                cost_type=EnumTierCostType.FREE_LOCAL,
+                monthly_cap_usd=10.0,
+            )
+
+    def test_metered_requires_positive_rate(self) -> None:
+        with pytest.raises(ValidationError, match="rate_per_1k_usd > 0"):
+            ModelTierCost(cost_type=EnumTierCostType.METERED)
+
+    def test_metered_rejects_cap(self) -> None:
+        with pytest.raises(ValidationError, match="must not declare monthly_cap_usd"):
+            ModelTierCost(
+                cost_type=EnumTierCostType.METERED,
+                rate_per_1k_usd=0.002,
+                monthly_cap_usd=10.0,
+            )
+
+    def test_budgeted_requires_cap_and_overage(self) -> None:
+        with pytest.raises(ValidationError, match="requires monthly_cap_usd"):
+            ModelTierCost(
+                cost_type=EnumTierCostType.BUDGETED,
+                rate_per_1k_usd=0.001,
+            )
+        with pytest.raises(ValidationError, match="overage_rate_per_1k_usd > 0"):
+            ModelTierCost(
+                cost_type=EnumTierCostType.BUDGETED,
+                rate_per_1k_usd=0.001,
+                monthly_cap_usd=10.0,
+            )
+
+    def test_budgeted_valid(self) -> None:
+        cost = ModelTierCost(
+            cost_type=EnumTierCostType.BUDGETED,
+            rate_per_1k_usd=0.001,
+            monthly_cap_usd=10.0,
+            overage_rate_per_1k_usd=0.003,
+        )
+        assert cost.monthly_cap_usd == 10.0
+        assert cost.overage_rate_per_1k_usd == 0.003
+
+    def test_frozen(self) -> None:
+        cost = ModelTierCost(cost_type=EnumTierCostType.FREE_LOCAL)
+        with pytest.raises(ValidationError):
+            cost.rate_per_1k_usd = 0.5  # type: ignore[misc]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## OMN-13234: typed tier cost model on delegation wire DTOs

Foundation for honest savings: add the canonical typed per-tier cost model that
the omnimarket routing parser, pricing computation, and `delegation_events`
projection consume.

### What
- `EnumTierCostType`: `free_local` | `metered` | `budgeted`
- `ModelTierCost`: `rate_per_1k_usd` / `monthly_cap_usd` / `overage_rate_per_1k_usd`
  with regime-aware validation (free_local zero-rate; metered positive-rate;
  budgeted cap+overage required).
- `ModelRoutingTier.cost`: optional typed cost block (None = not yet migrated;
  legacy flat `cost_per_1k_tokens` retained for the routing-policy ceiling check).
- `ModelTaskDelegatedEvent`: `cost_tier_type` / `cost_tier_name` /
  `cost_measurement_source` / `budget_headroom_consumed_usd` carrier fields.

### Local verify (worktree)
- `uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q` -> 79 passed
- `uv run mypy src/omnibase_core/models/delegation/wire/model_routing_config.py --strict` -> clean
- `pre-commit run` on changed files -> all pass (deterministic-skill-routing passes with DETERMINISTIC_SKILL_ROOT pointed at omniclaude skills root)

### Evidence
- Evidence-Source: branch `jonah/omn-13234-13362-typed-tier-cost-and-dual-table` @ this PR head
- Evidence-Ticket: OMN-13234
- OCC contract: `contracts/OMN-13234.yaml`

Cross-repo: omnimarket consumes these symbols (OMN-13234 omnimarket PR). Core pin
bump propagates after merge. No merge here — sweep owns merge + OCC receipt pairing.

OMN-13234



---

## OCC Evidence pairing (savings cluster)

Evidence-Source: OCC#2868
Evidence-Ticket: OMN-13234

OCC#2868 carries `contracts/OMN-13234.yaml` + PASS receipts (core #1290 79 wire-model tests).

<!-- occ-head: 1747bb7d5 -->
