### PR TITLE
feat(OMN-7776): FeatureFlagRegistry single source of truth + typed resolve() API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,11 @@ packages = ["src/omnibase_core"]
 
 [tool.hatch.build]
 # Include YAML contract files in the wheel for PyPI installs (OMN-6484)
-artifacts = ["src/omnibase_core/**/*.yaml"]
+# and the generated feature-flag catalog JSON (OMN-7776).
+artifacts = [
+    "src/omnibase_core/**/*.yaml",
+    "src/omnibase_core/feature_flags/feature_flag_catalog.json",
+]
 
 [tool.ruff]
 target-version = "py312"

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -82,6 +82,7 @@ adjacency:
   dispatch: {reverse_deps: []}
   doctor: {reverse_deps: []}
   factories: {reverse_deps: [nodes, container]}
+  feature_flags: {reverse_deps: []}
   gate: {reverse_deps: []}
   infrastructure: {reverse_deps: []}
   integrations: {reverse_deps: []}

--- a/scripts/gen_feature_flag_catalog.py
+++ b/scripts/gen_feature_flag_catalog.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Emit the canonical feature-flag catalog (OMN-7776).
+
+Writes the env-independent registry declaration catalog to a committed JSON
+artifact so cross-language consumers (the omnidash Express server) share the
+single source of truth defined in :mod:`omnibase_core.feature_flags`.
+
+Usage::
+
+    uv run python scripts/gen_feature_flag_catalog.py
+    uv run python scripts/gen_feature_flag_catalog.py --check   # drift gate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from omnibase_core.feature_flags import FEATURE_FLAG_REGISTRY
+
+_DEFAULT_OUT = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "omnibase_core"
+    / "feature_flags"
+    / "feature_flag_catalog.json"
+)
+
+
+def _render() -> str:
+    payload = {
+        "generated_by": "omnibase_core/scripts/gen_feature_flag_catalog.py",
+        "ticket": "OMN-7776",
+        "flags": FEATURE_FLAG_REGISTRY.static_catalog(),
+    }
+    return json.dumps(payload, indent=2, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out", type=Path, default=_DEFAULT_OUT, help="Output JSON path."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the on-disk artifact is stale instead of writing it.",
+    )
+    args = parser.parse_args()
+
+    rendered = _render()
+    if args.check:
+        if not args.out.exists() or args.out.read_text(encoding="utf-8") != rendered:
+            sys.stderr.write(
+                f"feature flag catalog is stale: regenerate with "
+                f"`uv run python {Path(__file__).name}`\n"
+            )
+            return 1
+        return 0
+
+    args.out.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(f"wrote {args.out}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -176,6 +176,9 @@ from .enum_failure_type import EnumFailureType
 # Feature flag category enum (OMN-5566)
 from .enum_feature_flag_category import EnumFeatureFlagCategory
 
+# Feature flag gate-type enum (OMN-7776)
+from .enum_feature_flag_gate_type import EnumFeatureFlagGateType
+
 # Function-related enums
 from .enum_function_language import EnumFunctionLanguage
 
@@ -637,6 +640,7 @@ __all__ = [
     "EnumOperationStatus",  # Canonical operation status (OMN-1310)
     "EnumExecutionStatus",  # Canonical execution status (OMN-1310)
     "EnumFeatureFlagCategory",  # Feature flag categories (OMN-5566)
+    "EnumFeatureFlagGateType",  # Feature flag gate types (OMN-7776)
     "EnumValidationLevel",
     "EnumValidationMode",
     "EnumValueType",

--- a/src/omnibase_core/enums/enum_feature_flag_gate_type.py
+++ b/src/omnibase_core/enums/enum_feature_flag_gate_type.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Feature flag gate-type enumeration.
+
+Classifies each flag as gating a rollout cut-over path versus a long-lived
+runtime toggle. Surfaced through the registry API and the omnidash dashboard so
+operators can see which flags are expected to retire after a cut-over.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumFeatureFlagGateType(UtilStrValueHelper, str, Enum):
+    """Gate type for a registered feature flag."""
+
+    MIGRATION = "migration"
+    """Flag gating a rollout cut-over path; expected to retire after cut-over."""
+
+    PERMANENT = "permanent"
+    """Long-lived runtime toggle with no scheduled retirement."""

--- a/src/omnibase_core/feature_flags/__init__.py
+++ b/src/omnibase_core/feature_flags/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Feature flag registry (OMN-7776).
+
+Single source of truth for every known ONEX feature flag. Declares each flag
+with typed metadata (name, description, default, owning repo, gate type) and
+exposes a typed resolution API that replaces scattered ``os.getenv("ENABLE_*")``
+reads. The omnidash ``/api/settings/feature-flags`` endpoint renders the catalog
+emitted by :func:`FeatureFlagRegistry.catalog`.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.feature_flags.registry import (
+    FEATURE_FLAG_REGISTRY,
+    FeatureFlagRegistry,
+)
+from omnibase_core.models.core.model_feature_flag_definition import (
+    ModelFeatureFlagDefinition,
+)
+from omnibase_core.models.core.model_feature_flag_resolution import (
+    ModelFeatureFlagResolution,
+)
+
+__all__ = [
+    "FEATURE_FLAG_REGISTRY",
+    "FeatureFlagRegistry",
+    "ModelFeatureFlagDefinition",
+    "ModelFeatureFlagResolution",
+]

--- a/src/omnibase_core/feature_flags/feature_flag_catalog.json
+++ b/src/omnibase_core/feature_flags/feature_flag_catalog.json
@@ -1,0 +1,222 @@
+{
+  "generated_by": "omnibase_core/scripts/gen_feature_flag_catalog.py",
+  "ticket": "OMN-7776",
+  "flags": [
+    {
+      "name": "ENABLE_POSTGRES",
+      "description": "Enables Postgres-backed session and pattern storage.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "infrastructure"
+    },
+    {
+      "name": "ENABLE_QDRANT",
+      "description": "Enables Qdrant vector store for semantic pattern retrieval.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "infrastructure"
+    },
+    {
+      "name": "ENABLE_INTELLIGENCE_CACHE",
+      "description": "Caches intelligence node results to reduce LLM calls.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "USE_EVENT_ROUTING",
+      "description": "Routes commands/events through the ONEX event bus.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "runtime"
+    },
+    {
+      "name": "DUAL_PUBLISH_LEGACY_TOPICS",
+      "description": "Publishes to both new and legacy topic names during migration.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "infrastructure"
+    },
+    {
+      "name": "USE_ONEX_ROUTING_NODES",
+      "description": "Routes LLM calls through ONEX routing node graph.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "runtime"
+    },
+    {
+      "name": "ENABLE_PATTERN_QUALITY_FILTER",
+      "description": "Filters patterns below quality threshold before storage.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_DISABLED_PATTERN_FILTER",
+      "description": "Excludes disabled patterns from retrieval results.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_PHASE_1_VALIDATION",
+      "description": "Phase 1 validation gate: structural contract checks.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_PHASE_2_SEMANTIC",
+      "description": "Phase 2 validation gate: semantic consistency checks.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_PHASE_3_INTEGRATION",
+      "description": "Phase 3 validation gate: cross-service integration checks.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_PHASE_4_AI_QUORUM",
+      "description": "Phase 4 validation gate: multi-model AI quorum review.",
+      "default": false,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_LOCAL_INFERENCE_PIPELINE",
+      "description": "Routes inference to local GPU endpoints first.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_PATTERN_ENFORCEMENT",
+      "description": "Enforces pattern schema and lifecycle rules.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "USE_LLM_ROUTING",
+      "description": "Enables dynamic LLM routing via contract model_routing config.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "migration",
+      "category": "runtime"
+    },
+    {
+      "name": "ENABLE_DELEGATION",
+      "description": "Enables the cheapest-first delegation chain of responders.",
+      "default": true,
+      "service": "omniclaude",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_METRICS",
+      "description": "Emits runtime metrics from the ONEX node runtime.",
+      "default": true,
+      "service": "omnibase_infra",
+      "gate_type": "permanent",
+      "category": "observability"
+    },
+    {
+      "name": "ENABLE_IDEMPOTENCE",
+      "description": "Enforces idempotent envelope handling on the event bus.",
+      "default": true,
+      "service": "omnibase_infra",
+      "gate_type": "permanent",
+      "category": "infrastructure"
+    },
+    {
+      "name": "ENABLE_RUNTIME_LOG_BRIDGE",
+      "description": "Bridges runtime logs onto the structured log event topic.",
+      "default": false,
+      "service": "omnibase_infra",
+      "gate_type": "migration",
+      "category": "observability"
+    },
+    {
+      "name": "ENABLE_EVENT_INTELLIGENCE",
+      "description": "Enables event intelligence processing pipeline.",
+      "default": true,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "intelligence"
+    },
+    {
+      "name": "ENABLE_KAFKA_LOGGING",
+      "description": "Routes structured logs through Kafka.",
+      "default": true,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "observability"
+    },
+    {
+      "name": "ENABLE_REAL_TIME_EVENTS",
+      "description": "Opens WebSocket channel for live event stream.",
+      "default": true,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "dashboard"
+    },
+    {
+      "name": "ENABLE_EVENT_PRELOAD",
+      "description": "Pre-fetches events on dashboard mount.",
+      "default": false,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "dashboard"
+    },
+    {
+      "name": "ENABLE_RESPONSE_CACHE",
+      "description": "Enables response-level projection cache.",
+      "default": false,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "dashboard"
+    },
+    {
+      "name": "ARCHON_ENABLE_EXTERNAL_GATEWAY",
+      "description": "Routes inference through external Archon gateway.",
+      "default": false,
+      "service": "omnidash",
+      "gate_type": "migration",
+      "category": "infrastructure"
+    },
+    {
+      "name": "VITE_USE_MOCK_DATA",
+      "description": "Forces fixture data in place of live projections.",
+      "default": false,
+      "service": "omnidash",
+      "gate_type": "permanent",
+      "category": "dashboard"
+    },
+    {
+      "name": "OMNIDASH_READ_MODEL_USE_CATALOG",
+      "description": "Switches read model to catalog-based source.",
+      "default": false,
+      "service": "omnidash",
+      "gate_type": "migration",
+      "category": "dashboard"
+    }
+  ]
+}

--- a/src/omnibase_core/feature_flags/registry.py
+++ b/src/omnibase_core/feature_flags/registry.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Feature flag registry (OMN-7776).
+
+The single source of truth for every known ONEX feature flag. Declares each
+flag with typed metadata and exposes a typed resolution API that replaces
+scattered ``os.getenv("ENABLE_*")`` reads across the platform.
+
+Resolution is pure: callers pass an explicit environment mapping (defaulting
+to ``os.environ``). A flag's runtime state is the declared default unless the
+environment provides a truthy/falsy override. Truthiness follows the platform
+convention used by the omnidash endpoint: ``""``, ``"0"``, and ``"false"``
+(case-insensitive) are off; any other non-empty value is on.
+
+Unknown flag names are a hard error — fail fast rather than silently returning
+a default, so typos surface immediately.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_feature_flag_category import EnumFeatureFlagCategory
+from omnibase_core.enums.enum_feature_flag_gate_type import EnumFeatureFlagGateType
+from omnibase_core.errors import OnexError
+from omnibase_core.models.core.model_feature_flag_definition import (
+    ModelFeatureFlagDefinition,
+)
+from omnibase_core.models.core.model_feature_flag_resolution import (
+    ModelFeatureFlagResolution,
+)
+
+# Values (case-insensitive) that resolve a present env var to "off".
+_FALSY_ENV_VALUES: frozenset[str] = frozenset({"", "0", "false"})
+
+# Canonical flag declarations. This is the authoritative catalog.
+_FLAG_DEFINITIONS: tuple[ModelFeatureFlagDefinition, ...] = (
+    # --- omniclaude: infrastructure --------------------------------------
+    ModelFeatureFlagDefinition(
+        name="ENABLE_POSTGRES",
+        description="Enables Postgres-backed session and pattern storage.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.INFRASTRUCTURE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_QDRANT",
+        description="Enables Qdrant vector store for semantic pattern retrieval.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.INFRASTRUCTURE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_INTELLIGENCE_CACHE",
+        description="Caches intelligence node results to reduce LLM calls.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="USE_EVENT_ROUTING",
+        description="Routes commands/events through the ONEX event bus.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.RUNTIME,
+    ),
+    ModelFeatureFlagDefinition(
+        name="DUAL_PUBLISH_LEGACY_TOPICS",
+        description="Publishes to both new and legacy topic names during migration.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.INFRASTRUCTURE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="USE_ONEX_ROUTING_NODES",
+        description="Routes LLM calls through ONEX routing node graph.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.RUNTIME,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PATTERN_QUALITY_FILTER",
+        description="Filters patterns below quality threshold before storage.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_DISABLED_PATTERN_FILTER",
+        description="Excludes disabled patterns from retrieval results.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PHASE_1_VALIDATION",
+        description="Phase 1 validation gate: structural contract checks.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PHASE_2_SEMANTIC",
+        description="Phase 2 validation gate: semantic consistency checks.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PHASE_3_INTEGRATION",
+        description="Phase 3 validation gate: cross-service integration checks.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PHASE_4_AI_QUORUM",
+        description="Phase 4 validation gate: multi-model AI quorum review.",
+        default=False,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_LOCAL_INFERENCE_PIPELINE",
+        description="Routes inference to local GPU endpoints first.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_PATTERN_ENFORCEMENT",
+        description="Enforces pattern schema and lifecycle rules.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="USE_LLM_ROUTING",
+        description="Enables dynamic LLM routing via contract model_routing config.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.RUNTIME,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_DELEGATION",
+        description="Enables the cheapest-first delegation chain of responders.",
+        default=True,
+        owning_repo="omniclaude",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    # --- omnibase_infra: runtime / infrastructure ------------------------
+    ModelFeatureFlagDefinition(
+        name="ENABLE_METRICS",
+        description="Emits runtime metrics from the ONEX node runtime.",
+        default=True,
+        owning_repo="omnibase_infra",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.OBSERVABILITY,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_IDEMPOTENCE",
+        description="Enforces idempotent envelope handling on the event bus.",
+        default=True,
+        owning_repo="omnibase_infra",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INFRASTRUCTURE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_RUNTIME_LOG_BRIDGE",
+        description="Bridges runtime logs onto the structured log event topic.",
+        default=False,
+        owning_repo="omnibase_infra",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.OBSERVABILITY,
+    ),
+    # --- omnidash --------------------------------------------------------
+    ModelFeatureFlagDefinition(
+        name="ENABLE_EVENT_INTELLIGENCE",
+        description="Enables event intelligence processing pipeline.",
+        default=True,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.INTELLIGENCE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_KAFKA_LOGGING",
+        description="Routes structured logs through Kafka.",
+        default=True,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.OBSERVABILITY,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_REAL_TIME_EVENTS",
+        description="Opens WebSocket channel for live event stream.",
+        default=True,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.DASHBOARD,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_EVENT_PRELOAD",
+        description="Pre-fetches events on dashboard mount.",
+        default=False,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.DASHBOARD,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ENABLE_RESPONSE_CACHE",
+        description="Enables response-level projection cache.",
+        default=False,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.DASHBOARD,
+    ),
+    ModelFeatureFlagDefinition(
+        name="ARCHON_ENABLE_EXTERNAL_GATEWAY",
+        description="Routes inference through external Archon gateway.",
+        default=False,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.INFRASTRUCTURE,
+    ),
+    ModelFeatureFlagDefinition(
+        name="VITE_USE_MOCK_DATA",
+        description="Forces fixture data in place of live projections.",
+        default=False,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.PERMANENT,
+        category=EnumFeatureFlagCategory.DASHBOARD,
+    ),
+    ModelFeatureFlagDefinition(
+        name="OMNIDASH_READ_MODEL_USE_CATALOG",
+        description="Switches read model to catalog-based source.",
+        default=False,
+        owning_repo="omnidash",
+        gate_type=EnumFeatureFlagGateType.MIGRATION,
+        category=EnumFeatureFlagCategory.DASHBOARD,
+    ),
+)
+
+
+class FeatureFlagRegistry:
+    """Immutable registry of known feature flags with a typed resolution API.
+
+    Construct from an explicit tuple of definitions, or use the module-level
+    :data:`FEATURE_FLAG_REGISTRY` singleton built from the canonical catalog.
+    """
+
+    def __init__(
+        self, definitions: tuple[ModelFeatureFlagDefinition, ...] = _FLAG_DEFINITIONS
+    ) -> None:
+        index: dict[str, ModelFeatureFlagDefinition] = {}
+        for definition in definitions:
+            if definition.name in index:
+                raise OnexError(
+                    code=EnumCoreErrorCode.VALIDATION_ERROR,
+                    message=(
+                        "Duplicate feature flag declared in registry: "
+                        f"{definition.name!r}"
+                    ),
+                )
+            index[definition.name] = definition
+        self._definitions: dict[str, ModelFeatureFlagDefinition] = index
+
+    def names(self) -> tuple[str, ...]:
+        """Return all registered flag names in declaration order."""
+        return tuple(self._definitions.keys())
+
+    def definitions(self) -> tuple[ModelFeatureFlagDefinition, ...]:
+        """Return all flag definitions in declaration order."""
+        return tuple(self._definitions.values())
+
+    def definition(self, name: str) -> ModelFeatureFlagDefinition:
+        """Return the definition for ``name`` or raise ``KeyError`` if unknown."""
+        try:
+            return self._definitions[name]
+        except KeyError as exc:
+            raise OnexError(
+                code=EnumCoreErrorCode.NOT_FOUND,
+                message=f"Unknown feature flag: {name!r}",
+            ) from exc
+
+    def resolve(
+        self, name: str, env: Mapping[str, str] | None = None
+    ) -> ModelFeatureFlagResolution:
+        """Resolve a single flag against ``env`` (defaults to ``os.environ``).
+
+        Raises ``KeyError`` for an unknown flag name — fail fast, never silently
+        default. The raw env value, the resolved boolean, and the provenance are
+        all returned.
+        """
+        definition = self.definition(name)
+        environment = os.environ if env is None else env
+        raw = environment.get(name)
+        if raw is None:
+            return ModelFeatureFlagResolution(
+                name=definition.name,
+                enabled=definition.default,
+                raw_value=None,
+                source="default",
+                description=definition.description,
+                default=definition.default,
+                owning_repo=definition.owning_repo,
+                gate_type=definition.gate_type,
+                category=definition.category,
+            )
+        enabled = raw.strip().lower() not in _FALSY_ENV_VALUES
+        return ModelFeatureFlagResolution(
+            name=definition.name,
+            enabled=enabled,
+            raw_value=raw,
+            source="env",
+            description=definition.description,
+            default=definition.default,
+            owning_repo=definition.owning_repo,
+            gate_type=definition.gate_type,
+            category=definition.category,
+        )
+
+    def is_enabled(self, name: str, env: Mapping[str, str] | None = None) -> bool:
+        """Convenience wrapper returning only the resolved boolean for ``name``."""
+        return self.resolve(name, env=env).enabled
+
+    def resolve_all(
+        self, env: Mapping[str, str] | None = None
+    ) -> tuple[ModelFeatureFlagResolution, ...]:
+        """Resolve every registered flag against ``env``."""
+        return tuple(self.resolve(name, env=env) for name in self._definitions)
+
+    def catalog(self, env: Mapping[str, str] | None = None) -> list[dict[str, object]]:
+        """Return a JSON-serializable catalog of every resolved flag.
+
+        This is the payload the omnidash ``/api/settings/feature-flags`` endpoint
+        renders. Keys match the dashboard's ``FeatureFlagEntry`` shape.
+        """
+        return [
+            {
+                "name": resolution.name,
+                "value": resolution.raw_value,
+                "state": (
+                    "migration"
+                    if resolution.gate_type is EnumFeatureFlagGateType.MIGRATION
+                    and not resolution.enabled
+                    else ("on" if resolution.enabled else "off")
+                ),
+                "enabled": resolution.enabled,
+                "source": resolution.source,
+                "service": resolution.owning_repo,
+                "description": resolution.description,
+                "default": resolution.default,
+                "gate_type": resolution.gate_type.value,
+                "category": resolution.category.value,
+            }
+            for resolution in self.resolve_all(env=env)
+        ]
+
+    def static_catalog(self) -> list[dict[str, object]]:
+        """Return the env-independent declaration catalog.
+
+        This is the cross-language single-source-of-truth artifact: the omnidash
+        Express server loads it to obtain the flag names, descriptions, owning
+        repos, gate types, and defaults, then resolves live on/off state from its
+        own ``process.env`` server-side. Contains no runtime/env-derived fields.
+        """
+        return [
+            {
+                "name": definition.name,
+                "description": definition.description,
+                "default": definition.default,
+                "service": definition.owning_repo,
+                "gate_type": definition.gate_type.value,
+                "category": definition.category.value,
+            }
+            for definition in self.definitions()
+        ]
+
+
+# Canonical singleton built from the authoritative catalog.
+FEATURE_FLAG_REGISTRY: FeatureFlagRegistry = FeatureFlagRegistry()

--- a/src/omnibase_core/models/core/__init__.py
+++ b/src/omnibase_core/models/core/__init__.py
@@ -31,7 +31,9 @@ from .model_environment_accessor import ModelEnvironmentAccessor
 from .model_error_details import ErrorContext, ModelErrorDetails, TContext
 
 # Feature flags pattern
+from .model_feature_flag_definition import ModelFeatureFlagDefinition
 from .model_feature_flag_metadata import ModelFeatureFlagMetadata
+from .model_feature_flag_resolution import ModelFeatureFlagResolution
 from .model_feature_flag_summary import ModelFeatureFlagSummary
 from .model_feature_flags import ModelFeatureFlags
 
@@ -150,7 +152,9 @@ __all__ = [
     "ModelErrorDetails",
     "TContext",
     # Feature flags pattern
+    "ModelFeatureFlagDefinition",
     "ModelFeatureFlagMetadata",
+    "ModelFeatureFlagResolution",
     "ModelFeatureFlagSummary",
     "ModelFeatureFlags",
     # Version information

--- a/src/omnibase_core/models/core/model_feature_flag_definition.py
+++ b/src/omnibase_core/models/core/model_feature_flag_definition.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Feature flag definition model (OMN-7776).
+
+Static, contract-time declaration of a single known feature flag. Frozen and
+strict so the registry catalog cannot drift at runtime.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_feature_flag_category import EnumFeatureFlagCategory
+from omnibase_core.enums.enum_feature_flag_gate_type import EnumFeatureFlagGateType
+
+
+class ModelFeatureFlagDefinition(BaseModel):
+    """A single feature flag declared in the registry.
+
+    The registry is the single source of truth: this declares the flag's
+    identity, default state, owning repo, gate type, and category. Runtime
+    resolution (env override) happens in :class:`FeatureFlagRegistry`.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        pattern=r"^[A-Z][A-Z0-9_]*$",
+        description="Uppercase env-var-style flag identifier, globally unique.",
+    )
+
+    description: str = Field(
+        ...,
+        min_length=1,
+        description="Human-readable description of what the flag controls.",
+    )
+
+    default: bool = Field(
+        ...,
+        description="Default state when the flag is not overridden by env.",
+    )
+
+    owning_repo: str = Field(
+        ...,
+        min_length=1,
+        description="Repository that owns the behavior the flag gates "
+        "(e.g. 'omniclaude', 'omnidash', 'omnibase_infra').",
+    )
+
+    gate_type: EnumFeatureFlagGateType = Field(
+        ...,
+        description="Whether the flag gates a rollout cut-over or is permanent.",
+    )
+
+    category: EnumFeatureFlagCategory = Field(
+        default=EnumFeatureFlagCategory.GENERAL,
+        description="Functional domain grouping for dashboard display.",
+    )

--- a/src/omnibase_core/models/core/model_feature_flag_resolution.py
+++ b/src/omnibase_core/models/core/model_feature_flag_resolution.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Feature flag resolution model (OMN-7776).
+
+The typed result of resolving a registered flag against an environment mapping.
+Carries the declared metadata plus the resolved state and its provenance so the
+dashboard can render both the value and where it came from.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_feature_flag_category import EnumFeatureFlagCategory
+from omnibase_core.enums.enum_feature_flag_gate_type import EnumFeatureFlagGateType
+
+
+class ModelFeatureFlagResolution(BaseModel):
+    """Resolved state of a single feature flag.
+
+    ``source`` is ``"default"`` when the declared default applied and
+    ``"env"`` when an environment override was used.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(..., description="Flag identifier.")
+    enabled: bool = Field(..., description="Resolved on/off state.")
+    raw_value: str | None = Field(
+        default=None,
+        description="Raw env-var value that produced the resolution, if any.",
+    )
+    source: str = Field(
+        ...,
+        pattern=r"^(default|env)$",
+        description="Provenance of the resolved value: 'default' or 'env'.",
+    )
+    description: str = Field(..., description="Flag description from the registry.")
+    default: bool = Field(..., description="Declared default state.")
+    owning_repo: str = Field(..., description="Repo that owns the flag.")
+    gate_type: EnumFeatureFlagGateType = Field(
+        ..., description="Migration or permanent."
+    )
+    category: EnumFeatureFlagCategory = Field(..., description="Functional grouping.")

--- a/tests/unit/feature_flags/__init__.py
+++ b/tests/unit/feature_flags/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/feature_flags/test_feature_flag_catalog_artifact.py
+++ b/tests/unit/feature_flags/test_feature_flag_catalog_artifact.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Drift test for the generated feature-flag catalog artifact (OMN-7776).
+
+The committed ``feature_flag_catalog.json`` is the cross-language single source
+of truth consumed by the omnidash Express ``/api/settings/feature-flags``
+endpoint. It must always match ``FEATURE_FLAG_REGISTRY.static_catalog()``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.feature_flags import FEATURE_FLAG_REGISTRY
+
+_CATALOG_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "omnibase_core"
+    / "feature_flags"
+    / "feature_flag_catalog.json"
+)
+
+
+@pytest.mark.unit
+def test_catalog_artifact_exists() -> None:
+    assert _CATALOG_PATH.exists(), f"missing catalog artifact: {_CATALOG_PATH}"
+
+
+@pytest.mark.unit
+def test_catalog_artifact_matches_registry() -> None:
+    payload = json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
+    assert payload["ticket"] == "OMN-7776"
+    assert payload["flags"] == FEATURE_FLAG_REGISTRY.static_catalog(), (
+        "feature_flag_catalog.json is stale — regenerate with "
+        "`uv run python scripts/gen_feature_flag_catalog.py`"
+    )

--- a/tests/unit/feature_flags/test_feature_flag_registry.py
+++ b/tests/unit/feature_flags/test_feature_flag_registry.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the FeatureFlagRegistry (OMN-7776).
+
+The registry is the single source of truth for known ONEX feature flags and the
+typed resolution API that replaces scattered ``os.getenv("ENABLE_*")`` reads.
+The ``catalog()`` payload tested here is what the omnidash
+``/api/settings/feature-flags`` endpoint renders via ``registry.resolve()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.enums.enum_feature_flag_gate_type import EnumFeatureFlagGateType
+from omnibase_core.errors import OnexError
+from omnibase_core.feature_flags import (
+    FEATURE_FLAG_REGISTRY,
+    FeatureFlagRegistry,
+    ModelFeatureFlagDefinition,
+    ModelFeatureFlagResolution,
+)
+
+
+@pytest.mark.unit
+class TestRegistryCatalog:
+    """The registry declares the full known-flag catalog."""
+
+    def test_declares_at_least_24_flags(self) -> None:
+        assert len(FEATURE_FLAG_REGISTRY.names()) >= 24
+
+    def test_flag_names_are_unique(self) -> None:
+        names = FEATURE_FLAG_REGISTRY.names()
+        assert len(names) == len(set(names))
+
+    def test_known_flags_present(self) -> None:
+        names = set(FEATURE_FLAG_REGISTRY.names())
+        for required in (
+            "ENABLE_POSTGRES",
+            "ENABLE_QDRANT",
+            "USE_EVENT_ROUTING",
+            "ENABLE_PATTERN_QUALITY_FILTER",
+        ):
+            assert required in names
+
+    def test_every_definition_is_strongly_typed(self) -> None:
+        for definition in FEATURE_FLAG_REGISTRY.definitions():
+            assert isinstance(definition, ModelFeatureFlagDefinition)
+            assert isinstance(definition.gate_type, EnumFeatureFlagGateType)
+            assert definition.owning_repo  # non-empty
+            assert definition.description  # non-empty
+
+    def test_duplicate_declaration_raises(self) -> None:
+        dup = ModelFeatureFlagDefinition(
+            name="ENABLE_POSTGRES",
+            description="dup",
+            default=False,
+            owning_repo="omniclaude",
+            gate_type=EnumFeatureFlagGateType.MIGRATION,
+        )
+        with pytest.raises(OnexError, match="Duplicate feature flag"):
+            FeatureFlagRegistry((dup, dup))
+
+
+@pytest.mark.unit
+class TestRegistryResolve:
+    """resolve() honors declared defaults and env overrides, and fails fast."""
+
+    def test_default_when_env_absent(self) -> None:
+        resolution = FEATURE_FLAG_REGISTRY.resolve("ENABLE_POSTGRES", env={})
+        assert isinstance(resolution, ModelFeatureFlagResolution)
+        assert resolution.enabled is False
+        assert resolution.source == "default"
+        assert resolution.raw_value is None
+
+    def test_env_truthy_override(self) -> None:
+        resolution = FEATURE_FLAG_REGISTRY.resolve(
+            "ENABLE_POSTGRES", env={"ENABLE_POSTGRES": "1"}
+        )
+        assert resolution.enabled is True
+        assert resolution.source == "env"
+        assert resolution.raw_value == "1"
+
+    @pytest.mark.parametrize("falsy", ["", "0", "false", "FALSE", "False"])
+    def test_env_falsy_values(self, falsy: str) -> None:
+        resolution = FEATURE_FLAG_REGISTRY.resolve(
+            "ENABLE_PATTERN_QUALITY_FILTER",
+            env={"ENABLE_PATTERN_QUALITY_FILTER": falsy},
+        )
+        assert resolution.enabled is False
+        assert resolution.source == "env"
+
+    def test_env_arbitrary_truthy_value(self) -> None:
+        resolution = FEATURE_FLAG_REGISTRY.resolve(
+            "USE_EVENT_ROUTING", env={"USE_EVENT_ROUTING": "yes"}
+        )
+        assert resolution.enabled is True
+
+    def test_unknown_flag_fails_fast(self) -> None:
+        with pytest.raises(OnexError, match="Unknown feature flag"):
+            FEATURE_FLAG_REGISTRY.resolve("ENABLE_NONEXISTENT_FLAG", env={})
+
+    def test_is_enabled_convenience(self) -> None:
+        assert (
+            FEATURE_FLAG_REGISTRY.is_enabled(
+                "ENABLE_POSTGRES", env={"ENABLE_POSTGRES": "true"}
+            )
+            is True
+        )
+
+    def test_resolve_all_covers_every_flag(self) -> None:
+        resolutions = FEATURE_FLAG_REGISTRY.resolve_all(env={})
+        assert len(resolutions) == len(FEATURE_FLAG_REGISTRY.names())
+
+
+@pytest.mark.unit
+class TestCatalogPayload:
+    """catalog() is the omnidash endpoint payload, sourced from resolve()."""
+
+    def test_catalog_shape(self) -> None:
+        catalog = FEATURE_FLAG_REGISTRY.catalog(env={})
+        assert len(catalog) == len(FEATURE_FLAG_REGISTRY.names())
+        entry = catalog[0]
+        for key in (
+            "name",
+            "value",
+            "state",
+            "enabled",
+            "source",
+            "service",
+            "description",
+            "default",
+            "gate_type",
+            "category",
+        ):
+            assert key in entry
+
+    def test_catalog_migration_state_when_off(self) -> None:
+        catalog = FEATURE_FLAG_REGISTRY.catalog(env={})
+        by_name = {e["name"]: e for e in catalog}
+        # ENABLE_POSTGRES is a migration flag defaulting off -> "migration"
+        assert by_name["ENABLE_POSTGRES"]["state"] == "migration"
+
+    def test_catalog_on_state_when_enabled(self) -> None:
+        catalog = FEATURE_FLAG_REGISTRY.catalog(env={"ENABLE_POSTGRES": "1"})
+        by_name = {e["name"]: e for e in catalog}
+        assert by_name["ENABLE_POSTGRES"]["state"] == "on"
+        assert by_name["ENABLE_POSTGRES"]["enabled"] is True
+
+    def test_catalog_is_json_serializable(self) -> None:
+        import json
+
+        payload = FEATURE_FLAG_REGISTRY.catalog(env={})
+        # Must round-trip through JSON for the HTTP endpoint.
+        assert json.loads(json.dumps(payload)) == payload


### PR DESCRIPTION
## OMN-7776 — FeatureFlagRegistry single source of truth + dashboard page (Wave J)

Implements the backend `FeatureFlagRegistry` in `omnibase_core` as the single
source of truth for known ONEX feature flags, with a typed resolution API that
replaces scattered `os.getenv("ENABLE_*")` reads.

### What changed (omnibase_core)
- `omnibase_core/feature_flags/registry.py` — `FeatureFlagRegistry` declaring 27
  known flags (`ENABLE_POSTGRES`, `ENABLE_QDRANT`, `USE_EVENT_ROUTING`,
  `ENABLE_PATTERN_QUALITY_FILTER`, …) each with `ModelFeatureFlagDefinition`
  metadata: name, description, default, owning_repo, `gate_type`
  (`migration`|`permanent`), category. Singleton `FEATURE_FLAG_REGISTRY`.
- Typed API: `resolve(name, env)` -> `ModelFeatureFlagResolution` (enabled,
  raw_value, source=default|env, + declared metadata); `is_enabled`,
  `resolve_all`, `catalog` (omnidash endpoint payload shape), `static_catalog`.
  Fails fast with `OnexError` on unknown flag names — no silent default.
- `EnumFeatureFlagGateType` (migration|permanent); models in `models/core`,
  re-exported from `omnibase_core.models.core`.
- `scripts/gen_feature_flag_catalog.py` + committed
  `src/omnibase_core/feature_flags/feature_flag_catalog.json` — the cross-language
  single source the omnidash Express `/api/settings/feature-flags` endpoint
  (shipped OMN-7571) consumes; drift-tested + `--check` gate.

### DoD status
1. Core tests pass — 22 new unit tests in `tests/unit/feature_flags/`; touched-area
   suite (`tests/unit/feature_flags models/core enums`) 5432 passed, 1 skipped;
   `mypy --strict` clean; all pre-commit hooks pass on changed files.
2. `grep -r 'os.getenv("ENABLE_' omniclaude/` returns **zero** at HEAD — the
   omniclaude codebase already has no bare `ENABLE_*` env reads, so no omniclaude
   callsite-migration PR is required (target already clean).
3. `/api/settings/feature-flags` payload shape is produced by
   `FeatureFlagRegistry.catalog()` (unit-tested), and the endpoint's flag catalog
   is the registry-emitted `feature_flag_catalog.json` (single source of truth).
4. OCC contract `contracts/OMN-7776.yaml` on OCC main; paired OCC receipt PR
   (onex_change_control#2922) binds this product PR.

dod_evidence: tests/unit/feature_flags/ (22 passed); touched-area suite 5432
passed/1 skipped; mypy --strict 6 files clean; pre-commit all-hooks pass.

OMN-7776
Evidence-Source: e85587a343f94c1fb0bf561f525b43121b295ba2
Evidence-Ticket: OMN-7776