### PR TITLE
fix(OMN-12445): unique CI concurrency group per merge_group batch commit (unblock core dev queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,18 @@ on:
   schedule:
     - cron: "13 7 * * *"   # 07:13 UTC nightly
 
-# Prevent auto-cancellation for normal PR/push workflows, but cancel superseded
-# merge_group runs so stale merge-queue attempts do not accumulate.
+# Prevent auto-cancellation for normal PR/push workflows. For merge_group runs the
+# concurrency group MUST be unique per queued batch commit: GitHub forms one
+# merge_group commit per queue position, and keying the group on base_ref (shared
+# by every dev-targeted merge_group run) made each newly-formed batch commit cancel
+# the CI of the entries ahead of it, leaving the queue front permanently in
+# AWAITING_CHECKS (CI Summary never reported). Keying on github.ref — the
+# gh-readonly-queue/<base>/pr-<n>-<sha> ref, which is unique per batch commit —
+# gives every queued position its own CI run while still cancelling a superseded
+# re-attempt of the same batch commit. Mirrors the OMN-6488 test.yml fix already
+# applied in omnibase_infra. (OMN-12445)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 env:


### PR DESCRIPTION
## OMN-12445 — unblock omnibase_core dev merge queue (CI concurrency deadlock)

### Problem (observed, with evidence)
The `omnibase_core` dev merge queue has been deadlocked since ~16:15 UTC (2026-06-20). Multiple CLEAN, MERGEABLE PRs (#1286, #1287, #1288, #1289) sit permanently in `AWAITING_CHECKS`.

Root cause is the `CI` workflow concurrency config:
```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
cancel-in-progress: ${{ github.event_name == 'merge_group' }}
```
For `merge_group` events the group is keyed on `merge_group.base_ref` = `refs/heads/dev`, which is **identical for every dev-targeted merge_group run**. GitHub forms one merge_group commit per queue position; each newly-formed batch commit lands in the same concurrency group as the entries ahead of it and **cancels their CI at the run level before any job dispatches**. The queue front's required `CI Summary` check never reports, so the entry never leaves `AWAITING_CHECKS`.

Evidence:
- merge_group CI runs on queue SHAs `3df2602e`, `5bb7e28b`, `d3adf8ff` all `cancelled` within seconds, **0 jobs dispatched**.
- Combined status on queue-front SHA `5bb7e28b` = `pending`; no `CI Summary` check-run present.
- Only the deepest (last-formed) batch commit's CI survives each cycle; everything ahead of it dies. A merge-sweep tick re-forming the batch every ~5 min reproduces the cancellation indefinitely.

### Fix
Key the merge_group concurrency group on `github.ref` (the unique `gh-readonly-queue/dev/pr-<n>-<sha>` ref). Every queued position now gets its own CI run; a superseded re-attempt of the *same* batch commit is still cancelled. Mirrors the **OMN-6488** `test.yml` fix already shipped in `omnibase_infra`.

### Impact
Unblocks the entire core dev queue, including the BAC core-enum PRs #1288 (OMN-12846) and #1289 (OMN-12843) required to reconcile the omnimarket custom-core-pin divergence (OMN-12843/12844/12846).

Evidence-Source: workflow-only change; behavior provable from the merge_group CI run-cancellation evidence above.
Evidence-Ticket: OMN-12445

[skip-receipt-gate: CI-workflow-only change (.github/workflows/ci.yml), no contract/runtime surface]