### PR TITLE
fix(OMN-13541): add code_review to delegation wire task_type taxonomy

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -75,6 +75,7 @@ class ModelDelegationRequest(BaseModel):
         "document",
         "research",
         "code_generation",
+        "code_review",
         "refactor",
         "reasoning",
         "complex_reasoning",

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -139,6 +139,7 @@ class TestModelDelegationRequest:
             "document",
             "research",
             "code_generation",
+            "code_review",
             "refactor",
             "reasoning",
             "complex_reasoning",
@@ -150,7 +151,14 @@ class TestModelDelegationRequest:
         ],
     )
     def test_all_compat_task_types_accepted(self, task_type: str) -> None:
-        """All 12 compat task_type values must be accepted (OMN-12663 parity fix)."""
+        """All compat task_type values must be accepted (OMN-12663 parity fix).
+
+        OMN-13541: ``code_review`` added — the consumer-facing delegation surface
+        (node_delegate_skill_orchestrator.allowed_task_types + the claude/codex
+        adapter) already accepts it, so the wire DTO must carry it or the bus
+        consumer rejects the command and emits no terminal event (Pattern-B
+        timeout, zero inference).
+        """
         r = self._make(task_type=task_type)
         assert r.task_type == task_type
 


### PR DESCRIPTION
Evidence-Source: 625a42eeffa6d0eccd97f8b5b7fd3c6c936079a6
Evidence-Ticket: OMN-13541

## OMN-13541 — add `code_review` to the delegation wire task_type taxonomy

Root cause of the dogfood FC-1 failure (`code_review` 0/2, Pattern-B timeout, zero
inference). The consumer-facing delegation surface accepts `code_review`:

- `node_delegate_skill_orchestrator/contract.yaml` `allowed_task_types` includes `code_review`
- `omnimarket/adapters/claude_code/delegate.py::_ALLOWED_TASK_TYPES` includes `code_review`

…but the binding wire DTO `ModelDelegationRequest.task_type` was a closed `Literal`
that omitted it. When a `code_review` delegation crossed the bus, the downstream
consumer (`node_delegation_orchestrator` → `dispatcher_delegation_request.py:100`)
called `ModelDelegationRequest.model_validate(...)`, which raised a pydantic
`ValidationError`. The dispatcher caught it as `INVALID_MESSAGE` and returned
`output_events=[]` — **no `delegation-failed` event was published**. The FSM workflow
was never created, routing/inference never ran, and the skill orchestrator's Pattern-B
wait timed out and wrote a blank `delegation_events` row (`model_name=''`, `latency=0`).

### Change

Add `"code_review"` to the `task_type` `Literal` in
`src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py` (next to
`code_generation`). Pure additive — no existing member removed, no behavior change for
the other 12 task types.

### dod_evidence

Parametrized acceptance test extended to cover `code_review`:

```
uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -v
=> 83 passed
```

`test_all_compat_task_types_accepted[code_review] PASSED` — the wire DTO now accepts the value.

mypy --strict: `Success: no issues found in 1 source file`
ruff format + check: all clean
pre-commit (staged files): all hooks pass.

### Downstream

The deployed runtime picks up the new value via the paired omnimarket PR, which bumps
the omnimarket core pin to this commit and adds the `code_review` task-class contract +
routing-tier fallback, then dev-redeploys and re-proves both `research` and `code_review`
live on the dev lane. See `docs/evidence/OMN-13541/root-cause.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "code_review" as a supported task type option for delegation requests, expanding available workflow classifications.

* **Tests**
  * Updated test coverage to validate the new task type option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
