### PR TITLE
refactor(OMN-13559): Postgres doctor-probe endpoint resolves via overlay seam (Wave 1 env→overlay)

### DIFF
--- a/src/omnibase_core/doctor/checks/check_postgres.py
+++ b/src/omnibase_core/doctor/checks/check_postgres.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-import os
 import socket
 import time
 
@@ -9,6 +8,9 @@ from omnibase_core.doctor.doctor_check_base import DoctorCheckBase
 from omnibase_core.enums.enum_doctor_category import EnumDoctorCategory
 from omnibase_core.enums.enum_health_status_value import EnumHealthStatusValue
 from omnibase_core.models.doctor.model_doctor_check_result import ModelDoctorCheckResult
+from omnibase_core.models.doctor.model_postgres_probe_config import (
+    ModelPostgresProbeConfig,
+)
 
 
 class CheckPostgres(DoctorCheckBase):
@@ -18,8 +20,12 @@ class CheckPostgres(DoctorCheckBase):
 
     def run(self) -> ModelDoctorCheckResult:
         start = time.monotonic()
-        host = os.environ["POSTGRES_HOST"]
-        port = int(os.environ["POSTGRES_PORT"])
+        # Endpoint resolves via the sanctioned overlay boundary
+        # (${env.POSTGRES_HOST} / ${env.POSTGRES_PORT}), fail-closed — never a
+        # direct os.environ read or localhost default (OMN-13559).
+        probe = ModelPostgresProbeConfig.from_overlay()
+        host = probe.host
+        port = probe.port
         try:
             conn = socket.create_connection((host, port), timeout=3)
             conn.close()

--- a/src/omnibase_core/models/doctor/model_postgres_probe_config.py
+++ b/src/omnibase_core/models/doctor/model_postgres_probe_config.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Overlay-resolved endpoint config for the Postgres doctor probe.
+
+OMN-13559 (Wave 1 endpoint→overlay) — the ``postgres`` doctor check no longer
+reads ``os.environ["POSTGRES_HOST"]`` / ``os.environ["POSTGRES_PORT"]`` directly.
+The probe endpoint resolves through the sanctioned overlay boundary
+(``expand_contract_env_refs`` against the contract references
+``${env.POSTGRES_HOST}`` / ``${env.POSTGRES_PORT}``); a per-lane overlay binds
+those vars to the dev/stability/prod value. Resolution fails closed (raises)
+when the active overlay does not bind them, rather than silently defaulting to
+localhost.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.overlays.contract_env_ref import expand_contract_env_refs
+
+__all__ = ["ModelPostgresProbeConfig"]
+
+# Contract-declared endpoint references. The Postgres host/port for the doctor
+# probe resolve through the sanctioned overlay boundary
+# (``expand_contract_env_refs``, the one core-resident env-reading surface) — a
+# per-lane overlay binds these to the dev/stability/prod value. The check must
+# NOT read ``os.environ`` directly (OMN-13559 endpoint-overlay migration).
+_HOST_CONTRACT_REF = "${env.POSTGRES_HOST}"
+_PORT_CONTRACT_REF = "${env.POSTGRES_PORT}"
+
+
+class ModelPostgresProbeConfig(BaseModel):
+    """Endpoint config for the Postgres doctor probe.
+
+    Construct via :meth:`from_overlay`, which resolves ``host`` / ``port`` from
+    the contract + per-lane overlay through the sanctioned overlay boundary. If
+    the active overlay does not bind ``${env.POSTGRES_HOST}`` /
+    ``${env.POSTGRES_PORT}``, resolution fails closed with a ``ValueError``
+    rather than silently falling back to localhost.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    host: str = Field(
+        default=...,
+        description=(
+            "Postgres host for the doctor probe "
+            "(contract ${env.POSTGRES_HOST}, resolved via overlay)"
+        ),
+    )
+    port: int = Field(
+        default=...,
+        ge=1,
+        le=65535,
+        description=(
+            "Postgres port for the doctor probe "
+            "(contract ${env.POSTGRES_PORT}, resolved via overlay)"
+        ),
+    )
+
+    @classmethod
+    def from_overlay(cls) -> ModelPostgresProbeConfig:
+        """Resolve host/port through the overlay seam — fail closed if unbound.
+
+        The contract declares the endpoint as ``${env.POSTGRES_HOST}`` /
+        ``${env.POSTGRES_PORT}``; the overlay resolver expands each reference
+        against the lane environment. An unset var expands to the empty string,
+        which fails the explicit guards below rather than silently falling back
+        to localhost.
+        """
+        host = expand_contract_env_refs(_HOST_CONTRACT_REF)
+        if not host:
+            raise ValueError(
+                "POSTGRES_HOST is not bound by the active overlay; declare it in "
+                "the per-lane overlay so the contract reference "
+                f"{_HOST_CONTRACT_REF!r} resolves to a Postgres host."
+            )
+        port_str = expand_contract_env_refs(_PORT_CONTRACT_REF)
+        if not port_str:
+            raise ValueError(
+                "POSTGRES_PORT is not bound by the active overlay; declare it in "
+                "the per-lane overlay so the contract reference "
+                f"{_PORT_CONTRACT_REF!r} resolves to a Postgres port."
+            )
+        try:
+            port = int(port_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"POSTGRES_PORT overlay value {port_str!r} is not a valid port integer."
+            ) from exc
+        return cls(host=host, port=port)

--- a/src/omnibase_core/overlays/contract_env_ref.py
+++ b/src/omnibase_core/overlays/contract_env_ref.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Core-resident ``${env.VAR}`` overlay expansion for contract string values.
+
+This is the sanctioned overlay-resolution surface for the ``${env.VAR}`` /
+``${env.VAR:default}`` convention that contract descriptors use to bind a
+lane-specific value (an endpoint host, a port, a connection URI) from the
+operator environment WITHOUT hardcoding the value in source.
+
+``omnibase_core`` owns the resolver authority that every downstream repo imports
+(OMN-13556 / OMN-13559: "core owns the resolver authority every other repo
+imports"). The runtime overlay package in ``omnibase_infra``
+(``omnibase_infra.runtime.overlay.contract_env_ref``) is the infra-layer mirror
+of this surface; core cannot import infra (compat → core → spi → infra layering),
+so the contract-env-ref expansion lives here for any core-resident consumer
+(doctor probes, config models) that must resolve a contract-declared endpoint
+reference without reaching upward into infra.
+
+An unset var with no inline default expands to the empty string, so the caller's
+fail-closed check rejects it (rather than leaving a literal ``${env.…}``
+placeholder, or silently falling back to localhost).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+# ``${env.VAR}`` / ``${env.VAR:default}`` — the same env-overlay convention
+# the infra runtime overlay and node_contract_loader_effect use for endpoints.
+_ENV_REF = re.compile(
+    r"\$\{env\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::(?P<default>[^}]*))?\}"
+)
+
+
+def expand_contract_env_refs(value: str) -> str:
+    """Expand ``${env.VAR}`` / ``${env.VAR:default}`` references in ``value``.
+
+    Resolves each reference from the operator environment; an unset var with no
+    inline default expands to the empty string (so the caller fails closed rather
+    than passing a literal ``${env.…}`` placeholder downstream or defaulting to
+    localhost).
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group("name")
+        default = match.group("default")
+        return os.environ.get(name, default if default is not None else "")
+
+    return _ENV_REF.sub(_sub, value)
+
+
+__all__: list[str] = ["expand_contract_env_refs"]

--- a/tests/test_doctor/test_postgres_probe_overlay_resolution.py
+++ b/tests/test_doctor/test_postgres_probe_overlay_resolution.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolution-equivalence tests for the Postgres-probe overlay migration.
+
+OMN-13559 (Wave 1 endpoint→overlay) — the ``postgres`` doctor check no longer
+reads ``os.environ["POSTGRES_HOST"]`` / ``os.environ["POSTGRES_PORT"]`` directly;
+it resolves the probe endpoint through the sanctioned overlay boundary
+(``expand_contract_env_refs`` against the contract references
+``${env.POSTGRES_HOST}`` / ``${env.POSTGRES_PORT}``).
+
+These tests assert:
+1. The overlay-resolved values equal the values the prior direct env reads gave,
+   for representative dev/stability/prod lane bindings (resolution equivalence).
+2. The model fails closed (raises) when the overlay does not bind the var,
+   rather than silently falling back to localhost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.doctor.model_postgres_probe_config import (
+    ModelPostgresProbeConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+# Representative per-lane (host, port) bindings the existing deployment env
+# injects. Hostnames only (no LAN IP literals — the equivalence assertion is
+# value-agnostic: the overlay must resolve whatever the lane binds, byte-for-byte).
+_LANE_BINDINGS = (
+    ("postgres", "5432"),  # dev (compose service DNS)
+    ("postgres-stability", "25432"),  # stability-test lane host/port
+    ("postgres-prod", "35432"),  # prod lane host/port
+)
+
+
+class TestPostgresProbeOverlayResolution:
+    """Overlay resolution equivalence for POSTGRES_HOST / POSTGRES_PORT."""
+
+    @pytest.mark.parametrize(("lane_host", "lane_port"), _LANE_BINDINGS)
+    def test_overlay_resolves_same_value_as_env_read(
+        self, lane_host: str, lane_port: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The overlay default_factory resolves the exact env-bound endpoint.
+
+        Equivalent to what the prior ``os.environ["POSTGRES_HOST"]`` /
+        ``int(os.environ["POSTGRES_PORT"])`` reads returned — same vars, same
+        values, now via the sanctioned overlay seam.
+        """
+        monkeypatch.setenv("POSTGRES_HOST", lane_host)
+        monkeypatch.setenv("POSTGRES_PORT", lane_port)
+        config = ModelPostgresProbeConfig.from_overlay()
+        assert config.host == lane_host
+        assert config.port == int(lane_port)
+
+    def test_explicit_values_bypass_overlay(self) -> None:
+        """Explicitly constructed host/port do not invoke the overlay resolver."""
+        config = ModelPostgresProbeConfig(host="explicit-host", port=15432)
+        assert config.host == "explicit-host"
+        assert config.port == 15432
+
+    def test_host_fails_closed_when_overlay_unbound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unset host binding fails closed instead of defaulting to localhost."""
+        monkeypatch.delenv("POSTGRES_HOST", raising=False)
+        monkeypatch.setenv("POSTGRES_PORT", "5432")
+        with pytest.raises(ValueError, match="POSTGRES_HOST is not bound"):
+            ModelPostgresProbeConfig.from_overlay()
+
+    def test_port_fails_closed_when_overlay_unbound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unset port binding fails closed instead of defaulting."""
+        monkeypatch.setenv("POSTGRES_HOST", "somehost")
+        monkeypatch.delenv("POSTGRES_PORT", raising=False)
+        with pytest.raises(ValueError, match="POSTGRES_PORT is not bound"):
+            ModelPostgresProbeConfig.from_overlay()
+
+    def test_port_fails_closed_on_non_integer_overlay_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-integer overlay-bound port fails closed with a clear error."""
+        monkeypatch.setenv("POSTGRES_HOST", "somehost")
+        monkeypatch.setenv("POSTGRES_PORT", "not-a-port")
+        with pytest.raises(ValueError, match="not a valid port integer"):
+            ModelPostgresProbeConfig.from_overlay()

--- a/tests/unit/overlays/test_contract_env_ref.py
+++ b/tests/unit/overlays/test_contract_env_ref.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the core-resident ``${env.VAR}`` overlay expander.
+
+OMN-13559 — ``omnibase_core.overlays.contract_env_ref.expand_contract_env_refs``
+is the sanctioned core-resident overlay-resolution surface (the infra-layer
+mirror lives in ``omnibase_infra.runtime.overlay.contract_env_ref``; core cannot
+import infra). These tests pin the contract:
+
+* ``${env.VAR}`` resolves from the operator environment.
+* ``${env.VAR:default}`` uses the inline default when the var is unset.
+* An unset var with no inline default expands to the empty string, so the
+  caller can fail closed rather than receive a literal placeholder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.overlays.contract_env_ref import expand_contract_env_refs
+
+pytestmark = pytest.mark.unit
+
+
+class TestExpandContractEnvRefs:
+    """Behavioral contract for the core overlay env-ref expander."""
+
+    def test_resolves_bound_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMN_TEST_HOST", "db.example")
+        assert expand_contract_env_refs("${env.OMN_TEST_HOST}") == "db.example"
+
+    def test_inline_default_used_when_unbound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OMN_TEST_HOST", raising=False)
+        assert expand_contract_env_refs("${env.OMN_TEST_HOST:fallback}") == "fallback"
+
+    def test_bound_var_overrides_inline_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OMN_TEST_HOST", "real")
+        assert expand_contract_env_refs("${env.OMN_TEST_HOST:fallback}") == "real"
+
+    def test_unbound_no_default_expands_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-closed substrate: caller sees empty string, not a placeholder."""
+        monkeypatch.delenv("OMN_TEST_HOST", raising=False)
+        assert expand_contract_env_refs("${env.OMN_TEST_HOST}") == ""
+
+    def test_embeds_within_surrounding_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OMN_TEST_PORT", "5432")
+        assert (
+            expand_contract_env_refs("host:${env.OMN_TEST_PORT}/db") == "host:5432/db"
+        )
+
+    def test_literal_without_ref_passes_through(self) -> None:
+        assert (
+            expand_contract_env_refs("bolt://memgraph:7687") == "bolt://memgraph:7687"
+        )


### PR DESCRIPTION
## OMN-13559 — Postgres doctor-probe endpoint → overlay seam (epic OMN-13556 Wave 1)

Migrates the first coherent Wave-1 endpoint cluster in omnibase_core off direct `os.environ` reads to the contract+overlay seam, following the proven template (infra#2096 QDRANT_URL, omnimarket#1383 ARCH_GRAPH_BOLT_URI).

### What this PR does
- **`src/omnibase_core/doctor/checks/check_postgres.py`** no longer reads `os.environ["POSTGRES_HOST"]` / `os.environ["POSTGRES_PORT"]` directly. It constructs `ModelPostgresProbeConfig.from_overlay()`.
- **New core-resident sanctioned overlay surface** `src/omnibase_core/overlays/contract_env_ref.py::expand_contract_env_refs` — the core-layer mirror of `omnibase_infra.runtime.overlay.contract_env_ref` (the one sanctioned env-reading boundary). Core owns the resolver authority every downstream repo imports (per OMN-13559); core **cannot** import infra under the `compat→core→spi→infra` layering, so the expander is core-resident.
- **New config model** `src/omnibase_core/models/doctor/model_postgres_probe_config.py` declares the endpoint as contract references `${env.POSTGRES_HOST}` / `${env.POSTGRES_PORT}`, resolved via the overlay expander in `from_overlay()`, **fail-closed** with a `ValueError` when the active overlay does not bind the var — never a silent localhost default.

### Tests (resolution-equivalence + fail-closed)
- `tests/test_doctor/test_postgres_probe_overlay_resolution.py` — overlay resolves the same dev/stability/prod value the prior env read returned (parametrized), explicit-value bypass, and fail-closed on unbound host / unbound port / non-integer port.
- `tests/unit/overlays/test_contract_env_ref.py` — pins the core expander contract (bound var, inline default, override, fail-closed empty-on-unset, embedded refs, literal passthrough).
- Existing `tests/test_doctor/test_checks_services.py` Postgres cases still pass unchanged — they set the env vars and the overlay resolves the same values (integration-level equivalence proof).

### Gates
- `url-authority` PASSED (0 new violations, 0 grandfathered).
- `contract-config-compliance` PASSED.
- `no-env-fallbacks` PASSED on changed files.
- mypy strict clean; ruff clean. No `# url-authority-ok` / `# contract-config-ok` suppression was needed or added (these doctor reads were never grandfathered — they live outside the handler/script scan scope; this is a genuine source-level removal of two `os.environ` endpoint reads, not a baseline shuffle).

### Scope
Coherent subset of the 13 Wave-1 endpoint candidates. Deferred to later w1 increments: KAFKA_BOOTSTRAP_SERVERS (cli/doctor), the `model_database_secure_config` / `model_node_service_config` mega-units, and the `${env_prefix}` dynamic-key constructors. `LLM_*_URL` is Bifrost-owned (OMN-12803/12815) and not touched. Remaining endpoint candidates after this PR: 11.

Evidence-Ticket: OMN-13559

Refs OMN-13559, epic OMN-13556.

Evidence-Source: 6f91de0e61e26b9d568b5b299d18b98359914db3
