### PR TITLE
feat(OMN-12835): wire typed contract-side execution-graph DAG into orchestrator contracts

### DIFF
--- a/src/omnibase_core/models/contracts/__init__.py
+++ b/src/omnibase_core/models/contracts/__init__.py
@@ -111,6 +111,7 @@ from .model_contract_base import ModelContractBase
 from .model_contract_compute import ModelContractCompute
 from .model_contract_config import ModelContractConfig
 from .model_contract_effect import ModelContractEffect
+from .model_contract_execution_graph import ModelContractExecutionGraph
 from .model_contract_fingerprint import ModelContractFingerprint
 from .model_contract_meta import (
     ModelContractMeta,
@@ -123,6 +124,9 @@ from .model_contract_orchestrator import ModelContractOrchestrator
 from .model_contract_patch import ModelContractPatch
 from .model_contract_reducer import ModelContractReducer
 from .model_contract_version import ModelContractVersion
+from .model_contract_workflow_definition import ModelContractWorkflowDefinition
+from .model_contract_workflow_metadata import ModelContractWorkflowMetadata
+from .model_contract_workflow_node import ModelContractWorkflowNode
 from .model_corpus_classification import ModelCorpusClassification
 
 # Database repository contract models (OMN-1782)
@@ -321,6 +325,10 @@ __all__ = [
     "ModelConditionValue",
     "ModelConditionValueList",
     "ModelWorkflowCondition",
+    "ModelContractExecutionGraph",
+    "ModelContractWorkflowDefinition",
+    "ModelContractWorkflowMetadata",
+    "ModelContractWorkflowNode",
     "ModelWorkflowConfig",
     "ModelWorkflowDependency",
     # Orchestrator dependency models

--- a/src/omnibase_core/models/contracts/model_contract_execution_graph.py
+++ b/src/omnibase_core/models/contracts/model_contract_execution_graph.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-side execution-graph DAG model (OMN-12835).
+
+Typed, validated binding of an orchestrator contract's declared
+``execution_graph`` block. Enforces no-duplicate-id, no-dangling-edge, and
+acyclicity invariants at parse time so declared graphs are no longer silently
+dropped.
+
+Strict typing is enforced: No Any types allowed in implementation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.contracts.model_contract_workflow_node import (
+    ModelContractWorkflowNode,
+)
+
+
+class ModelContractExecutionGraph(BaseModel):
+    """
+    Typed, validated execution-graph DAG declared by an orchestrator contract.
+
+    Enforces structural integrity at parse time:
+    - no duplicate ``node_id`` values
+    - no dangling ``depends_on`` edges (every referenced id must exist)
+    - acyclicity (the graph must be a DAG)
+    """
+
+    nodes: list[ModelContractWorkflowNode] = Field(
+        default_factory=list,
+        description="Execution graph nodes with declared dependency edges",
+    )
+
+    @model_validator(mode="after")
+    def validate_graph_integrity(self) -> "ModelContractExecutionGraph":
+        """Enforce no-duplicate-id, no-dangling-edge, and acyclicity invariants."""
+        node_ids = [node.node_id for node in self.nodes]
+
+        # No duplicate node ids.
+        duplicates = sorted({nid for nid in node_ids if node_ids.count(nid) > 1})
+        if duplicates:
+            msg = f"Execution graph has duplicate node_id values: {duplicates}"
+            raise ValueError(msg)
+
+        id_set = set(node_ids)
+
+        # No dangling edges: every depends_on target must be a declared node.
+        for node in self.nodes:
+            missing = [dep for dep in node.depends_on if dep not in id_set]
+            if missing:
+                msg = (
+                    f"Execution graph node '{node.node_id}' depends on "
+                    f"undeclared node_id(s): {sorted(missing)}"
+                )
+                raise ValueError(msg)
+
+        # Acyclicity: Kahn's algorithm over the dependency edges.
+        adjacency: dict[str, list[str]] = {nid: [] for nid in id_set}
+        in_degree: dict[str, int] = dict.fromkeys(id_set, 0)
+        for node in self.nodes:
+            for dep in node.depends_on:
+                adjacency[dep].append(node.node_id)
+                in_degree[node.node_id] += 1
+
+        queue = [nid for nid, deg in in_degree.items() if deg == 0]
+        visited = 0
+        while queue:
+            current = queue.pop()
+            visited += 1
+            for downstream in adjacency[current]:
+                in_degree[downstream] -= 1
+                if in_degree[downstream] == 0:
+                    queue.append(downstream)
+
+        if visited != len(id_set):
+            msg = "Execution graph contains a cycle (must be a DAG)"
+            raise ValueError(msg)
+
+        return self
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="ignore",
+        use_enum_values=False,
+        validate_assignment=True,
+    )

--- a/src/omnibase_core/models/contracts/model_contract_orchestrator.py
+++ b/src/omnibase_core/models/contracts/model_contract_orchestrator.py
@@ -75,8 +75,11 @@ class ModelContractOrchestrator(MixinNodeTypeValidator, ModelContractBase):
     Strict typing is enforced: No Any types allowed in implementation.
     """
 
-    # Interface version for code generation stability
-    INTERFACE_VERSION: ClassVar[ModelSemVer] = ModelSemVer(major=1, minor=0, patch=0)
+    # Interface version for code generation stability.
+    # Bumped 1.0.0 -> 1.1.0 (OMN-12835): added typed contract-side execution-graph
+    # DAG binding via ModelWorkflowConfig.workflow_definition so declared
+    # execution_graph fields are no longer silently dropped on parse.
+    INTERFACE_VERSION: ClassVar[ModelSemVer] = ModelSemVer(major=1, minor=1, patch=0)
 
     # Default node type for ORCHESTRATOR contracts (used by MixinNodeTypeValidator)
     _DEFAULT_NODE_TYPE: ClassVar[EnumNodeType] = EnumNodeType.ORCHESTRATOR_GENERIC

--- a/src/omnibase_core/models/contracts/model_contract_workflow_definition.py
+++ b/src/omnibase_core/models/contracts/model_contract_workflow_definition.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-side workflow definition model (OMN-12835).
+
+Typed binding of a contract's declared ``workflow_definition`` block: workflow
+metadata plus the typed execution-graph DAG, so declared graphs are no longer
+silently dropped on parse.
+
+Strict typing is enforced: No Any types allowed in implementation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.contracts.model_contract_execution_graph import (
+    ModelContractExecutionGraph,
+)
+from omnibase_core.models.contracts.model_contract_workflow_metadata import (
+    ModelContractWorkflowMetadata,
+)
+
+
+class ModelContractWorkflowDefinition(BaseModel):
+    """
+    Typed binding of a contract's declared ``workflow_definition`` block.
+
+    Carries workflow metadata plus the typed execution-graph DAG so that
+    declared graphs are no longer silently dropped on parse. ``coordination_rules``
+    is intentionally left as a free-form mapping — it overlays runtime
+    coordination knobs that are validated downstream, not structurally here.
+    """
+
+    workflow_metadata: ModelContractWorkflowMetadata = Field(
+        description="Descriptive metadata for the declared workflow",
+    )
+
+    execution_graph: ModelContractExecutionGraph = Field(
+        description="Typed, validated execution-graph DAG",
+    )
+
+    coordination_rules: dict[str, object] | None = Field(
+        default=None,
+        description="Optional free-form coordination overlay (execution_mode, retries, etc.)",
+    )
+
+    model_config = ConfigDict(
+        extra="ignore",
+        use_enum_values=False,
+        validate_assignment=True,
+    )

--- a/src/omnibase_core/models/contracts/model_contract_workflow_metadata.py
+++ b/src/omnibase_core/models/contracts/model_contract_workflow_metadata.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-side workflow metadata model (OMN-12835).
+
+Descriptive metadata for a contract-declared workflow definition.
+
+Strict typing is enforced: No Any types allowed in implementation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractWorkflowMetadata(BaseModel):
+    """Descriptive metadata for a contract-declared workflow definition."""
+
+    workflow_name: str = Field(
+        description="Human-readable workflow name",
+    )
+
+    description: str | None = Field(
+        default=None,
+        description="Optional workflow description",
+    )
+
+    model_config = ConfigDict(
+        extra="ignore",
+        use_enum_values=False,
+        validate_assignment=True,
+    )

--- a/src/omnibase_core/models/contracts/model_contract_workflow_node.py
+++ b/src/omnibase_core/models/contracts/model_contract_workflow_node.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-side execution-graph node model (OMN-12835).
+
+A single node in a contract-declared execution graph (DAG), mirroring the
+``execution_graph.nodes[]`` entries declared in orchestrator contracts.
+
+Strict typing is enforced: No Any types allowed in implementation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractWorkflowNode(BaseModel):
+    """
+    A single node in a contract-declared execution graph (DAG).
+
+    Mirrors the ``execution_graph.nodes[]`` entries declared in orchestrator
+    contracts. Extra contract fields (``description``, ``step_config``) are
+    tolerated via ``extra="ignore"`` so the typed binding does not force every
+    declaring contract to be exhaustively modeled here — only the structural
+    DAG fields (``node_id``, ``node_type``, ``depends_on``) are load-bearing.
+    """
+
+    node_id: str = Field(
+        description="Unique identifier for this workflow node within the graph",
+    )
+
+    node_type: str = Field(
+        description="Node archetype classification (e.g. EFFECT_GENERIC, ORCHESTRATOR_INTERNAL)",
+    )
+
+    depends_on: list[str] = Field(
+        default_factory=list,
+        description="node_id values this node depends on (incoming DAG edges)",
+    )
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="ignore",
+        use_enum_values=False,
+        validate_assignment=True,
+    )

--- a/src/omnibase_core/models/contracts/model_workflow_config.py
+++ b/src/omnibase_core/models/contracts/model_workflow_config.py
@@ -12,6 +12,10 @@ Strict typing is enforced: No Any types allowed in implementation.
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.models.contracts.model_contract_workflow_definition import (
+    ModelContractWorkflowDefinition,
+)
+
 
 class ModelWorkflowConfig(BaseModel):
     """
@@ -62,6 +66,11 @@ class ModelWorkflowConfig(BaseModel):
     recovery_enabled: bool = Field(
         default=True,
         description="Enable automatic workflow recovery",
+    )
+
+    workflow_definition: ModelContractWorkflowDefinition | None = Field(
+        default=None,
+        description="Typed contract-side workflow definition with execution-graph DAG",
     )
 
     model_config = ConfigDict(

--- a/tests/unit/models/contracts/test_model_contract_execution_graph.py
+++ b/tests/unit/models/contracts/test_model_contract_execution_graph.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the typed contract-side execution-graph DAG binding (OMN-12835).
+
+Before OMN-12835, orchestrator contracts could declare a
+``workflow_coordination.workflow_definition.execution_graph`` block but the
+typed contract model (``ModelWorkflowConfig``) had no field for it, so the
+declared graph was silently dropped on parse. These tests prove the graph is
+now typed-bound and traversable, and that the DAG integrity validators
+(no-duplicate-id, no-dangling-edge, acyclicity) are enforced.
+
+The fixture mirrors the canonical node_intelligence_orchestrator contract:
+5 nodes / 4 edges
+(receive_request -> route_operation -> execute_compute -> execute_effects ->
+publish_outcome).
+"""
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.model_contract_execution_graph import (
+    ModelContractExecutionGraph,
+)
+from omnibase_core.models.contracts.model_contract_workflow_definition import (
+    ModelContractWorkflowDefinition,
+)
+from omnibase_core.models.contracts.model_workflow_config import ModelWorkflowConfig
+
+# Mirrors node_intelligence_orchestrator/contract.yaml workflow_coordination block.
+INTELLIGENCE_ORCHESTRATOR_WORKFLOW_YAML = """
+workflow_definition:
+  workflow_metadata:
+    workflow_name: "intelligence_workflow"
+    workflow_version:
+      major: 1
+      minor: 0
+      patch: 0
+    description: "Routes intelligence operations to appropriate compute/effect nodes"
+  execution_graph:
+    nodes:
+      - node_id: "receive_request"
+        node_type: EFFECT_GENERIC
+        description: "Receive intelligence operation request"
+        step_config:
+          event_pattern: ["intelligence.*"]
+      - node_id: "route_operation"
+        node_type: ORCHESTRATOR_INTERNAL
+        description: "Route operation based on EnumIntelligenceOperationType"
+        depends_on: ["receive_request"]
+        step_config:
+          routing_field: "operation_type"
+      - node_id: "execute_compute"
+        node_type: ORCHESTRATOR_INTERNAL
+        description: "Dispatch to appropriate compute node based on operation routing"
+        depends_on: ["route_operation"]
+      - node_id: "execute_effects"
+        node_type: EFFECT_GENERIC
+        description: "Execute effect nodes for persistence"
+        depends_on: ["execute_compute"]
+      - node_id: "publish_outcome"
+        node_type: EFFECT_GENERIC
+        description: "Publish workflow outcome event"
+        depends_on: ["execute_effects"]
+  coordination_rules:
+    execution_mode: parallel
+    parallel_execution_allowed: true
+    max_parallel_branches: 5
+"""
+
+
+@pytest.mark.unit
+def test_intelligence_orchestrator_execution_graph_is_typed_bound() -> None:
+    """The declared execution_graph parses into typed nodes (5 nodes / 4 edges)."""
+    raw = yaml.safe_load(INTELLIGENCE_ORCHESTRATOR_WORKFLOW_YAML)
+    config = ModelWorkflowConfig.model_validate(raw)
+
+    assert config.workflow_definition is not None
+    graph = config.workflow_definition.execution_graph
+
+    # 5 nodes — no silent drop.
+    assert len(graph.nodes) == 5
+    assert [n.node_id for n in graph.nodes] == [
+        "receive_request",
+        "route_operation",
+        "execute_compute",
+        "execute_effects",
+        "publish_outcome",
+    ]
+
+    # 4 edges across the chain.
+    total_edges = sum(len(n.depends_on) for n in graph.nodes)
+    assert total_edges == 4
+
+    # Edges are traversable / correctly wired.
+    by_id = {n.node_id: n for n in graph.nodes}
+    assert by_id["receive_request"].depends_on == []
+    assert by_id["route_operation"].depends_on == ["receive_request"]
+    assert by_id["execute_compute"].depends_on == ["route_operation"]
+    assert by_id["execute_effects"].depends_on == ["execute_compute"]
+    assert by_id["publish_outcome"].depends_on == ["execute_effects"]
+
+    # Metadata bound too.
+    assert (
+        config.workflow_definition.workflow_metadata.workflow_name
+        == "intelligence_workflow"
+    )
+
+
+@pytest.mark.unit
+def test_non_declaring_workflow_config_unaffected() -> None:
+    """A workflow config without a workflow_definition stays None (no regression)."""
+    config = ModelWorkflowConfig(execution_mode="sequential")
+    assert config.workflow_definition is None
+
+
+@pytest.mark.unit
+def test_workflow_node_extra_fields_ignored() -> None:
+    """Contract-extra fields (description, step_config) are tolerated."""
+    graph = ModelContractExecutionGraph.model_validate(
+        {
+            "nodes": [
+                {
+                    "node_id": "a",
+                    "node_type": "EFFECT_GENERIC",
+                    "description": "ignored",
+                    "step_config": {"k": "v"},
+                },
+            ]
+        }
+    )
+    assert graph.nodes[0].node_id == "a"
+    assert graph.nodes[0].depends_on == []
+
+
+@pytest.mark.unit
+def test_duplicate_node_id_rejected() -> None:
+    with pytest.raises(ValidationError, match="duplicate node_id"):
+        ModelContractExecutionGraph.model_validate(
+            {
+                "nodes": [
+                    {"node_id": "a", "node_type": "EFFECT_GENERIC"},
+                    {"node_id": "a", "node_type": "COMPUTE_GENERIC"},
+                ]
+            }
+        )
+
+
+@pytest.mark.unit
+def test_dangling_edge_rejected() -> None:
+    with pytest.raises(ValidationError, match="undeclared node_id"):
+        ModelContractExecutionGraph.model_validate(
+            {
+                "nodes": [
+                    {
+                        "node_id": "a",
+                        "node_type": "EFFECT_GENERIC",
+                        "depends_on": ["does_not_exist"],
+                    },
+                ]
+            }
+        )
+
+
+@pytest.mark.unit
+def test_cycle_rejected() -> None:
+    with pytest.raises(ValidationError, match="cycle"):
+        ModelContractExecutionGraph.model_validate(
+            {
+                "nodes": [
+                    {
+                        "node_id": "a",
+                        "node_type": "COMPUTE_GENERIC",
+                        "depends_on": ["b"],
+                    },
+                    {
+                        "node_id": "b",
+                        "node_type": "COMPUTE_GENERIC",
+                        "depends_on": ["a"],
+                    },
+                ]
+            }
+        )
+
+
+@pytest.mark.unit
+def test_workflow_node_is_frozen() -> None:
+    definition = ModelContractWorkflowDefinition.model_validate(
+        {
+            "workflow_metadata": {"workflow_name": "w"},
+            "execution_graph": {
+                "nodes": [{"node_id": "a", "node_type": "EFFECT_GENERIC"}]
+            },
+        }
+    )
+    node = definition.execution_graph.nodes[0]
+    with pytest.raises(ValidationError):
+        node.node_id = "mutated"


### PR DESCRIPTION
## OMN-12835 — stop silently dropping declared orchestrator DAGs

Orchestrator contracts declare their execution flow as a graph under `workflow_coordination.workflow_definition.execution_graph`, but `ModelWorkflowConfig` had **no** `workflow_definition` field and `extra="ignore"` — so the declared DAG was parsed and **silently thrown away**. ~10 of ~62 orchestrator contracts already declare a DAG (string `node_id` + `depends_on`), all silently ignored at the type boundary. This blocked contract-derived golden-chain traversal.

### Change (additive, 0 blast radius on the ~52 non-declaring contracts)
- New `ModelContractWorkflowNode` (`node_id: str`, `node_type: str`, `depends_on: list[str] = []`; frozen).
- New `ModelContractExecutionGraph` with parse-time validators: **no duplicate node_id, no dangling `depends_on`, acyclic** (Kahn topo-sort).
- New `ModelContractWorkflowMetadata` + `ModelContractWorkflowDefinition` (`workflow_metadata`, `execution_graph`, optional `coordination_rules`).
- `ModelWorkflowConfig.workflow_definition: ModelContractWorkflowDefinition | None = None`.
- `ModelContractOrchestrator.INTERFACE_VERSION` 1.0.0 → **1.1.0**.
- Each new model in its own file (onex-single-class-per-file).
- The contract-side string-keyed DAG is kept separate from the runtime UUID model per OMN-7591/7782; full unification is the gated OMN-12525 Phase 2 / OMN-656 follow-up.

### dod_evidence
- **Typed-bound, traversable (no silent drop):** TDD test loads the canonical `node_intelligence_orchestrator` workflow block → `execution_graph.nodes` populated with **5 nodes** (receive_request → route_operation → execute_compute → execute_effects → publish_outcome) and **4 edges**, each `depends_on` correctly wired. Live `node_intelligence_orchestrator/contract.yaml` validates through `ModelWorkflowConfig` producing **5 nodes / 4 edges**. 7/7 focused tests pass.
- **Validators enforced:** duplicate-id, dangling-edge, cyclic graphs each raise `ValidationError` (negative tests). Non-declaring configs default to `None`.
- **Quality gates green:** `mypy --strict` on the 5 changed/new files (no issues); ruff check/format clean; `tests/unit/models/contracts` full suite **3114 passed, 1 skipped**; `pre-commit run --files <changed>` exits 0.

Evidence-Source: 08773f7141dd0a32d2cca542777e546024674c37
Evidence-Ticket: OMN-12835