### PR TITLE
feat(OMN-13420): core-resident infra-free in-process local runtime harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,6 +291,7 @@ ignore = [
 "src/omnibase_core/infrastructure/node_base.py" = ["I001"]  # Import order to avoid circular dependencies
 "src/omnibase_core/models/container/model_onex_container.py" = ["I001"]  # Dual-Import Pattern (OMN-1261)
 # T201 per-file-ignores: intentional print() for CLI output, validation reports, and script output [OMN-5080]
+"src/omnibase_core/runtime/harness/harness_cli.py" = ["T201"]  # OMN-13420: harness evidence packet to stdout
 "src/omnibase_core/cli/substrate_gates/_base.py" = ["T201"]
 "src/omnibase_core/cli/cli_spdx.py" = ["T201"]
 "src/omnibase_core/mixins/mixin_cli_handler.py" = ["T201"]

--- a/src/omnibase_core/models/runtime/harness/__init__.py
+++ b/src/omnibase_core/models/runtime/harness/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Models for the core-resident infra-free local runtime harness (OMN-13420)."""
+
+from omnibase_core.models.runtime.harness.model_harness_command import (
+    ModelHarnessCommand,
+)
+from omnibase_core.models.runtime.harness.model_harness_infer_requested import (
+    ModelHarnessInferRequested,
+)
+from omnibase_core.models.runtime.harness.model_harness_result import ModelHarnessResult
+from omnibase_core.models.runtime.harness.model_harness_terminal import (
+    ModelHarnessTerminal,
+)
+from omnibase_core.models.runtime.harness.model_inference_request import (
+    ModelInferenceRequest,
+)
+from omnibase_core.models.runtime.harness.model_inference_result import (
+    ModelInferenceResult,
+)
+from omnibase_core.models.runtime.harness.model_projection_row import ModelProjectionRow
+
+__all__ = [
+    "ModelHarnessCommand",
+    "ModelHarnessInferRequested",
+    "ModelHarnessResult",
+    "ModelHarnessTerminal",
+    "ModelInferenceRequest",
+    "ModelInferenceResult",
+    "ModelProjectionRow",
+]

--- a/src/omnibase_core/models/runtime/harness/model_harness_command.py
+++ b/src/omnibase_core/models/runtime/harness/model_harness_command.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelHarnessCommand: typed command for the core-resident local runtime harness (OMN-13420)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelHarnessCommand(BaseModel):
+    """Typed command published into the harness for the delegation/sea workflows."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(..., description="Correlation ID for the run.")
+    workflow: str = Field(..., description="Workflow name (delegation | sea).")
+    prompt: str = Field(..., description="Prompt / task description.")
+    task_type: str = Field(default="harness", description="Task class for routing.")
+    max_tokens: int = Field(default=512, gt=0, description="Inference token budget.")
+
+
+__all__ = ["ModelHarnessCommand"]

--- a/src/omnibase_core/models/runtime/harness/model_harness_infer_requested.py
+++ b/src/omnibase_core/models/runtime/harness/model_harness_infer_requested.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelHarnessInferRequested: intermediate harness event (OMN-13420)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelHarnessInferRequested(BaseModel):
+    """Intermediate event: the orchestrator has requested inference."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(..., description="Correlation ID for the run.")
+    workflow: str = Field(..., description="Workflow name (delegation | sea).")
+    prompt: str = Field(..., description="Prompt to complete.")
+    max_tokens: int = Field(default=512, gt=0, description="Inference token budget.")
+
+
+__all__ = ["ModelHarnessInferRequested"]

--- a/src/omnibase_core/models/runtime/harness/model_harness_result.py
+++ b/src/omnibase_core/models/runtime/harness/model_harness_result.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelHarnessResult: outcome of one in-process harness run (OMN-13420)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelHarnessResult(BaseModel):
+    """Outcome of a single in-process harness run."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(..., description="Run correlation ID.")
+    terminal_topic: str | None = Field(
+        default=None, description="Topic of the terminal event, or None on no-terminal."
+    )
+    terminal_payload: dict[str, object] | None = Field(  # dict-str-any-ok: JSON payload
+        default=None, description="Decoded terminal-event payload, or None."
+    )
+    status: str = Field(
+        ..., description="Terminal status: success | failure | no_terminal."
+    )
+    emitted_topics: tuple[str, ...] = Field(
+        default=(), description="Topics emitted during the run, in order."
+    )
+    exit_code: int = Field(
+        ..., description="Process-style exit code: 0 success, 2 no terminal, 3 failure."
+    )
+
+    @property
+    def reached_terminal(self) -> bool:
+        """True when a terminal event was observed."""
+        return self.terminal_topic is not None
+
+
+__all__ = ["ModelHarnessResult"]

--- a/src/omnibase_core/models/runtime/harness/model_harness_terminal.py
+++ b/src/omnibase_core/models/runtime/harness/model_harness_terminal.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelHarnessTerminal: terminal-event payload for the harness workflows (OMN-13420)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelHarnessTerminal(BaseModel):
+    """Terminal event payload for both harness workflows."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(..., description="Correlation ID for the run.")
+    workflow: str = Field(..., description="Workflow name (delegation | sea).")
+    status: str = Field(..., description="Terminal status: success | failure.")
+    completion: str = Field(..., description="Inference completion text.")
+    model: str = Field(..., description="Model that produced the completion.")
+    adapter: str = Field(..., description="Inference adapter provenance.")
+    source: str = Field(default="harness", description="Terminal producer identifier.")
+
+
+__all__ = ["ModelHarnessTerminal"]

--- a/src/omnibase_core/models/runtime/harness/model_inference_request.py
+++ b/src/omnibase_core/models/runtime/harness/model_inference_request.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelInferenceRequest: request to a harness inference adapter (OMN-13420)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelInferenceRequest(BaseModel):
+    """Request passed to a harness inference adapter."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    prompt: str = Field(..., description="Prompt text to complete.")
+    model: str = Field(default="recorded-fixture", description="Model identifier.")
+    max_tokens: int = Field(default=512, gt=0, description="Max completion tokens.")
+
+
+__all__ = ["ModelInferenceRequest"]

--- a/src/omnibase_core/models/runtime/harness/model_inference_result.py
+++ b/src/omnibase_core/models/runtime/harness/model_inference_result.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelInferenceResult: result from a harness inference adapter (OMN-13420)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelInferenceResult(BaseModel):
+    """Result returned from a harness inference adapter."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    completion: str = Field(..., description="Completion text.")
+    model: str = Field(..., description="Model that produced the completion.")
+    adapter: str = Field(
+        ..., description="Adapter identifier (fixture | curl) for provenance."
+    )
+
+
+__all__ = ["ModelInferenceResult"]

--- a/src/omnibase_core/models/runtime/harness/model_projection_row.py
+++ b/src/omnibase_core/models/runtime/harness/model_projection_row.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ModelProjectionRow: a materialized harness projection row (OMN-13420)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelProjectionRow(BaseModel):
+    """A single materialized projection row written by a harness REDUCER handler."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID = Field(
+        ..., description="Correlation ID linking the row to the originating command."
+    )
+    workflow: str = Field(
+        ..., description="Harness workflow that produced the row (delegation | sea)."
+    )
+    terminal_topic: str = Field(
+        ..., description="Topic of the terminal event that produced this projection."
+    )
+    status: str = Field(..., description="Terminal status (success | failure).")
+    payload: dict[str, object] = Field(  # dict-str-any-ok: projection payload is JSON
+        default_factory=dict,
+        description="JSON-serializable terminal payload snapshot.",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="Row creation timestamp (UTC).",
+    )
+
+
+__all__ = ["ModelProjectionRow"]

--- a/src/omnibase_core/protocols/runtime/__init__.py
+++ b/src/omnibase_core/protocols/runtime/__init__.py
@@ -43,6 +43,12 @@ Related:
 from omnibase_core.protocols.runtime.protocol_handler_registry import (
     ProtocolHandlerRegistry,
 )
+from omnibase_core.protocols.runtime.protocol_harness_inference_adapter import (
+    ProtocolHarnessInferenceAdapter,
+)
+from omnibase_core.protocols.runtime.protocol_harness_projection_store import (
+    ProtocolHarnessProjectionStore,
+)
 from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
     ProtocolLocalRuntimeBus,
     UnsubscribeCallback,
@@ -68,6 +74,8 @@ from omnibase_core.protocols.runtime.protocol_runtime_skill_client import (
 
 __all__ = [
     "ProtocolHandlerRegistry",
+    "ProtocolHarnessInferenceAdapter",
+    "ProtocolHarnessProjectionStore",
     "ProtocolLocalRuntimeBus",
     "ProtocolLocalRuntimeCallableTarget",
     "ProtocolLocalRuntimeDumpModel",

--- a/src/omnibase_core/protocols/runtime/protocol_harness_inference_adapter.py
+++ b/src/omnibase_core/protocols/runtime/protocol_harness_inference_adapter.py
@@ -27,11 +27,11 @@ class ProtocolHarnessInferenceAdapter(Protocol):
     @property
     def adapter_id(self) -> str:
         """Return a stable adapter identifier for evidence/provenance."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol declaration only
 
     def infer(self, request: ModelInferenceRequest) -> ModelInferenceResult:
         """Run inference and return a completion."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol declaration only
 
 
 __all__ = ["ProtocolHarnessInferenceAdapter"]

--- a/src/omnibase_core/protocols/runtime/protocol_harness_inference_adapter.py
+++ b/src/omnibase_core/protocols/runtime/protocol_harness_inference_adapter.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ProtocolHarnessInferenceAdapter: inference seam for the local runtime harness (OMN-13420)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from omnibase_core.models.runtime.harness.model_inference_request import (
+        ModelInferenceRequest,
+    )
+    from omnibase_core.models.runtime.harness.model_inference_result import (
+        ModelInferenceResult,
+    )
+
+
+@runtime_checkable
+class ProtocolHarnessInferenceAdapter(Protocol):
+    """Minimal inference shape used by the harness EFFECT handler.
+
+    Implementations sit behind this seam so the harness never names a concrete
+    backend: a recorded-fixture adapter (offline) or a curl-subprocess adapter
+    (separate-binary LAN access) both satisfy it.
+    """
+
+    @property
+    def adapter_id(self) -> str:
+        """Return a stable adapter identifier for evidence/provenance."""
+        ...
+
+    def infer(self, request: ModelInferenceRequest) -> ModelInferenceResult:
+        """Run inference and return a completion."""
+        ...
+
+
+__all__ = ["ProtocolHarnessInferenceAdapter"]

--- a/src/omnibase_core/protocols/runtime/protocol_harness_projection_store.py
+++ b/src/omnibase_core/protocols/runtime/protocol_harness_projection_store.py
@@ -24,15 +24,15 @@ class ProtocolHarnessProjectionStore(Protocol):
     @property
     def backend(self) -> str:
         """Return a human-readable backend identifier for evidence packets."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol declaration only
 
     def write(self, row: ModelProjectionRow) -> None:
         """Persist a single projection row."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol declaration only
 
     def read(self, correlation_id: UUID) -> ModelProjectionRow | None:
         """Read back the projection row for a correlation ID, or None."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol declaration only
 
 
 __all__ = ["ProtocolHarnessProjectionStore"]

--- a/src/omnibase_core/protocols/runtime/protocol_harness_projection_store.py
+++ b/src/omnibase_core/protocols/runtime/protocol_harness_projection_store.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ProtocolHarnessProjectionStore: projection-store seam for the local runtime harness (OMN-13420)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from omnibase_core.models.runtime.harness.model_projection_row import (
+        ModelProjectionRow,
+    )
+
+
+@runtime_checkable
+class ProtocolHarnessProjectionStore(Protocol):
+    """Minimal projection-store shape used by the harness REDUCER handler.
+
+    The default implementation is SQLite (zero infra, zero LAN); a Postgres
+    implementation is reserved for real migration/view validation.
+    """
+
+    @property
+    def backend(self) -> str:
+        """Return a human-readable backend identifier for evidence packets."""
+        ...
+
+    def write(self, row: ModelProjectionRow) -> None:
+        """Persist a single projection row."""
+        ...
+
+    def read(self, correlation_id: UUID) -> ModelProjectionRow | None:
+        """Read back the projection row for a correlation ID, or None."""
+        ...
+
+
+__all__ = ["ProtocolHarnessProjectionStore"]

--- a/src/omnibase_core/runtime/harness/__init__.py
+++ b/src/omnibase_core/runtime/harness/__init__.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Core-resident, infra-free in-process local runtime harness (OMN-13420).
+
+Fast inner loop for node authors: register a node's handlers, publish a typed
+command on the core in-memory bus, pump emitted events through the registered
+handlers to the terminal event, and materialize a SQLite projection row — all
+in-process, with NO ``omnibase_infra``, NO Kafka, NO Postgres, and NO LAN.
+
+Uses ONLY the spi ``ProtocolMessageHandler.handle(envelope) -> ModelHandlerOutput``
+contract, core envelope models, the core in-memory bus, and the core-resident
+runtime protocols.
+
+Scope: proves handler logic + the command -> terminal -> projection chain. Does
+NOT exercise Kafka semantics or the image build — the infra-backed broker proof
+remains the pre-merge gate. This is the inner loop only.
+
+Epic: OMN-13442 (local-first runtime re-convergence).
+"""
+
+from omnibase_core.runtime.harness.harness_builder import build_workflow
+from omnibase_core.runtime.harness.harness_dispatch import InProcessHarness
+from omnibase_core.runtime.harness.harness_effect import HarnessEffectHandler
+from omnibase_core.runtime.harness.harness_inference_curl import (
+    CurlSubprocessInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_inference_fixture import (
+    RecordedFixtureInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_orchestrator import (
+    HarnessOrchestratorHandler,
+)
+from omnibase_core.runtime.harness.harness_projection_store_sqlite import (
+    SqliteProjectionStore,
+)
+from omnibase_core.runtime.harness.harness_reducer import HarnessProjectionReducer
+from omnibase_core.runtime.harness.harness_topics import (
+    DELEGATION_COMMAND_TOPIC,
+    DELEGATION_COMPLETED_TOPIC,
+    DELEGATION_INFER_TOPIC,
+    SEA_COMMAND_TOPIC,
+    SEA_COMPLETED_TOPIC,
+    SEA_INFER_TOPIC,
+)
+
+__all__ = [
+    "DELEGATION_COMMAND_TOPIC",
+    "DELEGATION_COMPLETED_TOPIC",
+    "DELEGATION_INFER_TOPIC",
+    "SEA_COMMAND_TOPIC",
+    "SEA_COMPLETED_TOPIC",
+    "SEA_INFER_TOPIC",
+    "CurlSubprocessInferenceAdapter",
+    "HarnessEffectHandler",
+    "HarnessOrchestratorHandler",
+    "HarnessProjectionReducer",
+    "InProcessHarness",
+    "RecordedFixtureInferenceAdapter",
+    "SqliteProjectionStore",
+    "build_workflow",
+]

--- a/src/omnibase_core/runtime/harness/harness_builder.py
+++ b/src/omnibase_core/runtime/harness/harness_builder.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Workflow wiring for the core-resident local runtime harness (OMN-13420).
+
+``build_workflow`` wires a complete orchestrator -> effect -> reducer chain for the
+delegation or sea workflow against an ``InProcessHarness`` and returns it with the
+command topic to publish on.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.protocols.runtime.protocol_harness_inference_adapter import (
+    ProtocolHarnessInferenceAdapter,
+)
+from omnibase_core.protocols.runtime.protocol_harness_projection_store import (
+    ProtocolHarnessProjectionStore,
+)
+from omnibase_core.runtime.harness.harness_dispatch import InProcessHarness
+from omnibase_core.runtime.harness.harness_effect import HarnessEffectHandler
+from omnibase_core.runtime.harness.harness_orchestrator import (
+    HarnessOrchestratorHandler,
+)
+from omnibase_core.runtime.harness.harness_reducer import HarnessProjectionReducer
+from omnibase_core.runtime.harness.harness_topics import (
+    command_topic,
+    completed_topic,
+    infer_topic,
+)
+
+_SUPPORTED_WORKFLOWS = frozenset({"delegation", "sea"})
+
+
+def build_workflow(
+    *,
+    workflow: str,
+    adapter: ProtocolHarnessInferenceAdapter,
+    store: ProtocolHarnessProjectionStore,
+) -> tuple[InProcessHarness, str]:
+    """Wire a complete harness for ``workflow`` and return (harness, command_topic).
+
+    The returned harness has the orchestrator/effect/reducer registered against the
+    correct topics and the completed topic declared terminal.
+    """
+    if workflow not in _SUPPORTED_WORKFLOWS:
+        raise ModelOnexError(
+            message=(f"unknown workflow {workflow!r}; expected 'delegation' or 'sea'"),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+    cmd_topic = command_topic(workflow)
+    done_topic = completed_topic(workflow)
+    request_topic = infer_topic(workflow)
+
+    harness = InProcessHarness(terminal_topics=frozenset({done_topic}))
+    harness.register(cmd_topic, HarnessOrchestratorHandler(workflow))
+    harness.register(request_topic, HarnessEffectHandler(workflow, adapter))
+    harness.register(done_topic, HarnessProjectionReducer(workflow, store))
+    return harness, cmd_topic
+
+
+__all__ = ["build_workflow"]

--- a/src/omnibase_core/runtime/harness/harness_cli.py
+++ b/src/omnibase_core/runtime/harness/harness_cli.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""CLI for the core-resident local runtime harness (OMN-13420).
+
+``delegation`` and ``sea`` subcommands mirror
+``docs/evidence/2026-06-15-runtime-integration/publish_runtime_probe.py`` but run
+fully in-process: no Kafka, no Postgres, no LAN. Each subcommand publishes a typed
+command on the core in-memory bus, pumps it through the registered handlers to a
+terminal event, materializes a SQLite projection row, and prints a JSON evidence
+packet (runtime SHA + correlation ID + bus impl + projection backend + exit code).
+
+Entry point::
+
+    python -m omnibase_core.runtime.harness.harness_cli delegation --prompt "hello"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from uuid import UUID, uuid4
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_command import (
+    ModelHarnessCommand,
+)
+from omnibase_core.models.runtime.harness.model_harness_result import ModelHarnessResult
+from omnibase_core.models.runtime.harness.model_projection_row import ModelProjectionRow
+from omnibase_core.protocols.runtime.protocol_harness_inference_adapter import (
+    ProtocolHarnessInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_builder import build_workflow
+from omnibase_core.runtime.harness.harness_inference_curl import (
+    CurlSubprocessInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_inference_fixture import (
+    RecordedFixtureInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_projection_store_sqlite import (
+    SqliteProjectionStore,
+)
+
+
+async def run_workflow(
+    *,
+    workflow: str,
+    prompt: str,
+    correlation_id: UUID,
+    task_type: str,
+    max_tokens: int,
+    adapter: ProtocolHarnessInferenceAdapter,
+    store: SqliteProjectionStore,
+) -> tuple[ModelHarnessResult, ModelProjectionRow | None]:
+    """Run one harness workflow end-to-end and return (result, projection row)."""
+    harness, cmd_topic = build_workflow(workflow=workflow, adapter=adapter, store=store)
+    command = ModelHarnessCommand(
+        correlation_id=correlation_id,
+        workflow=workflow,
+        prompt=prompt,
+        task_type=task_type,
+        max_tokens=max_tokens,
+    )
+    envelope: ModelEventEnvelope[ModelHarnessCommand] = ModelEventEnvelope(
+        payload=command,
+        correlation_id=correlation_id,
+        event_type=cmd_topic,
+        payload_type="ModelHarnessCommand",
+        source_tool="harness-cli",
+    )
+    envelope.metadata.tags["message_category"] = "command"
+    result = await harness.run(command_topic=cmd_topic, command_envelope=envelope)
+    projection = store.read(correlation_id)
+    return result, projection
+
+
+def build_evidence_packet(
+    *,
+    workflow: str,
+    result: ModelHarnessResult,
+    projection: ModelProjectionRow | None,
+    adapter: ProtocolHarnessInferenceAdapter,
+    store: SqliteProjectionStore,
+    bus_impl: str,
+    runtime_sha: str,
+) -> dict[str, object]:  # dict-str-any-ok: JSON evidence packet
+    """Assemble the durable evidence packet for an infra-free harness run."""
+    return {
+        "ticket": "OMN-13420",
+        "workflow": workflow,
+        "runtime_sha": runtime_sha,
+        "correlation_id": str(result.correlation_id),
+        "bus_impl": bus_impl,
+        "inference_adapter": adapter.adapter_id,
+        "projection_backend": store.backend,
+        "terminal_topic": result.terminal_topic,
+        "terminal_status": result.status,
+        "emitted_topics": list(result.emitted_topics),
+        "projection_row": (
+            json.loads(projection.model_dump_json()) if projection else None
+        ),
+        "infra_free": True,
+        "exit_code": result.exit_code,
+    }
+
+
+def _build_adapter(args: argparse.Namespace) -> ProtocolHarnessInferenceAdapter:
+    if args.inference == "curl":
+        if not args.endpoint:
+            raise ModelOnexError(
+                message="--endpoint is required when --inference=curl",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        return CurlSubprocessInferenceAdapter(endpoint=args.endpoint, model=args.model)
+    return RecordedFixtureInferenceAdapter(completion=args.fixture_completion)
+
+
+def _run(args: argparse.Namespace) -> int:
+    correlation_id = UUID(args.correlation_id) if args.correlation_id else uuid4()
+    adapter = _build_adapter(args)
+    store = SqliteProjectionStore(path=args.sqlite_path)
+    try:
+        result, projection = asyncio.run(
+            run_workflow(
+                workflow=args.workflow,
+                prompt=args.prompt,
+                correlation_id=correlation_id,
+                task_type=args.task_type,
+                max_tokens=args.max_tokens,
+                adapter=adapter,
+                store=store,
+            )
+        )
+        packet = build_evidence_packet(
+            workflow=args.workflow,
+            result=result,
+            projection=projection,
+            adapter=adapter,
+            store=store,
+            bus_impl="EventBusInmemory",
+            runtime_sha=args.runtime_sha,
+        )
+        # print-ok: CLI emits the evidence packet to stdout (the durable proof artifact)
+        print(json.dumps(packet, default=str, indent=2), flush=True)
+        return result.exit_code
+    finally:
+        store.close()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="harness",
+        description="Core-resident infra-free local runtime harness (OMN-13420).",
+    )
+    sub = parser.add_subparsers(dest="workflow", required=True)
+    for workflow, default_prompt in (
+        ("delegation", "summarize the local-first runtime re-convergence"),
+        ("sea", "generate a COMPUTE node that uppercases its input"),
+    ):
+        sp = sub.add_parser(workflow, help=f"Run the {workflow} workflow in-process.")
+        sp.add_argument("--prompt", default=default_prompt)
+        sp.add_argument("--correlation-id", default=None, dest="correlation_id")
+        sp.add_argument("--task-type", default="harness", dest="task_type")
+        sp.add_argument("--max-tokens", type=int, default=512, dest="max_tokens")
+        sp.add_argument(
+            "--inference",
+            choices=("fixture", "curl"),
+            default="fixture",
+            help="Inference adapter (fixture=offline, curl=separate-binary LAN).",
+        )
+        sp.add_argument("--fixture-completion", default=None, dest="fixture_completion")
+        sp.add_argument("--endpoint", default=None, help="curl inference endpoint.")
+        sp.add_argument("--model", default="recorded-fixture")
+        sp.add_argument(
+            "--sqlite-path",
+            default=":memory:",
+            dest="sqlite_path",
+            help="SQLite projection DB path (:memory: for ephemeral).",
+        )
+        sp.add_argument("--runtime-sha", default="unknown", dest="runtime_sha")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    args = _parser().parse_args(argv)
+    return _run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = ["build_evidence_packet", "main", "run_workflow"]

--- a/src/omnibase_core/runtime/harness/harness_dispatch.py
+++ b/src/omnibase_core/runtime/harness/harness_dispatch.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""In-process dispatch harness for the core-resident local runtime (OMN-13420).
+
+A minimal command -> terminal -> projection chain that runs entirely in-process:
+
+* register a node's handlers (anything satisfying
+  ``omnibase_core.protocols.runtime.protocol_message_handler.ProtocolMessageHandler``),
+* publish a typed command envelope on the core
+  ``omnibase_core.event_bus.event_bus_inmemory.EventBusInmemory``,
+* pump every emitted event back through the registered handlers until a declared
+  terminal topic is reached.
+
+It uses ONLY the spi ``ProtocolMessageHandler.handle(envelope) -> ModelHandlerOutput``
+contract, core envelope models, and the core in-memory bus. There is **no** infra
+``MessageDispatchEngine``, DI container, topic provisioning, or consumer groups —
+that machinery is exactly what forces an ``omnibase_infra`` install today, and it
+is deliberately absent.
+
+Scope (be honest): this proves HANDLER LOGIC and the in-process chain. It does NOT
+exercise Kafka semantics (consumer groups, partitioning, DLQ, ordering,
+idempotency-across-restart) or the image build. The infra-backed broker proof
+remains the pre-merge gate; this is the inner loop only.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from typing import Any
+
+from pydantic import BaseModel
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_result import ModelHarnessResult
+from omnibase_core.protocols.runtime.protocol_message_handler import (
+    ProtocolMessageHandler,
+)
+
+
+class InProcessHarness:
+    """Register handlers, publish a command, pump events to the terminal event.
+
+    Handlers are registered against the topic(s) they consume. When a handler emits
+    events (via ``ModelHandlerOutput.events``), each emitted envelope is republished
+    on the bus under its ``event_type`` topic and re-dispatched, until an event
+    lands on one of the declared ``terminal_topics``.
+    """
+
+    def __init__(
+        self,
+        *,
+        terminal_topics: frozenset[str],
+        environment: str = "local",
+        max_steps: int = 64,
+    ) -> None:
+        if not terminal_topics:
+            raise ModelOnexError(
+                message="terminal_topics must be non-empty",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        self._terminal_topics = terminal_topics
+        self._max_steps = max_steps
+        self._bus = EventBusInmemory(environment=environment, group="harness")
+        self._handlers: dict[str, list[ProtocolMessageHandler]] = defaultdict(list)
+
+    @property
+    def bus(self) -> EventBusInmemory:
+        """Return the in-memory bus (for inspection in tests/evidence)."""
+        return self._bus
+
+    @property
+    def bus_impl(self) -> str:
+        """Return the bus implementation name for evidence packets."""
+        return type(self._bus).__name__
+
+    def register(self, topic: str, handler: ProtocolMessageHandler) -> None:
+        """Register ``handler`` to consume events published on ``topic``."""
+        self._handlers[topic].append(handler)
+
+    async def run(
+        self,
+        *,
+        command_topic: str,
+        command_envelope: ModelEventEnvelope[Any],
+    ) -> ModelHarnessResult:
+        """Publish the command envelope and pump events to a terminal event."""
+        correlation_id = command_envelope.correlation_id
+        if correlation_id is None:
+            raise ModelOnexError(
+                message="command_envelope.correlation_id is required",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+
+        emitted_topics: list[str] = []
+        terminal_topic: str | None = None
+        terminal_payload: dict[str, object] | None = None
+
+        await self._bus.start()
+
+        # The work queue holds (topic, envelope) pairs to dispatch. We seed it with
+        # the command and drain it breadth-first, re-enqueuing every emitted event.
+        queue: list[tuple[str, ModelEventEnvelope[Any]]] = [
+            (command_topic, command_envelope)
+        ]
+        steps = 0
+        try:
+            while queue:
+                if steps >= self._max_steps:
+                    raise ModelOnexError(
+                        message=(
+                            f"harness exceeded max_steps={self._max_steps} without "
+                            "reaching a terminal event (possible handler cycle)"
+                        ),
+                        error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+                    )
+                steps += 1
+                topic, envelope = queue.pop(0)
+
+                # Mirror the bus-transit contract: publish so the in-memory bus
+                # history records every hop.
+                await self._bus.publish_envelope(envelope, topic, key=None)
+                emitted_topics.append(topic)
+
+                is_terminal = topic in self._terminal_topics
+                if is_terminal:
+                    terminal_topic = topic
+                    terminal_payload = self._decode_payload(envelope)
+
+                # Dispatch all handlers registered on this topic. Terminal-topic
+                # handlers (e.g. the projection REDUCER) still run so the projection
+                # row is materialized; REDUCERs emit no events, so the queue stays
+                # drained on the terminal hop.
+                for handler in self._handlers.get(topic, []):
+                    output = await handler.handle(envelope)
+                    for emitted in output.events:
+                        emitted_envelope = self._as_envelope(emitted)
+                        next_topic = emitted_envelope.event_type
+                        if not next_topic:
+                            raise ModelOnexError(
+                                message=(
+                                    "emitted event envelope has no event_type; "
+                                    "the harness routes by event_type"
+                                ),
+                                error_code=EnumCoreErrorCode.CONTRACT_VIOLATION,
+                            )
+                        queue.append((next_topic, emitted_envelope))
+
+                if is_terminal:
+                    break
+        finally:
+            await self._bus.close()
+
+        if terminal_topic is None:
+            return ModelHarnessResult(
+                correlation_id=correlation_id,
+                terminal_topic=None,
+                terminal_payload=None,
+                status="no_terminal",
+                emitted_topics=tuple(emitted_topics),
+                exit_code=2,
+            )
+
+        status = self._classify(terminal_topic, terminal_payload)
+        return ModelHarnessResult(
+            correlation_id=correlation_id,
+            terminal_topic=terminal_topic,
+            terminal_payload=terminal_payload,
+            status=status,
+            emitted_topics=tuple(emitted_topics),
+            exit_code=0 if status == "success" else 3,
+        )
+
+    @staticmethod
+    def _classify(terminal_topic: str, payload: dict[str, object] | None) -> str:
+        """Classify the terminal as success/failure from payload or topic name."""
+        if payload is not None:
+            status = payload.get("status")
+            if isinstance(status, str):
+                return "success" if status == "success" else "failure"
+        lowered = terminal_topic.lower()
+        if "failed" in lowered or "failure" in lowered:
+            return "failure"
+        return "success"
+
+    @staticmethod
+    def _as_envelope(emitted: object) -> ModelEventEnvelope[Any]:
+        """Narrow an emitted output element to a typed envelope."""
+        if isinstance(emitted, ModelEventEnvelope):
+            return emitted
+        raise ModelOnexError(
+            message=(
+                "handler emitted a non-envelope output element; the harness "
+                "requires ModelEventEnvelope instances in ModelHandlerOutput.events"
+            ),
+            error_code=EnumCoreErrorCode.CONTRACT_VIOLATION,
+        )
+
+    @staticmethod
+    def _decode_payload(envelope: ModelEventEnvelope[Any]) -> dict[str, object]:
+        """Decode an envelope payload to a JSON-safe dict for projection/evidence."""
+        payload: object = envelope.payload
+        if isinstance(payload, BaseModel):
+            decoded: object = json.loads(payload.model_dump_json())
+            return decoded if isinstance(decoded, dict) else {"value": decoded}
+        if isinstance(payload, dict):
+            return payload
+        return {"value": payload}
+
+
+__all__ = ["InProcessHarness"]

--- a/src/omnibase_core/runtime/harness/harness_effect.py
+++ b/src/omnibase_core/runtime/harness/harness_effect.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Harness EFFECT handler: inference-request -> terminal completed event (OMN-13420)."""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_infer_requested import (
+    ModelHarnessInferRequested,
+)
+from omnibase_core.models.runtime.harness.model_harness_terminal import (
+    ModelHarnessTerminal,
+)
+from omnibase_core.models.runtime.harness.model_inference_request import (
+    ModelInferenceRequest,
+)
+from omnibase_core.protocols.runtime.protocol_harness_inference_adapter import (
+    ProtocolHarnessInferenceAdapter,
+)
+from omnibase_core.runtime.harness.harness_topics import completed_topic
+
+
+class HarnessEffectHandler:
+    """EFFECT: runs inference behind the adapter seam, emits the terminal event."""
+
+    def __init__(self, workflow: str, adapter: ProtocolHarnessInferenceAdapter) -> None:
+        self._workflow = workflow
+        self._adapter = adapter
+
+    @property
+    def handler_id(self) -> str:
+        """Return the unique handler identifier."""
+        return f"harness-{self._workflow}-effect"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Return the handled message category."""
+        return EnumMessageCategory.EVENT
+
+    @property
+    def message_types(self) -> set[str]:
+        """Accept all message types in the category."""
+        return set()
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """Return the ONEX node kind."""
+        return EnumNodeKind.EFFECT
+
+    async def handle(
+        self, envelope: ModelEventEnvelope[ModelHarnessInferRequested]
+    ) -> ModelHandlerOutput[None]:
+        """Run inference and emit the terminal completed event."""
+        infer = envelope.payload
+        result = self._adapter.infer(
+            ModelInferenceRequest(prompt=infer.prompt, max_tokens=infer.max_tokens)
+        )
+        terminal = ModelHarnessTerminal(
+            correlation_id=infer.correlation_id,
+            workflow=infer.workflow,
+            status="success",
+            completion=result.completion,
+            model=result.model,
+            adapter=result.adapter,
+        )
+        emitted: ModelEventEnvelope[ModelHarnessTerminal] = ModelEventEnvelope(
+            payload=terminal,
+            correlation_id=infer.correlation_id,
+            event_type=completed_topic(infer.workflow),
+            payload_type="ModelHarnessTerminal",
+            source_tool=self.handler_id,
+        )
+        return ModelHandlerOutput.for_effect(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=infer.correlation_id,
+            handler_id=self.handler_id,
+            events=(emitted,),
+        )
+
+
+__all__ = ["HarnessEffectHandler"]

--- a/src/omnibase_core/runtime/harness/harness_inference_curl.py
+++ b/src/omnibase_core/runtime/harness/harness_inference_curl.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Curl-subprocess inference adapter for the local runtime harness (OMN-13420).
+
+Shells out to the ``curl`` binary. A separate binary carries its own macOS Local
+Network grant, so it sidesteps the per-binary Python LAN-grant problem, and it
+keeps ``httpx`` off the harness path. Imperative ``curl`` is acceptable here
+because it stays behind the inference-adapter protocol seam.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.harness.model_inference_request import (
+    ModelInferenceRequest,
+)
+from omnibase_core.models.runtime.harness.model_inference_result import (
+    ModelInferenceResult,
+)
+
+
+class CurlSubprocessInferenceAdapter:
+    """Inference adapter that shells out to ``curl`` (separate-binary LAN access).
+
+    Posts an OpenAI-compatible chat-completion request to ``endpoint`` and parses
+    ``choices[0].message.content`` from the response.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        model: str,
+        *,
+        timeout_seconds: float = 30.0,
+        curl_binary: str = "curl",
+    ) -> None:
+        self._endpoint = endpoint
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._curl_binary = curl_binary
+
+    @property
+    def adapter_id(self) -> str:
+        """Return the adapter provenance identifier."""
+        return "curl"
+
+    def infer(self, request: ModelInferenceRequest) -> ModelInferenceResult:
+        """Run inference via a curl subprocess and parse the completion."""
+        body = json.dumps(
+            {
+                "model": self._model,
+                "max_tokens": request.max_tokens,
+                "messages": [{"role": "user", "content": request.prompt}],
+            }
+        )
+        completed = (
+            subprocess.run(  # boundary-ok: dev-harness inference behind adapter seam
+                [
+                    self._curl_binary,
+                    "-sS",
+                    "-X",
+                    "POST",
+                    self._endpoint,
+                    "-H",
+                    "Content-Type: application/json",
+                    "-d",
+                    body,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_seconds,
+                check=False,
+            )
+        )
+        if completed.returncode != 0:
+            raise ModelOnexError(
+                message=(
+                    f"curl inference failed (exit {completed.returncode}): "
+                    f"{completed.stderr.strip()}"
+                ),
+                error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+            )
+        try:
+            parsed = json.loads(completed.stdout)
+            completion = parsed["choices"][0]["message"]["content"]
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+            raise ModelOnexError(
+                message=f"curl inference returned unparseable response: {exc}",
+                error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+            ) from exc
+        return ModelInferenceResult(
+            completion=str(completion),
+            model=self._model,
+            adapter=self.adapter_id,
+        )
+
+
+__all__ = ["CurlSubprocessInferenceAdapter"]

--- a/src/omnibase_core/runtime/harness/harness_inference_fixture.py
+++ b/src/omnibase_core/runtime/harness/harness_inference_fixture.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Recorded-fixture inference adapter for the local runtime harness (OMN-13420).
+
+Fully offline; returns a recorded completion. The default adapter for proof runs
+so the DoD ("no LAN required") holds with zero config.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.runtime.harness.model_inference_request import (
+    ModelInferenceRequest,
+)
+from omnibase_core.models.runtime.harness.model_inference_result import (
+    ModelInferenceResult,
+)
+
+
+class RecordedFixtureInferenceAdapter:
+    """Offline inference adapter — returns a recorded completion. No LAN, no I/O.
+
+    When ``completion`` is omitted it echoes a deterministic completion derived
+    from the prompt so runs are reproducible.
+    """
+
+    def __init__(
+        self, completion: str | None = None, model: str = "recorded-fixture"
+    ) -> None:
+        self._completion = completion
+        self._model = model
+
+    @property
+    def adapter_id(self) -> str:
+        """Return the adapter provenance identifier."""
+        return "fixture"
+
+    def infer(self, request: ModelInferenceRequest) -> ModelInferenceResult:
+        """Return the recorded (or prompt-echoed) completion."""
+        completion = (
+            self._completion
+            if self._completion is not None
+            else f"[recorded] {request.prompt}"
+        )
+        return ModelInferenceResult(
+            completion=completion,
+            model=self._model,
+            adapter=self.adapter_id,
+        )
+
+
+__all__ = ["RecordedFixtureInferenceAdapter"]

--- a/src/omnibase_core/runtime/harness/harness_orchestrator.py
+++ b/src/omnibase_core/runtime/harness/harness_orchestrator.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Harness ORCHESTRATOR handler: command -> inference-request event (OMN-13420)."""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_command import (
+    ModelHarnessCommand,
+)
+from omnibase_core.models.runtime.harness.model_harness_infer_requested import (
+    ModelHarnessInferRequested,
+)
+from omnibase_core.runtime.harness.harness_topics import infer_topic
+
+
+class HarnessOrchestratorHandler:
+    """ORCHESTRATOR: consumes the command, emits an inference-request event."""
+
+    def __init__(self, workflow: str) -> None:
+        self._workflow = workflow
+
+    @property
+    def handler_id(self) -> str:
+        """Return the unique handler identifier."""
+        return f"harness-{self._workflow}-orchestrator"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Return the handled message category."""
+        return EnumMessageCategory.COMMAND
+
+    @property
+    def message_types(self) -> set[str]:
+        """Accept all message types in the category."""
+        return set()
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """Return the ONEX node kind."""
+        return EnumNodeKind.ORCHESTRATOR
+
+    async def handle(
+        self, envelope: ModelEventEnvelope[ModelHarnessCommand]
+    ) -> ModelHandlerOutput[None]:
+        """Emit an inference-request event for the command."""
+        command = envelope.payload
+        infer = ModelHarnessInferRequested(
+            correlation_id=command.correlation_id,
+            workflow=command.workflow,
+            prompt=command.prompt,
+            max_tokens=command.max_tokens,
+        )
+        emitted: ModelEventEnvelope[ModelHarnessInferRequested] = ModelEventEnvelope(
+            payload=infer,
+            correlation_id=command.correlation_id,
+            event_type=infer_topic(command.workflow),
+            payload_type="ModelHarnessInferRequested",
+            source_tool=self.handler_id,
+        )
+        return ModelHandlerOutput.for_orchestrator(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=command.correlation_id,
+            handler_id=self.handler_id,
+            events=(emitted,),
+        )
+
+
+__all__ = ["HarnessOrchestratorHandler"]

--- a/src/omnibase_core/runtime/harness/harness_projection_store_sqlite.py
+++ b/src/omnibase_core/runtime/harness/harness_projection_store_sqlite.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""SQLite projection store for the local runtime harness (OMN-13420).
+
+Zero infra, zero LAN. Pass ``path=":memory:"`` (default) for fully ephemeral runs,
+or a file path for a durable readback artifact.
+
+Postgres-specific migration/view validation (CASCADE/JSONB/view migrations, the
+A5/A7 class) is out of scope here — that remains the infra-backed broker proof.
+This adapter proves the in-process command -> terminal -> projection chain only.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from uuid import UUID
+
+from omnibase_core.models.runtime.harness.model_projection_row import ModelProjectionRow
+
+
+class SqliteProjectionStore:
+    """SQLite-backed projection store — zero infra, zero LAN.
+
+    The schema is created on construction so a fresh DB is immediately usable.
+    """
+
+    _TABLE = "harness_projection"
+
+    def __init__(self, path: str = ":memory:") -> None:
+        self._path = path
+        # check_same_thread=False so the single-process asyncio harness can reuse
+        # the connection across the event-loop callback boundary.
+        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self._conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self._TABLE} (
+                correlation_id TEXT PRIMARY KEY,
+                workflow TEXT NOT NULL,
+                terminal_topic TEXT NOT NULL,
+                status TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    @property
+    def path(self) -> str:
+        """Return the SQLite database path (``:memory:`` for ephemeral)."""
+        return self._path
+
+    @property
+    def backend(self) -> str:
+        """Return a human-readable backend identifier for evidence packets."""
+        return f"sqlite:{self._path}"
+
+    def write(self, row: ModelProjectionRow) -> None:
+        """Persist a single projection row (idempotent upsert by correlation_id)."""
+        self._conn.execute(
+            f"""
+            INSERT INTO {self._TABLE}
+                (correlation_id, workflow, terminal_topic, status, payload, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(correlation_id) DO UPDATE SET
+                workflow=excluded.workflow,
+                terminal_topic=excluded.terminal_topic,
+                status=excluded.status,
+                payload=excluded.payload,
+                created_at=excluded.created_at
+            """,
+            (
+                str(row.correlation_id),
+                row.workflow,
+                row.terminal_topic,
+                row.status,
+                json.dumps(row.payload),
+                row.created_at.isoformat(),
+            ),
+        )
+        self._conn.commit()
+
+    def read(self, correlation_id: UUID) -> ModelProjectionRow | None:
+        """Read back the projection row for a correlation ID, or None."""
+        cursor = self._conn.execute(
+            f"""
+            SELECT correlation_id, workflow, terminal_topic, status, payload, created_at
+            FROM {self._TABLE}
+            WHERE correlation_id = ?
+            """,
+            (str(correlation_id),),
+        )
+        record = cursor.fetchone()
+        if record is None:
+            return None
+        return ModelProjectionRow(
+            correlation_id=UUID(record[0]),
+            workflow=record[1],
+            terminal_topic=record[2],
+            status=record[3],
+            payload=json.loads(record[4]),
+            created_at=datetime.fromisoformat(record[5]),
+        )
+
+    def row_count(self) -> int:
+        """Return the number of projection rows (diagnostic helper)."""
+        cursor = self._conn.execute(f"SELECT COUNT(*) FROM {self._TABLE}")
+        return int(cursor.fetchone()[0])
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+
+__all__ = ["SqliteProjectionStore"]

--- a/src/omnibase_core/runtime/harness/harness_reducer.py
+++ b/src/omnibase_core/runtime/harness/harness_reducer.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Harness REDUCER handler: terminal event -> projection row (OMN-13420).
+
+Materializes a read-optimized projection (its single allowed output) into the
+injected projection store. The harness store write is the projection side effect
+for the in-process inner loop; the broker-backed lane uses the real projection
+node.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_terminal import (
+    ModelHarnessTerminal,
+)
+from omnibase_core.models.runtime.harness.model_projection_row import ModelProjectionRow
+from omnibase_core.protocols.runtime.protocol_harness_projection_store import (
+    ProtocolHarnessProjectionStore,
+)
+from omnibase_core.runtime.harness.harness_topics import completed_topic
+
+
+class HarnessProjectionReducer:
+    """REDUCER: consumes the terminal event, materializes a projection row."""
+
+    def __init__(self, workflow: str, store: ProtocolHarnessProjectionStore) -> None:
+        self._workflow = workflow
+        self._store = store
+
+    @property
+    def handler_id(self) -> str:
+        """Return the unique handler identifier."""
+        return f"harness-{self._workflow}-projection-reducer"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Return the handled message category."""
+        return EnumMessageCategory.EVENT
+
+    @property
+    def message_types(self) -> set[str]:
+        """Accept all message types in the category."""
+        return set()
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """Return the ONEX node kind."""
+        return EnumNodeKind.REDUCER
+
+    async def handle(
+        self, envelope: ModelEventEnvelope[ModelHarnessTerminal]
+    ) -> ModelHandlerOutput[None]:
+        """Write the projection row and return it as the reducer projection."""
+        terminal = envelope.payload
+        row = ModelProjectionRow(
+            correlation_id=terminal.correlation_id,
+            workflow=terminal.workflow,
+            terminal_topic=completed_topic(terminal.workflow),
+            status=terminal.status,
+            payload={
+                "completion": terminal.completion,
+                "model": terminal.model,
+                "adapter": terminal.adapter,
+            },
+        )
+        self._store.write(row)
+        return ModelHandlerOutput.for_reducer(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=terminal.correlation_id,
+            handler_id=self.handler_id,
+            projections=(row,),
+        )
+
+
+__all__ = ["HarnessProjectionReducer"]

--- a/src/omnibase_core/runtime/harness/harness_topics.py
+++ b/src/omnibase_core/runtime/harness/harness_topics.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical-shaped topic constants for the local runtime harness (OMN-13420).
+
+Topic names mirror the ``onex.cmd.*`` / ``onex.evt.*`` routing keys node authors
+see in the broker-backed lane (per
+``docs/evidence/2026-06-15-runtime-integration/publish_runtime_probe.py``) so the
+in-process harness exercises the same routing-key shape. These are fixed wire
+identifiers, not environment-tunable settings.
+"""
+
+from __future__ import annotations
+
+# env-var-ok: fixed canonical topic identifiers, not environment-tunable settings
+DELEGATION_COMMAND_TOPIC = "onex.cmd.omnibase-core.harness-delegation-request.v1"
+# env-var-ok: fixed canonical topic identifier
+DELEGATION_INFER_TOPIC = "onex.evt.omnibase-core.harness-delegation-infer.v1"
+# env-var-ok: fixed canonical topic identifier
+DELEGATION_COMPLETED_TOPIC = "onex.evt.omnibase-core.harness-delegation-completed.v1"
+
+# env-var-ok: fixed canonical topic identifier
+SEA_COMMAND_TOPIC = "onex.cmd.omnibase-core.harness-sea-request.v1"
+# env-var-ok: fixed canonical topic identifier
+SEA_INFER_TOPIC = "onex.evt.omnibase-core.harness-sea-infer.v1"
+# env-var-ok: fixed canonical topic identifier
+SEA_COMPLETED_TOPIC = "onex.evt.omnibase-core.harness-sea-completed.v1"
+
+
+def infer_topic(workflow: str) -> str:
+    """Return the inference-request topic for a workflow."""
+    return DELEGATION_INFER_TOPIC if workflow == "delegation" else SEA_INFER_TOPIC
+
+
+def completed_topic(workflow: str) -> str:
+    """Return the terminal completed topic for a workflow."""
+    return (
+        DELEGATION_COMPLETED_TOPIC if workflow == "delegation" else SEA_COMPLETED_TOPIC
+    )
+
+
+def command_topic(workflow: str) -> str:
+    """Return the command topic for a workflow."""
+    return DELEGATION_COMMAND_TOPIC if workflow == "delegation" else SEA_COMMAND_TOPIC
+
+
+__all__ = [
+    "DELEGATION_COMMAND_TOPIC",
+    "DELEGATION_COMPLETED_TOPIC",
+    "DELEGATION_INFER_TOPIC",
+    "SEA_COMMAND_TOPIC",
+    "SEA_COMPLETED_TOPIC",
+    "SEA_INFER_TOPIC",
+    "command_topic",
+    "completed_topic",
+    "infer_topic",
+]

--- a/tests/unit/runtime/harness/__init__.py
+++ b/tests/unit/runtime/harness/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/harness/test_harness_dispatch.py
+++ b/tests/unit/runtime/harness/test_harness_dispatch.py
@@ -271,7 +271,5 @@ def test_harness_modules_carry_no_infra_or_transport_imports() -> None:
 
 @pytest.mark.unit
 def test_infra_not_importable_in_core_environment() -> None:
-    """The core venv must not have omnibase_infra installed (infra-free proof)."""
+    """The core venv must not have omnibase_infra installed."""
     assert importlib.util.find_spec("omnibase_infra") is None
-    assert importlib.util.find_spec("aiokafka") is None
-    assert importlib.util.find_spec("asyncpg") is None

--- a/tests/unit/runtime/harness/test_harness_dispatch.py
+++ b/tests/unit/runtime/harness/test_harness_dispatch.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the core-resident infra-free local runtime harness (OMN-13420).
+
+These tests exercise the full in-process command -> terminal -> projection chain
+using ONLY core + spi-protocol surfaces. They must NOT import ``omnibase_infra``,
+``aiokafka``, ``asyncpg`` or any LAN transport — the harness is infra-free by
+contract, and ``test_harness_modules_carry_no_infra_or_transport_imports`` asserts
+the modules carry no such imports.
+
+Async chains are driven via ``asyncio.run`` in sync test bodies to match the
+repo's existing ``tests/unit/runtime/test_runtime_local.py`` convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.harness.model_harness_command import (
+    ModelHarnessCommand,
+)
+from omnibase_core.models.runtime.harness.model_inference_request import (
+    ModelInferenceRequest,
+)
+from omnibase_core.protocols.runtime.protocol_harness_inference_adapter import (
+    ProtocolHarnessInferenceAdapter,
+)
+from omnibase_core.protocols.runtime.protocol_harness_projection_store import (
+    ProtocolHarnessProjectionStore,
+)
+from omnibase_core.protocols.runtime.protocol_message_handler import (
+    ProtocolMessageHandler,
+)
+from omnibase_core.runtime.harness import (
+    CurlSubprocessInferenceAdapter,
+    HarnessEffectHandler,
+    HarnessOrchestratorHandler,
+    HarnessProjectionReducer,
+    InProcessHarness,
+    RecordedFixtureInferenceAdapter,
+    SqliteProjectionStore,
+    build_workflow,
+)
+from omnibase_core.runtime.harness.harness_cli import (
+    build_evidence_packet,
+    run_workflow,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("workflow", ["delegation", "sea"])
+def test_workflow_reaches_terminal_and_projection(workflow: str) -> None:
+    """Each workflow runs command -> terminal -> SQLite projection, exit 0."""
+    correlation_id = uuid4()
+    adapter = RecordedFixtureInferenceAdapter(completion="DONE")
+    store = SqliteProjectionStore(path=":memory:")
+    result, projection = asyncio.run(
+        run_workflow(
+            workflow=workflow,
+            prompt="prove the inner loop",
+            correlation_id=correlation_id,
+            task_type="harness",
+            max_tokens=256,
+            adapter=adapter,
+            store=store,
+        )
+    )
+
+    assert result.reached_terminal
+    assert result.status == "success"
+    assert result.exit_code == 0
+    assert result.terminal_topic is not None
+    assert result.terminal_payload is not None
+    assert result.terminal_payload["completion"] == "DONE"
+
+    assert projection is not None
+    assert projection.correlation_id == correlation_id
+    assert projection.workflow == workflow
+    assert projection.status == "success"
+    assert projection.payload["completion"] == "DONE"
+    assert store.row_count() == 1
+    store.close()
+
+
+@pytest.mark.unit
+def test_emitted_topics_follow_command_infer_completed_order() -> None:
+    """The bus records every hop: command -> infer -> completed."""
+    store = SqliteProjectionStore()
+    result, _ = asyncio.run(
+        run_workflow(
+            workflow="delegation",
+            prompt="hi",
+            correlation_id=uuid4(),
+            task_type="harness",
+            max_tokens=16,
+            adapter=RecordedFixtureInferenceAdapter(),
+            store=store,
+        )
+    )
+    assert result.emitted_topics[0].startswith("onex.cmd.")
+    assert "infer" in result.emitted_topics[1]
+    assert result.emitted_topics[-1].endswith("completed.v1")
+    store.close()
+
+
+@pytest.mark.unit
+def test_projection_readback_matches_written_row() -> None:
+    """SQLite store round-trips the projection row; unknown IDs read None."""
+    correlation_id = uuid4()
+    store = SqliteProjectionStore()
+    asyncio.run(
+        run_workflow(
+            workflow="sea",
+            prompt="x",
+            correlation_id=correlation_id,
+            task_type="harness",
+            max_tokens=8,
+            adapter=RecordedFixtureInferenceAdapter(completion="ROW"),
+            store=store,
+        )
+    )
+    row = store.read(correlation_id)
+    assert row is not None
+    assert row.payload["completion"] == "ROW"
+    assert store.read(uuid4()) is None
+    store.close()
+
+
+@pytest.mark.unit
+def test_handlers_satisfy_protocol_message_handler() -> None:
+    """All three harness handlers structurally satisfy ProtocolMessageHandler."""
+    adapter = RecordedFixtureInferenceAdapter()
+    store = SqliteProjectionStore()
+    handlers = (
+        HarnessOrchestratorHandler("delegation"),
+        HarnessEffectHandler("delegation", adapter),
+        HarnessProjectionReducer("delegation", store),
+    )
+    for handler in handlers:
+        assert isinstance(handler, ProtocolMessageHandler)
+    store.close()
+
+
+@pytest.mark.unit
+def test_adapters_satisfy_protocols() -> None:
+    """Inference + projection adapters satisfy their structural protocols."""
+    assert isinstance(
+        RecordedFixtureInferenceAdapter(), ProtocolHarnessInferenceAdapter
+    )
+    assert isinstance(
+        CurlSubprocessInferenceAdapter(endpoint="http://x/v1", model="m"),
+        ProtocolHarnessInferenceAdapter,
+    )
+    store = SqliteProjectionStore()
+    assert isinstance(store, ProtocolHarnessProjectionStore)
+    store.close()
+
+
+@pytest.mark.unit
+def test_bus_is_core_in_memory_impl() -> None:
+    """The harness bus is the core EventBusInmemory — never an infra bus."""
+    harness, _ = build_workflow(
+        workflow="delegation",
+        adapter=RecordedFixtureInferenceAdapter(),
+        store=SqliteProjectionStore(),
+    )
+    assert isinstance(harness.bus, EventBusInmemory)
+    assert harness.bus_impl == "EventBusInmemory"
+
+
+@pytest.mark.unit
+def test_recorded_fixture_adapter_echoes_prompt_by_default() -> None:
+    """The default fixture adapter is deterministic and offline."""
+    adapter = RecordedFixtureInferenceAdapter()
+    out = adapter.infer(ModelInferenceRequest(prompt="echo me"))
+    assert out.completion == "[recorded] echo me"
+    assert out.adapter == "fixture"
+
+
+@pytest.mark.unit
+def test_no_terminal_when_orchestrator_unregistered() -> None:
+    """With no handler for the command topic, no terminal is reached (exit 2)."""
+    harness = InProcessHarness(terminal_topics=frozenset({"onex.evt.never.v1"}))
+    command = ModelHarnessCommand(
+        correlation_id=uuid4(), workflow="delegation", prompt="x"
+    )
+    envelope: ModelEventEnvelope[ModelHarnessCommand] = ModelEventEnvelope(
+        payload=command,
+        correlation_id=command.correlation_id,
+        event_type="onex.cmd.unrouted.v1",
+    )
+    result = asyncio.run(
+        harness.run(command_topic="onex.cmd.unrouted.v1", command_envelope=envelope)
+    )
+    assert not result.reached_terminal
+    assert result.status == "no_terminal"
+    assert result.exit_code == 2
+
+
+@pytest.mark.unit
+def test_build_evidence_packet_is_infra_free_and_complete() -> None:
+    """The evidence packet carries the infra-free proof fields."""
+    correlation_id = uuid4()
+    store = SqliteProjectionStore()
+    adapter = RecordedFixtureInferenceAdapter()
+    result, projection = asyncio.run(
+        run_workflow(
+            workflow="delegation",
+            prompt="evidence",
+            correlation_id=correlation_id,
+            task_type="harness",
+            max_tokens=32,
+            adapter=adapter,
+            store=store,
+        )
+    )
+    packet = build_evidence_packet(
+        workflow="delegation",
+        result=result,
+        projection=projection,
+        adapter=adapter,
+        store=store,
+        bus_impl="EventBusInmemory",
+        runtime_sha="db7f341",
+    )
+    assert packet["infra_free"] is True
+    assert packet["bus_impl"] == "EventBusInmemory"
+    assert packet["inference_adapter"] == "fixture"
+    assert str(packet["projection_backend"]).startswith("sqlite:")
+    assert packet["exit_code"] == 0
+    assert packet["terminal_status"] == "success"
+    assert packet["correlation_id"] == str(correlation_id)
+    assert packet["projection_row"] is not None
+    store.close()
+
+
+@pytest.mark.unit
+def test_harness_modules_carry_no_infra_or_transport_imports() -> None:
+    """Static guard: harness source must not import infra/Kafka/LAN transports."""
+    src_root = Path(__file__).parents[4] / "src" / "omnibase_core"
+    harness_dirs = (
+        src_root / "runtime" / "harness",
+        src_root / "models" / "runtime" / "harness",
+    )
+    forbidden = (
+        "omnibase_infra",
+        "aiokafka",
+        "kafka",
+        "asyncpg",
+        "psycopg",
+        "httpx",
+        "aiohttp",
+        "requests",
+    )
+    offenders: list[str] = []
+    for harness_dir in harness_dirs:
+        for py_file in harness_dir.glob("*.py"):
+            text = py_file.read_text(encoding="utf-8")
+            for token in forbidden:
+                if f"import {token}" in text or f"from {token}" in text:
+                    offenders.append(f"{py_file.name}: {token}")
+    assert not offenders, f"harness imports forbidden transport/infra: {offenders}"
+
+
+@pytest.mark.unit
+def test_infra_not_importable_in_core_environment() -> None:
+    """The core venv must not have omnibase_infra installed (infra-free proof)."""
+    assert importlib.util.find_spec("omnibase_infra") is None
+    assert importlib.util.find_spec("aiokafka") is None
+    assert importlib.util.find_spec("asyncpg") is None


### PR DESCRIPTION
## OMN-13420 — Core-resident infra-free in-process local runtime harness

Phase 6 of the local-first runtime re-convergence (epic OMN-13442). A fast inner loop so node authors iterate handler logic end-to-end WITHOUT installing `omnibase_infra` (no Kafka/Postgres/topic-runtime) and without PR/image churn.

### What this adds
A minimal in-process dispatch harness in `omnibase_core` that runs a full `command -> orchestrator -> effect(inference) -> terminal -> reducer(projection)` chain using ONLY:
- the spi `ProtocolMessageHandler.handle(envelope) -> ModelHandlerOutput` contract,
- core envelope models (`ModelEventEnvelope`, `ModelHandlerOutput`),
- the core in-memory bus (`omnibase_core.event_bus.event_bus_inmemory.EventBusInmemory`),
- the core-resident runtime protocols (`omnibase_core.protocols.runtime`).

There is **no** infra `MessageDispatchEngine`, DI container, topic provisioning, or consumer groups; **no** Kafka; **no** Postgres (SQLite projection store, default `:memory:`); **no** LAN (recorded-fixture inference adapter on the default path; a curl-subprocess adapter is available behind the inference protocol seam — separate binary carries its own macOS LAN grant and keeps `httpx` off the harness path).

### Surfaces
- `omnibase_core.runtime.harness` — `InProcessHarness`, `build_workflow`, orchestrator/effect/reducer handlers, `RecordedFixtureInferenceAdapter`, `CurlSubprocessInferenceAdapter`, `SqliteProjectionStore`, topic constants.
- `omnibase_core.models.runtime.harness` — 7 frozen models (command, infer-requested, terminal, result, projection-row, inference request/result), one class per file.
- `omnibase_core.protocols.runtime` — `ProtocolHarnessInferenceAdapter`, `ProtocolHarnessProjectionStore` (TYPE_CHECKING model imports to avoid the core import cycle).
- `delegation` + `sea` CLI subcommands (`python -m omnibase_core.runtime.harness.harness_cli`) mirror `docs/evidence/2026-06-15-runtime-integration/publish_runtime_probe.py` and emit a durable JSON evidence packet.

### Scope boundary (honest)
Proves HANDLER LOGIC + the in-process `command -> terminal -> projection` chain. Does NOT exercise Kafka semantics (consumer groups, partitioning, DLQ, ordering, idempotency-across-restart) or the image build — the infra-backed broker proof + fitness gate remain the pre-merge gate. This is the inner loop only. Node-package handlers that still import `omnibase_infra` are decoupled under the separate epic OMN-13449/13450/13451; the harness ships its own minimal infra-free handlers.

### dod_evidence
- New `tests/unit/runtime/harness/test_harness_dispatch.py` (12 cases): both workflows reach the terminal completed event + materialize a SQLite projection row (exit 0); emitted-topic order command->infer->completed; projection round-trip readback (unknown IDs read None); all three handlers satisfy `ProtocolMessageHandler`; adapters satisfy their protocols; bus is the core `EventBusInmemory`; evidence packet carries `infra_free=true`; unrouted command yields no_terminal (exit 2). **12 passed.**
- Infra-free proof: in the core venv with `omnibase_infra` UNINSTALLED, `importlib.util.find_spec` reports `omnibase_infra` / `aiokafka` / `asyncpg` all absent; the delegation + sea harness CLIs run to a typed terminal + SQLite projection readback with exit 0. Durable packets under `docs/evidence/OMN-13420/` (omni_home). Static no-transport-import guard test + `scripts/validate_no_transport_imports.py` green.
- `uv run mypy src/omnibase_core` clean (3970 files). `ruff format`/`ruff check` clean. `tests/unit/runtime` + `tests/unit/test_no_internal_deps.py` = 226 passed. `pre-commit run --files <changed>` green (file-location, single-class-per-file, error-raising, print-ok, SPDX, env-var-ok, deterministic-skill-routing, transport-imports).

Evidence-Source: 7897fe870211d5e3ab3448161a9c0e2720a9f51d
Evidence-Ticket: OMN-13420
