### PR TITLE
feat(OMN-13152): ArtifactStore Phase 1 hardening — retention/quota/redaction/restricted-tier read

### DIFF
--- a/src/omnibase_core/artifacts/__init__.py
+++ b/src/omnibase_core/artifacts/__init__.py
@@ -1,23 +1,36 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Content-addressed artifact store (OMN-13093, minimal slice).
+"""Content-addressed artifact store (OMN-13093 slice; OMN-13152 Phase 1).
 
 Provides :class:`ArtifactStore`, the durable-capture blob store consumed by
-the skill-output suppression slice (OMN-13089) and extended in place by the
-parent durable-capture plan's Phase 1.
+the skill-output suppression slice (OMN-13089) and hardened in place by the
+durable-capture plan's Phase 1 (retention, quota, redaction, restricted-tier
+read authorization).
 """
 
 from __future__ import annotations
 
 from omnibase_core.artifacts.artifact_store import (
     ARTIFACT_STORE_ROOT_ENV,
+    DEFAULT_READ_CHUNK_BYTES,
+    RESTRICTED_ARTIFACT_KINDS,
     WRITER_VERSION,
+    ArtifactQuotaExceededError,
+    ArtifactSecretDetectedError,
     ArtifactStore,
+    ArtifactUnauthorizedError,
+    SecretDetector,
 )
 
 __all__ = [
     "ARTIFACT_STORE_ROOT_ENV",
+    "DEFAULT_READ_CHUNK_BYTES",
+    "RESTRICTED_ARTIFACT_KINDS",
     "WRITER_VERSION",
+    "ArtifactQuotaExceededError",
+    "ArtifactSecretDetectedError",
     "ArtifactStore",
+    "ArtifactUnauthorizedError",
+    "SecretDetector",
 ]

--- a/src/omnibase_core/artifacts/artifact_store.py
+++ b/src/omnibase_core/artifacts/artifact_store.py
@@ -1,55 +1,86 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-# parent-plan: Phase 1 extends this — this is the MINIMAL slice of the
-# durable-capture artifact store (docs/plans/
-# 2026-06-12-durable-capture-ingestion-intelligence-plan.md, Phase 1),
-# built for the skill-output suppression slice (OMN-13089 / OMN-13093).
-# Explicitly deferred to parent Phase 1 (extend in place, same module):
-# retention/quota policy, redaction transforms, restricted-topic handling,
-# authorized read API. Do NOT mistake this for the finished store.
-
-"""Minimal content-addressed artifact store (OMN-13093).
+"""Content-addressed artifact store (OMN-13093 minimal slice; OMN-13152 Phase 1).
 
 Blobs are stored under ``$ONEX_ARTIFACT_STORE_ROOT`` at the sharded path
 ``<root>/<hh>/<full-hex>`` where ``<hh>`` is the first two hex chars of the
 blob's SHA-256 digest. Every blob carries a JSON metadata sidecar
-``<full-hex>.meta.json`` with the ``artifact-captured`` required fields.
+``<full-hex>.meta.json`` typed by :class:`ModelArtifactMetadata`.
 
-Design constraints (ticket spec):
+Phase 1 hardening (OMN-13152) added in place:
+
+- **Retention classes** (:class:`EnumArtifactRetentionClass`) with a
+  configurable TTL per class, recorded on the sidecar.
+- **Quota enforcement**: a max per-write size and a max total store size per
+  scope. Exceeding either raises :class:`ArtifactQuotaExceededError` — there is
+  no silent truncation or partial write.
+- **Redaction state** (:class:`EnumArtifactRedactionState`) on the sidecar. On
+  secret detection the store sets ``secret_detected`` and refuses the raw
+  write; an applied redaction transform records itself on the sidecar.
+- **Restricted visibility tier**: ``session_transcript`` and ``hook_trace``
+  artifact kinds are restricted by default; :meth:`read` requires an authorized
+  :class:`ModelArtifactAuthContext`.
+- **Hardened read**: :meth:`read` hash-verifies on every read, enforces the
+  restricted-topic auth gate, exposes the redaction state, supports chunked
+  streaming, and raises explicitly on a missing artifact.
+
+Design constraints (unchanged from the minimal slice):
 
 - stdlib + Pydantic only — no infra deps — so omniclaude hooks import this
   module cleanly (layering rule 7 / F14)
 - store root from ``os.environ["ONEX_ARTIFACT_STORE_ROOT"]`` — required env,
-  ``KeyError`` on absence (fail-fast, Operating Rule 8); callers set it from
-  ``$OMNI_HOME/.onex_state/artifacts/``
+  ``KeyError`` on absence (fail-fast, Operating Rule 8)
 - atomic temp+rename writes, idempotent on existing hash
 - reads are hash-verified against the content address
 
 .. versionadded:: OMN-13093
+.. versionchanged:: OMN-13152
+   Retention, quota, redaction, restricted-tier read auth, typed sidecar.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import re
 import tempfile
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
+from omnibase_core.enums.artifacts.enum_artifact_redaction_state import (
+    EnumArtifactRedactionState,
+)
+from omnibase_core.enums.artifacts.enum_artifact_retention_class import (
+    EnumArtifactRetentionClass,
+)
+from omnibase_core.models.artifacts.model_artifact_auth_context import (
+    ModelArtifactAuthContext,
+)
+from omnibase_core.models.artifacts.model_artifact_metadata import (
+    ModelArtifactMetadata,
+)
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
 
 __all__ = [
     "ARTIFACT_STORE_ROOT_ENV",
+    "DEFAULT_READ_CHUNK_BYTES",
+    "RESTRICTED_ARTIFACT_KINDS",
     "WRITER_VERSION",
+    "ArtifactQuotaExceededError",
+    "ArtifactSecretDetectedError",
     "ArtifactStore",
+    "ArtifactUnauthorizedError",
+    "SecretDetector",
 ]
 
 ARTIFACT_STORE_ROOT_ENV = "ONEX_ARTIFACT_STORE_ROOT"
 
-# Sidecar generation marker. Parent Phase 1 extensions (retention, redaction,
-# read-API hardening) bump this so they can distinguish sidecar generations.
-WRITER_VERSION = "omn-13093-minimal-1"
+# Sidecar generation marker. Bumped from the minimal slice now that the sidecar
+# is typed and carries retention/redaction/visibility fields.
+WRITER_VERSION = "omn-13152-phase1-1"
 
 # Crude byte-based token estimate (~4 bytes/token for English-ish text).
 # Good enough for projection previews and budget heuristics; NOT a tokenizer.
@@ -57,19 +88,99 @@ _BYTES_PER_TOKEN_ESTIMATE = 4
 
 _META_SUFFIX = ".meta.json"
 
+# Default chunk size for streaming reads.
+DEFAULT_READ_CHUNK_BYTES = 64 * 1024
 
-class ArtifactStore:
-    """Content-addressed blob store with JSON metadata sidecars.
+# Artifact kinds whose reads are restricted by default (require auth_context).
+RESTRICTED_ARTIFACT_KINDS: frozenset[str] = frozenset(
+    {"session_transcript", "hook_trace"}
+)
 
-    The blob's :class:`ModelArtifactRef` (``sha256:<hex>``) is both its
-    identity and its integrity proof: :meth:`read_blob` re-hashes the bytes
-    on retrieval and fails on mismatch.
+# A redaction transform is a pure ``bytes -> bytes`` callable returning the
+# sanitized bytes. It identifies itself via a name passed alongside.
+RedactionTransform = Callable[[bytes], bytes]
+
+
+class ArtifactQuotaExceededError(Exception):
+    """Raised when a write would exceed a per-write or per-scope size quota.
+
+    No bytes are persisted when this is raised — the write fails closed with no
+    silent truncation.
     """
 
-    def __init__(self) -> None:
+
+class ArtifactSecretDetectedError(Exception):
+    """Raised when a secret is detected in bytes submitted for a raw write.
+
+    The raw bytes are refused and never persisted; a ``secret_detected``
+    sidecar is recorded instead so the detection is auditable.
+    """
+
+    def __init__(self, ref: ModelArtifactRef) -> None:
+        self.ref = ref
+        super().__init__(
+            f"secret detected in artifact {ref.ref}; raw write refused "
+            "(secret_detected sidecar recorded)"
+        )
+
+
+class ArtifactUnauthorizedError(Exception):
+    """Raised when a restricted artifact is read without sufficient authorization."""
+
+
+# Default secret patterns. Deliberately conservative — high-signal token shapes
+# only — so the gate does not false-positive on ordinary tool output.
+_DEFAULT_SECRET_PATTERNS: tuple[re.Pattern[bytes], ...] = (
+    re.compile(rb"AKIA[0-9A-Z]{16}"),  # AWS access key id
+    re.compile(rb"-----BEGIN [A-Z ]*PRIVATE KEY-----"),  # PEM private key
+    re.compile(rb"ghp_[0-9A-Za-z]{36}"),  # GitHub personal access token
+    re.compile(rb"xox[baprs]-[0-9A-Za-z-]{10,}"),  # Slack token
+    re.compile(rb"sk-[0-9A-Za-z]{20,}"),  # OpenAI-style secret key
+)
+
+
+class SecretDetector:
+    """Pattern-based secret detector for the raw-write gate.
+
+    Stateless and deterministic. Callers may supply their own patterns; the
+    default set targets high-signal credential shapes only.
+    """
+
+    def __init__(self, patterns: tuple[re.Pattern[bytes], ...] | None = None) -> None:
+        self._patterns = patterns if patterns is not None else _DEFAULT_SECRET_PATTERNS
+
+    def contains_secret(self, data: bytes) -> bool:
+        """Return whether ``data`` matches any configured secret pattern."""
+        return any(pattern.search(data) for pattern in self._patterns)
+
+
+class ArtifactStore:
+    """Content-addressed blob store with typed metadata sidecars.
+
+    The blob's :class:`ModelArtifactRef` (``sha256:<hex>``) is both its
+    identity and its integrity proof: :meth:`read` re-hashes the bytes on
+    retrieval and fails on mismatch.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_artifact_bytes: int | None = None,
+        max_scope_bytes: int | None = None,
+        secret_detector: SecretDetector | None = None,
+    ) -> None:
         # Fail-fast: KeyError when ONEX_ARTIFACT_STORE_ROOT is unset.
         # No silent default — a wrong default is worse than a loud crash.
         self._root = Path(os.environ[ARTIFACT_STORE_ROOT_ENV])
+        if max_artifact_bytes is not None and max_artifact_bytes < 0:
+            msg = f"max_artifact_bytes must be >= 0, got {max_artifact_bytes}"
+            raise ValueError(msg)
+        if max_scope_bytes is not None and max_scope_bytes < 0:
+            msg = f"max_scope_bytes must be >= 0, got {max_scope_bytes}"
+            raise ValueError(msg)
+        self._max_artifact_bytes = max_artifact_bytes
+        self._max_scope_bytes = max_scope_bytes
+        self._secret_detector = secret_detector or SecretDetector()
 
     @property
     def root(self) -> Path:
@@ -85,53 +196,344 @@ class ArtifactStore:
         source_system: str,
         scope_ref: str | None,
         correlation_id: str | None,
+        retention_class: EnumArtifactRetentionClass = EnumArtifactRetentionClass.SESSION,
+        retention_ttl_seconds: int | None = None,
+        redaction_transform: RedactionTransform | None = None,
+        redaction_transform_name: str | None = None,
+        restricted: bool | None = None,
     ) -> ModelArtifactRef:
         """Store ``data`` content-addressed and return its ref.
 
-        Writes are atomic (temp file + ``os.replace`` in the destination
-        directory) and idempotent: if a blob with the same hash already
-        exists, neither the blob nor its sidecar is rewritten (first writer
-        wins for metadata).
+        Writes are atomic (temp file + ``os.replace``) and idempotent: a blob
+        with an existing hash is not rewritten (first writer wins for metadata).
+
+        Hardening:
+
+        - Quota: enforced against ``max_artifact_bytes`` and ``max_scope_bytes``
+          (per ``scope_ref``) before any bytes are written. Exceeding either
+          raises :class:`ArtifactQuotaExceededError`.
+        - Secret detection: runs on the bytes the store would persist (after any
+          redaction transform). On detection the store records a
+          ``secret_detected`` sidecar and raises
+          :class:`ArtifactSecretDetectedError` — raw bytes are never written.
+        - Redaction: if ``redaction_transform`` is given it is applied and the
+          stored bytes are the transformed bytes; the sidecar records
+          ``redacted`` state and the transform name.
+        - Restricted tier: defaults to True for restricted artifact kinds;
+          ``restricted`` overrides explicitly.
+
+        Raises:
+            ArtifactQuotaExceededError: a quota would be exceeded.
+            ArtifactSecretDetectedError: a secret was detected in the bytes.
+            ValueError: redaction_transform supplied without a name.
         """
-        ref = ModelArtifactRef.from_bytes(data)
+        if redaction_transform is not None and not redaction_transform_name:
+            msg = "redaction_transform_name is required when redaction_transform is set"
+            raise ValueError(msg)
+
+        if redaction_transform is not None:
+            stored_bytes = redaction_transform(data)
+            redaction_state = EnumArtifactRedactionState.REDACTED
+            transform_name = redaction_transform_name
+        else:
+            stored_bytes = data
+            redaction_state = EnumArtifactRedactionState.RAW
+            transform_name = None
+
+        is_restricted = (
+            restricted
+            if restricted is not None
+            else artifact_kind in RESTRICTED_ARTIFACT_KINDS
+        )
+
+        # Quota: per-write cap is checked first so an oversize single write is
+        # rejected even when the scope is otherwise empty.
+        self._enforce_per_write_quota(stored_bytes)
+
+        # Secret detection runs on the bytes that would be persisted.
+        if self._secret_detector.contains_secret(stored_bytes):
+            secret_ref = ModelArtifactRef.from_bytes(stored_bytes)
+            self._record_secret_detected(
+                secret_ref,
+                media_type=media_type,
+                artifact_kind=artifact_kind,
+                source_system=source_system,
+                scope_ref=scope_ref,
+                correlation_id=correlation_id,
+                retention_class=retention_class,
+                retention_ttl_seconds=retention_ttl_seconds,
+                restricted=is_restricted,
+                size_bytes=len(stored_bytes),
+            )
+            raise ArtifactSecretDetectedError(secret_ref)
+
+        ref = ModelArtifactRef.from_bytes(stored_bytes)
         blob_path = self._blob_path(ref)
         if blob_path.exists():
             return ref
 
+        # Per-scope quota is checked against the live on-disk size, immediately
+        # before the write, so concurrent growth is accounted for.
+        self._enforce_scope_quota(scope_ref, len(stored_bytes))
+
         shard_dir = blob_path.parent
         shard_dir.mkdir(parents=True, exist_ok=True)
 
-        meta = {
-            "artifact_hash": ref.hex_digest,
-            "artifact_size_bytes": len(data),
-            "artifact_media_type": media_type,
-            "artifact_kind": artifact_kind,
-            "source_system": source_system,
-            "scope_ref": scope_ref,
-            "correlation_id": correlation_id,
-            # Minimal slice always stores raw bytes; redaction transforms are
-            # a parent Phase 1 extension.
-            "redaction_state": "raw",
-            "token_estimate": len(data) // _BYTES_PER_TOKEN_ESTIMATE,
-            "created_at_utc": datetime.now(UTC).isoformat(),
-            "writer_version": WRITER_VERSION,
-        }
+        effective_ttl = (
+            retention_ttl_seconds
+            if retention_ttl_seconds is not None
+            else retention_class.default_ttl_seconds
+        )
 
-        # Sidecar first, blob last: blob presence is the idempotency signal,
-        # so a crash between the two writes never yields a blob without meta.
-        self._atomic_write(self._meta_path(ref), json.dumps(meta, indent=2).encode())
-        self._atomic_write(blob_path, data)
+        meta = ModelArtifactMetadata(
+            artifact_hash=ref.hex_digest,
+            artifact_size_bytes=len(stored_bytes),
+            artifact_media_type=media_type,
+            artifact_kind=artifact_kind,
+            source_system=source_system,
+            scope_ref=scope_ref,
+            correlation_id=correlation_id,
+            retention_class=retention_class,
+            retention_ttl_seconds=effective_ttl,
+            redaction_state=redaction_state,
+            redaction_transform=transform_name,
+            restricted=is_restricted,
+            token_estimate=len(stored_bytes) // _BYTES_PER_TOKEN_ESTIMATE,
+            created_at_utc=datetime.now(UTC).isoformat(),
+            writer_version=WRITER_VERSION,
+        )
+
+        # Sidecar first, blob last: blob presence is the idempotency signal, so
+        # a crash between the two writes never yields a blob without meta.
+        self._atomic_write(self._meta_path(ref), self._serialize_meta(meta))
+        self._atomic_write(blob_path, stored_bytes)
         return ref
 
+    def read(
+        self,
+        artifact_ref: ModelArtifactRef,
+        *,
+        auth_context: ModelArtifactAuthContext | None = None,
+    ) -> bytes:
+        """Return the blob bytes for ``artifact_ref``, fully gated.
+
+        On every read: the sidecar is loaded, the restricted-tier auth gate is
+        enforced, the bytes are hash-verified against the ref, and the bytes are
+        returned. Reading a ``secret_detected`` artifact is impossible because
+        no blob was ever persisted for it.
+
+        Raises:
+            FileNotFoundError: no blob/sidecar exists for ``artifact_ref``.
+            ArtifactUnauthorizedError: artifact is restricted and ``auth_context``
+                does not authorize its kind.
+            ValueError: stored bytes do not hash to ``artifact_ref`` (corruption).
+        """
+        meta = self.read_meta(artifact_ref)
+        self._enforce_read_auth(artifact_ref, meta, auth_context)
+
+        blob_path = self._blob_path(artifact_ref)
+        if not blob_path.is_file():
+            msg = f"no artifact blob for {artifact_ref.ref}"
+            raise FileNotFoundError(msg)
+        data = blob_path.read_bytes()
+        self._verify_hash(artifact_ref, data)
+        return data
+
+    def read_chunks(
+        self,
+        artifact_ref: ModelArtifactRef,
+        *,
+        auth_context: ModelArtifactAuthContext | None = None,
+        chunk_size: int = DEFAULT_READ_CHUNK_BYTES,
+    ) -> Iterator[bytes]:
+        """Stream the blob for ``artifact_ref`` in ``chunk_size`` byte chunks.
+
+        Applies the same restricted-tier auth gate as :meth:`read`, then yields
+        chunks while hash-verifying the full stream. The final hash check
+        happens after the last chunk; a mismatch raises :class:`ValueError`
+        once the stream is exhausted.
+
+        Raises:
+            FileNotFoundError: no blob/sidecar exists for ``artifact_ref``.
+            ArtifactUnauthorizedError: artifact is restricted and unauthorized.
+            ValueError: ``chunk_size`` <= 0, or the streamed bytes do not hash
+                to ``artifact_ref``.
+        """
+        if chunk_size <= 0:
+            msg = f"chunk_size must be > 0, got {chunk_size}"
+            raise ValueError(msg)
+
+        meta = self.read_meta(artifact_ref)
+        self._enforce_read_auth(artifact_ref, meta, auth_context)
+
+        blob_path = self._blob_path(artifact_ref)
+        if not blob_path.is_file():
+            msg = f"no artifact blob for {artifact_ref.ref}"
+            raise FileNotFoundError(msg)
+
+        hasher = hashlib.sha256()
+        with blob_path.open("rb") as handle:
+            while True:
+                chunk = handle.read(chunk_size)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+                yield chunk
+        actual = f"sha256:{hasher.hexdigest()}"
+        if actual != artifact_ref.ref:
+            msg = (
+                f"artifact hash mismatch for {artifact_ref.ref}: streamed bytes "
+                f"hash to {actual} (on-disk corruption or tampering)"
+            )
+            raise ValueError(msg)
+
     def read_blob(self, ref: ModelArtifactRef) -> bytes:
-        """Return the blob bytes for ``ref``, hash-verified.
+        """Return the blob bytes for ``ref``, hash-verified (no auth gate).
+
+        Retained for the unrestricted internal callers from the minimal slice.
+        Restricted-kind reads must go through :meth:`read` with an
+        ``auth_context``; this method does not enforce the restricted-tier gate.
 
         Raises:
             FileNotFoundError: if no blob exists for ``ref``.
-            ValueError: if the stored bytes do not hash to ``ref``
-                (on-disk corruption or tampering).
+            ValueError: if the stored bytes do not hash to ``ref``.
         """
-        data = self._blob_path(ref).read_bytes()
+        blob_path = self._blob_path(ref)
+        if not blob_path.is_file():
+            msg = f"no artifact blob for {ref.ref}"
+            raise FileNotFoundError(msg)
+        data = blob_path.read_bytes()
+        self._verify_hash(ref, data)
+        return data
+
+    def read_meta(self, ref: ModelArtifactRef) -> ModelArtifactMetadata:
+        """Return the typed sidecar metadata for ``ref``.
+
+        Raises:
+            FileNotFoundError: if no sidecar exists for ``ref``.
+            ValueError: if the sidecar is not a JSON object or fails validation.
+        """
+        meta_path = self._meta_path(ref)
+        if not meta_path.is_file():
+            msg = f"no artifact sidecar for {ref.ref}"
+            raise FileNotFoundError(msg)
+        raw = meta_path.read_bytes()
+        loaded: object = json.loads(raw)
+        if not isinstance(loaded, dict):
+            msg = f"artifact sidecar for {ref.ref} is not a JSON object"
+            raise ValueError(msg)
+        return ModelArtifactMetadata.model_validate(loaded)
+
+    def scope_size_bytes(self, scope_ref: str | None) -> int:
+        """Total on-disk blob bytes currently attributed to ``scope_ref``.
+
+        ``secret_detected`` sidecars (which have no blob) are excluded.
+        """
+        total = 0
+        for meta_path in self._iter_meta_paths():
+            try:
+                loaded = json.loads(meta_path.read_bytes())
+            except (OSError, json.JSONDecodeError):  # fallback-ok: skip unreadable
+                continue
+            if not isinstance(loaded, dict):
+                continue
+            if loaded.get("scope_ref") != scope_ref:
+                continue
+            if (
+                loaded.get("redaction_state")
+                == EnumArtifactRedactionState.SECRET_DETECTED.value
+            ):
+                continue
+            size = loaded.get("artifact_size_bytes")
+            if isinstance(size, int):
+                total += size
+        return total
+
+    def _enforce_per_write_quota(self, stored_bytes: bytes) -> None:
+        if (
+            self._max_artifact_bytes is not None
+            and len(stored_bytes) > self._max_artifact_bytes
+        ):
+            msg = (
+                f"artifact size {len(stored_bytes)} exceeds per-write quota "
+                f"{self._max_artifact_bytes}"
+            )
+            raise ArtifactQuotaExceededError(msg)
+
+    def _enforce_scope_quota(self, scope_ref: str | None, incoming: int) -> None:
+        if self._max_scope_bytes is None:
+            return
+        current = self.scope_size_bytes(scope_ref)
+        if current + incoming > self._max_scope_bytes:
+            msg = (
+                f"scope {scope_ref!r} total {current + incoming} would exceed "
+                f"per-scope quota {self._max_scope_bytes}"
+            )
+            raise ArtifactQuotaExceededError(msg)
+
+    def _enforce_read_auth(
+        self,
+        ref: ModelArtifactRef,
+        meta: ModelArtifactMetadata,
+        auth_context: ModelArtifactAuthContext | None,
+    ) -> None:
+        if not meta.restricted:
+            return
+        if auth_context is None or not auth_context.is_authorized_for(
+            meta.artifact_kind
+        ):
+            principal = auth_context.principal if auth_context is not None else "<none>"
+            msg = (
+                f"restricted artifact {ref.ref} (kind={meta.artifact_kind}) "
+                f"read denied for principal {principal!r}"
+            )
+            raise ArtifactUnauthorizedError(msg)
+
+    def _record_secret_detected(
+        self,
+        ref: ModelArtifactRef,
+        *,
+        media_type: str,
+        artifact_kind: str,
+        source_system: str,
+        scope_ref: str | None,
+        correlation_id: str | None,
+        retention_class: EnumArtifactRetentionClass,
+        retention_ttl_seconds: int | None,
+        restricted: bool,
+        size_bytes: int,
+    ) -> None:
+        """Write a secret_detected sidecar with NO accompanying blob."""
+        meta_path = self._meta_path(ref)
+        if meta_path.exists():
+            return
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        effective_ttl = (
+            retention_ttl_seconds
+            if retention_ttl_seconds is not None
+            else retention_class.default_ttl_seconds
+        )
+        meta = ModelArtifactMetadata(
+            artifact_hash=ref.hex_digest,
+            artifact_size_bytes=size_bytes,
+            artifact_media_type=media_type,
+            artifact_kind=artifact_kind,
+            source_system=source_system,
+            scope_ref=scope_ref,
+            correlation_id=correlation_id,
+            retention_class=retention_class,
+            retention_ttl_seconds=effective_ttl,
+            redaction_state=EnumArtifactRedactionState.SECRET_DETECTED,
+            redaction_transform=None,
+            restricted=restricted,
+            token_estimate=0,
+            created_at_utc=datetime.now(UTC).isoformat(),
+            writer_version=WRITER_VERSION,
+        )
+        self._atomic_write(meta_path, self._serialize_meta(meta))
+
+    @staticmethod
+    def _verify_hash(ref: ModelArtifactRef, data: bytes) -> None:
         actual = ModelArtifactRef.from_bytes(data)
         if actual != ref:
             msg = (
@@ -139,21 +541,20 @@ class ArtifactStore:
                 f"{actual.ref} (on-disk corruption or tampering)"
             )
             raise ValueError(msg)
-        return data
 
-    def read_meta(self, ref: ModelArtifactRef) -> dict[str, object]:
-        """Return the JSON sidecar metadata for ``ref``.
+    @staticmethod
+    def _serialize_meta(meta: ModelArtifactMetadata) -> bytes:
+        return meta.model_dump_json(indent=2).encode()
 
-        Raises:
-            FileNotFoundError: if no sidecar exists for ``ref``.
-            ValueError: if the sidecar does not contain a JSON object.
-        """
-        raw = self._meta_path(ref).read_bytes()
-        meta: object = json.loads(raw)
-        if not isinstance(meta, dict):
-            msg = f"artifact sidecar for {ref.ref} is not a JSON object"
-            raise ValueError(msg)
-        return meta
+    def _iter_meta_paths(self) -> Iterator[Path]:
+        if not self._root.is_dir():
+            return
+        for shard in self._root.iterdir():
+            if not shard.is_dir():
+                continue
+            for path in shard.iterdir():
+                if path.name.endswith(_META_SUFFIX):
+                    yield path
 
     def _blob_path(self, ref: ModelArtifactRef) -> Path:
         hex_digest = ref.hex_digest

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -8,6 +8,10 @@ organized by functional domains for better maintainability.
 """
 
 # Action status enum (OMN-1309)
+# Artifact-store retention/redaction states (OMN-13152)
+from .artifacts.enum_artifact_redaction_state import EnumArtifactRedactionState
+from .artifacts.enum_artifact_retention_class import EnumArtifactRetentionClass
+
 # Audit enforcement level (OMN-5232 — context integrity)
 from .audit.enum_audit_enforcement_level import EnumAuditEnforcementLevel
 from .enum_accessibility_tier import EnumAccessibilityTier
@@ -578,6 +582,8 @@ __all__ = [
     "get_core_error_description",
     "get_exit_code_for_core_error",
     # Artifact domain
+    "EnumArtifactRedactionState",
+    "EnumArtifactRetentionClass",
     "EnumArtifactType",
     # Category filter domain
     "EnumCategoryFilter",

--- a/src/omnibase_core/enums/artifacts/__init__.py
+++ b/src/omnibase_core/enums/artifacts/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Artifact-store-scoped enums (OMN-13152).
+
+Retention classes and redaction states for the durable-capture
+:class:`~omnibase_core.artifacts.artifact_store.ArtifactStore` Phase 1
+hardening. These are distinct from the compliance-lifecycle
+``EnumRetentionPolicy`` and the delegation-envelope ``EnumRedactionPolicy``:
+they are the closed value sets the artifact-store write/read path enforces.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.artifacts.enum_artifact_redaction_state import (
+    EnumArtifactRedactionState,
+)
+from omnibase_core.enums.artifacts.enum_artifact_retention_class import (
+    EnumArtifactRetentionClass,
+)
+
+__all__ = [
+    "EnumArtifactRedactionState",
+    "EnumArtifactRetentionClass",
+]

--- a/src/omnibase_core/enums/artifacts/enum_artifact_redaction_state.py
+++ b/src/omnibase_core/enums/artifacts/enum_artifact_redaction_state.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Artifact redaction states (OMN-13152).
+
+The closed set of redaction states recorded on an artifact's metadata sidecar.
+``SECRET_DETECTED`` is terminal for the raw bytes: the store refuses to persist
+raw content once a secret is detected.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["EnumArtifactRedactionState"]
+
+
+class EnumArtifactRedactionState(StrEnum):
+    """Redaction state of a stored artifact's bytes."""
+
+    RAW = "raw"
+    """Unmodified original bytes (no redaction applied)."""
+
+    REDACTED = "redacted"
+    """A redaction transform has been applied; the stored bytes are sanitized."""
+
+    RESTRICTED = "restricted"
+    """Bytes are intact but read access is gated behind authorization."""
+
+    SECRET_DETECTED = "secret_detected"
+    """A secret was detected; raw bytes were refused and never persisted."""

--- a/src/omnibase_core/enums/artifacts/enum_artifact_redaction_state.py
+++ b/src/omnibase_core/enums/artifacts/enum_artifact_redaction_state.py
@@ -27,5 +27,5 @@ class EnumArtifactRedactionState(StrEnum):
     RESTRICTED = "restricted"
     """Bytes are intact but read access is gated behind authorization."""
 
-    SECRET_DETECTED = "secret_detected"
+    SECRET_DETECTED = "secret_detected"  # pragma: allowlist secret
     """A secret was detected; raw bytes were refused and never persisted."""

--- a/src/omnibase_core/enums/artifacts/enum_artifact_retention_class.py
+++ b/src/omnibase_core/enums/artifacts/enum_artifact_retention_class.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Artifact retention classes (OMN-13152).
+
+The closed set of retention classes the durable-capture
+:class:`~omnibase_core.artifacts.artifact_store.ArtifactStore` supports. Each
+class maps to a configurable default TTL (seconds); ``PERMANENT`` never
+expires (``None`` TTL).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["EnumArtifactRetentionClass"]
+
+# Default TTLs in seconds per class. PERMANENT has no TTL (never expires).
+_DEFAULT_TTL_SECONDS: dict[str, int | None] = {
+    "ephemeral": 60 * 60,  # 1 hour
+    "session": 24 * 60 * 60,  # 1 day
+    "ticket": 90 * 24 * 60 * 60,  # 90 days
+    "permanent": None,
+}
+
+
+class EnumArtifactRetentionClass(StrEnum):
+    """Retention class governing how long an artifact is kept.
+
+    The default TTL per class is a starting policy; callers may override the
+    effective TTL per write. ``PERMANENT`` artifacts have no TTL and are never
+    eligible for retention-driven eviction.
+    """
+
+    EPHEMERAL = "ephemeral"
+    """Short-lived scratch output; default TTL 1 hour."""
+
+    SESSION = "session"
+    """Lives for the duration of a working session; default TTL 1 day."""
+
+    TICKET = "ticket"
+    """Retained for the lifetime of a ticket's work; default TTL 90 days."""
+
+    PERMANENT = "permanent"
+    """Never expires (no TTL)."""
+
+    @property
+    def default_ttl_seconds(self) -> int | None:
+        """Default time-to-live in seconds, or ``None`` for ``PERMANENT``."""
+        return _DEFAULT_TTL_SECONDS[self.value]

--- a/src/omnibase_core/models/artifacts/__init__.py
+++ b/src/omnibase_core/models/artifacts/__init__.py
@@ -3,14 +3,23 @@
 
 """Content-addressed artifact models.
 
-Provides ``ModelArtifactRef``, the canonical ``sha256:<hex>`` reference type
-for the durable-capture artifact store (OMN-13091).
+Provides ``ModelArtifactRef`` (the canonical ``sha256:<hex>`` reference type,
+OMN-13091), the typed metadata sidecar ``ModelArtifactMetadata``, and the
+read-time authorization context ``ModelArtifactAuthContext`` (OMN-13152).
 """
 
 from __future__ import annotations
 
+from omnibase_core.models.artifacts.model_artifact_auth_context import (
+    ModelArtifactAuthContext,
+)
+from omnibase_core.models.artifacts.model_artifact_metadata import (
+    ModelArtifactMetadata,
+)
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
 
 __all__ = [
+    "ModelArtifactAuthContext",
+    "ModelArtifactMetadata",
     "ModelArtifactRef",
 ]

--- a/src/omnibase_core/models/artifacts/model_artifact_auth_context.py
+++ b/src/omnibase_core/models/artifacts/model_artifact_auth_context.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Authorization context for artifact reads (OMN-13152).
+
+``ModelArtifactAuthContext`` carries the caller's identity and the set of
+artifact kinds the caller is authorized to read. Restricted artifact kinds
+(``session_transcript``, ``hook_trace``) require the requested kind to appear
+in :attr:`authorized_kinds`.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelArtifactAuthContext"]
+
+
+class ModelArtifactAuthContext(BaseModel):
+    """Caller authorization context for a restricted artifact read.
+
+    A read of a restricted artifact kind is permitted only when that kind is
+    present in :attr:`authorized_kinds`. There is no implicit wildcard: an
+    empty set authorizes nothing.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    principal: str = Field(
+        ...,
+        min_length=1,
+        description="Stable identity of the caller requesting the read.",
+    )
+    authorized_kinds: frozenset[str] = Field(
+        default_factory=frozenset,
+        description=(
+            "Artifact kinds this principal may read. Restricted kinds "
+            "(session_transcript, hook_trace) require membership here."
+        ),
+    )
+
+    def is_authorized_for(self, artifact_kind: str) -> bool:
+        """Return whether this context authorizes reading ``artifact_kind``."""
+        return artifact_kind in self.authorized_kinds

--- a/src/omnibase_core/models/artifacts/model_artifact_metadata.py
+++ b/src/omnibase_core/models/artifacts/model_artifact_metadata.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Artifact metadata sidecar model (OMN-13152).
+
+``ModelArtifactMetadata`` is the typed representation of the JSON sidecar
+(``<hex>.meta.json``) written next to every blob in the durable-capture
+:class:`~omnibase_core.artifacts.artifact_store.ArtifactStore`. It finalizes
+the Phase 1 sidecar fields: retention class + TTL, redaction state + applied
+transform, and visibility tier.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.artifacts.enum_artifact_redaction_state import (
+    EnumArtifactRedactionState,
+)
+from omnibase_core.enums.artifacts.enum_artifact_retention_class import (
+    EnumArtifactRetentionClass,
+)
+
+__all__ = ["ModelArtifactMetadata"]
+
+
+class ModelArtifactMetadata(BaseModel):
+    """Typed metadata sidecar for a stored artifact.
+
+    Persisted as the ``<hex>.meta.json`` sidecar. The model is the source of
+    truth for the sidecar shape; :class:`ArtifactStore` serializes it on write
+    and validates it on read. ``extra="forbid"`` so an unexpected on-disk field
+    fails loudly rather than being silently dropped.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    artifact_hash: str = Field(
+        ...,
+        description="Bare 64-char lowercase SHA-256 hex digest of the stored bytes.",
+    )
+    artifact_size_bytes: int = Field(
+        ...,
+        ge=0,
+        description="Size of the stored bytes in bytes.",
+    )
+    artifact_media_type: str = Field(
+        ...,
+        min_length=1,
+        description="IANA media type of the artifact content.",
+    )
+    artifact_kind: str = Field(
+        ...,
+        min_length=1,
+        description="Logical kind of the artifact (e.g. tool_stdout, session_transcript).",
+    )
+    source_system: str = Field(
+        ...,
+        min_length=1,
+        description="System that produced the artifact (e.g. local_cli, onex_node).",
+    )
+    scope_ref: str | None = Field(
+        default=None,
+        description="Optional scope the artifact belongs to (e.g. ticket/repo ref).",
+    )
+    correlation_id: str | None = Field(
+        default=None,
+        description="Optional correlation id linking the artifact to a workflow.",
+    )
+
+    retention_class: EnumArtifactRetentionClass = Field(
+        ...,
+        description="Retention class governing eviction eligibility.",
+    )
+    retention_ttl_seconds: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Effective TTL in seconds; None means no expiry (permanent class)."
+        ),
+    )
+
+    redaction_state: EnumArtifactRedactionState = Field(
+        ...,
+        description="Redaction state of the stored bytes.",
+    )
+    redaction_transform: str | None = Field(
+        default=None,
+        description=(
+            "Identifier of the redaction transform applied, if any. Set when "
+            "redaction_state is 'redacted'."
+        ),
+    )
+
+    restricted: bool = Field(
+        default=False,
+        description=(
+            "Whether reads require authorization (restricted visibility tier)."
+        ),
+    )
+
+    token_estimate: int = Field(
+        ...,
+        ge=0,
+        description="Crude byte-based token estimate for budget previews.",
+    )
+    created_at_utc: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp of creation.",
+    )
+    writer_version: str = Field(
+        ...,
+        min_length=1,
+        description="Sidecar generation marker of the writer that produced it.",
+    )

--- a/tests/unit/artifacts/test_artifact_store.py
+++ b/tests/unit/artifacts/test_artifact_store.py
@@ -358,7 +358,7 @@ class TestArtifactRedactionAndSecrets:
     """Redaction state and secret-detection refusal."""
 
     def test_secret_detected_refuses_raw_write(self, store: ArtifactStore) -> None:
-        payload = b"export AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"
+        payload = b"export AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"  # pragma: allowlist secret
         with pytest.raises(ArtifactSecretDetectedError):
             store.write_blob(
                 payload,

--- a/tests/unit/artifacts/test_artifact_store.py
+++ b/tests/unit/artifacts/test_artifact_store.py
@@ -1,25 +1,43 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for the minimal content-addressed ArtifactStore slice (OMN-13093).
+"""Tests for the content-addressed ArtifactStore (OMN-13093 slice; OMN-13152 Phase 1).
 
-Covers write/read round-trips, content addressing, sharded layout, sidecar
-metadata, idempotency, hash verification on read, and fail-fast behavior on
-a missing ``ONEX_ARTIFACT_STORE_ROOT`` env var.
+Covers write/read round-trips, content addressing, sharded layout, typed
+sidecar metadata, idempotency, hash verification on read, fail-fast on a
+missing ``ONEX_ARTIFACT_STORE_ROOT`` env var, and the Phase 1 hardening:
+retention classes, quota enforcement (per-write + per-scope), redaction state +
+secret detection, the restricted visibility tier, and the authorized read API
+with chunked streaming.
 """
 
 from __future__ import annotations
 
 import hashlib
 import os
+import re
 from pathlib import Path
 
 import pytest
 
 from omnibase_core.artifacts.artifact_store import (
     ARTIFACT_STORE_ROOT_ENV,
+    RESTRICTED_ARTIFACT_KINDS,
     WRITER_VERSION,
+    ArtifactQuotaExceededError,
+    ArtifactSecretDetectedError,
     ArtifactStore,
+    ArtifactUnauthorizedError,
+    SecretDetector,
+)
+from omnibase_core.enums.artifacts.enum_artifact_redaction_state import (
+    EnumArtifactRedactionState,
+)
+from omnibase_core.enums.artifacts.enum_artifact_retention_class import (
+    EnumArtifactRetentionClass,
+)
+from omnibase_core.models.artifacts.model_artifact_auth_context import (
+    ModelArtifactAuthContext,
 )
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
 
@@ -61,6 +79,15 @@ class TestArtifactStoreEnv:
         store = ArtifactStore()
         ref = _write(store)
         assert (root / ref.hex_digest[:2] / ref.hex_digest).is_file()
+
+    def test_negative_quota_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        with pytest.raises(ValueError, match="max_artifact_bytes"):
+            ArtifactStore(max_artifact_bytes=-1)
+        with pytest.raises(ValueError, match="max_scope_bytes"):
+            ArtifactStore(max_scope_bytes=-1)
 
 
 @pytest.mark.unit
@@ -116,7 +143,7 @@ class TestArtifactStoreWrite:
 
 @pytest.mark.unit
 class TestArtifactStoreSidecar:
-    """JSON metadata sidecar carries the artifact-captured required fields."""
+    """Typed metadata sidecar carries the artifact-captured required fields."""
 
     def test_sidecar_written_next_to_blob(
         self, store: ArtifactStore, tmp_path: Path
@@ -128,19 +155,20 @@ class TestArtifactStoreSidecar:
     def test_sidecar_required_fields(self, store: ArtifactStore) -> None:
         ref = _write(store)
         meta = store.read_meta(ref)
-        assert meta["artifact_hash"] == ref.hex_digest
-        assert meta["artifact_size_bytes"] == len(_PAYLOAD)
-        assert meta["artifact_media_type"] == "text/plain"
-        assert meta["artifact_kind"] == "tool_stdout"
-        assert meta["source_system"] == "local_cli"
-        assert meta["scope_ref"] == "omnibase_core/OMN-13093"
-        assert meta["correlation_id"] == "11111111-2222-3333-4444-555555555555"
-        assert meta["redaction_state"] == "raw"
-        assert isinstance(meta["token_estimate"], int)
-        assert meta["token_estimate"] > 0
-        assert isinstance(meta["created_at_utc"], str)
-        assert meta["created_at_utc"].endswith("+00:00")
-        assert meta["writer_version"] == WRITER_VERSION
+        assert meta.artifact_hash == ref.hex_digest
+        assert meta.artifact_size_bytes == len(_PAYLOAD)
+        assert meta.artifact_media_type == "text/plain"
+        assert meta.artifact_kind == "tool_stdout"
+        assert meta.source_system == "local_cli"
+        assert meta.scope_ref == "omnibase_core/OMN-13093"
+        assert meta.correlation_id == "11111111-2222-3333-4444-555555555555"
+        assert meta.redaction_state is EnumArtifactRedactionState.RAW
+        assert meta.redaction_transform is None
+        assert meta.restricted is False
+        assert meta.retention_class is EnumArtifactRetentionClass.SESSION
+        assert meta.token_estimate > 0
+        assert meta.created_at_utc.endswith("+00:00")
+        assert meta.writer_version == WRITER_VERSION
 
     def test_sidecar_none_fields_serialized_as_null(self, store: ArtifactStore) -> None:
         ref = store.write_blob(
@@ -152,12 +180,10 @@ class TestArtifactStoreSidecar:
             correlation_id=None,
         )
         meta = store.read_meta(ref)
-        assert meta["scope_ref"] is None
-        assert meta["correlation_id"] is None
+        assert meta.scope_ref is None
+        assert meta.correlation_id is None
 
-    def test_sidecar_first_writer_wins(
-        self, store: ArtifactStore, tmp_path: Path
-    ) -> None:
+    def test_sidecar_first_writer_wins(self, store: ArtifactStore) -> None:
         ref = _write(store)
         first_meta = store.read_meta(ref)
         # Re-write same bytes with different metadata: blob is idempotent and
@@ -174,22 +200,382 @@ class TestArtifactStoreSidecar:
 
 
 @pytest.mark.unit
-class TestArtifactStoreRead:
-    """Hash-verified retrieval."""
+class TestArtifactRetention:
+    """Retention classes and configurable TTL."""
 
-    def test_read_blob_roundtrip(self, store: ArtifactStore) -> None:
+    def test_default_retention_class_is_session(self, store: ArtifactStore) -> None:
         ref = _write(store)
-        assert store.read_blob(ref) == _PAYLOAD
+        meta = store.read_meta(ref)
+        assert meta.retention_class is EnumArtifactRetentionClass.SESSION
+        assert meta.retention_ttl_seconds == 24 * 60 * 60
 
-    def test_read_blob_large_payload(self, store: ArtifactStore) -> None:
+    @pytest.mark.parametrize(
+        ("retention_class", "expected_ttl"),
+        [
+            (EnumArtifactRetentionClass.EPHEMERAL, 3600),
+            (EnumArtifactRetentionClass.SESSION, 86400),
+            (EnumArtifactRetentionClass.TICKET, 90 * 86400),
+            (EnumArtifactRetentionClass.PERMANENT, None),
+        ],
+    )
+    def test_retention_class_default_ttl(
+        self,
+        store: ArtifactStore,
+        retention_class: EnumArtifactRetentionClass,
+        expected_ttl: int | None,
+    ) -> None:
+        ref = store.write_blob(
+            f"payload-{retention_class.value}".encode(),
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+            retention_class=retention_class,
+        )
+        meta = store.read_meta(ref)
+        assert meta.retention_class is retention_class
+        assert meta.retention_ttl_seconds == expected_ttl
+
+    def test_explicit_ttl_override(self, store: ArtifactStore) -> None:
+        ref = store.write_blob(
+            b"custom-ttl-payload",
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+            retention_class=EnumArtifactRetentionClass.EPHEMERAL,
+            retention_ttl_seconds=42,
+        )
+        meta = store.read_meta(ref)
+        assert meta.retention_ttl_seconds == 42
+
+
+@pytest.mark.unit
+class TestArtifactQuota:
+    """Per-write and per-scope quota enforcement — no silent truncation."""
+
+    def test_per_write_quota_exceeded_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        store = ArtifactStore(max_artifact_bytes=10)
+        with pytest.raises(ArtifactQuotaExceededError, match="per-write quota"):
+            store.write_blob(
+                b"x" * 11,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+
+    def test_per_write_quota_rejects_with_no_blob_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        store = ArtifactStore(max_artifact_bytes=10)
+        data = b"x" * 11
+        ref = ModelArtifactRef.from_bytes(data)
+        with pytest.raises(ArtifactQuotaExceededError):
+            store.write_blob(
+                data,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+        # No silent truncation: nothing persisted at all.
+        assert not (tmp_path / ref.hex_digest[:2] / ref.hex_digest).exists()
+
+    def test_per_write_quota_at_limit_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        store = ArtifactStore(max_artifact_bytes=10)
+        ref = store.write_blob(
+            b"x" * 10,
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        assert store.read_blob(ref) == b"x" * 10
+
+    def test_per_scope_quota_exceeded_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        store = ArtifactStore(max_scope_bytes=20)
+        store.write_blob(
+            b"a" * 15,
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref="scope-A",
+            correlation_id=None,
+        )
+        with pytest.raises(ArtifactQuotaExceededError, match="per-scope quota"):
+            store.write_blob(
+                b"b" * 10,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref="scope-A",
+                correlation_id=None,
+            )
+
+    def test_per_scope_quota_isolated_per_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        store = ArtifactStore(max_scope_bytes=20)
+        store.write_blob(
+            b"a" * 15,
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref="scope-A",
+            correlation_id=None,
+        )
+        # A different scope is unaffected by scope-A's usage.
+        ref = store.write_blob(
+            b"b" * 15,
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref="scope-B",
+            correlation_id=None,
+        )
+        assert store.read_blob(ref) == b"b" * 15
+
+
+@pytest.mark.unit
+class TestArtifactRedactionAndSecrets:
+    """Redaction state and secret-detection refusal."""
+
+    def test_secret_detected_refuses_raw_write(self, store: ArtifactStore) -> None:
+        payload = b"export AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"
+        with pytest.raises(ArtifactSecretDetectedError):
+            store.write_blob(
+                payload,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+
+    def test_secret_detected_no_blob_persisted(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        payload = b"token=ghp_" + b"a" * 36 + b"\n"
+        ref = ModelArtifactRef.from_bytes(payload)
+        with pytest.raises(ArtifactSecretDetectedError) as exc_info:
+            store.write_blob(
+                payload,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+        assert exc_info.value.ref == ref
+        # No blob bytes on disk.
+        assert not (tmp_path / ref.hex_digest[:2] / ref.hex_digest).exists()
+        # But an auditable secret_detected sidecar IS recorded.
+        meta = store.read_meta(ref)
+        assert meta.redaction_state is EnumArtifactRedactionState.SECRET_DETECTED
+
+    def test_secret_detected_blob_read_fails_missing(
+        self, store: ArtifactStore
+    ) -> None:
+        payload = b"token=ghp_" + b"b" * 36 + b"\n"
+        ref = ModelArtifactRef.from_bytes(payload)
+        with pytest.raises(ArtifactSecretDetectedError):
+            store.write_blob(
+                payload,
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+        # The blob never existed, so a read fails explicitly.
+        with pytest.raises(FileNotFoundError):
+            store.read(ref)
+
+    def test_redaction_transform_records_itself(self, store: ArtifactStore) -> None:
+        def _strip(_data: bytes) -> bytes:
+            return b"[REDACTED]"
+
+        ref = store.write_blob(
+            b"sensitive original content",
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+            redaction_transform=_strip,
+            redaction_transform_name="strip_all_v1",
+        )
+        meta = store.read_meta(ref)
+        assert meta.redaction_state is EnumArtifactRedactionState.REDACTED
+        assert meta.redaction_transform == "strip_all_v1"
+        # The STORED bytes are the transform output, content-addressed.
+        assert store.read_blob(ref) == b"[REDACTED]"
+        assert ref == ModelArtifactRef.from_bytes(b"[REDACTED]")
+
+    def test_redaction_transform_requires_name(self, store: ArtifactStore) -> None:
+        with pytest.raises(ValueError, match="redaction_transform_name"):
+            store.write_blob(
+                b"data",
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+                redaction_transform=lambda d: d,
+            )
+
+    def test_custom_secret_detector(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ARTIFACT_STORE_ROOT_ENV, str(tmp_path))
+        detector = SecretDetector(patterns=(re.compile(rb"TOPSECRET"),))
+        store = ArtifactStore(secret_detector=detector)
+        with pytest.raises(ArtifactSecretDetectedError):
+            store.write_blob(
+                b"this is TOPSECRET data",
+                media_type="text/plain",
+                artifact_kind="tool_stdout",
+                source_system="local_cli",
+                scope_ref=None,
+                correlation_id=None,
+            )
+
+
+@pytest.mark.unit
+class TestArtifactRestrictedTier:
+    """Restricted visibility tier + authorized read gate."""
+
+    def test_restricted_kinds_default_to_restricted(self, store: ArtifactStore) -> None:
+        for kind in RESTRICTED_ARTIFACT_KINDS:
+            ref = store.write_blob(
+                f"body-{kind}".encode(),
+                media_type="text/plain",
+                artifact_kind=kind,
+                source_system="claude_code",
+                scope_ref=None,
+                correlation_id=None,
+            )
+            assert store.read_meta(ref).restricted is True
+
+    def test_unrestricted_kind_not_restricted(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        assert store.read_meta(ref).restricted is False
+
+    def test_restricted_read_without_auth_raises(self, store: ArtifactStore) -> None:
+        ref = store.write_blob(
+            b"session body",
+            media_type="text/plain",
+            artifact_kind="session_transcript",
+            source_system="claude_code",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        with pytest.raises(ArtifactUnauthorizedError):
+            store.read(ref)
+
+    def test_restricted_read_with_wrong_kind_auth_raises(
+        self, store: ArtifactStore
+    ) -> None:
+        ref = store.write_blob(
+            b"session body",
+            media_type="text/plain",
+            artifact_kind="session_transcript",
+            source_system="claude_code",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        auth = ModelArtifactAuthContext(
+            principal="agent-x",
+            authorized_kinds=frozenset({"hook_trace"}),
+        )
+        with pytest.raises(ArtifactUnauthorizedError):
+            store.read(ref, auth_context=auth)
+
+    def test_restricted_read_with_auth_succeeds(self, store: ArtifactStore) -> None:
+        body = b"session body content"
+        ref = store.write_blob(
+            body,
+            media_type="text/plain",
+            artifact_kind="session_transcript",
+            source_system="claude_code",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        auth = ModelArtifactAuthContext(
+            principal="agent-x",
+            authorized_kinds=frozenset({"session_transcript"}),
+        )
+        assert store.read(ref, auth_context=auth) == body
+
+    def test_unrestricted_read_needs_no_auth(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        assert store.read(ref) == _PAYLOAD
+
+    def test_explicit_restricted_override_on_unrestricted_kind(
+        self, store: ArtifactStore
+    ) -> None:
+        ref = store.write_blob(
+            b"normally open",
+            media_type="text/plain",
+            artifact_kind="tool_stdout",
+            source_system="local_cli",
+            scope_ref=None,
+            correlation_id=None,
+            restricted=True,
+        )
+        assert store.read_meta(ref).restricted is True
+        with pytest.raises(ArtifactUnauthorizedError):
+            store.read(ref)
+
+
+@pytest.mark.unit
+class TestArtifactStoreRead:
+    """Hash-verified retrieval, missing-artifact, streaming."""
+
+    def test_read_roundtrip(self, store: ArtifactStore) -> None:
+        ref = _write(store)
+        assert store.read(ref) == _PAYLOAD
+
+    def test_read_large_payload(self, store: ArtifactStore) -> None:
         data = b"x" * 100_000
         ref = _write(store, data)
-        assert store.read_blob(ref) == data
+        assert store.read(ref) == data
+
+    def test_read_missing_raises(self, store: ArtifactStore) -> None:
+        ref = ModelArtifactRef.from_bytes(b"never written")
+        with pytest.raises(FileNotFoundError):
+            store.read(ref)
 
     def test_read_blob_missing_raises(self, store: ArtifactStore) -> None:
         ref = ModelArtifactRef.from_bytes(b"never written")
         with pytest.raises(FileNotFoundError):
             store.read_blob(ref)
+
+    def test_read_detects_corruption(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        blob_path = tmp_path / ref.hex_digest[:2] / ref.hex_digest
+        blob_path.write_bytes(b"tampered bytes")
+        with pytest.raises(ValueError, match="hash mismatch"):
+            store.read(ref)
 
     def test_read_blob_detects_corruption(
         self, store: ArtifactStore, tmp_path: Path
@@ -204,6 +590,40 @@ class TestArtifactStoreRead:
         ref = ModelArtifactRef.from_bytes(b"never written")
         with pytest.raises(FileNotFoundError):
             store.read_meta(ref)
+
+    def test_read_chunks_roundtrip(self, store: ArtifactStore) -> None:
+        data = b"y" * 200_000
+        ref = _write(store, data)
+        chunks = b"".join(store.read_chunks(ref, chunk_size=64 * 1024))
+        assert chunks == data
+
+    def test_read_chunks_restricted_auth_enforced(self, store: ArtifactStore) -> None:
+        ref = store.write_blob(
+            b"hook trace body",
+            media_type="text/plain",
+            artifact_kind="hook_trace",
+            source_system="claude_code",
+            scope_ref=None,
+            correlation_id=None,
+        )
+        with pytest.raises(ArtifactUnauthorizedError):
+            list(store.read_chunks(ref))
+
+    def test_read_chunks_detects_corruption(
+        self, store: ArtifactStore, tmp_path: Path
+    ) -> None:
+        ref = _write(store)
+        blob_path = tmp_path / ref.hex_digest[:2] / ref.hex_digest
+        blob_path.write_bytes(b"tampered")
+        with pytest.raises(ValueError, match="hash mismatch"):
+            list(store.read_chunks(ref))
+
+    def test_read_chunks_rejects_nonpositive_chunk_size(
+        self, store: ArtifactStore
+    ) -> None:
+        ref = _write(store)
+        with pytest.raises(ValueError, match="chunk_size"):
+            list(store.read_chunks(ref, chunk_size=0))
 
 
 @pytest.mark.unit
@@ -222,5 +642,5 @@ class TestAcceptanceProbe:
             scope_ref=None,
             correlation_id=None,
         )
-        assert store.read_blob(ref) == b"x" * 100_000
+        assert store.read(ref) == b"x" * 100_000
         assert ref.ref.startswith("sha256:")


### PR DESCRIPTION
## OMN-13152 — ArtifactStore Phase 1 hardening (Wave I)

Extends the durable-capture `ArtifactStore` (OMN-13093 minimal slice) in place with Phase 1 hardening. All changes are in omnibase_core (stdlib + Pydantic only, no infra deps).

### What changed
- **Retention classes** (`EnumArtifactRetentionClass`: ephemeral/session/ticket/permanent) with a configurable per-class default TTL; explicit per-write TTL override. Recorded on the sidecar.
- **Quota enforcement**: `max_artifact_bytes` (per write) and `max_scope_bytes` (per `scope_ref`). Exceeding either raises `ArtifactQuotaExceededError` — no silent truncation, no partial write (verified: nothing persisted on reject).
- **Redaction state** (`EnumArtifactRedactionState`: raw/redacted/restricted/secret_detected) on the sidecar. On secret detection the store refuses the raw write and records an auditable `secret_detected` sidecar with NO blob, raising `ArtifactSecretDetectedError`. A supplied redaction transform is applied and records its name; stored bytes are content-addressed over the transformed output.
- **Restricted visibility tier**: `session_transcript` and `hook_trace` are restricted by default; `ArtifactStore.read(artifact_ref, *, auth_context)` gates restricted reads behind `ModelArtifactAuthContext`, hash-verifies on every read, supports chunked streaming (`read_chunks`), and raises explicitly on a missing artifact.
- **Typed sidecar**: `ModelArtifactMetadata` (frozen, `extra="forbid"`) replaces the dict sidecar; `read_meta` now returns the typed model.

### dod_evidence
- 76 unit tests green: `uv run pytest tests/unit/artifacts tests/unit/models/artifacts tests/unit/enums/test_enum_contract_completeness.py`.
- Dedicated failing-now-passing tests for each DoD path: hash-mismatch (`read`/`read_blob`/`read_chunks`), missing-artifact, quota-exceeded (per-write + per-scope), secret_detected (raw write refused, no blob), restricted-without-auth (and wrong-kind auth).
- `mypy src/omnibase_core/artifacts src/omnibase_core/enums/artifacts src/omnibase_core/models/artifacts --strict` clean; ruff clean.
- Full-suite collection clean: 42267 tests collected, 0 import errors (read_meta return-type change has no in-repo or cross-repo consumers).
- `pre-commit run --files <changed>` green (incl. ONEX Deterministic Skill Routing, Enum Governance, no-untyped-metadata-dict).

Evidence-Source: 324d16d9469cd60a06ba2c501c0d8277d5fb8076

No silent truncation or fallback anywhere in the write/read path.

---
**Evidence-Source:** OCC receipt PR OmniNode-ai/onex_change_control#2920 (contracts/OMN-13152.yaml @ commit d67595762; dod-omnibase-core-pr-1301 binds this PR #1301 by pr_number + commit_sha).
**Evidence-Ticket:** OMN-13152

Evidence-Ticket: OMN-13152