### PR TITLE
feat(OMN-13407): carry delegation context pack hash

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -96,6 +96,20 @@ class ModelDelegationRequest(BaseModel):
         default=None,
         description="File context for the delegation, if any.",
     )
+    context_pack: str = Field(
+        default="",
+        description=(
+            "Optional assembled context injected ahead of the prompt for context "
+            "ON/OFF experiments. Empty string means no context pack."
+        ),
+    )
+    context_pack_hash: str = Field(
+        default="",
+        description=(
+            "Stable hash of context_pack for projection readback and ROI "
+            "measurement. Empty string means no context pack was injected."
+        ),
+    )
     correlation_id: UUID = Field(
         ...,
         description="Unique identifier for tracking through the pipeline.",

--- a/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
+++ b/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
@@ -89,6 +89,13 @@ class ModelTaskDelegatedEvent(BaseModel):
         default=None,
         description="Raw response received from the delegated model.",
     )
+    context_pack_hash: str = Field(
+        default="",
+        description=(
+            "Stable hash of the context pack injected into the delegated prompt. "
+            "Empty string means the OFF arm or no context pack."
+        ),
+    )
     pricing_manifest_version: int = Field(
         default=0,
         ge=0,

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -75,6 +75,19 @@ class TestModelDelegationRequest:
         r = self._make()
         assert r.task_type == "test"
 
+    def test_context_pack_hash_defaults_to_off_arm(self) -> None:
+        r = self._make()
+        assert r.context_pack == ""
+        assert r.context_pack_hash == ""
+
+    def test_context_pack_hash_is_accepted(self) -> None:
+        r = self._make(
+            context_pack="Relevant repo facts.",
+            context_pack_hash="sha256:abc123",
+        )
+        assert r.context_pack == "Relevant repo facts."
+        assert r.context_pack_hash == "sha256:abc123"
+
     def test_compliance_budget_required_when_schema_key_set(self) -> None:
         with pytest.raises(ValueError, match="compliance_budget is required"):
             self._make(output_schema_key="some_schema")
@@ -607,6 +620,18 @@ class TestModelTaskDelegatedEvent:
         )
         assert event.topic == TASK_DELEGATED_TOPIC_V1
         assert event.escalation_count == 0
+        assert event.context_pack_hash == ""
+
+    def test_carries_context_pack_hash(self) -> None:
+        event = ModelTaskDelegatedEvent(
+            timestamp="2026-05-26T00:00:00Z",
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            delegated_to="local_qwen3",
+            quality_gate_passed=True,
+            context_pack_hash="sha256:ctx",
+        )
+        assert event.context_pack_hash == "sha256:ctx"
 
     def test_rejects_invalid_topic_and_negative_metrics(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- Adds context_pack and context_pack_hash to the canonical delegation request DTO.
- Carries context_pack_hash on the canonical task-delegated event.
- Adds focused DTO tests for OFF/default and ON/hash cases.

## Evidence
- dod_evidence: uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q -> 82 passed.
- dod_evidence: pre-commit run --files src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py src/omnibase_core/models/delegation/wire/model_task_delegated_event.py tests/unit/models/delegation/wire/test_delegation_wire_models.py -> passed.

## Known gate state
- pre-commit run --all-files is currently red on pre-existing repository-wide validator debt outside this PR's changed files: string-id/version, manual YAML parsing, fallback patterns, hardcoded env constants, local path fixtures, exception-handling comments, and hardcoded harness topics.
- This PR should not be considered fully merge-ready until that prerequisite gate debt is resolved or represented by the owning core gate-fix workstream.

## Closeout linkage
- Supports OMN-13407 Phase C finding from docs/evidence/2026-06-21-sea-dogfood/02-cycles/results.md: context_pack_hash absent from delegation request/projection, first failing layer context-assembly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model delegation requests now support context pack injection with stable hash tracking for improved context identification.
  * Task delegation events now include context pack hash identifiers to enable comprehensive tracking of injected context throughout the delegation lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#2897
Evidence-Ticket: OMN-13407