### PR TITLE
fix(OMN-13542): acceptance_criteria validation returns actionable error naming allowed slugs

### DIFF
--- a/contracts/OMN-13542.yaml
+++ b/contracts/OMN-13542.yaml
@@ -1,18 +1,16 @@
 ---
 schema_version: "1.0.0"
 ticket_id: "OMN-13542"
-title: "fix(OMN-13542): acceptance_criteria validation error is now actionable — names allowed slugs and max_words_per_sentence_N pattern"
+title: "fix(OMN-13542): acceptance_criteria validation error is now actionable — names allowed slugs and
+  max_words_per_sentence_N pattern"
 summary: >
-  Free-text acceptance_criteria strings were rejected with an opaque error
-  ('unsupported acceptance criteria: <text>') that gave callers no guidance on
-  valid forms. The fix improves validate_acceptance_criteria to quote the
-  rejected values and append the full allowed slug set plus the
-  max_words_per_sentence_N pattern. Three new tests cover the I4 strict
-  code_generation corpus case (OMN-13540).
+  Free-text acceptance_criteria strings were rejected with an opaque error ('unsupported acceptance criteria:
+  <text>') that gave callers no guidance on valid forms. The fix improves validate_acceptance_criteria
+  to quote the rejected values and append the full allowed slug set plus the max_words_per_sentence_N
+  pattern. Three new tests cover the I4 strict code_generation corpus case (OMN-13540).
 is_seam_ticket: false
 interface_change: false
-interfaces_touched:
-  - "models/delegation/wire/model_delegation_wire_request.py"
+interfaces_touched: []
 evidence_requirements:
   - kind: "tests"
     description: "Delegation wire model unit tests green including 3 new OMN-13542 cases"
@@ -36,10 +34,13 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "uv run mypy src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py --strict"
+        check_value: "uv run mypy src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+          --strict"
   - id: "dod-deploy"
-    description: "Deploy-gate: wire DTO error message improvement only; no topic changes, no schema migrations, no Docker image rebuild required"
+    description: "Deploy-gate: wire DTO error message improvement only; no topic changes, no schema migrations,
+      no Docker image rebuild required"
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "echo 'deploy-gate: OMN-13542 improves error message in validate_acceptance_criteria only; no runtime deploy required'"
+        check_value: "echo 'deploy-gate: OMN-13542 improves error message in validate_acceptance_criteria
+          only; no runtime deploy required'"

--- a/contracts/OMN-13542.yaml
+++ b/contracts/OMN-13542.yaml
@@ -1,0 +1,45 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13542"
+title: "fix(OMN-13542): acceptance_criteria validation error is now actionable — names allowed slugs and max_words_per_sentence_N pattern"
+summary: >
+  Free-text acceptance_criteria strings were rejected with an opaque error
+  ('unsupported acceptance criteria: <text>') that gave callers no guidance on
+  valid forms. The fix improves validate_acceptance_criteria to quote the
+  rejected values and append the full allowed slug set plus the
+  max_words_per_sentence_N pattern. Three new tests cover the I4 strict
+  code_generation corpus case (OMN-13540).
+is_seam_ticket: false
+interface_change: false
+interfaces_touched:
+  - "models/delegation/wire/model_delegation_wire_request.py"
+evidence_requirements:
+  - kind: "tests"
+    description: "Delegation wire model unit tests green including 3 new OMN-13542 cases"
+    command: "uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -v"
+  - kind: "ci"
+    description: "omnibase_core PR CI checks pass"
+    command: "gh pr checks --repo OmniNode-ai/omnibase_core"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-unit-tests"
+    description: "85 delegation wire model tests pass including 3 new OMN-13542 actionable-error cases"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -v"
+  - id: "dod-mypy"
+    description: "mypy --strict passes on changed file"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run mypy src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py --strict"
+  - id: "dod-deploy"
+    description: "Deploy-gate: wire DTO error message improvement only; no topic changes, no schema migrations, no Docker image rebuild required"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13542 improves error message in validate_acceptance_criteria only; no runtime deploy required'"

--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -48,7 +48,14 @@ MAX_WORDS_PER_SENTENCE_RE = re.compile(r"^max_words_per_sentence_([1-9]\d*)$")
 
 
 def validate_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
-    """Validate request-level quality criteria before they enter dispatch."""
+    """Validate request-level quality criteria before they enter dispatch.
+
+    Each criterion must be a slug from ``SUPPORTED_ACCEPTANCE_CRITERIA`` or match
+    the ``max_words_per_sentence_N`` pattern (e.g. ``max_words_per_sentence_20``).
+    Free-text strings are not accepted: every criterion maps to a concrete
+    deterministic or heuristic check in the quality gate; an unrecognised slug
+    has no implementation and would silently be evaluated as ``MALFORMED``.
+    """
     unsupported = [
         item
         for item in criteria
@@ -56,9 +63,15 @@ def validate_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
         and not MAX_WORDS_PER_SENTENCE_RE.match(item)
     ]
     if unsupported:
-        joined = ", ".join(sorted(unsupported))
+        joined = ", ".join(f"'{item}'" for item in sorted(unsupported))
+        allowed = ", ".join(sorted(SUPPORTED_ACCEPTANCE_CRITERIA))
         # error-ok: wire DTO boundary check; pydantic model_validator surface, not an OnexError call site
-        raise ValueError(f"unsupported acceptance criteria: {joined}")
+        raise ValueError(
+            f"unsupported acceptance criteria: {joined}. "
+            f"Each criterion must be a slug from the allowed set or match "
+            f"'max_words_per_sentence_N' (e.g. 'max_words_per_sentence_20'). "
+            f"Allowed slugs: {allowed}"
+        )
     return criteria
 
 

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -101,6 +101,63 @@ class TestModelDelegationRequest:
         with pytest.raises(ValueError, match="unsupported acceptance criteria"):
             self._make(acceptance_criteria=("not_a_real_criterion",))
 
+    def test_invalid_acceptance_criteria_error_lists_allowed_slugs(self) -> None:
+        """Error message must name valid slugs so callers can self-correct (OMN-13542)."""
+        with pytest.raises(ValueError) as exc_info:
+            self._make(acceptance_criteria=("not_a_real_criterion",))
+        msg = str(exc_info.value)
+        assert "Allowed slugs:" in msg
+        assert "max_words_per_sentence_N" in msg
+        # At least one canonical slug must appear in the hint
+        assert "response_non_empty" in msg
+
+    def test_invalid_acceptance_criteria_error_quotes_bad_values(self) -> None:
+        """Unsupported values are quoted in the error so they are easy to identify."""
+        with pytest.raises(ValueError) as exc_info:
+            self._make(
+                acceptance_criteria=(
+                    "Function must be typed with full PEP 604 type annotations",
+                    "Must handle HTTP errors",
+                )
+            )
+        msg = str(exc_info.value)
+        assert "'Function must be typed with full PEP 604 type annotations'" in msg
+        assert "'Must handle HTTP errors'" in msg
+        assert "Allowed slugs:" in msg
+
+    def test_i4_strict_code_generation_free_text_criteria_rejected_with_actionable_error(
+        self,
+    ) -> None:
+        """OMN-13542 / OMN-13540 I4: strict code_generation with realistic free-text
+        acceptance criteria must fail with a documented, actionable error naming valid
+        forms — not an opaque 'unsupported acceptance criteria: <text>' with no guidance.
+        """
+        free_text_criteria = (
+            "Function must be typed with full PEP 604 type annotations",
+            "Must handle HTTP errors with appropriate status codes",
+            "No global state mutations",
+            "All branches covered by at least one test",
+            "Docstring uses Google style",
+        )
+        with pytest.raises(ValueError) as exc_info:
+            self._make(
+                task_type="code_generation",
+                acceptance_criteria=free_text_criteria,
+            )
+        msg = str(exc_info.value)
+        # Error must be actionable: list the allowed set so the caller knows what to use
+        assert "Allowed slugs:" in msg, (
+            "Error must name the allowed slug set; got: " + msg
+        )
+        assert "max_words_per_sentence_N" in msg, (
+            "Error must document the max_words_per_sentence_N pattern; got: " + msg
+        )
+        # At least one of the bad inputs must be quoted in the message
+        assert any(f"'{c}'" in msg for c in free_text_criteria), (
+            "At least one unsupported criterion must be quoted in the error; got: "
+            + msg
+        )
+
     def test_valid_acceptance_criteria(self) -> None:
         r = self._make(acceptance_criteria=("response_non_empty",))
         assert "response_non_empty" in r.acceptance_criteria

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -101,6 +101,7 @@ class TestModelDelegationRequest:
         with pytest.raises(ValueError, match="unsupported acceptance criteria"):
             self._make(acceptance_criteria=("not_a_real_criterion",))
 
+    @pytest.mark.unit
     def test_invalid_acceptance_criteria_error_lists_allowed_slugs(self) -> None:
         """Error message must name valid slugs so callers can self-correct (OMN-13542)."""
         with pytest.raises(ValueError) as exc_info:
@@ -111,6 +112,7 @@ class TestModelDelegationRequest:
         # At least one canonical slug must appear in the hint
         assert "response_non_empty" in msg
 
+    @pytest.mark.unit
     def test_invalid_acceptance_criteria_error_quotes_bad_values(self) -> None:
         """Unsupported values are quoted in the error so they are easy to identify."""
         with pytest.raises(ValueError) as exc_info:
@@ -125,6 +127,7 @@ class TestModelDelegationRequest:
         assert "'Must handle HTTP errors'" in msg
         assert "Allowed slugs:" in msg
 
+    @pytest.mark.unit
     def test_i4_strict_code_generation_free_text_criteria_rejected_with_actionable_error(
         self,
     ) -> None:


### PR DESCRIPTION
Evidence-Source: 309fb516557e92fe044c993e4e4e442264ed6c71
Evidence-Ticket: OMN-13542

## OMN-13542 — acceptance_criteria validation error is now actionable

### Root cause

`validate_acceptance_criteria` rejected any criterion not in `SUPPORTED_ACCEPTANCE_CRITERIA` with:

```
unsupported acceptance criteria: Function must be typed with full PEP 604 type annotations, Must handle HTTP errors...
```

This gave callers zero guidance. The allowed set is a fixed enumerated list of slugs — each maps to a concrete deterministic or heuristic check in the quality gate. Free-text strings have no implementation behind them and must be rejected. The problem was the error message, not the policy.

### Fix

`validate_acceptance_criteria` now:
1. Quotes each rejected value (e.g. `'Function must be typed...'`)
2. Appends the full allowed slug set: `Allowed slugs: cites_specific_lines, compiles_without_errors, ...`
3. Documents the `max_words_per_sentence_N` pattern (e.g. `max_words_per_sentence_20`)

### dod_evidence

**85 tests pass** including 3 new OMN-13542 cases:

```
tests/unit/models/delegation/wire/test_delegation_wire_models.py::TestModelDelegationRequest::test_invalid_acceptance_criteria_error_lists_allowed_slugs PASSED
tests/unit/models/delegation/wire/test_delegation_wire_models.py::TestModelDelegationRequest::test_invalid_acceptance_criteria_error_quotes_bad_values PASSED
tests/unit/models/delegation/wire/test_delegation_wire_models.py::TestModelDelegationRequest::test_i4_strict_code_generation_free_text_criteria_rejected_with_actionable_error PASSED
```

Full run: `tests/unit/models/delegation/wire/test_delegation_wire_models.py` → **85 passed** in 6.73s

**mypy --strict**: `Success: no issues found in 1 source file`

**I4 corpus case (OMN-13540)**: `test_i4_strict_code_generation_free_text_criteria_rejected_with_actionable_error` covers the exact `code_gen_002_strict` scenario with 5 realistic free-text criteria. Error now names allowed slugs + pattern.

**Deploy-gate**: wire DTO error message improvement only; no topic changes, no schema migrations, no Docker image rebuild required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation error messages for acceptance criteria. Unsupported values are now quoted, allowed criteria are explicitly listed, and accepted patterns are documented for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



