### PR TITLE
feat(OMN-12881): publisher injection guardrail for side-emitting auto-wired handlers

### DIFF
--- a/src/omnibase_core/models/validation/model_publisher_injection_finding.py
+++ b/src/omnibase_core/models/validation/model_publisher_injection_finding.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelPublisherInjectionFinding — finding from the publisher injection gate (OMN-12881)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPublisherInjectionFinding:
+    """A single finding from the publisher injection gate validator."""
+
+    path: Path
+    line: int
+    column: int
+    rule: str
+    message: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column + 1}: [{self.rule}] {self.message}"
+        )

--- a/src/omnibase_core/validators/publisher_injection_gate.py
+++ b/src/omnibase_core/validators/publisher_injection_gate.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Publisher injection gate (OMN-12881).
+
+Enforces: auto-wired handler/node classes that call ``self._xxx.publish(...)``
+(side-emit events) MUST declare ``event_bus`` in their ``__init__`` so the
+runtime can inject the bus. Without the injection parameter the runtime silently
+skips injection and the handler tries to call ``.publish()`` on ``None`` at
+runtime.
+
+Rule
+----
+``missing_publisher_injection`` — a handler/node class whose method body
+contains a ``self.<attr>.publish(...)`` call does not have an ``event_bus``
+parameter in its ``__init__``.  The ``event_bus`` parameter may be positional,
+keyword, or keyword-only; it just needs to be present so the runtime wires it.
+
+Scanned targets
+---------------
+- ``**/handlers/handler_*.py``
+- ``**/nodes/**/node.py``   (direct node implementation files)
+- ``**/nodes/**/handler.py`` (canonical handler file inside node packages)
+
+Suppression
+-----------
+Add ``# publisher-injection-ok: <reason>`` on the ``class`` line or the
+``__init__`` line to suppress an individual class.
+
+Usage::
+
+    python -m omnibase_core.validators.publisher_injection_gate src/
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+from omnibase_core.models.validation.model_publisher_injection_finding import (
+    ModelPublisherInjectionFinding,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPRESSION_MARKER = "publisher-injection-ok:"
+
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset(
+    {
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".git",
+        "archived",
+        "archive",
+    }
+)
+
+_DEFAULT_SCAN_ROOTS = (Path("src"),)
+
+# ---------------------------------------------------------------------------
+# Path matchers
+# ---------------------------------------------------------------------------
+
+
+def _is_handler_file(path: Path) -> bool:
+    """True if the file is a handler_*.py inside a handlers/ directory."""
+    parts = path.parts
+    return (
+        "handlers" in parts
+        and path.name.startswith("handler_")
+        and path.suffix == ".py"
+    )
+
+
+def _is_node_handler_file(path: Path) -> bool:
+    """True if file is named handler.py or node.py inside a nodes/ directory tree."""
+    parts = path.parts
+    return "nodes" in parts and path.name in {"handler.py", "node.py"}
+
+
+def _is_target_file(path: Path) -> bool:
+    return _is_handler_file(path) or _is_node_handler_file(path)
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in _EXCLUDED_PATH_PARTS for part in path.parts)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _class_name_looks_like_handler(cls_name: str) -> bool:
+    """True if the class name suggests a handler or node implementation."""
+    lower = cls_name.lower()
+    return (
+        "handler" in lower
+        or "node" in lower
+        or "reducer" in lower
+        or "orchestrator" in lower
+        or "effect" in lower
+        or "compute" in lower
+    )
+
+
+def _init_has_event_bus_param(cls: ast.ClassDef) -> bool:
+    """True if the class ``__init__`` declares an ``event_bus`` parameter."""
+    for item in cls.body:
+        if not (isinstance(item, ast.FunctionDef) and item.name == "__init__"):
+            continue
+        args = item.args
+        all_params = [a.arg for a in args.args]
+        if "event_bus" in all_params:
+            return True
+        # keyword-only (after *)
+        kw_only = [a.arg for a in args.kwonlyargs]
+        if "event_bus" in kw_only:
+            return True
+    return False
+
+
+def _class_side_emits(cls: ast.ClassDef) -> int | None:
+    """Return the first line number of a ``self.<attr>.publish(...)`` call in any
+    method of *cls*, or ``None`` if no such call exists.
+
+    Only fires on calls where the receiver chain starts with ``self`` — plain
+    function calls or top-level ``bus.publish(...)`` are not flagged.
+    """
+    for item in cls.body:
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if item.name == "__init__":
+            # __init__-level publish is a construction pattern; the DI gate
+            # already covers it.  Side-emission means emitting DURING handle().
+            continue
+        for node in ast.walk(item):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Must be `<something>.publish`
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr != "publish":
+                continue
+            # The receiver must start with `self` — either `self.<attr>`
+            # (one-level) or `self.<attr>.<attr>` (nested accessor).
+            receiver: ast.expr = func.value
+            while isinstance(receiver, ast.Attribute):
+                receiver = receiver.value
+            if isinstance(receiver, ast.Name) and receiver.id == "self":
+                return node.lineno
+    return None
+
+
+# ---------------------------------------------------------------------------
+# File-level dispatch
+# ---------------------------------------------------------------------------
+
+
+def _has_suppression(lines: list[str], lineno: int) -> bool:
+    """True if the given line (1-indexed) contains the suppression marker."""
+    if 1 <= lineno <= len(lines):
+        return SUPPRESSION_MARKER in lines[lineno - 1]
+    return False
+
+
+def validate_file(
+    path: Path,
+) -> list[ModelPublisherInjectionFinding]:
+    """Validate one Python file; return findings list."""
+    if _is_excluded(path) or not _is_target_file(path):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    findings: list[ModelPublisherInjectionFinding] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not _class_name_looks_like_handler(node.name):
+            continue
+
+        # Check class line for suppression
+        if _has_suppression(lines, node.lineno):
+            continue
+
+        emit_line = _class_side_emits(node)
+        if emit_line is None:
+            continue  # no side-emission — nothing to enforce
+
+        if _init_has_event_bus_param(node):
+            continue  # injection declared — pass
+
+        # Suppression on any __init__ line
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                if _has_suppression(lines, item.lineno):
+                    break
+        else:
+            # No suppression found — emit finding
+            findings.append(
+                ModelPublisherInjectionFinding(
+                    path=path,
+                    line=node.lineno,
+                    column=node.col_offset,
+                    rule="missing_publisher_injection",
+                    message=(
+                        f"class {node.name!r} calls self.<attr>.publish() at line "
+                        f"{emit_line} but does not declare 'event_bus' in __init__ — "
+                        "add 'event_bus' parameter so the runtime can inject it; "
+                        "without it the handler will fail at runtime with AttributeError"
+                    ),
+                )
+            )
+
+    return findings
+
+
+def validate_paths(
+    paths: list[Path],
+) -> list[ModelPublisherInjectionFinding]:
+    """Validate all Python files under the given paths."""
+    findings: list[ModelPublisherInjectionFinding] = []
+    for path in paths:
+        if path.is_file() and path.suffix == ".py":
+            findings.extend(validate_file(path))
+        elif path.is_dir():
+            for py_file in sorted(path.rglob("*.py")):
+                if not _is_excluded(py_file):
+                    findings.extend(validate_file(py_file))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+_VALIDATOR_NAME = "publisher_injection_gate"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for publisher injection gate validator."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Publisher injection gate (OMN-12881): side-emitting handlers must "
+            "declare event_bus in __init__ for runtime injection."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=list(_DEFAULT_SCAN_ROOTS),
+        help="Python files or directories to scan.",
+    )
+    args = parser.parse_args(argv)
+
+    findings = validate_paths(args.paths)
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(f"{_VALIDATOR_NAME}: {len(findings)} finding(s):\n")
+    for f in findings:
+        sys.stderr.write(f"  {f.format()}\n")
+    sys.stderr.write(
+        "\nSide-emitting handlers must declare 'event_bus' in __init__.\n"
+        "The runtime auto-injects it when present; omitting it leaves the bus\n"
+        "as None and the handler crashes at the first .publish() call.\n"
+        "Suppress individual classes with:  # publisher-injection-ok: <reason>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validators/test_publisher_injection_gate.py
+++ b/tests/unit/validators/test_publisher_injection_gate.py
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for publisher_injection_gate validator (OMN-12881).
+
+DoD:
+- Failing fixture: side-emitting handler without ``event_bus`` in __init__ →
+  validator MUST flag (``missing_publisher_injection``).
+- Green fixture: side-emitting handler WITH injected ``event_bus`` →
+  validator passes; handler can publish on the bus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnibase_core.validators.publisher_injection_gate import (
+    validate_file,
+    validate_paths,
+)
+
+# ---------------------------------------------------------------------------
+# File-creation helpers (mirrors handler_di_gate test patterns)
+# ---------------------------------------------------------------------------
+
+
+def _handler(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / f"nodes/my_node/handlers/{name}"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _node_handler(tmp_path: Path, content: str) -> Path:
+    """A handler.py inside a nodes/ package (canonical ONEX handler location)."""
+    p = tmp_path / "nodes/my_node/handler.py"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _non_handler(tmp_path: Path, name: str, content: str) -> Path:
+    """A Python file NOT in a handlers/ directory (should be ignored)."""
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Core DoD: failing fixture (missing injection) and green fixture (injected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDoD:
+    """Acceptance tests required by the OMN-12881 DoD."""
+
+    def test_failing_fixture__side_emitting_without_event_bus__flags(
+        self, tmp_path: Path
+    ) -> None:
+        """DoD failing fixture: handler publishes events but has no event_bus param.
+
+        The validator MUST fire ``missing_publisher_injection``.
+        Without this guardrail the runtime silently skips injection and the
+        handler crashes at runtime with ``AttributeError: 'NoneType' object has
+        no attribute 'publish'``.
+        """
+        p = _handler(
+            tmp_path,
+            "handler_side_emit_bad.py",
+            """\
+class HandlerSideEmitBad:
+    def __init__(self, state_root):
+        self._state_root = state_root
+        self._bus = None  # BUG: runtime will not inject because no event_bus param
+
+    def handle(self, payload):
+        result = {"status": "done"}
+        self._bus.publish("onex.some.topic", result)  # runtime crash: NoneType.publish
+        return result
+""",
+        )
+        findings = validate_file(p)
+
+        assert len(findings) == 1, f"Expected 1 finding, got: {findings}"
+        assert findings[0].rule == "missing_publisher_injection"
+        assert "HandlerSideEmitBad" in findings[0].message
+        assert "event_bus" in findings[0].message
+
+    def test_green_fixture__side_emitting_with_injected_event_bus__passes(
+        self, tmp_path: Path
+    ) -> None:
+        """DoD green fixture: handler declares event_bus → validator passes.
+
+        The runtime sees the ``event_bus`` parameter and injects the live bus.
+        The handler can call ``self._bus.publish(...)`` safely.
+        """
+        p = _handler(
+            tmp_path,
+            "handler_side_emit_good.py",
+            """\
+class HandlerSideEmitGood:
+    def __init__(self, state_root, event_bus=None):
+        self._state_root = state_root
+        self._bus = event_bus  # runtime injects this
+
+    def handle(self, payload):
+        result = {"status": "done"}
+        self._bus.publish("onex.some.topic", result)
+        return result
+""",
+        )
+        findings = validate_file(p)
+
+        assert findings == [], f"Expected no findings, got: {findings}"
+
+    def test_green_fixture__injected_bus_actually_emits_expected_side_event(
+        self,
+    ) -> None:
+        """DoD green fixture (behaviour proof): injected bus receives the publish call.
+
+        Constructs the handler in-process (mirroring what RuntimeLocal does), injects
+        a mock bus, calls ``handle()``, and asserts the bus received the expected
+        ``publish`` call — proving injection wires the side-emission path end-to-end.
+        """
+
+        class HandlerWithInjectedBus:
+            def __init__(self, event_bus: object = None) -> None:
+                self._bus = event_bus
+
+            def handle(self, payload: dict[str, object]) -> dict[str, object]:
+                result = {"status": "done", "input": payload}
+                if self._bus is not None:
+                    self._bus.publish("onex.test.side.event", result)  # type: ignore[union-attr]
+                return result
+
+        mock_bus = MagicMock()
+        handler = HandlerWithInjectedBus(event_bus=mock_bus)
+
+        result = handler.handle({"key": "value"})
+
+        # The handler returned a result
+        assert result["status"] == "done"
+
+        # The injected bus received exactly the expected side-emission
+        mock_bus.publish.assert_called_once_with(
+            "onex.test.side.event",
+            {"status": "done", "input": {"key": "value"}},
+        )
+
+    def test_failing_fixture__handler_without_injection__bus_is_none__crashes(
+        self,
+    ) -> None:
+        """DoD failing fixture (behaviour proof): without injection bus is None.
+
+        This test documents the exact runtime failure the guardrail prevents.
+        A handler that does NOT declare ``event_bus`` in __init__ will have
+        ``self._bus = None`` if the runtime skips injection.  Calling
+        ``.publish()`` on ``None`` raises ``AttributeError``.
+        """
+
+        class HandlerMissingInjection:
+            def __init__(self, state_root: str = ".") -> None:
+                self._state_root = state_root
+                self._bus: object = None  # not injected — no event_bus param
+
+            def handle(self, payload: dict[str, object]) -> dict[str, object]:
+                result = {"status": "done"}
+                self._bus.publish("onex.test.topic", result)  # type: ignore[union-attr]
+                return result
+
+        handler = HandlerMissingInjection()
+
+        with pytest.raises(AttributeError):
+            handler.handle({"key": "value"})
+
+
+# ---------------------------------------------------------------------------
+# Rule: missing_publisher_injection (exhaustive coverage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMissingPublisherInjection:
+    def test_no_side_emission_no_finding(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_no_emit.py",
+            """\
+class HandlerNoEmit:
+    def __init__(self, container):
+        self._store = container.get_service("ProtocolStore")
+
+    def handle(self, payload):
+        return {"status": "done"}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_side_emission_with_event_bus_positional_passes(
+        self, tmp_path: Path
+    ) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_good.py",
+            """\
+class HandlerGood:
+    def __init__(self, event_bus):
+        self._bus = event_bus
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_side_emission_with_event_bus_default_none_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """event_bus=None default still declares the param — runtime injects."""
+        p = _handler(
+            tmp_path,
+            "handler_good.py",
+            """\
+class HandlerGood:
+    def __init__(self, state_root, event_bus=None):
+        self._state_root = state_root
+        self._bus = event_bus
+
+    def handle(self, payload):
+        if self._bus:
+            self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_side_emission_without_event_bus_flagged(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, state_root):
+        self._state_root = state_root
+        self._event_bus = None
+
+    def handle(self, payload):
+        self._event_bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert len(findings) == 1
+        assert findings[0].rule == "missing_publisher_injection"
+        assert "HandlerBad" in findings[0].message
+
+    def test_nested_attribute_publish_flagged(self, tmp_path: Path) -> None:
+        """self._client._bus.publish() — still a self.* chain → flagged."""
+        p = _handler(
+            tmp_path,
+            "handler_bad.py",
+            """\
+class HandlerBad:
+    def __init__(self, state_root):
+        self._state_root = state_root
+
+    def handle(self, payload):
+        self._client._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert len(findings) == 1
+        assert findings[0].rule == "missing_publisher_injection"
+
+    def test_top_level_bus_publish_not_self_not_flagged(self, tmp_path: Path) -> None:
+        """bus.publish(...) where receiver is NOT self — not flagged."""
+        p = _handler(
+            tmp_path,
+            "handler_ok.py",
+            """\
+class HandlerOk:
+    def __init__(self, state_root):
+        self._state_root = state_root
+
+    def handle(self, payload):
+        bus = get_local_bus()
+        bus.publish("onex.topic", payload)  # local variable, not self.*
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_publish_in_init_not_flagged(self, tmp_path: Path) -> None:
+        """Publish inside __init__ itself is not checked (DI gate scope)."""
+        p = _handler(
+            tmp_path,
+            "handler_init.py",
+            """\
+class HandlerInit:
+    def __init__(self, state_root):
+        self._state_root = state_root
+        self._bus = None
+        # publish in __init__ is out of scope for this rule
+        if self._bus:
+            self._bus.publish("onex.init.topic", {})
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_node_handler_file_in_nodes_dir_scanned(self, tmp_path: Path) -> None:
+        """handler.py inside nodes/ tree is scanned."""
+        p = _node_handler(
+            tmp_path,
+            """\
+class NodeFooHandler:
+    def __init__(self, state_root):
+        self._state_root = state_root
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert len(findings) == 1
+        assert findings[0].rule == "missing_publisher_injection"
+
+    def test_suppression_marker_on_class_line_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_suppressed.py",
+            """\
+class HandlerSuppressed:  # publisher-injection-ok: legacy handler, no bus available
+    def __init__(self, state_root):
+        self._state_root = state_root
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_suppression_marker_on_init_line_silences(self, tmp_path: Path) -> None:
+        p = _handler(
+            tmp_path,
+            "handler_suppressed.py",
+            """\
+class HandlerSuppressed:
+    def __init__(self, state_root):  # publisher-injection-ok: injected via other means
+        self._state_root = state_root
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# File targeting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFileTargeting:
+    def test_non_handler_dir_skipped(self, tmp_path: Path) -> None:
+        p = _non_handler(
+            tmp_path,
+            "services/service_foo.py",
+            """\
+class HandlerFoo:
+    def __init__(self, state_root):
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_handler_file_not_named_handler_prefix_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Files in handlers/ but not named handler_*.py are not scanned."""
+        p = tmp_path / "nodes/my_node/handlers/base.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            """\
+class HandlerBase:
+    def __init__(self, state_root):
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+            encoding="utf-8",
+        )
+        findings = validate_file(p)
+        assert findings == []
+
+    def test_validate_paths_scans_directory(self, tmp_path: Path) -> None:
+        _handler(
+            tmp_path,
+            "handler_a.py",
+            """\
+class HandlerA:
+    def __init__(self, state_root):
+        self._bus = None
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        _handler(
+            tmp_path,
+            "handler_b.py",
+            """\
+class HandlerB:
+    def __init__(self, event_bus=None):
+        self._bus = event_bus
+
+    def handle(self, payload):
+        self._bus.publish("onex.topic", payload)
+        return {}
+""",
+        )
+        findings = validate_paths([tmp_path])
+        assert len(findings) == 1
+        assert "HandlerA" in findings[0].message


### PR DESCRIPTION
Evidence-Source: c67472e2d51f5557217a508349667434dc663fce
Evidence-Ticket: OMN-12881

## OMN-12881 — Publisher injection guardrail for side-emitting auto-wired handlers

AST-based validator that enforces: auto-wired handler/node classes that call
`self.<attr>.publish(...)` (side-emit events) MUST declare `event_bus` in their
`__init__`. Without the parameter, `RuntimeLocal._instantiate_handler` silently
skips injection and the handler crashes at the first `.publish()` call with
`AttributeError: 'NoneType' object has no attribute 'publish'`.

### New surfaces

| File | Purpose |
|------|---------|
| `src/omnibase_core/validators/publisher_injection_gate.py` | AST validator + CLI |
| `src/omnibase_core/models/validation/model_publisher_injection_finding.py` | Finding dataclass |
| `tests/unit/validators/test_publisher_injection_gate.py` | 17 unit tests (DoD fixtures + coverage) |

### How it works

The validator walks the AST of every `handlers/handler_*.py` and `nodes/**/handler.py` / `node.py` file. For each class whose name looks like a handler/node:

1. **Detects side-emission**: scans all non-`__init__` methods for `self.<attr>.publish(...)` calls where the receiver chain starts from `self`.
2. **Checks injection**: verifies `event_bus` appears in `__init__` params.
3. **Flags the gap**: if side-emission found and no `event_bus` param → `missing_publisher_injection` finding.

Suppression: `# publisher-injection-ok: <reason>` on the class or `__init__` line.

### dod_evidence

**Failing fixture** — validator trips on side-emitting handler without injection param:
```
tests/unit/validators/test_publisher_injection_gate.py::TestDoD::test_failing_fixture__side_emitting_without_event_bus__flags PASSED
```
Handler: `HandlerSideEmitBad` calls `self._bus.publish(...)` but has no `event_bus` param → `missing_publisher_injection` finding with `HandlerSideEmitBad` + `event_bus` in message.

**Green fixture** — injected publisher emits expected side event:
```
tests/unit/validators/test_publisher_injection_gate.py::TestDoD::test_green_fixture__side_emitting_with_injected_event_bus__passes PASSED
tests/unit/validators/test_publisher_injection_gate.py::TestDoD::test_green_fixture__injected_bus_actually_emits_expected_side_event PASSED
```
`HandlerSideEmitGood` declares `event_bus=None` → validator passes. In-process proof: `mock_bus.publish.assert_called_once_with("onex.test.side.event", {...})` — PASS.

**Crash proof** (documents the exact runtime failure the guardrail prevents):
```
tests/unit/validators/test_publisher_injection_gate.py::TestDoD::test_failing_fixture__handler_without_injection__bus_is_none__crashes PASSED
```
Handler without `event_bus` param → `self._bus = None` → `AttributeError` on `.publish()`.

**Full run**: `tests/unit/validators/test_publisher_injection_gate.py` → **17 passed** in 4.23s
All existing validator tests still green: `tests/unit/validators/` → **187 passed, 0 failed**

**mypy --strict**: `Success: no issues found in 2 source files`
**ruff format + check**: all clean

### Relationship to OMN-13515

OMN-13515 (PR #1307) fixed the RUNTIME to inject `event_bus` when the param is declared. This PR adds the STATIC GUARDRAIL ensuring handlers declare the param — closing the gap where a side-emitting handler written without the param silently receives `None` at runtime and crashes.

