### PR TITLE
feat(OMN-13480): wire required CI gate for SEA-generated todo-marker COMPUTE validator

### DIFF
--- a/.github/workflows/validator-todo-marker.yml
+++ b/.github/workflows/validator-todo-marker.yml
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Agent-left unfinished-work-marker gate [OMN-13480, G2 SEA-dogfood]
+#
+# Required status check context: "TODO Marker Validator / validate"
+#
+# Blocks agent-left TODO/FIXME/HACK unfinished-work markers in shipped source.
+# The scanning logic is a generated COMPUTE node (HandlerTodoMarkerCompute):
+# produced by node_generation_consumer (omnimarket) against the live model and
+# accepted ONLY because it passed a deterministic acceptance corpus
+# (corpus_todo_marker.TODO_MARKER_CORPUS) in the hardened sandbox on the FIRST
+# attempt. The corpus — not the LLM self-report — is the acceptance authority.
+#
+# Two-transport seam: the same HandlerTodoMarkerCompute runs over a swappable
+# event-bus backend. Pre-commit runs it on the in-memory backend over STAGED
+# files; this gate runs the SAME handler (via runtime_todo_marker) over the
+# files a PR changed, so local and CI verdicts cannot drift.
+#
+# Enforcement scope: this gate scans only the files the PR changed (mirroring
+# the pre-commit hook's pass_filenames / STAGED-only semantics). A full-tree
+# scan would fail on legitimate pre-existing ticket-referenced markers and
+# validator/contract source whose subject IS the marker token. Blocking only on
+# changed files prevents NEW agent-left markers from merging without forcing a
+# repo-wide cleanup first. Suppress a line with `# onex-allow-todo-marker`; a
+# documentation-heavy file whose subject IS the marker token with
+# `# onex-allow-file-todo-marker`.
+
+name: TODO Marker Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-todo-marker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # Verifier: the corpus-pinned unit tests are the acceptance authority. If
+      # the handler ever drifts off the corpus invariant these fail first.
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validation/todo_marker/ -v
+
+      # Enforcement: run the SAME COMPUTE handler (via its bus runtime) over the
+      # files this PR/merge changed. Exit non-zero (fails the check) on any
+      # agent-left marker in changed text source. Mirrors the pre-commit hook's
+      # excludes (tests/ + docs/ reference the marker tokens as their subject).
+      - name: Scan changed files for agent-left markers
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve the base ref to diff against.
+          #  - pull_request: the PR base branch
+          #  - merge_group / push: the previous tip (event before SHA)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] \
+               && git cat-file -e "${{ github.event.before }}^{commit}" 2>/dev/null; then
+            BASE_SHA="${{ github.event.before }}"
+          else
+            # Fallback: diff against the merge-base with origin/dev.
+            git fetch --no-tags --depth=200 origin dev || true
+            BASE_SHA="$(git merge-base HEAD origin/dev 2>/dev/null || git rev-parse HEAD~1)"
+          fi
+          echo "Diffing changed files against base: $BASE_SHA"
+
+          # Changed files in scope: text source, excluding tests/ and docs/ (whose
+          # subject legitimately IS the marker token) and the secrets baseline.
+          CHANGED="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD \
+            | grep -E '\.(py|md|yaml|yml|json|sh|toml|txt|rst|cfg|ini)$' \
+            | grep -Ev '^(tests/|docs/|\.secrets\.baseline$|archived/|archive/)' \
+            || true)"
+
+          if [ -z "$CHANGED" ]; then
+            echo "No in-scope changed text files -- nothing to scan."
+            exit 0
+          fi
+
+          echo "Scanning changed files:"
+          echo "$CHANGED" | sed 's/^/  /'
+
+          # Only pass paths that still exist in the worktree (ACMR excludes
+          # deletions, but be defensive).
+          EXISTING=""
+          while IFS= read -r f; do
+            [ -f "$f" ] && EXISTING="$EXISTING $f"
+          done <<< "$CHANGED"
+
+          if [ -z "${EXISTING// /}" ]; then
+            echo "No existing in-scope changed files -- nothing to scan."
+            exit 0
+          fi
+
+          # Same COMPUTE handler over the in-memory bus as the pre-commit hook.
+          # Exit 1 on any finding -> the required check fails.
+          uv run python -m omnibase_core.validation.todo_marker.runtime_todo_marker $EXISTING

--- a/src/omnibase_core/validation/todo_marker/GENERATION_PROVENANCE.md
+++ b/src/omnibase_core/validation/todo_marker/GENERATION_PROVENANCE.md
@@ -146,3 +146,35 @@ EXIT=0
 
 A planted marker makes the gate exit non-zero; the revert restores green. The gate
 BLOCKS.
+
+## Required CI gate — enforcement, not detection (Rule 5)
+
+The pre-commit hook (`check-todo-fixme-marker-compute`) is the binding local gate
+(`--no-verify` is prohibited). To close the enforcement story so a pre-commit
+bypass cannot land an agent-left marker, the SAME `HandlerTodoMarkerCompute` is
+wired as a standalone CI workflow:
+
+```
+.github/workflows/validator-todo-marker.yml   (job: validate)
+```
+
+This mirrors the sibling generated validators (`validator-pin-hygiene.yml`,
+`validator-no-none-guard-publish.yml`) one-for-one. The workflow runs on every
+`pull_request` / `push` / `merge_group` against `main` / `develop` / `dev`:
+
+1. **Verifier** — `pytest tests/unit/validation/todo_marker/` (the corpus-pinned
+   parametrized tests are the acceptance authority; they fail first if the
+   handler ever drifts off the corpus invariant).
+2. **Enforcement** — runs `runtime_todo_marker` (the same in-memory-bus COMPUTE
+   handler the pre-commit hook uses) over **only the files the PR changed**
+   (diff vs base ref), excluding `tests/` + `docs/` (whose subject legitimately
+   IS the marker token). Exit non-zero on any agent-left marker → the check
+   fails.
+
+The CI scan is intentionally changed-files-only (not a full `src/` scan): a
+repo-wide blocking scan would fail on the legitimate pre-existing
+ticket-referenced markers and validator/contract source whose subject IS the
+marker pattern (the 66-token full-tree census above). Changed-files-only is the
+exact STAGED-only semantics of the `pass_filenames: true` pre-commit hook, so
+local and CI verdicts cannot drift. The CI scan command was proven fail-closed
+on a planted marker (`EXIT=1`) before landing.


### PR DESCRIPTION
## OMN-13480 — wire the required CI gate for the SEA-generated todo-marker COMPUTE validator

G2 residual under **OMN-13294** (todo-fixme-marker provenance). The marquee dogfood — *omninode generates omninode via SEA* — was already proven for this validator: `HandlerTodoMarkerCompute` was generated by the **real** generation node (`node_generation_consumer` / `HandlerGenerationConsumer`, omnimarket) against the live local coder model (`Qwen3.6-35B-A3B` at `http://192.168.86.201:8000/v1/chat/completions`), corpus-accepted on attempt 1, and landed in #1304. The **corpus** — not the LLM — was the acceptance authority.

The validator was wired only as a **pre-commit hook**, with **no required CI gate**. Per **Rule 5 (enforcement, not detection)** that is incomplete: a pre-commit bypass could land an agent-left marker. This PR closes the enforcement story by adding the standalone CI workflow, mirroring the sibling generated validators (`validator-pin-hygiene.yml` / OMN-13509, `validator-no-none-guard-publish.yml`) one-for-one.

### What changed
- **`.github/workflows/validator-todo-marker.yml`** (new) — job `validate` on `pull_request` / `push` / `merge_group` vs `main`/`develop`/`dev`:
  1. **Verifier** — `pytest tests/unit/validation/todo_marker/` (corpus-pinned parametrized tests; fail first on any drift off the corpus invariant).
  2. **Enforcement** — runs the **same** in-memory-bus COMPUTE handler (`runtime_todo_marker`) over **only the files the PR changed** (diff vs base), excluding `tests/`+`docs/` (whose subject IS the marker token). Exit non-zero on any agent-left `TODO`/`FIXME`/`HACK` → the check fails.
- **`GENERATION_PROVENANCE.md`** — added the "Required CI gate" section documenting the enforcement closure.

Changed-files scope == the pre-commit hook's `pass_filenames: true` / STAGED-only semantics, so **local and CI verdicts cannot drift**. A full-tree `src/` blocking scan would (correctly) flag the 66 legitimate pre-existing ticket-referenced markers + validator/contract source whose subject IS the marker pattern — so blocking is scoped to new changes, exactly like the G1/G2 canaries.

### dod_evidence
- **Generation (SEA, real node, corpus authority):** `docs/evidence/2026-06-22-sea-dogfood-handler/todo-fixme-marker.generation.json` (omni_home) — `accepted:true`, `corpus_checked:true`, `corpus_passed:true`, `corpus_errors:[]`, `attempt_count:1`, `usage_source:measured`, `provider:local`, `model_id:Qwen3.6-35B-A3B`, `routing_source:contract`, `resolved_endpoint:http://192.168.86.201:8000/...`. 5 violation fixtures + 4 clean fixtures.
- **Verifier ≠ runner corpus re-check (reproduced this session):** the omnimarket `TODO_MARKER_CORPUS` re-run against the committed `handler.scan_source` → **violation_fixtures flagged: 5/5**, **clean_fixtures passed: 4/4**, **VERDICT: ACCEPTED**.
- **Fail-closed proof of the gate:** planted `# TODO`/`# FIXME` marker → `runtime_todo_marker` EXIT=1; reverted clean file → EXIT=0. The CI scan command itself was proven fail-closed on a planted marker (EXIT=1).
- **Unit tests:** `tests/unit/validation/todo_marker/` — **18 passed**.
- **Shadow-run clean:** the validator's pre-commit hook passes on this PR's changed source (`validator-todo-marker.yml` carries the file-level suppression — its subject IS the marker token; `GENERATION_PROVENANCE.md` already carries it).
- **Local gates green:** `ruff format`/`check` clean, `mypy --strict` clean (4 files), full `pre-commit run --files` on the staged set → all hooks Passed/Skipped.

Tickets: OMN-13480 (G2 residual), OMN-13294 (parent provenance).


---

Evidence-Source: OCC#2969
Evidence-Ticket: OMN-13480


<!-- receipt-gate re-trigger: OCC#2969 head 6b4589238 (eligible) -->
