### PR TITLE
refactor(OMN-592): extract NodeReducer._build_fsm_context with reserved-key handling

### DIFF
--- a/src/omnibase_core/nodes/node_reducer.py
+++ b/src/omnibase_core/nodes/node_reducer.py
@@ -11,10 +11,7 @@ Zero custom Python code required - all state transitions defined declaratively.
 import copy
 import time
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, cast
-
-if TYPE_CHECKING:
-    from omnibase_core.types.type_serializable_value import SerializedDict
+from typing import cast
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
@@ -42,10 +39,14 @@ from omnibase_core.models.reducer.model_reducer_fsm_metadata import (
 )
 from omnibase_core.models.reducer.model_reducer_input import ModelReducerInput
 from omnibase_core.models.reducer.model_reducer_output import ModelReducerOutput
+from omnibase_core.models.reducer.payloads.model_payload_log_event import (
+    ModelPayloadLogEvent,
+)
 from omnibase_core.models.reducer.payloads.model_payload_projection_intent import (
     ModelPayloadProjectionIntent,
 )
 from omnibase_core.types.type_json import JsonType
+from omnibase_core.types.type_serializable_value import SerializedDict
 
 # 7-key FSM metadata contract (OMN-596, BETA-02).
 # All seven keys must be present in every ``ModelReducerOutput.metadata`` value
@@ -69,6 +70,14 @@ _ERR_FSM_METADATA_MISSING_KEYS = (
     "All 7 keys of the v1.0.4 metadata contract must be present (values may be "
     "None). See ModelReducerFsmMetadata for the canonical schema."
 )
+
+# Reserved-key contract for FSM execution context (OMN-592, BETA / Context
+# Construction section of CONTRACT_DRIVEN_NODEREDUCER_V1_0.md).
+# Keys with this prefix are reserved for system use inside the FSM execution
+# context. If user metadata supplies a key with this prefix it is NOT merged
+# into the context (the system value, if any, is never overwritten) and a
+# WARNING intent is emitted so the conflict is observable.
+_FSM_RESERVED_CONTEXT_PREFIX = "_fsm_"
 
 
 def _validate_fsm_metadata_keys(metadata: ModelReducerMetadata) -> None:
@@ -394,18 +403,10 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
         # If trigger is provided in metadata, use it; otherwise default to "process"
         trigger = input_data.metadata.trigger or "process"
 
-        # Build context from input data - context contains serializable values
-        # Convert metadata to dict for context (excluding None values)
-        metadata_dict = input_data.metadata.model_dump(exclude_none=True)
-        # Cast input_data.data to JsonType since T_Input should be JSON-serializable
-        # but the generic type doesn't encode this constraint
-        input_data_value: JsonType = cast(JsonType, input_data.data)
-        context: SerializedDict = {
-            "input_data": input_data_value,
-            "reduction_type": input_data.reduction_type.value,
-            "operation_id": str(input_data.operation_id),
-            **metadata_dict,
-        }
+        # Build the FSM execution context from the reducer input (OMN-592).
+        # Returns (context, reserved_key_warnings): warnings are WARNING-level
+        # log intents emitted when user metadata supplies _fsm_*-prefixed keys.
+        context, reserved_key_warnings = self._build_fsm_context(input_data)
 
         # Execute FSM transition with timing measurement
         start_time = time.perf_counter()
@@ -476,9 +477,15 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
         # The Effect executor is responsible for resolving these before advancing the pipeline.
         projection_intent_models = self._build_projection_intents(projection_intents)
 
-        # Combine FSM intents with projection intents.
-        # FSM intents come first (state management), projection intents follow (read model).
-        all_intents = (*fsm_result.intents, *projection_intent_models)
+        # Combine context-construction warnings, FSM intents, and projection intents.
+        # Reserved-key warnings (OMN-592) come first so the observability signal
+        # is not lost behind state/read-model intents, then FSM intents (state
+        # management), then projection intents (read model).
+        all_intents = (
+            *reserved_key_warnings,
+            *fsm_result.intents,
+            *projection_intent_models,
+        )
 
         output: ModelReducerOutput[T_Output] = ModelReducerOutput(
             result=cast(
@@ -499,6 +506,96 @@ class NodeReducer[T_Input, T_Output](NodeCoreBase, MixinFSMExecution):
         )
 
         return output
+
+    def _build_fsm_context(
+        self,
+        input_data: ModelReducerInput[T_Input],
+    ) -> tuple[SerializedDict, tuple[ModelIntent, ...]]:
+        """Construct the FSM execution context from reducer input (OMN-592).
+
+        Builds the serializable context dict passed to the FSM executor from a
+        ``ModelReducerInput``. The resulting context always carries three
+        system-owned keys plus the caller's (non-reserved) metadata:
+
+        Context structure:
+            * ``input_data``   -- the reducer payload (``input_data.data``),
+              cast to ``JsonType`` for serialization.
+            * ``reduction_type`` -- the reduction strategy value
+              (``input_data.reduction_type.value``).
+            * ``operation_id`` -- the operation UUID rendered as ``str``.
+            * ``**metadata``   -- every non-``None`` field from
+              ``input_data.metadata`` (``model_dump(exclude_none=True)``)
+              EXCEPT keys reserved for system use (see below).
+
+        Reserved keys:
+            Keys prefixed with ``_fsm_`` (``_FSM_RESERVED_CONTEXT_PREFIX``) are
+            reserved for system use. If the caller supplies such a key in
+            metadata it is **not** merged into the context — the system context
+            is never overwritten by caller input — and a ``WARNING``-level
+            ``log_event`` intent is emitted naming the rejected keys so the
+            conflict is observable. This follows the pure-FSM pattern: warn via
+            intent emission, never raise.
+
+        Args:
+            input_data: Reducer input carrying data, reduction type,
+                operation id, and metadata.
+
+        Returns:
+            A ``(context, warnings)`` tuple:
+              * ``context``  -- the assembled ``SerializedDict``.
+              * ``warnings`` -- a tuple of ``ModelIntent`` log-event intents
+                (empty when no reserved-key conflict occurred).
+        """
+        # Convert metadata to a plain dict for context merging (drop None values).
+        metadata_dict = input_data.metadata.model_dump(exclude_none=True)
+
+        # Separate caller metadata into mergeable vs reserved (_fsm_*) keys.
+        # Reserved keys are dropped from the merge and reported via a warning
+        # intent; the system context below is authoritative and never clobbered.
+        reserved_keys = sorted(
+            key for key in metadata_dict if key.startswith(_FSM_RESERVED_CONTEXT_PREFIX)
+        )
+        mergeable_metadata = {
+            key: value
+            for key, value in metadata_dict.items()
+            if not key.startswith(_FSM_RESERVED_CONTEXT_PREFIX)
+        }
+
+        # Cast input_data.data to JsonType since T_Input should be JSON-serializable
+        # but the generic type doesn't encode this constraint.
+        input_data_value: JsonType = cast(JsonType, input_data.data)
+        context: SerializedDict = {
+            "input_data": input_data_value,
+            "reduction_type": input_data.reduction_type.value,
+            "operation_id": str(input_data.operation_id),
+            **mergeable_metadata,
+        }
+
+        warnings: tuple[ModelIntent, ...] = ()
+        if reserved_keys:
+            warnings = (
+                ModelIntent(
+                    intent_type="log_event",
+                    target="logging_service",
+                    payload=ModelPayloadLogEvent(
+                        level="WARNING",
+                        message=(
+                            "Ignoring reserved FSM context keys supplied in "
+                            f"reducer metadata: {reserved_keys}. Keys prefixed "
+                            f"'{_FSM_RESERVED_CONTEXT_PREFIX}' are reserved for "
+                            "system use and are not merged into the FSM context."
+                        ),
+                        context={
+                            "operation_id": str(input_data.operation_id),
+                            "reserved_keys": reserved_keys,
+                            "reserved_prefix": _FSM_RESERVED_CONTEXT_PREFIX,
+                        },
+                    ),
+                    priority=3,
+                ),
+            )
+
+        return context, warnings
 
     def _build_projection_intents(
         self,

--- a/tests/unit/nodes/test_node_reducer_build_fsm_context.py
+++ b/tests/unit/nodes/test_node_reducer_build_fsm_context.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for NodeReducer._build_fsm_context (OMN-592, BETA).
+
+Verifies the extracted context-construction method:
+
+* builds the FSM execution context from a ``ModelReducerInput``
+* merges ``metadata`` + ``input_data`` + ``operation_id`` into the context
+* drops reserved ``_fsm_*``-prefixed keys (never overwrites system context)
+  and emits a single WARNING ``log_event`` intent naming them
+
+Spec reference: CONTRACT_DRIVEN_NODEREDUCER_V1_0.md — Context Construction.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.enums.enum_reducer_types import EnumReductionType
+from omnibase_core.models.common.model_reducer_metadata import ModelReducerMetadata
+from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+from omnibase_core.models.reducer.model_reducer_input import ModelReducerInput
+from omnibase_core.models.reducer.payloads.model_payload_log_event import (
+    ModelPayloadLogEvent,
+)
+from omnibase_core.nodes.node_reducer import (
+    _FSM_RESERVED_CONTEXT_PREFIX,
+    NodeReducer,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def node() -> NodeReducer[int, list[int]]:
+    """A bare NodeReducer — _build_fsm_context reads only the input arg."""
+    return NodeReducer(ModelONEXContainer())
+
+
+def _make_input(
+    *, metadata: ModelReducerMetadata, data: list[int] | None = None
+) -> ModelReducerInput[int]:
+    return ModelReducerInput(
+        data=data if data is not None else [1, 2, 3],
+        reduction_type=EnumReductionType.AGGREGATE,
+        operation_id=uuid4(),
+        metadata=metadata,
+    )
+
+
+def test_build_context_includes_system_keys(node: NodeReducer[int, list[int]]) -> None:
+    """Context always carries input_data, reduction_type, and operation_id."""
+    input_data = _make_input(metadata=ModelReducerMetadata(trigger="start"))
+
+    context, warnings = node._build_fsm_context(input_data)
+
+    assert warnings == ()
+    assert context["input_data"] == [1, 2, 3]
+    assert context["reduction_type"] == EnumReductionType.AGGREGATE.value
+    assert context["operation_id"] == str(input_data.operation_id)
+
+
+def test_build_context_merges_user_metadata(
+    node: NodeReducer[int, list[int]],
+) -> None:
+    """Non-reserved metadata fields (declared + extra) merge into the context."""
+    metadata = ModelReducerMetadata(trigger="start", user_id="abc", attempt=2)
+    input_data = _make_input(metadata=metadata)
+
+    context, warnings = node._build_fsm_context(input_data)
+
+    assert warnings == ()
+    # Declared metadata field present.
+    assert context["trigger"] == "start"
+    # Extra (extra="allow") metadata fields merged.
+    assert context["user_id"] == "abc"
+    assert context["attempt"] == 2
+
+
+def test_build_context_excludes_none_metadata(
+    node: NodeReducer[int, list[int]],
+) -> None:
+    """None-valued metadata fields are excluded from the context."""
+    input_data = _make_input(metadata=ModelReducerMetadata(trigger=None))
+
+    context, _ = node._build_fsm_context(input_data)
+
+    assert "trigger" not in context
+
+
+def test_reserved_key_is_dropped_and_warns(
+    node: NodeReducer[int, list[int]],
+) -> None:
+    """A user-supplied _fsm_* key is NOT merged and produces one WARNING intent."""
+    reserved_key = f"{_FSM_RESERVED_CONTEXT_PREFIX}state"
+    metadata = ModelReducerMetadata.model_validate(
+        {"trigger": "start", reserved_key: "TAMPERED"}
+    )
+    input_data = _make_input(metadata=metadata)
+
+    context, warnings = node._build_fsm_context(input_data)
+
+    # Reserved key must not leak into the system context.
+    assert reserved_key not in context
+    # Non-reserved key still merged.
+    assert context["trigger"] == "start"
+
+    # Exactly one WARNING log_event intent naming the rejected key.
+    assert len(warnings) == 1
+    intent = warnings[0]
+    assert intent.intent_type == "log_event"
+    payload = intent.payload
+    assert isinstance(payload, ModelPayloadLogEvent)
+    assert payload.level == "WARNING"
+    assert reserved_key in payload.context["reserved_keys"]
+    assert payload.context["reserved_prefix"] == _FSM_RESERVED_CONTEXT_PREFIX
+
+
+def test_multiple_reserved_keys_reported_sorted_in_single_intent(
+    node: NodeReducer[int, list[int]],
+) -> None:
+    """All reserved keys surface, sorted, in a single warning intent."""
+    metadata = ModelReducerMetadata.model_validate(
+        {
+            "trigger": "start",
+            f"{_FSM_RESERVED_CONTEXT_PREFIX}zeta": 1,
+            f"{_FSM_RESERVED_CONTEXT_PREFIX}alpha": 2,
+        }
+    )
+    input_data = _make_input(metadata=metadata)
+
+    context, warnings = node._build_fsm_context(input_data)
+
+    assert f"{_FSM_RESERVED_CONTEXT_PREFIX}zeta" not in context
+    assert f"{_FSM_RESERVED_CONTEXT_PREFIX}alpha" not in context
+
+    assert len(warnings) == 1
+    payload = warnings[0].payload
+    assert isinstance(payload, ModelPayloadLogEvent)
+    assert payload.context["reserved_keys"] == [
+        f"{_FSM_RESERVED_CONTEXT_PREFIX}alpha",
+        f"{_FSM_RESERVED_CONTEXT_PREFIX}zeta",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_emits_reserved_key_warning_intent(
+    node: NodeReducer[int, list[int]],
+) -> None:
+    """End-to-end: process() surfaces the reserved-key warning in output intents."""
+    from omnibase_core.models.contracts.subcontracts.model_fsm_state_definition import (
+        ModelFSMStateDefinition,
+    )
+    from omnibase_core.models.contracts.subcontracts.model_fsm_state_transition import (
+        ModelFSMStateTransition,
+    )
+    from omnibase_core.models.contracts.subcontracts.model_fsm_subcontract import (
+        ModelFSMSubcontract,
+    )
+    from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+    v = ModelSemVer(major=1, minor=0, patch=0)
+    node.fsm_contract = ModelFSMSubcontract(
+        state_machine_name="build_ctx_fsm",
+        description="Context-construction e2e FSM",
+        state_machine_version=v,
+        version=v,
+        initial_state="idle",
+        states=[
+            ModelFSMStateDefinition(
+                state_name="idle",
+                state_type="operational",
+                description="Initial state",
+                version=v,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+            ModelFSMStateDefinition(
+                state_name="processing",
+                state_type="operational",
+                description="Processing state",
+                version=v,
+                entry_actions=[],
+                exit_actions=[],
+            ),
+        ],
+        transitions=[
+            ModelFSMStateTransition(
+                transition_name="start",
+                from_state="idle",
+                to_state="processing",
+                trigger="start_event",
+                version=v,
+                conditions=[],
+                actions=[],
+            ),
+        ],
+        terminal_states=[],
+        error_states=[],
+        operations=[],
+        persistence_enabled=False,
+        recovery_enabled=False,
+    )
+
+    metadata = ModelReducerMetadata.model_validate(
+        {"trigger": "start_event", f"{_FSM_RESERVED_CONTEXT_PREFIX}state": "BAD"}
+    )
+    result = await node.process(_make_input(metadata=metadata))
+
+    log_intents = [i for i in result.intents if i.intent_type == "log_event"]
+    reserved_warnings = [
+        i
+        for i in log_intents
+        if isinstance(i.payload, ModelPayloadLogEvent)
+        and i.payload.level == "WARNING"
+        and "reserved" in i.payload.message.lower()
+    ]
+    assert len(reserved_warnings) == 1


### PR DESCRIPTION
Evidence-Source: 421da92ede2a59448213c28f7d2e2c67f473b0ba
Evidence-Ticket: OMN-592

## OMN-592 — [BETA] Refactor: Extract _build_fsm_context method

Extracts `NodeReducer._build_fsm_context(input_data) -> (context, warnings)` from the inline context construction in `process()`.

### Changes (feature repo — implementation only)
- `src/omnibase_core/nodes/node_reducer.py`
  - New `_build_fsm_context` method: merges `input.data`, `reduction_type`, `operation_id`, and non-reserved `metadata` into the serializable FSM execution context.
  - Reserved-key handling: keys prefixed `_fsm_` (`_FSM_RESERVED_CONTEXT_PREFIX`) are reserved for system use. Caller-supplied reserved keys are **dropped** from the merge (system context is never overwritten) and a single `WARNING`-level `log_event` intent naming the rejected keys is emitted — pure-FSM pattern: warn via intent, never raise.
  - `process()` consumes `(context, reserved_key_warnings)` and prepends the warnings ahead of FSM and projection intents so the observability signal is not lost.
- `tests/unit/nodes/test_node_reducer_build_fsm_context.py` — 6 tests covering system keys, metadata merge (declared + extra), None exclusion, single + multiple reserved-key drop-and-warn, and an end-to-end `process()` intent surfacing.

The diff against dev is exactly these two files.

### Acceptance criteria (DoD)
- [x] Builds context from `ModelReducerInput`
- [x] `metadata` + `data` + `operation_id` merged
- [x] Reserved key handling (warn via intent, don't overwrite)
- [x] Clear documentation of context structure (method docstring)

### dod_evidence
DoD receipts live in `onex_change_control` (OCC PR #2966, **merged** as `421da92ede2a59448213c28f7d2e2c67f473b0ba` on OCC dev) under `drift/dod_receipts/OMN-592/` — `dod-omnibase-core-pr-1311` (binds this PR), `dod-deploy-no-runtime-impact` (deploy-gate evidence), `dod-occ-pr-self`. All PASS, hash-bound to the OMN-592 contract, PR-bound to #1311.
- `uv run pytest tests/unit/nodes/test_node_reducer_build_fsm_context.py` → **6 passed**.
- OCC merge-eligibility validator run locally against the merged OCC commit → `eligible: true`, hash-bound + PR-bound.
- `ruff format`/`ruff check` clean; `mypy src/omnibase_core/nodes/node_reducer.py --strict` → Success.

Note: this PR previously had an in-progress separate OCC pairing branch; it was closed in favor of the sibling OCC PR #2966 which carries the canonical OMN-592 evidence (and OMN-604/13480) — avoiding duplicate competing OCC contracts.

Closes OMN-592.