### PR TITLE
fix(OMN-13496): remove SEA harness fixture prompt-echo stub (false-green)

### DIFF
--- a/src/omnibase_core/runtime/harness/harness_cli.py
+++ b/src/omnibase_core/runtime/harness/harness_cli.py
@@ -115,6 +115,19 @@ def _build_adapter(args: argparse.Namespace) -> ProtocolHarnessInferenceAdapter:
                 error_code=EnumCoreErrorCode.VALIDATION_ERROR,
             )
         return CurlSubprocessInferenceAdapter(endpoint=args.endpoint, model=args.model)
+    # fixture replays a completion recorded from a real model call. There is no
+    # prompt-echo default: a run with no real or recorded inference must FAIL,
+    # never report success on nothing (OMN-13496).
+    if not args.fixture_completion or not args.fixture_completion.strip():
+        raise ModelOnexError(
+            message=(
+                "--fixture-completion is required when --inference=fixture; it must "
+                "be a completion recorded from a real model call (golden-chain "
+                "replay). Use --inference=curl for a live model. A fixture run with "
+                "no recorded completion is a false-green stub (OMN-13496)."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
     return RecordedFixtureInferenceAdapter(completion=args.fixture_completion)
 
 
@@ -169,9 +182,21 @@ def _parser() -> argparse.ArgumentParser:
             "--inference",
             choices=("fixture", "curl"),
             default="fixture",
-            help="Inference adapter (fixture=offline, curl=separate-binary LAN).",
+            help=(
+                "Inference adapter. fixture=replay a real-recorded completion "
+                "(requires --fixture-completion), curl=live model via separate-binary "
+                "LAN. There is no prompt-echo path."
+            ),
         )
-        sp.add_argument("--fixture-completion", default=None, dest="fixture_completion")
+        sp.add_argument(
+            "--fixture-completion",
+            default=None,
+            dest="fixture_completion",
+            help=(
+                "Completion recorded from a real model call to replay (required for "
+                "--inference=fixture). No prompt-echo / synthesized default."
+            ),
+        )
         sp.add_argument("--endpoint", default=None, help="curl inference endpoint.")
         sp.add_argument("--model", default="recorded-fixture")
         sp.add_argument(

--- a/src/omnibase_core/runtime/harness/harness_inference_fixture.py
+++ b/src/omnibase_core/runtime/harness/harness_inference_fixture.py
@@ -2,12 +2,17 @@
 # SPDX-License-Identifier: MIT
 """Recorded-fixture inference adapter for the local runtime harness (OMN-13420).
 
-Fully offline; returns a recorded completion. The default adapter for proof runs
-so the DoD ("no LAN required") holds with zero config.
+Fully offline; replays a completion that was **recorded from a real model call**
+(golden-chain replay). It never derives the completion from the prompt: a
+prompt-echo would let a harness run report ``terminal_status: success`` while
+generating nothing — a false-green stub (OMN-13496). A recorded completion is
+therefore mandatory; constructing the adapter without one fails fast.
 """
 
 from __future__ import annotations
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.runtime.harness.model_inference_request import (
     ModelInferenceRequest,
 )
@@ -17,15 +22,23 @@ from omnibase_core.models.runtime.harness.model_inference_result import (
 
 
 class RecordedFixtureInferenceAdapter:
-    """Offline inference adapter — returns a recorded completion. No LAN, no I/O.
+    """Offline inference adapter — replays a recorded completion. No LAN, no I/O.
 
-    When ``completion`` is omitted it echoes a deterministic completion derived
-    from the prompt so runs are reproducible.
+    ``completion`` MUST be a non-empty string recorded from a real model call.
+    There is no prompt-echo / prompt-derived default: that path produced a
+    false-green where a run generated nothing yet reported success (OMN-13496).
     """
 
-    def __init__(
-        self, completion: str | None = None, model: str = "recorded-fixture"
-    ) -> None:
+    def __init__(self, completion: str, model: str = "recorded-fixture") -> None:
+        if not completion.strip():
+            raise ModelOnexError(
+                message=(
+                    "RecordedFixtureInferenceAdapter requires a non-empty completion "
+                    "recorded from a real model call; prompt-echo / empty completions "
+                    "are a false-green stub (OMN-13496)."
+                ),
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
         self._completion = completion
         self._model = model
 
@@ -35,14 +48,9 @@ class RecordedFixtureInferenceAdapter:
         return "fixture"
 
     def infer(self, request: ModelInferenceRequest) -> ModelInferenceResult:
-        """Return the recorded (or prompt-echoed) completion."""
-        completion = (
-            self._completion
-            if self._completion is not None
-            else f"[recorded] {request.prompt}"
-        )
+        """Return the recorded completion (replayed, never derived from the prompt)."""
         return ModelInferenceResult(
-            completion=completion,
+            completion=self._completion,
             model=self._model,
             adapter=self.adapter_id,
         )

--- a/tests/unit/runtime/harness/test_harness_dispatch.py
+++ b/tests/unit/runtime/harness/test_harness_dispatch.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 import pytest
 
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.models.runtime.harness.model_harness_command import (
     ModelHarnessCommand,
@@ -52,6 +53,7 @@ from omnibase_core.runtime.harness.harness_cli import (
     build_evidence_packet,
     run_workflow,
 )
+from omnibase_core.runtime.harness.harness_cli import main as cli_main
 
 
 @pytest.mark.unit
@@ -100,7 +102,7 @@ def test_emitted_topics_follow_command_infer_completed_order() -> None:
             correlation_id=uuid4(),
             task_type="harness",
             max_tokens=16,
-            adapter=RecordedFixtureInferenceAdapter(),
+            adapter=RecordedFixtureInferenceAdapter(completion="HOP"),
             store=store,
         )
     )
@@ -136,7 +138,7 @@ def test_projection_readback_matches_written_row() -> None:
 @pytest.mark.unit
 def test_handlers_satisfy_protocol_message_handler() -> None:
     """All three harness handlers structurally satisfy ProtocolMessageHandler."""
-    adapter = RecordedFixtureInferenceAdapter()
+    adapter = RecordedFixtureInferenceAdapter(completion="OK")
     store = SqliteProjectionStore()
     handlers = (
         HarnessOrchestratorHandler("delegation"),
@@ -152,7 +154,8 @@ def test_handlers_satisfy_protocol_message_handler() -> None:
 def test_adapters_satisfy_protocols() -> None:
     """Inference + projection adapters satisfy their structural protocols."""
     assert isinstance(
-        RecordedFixtureInferenceAdapter(), ProtocolHarnessInferenceAdapter
+        RecordedFixtureInferenceAdapter(completion="OK"),
+        ProtocolHarnessInferenceAdapter,
     )
     assert isinstance(
         CurlSubprocessInferenceAdapter(endpoint="http://x/v1", model="m"),
@@ -168,7 +171,7 @@ def test_bus_is_core_in_memory_impl() -> None:
     """The harness bus is the core EventBusInmemory — never an infra bus."""
     harness, _ = build_workflow(
         workflow="delegation",
-        adapter=RecordedFixtureInferenceAdapter(),
+        adapter=RecordedFixtureInferenceAdapter(completion="OK"),
         store=SqliteProjectionStore(),
     )
     assert isinstance(harness.bus, EventBusInmemory)
@@ -176,12 +179,43 @@ def test_bus_is_core_in_memory_impl() -> None:
 
 
 @pytest.mark.unit
-def test_recorded_fixture_adapter_echoes_prompt_by_default() -> None:
-    """The default fixture adapter is deterministic and offline."""
-    adapter = RecordedFixtureInferenceAdapter()
+def test_recorded_fixture_adapter_replays_recorded_completion_verbatim() -> None:
+    """The fixture adapter replays the recorded completion, never the prompt."""
+    adapter = RecordedFixtureInferenceAdapter(completion="recorded-from-real")
     out = adapter.infer(ModelInferenceRequest(prompt="echo me"))
-    assert out.completion == "[recorded] echo me"
+    assert out.completion == "recorded-from-real"
+    assert "echo me" not in out.completion
     assert out.adapter == "fixture"
+
+
+@pytest.mark.unit
+def test_recorded_fixture_adapter_rejects_empty_completion() -> None:
+    """A blank recorded completion is a false-green stub — construction fails."""
+    for blank in ("", "   "):
+        with pytest.raises(ModelOnexError):
+            RecordedFixtureInferenceAdapter(completion=blank)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("workflow", ["delegation", "sea"])
+def test_cli_fixture_run_fails_without_recorded_completion(workflow: str) -> None:
+    """A fixture run with no recorded completion cannot reach success (OMN-13496).
+
+    The prompt-echo default is gone: ``--inference=fixture`` with no
+    ``--fixture-completion`` must raise rather than report ``success`` on a run
+    that generated nothing. There is no argv that reaches ``terminal_status:
+    success`` without a real or recorded-from-real inference.
+    """
+    with pytest.raises(ModelOnexError):
+        cli_main(
+            [
+                workflow,
+                "--prompt",
+                "generate a COMPUTE node that returns the SHA-256 hex digest",
+                "--inference",
+                "fixture",
+            ]
+        )
 
 
 @pytest.mark.unit
@@ -209,7 +243,7 @@ def test_build_evidence_packet_is_infra_free_and_complete() -> None:
     """The evidence packet carries the infra-free proof fields."""
     correlation_id = uuid4()
     store = SqliteProjectionStore()
-    adapter = RecordedFixtureInferenceAdapter()
+    adapter = RecordedFixtureInferenceAdapter(completion="EVIDENCE")
     result, projection = asyncio.run(
         run_workflow(
             workflow="delegation",


### PR DESCRIPTION
## OMN-13496

The SEA/delegation in-process harness (`omnibase_core.runtime.harness`, OMN-13420) shipped a **false-green stub**: `RecordedFixtureInferenceAdapter` echoed the prompt as `"[recorded] {prompt}"` when no recorded completion was supplied, and `harness_cli`'s `--inference fixture` defaulted to that path. A run of

```
python -m omnibase_core.runtime.harness.harness_cli sea --prompt "generate a COMPUTE node that returns the SHA-256 hex digest of its input"
```

reported `terminal_status: success`, `inference_adapter: "fixture"`, `model: "recorded-fixture"`, `payload.completion: "[recorded] generate a COMPUTE node..."` — i.e. it **generated nothing and reported success.**

### Fix
- `RecordedFixtureInferenceAdapter` now REQUIRES a non-empty completion **recorded from a real model call** (golden-chain replay); the prompt-echo / prompt-derived default is deleted and an empty/blank completion fails fast (`ModelOnexError`). The recorded completion is replayed verbatim — the prompt is never echoed.
- `harness_cli --inference fixture` requires `--fixture-completion`; a fixture run with no recorded completion raises rather than reporting success on nothing. `--inference` / `--fixture-completion` help text no longer advertises a prompt-echo path.
- Tests assert the prompt-echo path is unreachable: verbatim replay (prompt absent from completion), empty-completion rejection, and a CLI `sea`/`delegation` fixture run with no `--fixture-completion` cannot reach `terminal_status: success` (parametrized over both workflows).

### Verification
- `tests/unit/runtime/harness/test_harness_dispatch.py`: 16 passed.
- `tests/unit/runtime/ tests/unit/validation/` subtrees: 4811 passed, 5 skipped.
- ruff format/check + mypy --strict clean on the changed source; pre-commit green.

Evidence-Ticket: OMN-13496
Evidence-Source: 005af32e9c8d5b334fa2335a00c5cefe7524e9ea
