### PR TITLE
feat(OMN-13389): add ModelRendererThemeContract — versioned design-token contract

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -35,8 +35,8 @@ allowed_files:
       structural fact — descriptor.agent_invocation — from the enclosing node contract.yaml. contract.yaml
       schemas vary by node_type (ModelContractCompute/Effect/Reducer/Orchestrator) and the gate must tolerate
       ANY contract shape while reading a single boolean; no single Pydantic model applies, so raw yaml.safe_load
-      extracts the flat fact (same architectural pattern as validator_banned_compose_vars.py and
-      mixin_contract_publisher.py). The result is coerced to a strict bool (descriptor.get(...) is True).
+      extracts the flat fact (same architectural pattern as validator_banned_compose_vars.py and mixin_contract_publisher.py).
+      The result is coerced to a strict bool (descriptor.get(...) is True).
     added: "2026-06-18"
     review: "2026-12-13"
 

--- a/contracts/OMN-13130.yaml
+++ b/contracts/OMN-13130.yaml
@@ -3,29 +3,31 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13130"
 title: "feat(OMN-13130): UI contract primitives + EnumEmptyStateReason in omnibase_core"
 summary: >
-  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract
-  primitives to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract,
-  PermissionContract, EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason
-  (four values mirroring omnidash/shared/types/chart-config.ts exactly) and supporting enums
-  (EnumBindingOrderDirection, EnumEvidenceGateMoment, EnumRendererInteractionModel, EnumAccessibilityTier).
-  ActionContract COMPOSES the existing ModelGate approval primitive (no duplication, per the ADR);
-  EvidenceRequirementContract composes the OCC ModelEvidenceRequirement. ModelGate and ModelGateSpec
-  source are untouched. All six models registered in scripts/emit_ts_types.py for Stage 2 TS codegen.
-  Additive only — every existing omnidash manifest still validates and the dashboard export-surface test
-  was extended (not broken).
+  Phase 0 of the Contract-Driven UI Platform (epic OMN-13129). Adds six frozen Pydantic UI contract primitives
+  to omnibase_core/models/dashboard (ComponentContract, ActionContract, DataBindingContract, PermissionContract,
+  EvidenceRequirementContract, RendererCapabilityContract) plus EnumEmptyStateReason (four values mirroring
+  omnidash/shared/types/chart-config.ts exactly) and supporting enums (EnumBindingOrderDirection, EnumEvidenceGateMoment,
+  EnumRendererInteractionModel, EnumAccessibilityTier). ActionContract COMPOSES the existing ModelGate
+  approval primitive (no duplication, per the ADR); EvidenceRequirementContract composes the OCC ModelEvidenceRequirement.
+  ModelGate and ModelGateSpec source are untouched. All six models registered in scripts/emit_ts_types.py
+  for Stage 2 TS codegen. Additive only — every existing omnidash manifest still validates and the dashboard
+  export-surface test was extended (not broken).
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
   - "public_api"
 evidence_requirements:
   - kind: "tests"
-    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid, required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
-    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py -q"
+    description: "36 new unit tests for the six primitives + EnumEmptyStateReason (frozen, extra=forbid,
+      required fields, strong typing, ModelGate composition); existing dashboard export-surface test extended"
+    command: "uv run pytest tests/unit/models/dashboard/test_ui_contract_primitives.py tests/unit/models/dashboard/test_dashboard_imports.py
+      -q"
   - kind: "tests"
     description: "Full models + enums suites pass with no regression (25095 passed, 5 skipped)"
     command: "uv run pytest tests/unit/models/ tests/unit/enums/ -q -n auto"
   - kind: "ci"
-    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing on origin/dev in contract_loader.py and cli_install.py)"
+    description: "mypy --strict clean on all new files (the 3 remaining repo-wide errors are pre-existing
+      on origin/dev in contract_loader.py and cli_install.py)"
     command: "uv run mypy src/ --strict"
   - kind: "ci"
     description: "ruff lint and format pass on src/ tests/"
@@ -39,7 +41,9 @@ emergency_bypass:
   follow_up_ticket_id: ""
 dod_evidence:
   - id: "dod-ui-primitive-tests"
-    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises, extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not duplicated"
+    description: "36 new unit tests pass (six primitives + EnumEmptyStateReason): frozen mutation raises,
+      extra=forbid rejects unknown keys, required fields enforced, strong typing, ModelGate composed not
+      duplicated"
     source: "manual"
     checks:
       - check_type: "command"
@@ -47,7 +51,9 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '36 passed'"
   - id: "dod-additive-no-regression"
-    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected, zero import errors)"
+    description: "Additive only: full models + enums suites pass (25095 passed, 5 skipped); dashboard
+      export-surface test extended to assert the new symbols; full tests/ collection succeeds (41765 collected,
+      zero import errors)"
     source: "manual"
     checks:
       - check_type: "command"
@@ -55,19 +61,23 @@ dod_evidence:
       - check_type: "command"
         check_value: "echo '25095 passed, 5 skipped'"
   - id: "dod-mypy-strict"
-    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704, cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
+    description: "mypy --strict reports zero errors in any new file; the only 3 src-wide errors (contract_loader.py:570/704,
+      cli_install.py:45) are byte-identical on origin/dev (pre-existing)"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py --strict"
+        check_value: "uv run mypy src/omnibase_core/models/dashboard/ src/omnibase_core/enums/enum_empty_state_reason.py
+          --strict"
   - id: "dod-emit-ts-registration"
-    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
+    description: "All six UI contract primitives registered in scripts/emit_ts_types.py MODELS dict and
+      present in the emitted JSON-Schema $defs for Stage 2 TS codegen"
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "uv run python scripts/emit_ts_types.py /tmp/omn13130-ts-types.json"
       - check_type: "command"
-        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract, ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
+        check_value: "echo 'all 6 registered: ModelComponentContract, ModelActionContract, ModelDataBindingContract,
+          ModelPermissionContract, ModelEvidenceRequirementContract, ModelRendererCapabilityContract'"
   - id: "dod-gate-disambiguation"
     description: >
       Per ADR docs/adr/2026-06-17-ui-deterministic-projection-effect-layer.md (D2): ActionContract composes
@@ -77,15 +87,16 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py src/omnibase_core/models/objective/model_gate_spec.py"
+        check_value: "git diff --name-only origin/dev -- src/omnibase_core/models/ticket/model_gate.py
+          src/omnibase_core/models/objective/model_gate_spec.py"
       - check_type: "command"
         check_value: "echo 'no changes to ModelGate / ModelGateSpec source'"
   - id: "dod-deploy-gate"
     description: >
       Deploy-gate evidence: pure additive Pydantic model + enum additions in omnibase_core. No Kafka topic
       schema changes, no new topics, no node/handler, no Docker image rebuild, no runtime process restart,
-      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer and
-      topic are Phase 1.
+      no database migration. RendererCapabilityContract is model-only this phase; its omnimarket reducer
+      and topic are Phase 1.
     source: "manual"
     checks:
       - check_type: "command"

--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -33,6 +33,7 @@ from omnibase_core.models.dashboard import (
     ModelEvidenceRequirementContract,
     ModelPermissionContract,
     ModelRendererCapabilityContract,
+    ModelRendererThemeContract,
 )
 from omnibase_core.models.notifications import ModelStateTransitionNotification
 from omnibase_core.models.projectors import (
@@ -62,6 +63,8 @@ MODELS: dict[str, type[BaseModel]] = {
     "ModelPermissionContract": ModelPermissionContract,
     "ModelEvidenceRequirementContract": ModelEvidenceRequirementContract,
     "ModelRendererCapabilityContract": ModelRendererCapabilityContract,
+    # Versioned design-token contract (OMN-13389)
+    "ModelRendererThemeContract": ModelRendererThemeContract,
 }
 
 

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -84,6 +84,9 @@ from omnibase_core.models.dashboard.model_permission_contract import (
 from omnibase_core.models.dashboard.model_renderer_capability_contract import (
     ModelRendererCapabilityContract,
 )
+from omnibase_core.models.dashboard.model_renderer_theme_contract import (
+    ModelRendererThemeContract,
+)
 from omnibase_core.models.dashboard.model_status_item_config import (
     ModelStatusItemConfig,
 )
@@ -145,4 +148,6 @@ __all__: tuple[str, ...] = (
     "ModelPermissionContract",
     "ModelEvidenceRequirementContract",
     "ModelRendererCapabilityContract",
+    # Versioned design-token contract (OMN-13389)
+    "ModelRendererThemeContract",
 )

--- a/src/omnibase_core/models/dashboard/model_renderer_theme_contract.py
+++ b/src/omnibase_core/models/dashboard/model_renderer_theme_contract.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RendererThemeContract — versioned design-token contract artifact.
+
+Phase 0 UI theming contract (OMN-13389, epic OMN-13129; plan
+docs/plans/2026-06-13-contract-driven-ui-platform-unified-plan.md §6, §7).
+
+Design tokens are declared here as **contract fields**, not prose. A renderer
+that wants to apply a theme reads every token from this model — no literal color
+or spacing value is permitted outside a ModelRendererThemeContract instance.
+The explicit ``contract_version`` field makes schema drift detectable; the
+``emit_ts_types.py`` pipeline mirrors this contract to TypeScript, and CI
+diffs the generated file to gate drift.
+
+Token taxonomy
+--------------
+Surfaces:
+  color_background_primary / secondary / elevated
+
+Text:
+  color_text_primary / secondary / disabled
+
+Brand / accent:
+  color_accent_primary / secondary
+
+Semantic status:
+  color_status_success / warning / error / info
+
+Borders:
+  color_border_default / strong
+
+Spacing scale (CSS rem strings):
+  spacing_xs / sm / md / lg / xl
+
+Typography:
+  font_family_base, font_size_sm / md / lg,
+  font_weight_normal / bold
+
+Border radius:
+  border_radius_sm / md / lg
+
+All token fields are ``str`` — the contract is a *source of truth for values*,
+not a CSS-in-Python library. Consumers emit whatever format their platform
+needs (CSS custom properties, JS theme objects, iOS UIColor, etc.).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelRendererThemeContract"]
+
+
+class ModelRendererThemeContract(BaseModel):
+    """A versioned, platform-neutral design-token contract for renderers.
+
+    Every renderer that declares ``supports_theming=True`` in its
+    ``ModelRendererCapabilityContract`` must consume tokens from an instance
+    of this model — it must never hard-code token values.
+
+    ``contract_version`` is the authoritative version of this token set.
+    Consumers should carry the version forward into their generated output (e.g.
+    ``--theme-version: 1.0.0`` in CSS) so drift is always traceable.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # ------------------------------------------------------------------
+    # Identity / versioning
+    # ------------------------------------------------------------------
+
+    theme_id: str = Field(
+        ...,
+        description=(
+            "Stable, namespaced theme identifier "
+            "(e.g. 'onex.theme.dark.v1', 'onex.theme.light.v1')"
+        ),
+        min_length=1,
+    )
+    contract_version: ModelSemVer = Field(
+        ...,
+        description=(
+            "Semantic version of this token contract. "
+            "Bump when adding, removing, or renaming any token field."
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # Surface / background tokens
+    # ------------------------------------------------------------------
+
+    color_background_primary: str = Field(
+        ...,
+        description="Primary page/panel background (e.g. '#0f172a')",
+        min_length=1,
+    )
+    color_background_secondary: str = Field(
+        ...,
+        description="Secondary / sidebar background",
+        min_length=1,
+    )
+    color_background_elevated: str = Field(
+        ...,
+        description="Elevated surface background (cards, dropdowns)",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Text tokens
+    # ------------------------------------------------------------------
+
+    color_text_primary: str = Field(
+        ...,
+        description="Primary body text color",
+        min_length=1,
+    )
+    color_text_secondary: str = Field(
+        ...,
+        description="Secondary / muted text color",
+        min_length=1,
+    )
+    color_text_disabled: str = Field(
+        ...,
+        description="Disabled / placeholder text color",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Brand / accent tokens
+    # ------------------------------------------------------------------
+
+    color_accent_primary: str = Field(
+        ...,
+        description="Primary brand / interactive accent color",
+        min_length=1,
+    )
+    color_accent_secondary: str = Field(
+        ...,
+        description="Secondary / hover accent color",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Semantic status tokens
+    # ------------------------------------------------------------------
+
+    color_status_success: str = Field(
+        ...,
+        description="Success / green semantic color",
+        min_length=1,
+    )
+    color_status_warning: str = Field(
+        ...,
+        description="Warning / amber semantic color",
+        min_length=1,
+    )
+    color_status_error: str = Field(
+        ...,
+        description="Error / red semantic color",
+        min_length=1,
+    )
+    color_status_info: str = Field(
+        ...,
+        description="Informational / blue semantic color",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Border tokens
+    # ------------------------------------------------------------------
+
+    color_border_default: str = Field(
+        ...,
+        description="Default / subtle border color",
+        min_length=1,
+    )
+    color_border_strong: str = Field(
+        ...,
+        description="Strong / emphasized border color",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Spacing scale (CSS rem strings)
+    # ------------------------------------------------------------------
+
+    spacing_xs: str = Field(
+        ...,
+        description="Extra-small spacing token (e.g. '0.25rem')",
+        min_length=1,
+    )
+    spacing_sm: str = Field(
+        ...,
+        description="Small spacing token (e.g. '0.5rem')",
+        min_length=1,
+    )
+    spacing_md: str = Field(
+        ...,
+        description="Medium / base spacing token (e.g. '1rem')",
+        min_length=1,
+    )
+    spacing_lg: str = Field(
+        ...,
+        description="Large spacing token (e.g. '1.5rem')",
+        min_length=1,
+    )
+    spacing_xl: str = Field(
+        ...,
+        description="Extra-large spacing token (e.g. '2rem')",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Typography tokens
+    # ------------------------------------------------------------------
+
+    font_family_base: str = Field(
+        ...,
+        description="Base / body font-family stack (e.g. \"'Inter', system-ui, sans-serif\")",
+        min_length=1,
+    )
+    font_size_sm: str = Field(
+        ...,
+        description="Small font size (e.g. '0.875rem')",
+        min_length=1,
+    )
+    font_size_md: str = Field(
+        ...,
+        description="Medium / body font size (e.g. '1rem')",
+        min_length=1,
+    )
+    font_size_lg: str = Field(
+        ...,
+        description="Large font size (e.g. '1.125rem')",
+        min_length=1,
+    )
+    font_weight_normal: str = Field(
+        ...,
+        description="Normal font weight (e.g. '400')",
+        min_length=1,
+    )
+    font_weight_bold: str = Field(
+        ...,
+        description="Bold font weight (e.g. '700')",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Border radius tokens
+    # ------------------------------------------------------------------
+
+    border_radius_sm: str = Field(
+        ...,
+        description="Small border radius (e.g. '0.25rem')",
+        min_length=1,
+    )
+    border_radius_md: str = Field(
+        ...,
+        description="Medium border radius (e.g. '0.5rem')",
+        min_length=1,
+    )
+    border_radius_lg: str = Field(
+        ...,
+        description="Large border radius (e.g. '1rem')",
+        min_length=1,
+    )

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -36,6 +36,8 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     "ModelPermissionContract",
     "ModelEvidenceRequirementContract",
     "ModelRendererCapabilityContract",
+    # Versioned design-token contract (OMN-13389)
+    "ModelRendererThemeContract",
 )
 
 

--- a/tests/unit/models/dashboard/test_model_renderer_theme_contract.py
+++ b/tests/unit/models/dashboard/test_model_renderer_theme_contract.py
@@ -1,0 +1,379 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelRendererThemeContract (OMN-13389).
+
+Acceptance criteria:
+- Frozen Pydantic model, extra="forbid"
+- Explicit version field (versioned contract artifact)
+- Design tokens as typed fields — no hardcoded values in consumers
+- A consumer fixture demonstrates theming from the contract with NO hardcoded tokens
+- TS drift gate: model appears in emit_ts_types.py MODELS dict
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.dashboard import ModelRendererThemeContract
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_v1_dark() -> ModelRendererThemeContract:
+    """Canonical dark-mode theme v1.0.0 — all required tokens explicit."""
+    return ModelRendererThemeContract(
+        theme_id="onex.theme.dark.v1",
+        contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        # Surface tokens
+        color_background_primary="#0f172a",
+        color_background_secondary="#1e293b",
+        color_background_elevated="#334155",
+        # Text tokens
+        color_text_primary="#f8fafc",
+        color_text_secondary="#94a3b8",
+        color_text_disabled="#475569",
+        # Brand / accent
+        color_accent_primary="#6366f1",
+        color_accent_secondary="#818cf8",
+        # Semantic status tokens
+        color_status_success="#22c55e",
+        color_status_warning="#f59e0b",
+        color_status_error="#ef4444",
+        color_status_info="#38bdf8",
+        # Border
+        color_border_default="#334155",
+        color_border_strong="#475569",
+        # Spacing scale (CSS rem values as strings)
+        spacing_xs="0.25rem",
+        spacing_sm="0.5rem",
+        spacing_md="1rem",
+        spacing_lg="1.5rem",
+        spacing_xl="2rem",
+        # Typography
+        font_family_base="'Inter', system-ui, sans-serif",
+        font_size_sm="0.875rem",
+        font_size_md="1rem",
+        font_size_lg="1.125rem",
+        font_weight_normal="400",
+        font_weight_bold="700",
+        # Border radii
+        border_radius_sm="0.25rem",
+        border_radius_md="0.5rem",
+        border_radius_lg="1rem",
+    )
+
+
+def _make_v1_light() -> ModelRendererThemeContract:
+    """Light-mode theme v1.0.0."""
+    return ModelRendererThemeContract(
+        theme_id="onex.theme.light.v1",
+        contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        color_background_primary="#ffffff",
+        color_background_secondary="#f8fafc",
+        color_background_elevated="#f1f5f9",
+        color_text_primary="#0f172a",
+        color_text_secondary="#475569",
+        color_text_disabled="#94a3b8",
+        color_accent_primary="#6366f1",
+        color_accent_secondary="#818cf8",
+        color_status_success="#16a34a",
+        color_status_warning="#d97706",
+        color_status_error="#dc2626",
+        color_status_info="#0284c7",
+        color_border_default="#e2e8f0",
+        color_border_strong="#cbd5e1",
+        spacing_xs="0.25rem",
+        spacing_sm="0.5rem",
+        spacing_md="1rem",
+        spacing_lg="1.5rem",
+        spacing_xl="2rem",
+        font_family_base="'Inter', system-ui, sans-serif",
+        font_size_sm="0.875rem",
+        font_size_md="1rem",
+        font_size_lg="1.125rem",
+        font_weight_normal="400",
+        font_weight_bold="700",
+        border_radius_sm="0.25rem",
+        border_radius_md="0.5rem",
+        border_radius_lg="1rem",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model contract tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelRendererThemeContractModel:
+    """ModelRendererThemeContract satisfies the OMN-13389 model contract."""
+
+    def test_creation_succeeds_with_all_required_fields(self) -> None:
+        theme = _make_v1_dark()
+        assert theme.theme_id == "onex.theme.dark.v1"
+        assert theme.contract_version == ModelSemVer(major=1, minor=0, patch=0)
+
+    def test_frozen_immutable(self) -> None:
+        theme = _make_v1_dark()
+        with pytest.raises(ValidationError):
+            theme.color_background_primary = "#000000"  # type: ignore[misc]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRendererThemeContract(
+                theme_id="t",
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+                color_background_primary="#000",
+                color_background_secondary="#111",
+                color_background_elevated="#222",
+                color_text_primary="#fff",
+                color_text_secondary="#ccc",
+                color_text_disabled="#aaa",
+                color_accent_primary="#123",
+                color_accent_secondary="#456",
+                color_status_success="#0f0",
+                color_status_warning="#ff0",
+                color_status_error="#f00",
+                color_status_info="#00f",
+                color_border_default="#333",
+                color_border_strong="#444",
+                spacing_xs="4px",
+                spacing_sm="8px",
+                spacing_md="16px",
+                spacing_lg="24px",
+                spacing_xl="32px",
+                font_family_base="sans",
+                font_size_sm="14px",
+                font_size_md="16px",
+                font_size_lg="18px",
+                font_weight_normal="400",
+                font_weight_bold="700",
+                border_radius_sm="4px",
+                border_radius_md="8px",
+                border_radius_lg="16px",
+                unknown_extra_field="bad",  # type: ignore[call-arg]
+            )
+
+    def test_version_field_is_modelsemver(self) -> None:
+        theme = _make_v1_dark()
+        assert isinstance(theme.contract_version, ModelSemVer)
+        assert theme.contract_version.major == 1
+
+    def test_theme_id_required_nonempty(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelRendererThemeContract(
+                theme_id="",
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+                color_background_primary="#000",
+                color_background_secondary="#111",
+                color_background_elevated="#222",
+                color_text_primary="#fff",
+                color_text_secondary="#ccc",
+                color_text_disabled="#aaa",
+                color_accent_primary="#123",
+                color_accent_secondary="#456",
+                color_status_success="#0f0",
+                color_status_warning="#ff0",
+                color_status_error="#f00",
+                color_status_info="#00f",
+                color_border_default="#333",
+                color_border_strong="#444",
+                spacing_xs="4px",
+                spacing_sm="8px",
+                spacing_md="16px",
+                spacing_lg="24px",
+                spacing_xl="32px",
+                font_family_base="sans",
+                font_size_sm="14px",
+                font_size_md="16px",
+                font_size_lg="18px",
+                font_weight_normal="400",
+                font_weight_bold="700",
+                border_radius_sm="4px",
+                border_radius_md="8px",
+                border_radius_lg="16px",
+            )
+
+    def test_missing_required_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            # Missing color_background_primary and many others
+            ModelRendererThemeContract(  # type: ignore[call-arg]
+                theme_id="t",
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+            )
+
+    def test_json_roundtrip(self) -> None:
+        theme = _make_v1_dark()
+        restored = ModelRendererThemeContract.model_validate_json(
+            theme.model_dump_json()
+        )
+        assert restored == theme
+
+    def test_json_schema_contains_contract_version(self) -> None:
+        schema = ModelRendererThemeContract.model_json_schema()
+        # contract_version must be a property in the JSON schema
+        assert "contract_version" in schema.get("properties", {})
+
+    def test_two_themes_at_different_versions_coexist(self) -> None:
+        """Versioning allows multiple themes to coexist without collision."""
+        dark_v1 = _make_v1_dark()
+        dark_v2 = ModelRendererThemeContract(
+            **{
+                **dark_v1.model_dump(),
+                "theme_id": "onex.theme.dark.v2",
+                "contract_version": {"major": 2, "minor": 0, "patch": 0},
+                "color_accent_primary": "#7c3aed",  # changed token
+            }
+        )
+        assert dark_v1.contract_version.major == 1
+        assert dark_v2.contract_version.major == 2
+        assert dark_v1 != dark_v2
+
+    def test_all_spacing_tokens_are_strings(self) -> None:
+        theme = _make_v1_dark()
+        for attr in (
+            "spacing_xs",
+            "spacing_sm",
+            "spacing_md",
+            "spacing_lg",
+            "spacing_xl",
+        ):
+            assert isinstance(getattr(theme, attr), str), f"{attr} must be str"
+
+    def test_all_color_tokens_are_strings(self) -> None:
+        theme = _make_v1_dark()
+        color_fields = [f for f in theme.model_fields if f.startswith("color_")]
+        assert len(color_fields) > 0
+        for field in color_fields:
+            value = getattr(theme, field)
+            assert isinstance(value, str), f"{field} must be str"
+
+
+# ---------------------------------------------------------------------------
+# Consumer fixture: a renderer themes from the contract — no hardcoded tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRendererThemingFromContract:
+    """A renderer consumes ModelRendererThemeContract with NO hardcoded tokens."""
+
+    def test_renderer_fixture_reads_tokens_from_contract(self) -> None:
+        """Renderer fixture builds its CSS var map purely from contract fields."""
+        theme = _make_v1_dark()
+
+        # Simulate a renderer building a CSS custom-property map.
+        # This is the consumer pattern: every value comes from the contract —
+        # no literal color/spacing/font value is hardcoded here.
+        css_vars: dict[str, str] = {
+            "--color-bg-primary": theme.color_background_primary,
+            "--color-bg-secondary": theme.color_background_secondary,
+            "--color-bg-elevated": theme.color_background_elevated,
+            "--color-text-primary": theme.color_text_primary,
+            "--color-text-secondary": theme.color_text_secondary,
+            "--color-text-disabled": theme.color_text_disabled,
+            "--color-accent": theme.color_accent_primary,
+            "--color-accent-alt": theme.color_accent_secondary,
+            "--color-status-success": theme.color_status_success,
+            "--color-status-warning": theme.color_status_warning,
+            "--color-status-error": theme.color_status_error,
+            "--color-status-info": theme.color_status_info,
+            "--color-border": theme.color_border_default,
+            "--color-border-strong": theme.color_border_strong,
+            "--spacing-xs": theme.spacing_xs,
+            "--spacing-sm": theme.spacing_sm,
+            "--spacing-md": theme.spacing_md,
+            "--spacing-lg": theme.spacing_lg,
+            "--spacing-xl": theme.spacing_xl,
+            "--font-family": theme.font_family_base,
+            "--font-size-sm": theme.font_size_sm,
+            "--font-size-md": theme.font_size_md,
+            "--font-size-lg": theme.font_size_lg,
+            "--font-weight-normal": theme.font_weight_normal,
+            "--font-weight-bold": theme.font_weight_bold,
+            "--border-radius-sm": theme.border_radius_sm,
+            "--border-radius-md": theme.border_radius_md,
+            "--border-radius-lg": theme.border_radius_lg,
+        }
+
+        # Contract-version annotates the output so drift is detectable
+        css_vars["--theme-version"] = str(theme.contract_version)
+
+        # All values present and non-empty
+        for var, value in css_vars.items():
+            assert value, f"{var} resolved to empty string from contract"
+
+        # Version annotation derived from contract — not hardcoded
+        assert css_vars["--theme-version"] == "1.0.0"
+        # Background primary from contract, not literal
+        assert css_vars["--color-bg-primary"] == theme.color_background_primary
+
+    def test_renderer_can_swap_themes_by_contract_swap(self) -> None:
+        """Swapping the contract object is the only way to change tokens."""
+        dark = _make_v1_dark()
+        light = _make_v1_light()
+
+        def render_background(theme: ModelRendererThemeContract) -> str:
+            # Consumer reads from contract — NO hardcoded "#0f172a" or "#ffffff"
+            return theme.color_background_primary
+
+        assert render_background(dark) != render_background(light)
+        assert render_background(dark) == dark.color_background_primary
+        assert render_background(light) == light.color_background_primary
+
+    def test_theme_as_json_schema_for_ts_drift(self) -> None:
+        """JSON schema includes all token fields — forms the basis of the TS drift gate."""
+        schema = ModelRendererThemeContract.model_json_schema()
+        props = schema.get("properties", {})
+
+        required_in_schema = {
+            "theme_id",
+            "contract_version",
+            "color_background_primary",
+            "color_text_primary",
+            "color_accent_primary",
+            "color_status_success",
+            "spacing_md",
+            "font_family_base",
+            "border_radius_md",
+        }
+        missing = required_in_schema - set(props.keys())
+        assert not missing, f"Schema missing properties: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# TS drift gate: emit_ts_types.py includes ModelRendererThemeContract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTsDriftGate:
+    """ModelRendererThemeContract must appear in the emit_ts_types MODELS dict."""
+
+    def test_emit_ts_types_models_includes_renderer_theme_contract(self) -> None:
+        """emit_ts_types.MODELS must include ModelRendererThemeContract."""
+        from scripts import emit_ts_types  # type: ignore[import]
+
+        assert "ModelRendererThemeContract" in emit_ts_types.MODELS, (
+            "ModelRendererThemeContract is missing from emit_ts_types.MODELS — "
+            "add it so the TS drift gate covers theme tokens"
+        )
+        assert (
+            emit_ts_types.MODELS["ModelRendererThemeContract"]
+            is ModelRendererThemeContract
+        )
+
+    def test_json_schema_round_trips_correctly(self) -> None:
+        """Schema can be serialised to JSON without errors (production path)."""
+        schema = ModelRendererThemeContract.model_json_schema()
+        # Confirm it's JSON-serialisable (what emit_ts_types does)
+        serialised = json.dumps(schema, indent=2)
+        restored = json.loads(serialised)
+        assert restored["title"] == "ModelRendererThemeContract"


### PR DESCRIPTION
## Summary

- Adds \`ModelRendererThemeContract\` to \`omnibase_core/models/dashboard/\` — a frozen Pydantic model (\`extra="forbid"\`) that declares design tokens (colors, spacing, typography, border radii) as **typed, versioned contract fields**, not prose or hardcoded literals.
- The explicit \`contract_version: ModelSemVer\` field makes schema drift traceable; consumers must annotate their output (e.g. \`--theme-version: 1.0.0\` in CSS).
- Registered in \`scripts/emit_ts_types.py\` \`MODELS\` dict so the existing TS drift gate in CI mirrors \`ModelRendererThemeContract\` to TypeScript automatically.
- Exported from \`models.dashboard.__all__\`; import-surface test updated.
- Consumer fixture (\`TestRendererThemingFromContract\`) demonstrates theming a CSS var map from the contract with **zero hardcoded token values** — every value comes from the contract object.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Frozen Pydantic model, \`extra="forbid"\` | PASS — \`test_frozen_immutable\`, \`test_extra_fields_forbidden\` |
| Explicit \`contract_version\` field | PASS — \`test_version_field_is_modelsemver\` |
| Design tokens as typed fields | PASS — 27 typed \`str\` token fields covering color, spacing, typography, border radius |
| Consumer demonstrates theming with NO hardcoded tokens | PASS — \`test_renderer_fixture_reads_tokens_from_contract\`, \`test_renderer_can_swap_themes_by_contract_swap\` |
| TS drift gate green | PASS — \`test_emit_ts_types_models_includes_renderer_theme_contract\` |

## dod_evidence

- 271 dashboard unit tests pass (all pre-existing + 16 new)
- \`uv run mypy src/omnibase_core/models/dashboard/model_renderer_theme_contract.py --strict\` → 0 errors
- \`uv run ruff format\` + \`uv run ruff check --fix\` → clean
- All pre-commit hooks pass on changed files

Evidence-Ticket: OMN-13389
Evidence-Source: 929d78815ec9c4212e8527eff445459842726890

