### PR TITLE
feat(OMN-13324): CI schema gate asserting every dispatched node contract declares handlers[0].operation

### DIFF
--- a/.github/workflows/validator-dispatched-contract-operation.yml
+++ b/.github/workflows/validator-dispatched-contract-operation.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# dispatched contract handlers[0].operation gate [OMN-13324]
+#
+# Required status check context:
+#   "dispatched contract handlers[0].operation Validator / validate"
+#
+# Runs the validator unit tests, then self-scans omnibase_core/src for any
+# dispatched node contract (contract.yaml with a non-empty
+# handler_routing.handlers list) whose handlers[0] lacks a non-empty 'operation'.
+# The dispatch-envelope unwrap (node_dod_verify test_dispatch_envelope_unwrap)
+# reads handler_routing.handlers[0].operation regardless of routing_strategy; a
+# missing value surfaces as 'handlers[0].operation is missing'. Unlike the
+# operation_match gate (OMN-13530), this one is strategy-agnostic and covers
+# payload_type_match dispatch targets. Consumer repos wire this by adding the
+# dispatched-contract-operation pre-commit hook and a mirror of the `validate`
+# job in their own CI.
+
+name: dispatched contract handlers[0].operation Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-dispatched-contract-operation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_dispatched_contract_operation.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.dispatched_contract_operation src/omnibase_core

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -313,6 +313,20 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # OMN-13324: require handlers[0].operation on every dispatched node contract.
+      # The dispatch-envelope unwrap (node_dod_verify test_dispatch_envelope_unwrap)
+      # reads handler_routing.handlers[0].operation regardless of routing_strategy;
+      # a missing value surfaces as 'handlers[0].operation is missing'. Strategy-
+      # agnostic, so it covers payload_type_match dispatch targets that OMN-13530
+      # exempts. Core dogfoods its own export.
+      - id: dispatched-contract-operation
+        name: dispatched contract handlers[0].operation guard (OMN-13324)
+        entry: uv run python -m omnibase_core.validators.dispatched_contract_operation src/omnibase_core
+        language: system
+        files: (^|/)contract\.yaml$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # CLASS vs FILE Naming Conventions:
       # - validate-naming-conventions: CLASS naming (ModelUser, EnumStatus, ProtocolEventBus)
       # - validate-file-naming-conventions: FILE naming (model_user.py, enum_status.py)
@@ -422,7 +436,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -468,3 +468,20 @@
   files: (^|/)contract\.yaml$
   pass_filenames: true
   stages: [pre-commit]
+
+- id: dispatched-contract-operation
+  name: dispatched contract handlers[0].operation guard (OMN-13324)
+  description: >
+    Require a non-empty 'operation' field on handlers[0] of every dispatched node contract — any contract.yaml
+    that declares a non-empty handler_routing.handlers list. The dispatch-envelope unwrap (node_dod_verify
+    test_dispatch_envelope_unwrap) resolves the primary handler's operation from handler_routing.handlers[0].operation;
+    a missing value surfaces as 'handlers[0].operation is missing' and the dispatch never resolves an
+    operation. Unlike operation-match-requires-operation (OMN-13530), this gate is strategy-agnostic:
+    it asserts handlers[0].operation even for payload_type_match dispatch targets, because the unwrap
+    reads it regardless of routing_strategy. Consumers reference this hook by id; it scans staged contract.yaml
+    files (or src/ when none are supplied).
+  language: python
+  entry: python -m omnibase_core.validators.dispatched_contract_operation
+  files: (^|/)contract\.yaml$
+  pass_filenames: true
+  stages: [pre-commit]

--- a/src/omnibase_core/models/validation/model_dispatched_contract_operation_finding.py
+++ b/src/omnibase_core/models/validation/model_dispatched_contract_operation_finding.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelDispatchedContractOperationFinding — dispatched-contract handlers[0].operation guard (OMN-13324)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDispatchedContractOperationFinding:
+    """A dispatched node contract whose ``handlers[0]`` lacks a non-empty ``operation``.
+
+    The dispatch-envelope unwrap path (``node_dod_verify``
+    ``test_dispatch_envelope_unwrap.py`` and the dispatch engine generally) resolves
+    the primary handler's ``operation`` from ``handler_routing.handlers[0].operation``.
+    A dispatched contract that omits it surfaces as ``handlers[0].operation is
+    missing`` and the dispatch never resolves an operation.
+
+    This finding is scoped to the FIRST handler of any contract that declares a
+    non-empty ``handler_routing.handlers`` list — i.e. every dispatchable node
+    contract. It is intentionally strategy-agnostic: unlike the operation_match
+    guard (OMN-13530), which exempts ``payload_type_match``, the dispatch-unwrap
+    surface reads ``handlers[0].operation`` regardless of routing_strategy.
+    """
+
+    path: Path
+    handler_name: str
+    routing_strategy: str
+
+    def format(self) -> str:
+        strategy = self.routing_strategy or "(absent)"
+        return (
+            f"{self.path}: handlers[0] (handler={self.handler_name}) is missing "
+            f"a non-empty 'operation' field (routing_strategy={strategy})"
+        )

--- a/src/omnibase_core/validators/dispatched_contract_operation.py
+++ b/src/omnibase_core/validators/dispatched_contract_operation.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Require ``handlers[0].operation`` on every dispatched node contract (OMN-13324).
+
+Enforcement Map F8 — verified plan UWP-18. The dispatch-envelope unwrap path
+(``node_dod_verify`` ``test_dispatch_envelope_unwrap.py`` and the dispatch engine
+generally) resolves the primary handler's operation from
+``handler_routing.handlers[0].operation``. A dispatched contract that omits it
+surfaces as ``handlers[0].operation is missing`` and the dispatch never resolves
+an operation to route on.
+
+Scope vs. the operation_match guard (OMN-13530)
+-----------------------------------------------
+``operation_match_requires_operation`` enforces ``operation`` on *every* handler
+entry whose ``routing_strategy`` is not ``payload_type_match`` — it EXEMPTS
+``payload_type_match`` because that strategy routes by ``event_model`` at the
+runtime-routing layer.
+
+This gate is narrower-but-orthogonal: it asserts that the FIRST handler of any
+dispatchable contract (any contract with a non-empty
+``handler_routing.handlers`` list) declares a non-empty ``operation`` —
+**regardless of routing_strategy**. The dispatch-envelope unwrap reads
+``handlers[0].operation`` to label the dispatch, independent of how the runtime
+later resolves which handler runs. A ``payload_type_match`` contract that is a
+dispatch target still needs ``handlers[0].operation`` for the unwrap to resolve.
+
+The two gates are complementary: OMN-13530 covers all entries of operation-routed
+contracts; this one covers ``handlers[0]`` of *every* dispatchable contract.
+
+Wire it as a pre-commit hook AND a required CI status check in every repo that
+carries ONEX node contracts so the dispatch-unwrap regression can never re-land
+silently.
+
+Usage::
+
+    python -m omnibase_core.validators.dispatched_contract_operation src/
+
+When pre-commit supplies staged filenames, only ``contract.yaml`` files among
+them are scanned. When no paths are supplied, ``src/`` is scanned recursively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent contract.yaml files
+
+from omnibase_core.models.validation.model_dispatched_contract_operation_finding import (
+    ModelDispatchedContractOperationFinding,
+)
+
+DEFAULT_SCAN_ROOT = Path("src")
+CONTRACT_FILENAME = "contract.yaml"
+
+
+def validate_paths(
+    paths: Sequence[Path],
+) -> list[ModelDispatchedContractOperationFinding]:
+    """Validate the contract.yaml files reachable from the provided paths."""
+    findings: list[ModelDispatchedContractOperationFinding] = []
+    for path in _iter_contract_files(paths):
+        finding = validate_file(path)
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+def validate_file(path: Path) -> ModelDispatchedContractOperationFinding | None:
+    """Validate one contract.yaml: dispatched contract must declare handlers[0].operation.
+
+    Returns a finding when the contract declares a non-empty
+    ``handler_routing.handlers`` list (i.e. it is a dispatch target) but its first
+    handler lacks a non-empty ``operation`` field. Returns ``None`` otherwise.
+    """
+    try:
+        # ONEX_EXCLUDE: manual_yaml - reading adjacent node contract for validation
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, UnicodeDecodeError):
+        # YAML/encoding validity is a separate contract-linter concern; this gate
+        # only asserts handlers[0].operation on parseable routing blocks.
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    routing = data.get("handler_routing")
+    if not isinstance(routing, dict):
+        return None
+
+    handlers = routing.get("handlers")
+    # A contract with no handlers list is not a dispatch target — out of scope.
+    if not isinstance(handlers, list) or not handlers:
+        return None
+
+    first = handlers[0]
+    if not isinstance(first, dict):
+        # A malformed first entry is a separate structural concern; the operation
+        # gate only asserts on dict-shaped handler entries.
+        return None
+
+    operation = first.get("operation")
+    if isinstance(operation, str) and operation.strip():
+        return None
+
+    strategy = routing.get("routing_strategy", "")
+    strategy = strategy if isinstance(strategy, str) else ""
+    return ModelDispatchedContractOperationFinding(
+        path=path,
+        handler_name=_handler_name(first),
+        routing_strategy=strategy,
+    )
+
+
+def _handler_name(entry: dict[str, object]) -> str:
+    handler = entry.get("handler")
+    if isinstance(handler, dict):
+        name = handler.get("name")
+        if isinstance(name, str) and name:
+            return name
+    handler_key = entry.get("handler_key")
+    if isinstance(handler_key, str) and handler_key:
+        return handler_key
+    handler_class = entry.get("handler_class")
+    if isinstance(handler_class, str) and handler_class:
+        return handler_class
+    return "<unnamed>"
+
+
+def _iter_contract_files(paths: Sequence[Path]) -> Iterator[Path]:
+    scan_paths = tuple(paths) or (DEFAULT_SCAN_ROOT,)
+    for path in scan_paths:
+        if path.is_file() and path.name == CONTRACT_FILENAME:
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob(CONTRACT_FILENAME)
+                if "__pycache__" not in candidate.parts
+            )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Require a non-empty 'operation' field on handlers[0] of every "
+            "dispatched node contract (any contract.yaml with a non-empty "
+            "handler_routing.handlers list). A missing handlers[0].operation makes "
+            "the dispatch-envelope unwrap fail with 'handlers[0].operation is "
+            "missing'."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SCAN_ROOT],
+        help="contract.yaml file or directory paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_paths(args.paths)
+    if not findings:
+        return 0
+
+    sys.stderr.write("dispatched contract handlers[0].operation guard failed:\n")
+    for finding in findings:
+        sys.stderr.write(f"  {finding.format()}\n")
+    sys.stderr.write(
+        "\nEvery dispatched node contract (any contract.yaml with a non-empty "
+        "handler_routing.handlers list) must declare a non-empty 'operation' field "
+        "on handlers[0]. Without it the dispatch-envelope unwrap fails with "
+        "'handlers[0].operation is missing' and the dispatch never resolves an "
+        "operation. Add 'operation: <verb>' to the first handler entry.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validators/test_dispatched_contract_operation.py
+++ b/tests/unit/validators/test_dispatched_contract_operation.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the dispatched-contract handlers[0].operation guard (OMN-13324)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.dispatched_contract_operation import (
+    main,
+    validate_file,
+    validate_paths,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_PASSING_CONTRACT = """\
+name: example_compute
+node_type: compute
+handler_routing:
+  routing_strategy: operation_match
+  handlers:
+    - operation: scan
+      handler:
+        name: HandlerExample
+        module: pkg.nodes.node_example.handlers.handler_example
+"""
+
+_MISSING_OPERATION_CONTRACT = """\
+name: example_broken
+node_type: compute
+handler_routing:
+  routing_strategy: operation_match
+  handlers:
+    - handler:
+        name: HandlerBroken
+        module: pkg.nodes.node_broken.handlers.handler_broken
+"""
+
+# payload_type_match is EXEMPT in the operation_match guard (OMN-13530) but a
+# dispatch target still needs handlers[0].operation for the unwrap (OMN-13324).
+_PAYLOAD_TYPE_MATCH_MISSING = """\
+name: example_payload_broken
+node_type: compute
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - event_model:
+        name: ModelExampleCommand
+        module: pkg.nodes.node_example.models.model_example_command
+      handler:
+        name: HandlerPayload
+        module: pkg.nodes.node_example.handlers.handler_payload
+"""
+
+_PAYLOAD_TYPE_MATCH_PRESENT = """\
+name: example_payload_ok
+node_type: compute
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - operation: dispatch
+      event_model:
+        name: ModelExampleCommand
+        module: pkg.nodes.node_example.models.model_example_command
+      handler:
+        name: HandlerPayload
+        module: pkg.nodes.node_example.handlers.handler_payload
+"""
+
+_ABSENT_STRATEGY_MISSING = """\
+name: example_absent
+node_type: compute
+handler_routing:
+  handlers:
+    - handler:
+        name: HandlerAbsent
+        module: pkg.nodes.node_absent.handlers.handler_absent
+"""
+
+# Second handler missing operation does NOT trip this gate — it only asserts on
+# handlers[0]. (OMN-13530 covers the rest.)
+_FIRST_OK_SECOND_MISSING = """\
+name: example_multi
+node_type: effect
+handler_routing:
+  routing_strategy: operation_match
+  handlers:
+    - operation: embed
+      handler:
+        name: HandlerEmbed
+        module: pkg.handlers.handler_embed
+    - handler:
+        name: HandlerAnalyze
+        module: pkg.handlers.handler_analyze
+"""
+
+# No handler_routing.handlers list — not a dispatch target, out of scope.
+_NO_HANDLERS_CONTRACT = """\
+name: example_no_routing
+node_type: compute
+event_bus:
+  subscribe_topics: []
+"""
+
+_EMPTY_OPERATION_CONTRACT = """\
+name: example_empty_op
+node_type: compute
+handler_routing:
+  routing_strategy: operation_match
+  handlers:
+    - operation: "   "
+      handler:
+        name: HandlerEmpty
+        module: pkg.handlers.handler_empty
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text(body, encoding="utf-8")
+    return contract
+
+
+def test_passing_contract_has_no_finding(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _PASSING_CONTRACT)
+    assert validate_file(contract) is None
+
+
+def test_missing_operation_is_flagged(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _MISSING_OPERATION_CONTRACT)
+    finding = validate_file(contract)
+    assert finding is not None
+    assert finding.handler_name == "HandlerBroken"
+    assert finding.routing_strategy == "operation_match"
+
+
+def test_payload_type_match_missing_is_flagged(tmp_path: Path) -> None:
+    # Distinct from OMN-13530: payload_type_match is NOT exempt here because the
+    # dispatch-envelope unwrap reads handlers[0].operation regardless of strategy.
+    contract = _write(tmp_path, _PAYLOAD_TYPE_MATCH_MISSING)
+    finding = validate_file(contract)
+    assert finding is not None
+    assert finding.handler_name == "HandlerPayload"
+    assert finding.routing_strategy == "payload_type_match"
+
+
+def test_payload_type_match_with_operation_passes(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _PAYLOAD_TYPE_MATCH_PRESENT)
+    assert validate_file(contract) is None
+
+
+def test_absent_strategy_missing_is_flagged(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _ABSENT_STRATEGY_MISSING)
+    finding = validate_file(contract)
+    assert finding is not None
+    assert finding.handler_name == "HandlerAbsent"
+    assert finding.routing_strategy == ""
+
+
+def test_only_first_handler_is_checked(tmp_path: Path) -> None:
+    # handlers[0] has an operation; handlers[1] does not — this gate is clean.
+    contract = _write(tmp_path, _FIRST_OK_SECOND_MISSING)
+    assert validate_file(contract) is None
+
+
+def test_contract_without_handlers_is_out_of_scope(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _NO_HANDLERS_CONTRACT)
+    assert validate_file(contract) is None
+
+
+def test_whitespace_only_operation_is_flagged(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _EMPTY_OPERATION_CONTRACT)
+    finding = validate_file(contract)
+    assert finding is not None
+    assert finding.handler_name == "HandlerEmpty"
+
+
+def test_main_returns_nonzero_on_violation(tmp_path: Path) -> None:
+    _write(tmp_path, _MISSING_OPERATION_CONTRACT)
+    assert main([str(tmp_path)]) == 1
+
+
+def test_main_returns_zero_when_clean(tmp_path: Path) -> None:
+    _write(tmp_path, _PASSING_CONTRACT)
+    assert main([str(tmp_path)]) == 0
+
+
+def test_validate_paths_scans_directory_recursively(tmp_path: Path) -> None:
+    broken = tmp_path / "nodes" / "node_broken"
+    broken.mkdir(parents=True)
+    (broken / "contract.yaml").write_text(_MISSING_OPERATION_CONTRACT, encoding="utf-8")
+    good = tmp_path / "nodes" / "node_ok"
+    good.mkdir(parents=True)
+    (good / "contract.yaml").write_text(_PASSING_CONTRACT, encoding="utf-8")
+    findings = validate_paths([tmp_path])
+    assert len(findings) == 1
+    assert findings[0].handler_name == "HandlerBroken"


### PR DESCRIPTION
## OMN-13324 — CI schema gate asserting every dispatched node contract declares handlers[0].operation

Enforcement Map **F8** (verified plan UWP-18). Relates OMN-12647 (Plan-to-Tickets & Dispatch-Engine Reliability), parent epic OMN-9048 (validators standardized + wired all repos).

### Problem
"handlers[0].operation is missing" surfaces from the dispatch-envelope unwrap (`node_dod_verify` `test_dispatch_envelope_unwrap.py`). The dispatch path resolves the primary handler's operation from `handler_routing.handlers[0].operation` **regardless of routing_strategy**. A dispatched contract that omits it fails closed with `handlers[0].operation is missing`.

### Fix
New contract-schema validator `omnibase_core.validators.dispatched_contract_operation` (validators-standardized home, `feedback_validators_standardized`): scans every `contract.yaml` and fails when a dispatched contract (any contract with a non-empty `handler_routing.handlers` list) omits a non-empty `operation` on `handlers[0]`.

**Distinct from OMN-13530** (`operation_match_requires_operation`): that gate EXEMPTS `payload_type_match`; this one is strategy-agnostic and covers `payload_type_match` dispatch targets too, because the unwrap reads `handlers[0].operation` independent of strategy. The two are complementary — OMN-13530 covers all entries of operation-routed contracts; this covers `handlers[0]` of every dispatchable contract.

### Wiring (enforcement, not detection)
- Pre-commit hook `dispatched-contract-operation` in `.pre-commit-config.yaml` (core dogfoods its own export against `src/omnibase_core`).
- Exportable hook in `.pre-commit-hooks.yaml` for consumer repos (per OMN-9048).
- Required CI status check: `.github/workflows/validator-dispatched-contract-operation.yml` (`dispatched contract handlers[0].operation Validator / validate`) — runs unit tests + self-scans `src/omnibase_core`.

### DoD — runnable planted-violation / revert (probe_stdout, verifier ≠ runner)

Planted a `payload_type_match` dispatch contract with no `handlers[0].operation` under `src/omnibase_core/nodes/`:

```
=== PLANTED VIOLATION: gate run ===
dispatched contract handlers[0].operation guard failed:
  src/omnibase_core/nodes/_planted_violation_OMN13324/contract.yaml: handlers[0] (handler=HandlerPlanted) is missing a non-empty 'operation' field (routing_strategy=payload_type_match)
EXIT_PLANTED=1

=== REVERT: remove planted contract ===
EXIT_REVERTED=0
```

Planted → gate exits non-zero **naming the contract**; revert → green. The planted contract is `payload_type_match`, proving this gate catches a case OMN-13530 would have exempted.

- `uv run pytest tests/unit/validators/test_dispatched_contract_operation.py` → 11 passed
- `uv run pytest tests/unit/validators/ tests/validation/` → 513 passed
- `uv run mypy ... --strict` → Success
- `pre-commit run --files <changed>` → green on a clean tree

### Files
- `src/omnibase_core/validators/dispatched_contract_operation.py`
- `src/omnibase_core/models/validation/model_dispatched_contract_operation_finding.py`
- `tests/unit/validators/test_dispatched_contract_operation.py`
- `.github/workflows/validator-dispatched-contract-operation.yml`
- `.pre-commit-config.yaml`, `.pre-commit-hooks.yaml`

Evidence-Source: 83c048dd559f75f3d378ff8b3a69583f2ae48cf3
Evidence-Ticket: OMN-13324
