### PR TITLE
docs(OMN-13460): refresh architecture docs + exhibit (omnibase_core)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -324,6 +324,7 @@ src/omnibase_core/
 ├── constants/              # Project constants
 ├── container/              # DI container implementation
 ├── context/                # Application context
+├── contract_graph/         # Contract/UI-component graph adapters + canonical hash + importer
 ├── contracts/              # Contract management
 ├── crypto/                 # Blake3 hashing, Ed25519 signing
 ├── decorators/             # Utility decorators (@standard_error_handling)
@@ -345,20 +346,25 @@ src/omnibase_core/
 ├── nodes/                  # EFFECT, COMPUTE, REDUCER, ORCHESTRATOR
 ├── normalization/          # Normalization pipeline
 ├── overlays/               # Contract overlay support
+├── package/                # ONCP package manifest models + builder/reader services
 ├── pipeline/               # Execution plan builders, runners
 ├── protocols/              # Protocol definitions
 ├── rendering/              # Report renderers (CLI, HTML, JSON, Markdown, Diff)
 ├── resolution/             # Execution, handler, protocol dependency resolvers
 ├── runtime/                # Runtime components (handler registry, message dispatch)
 ├── schemas/                # JSON Schema definitions
+├── scripts/                # Console-script entrypoints (e.g. onex-validate-links)
 ├── services/               # Service implementations
 ├── tools/                  # Mypy plugins
 ├── types/                  # TypedDict definitions
 ├── utils/                  # Utility functions
 ├── validators/             # Standalone validator modules
 ├── validation/             # Validation framework + cross-repo validators + DB validators
-└── workflows/              # Workflow support models
+├── workflows/              # Workflow support models
+└── topics.py               # Canonical wire-format Kafka topic names (TopicBase, build_topic)
 ```
+
+> **Provenance**: The package structure above was verified against `src/omnibase_core/` on this refresh (OMN-13460). The four node archetypes, `onex` CLI entrypoints, and `onex.nodes`/`onex.backends`/`onex.doctor` entry-point groups are declared in `pyproject.toml`.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,6 +5,8 @@
 
 **Status**: ✅ Complete
 
+> **Provenance**: Import paths and node archetypes in this document were verified against `src/omnibase_core/` on this refresh (OMN-13460). The four node base classes (`NodeCompute`, `NodeEffect`, `NodeReducer`, `NodeOrchestrator`) are exported from `omnibase_core.nodes`; service wrappers such as `ModelServiceCompute` live in `omnibase_core.infrastructure.infra_bases`.
+
 ## Overview
 
 This document provides a high-level overview of the ONEX architecture and its core components. The ONEX framework is built on a four-node pattern that provides clear separation of concerns, type safety, and scalable architecture for building distributed systems.


### PR DESCRIPTION
## Summary

Refreshes two omnibase_core architecture docs so the package map and import-path claims match the live `src/omnibase_core/` tree.

- `docs/INDEX.md`: adds the `contract_graph/`, `package/`, `scripts/` directories and `topics.py` to the package structure listing; adds a provenance note tying the structure to a same-refresh verification.
- `docs/architecture/overview.md`: adds a provenance note clarifying that the four node base classes (`NodeCompute`, `NodeEffect`, `NodeReducer`, `NodeOrchestrator`) export from `omnibase_core.nodes`, and service wrappers like `ModelServiceCompute` are importable from `omnibase_core.infrastructure.infra_bases`.

Ticket: OMN-13460
Parent epic: OMN-13454

## dod_evidence

OMN-13460 — every factual claim was verified against actual source before it was written (no invented names, paths, or symbols):

- Package directories — `ls src/omnibase_core/` confirms `contract_graph/`, `package/`, `scripts/`, `workflows/`, `nodes/`, `infrastructure/` and top-level `topics.py` all exist.
- `contract_graph/` description — contains `adapter_node_contract.py`, `adapter_ui_component.py`, `canonical_hash.py`, `importer.py`.
- `package/` description — contains ONCP manifest models plus `service_oncp_builder.py` and `service_oncp_reader.py`.
- `scripts/` console entrypoint — `pyproject.toml` declares `onex-validate-links = "omnibase_core.scripts.validate_markdown_links:main"`; `validate_markdown_links.py` defines `main()` at line 859.
- `topics.py` description — defines `class TopicBase(StrEnum)` (line 33) and `def build_topic` (line 775).
- Node base classes — `src/omnibase_core/nodes/__init__.py` imports and re-exports `NodeCompute`, `NodeEffect`, `NodeOrchestrator`, `NodeReducer`.
- `ModelServiceCompute` import path — `src/omnibase_core/infrastructure/infra_bases.py` re-exports `ModelServiceCompute` (import line 34, `__all__` line 42) from `omnibase_core.models.services.model_service_compute`.
- Entry-point groups — `pyproject.toml` declares `[project.scripts] onex` (line 59), `[project.entry-points."onex.backends"]` (line 79), `[project.entry-points."onex.doctor"]` (line 88), `[project.entry-points."onex.nodes"]` (line 99).

Leak scan: grep over the two changed files for internal IPs (`192.168.`, `10.0.`), absolute `/Users/`/`/Volumes/` paths, `infisical`/secret tokens, API-key shapes (`sk-`, `gho_`, `AIza`, `xoxb-`), and personal emails returned no matches — clean.

Local gates: `pre-commit run --files docs/INDEX.md docs/architecture/overview.md` ran clean (markdown-link validation, hardcoded-path/secret detection, and all other applicable hooks Passed; no `--no-verify`, no skip tokens).

Ground truth: all claims are backed by files read in this refresh; no model names, APIs, gateways, endpoints, ports, or paths were invented.

Evidence-Source: OCC#2889
Evidence-Ticket: OMN-13460
