### PR TITLE
chore(OMN-13561): burn down 3 omniintelligence url-authority grandfathered reads (Wave 1)

### DIFF
--- a/src/omnibase_core/validation/baselines/url_authority_baseline.json
+++ b/src/omnibase_core/validation/baselines/url_authority_baseline.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "count": 215,
+  "count": 212,
   "violations": [
     {
       "repo": "omnibase_core",
@@ -793,24 +793,6 @@
       "path": "src/omniintelligence/nodes/node_gmail_intent_evaluator_effect/handlers/handler_gmail_intent_evaluate.py",
       "rule": "env-url-read",
       "fingerprint": "c6bea17f518c4fa901e609e1832a2418d30da2ec74f5a82b5e0c492ae7a4b1f3"
-    },
-    {
-      "repo": "omniintelligence",
-      "path": "src/omniintelligence/nodes/node_navigation_retriever_effect/models/model_navigation_retrieve_input.py",
-      "rule": "env-url-read",
-      "fingerprint": "e75824d1cee782c892e4e2d5eda5435781a3d882f9af612f154ba920eeceba8a"
-    },
-    {
-      "repo": "omniintelligence",
-      "path": "src/omniintelligence/nodes/node_navigation_retriever_effect/node.py",
-      "rule": "env-url-read",
-      "fingerprint": "5aab715e0481642f8385ca89383c29f5a4ddb81edca4c811935ab1be1c4757e7"
-    },
-    {
-      "repo": "omniintelligence",
-      "path": "src/omniintelligence/nodes/node_navigation_retriever_effect/node.py",
-      "rule": "env-url-read",
-      "fingerprint": "b77dd88a1d2a07e33d02357fc6bddef62b52a2f0942f782928d2c0d7c09abb5b"
     },
     {
       "repo": "omniintelligence",


### PR DESCRIPTION
## OMN-13561 — url-authority baseline burn-down for omniintelligence (Wave 1, paired)

Epic **OMN-13556** Wave 1. Paired with omniintelligence PR
`OmniNode-ai/omniintelligence#734` (OMN-13561).

### What this PR does
Shrinks the shared url-authority baseline subset for `omniintelligence` by 3
entries. The three navigation-retriever docstring/Field `os.environ[...]`
endpoint references were removed at source in the paired omniintelligence PR;
the validator's `--update-baseline` (burn-down only) drops their fingerprints.

`src/omnibase_core/validation/baselines/url_authority_baseline.json`:
total `215 → 212`, omniintelligence subset `33 → 30`.

Regenerated deterministically via:
```
uv run python -m omnibase_core.validation.validator_url_authority \
  --update-baseline --repo omniintelligence --repo-root <omniintelligence> \
  --baseline src/omnibase_core/validation/baselines/url_authority_baseline.json
```

### Safety
Baseline is **burn-down only** — the validator's `assert_baseline_shrinks_only`
invariant guarantees it can never grow here. No source/logic change.

### DoD evidence
- Baseline shrinks (3 fewer grandfathered reads); shrink-only invariant holds.
- Net effect is a strict reduction in suppressed url-authority debt.

Evidence-Ticket: OMN-13561



Evidence-Source: a11466a0e0434130c3a61489cc691009c598244e





