### PR TITLE
fix(OMN-13408): carry tokens_input/tokens_output on ModelTaskDelegatedEvent (projection token clobber)

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
+++ b/src/omnibase_core/models/delegation/wire/model_task_delegated_event.py
@@ -170,6 +170,25 @@ class ModelTaskDelegatedEvent(BaseModel):
             "free_local / metered / overage tokens."
         ),
     )
+    tokens_input: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Prompt (input) tokens for the served inference (OMN-13408). Carried "
+            "so the delegation projection records real tokens even when this "
+            "compat task-delegated event is the last writer for a correlation_id; "
+            "previously unset (defaulted 0), clobbering the real tokens from the "
+            "delegation-completed/failed event in the projection upsert."
+        ),
+    )
+    tokens_output: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Completion (output) tokens for the served inference (OMN-13408). See "
+            "tokens_input."
+        ),
+    )
 
 
 __all__: list[str] = [


### PR DESCRIPTION
Evidence-Source: OCC#2901
Evidence-Ticket: OMN-13408

## OMN-13408 — carry token counts on the compat task-delegated event

Epic: **OMN-13471** · Parent: OMN-12296

### Problem

`ModelTaskDelegatedEvent` (the compat twin emitted on the canonical task-delegated topic) did not carry `tokens_input` / `tokens_output`. When this event was the **last writer** for a `correlation_id`, the delegation projection upsert overwrote the real token counts (carried by the delegation-completed/failed event) with the model's defaults, clobbering projection tokens to **0**.

### Fix (additive only — canonical event-bus model)

Two additive fields on the canonical terminal event's compat twin:

```python
tokens_input: int  = Field(default=0, ge=0, ...)   # prompt tokens
tokens_output: int = Field(default=0, ge=0, ...)   # completion tokens
```

File: `src/omnibase_core/models/delegation/wire/model_task_delegated_event.py`

- No new REST route, no bespoke endpoint, no direct DB write.
- Backward-compatible: both default `0`, so existing producers/serialized events deserialize unchanged.
- Scope is exactly these two fields; nothing else changed.

### dod_evidence

- `git diff` confirms only the two additive fields were added to `ModelTaskDelegatedEvent`.
- `uv run ruff format src/ tests/` + `uv run ruff check --fix src/ tests/` — **All checks passed**.
- mypy: CI invocations `uv run mypy src/omnibase_core` and `uv run mypy src/ --config-file=mypy.ini` both **Success: no issues found** (the 3 errors visible only under bare `--strict` are pre-existing on `dev` in unrelated files `contract_loader.py` / `cli_install.py`, confirmed by stash-out comparison; CI does not use the bare `--strict` flag).
- Changed-file mypy (pre-commit scope) on `model_task_delegated_event.py`: clean.
- `uv run pytest tests/ -q` (full suite, no `-k` filter): **42120 passed, 65 skipped, 12 xfailed, 43 xpassed, 0 failed** (17m08s, `-n auto`).
- Targeted: `tests/unit/models/delegation/wire/test_delegation_wire_models.py` — **82 passed**.
- Commit-time pre-commit hooks (staged-file scope) passed. Two `--all-files` hook failures (`no-hardcoded-topics` on `harness_topics.py` from OMN-13420 #1297; `validate-deterministic-skill-routing` on the omniclaude marketplace layout) are pre-existing on the clean `dev` base — confirmed identical with this change stashed out — and touch files outside this PR's scope.

### Receipt Gate note

The **Evidence-Source OCC receipt is PENDING** — it will be added in the OCC stage of this workstream. This PR is intentionally not merged yet (queue-controlled repo). Do not merge until the OCC receipt lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added token accounting fields to delegated model tasks to improve tracking accuracy for input and output token usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->