### PR TITLE
fix(OMN-13515): RuntimeLocal._instantiate_handler injects event_bus for handlers that declare it

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -284,11 +284,32 @@ class RuntimeLocal:
     # Handler instantiation (shared helper)
     # ------------------------------------------------------------------
 
-    def _instantiate_handler(self, module_name: str, class_name: str) -> object:
+    def _instantiate_handler(
+        self,
+        module_name: str,
+        class_name: str,
+        *,
+        bus: ProtocolLocalRuntimeBus | None = None,
+    ) -> object:
         """Import *module_name*, resolve *class_name*, and return an instance.
 
         Runtime-owned dependencies are injected explicitly when the constructor
-        advertises a supported parameter.
+        advertises a supported parameter:
+
+        * ``state_root`` — injected with the runtime's disk-state root.
+        * ``event_bus`` — injected with the in-scope runtime *bus* when one is
+          provided. Handlers that publish telemetry (e.g. the omnimarket sweep
+          and orchestrator handlers) declare a mandatory ``event_bus`` positional
+          arg; without this injection they fail to instantiate with
+          ``__init__() missing 1 required positional argument: 'event_bus'``
+          (OMN-13515). The bus is in scope at the event-driven and single-handler
+          call sites; the compute path owns no bus and passes ``bus=None``.
+
+        Args:
+            module_name: Dotted module path containing the handler class.
+            class_name: Handler class name within *module_name*.
+            bus: The runtime event bus, threaded from the calling execution path.
+                ``None`` on paths that own no bus (e.g. ``_run_compute``).
 
         Raises:
             ModelOnexError: If the module cannot be imported or the class is missing.
@@ -310,6 +331,8 @@ class RuntimeLocal:
             for param_name in sig.parameters:
                 if param_name == "state_root":
                     kwargs[param_name] = self.state_root
+                elif param_name == "event_bus" and bus is not None:
+                    kwargs[param_name] = bus
         except (ValueError, TypeError):
             # If signature inspection fails, instantiate with no kwargs.
             pass
@@ -458,7 +481,9 @@ class RuntimeLocal:
         handler_class = str(handler_class_name)
         self._handlers_wired = [f"{handler_module}.{handler_class}"]
 
-        handler_instance = self._instantiate_handler(handler_module, handler_class)
+        handler_instance = self._instantiate_handler(
+            handler_module, handler_class, bus=bus
+        )
 
         # Build initial payload from handler or contract input spec.
         # input_model may be a dotted string ("module.ClassName") — coerce to dict.
@@ -924,7 +949,7 @@ class RuntimeLocal:
 
         for entry in resolved_entries:
             handler_instance = self._instantiate_handler(
-                entry.handler_module, entry.handler_class
+                entry.handler_module, entry.handler_class, bus=bus
             )
 
             # Resolve the input model class. operation_match entries route by the

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -22,8 +22,10 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
@@ -342,3 +344,205 @@ def test_kafka_default_path_uses_default_factory(workflow_path: Path) -> None:
 
     assert isinstance(bus, _StubKafkaBus)
     assert bus.bootstrap_seen is None
+
+
+# ---------------------------------------------------------------------------
+# _instantiate_handler — runtime-owned dependency injection (OMN-13515)
+#
+# Regression guard: handlers that declare a mandatory ``event_bus`` positional
+# arg (8 omnimarket sweep/orchestrator handlers) must instantiate via the
+# runtime path. Before OMN-13515 the runtime injected only ``state_root`` and
+# never ``event_bus``, so every such handler crashed with
+# ``__init__() missing 1 required positional argument: 'event_bus'``.
+# ---------------------------------------------------------------------------
+
+
+class _HandlerRequiresEventBus:
+    """Mirror of the 8 omnimarket handlers: ``event_bus`` is mandatory."""
+
+    def __init__(self, event_bus: ProtocolLocalRuntimeBus) -> None:
+        self.event_bus = event_bus
+
+
+class _HandlerRequiresBusAndState:
+    """Handler that takes both runtime-owned deps by name."""
+
+    def __init__(self, event_bus: ProtocolLocalRuntimeBus, state_root: Path) -> None:
+        self.event_bus = event_bus
+        self.state_root = state_root
+
+
+class _HandlerTolerantBus:
+    """Reference for the already-working ``event_bus=... | None = None`` shape."""
+
+    def __init__(self, event_bus: ProtocolLocalRuntimeBus | None = None) -> None:
+        self.event_bus = event_bus
+
+
+class _HandlerNoDeps:
+    """Handler that advertises no runtime-owned params."""
+
+    def __init__(self) -> None:
+        self.created = True
+
+
+_THIS_MODULE = "tests.unit.runtime.test_runtime_local"
+
+
+@pytest.mark.unit
+def test_instantiate_handler_injects_event_bus(workflow_path: Path) -> None:
+    """A handler with a mandatory ``event_bus`` param instantiates and receives
+    the in-scope runtime bus."""
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    bus = EventBusInmemory(environment="local", group="runtime-local")
+
+    instance = runtime._instantiate_handler(
+        _THIS_MODULE, "_HandlerRequiresEventBus", bus=bus
+    )
+
+    assert isinstance(instance, _HandlerRequiresEventBus)
+    assert instance.event_bus is bus
+
+
+@pytest.mark.unit
+def test_instantiate_handler_injects_event_bus_and_state_root(
+    workflow_path: Path, tmp_path: Path
+) -> None:
+    """Both runtime-owned deps are injected by name; neither clobbers the other."""
+    state_root = tmp_path / "state"
+    runtime = RuntimeLocal(workflow_path=workflow_path, state_root=state_root)
+    bus = EventBusInmemory(environment="local", group="runtime-local")
+
+    instance = runtime._instantiate_handler(
+        _THIS_MODULE, "_HandlerRequiresBusAndState", bus=bus
+    )
+
+    assert isinstance(instance, _HandlerRequiresBusAndState)
+    assert instance.event_bus is bus
+    assert instance.state_root == state_root
+
+
+@pytest.mark.unit
+def test_instantiate_handler_tolerant_bus_handler_still_works(
+    workflow_path: Path,
+) -> None:
+    """Handlers using ``event_bus: ... | None = None`` still instantiate and now
+    receive the real bus rather than ``None``."""
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    bus = EventBusInmemory(environment="local", group="runtime-local")
+
+    instance = runtime._instantiate_handler(
+        _THIS_MODULE, "_HandlerTolerantBus", bus=bus
+    )
+
+    assert isinstance(instance, _HandlerTolerantBus)
+    assert instance.event_bus is bus
+
+
+@pytest.mark.unit
+def test_instantiate_handler_no_deps_handler_unaffected(
+    workflow_path: Path,
+) -> None:
+    """A handler that advertises no runtime-owned params still instantiates with
+    no kwargs even when a bus is in scope."""
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    bus = EventBusInmemory(environment="local", group="runtime-local")
+
+    instance = runtime._instantiate_handler(_THIS_MODULE, "_HandlerNoDeps", bus=bus)
+
+    assert isinstance(instance, _HandlerNoDeps)
+    assert instance.created is True
+
+
+@pytest.mark.unit
+def test_instantiate_handler_event_bus_optional_when_no_bus(
+    workflow_path: Path,
+) -> None:
+    """When no bus is threaded (e.g. compute path with bus=None), a handler that
+    declares ``event_bus`` is not injected — preserving prior behavior for paths
+    that do not own a bus."""
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+
+    # A no-dep handler must still work when bus is None.
+    instance = runtime._instantiate_handler(_THIS_MODULE, "_HandlerNoDeps", bus=None)
+    assert isinstance(instance, _HandlerNoDeps)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runtime path (OMN-13515) — DoD: load a contract whose handler
+# declares a mandatory ``event_bus`` and run the real RuntimeLocal execution
+# path; assert zero instantiation failures and a terminal completed result.
+# ---------------------------------------------------------------------------
+
+# Captured by the integration test handler so the test can assert the bus was
+# actually threaded through the runtime (not merely that instantiation passed).
+_EVENT_BUS_HANDLER_CAPTURE: dict[str, object] = {}
+
+
+class _IntegrationHandlerRequiresEventBus:
+    """Mirror of the 8 omnimarket handlers exercised via the real runtime path.
+
+    Declares ``event_bus`` as a mandatory positional arg (the exact shape that
+    crashed before OMN-13515) and a sync ``handle()`` that returns a non-failure
+    result object so the single-handler path classifies the workflow COMPLETED
+    and synthesizes a terminal event.
+    """
+
+    def __init__(self, event_bus: ProtocolLocalRuntimeBus) -> None:
+        self._event_bus = event_bus
+        _EVENT_BUS_HANDLER_CAPTURE["event_bus"] = event_bus
+
+    async def handle(self, payload: object) -> object:
+        _EVENT_BUS_HANDLER_CAPTURE["handled"] = True
+        # A non-None, non-failure result classifies COMPLETED and triggers the
+        # runtime-synthesized terminal event (OMN-8940).
+        return {"status": "success"}
+
+
+def _write_event_bus_handler_contract(target: Path, terminal_topic: str) -> None:
+    """Write a single-handler contract pointing at the event-bus-requiring handler."""
+    contract = {
+        "workflow_id": "omn-13515-event-bus-injection",
+        "terminal_event": terminal_topic,
+        "event_bus": {"publish_topics": [terminal_topic]},
+        "handler": {
+            "module": _THIS_MODULE,
+            "class": "_IntegrationHandlerRequiresEventBus",
+        },
+    }
+    target.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_local_instantiates_event_bus_handler_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """The real runtime path instantiates a handler with a mandatory ``event_bus``,
+    threads the in-memory bus into it, and reaches a COMPLETED terminal result.
+
+    This is the OMN-13515 regression gate: before the fix this run crashed with
+    ``__init__() missing 1 required positional argument: 'event_bus'`` and the
+    runtime recorded result=FAILED.
+    """
+    _EVENT_BUS_HANDLER_CAPTURE.clear()
+    terminal_topic = "onex.evt.omn13515.completed.v1"
+    contract_path = tmp_path / "contract.yaml"
+    _write_event_bus_handler_contract(contract_path, terminal_topic)
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        timeout=5,
+    )
+
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.COMPLETED
+    # The handler was instantiated (no missing-arg crash) and invoked.
+    assert _EVENT_BUS_HANDLER_CAPTURE.get("handled") is True
+    # The runtime threaded a real bus into the handler's mandatory event_bus arg.
+    captured_bus = _EVENT_BUS_HANDLER_CAPTURE.get("event_bus")
+    assert captured_bus is not None
+    assert isinstance(captured_bus, ProtocolLocalRuntimeBus)
+    assert isinstance(captured_bus, EventBusInmemory)


### PR DESCRIPTION
## Summary

Fixes **OMN-13515** (HIGH, core-runtime). `RuntimeLocal._instantiate_handler` injected only the `state_root` runtime dependency by parameter name and **never injected `event_bus`**, so any handler whose `__init__` declares a non-defaulted `event_bus` crashed at instantiation with:

```
TypeError: NodeX.__init__() missing 1 required positional argument: 'event_bus'
```

This broke 8 omnimarket handlers via the event-driven and single-handler runtime paths: `aislop_sweep`, `architectural_invariant_loop`, `autopilot_orchestrator`, `build_loop_orchestrator`, `overseer_verifier`, `pr_lifecycle_orchestrator`, `swarm_supervisor_orchestrator`, `version_skew_detector`. Surfaced by the `aislop_sweep` dogfood run on 2026-06-22 (the sweep could not scan because the runtime crashed instantiating its own handler).

## Root cause

`src/omnibase_core/runtime/runtime_local.py::RuntimeLocal._instantiate_handler` resolved the handler class and walked `inspect.signature(handler_cls.__init__)`, injecting `kwargs["state_root"]` only — `event_bus` was absent from the supported-parameter list even though the runtime holds the bus in scope at the call sites (`_run_event_driven(bus)`, `_run_single_handler(bus, ...)`).

## Fix (runtime-side — OMN-13515 preferred option)

- `_instantiate_handler` now takes a keyword-only `bus: ProtocolLocalRuntimeBus | None` and injects `kwargs["event_bus"] = bus` when the constructor advertises an `event_bus` param **and** a bus is provided — mirroring the existing `state_root` injection.
- The two bus-owning call sites (`_run_single_handler`, `_run_event_driven`) thread their in-scope `bus`.
- The compute path (`_run_compute`) owns no bus and keeps the default `bus=None` → handler not injected, prior behavior preserved.
- **Handlers are NOT changed** to make `event_bus` optional. That would hide the bug and silently disable sweep-result telemetry (per OMN-8172). The 2 already-tolerant handlers (`event_bus: ... | None = None`) keep working and now receive the real bus.

## TDD / dod_evidence

Failing-test-first. New tests in `tests/unit/runtime/test_runtime_local.py`:

1. `test_instantiate_handler_injects_event_bus` — handler with a mandatory `event_bus` instantiates and receives the in-scope bus.
2. `test_instantiate_handler_injects_event_bus_and_state_root` — both runtime-owned deps inject by name without clobbering.
3. `test_instantiate_handler_tolerant_bus_handler_still_works` — `| None = None` handlers still instantiate and now get the real bus.
4. `test_instantiate_handler_no_deps_handler_unaffected` — no-dep handler unaffected even with a bus in scope.
5. `test_instantiate_handler_event_bus_optional_when_no_bus` — compute-style `bus=None` path preserved.
6. `test_runtime_local_instantiates_event_bus_handler_end_to_end` — **integration gate**: loads a contract whose handler declares a mandatory `event_bus`, runs the real `RuntimeLocal.run_async()` path, and asserts COMPLETED + the bus was threaded into the handler.

**Red→green proof:** with the src fix stashed, test #6 reproduces the exact ticket error (`__init__() missing 1 required positional argument: 'event_bus'`, result=FAILED); with the fix applied it reaches COMPLETED.

**Verification:**
- `uv run pytest tests/unit/runtime/test_runtime_local.py` -> 29 passed (28 + new).
- Scoped broad run `tests/unit/{runtime,nodes,dispatch,pipeline}` (handler-instantiation surface) -> **1070 passed**, 0 failed.
- `uv run mypy src/omnibase_core/runtime/runtime_local.py --strict` -> clean.
- `uv run ruff format && ruff check` -> clean.
- `pre-commit run --files <changed>` -> all hooks pass (exit 0).

## Scope

This is omnibase_core only. Consumers pin-bump later — no consumer pins touched in this PR.

OMN-13515

Evidence-Source: OCC#2954
Evidence-Ticket: OMN-13515
