### PR TITLE
fix(OMN-12445): unique CI concurrency group per merge_group batch commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,18 @@ on:
   schedule:
     - cron: "13 7 * * *"   # 07:13 UTC nightly
 
-# Prevent auto-cancellation for normal PR/push workflows, but cancel superseded
-# merge_group runs so stale merge-queue attempts do not accumulate.
+# Prevent auto-cancellation for normal PR/push workflows. For merge_group runs the
+# concurrency group MUST be unique per queued batch commit: GitHub forms one
+# merge_group commit per queue position, and keying the group on base_ref (shared
+# by every dev-targeted merge_group run) made each newly-formed batch commit cancel
+# the CI of the entries ahead of it, leaving the queue front permanently in
+# AWAITING_CHECKS (CI Summary never reported). Keying on github.ref — the
+# gh-readonly-queue/<base>/pr-<n>-<sha> ref, which is unique per batch commit —
+# gives every queued position its own CI run while still cancelling a superseded
+# re-attempt of the same batch commit. Mirrors the OMN-6488 test.yml fix already
+# applied in omnibase_infra. (OMN-12445)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 env:


### PR DESCRIPTION
## OMN-12445 — unblock omnibase_core dev merge queue (CI concurrency deadlock)

### Diagnosis
The `omnibase_core` dev merge queue is repeatedly cancelling merge-group CI runs before the queue-front entry can publish the required `CI Summary` check.

Root cause is the `CI` workflow concurrency group for `merge_group` events. The old expression keyed every dev-targeted merge-group run on the shared base ref, so newly formed queue batch commits cancelled the CI runs ahead of them.

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
cancel-in-progress: ${{ github.event_name == 'merge_group' }}
```

### Live Evidence
Recent `merge_group` runs for `omnibase_core` dev show the pattern:

- `gh-readonly-queue/dev/pr-1289-*`, `pr-1288-*`, and `pr-1287-*` CI runs cancelled within seconds.
- Queue-front `pr-1286-*` CI remains pending/queued instead of producing the required `CI Summary`.
- PR checks for `#1288` and `#1289` are otherwise clean/mergeable but remain blocked behind queue checks.

### Fix
Key the `merge_group` concurrency group on `github.ref`, which is the unique `gh-readonly-queue/<base>/pr-<n>-<sha>` ref for each queue batch commit.

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

This gives every queued batch commit its own CI run while still allowing a superseded attempt of the same queue ref to be cancelled.

### Impact
Unblocks the core dev merge queue, including canonical enum PRs `#1288` and `#1289` and downstream pin reconciliation.

Evidence-Source: OCC#2867
Evidence-Ticket: OMN-12445