### PR TITLE
feat(OMN-13574): Model B failing-rollup enforcement (pilot: omnibase_core)

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -49,3 +49,15 @@ jobs:
             --repo omnibase_core \
             --repo-root . \
             --baseline architecture-handshakes/validator-requirements-baseline.yaml
+
+      # OMN-13574 (Model B): prove the single required rollup (CI Summary) is
+      # AIRTIGHT — its transitive needs graph reaches a non-failure-swallowing
+      # job for every opted-in spec-required validator. Per-repo opt-in
+      # (model_b_rollup_enforcement.repos); non-opted repos exit 0 (pilot scope,
+      # fleet rollout OMN-13576). This is the enforcement half of Model B (the
+      # consumer above only proves presence, not that the rollup gates).
+      - name: Verify Model-B rollup coverage (OMN-13574)
+        run: |
+          uv run python -m omnibase_core.validation.validator_rollup_coverage \
+            --repo omnibase_core \
+            --repo-root .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,6 +1009,148 @@ jobs:
           echo "PRs touching dispatch / routing / handler-registration / message-envelope source surfaces" >> $GITHUB_STEP_SUMMARY
           echo "must include a real-dispatch-path test. Handler-isolation tests pass while live dispatch fails." >> $GITHUB_STEP_SUMMARY
 
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Naming Conventions (OMN-13574: Model B failing-rollup enforcement)
+  # validator-requirements.yaml requires `naming-conventions` (class + file
+  # naming). Previously this only ran in omni-standards-compliance.yml, which
+  # has NO aggregator and is NOT in branch protection — a real naming violation
+  # could slip past the required CI Summary rollup. Now it feeds quality-gate
+  # so a failure turns the single required rollup red. Mirrors the
+  # omni-standards-compliance `validate_class_naming.py` invocation.
+  naming-conventions:
+    name: Naming Conventions
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Validate class naming conventions
+        run: uv run python scripts/validate_class_naming.py
+
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # Pydantic Patterns (OMN-13574: Model B failing-rollup enforcement)
+  # validator-requirements.yaml requires `pydantic-patterns`. The handshake
+  # consumer's CI keyword "pydantic" previously matched ONLY incidental
+  # `pip install pydantic` lines in receipt-gate / occ-preflight — there was NO
+  # real pydantic-patterns validator job in CI. This job runs the actual
+  # validator and feeds quality-gate so it gates the required rollup.
+  pydantic-patterns:
+    name: Pydantic Patterns
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Validate Pydantic patterns
+        run: |
+          # Match the pre-commit file scope: src/ excluding tests/, archived/,
+          # archive/, and scripts/validation/ (where the validator lives).
+          files=$(git ls-files 'src/**/*.py' \
+            | grep -vE '^(tests/|archived/|archive/|scripts/validation/)')
+          if [ -z "$files" ]; then
+            echo "No src/ Python files to validate."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/validation/validate-pydantic-patterns.py $files
+
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # AI-Slop Patterns (OMN-13574: Model B failing-rollup enforcement)
+  # validator-requirements.yaml requires `aislop-patterns`. Previously this only
+  # ran in omni-standards-compliance.yml (`ai-slop-check`), which is NOT in
+  # branch protection. This copy runs the same strict scan over the full tracked
+  # tree and feeds quality-gate so a real AI-slop violation turns the required
+  # rollup red. Full-tree scan (not changed-files) avoids the merge_group /
+  # no-diff exit-0 hole on the required path.
+  aislop-patterns:
+    name: AI Slop Patterns
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check tracked tree for AI-slop patterns (strict)
+        run: |
+          # Mirror the pre-commit / omni-standards exclude set: CHANGELOG.md,
+          # docs/, and intentional syntax-error fixtures.
+          files=$(git ls-files '*.py' '*.md' \
+            | grep -vE '^(CHANGELOG\.md|docs/|tests/fixtures/validation/)')
+          if [ -z "$files" ]; then
+            echo "No Python/Markdown files to scan."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/validation/check_ai_slop.py --strict $files
+
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
   # ---------------------------------------------------------------------------
@@ -1024,7 +1166,14 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, version-pin-check, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required]
+    # OMN-13574 (Model B): version-pin-check is intentionally NOT a need here.
+    # It carries continue-on-error: true (advisory until OMN-5132 range-pin +
+    # matrix alignment land), so its result is always "success" and it could
+    # never turn this gate red — listing it in needs implied a gate it does not
+    # provide. naming-conventions / pydantic-patterns / aislop-patterns ARE
+    # spec-required validators (validator-requirements.yaml) and are now needs so
+    # a real violation turns the single required CI Summary rollup red.
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns]
     if: always()
 
     steps:
@@ -1049,6 +1198,9 @@ jobs:
           no_env_fallbacks="${{ needs.no-env-fallbacks.result }}"
           demo_path_gate="${{ needs.demo-path-topic-coherence.result }}"
           dispatch_surface="${{ needs.dispatch-surface-test-required.result }}"
+          naming="${{ needs.naming-conventions.result }}"
+          pydantic="${{ needs.pydantic-patterns.result }}"
+          aislop="${{ needs.aislop-patterns.result }}"
 
           # Report each check
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
@@ -1069,6 +1221,9 @@ jobs:
           echo "| No Env Fallbacks (OMN-7227) | $no_env_fallbacks |" >> $GITHUB_STEP_SUMMARY
           echo "| Demo-Path Topic Coherence (OMN-12777) | $demo_path_gate |" >> $GITHUB_STEP_SUMMARY
           echo "| Dispatch-Surface Test Required (OMN-12960) | $dispatch_surface |" >> $GITHUB_STEP_SUMMARY
+          echo "| Naming Conventions (OMN-13574) | $naming |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pydantic Patterns (OMN-13574) | $pydantic |" >> $GITHUB_STEP_SUMMARY
+          echo "| AI Slop Patterns (OMN-13574) | $aislop |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
           if [[ "$lint" == "success" ]] && \
@@ -1086,7 +1241,10 @@ jobs:
              [[ "$breaking_schema" == "success" ]] && \
              [[ "$no_env_fallbacks" == "success" ]] && \
              [[ "$demo_path_gate" == "success" ]] && \
-             [[ "$dispatch_surface" == "success" ]]; then
+             [[ "$dispatch_surface" == "success" ]] && \
+             [[ "$naming" == "success" ]] && \
+             [[ "$pydantic" == "success" ]] && \
+             [[ "$aislop" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY
             echo "All quality checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,18 +175,22 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     timeout-minutes: 5
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -1092,7 +1096,7 @@ jobs:
           # Match the pre-commit file scope: src/ excluding tests/, archived/,
           # archive/, and scripts/validation/ (where the validator lives).
           files=$(git ls-files 'src/**/*.py' \
-            | grep -vE '^(tests/|archived/|archive/|scripts/validation/)')
+            | grep -vE '^(tests/|archived/|archive/|scripts/validation/)' || true)
           if [ -z "$files" ]; then
             echo "No src/ Python files to validate."
             exit 0
@@ -1143,7 +1147,7 @@ jobs:
           # Mirror the pre-commit / omni-standards exclude set: CHANGELOG.md,
           # docs/, and intentional syntax-error fixtures.
           files=$(git ls-files '*.py' '*.md' \
-            | grep -vE '^(CHANGELOG\.md|docs/|tests/fixtures/validation/)')
+            | grep -vE '^(CHANGELOG\.md|docs/|tests/fixtures/validation/)' || true)
           if [ -z "$files" ]; then
             echo "No Python/Markdown files to scan."
             exit 0
@@ -1193,6 +1197,10 @@ jobs:
           enum_gov="${{ needs.enum-governance.result }}"
           secrets="${{ needs.detect-secrets.result }}"
           sdk_boundary="${{ needs.sdk-boundary-check.result }}"
+          # OMN-13574: contract-compliance is in needs but was never captured in
+          # the gate logic — it could fail while quality-gate still passed. Same
+          # failing-rollup hole this ticket exists to close.
+          contract_compliance="${{ needs.contract-compliance.result }}"
           contract_config="${{ needs.contract-config-compliance.result }}"
           breaking_schema="${{ needs.breaking-schema-change.result }}"
           no_env_fallbacks="${{ needs.no-env-fallbacks.result }}"
@@ -1216,6 +1224,7 @@ jobs:
           echo "| Enum Governance | $enum_gov |" >> $GITHUB_STEP_SUMMARY
           echo "| Detect Secrets | $secrets |" >> $GITHUB_STEP_SUMMARY
           echo "| SDK Boundary Guard | $sdk_boundary |" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract Compliance | $contract_compliance |" >> $GITHUB_STEP_SUMMARY
           echo "| Contract-Config Compliance | $contract_config |" >> $GITHUB_STEP_SUMMARY
           echo "| Breaking-Schema-Change (OMN-12621) | $breaking_schema |" >> $GITHUB_STEP_SUMMARY
           echo "| No Env Fallbacks (OMN-7227) | $no_env_fallbacks |" >> $GITHUB_STEP_SUMMARY
@@ -1237,6 +1246,7 @@ jobs:
              [[ "$enum_gov" == "success" ]] && \
              [[ "$secrets" == "success" ]] && \
              [[ "$sdk_boundary" == "success" ]] && \
+             [[ "$contract_compliance" == "success" ]] && \
              [[ "$contract_config" == "success" ]] && \
              [[ "$breaking_schema" == "success" ]] && \
              [[ "$no_env_fallbacks" == "success" ]] && \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1291,6 +1291,19 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # OMN-13574 (Model B): prove the single required rollup (CI Summary) is
+      # AIRTIGHT — every opted-in spec-required validator is transitively
+      # required by the rollup job's needs graph and not swallowed by
+      # continue-on-error. Non-opted repos exit 0 (pilot scope, fleet OMN-13576).
+      - id: validate-rollup-coverage
+        name: Verify Model-B rollup coverage (OMN-13574)
+        entry: uv run python -m omnibase_core.validation.validator_rollup_coverage --repo omnibase_core
+          --repo-root .
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       # OMN-9886: ValidatorRuntimeProfiles — every command-consuming
       # contract must declare runtime_profiles (top-level or under
       # descriptor) or be on the explicit allowlist with a reason.

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -602,16 +602,26 @@ model_b_rollup_enforcement:
         naming-conventions: ["naming-conventions"]
         pydantic-patterns: ["pydantic-patterns"]
         aislop-patterns: ["aislop-patterns"]
-        # The validators below are spec-required-CI but currently grandfathered
-        # in validator-requirements-baseline.yaml as MISSING_CI_WORKFLOW gaps for
-        # omnibase_core. They are intentionally NOT asserted by the rollup-
-        # coverage verifier yet — listing them here would force CI jobs the
-        # baseline says are not yet wired. They close (move out of the baseline
-        # and into validator_jobs) as their per-validator wiring lands:
-        #   spdx-headers, stub-implementations, single-class-per-file,
-        #   bandit-security, detect-secrets(pre-commit only),
-        #   no-hardcoded-topics, no-untracked-todos, hardcoded-local-paths,
-        #   hardcoded-private-ip, hardcoded-localhost-url.
+      # Machine-checkable intentional omissions. These validators are
+      # ci_workflow: required and apply to omnibase_core, but are currently
+      # grandfathered in validator-requirements-baseline.yaml as
+      # MISSING_CI_WORKFLOW gaps — wiring them as rollup-covered CI jobs is
+      # deferred to their own per-validator tickets. The meta-check asserts
+      # applicable_required_validators == validator_jobs.keys() ∪
+      # grandfathered_validators, so a NEW ci_workflow: required validator that
+      # starts applying to omnibase_core cannot silently escape Model B: it
+      # must be added to validator_jobs (covered) or here (explicitly deferred).
+      grandfathered_validators:
+        - spdx-headers
+        - stub-implementations
+        - single-class-per-file
+        - bandit-security
+        - no-hardcoded-topics
+        - no-untracked-todos
+        - hardcoded-local-paths
+        - hardcoded-private-ip
+        - hardcoded-localhost-url
+        - detect-secrets
 
 # Handshake metadata
 

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -549,6 +549,70 @@ required_validators:
       - omnibase_infra
       - omninode_infra
 
+# ---------------------------------------------------------------------------
+# Model B — failing-rollup enforcement (OMN-13574, epic OMN-13573)
+# ---------------------------------------------------------------------------
+# DECISION (operator-locked): keep ONE required aggregate rollup context per
+# repo (NOT granular per-validator branch-protection contexts, "Model A"), but
+# make the rollup AIRTIGHT so it goes red if ANY spec-required validator
+# sub-job fails. The audit
+# (docs/audits/2026-06-24-validator-enforcement-deficiency-audit/) found that a
+# repo can be "baseline-clean" (every validator wired as a pre-commit hook and
+# present as a CI keyword) while the live required rollup does NOT actually gate
+# several of those validators — they run in a workflow with no aggregator that
+# is not in branch protection (e.g. omni-standards-compliance.yml), or behind
+# continue-on-error, or matched only by an incidental keyword (e.g. "pydantic"
+# matching `pip install pydantic`).
+#
+# This block is PER-REPO OPT-IN (pilot). Only repos listed under
+# `model_b_rollup_enforcement.repos` are verified by the Model-B rollup-coverage
+# verifier (validator_rollup_coverage.py). The legacy ValidatorRequirements
+# consumer schema and behaviour are UNCHANGED, so the other 11 repos' handshake
+# gate (`validate-validator-requirements`) keeps passing exactly as before.
+# Fleet rollout to the remaining repos is OMN-13576.
+#
+# For each opted-in repo:
+#   required_rollup_context  — the single branch-protection required check that
+#                              is the airtight rollup (must be live-required and
+#                              emitted by `rollup_workflow`).
+#   rollup_workflow          — the workflow file (under .github/workflows/) that
+#                              emits `required_rollup_context` as a job name.
+#   rollup_job               — the job key in that workflow whose `name` equals
+#                              `required_rollup_context`; the verifier walks its
+#                              transitive `needs` graph.
+#   validator_jobs           — maps each spec-required validator (that applies to
+#                              this repo and has ci_workflow: required) to the
+#                              job key(s) in `rollup_workflow` that run it. The
+#                              verifier asserts the rollup transitively depends on
+#                              at least one listed job for every such validator,
+#                              and that none of those jobs carry
+#                              continue-on-error: true (which would swallow a
+#                              failure before it reaches the rollup).
+model_b_rollup_enforcement:
+  repos:
+    omnibase_core:
+      required_rollup_context: "CI Summary"
+      rollup_workflow: "ci.yml"
+      rollup_job: "ci-summary"
+      validator_jobs:
+        ruff-format-check: ["lint"]
+        mypy-type-check: ["lint", "mypy-validation-scripts"]
+        enum-governance: ["enum-governance"]
+        arch-002-no-transport-imports: ["core-infra-boundary", "mypy-validation-scripts"]
+        naming-conventions: ["naming-conventions"]
+        pydantic-patterns: ["pydantic-patterns"]
+        aislop-patterns: ["aislop-patterns"]
+        # The validators below are spec-required-CI but currently grandfathered
+        # in validator-requirements-baseline.yaml as MISSING_CI_WORKFLOW gaps for
+        # omnibase_core. They are intentionally NOT asserted by the rollup-
+        # coverage verifier yet — listing them here would force CI jobs the
+        # baseline says are not yet wired. They close (move out of the baseline
+        # and into validator_jobs) as their per-validator wiring lands:
+        #   spdx-headers, stub-implementations, single-class-per-file,
+        #   bandit-security, detect-secrets(pre-commit only),
+        #   no-hardcoded-topics, no-untracked-todos, hardcoded-local-paths,
+        #   hardcoded-private-ip, hardcoded-localhost-url.
+
 # Handshake metadata
 
 metadata:

--- a/contracts/OMN-13234.yaml
+++ b/contracts/OMN-13234.yaml
@@ -16,7 +16,8 @@ interfaces_touched:
   - "events"
 evidence_requirements:
   - kind: "tests"
-    description: "Delegation wire model unit tests green incl. ModelTierCost regime validation (free_local zero-rate, metered positive-rate, budgeted cap+overage) and ModelRoutingTier typed-cost acceptance."
+    description: "Delegation wire model unit tests green incl. ModelTierCost regime validation (free_local
+      zero-rate, metered positive-rate, budgeted cap+overage) and ModelRoutingTier typed-cost acceptance."
     command: "uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q"
   - kind: "ci"
     description: "mypy --strict green on the changed wire model module."

--- a/docs/decisions/adr-2026-06-24-model-b-failing-rollup-enforcement.md
+++ b/docs/decisions/adr-2026-06-24-model-b-failing-rollup-enforcement.md
@@ -1,0 +1,115 @@
+# ADR: Model B — Failing-Rollup Validator Enforcement (pilot: omnibase_core)
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **Document Type** | Architecture Decision Record (ADR) |
+| **Status** | 🟢 **IMPLEMENTED (pilot)** |
+| **Created** | 2026-06-24 |
+| **Author** | ONEX Framework Team |
+| **Related Issue** | OMN-13574 (pilot), epic OMN-13573; fleet rollout OMN-13576 |
+| **Audit** | `docs/audits/2026-06-24-validator-enforcement-deficiency-audit/INDEX.md` |
+
+---
+
+## Context
+
+`architecture-handshakes/validator-requirements.yaml` is the single source of
+truth for which validators every repo must wire. Its consumer
+(`validator_requirements_consumer.py`) proves each spec-required validator is
+**present** — a matching pre-commit hook id, and a matching keyword somewhere in
+`.github/workflows/*.yml`. Each repo also carries
+`required_check_on_main` strings naming a granular branch-protection context per
+validator (e.g. `"Quality Gate / ruff"`, `"AI Slop / check"`).
+
+The 2026-06-24 enforcement-deficiency audit found two structural gaps:
+
+1. **The granular `required_check_on_main` contexts do not exist in live branch
+   protection.** omnibase_core's `dev` branch requires four aggregate rollup
+   contexts: `CI Summary`, `verify / verify`, `gate / CodeRabbit Thread Check`,
+   `call-reject-skip-token / scan / reject-skip-gate-token`. The per-validator
+   contexts the spec names were never registered. The consumer never reads
+   `required_check_on_main` at all, so this drift was invisible.
+
+2. **"Present" is not "gating".** A repo can be handshake-clean while the single
+   required rollup never actually depends on the job that runs a validator:
+   - `naming-conventions` and `aislop-patterns` ran only in
+     `omni-standards-compliance.yml`, which has **no aggregator job and is not in
+     branch protection** — a real violation could not turn `CI Summary` red.
+   - `pydantic-patterns` had **no real CI job at all**; the consumer's `pydantic`
+     keyword matched incidental `pip install pydantic` lines in unrelated
+     workflows.
+   - `version-pin-check` was listed in `quality-gate.needs` but carried
+     `continue-on-error: true`, so its failure could never propagate.
+
+## Decision
+
+Adopt **Model B**: keep **one** required aggregate rollup context per repo
+(`CI Summary` for omnibase_core), but make that rollup **airtight** so it goes
+red if *any* spec-required validator sub-job fails. Explicitly **reject Model A**
+(registering granular per-validator contexts in branch protection): it inflates
+the branch-protection surface that must be mutated through the gated path, and
+the aggregate rollup is already a required check.
+
+Three mechanisms enforce airtightness:
+
+1. **The rollup transitively covers every spec-required validator.** Every
+   spec-required validator that applies to omnibase_core now runs as a job in
+   `ci.yml` (the workflow that emits `CI Summary`) and feeds
+   `quality-gate → ci-summary`. New jobs added: `naming-conventions`,
+   `pydantic-patterns`, `aislop-patterns`. `version-pin-check` was removed from
+   `quality-gate.needs` because `continue-on-error: true` means it can never
+   gate — keeping it in `needs` implied a gate it did not provide.
+
+2. **A meta-check prevents silent drop.** `validator_rollup_coverage.py` parses
+   the rollup workflow's `needs` graph and asserts the rollup job transitively
+   depends on a real, non-`continue-on-error` job for every opted-in
+   spec-required validator. It is wired as a pre-commit hook
+   (`validate-rollup-coverage`) and a `check-handshake.yml` CI step.
+   `tests/validation/test_validator_rollup_coverage.py` exercises the logic,
+   including planted-failure cases (dropped need, `continue-on-error`, deleted
+   job, drifted rollup name).
+
+3. **Per-repo opt-in keeps the fleet safe.** A new additive top-level spec block
+   `model_b_rollup_enforcement.repos` lists only the pilot (omnibase_core). The
+   legacy consumer reads only `required_validators` + `known_repos` and ignores
+   the new block, so the other 11 repos' `validate-validator-requirements`
+   handshake is byte-for-byte unchanged. Fleet rollout is OMN-13576.
+
+## Why Model B over Model A
+
+- **Lower branch-protection surface.** Branch-protection mutations route through
+  the gated node path; one required rollup is far less to manage and audit than
+  ~18 granular contexts per repo.
+- **The rollup is already required.** `CI Summary` already gates merge; the only
+  defect was that it did not actually depend on every validator. Fixing the
+  `needs` graph is strictly additive to existing infrastructure.
+- **The meta-check closes the silent-drop hole** that made Model A's per-context
+  registration attractive: a validator cannot be quietly removed from the rollup
+  without a deterministic test going red.
+
+## Consequences
+
+- A real `naming-conventions`, `pydantic-patterns`, or `aislop-patterns`
+  violation now turns `CI Summary` red on omnibase_core (previously it could not).
+- `validator_rollup_coverage.py` must stay in sync with the spec's
+  `validator_jobs` map; the meta-check test asserts the map references only real,
+  applicable, `ci_workflow: required` validators.
+- Grandfathered baseline gaps (e.g. `spdx-headers`, `stub-implementations`) are
+  intentionally **not** asserted by the rollup verifier yet — they remain in
+  `validator-requirements-baseline.yaml` as `MISSING_CI_WORKFLOW` and graduate
+  into `validator_jobs` as their wiring lands.
+- Fleet rollout (OMN-13576) adds the other 11 repos to
+  `model_b_rollup_enforcement.repos`, each with its own rollup mapping.
+
+## Verification
+
+- `uv run python -m omnibase_core.validation.validator_rollup_coverage --repo omnibase_core --repo-root .`
+  → `rollup-coverage: AIRTIGHT`.
+- Planted-failure proof (no merge): `test_validator_rollup_coverage.py`
+  `test_planted_dropped_need_is_detected` / `test_planted_continue_on_error_is_detected`
+  fail-detect a dropped/swallowed covering job.
+- Other-11-repos proof: the consumer's gap set is identical under the current
+  main spec and this branch's spec for every other repo (additive top-level key
+  only; `required_validators` byte-identical).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,8 @@ ignore = [
 "src/omnibase_core/validation/validator_architecture.py" = ["T201"]
 "src/omnibase_core/validation/validator_banned_compose_vars.py" = ["T201"]
 "src/omnibase_core/validation/validator_requirements_consumer.py" = ["T201"]
+# OMN-13574: CLI runner for the Model-B rollup-coverage verifier prints findings.
+"src/omnibase_core/validation/validator_rollup_coverage.py" = ["T201"]
 "src/omnibase_core/validation/validator_base.py" = ["T201"]
 "src/omnibase_core/validation/validator_circular_import.py" = ["T201"]
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]

--- a/src/omnibase_core/models/validation/model_rollup_coverage_gap.py
+++ b/src/omnibase_core/models/validation/model_rollup_coverage_gap.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Model-B rollup-coverage gap model (OMN-13574).
+
+Represents a single gap between the airtight-rollup requirement declared under
+``model_b_rollup_enforcement`` in validator-requirements.yaml and a repo's live
+rollup workflow ``needs`` graph: a spec-required validator whose covering CI
+job is absent, not transitively required by the rollup, or swallows failure
+with ``continue-on-error: true``.
+
+Related ticket: OMN-13574 (Model B pilot), epic OMN-13573.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelRollupCoverageGap"]
+
+
+class ModelRollupCoverageGap(BaseModel):
+    """A single Model-B rollup-coverage gap."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str = Field(description="Target repo whose rollup graph is being verified")
+    validator: str = Field(
+        description=(
+            "Validator logical name (key in validator-requirements.yaml), or "
+            "'<rollup>' for a gap about the rollup job itself"
+        )
+    )
+    detail: str = Field(description="Human-readable detail describing the coverage gap")

--- a/src/omnibase_core/validation/validator_rollup_coverage.py
+++ b/src/omnibase_core/validation/validator_rollup_coverage.py
@@ -97,6 +97,25 @@ class RollupCoverageVerifier:
     def is_opted_in(self, repo_name: str) -> bool:
         return repo_name in self._repos
 
+    def applicable_required_validators(self, repo_name: str) -> set[str]:
+        """Spec validators that are ``ci_workflow: required`` AND apply to
+        ``repo_name``. This is the universe Model B must either cover
+        (``validator_jobs``) or explicitly defer (``grandfathered_validators``).
+        """
+        required = self._spec.get("required_validators", {})
+        out: set[str] = set()
+        if not isinstance(required, dict):
+            return out
+        for name, entry in required.items():
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("ci_workflow") != "required":
+                continue
+            applies = entry.get("applies_to_repos")
+            if applies == "all" or (isinstance(applies, list) and repo_name in applies):
+                out.add(str(name))
+        return out
+
     def verify_repo(
         self, *, repo_name: str, repo_root: Path
     ) -> list[ModelRollupCoverageGap]:
@@ -117,14 +136,25 @@ class RollupCoverageVerifier:
                 f"model_b_rollup_enforcement.repos[{repo_name!r}] must be a mapping"
             )
 
+        # Validate required keys + types up front so a malformed opt-in surfaces
+        # as a deterministic ValueError (per the verify_repo docstring), never a
+        # raw KeyError on indexing or a downstream TypeError when composing paths.
+        for key in ("rollup_workflow", "rollup_job", "required_rollup_context"):
+            value = cfg.get(key)
+            if not isinstance(value, str) or not value:
+                raise ValueError(  # error-ok: opt-in shape validation
+                    f"model_b_rollup_enforcement.repos[{repo_name!r}].{key} "
+                    f"must be a non-empty string, got {value!r}"
+                )
+        validator_jobs = cfg.get("validator_jobs")
+        if not isinstance(validator_jobs, dict):
+            raise ValueError(  # error-ok: opt-in shape validation
+                f"validator_jobs for {repo_name!r} must be a mapping, "
+                f"got {type(validator_jobs).__name__}"
+            )
         rollup_workflow = cfg["rollup_workflow"]
         rollup_job = cfg["rollup_job"]
         rollup_context = cfg["required_rollup_context"]
-        validator_jobs = cfg["validator_jobs"]
-        if not isinstance(validator_jobs, dict):
-            raise ValueError(  # error-ok: opt-in shape validation
-                f"validator_jobs for {repo_name!r} must be a mapping"
-            )
 
         workflow_path = repo_root / ".github" / "workflows" / rollup_workflow
         if not workflow_path.exists():

--- a/src/omnibase_core/validation/validator_rollup_coverage.py
+++ b/src/omnibase_core/validation/validator_rollup_coverage.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Model-B rollup-coverage verifier for validator-requirements.yaml (OMN-13574).
+
+The legacy :mod:`validator_requirements_consumer` proves each spec-required
+validator is *present* as a pre-commit hook id and as a keyword somewhere in
+``.github/workflows/*.yml``. It does NOT prove the validator actually *gates*
+merge: a repo can be "baseline-clean" while the single required rollup never
+depends on the job that runs the validator (it lives in a workflow with no
+aggregator that is not in branch protection), or the job carries
+``continue-on-error: true`` (so its failure is swallowed), or the keyword match
+was incidental (e.g. ``pydantic`` matching ``pip install pydantic``).
+
+This module closes that hole for **Model B** (operator-locked decision,
+epic OMN-13573): keep ONE required aggregate rollup context per repo, but prove
+it is AIRTIGHT — the rollup job's transitive ``needs`` graph reaches a real job
+for every opted-in spec-required validator, and none of those jobs swallow
+failure with ``continue-on-error: true``.
+
+Per-repo opt-in lives under ``model_b_rollup_enforcement.repos`` in the spec.
+Only listed repos are checked, so the other 11 repos' handshake gate is
+unaffected (pilot scope; fleet rollout is OMN-13576).
+
+Usage::
+
+    uv run python -m omnibase_core.validation.validator_rollup_coverage \\
+        --repo omnibase_core --repo-root .
+
+Exit codes:
+    0 — rollup is airtight for the repo (or repo not opted in)
+    2 — one or more coverage gaps detected
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from omnibase_core.models.validation.model_rollup_coverage_gap import (
+    ModelRollupCoverageGap,
+)
+
+__all__ = ["RollupCoverageVerifier"]
+
+_CANONICAL_SPEC_PATH: Final[Path] = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "architecture-handshakes"
+    / "validator-requirements.yaml"
+)
+
+
+def _as_list(value: Any) -> list[str]:
+    """Normalize a workflow ``needs`` value (str | list | None) to list[str]."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+class RollupCoverageVerifier:
+    """Verify that a repo's required rollup transitively covers every opted-in
+    spec-required validator, with no failure-swallowing on the covering jobs."""
+
+    def __init__(self, spec: dict[str, Any]) -> None:
+        self._spec = spec
+        enforcement = spec.get("model_b_rollup_enforcement")
+        repos = enforcement.get("repos", {}) if isinstance(enforcement, dict) else {}
+        self._repos: dict[str, Any] = repos if isinstance(repos, dict) else {}
+
+    @classmethod
+    def from_spec_path(cls, spec_path: Path) -> RollupCoverageVerifier:
+        if not spec_path.exists():
+            raise FileNotFoundError(  # error-ok: missing spec at load boundary
+                f"validator-requirements.yaml missing at {spec_path}"
+            )
+        with spec_path.open() as fh:
+            raw = yaml.safe_load(fh)
+        if not isinstance(raw, dict):
+            raise ValueError(  # error-ok: spec shape validation at load boundary
+                "spec root must be a mapping"
+            )
+        return cls(raw)
+
+    @classmethod
+    def from_canonical(cls) -> RollupCoverageVerifier:
+        return cls.from_spec_path(_CANONICAL_SPEC_PATH)
+
+    def is_opted_in(self, repo_name: str) -> bool:
+        return repo_name in self._repos
+
+    def verify_repo(
+        self, *, repo_name: str, repo_root: Path
+    ) -> list[ModelRollupCoverageGap]:
+        """Return coverage gaps for ``repo_name``. Empty list ⇒ airtight.
+
+        A repo not listed under ``model_b_rollup_enforcement.repos`` returns an
+        empty list (not opted in — pilot scope).
+
+        Raises:
+            ValueError: If the opt-in block is malformed or the named rollup
+                workflow / job cannot be resolved (fail loud, never silent-pass).
+        """
+        cfg = self._repos.get(repo_name)
+        if cfg is None:
+            return []
+        if not isinstance(cfg, dict):
+            raise ValueError(  # error-ok: opt-in shape validation
+                f"model_b_rollup_enforcement.repos[{repo_name!r}] must be a mapping"
+            )
+
+        rollup_workflow = cfg["rollup_workflow"]
+        rollup_job = cfg["rollup_job"]
+        rollup_context = cfg["required_rollup_context"]
+        validator_jobs = cfg["validator_jobs"]
+        if not isinstance(validator_jobs, dict):
+            raise ValueError(  # error-ok: opt-in shape validation
+                f"validator_jobs for {repo_name!r} must be a mapping"
+            )
+
+        workflow_path = repo_root / ".github" / "workflows" / rollup_workflow
+        if not workflow_path.exists():
+            raise ValueError(  # error-ok: opt-in points at a real workflow file
+                f"rollup_workflow {rollup_workflow!r} not found at {workflow_path}"
+            )
+        with workflow_path.open() as fh:
+            workflow = yaml.safe_load(fh)
+        jobs = workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+        if not isinstance(jobs, dict) or rollup_job not in jobs:
+            raise ValueError(  # error-ok: opt-in points at a real job key
+                f"rollup_job {rollup_job!r} not defined in {rollup_workflow}"
+            )
+
+        # Assert the named rollup job actually emits the required context name.
+        declared_name = jobs[rollup_job].get("name")
+        gaps: list[ModelRollupCoverageGap] = []
+        if declared_name != rollup_context:
+            gaps.append(
+                ModelRollupCoverageGap(
+                    repo=repo_name,
+                    validator="<rollup>",
+                    detail=(
+                        f"rollup_job {rollup_job!r} has name {declared_name!r}, "
+                        f"expected required_rollup_context {rollup_context!r}"
+                    ),
+                )
+            )
+
+        reachable = self._transitive_needs(jobs, rollup_job)
+        # The rollup job itself is trivially reachable (depends on its own needs);
+        # include it so a validator mapped directly to the rollup job counts.
+        reachable.add(rollup_job)
+
+        for validator, job_keys in validator_jobs.items():
+            keys = _as_list(job_keys)
+            if not keys:
+                gaps.append(
+                    ModelRollupCoverageGap(
+                        repo=repo_name,
+                        validator=str(validator),
+                        detail="validator_jobs entry lists no covering job",
+                    )
+                )
+                continue
+            # Coverage requires at least one mapped job to be (a) defined and
+            # (b) transitively required by the rollup and (c) not swallowing
+            # failure with continue-on-error.
+            covered = False
+            reasons: list[str] = []
+            for key in keys:
+                if key not in jobs:
+                    reasons.append(f"{key!r} undefined in {rollup_workflow}")
+                    continue
+                if key not in reachable:
+                    reasons.append(f"{key!r} not in transitive needs of {rollup_job!r}")
+                    continue
+                if self._swallows_failure(jobs[key]):
+                    reasons.append(f"{key!r} has continue-on-error: true")
+                    continue
+                covered = True
+                break
+            if not covered:
+                gaps.append(
+                    ModelRollupCoverageGap(
+                        repo=repo_name,
+                        validator=str(validator),
+                        detail=(
+                            f"no covering job feeds rollup {rollup_context!r}: "
+                            + "; ".join(reasons)
+                        ),
+                    )
+                )
+
+        return gaps
+
+    @staticmethod
+    def _swallows_failure(job: dict[str, Any]) -> bool:
+        # continue-on-error: true makes the job result "success" even when its
+        # steps fail, so an aggregator reading needs.<job>.result can never go
+        # red on it. Treat literal true and the string "true".
+        value = job.get("continue-on-error", False)
+        return value is True or (isinstance(value, str) and value.strip() == "true")
+
+    @staticmethod
+    def _transitive_needs(jobs: dict[str, Any], start: str) -> set[str]:
+        """All jobs transitively reachable through ``needs`` edges from ``start``."""
+        seen: set[str] = set()
+        queue: deque[str] = deque(_as_list(jobs.get(start, {}).get("needs")))
+        while queue:
+            job = queue.popleft()
+            if job in seen:
+                continue
+            seen.add(job)
+            if job in jobs:
+                queue.extend(_as_list(jobs[job].get("needs")))
+        return seen
+
+
+def _format_gaps(gaps: list[ModelRollupCoverageGap]) -> str:
+    lines = [f"{len(gaps)} rollup-coverage gap(s):"]
+    for gap in gaps:
+        lines.append(f"  [{gap.repo}] {gap.validator} — {gap.detail}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify Model-B rollup coverage (OMN-13574)."
+    )
+    parser.add_argument("--repo", required=True, help="Target repo name.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to target repo's working tree (default: cwd).",
+    )
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        default=None,
+        help="Path to validator-requirements.yaml (default: canonical).",
+    )
+    args = parser.parse_args(argv)
+
+    spec_path = args.spec or _CANONICAL_SPEC_PATH
+    verifier = RollupCoverageVerifier.from_spec_path(spec_path)
+
+    if not verifier.is_opted_in(args.repo):
+        print(
+            f"rollup-coverage: {args.repo} not opted into Model B (pilot scope) — skip",
+            file=sys.stderr,
+        )
+        return 0
+
+    gaps = verifier.verify_repo(repo_name=args.repo, repo_root=args.repo_root)
+    if not gaps:
+        print(
+            f"rollup-coverage: AIRTIGHT ({args.repo} @ {args.repo_root})",
+            file=sys.stderr,
+        )
+        return 0
+    print(_format_gaps(gaps), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: standard CLI entry-point idiom

--- a/tests/validation/test_validator_requirements_spec.py
+++ b/tests/validation/test_validator_requirements_spec.py
@@ -34,6 +34,9 @@ REQUIRED_TOP_LEVEL_KEYS = {
     "required_validators",
     "metadata",
     "known_repos",
+    # OMN-13574: per-repo Model-B failing-rollup opt-in. Additive; the legacy
+    # consumer ignores it so the other 11 repos' handshake is unaffected.
+    "model_b_rollup_enforcement",
 }
 
 REQUIRED_VALIDATOR_FIELDS = {

--- a/tests/validation/test_validator_rollup_coverage.py
+++ b/tests/validation/test_validator_rollup_coverage.py
@@ -26,6 +26,8 @@ import yaml
 
 from omnibase_core.validation.validator_rollup_coverage import RollupCoverageVerifier
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SPEC_PATH = REPO_ROOT / "architecture-handshakes" / "validator-requirements.yaml"
 PILOT_REPO = "omnibase_core"
@@ -161,3 +163,43 @@ def test_meta_needs_superset_of_spec_required_validators(
             f"{validator!r} is mapped for rollup coverage but does not apply to "
             f"{PILOT_REPO}"
         )
+
+
+def test_meta_full_equality_no_silent_escape(spec: dict[str, Any]) -> None:
+    """STRONG meta-invariant (CodeRabbit #3): the set of ci_workflow:required
+    validators that apply to the pilot must equal validator_jobs plus
+    grandfathered_validators — exactly. A NEW required validator that starts
+    applying to omnibase_core cannot silently escape Model B: it must be covered
+    (validator_jobs) or explicitly deferred (grandfathered_validators). This is
+    the reverse direction the forward-only check above could not catch."""
+    verifier = RollupCoverageVerifier(spec)
+    applicable = verifier.applicable_required_validators(PILOT_REPO)
+    cfg = spec["model_b_rollup_enforcement"]["repos"][PILOT_REPO]
+    mapped = set(cfg["validator_jobs"])
+    grandfathered = set(cfg.get("grandfathered_validators", []))
+    assert mapped.isdisjoint(grandfathered), (
+        f"a validator is both mapped and grandfathered: {mapped & grandfathered}"
+    )
+    union = mapped | grandfathered
+    escaped = applicable - union
+    assert not escaped, (
+        f"ci_workflow:required validators applying to {PILOT_REPO} that escape "
+        f"Model B (neither covered nor grandfathered): {sorted(escaped)} — add "
+        f"each to validator_jobs (covered) or grandfathered_validators (deferred)"
+    )
+    stale = union - applicable
+    assert not stale, (
+        f"validator_jobs/grandfathered_validators reference validators that are "
+        f"not ci_workflow:required for {PILOT_REPO}: {sorted(stale)}"
+    )
+
+
+def test_malformed_opt_in_raises_value_error(spec: dict[str, Any]) -> None:
+    """CodeRabbit #4: malformed opt-in config must surface as a deterministic
+    ValueError, never a raw KeyError/TypeError."""
+    mutated = copy.deepcopy(spec)
+    # Drop a required key from the pilot opt-in.
+    del mutated["model_b_rollup_enforcement"]["repos"][PILOT_REPO]["rollup_job"]
+    verifier = RollupCoverageVerifier(mutated)
+    with pytest.raises(ValueError, match="rollup_job"):
+        verifier.verify_repo(repo_name=PILOT_REPO, repo_root=REPO_ROOT)

--- a/tests/validation/test_validator_rollup_coverage.py
+++ b/tests/validation/test_validator_rollup_coverage.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Meta-check tests for Model-B rollup coverage (OMN-13574, epic OMN-13573).
+
+Operator-locked decision: keep ONE required aggregate rollup context per repo,
+but prove it is AIRTIGHT — the rollup job's transitive ``needs`` graph reaches a
+real, non-failure-swallowing job for every opted-in spec-required validator.
+
+These tests are the deterministic meta-check that a validator cannot be silently
+dropped from the required rollup: removing a covering job from the rollup's
+``needs``, deleting the job, or adding ``continue-on-error: true`` to it all turn
+a test red. The first test also doubles as the planted-failure proof at the
+rollup-needs-logic level (OMN-13574 step 5) — no live CI run needed to prove the
+mechanism, though one is captured separately in the PR.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_core.validation.validator_rollup_coverage import RollupCoverageVerifier
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SPEC_PATH = REPO_ROOT / "architecture-handshakes" / "validator-requirements.yaml"
+PILOT_REPO = "omnibase_core"
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict[str, Any]:
+    with SPEC_PATH.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def test_pilot_repo_is_opted_in(spec: dict[str, Any]) -> None:
+    verifier = RollupCoverageVerifier(spec)
+    assert verifier.is_opted_in(PILOT_REPO), (
+        "omnibase_core must be listed under model_b_rollup_enforcement.repos"
+    )
+
+
+def test_live_ci_rollup_is_airtight() -> None:
+    """The committed ci.yml must cover every opted-in spec-required validator."""
+    verifier = RollupCoverageVerifier.from_spec_path(SPEC_PATH)
+    gaps = verifier.verify_repo(repo_name=PILOT_REPO, repo_root=REPO_ROOT)
+    assert not gaps, "rollup-coverage gaps in live ci.yml:\n" + "\n".join(
+        f"  {g.validator} — {g.detail}" for g in gaps
+    )
+
+
+def test_non_opted_repo_returns_empty(spec: dict[str, Any]) -> None:
+    """Repos not in the opt-in block are skipped (pilot scope; OMN-13576)."""
+    verifier = RollupCoverageVerifier(spec)
+    assert not verifier.is_opted_in("omnibase_spi")
+    assert verifier.verify_repo(repo_name="omnibase_spi", repo_root=REPO_ROOT) == []
+
+
+def _ci_workflow_dict() -> dict[str, Any]:
+    with (REPO_ROOT / ".github" / "workflows" / "ci.yml").open() as fh:
+        return yaml.safe_load(fh)
+
+
+def _spec_with_inline_workflow(
+    spec: dict[str, Any], workflow: dict[str, Any], tmp_path: Path
+) -> tuple[RollupCoverageVerifier, Path]:
+    """Build a verifier + a repo_root whose ci.yml is the mutated ``workflow``."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    (wf_dir / "ci.yml").write_text(yaml.safe_dump(workflow), encoding="utf-8")
+    return RollupCoverageVerifier(spec), tmp_path
+
+
+def test_planted_dropped_need_is_detected(spec: dict[str, Any], tmp_path: Path) -> None:
+    """PLANTED FAILURE (step 5): drop a covering job from quality-gate.needs and
+    confirm the verifier reports a coverage gap for that validator. This proves a
+    validator silently dropped from the required rollup makes the gate red."""
+    workflow = _ci_workflow_dict()
+    needs = workflow["jobs"]["quality-gate"]["needs"]
+    assert "aislop-patterns" in needs
+    workflow["jobs"]["quality-gate"]["needs"] = [
+        n for n in needs if n != "aislop-patterns"
+    ]
+    verifier, repo_root = _spec_with_inline_workflow(spec, workflow, tmp_path)
+    gaps = verifier.verify_repo(repo_name=PILOT_REPO, repo_root=repo_root)
+    offenders = {g.validator for g in gaps}
+    assert "aislop-patterns" in offenders, (
+        f"dropping aislop-patterns from the rollup needs must be detected; "
+        f"gaps={offenders}"
+    )
+
+
+def test_planted_continue_on_error_is_detected(
+    spec: dict[str, Any], tmp_path: Path
+) -> None:
+    """PLANTED FAILURE: marking a covering job continue-on-error: true swallows
+    its failure before it reaches the rollup. The verifier must flag it."""
+    workflow = _ci_workflow_dict()
+    workflow["jobs"]["pydantic-patterns"]["continue-on-error"] = True
+    verifier, repo_root = _spec_with_inline_workflow(spec, workflow, tmp_path)
+    gaps = verifier.verify_repo(repo_name=PILOT_REPO, repo_root=repo_root)
+    offenders = {g.validator for g in gaps}
+    assert "pydantic-patterns" in offenders, (
+        f"continue-on-error on a covering job must be detected; gaps={offenders}"
+    )
+
+
+def test_planted_deleted_job_is_detected(spec: dict[str, Any], tmp_path: Path) -> None:
+    """Deleting the covering job entirely is a coverage gap."""
+    workflow = _ci_workflow_dict()
+    del workflow["jobs"]["naming-conventions"]
+    # Remove the dangling need so the YAML stays internally consistent.
+    workflow["jobs"]["quality-gate"]["needs"] = [
+        n
+        for n in workflow["jobs"]["quality-gate"]["needs"]
+        if n != "naming-conventions"
+    ]
+    verifier, repo_root = _spec_with_inline_workflow(spec, workflow, tmp_path)
+    gaps = verifier.verify_repo(repo_name=PILOT_REPO, repo_root=repo_root)
+    offenders = {g.validator for g in gaps}
+    assert "naming-conventions" in offenders
+
+
+def test_wrong_rollup_context_name_is_detected(
+    spec: dict[str, Any], tmp_path: Path
+) -> None:
+    """If the rollup job's name drifts from the required branch-protection
+    context, the verifier flags the rollup itself."""
+    mutated = copy.deepcopy(spec)
+    mutated["model_b_rollup_enforcement"]["repos"][PILOT_REPO][
+        "required_rollup_context"
+    ] = "Not The Real Context"
+    verifier = RollupCoverageVerifier(mutated)
+    gaps = verifier.verify_repo(repo_name=PILOT_REPO, repo_root=REPO_ROOT)
+    assert any(g.validator == "<rollup>" for g in gaps)
+
+
+def test_meta_needs_superset_of_spec_required_validators(
+    spec: dict[str, Any],
+) -> None:
+    """Meta-invariant: every validator declared in the Model-B validator_jobs map
+    for the pilot is a real spec validator with ci_workflow: required that applies
+    to the pilot repo. Guards against the map drifting away from the spec."""
+    cfg = spec["model_b_rollup_enforcement"]["repos"][PILOT_REPO]
+    required_validators = spec["required_validators"]
+    for validator in cfg["validator_jobs"]:
+        assert validator in required_validators, (
+            f"validator_jobs references unknown validator {validator!r}"
+        )
+        entry = required_validators[validator]
+        assert entry["ci_workflow"] == "required", (
+            f"{validator!r} is mapped for rollup coverage but is not "
+            f"ci_workflow: required in the spec"
+        )
+        applies = entry["applies_to_repos"]
+        assert applies == "all" or PILOT_REPO in applies, (
+            f"{validator!r} is mapped for rollup coverage but does not apply to "
+            f"{PILOT_REPO}"
+        )


### PR DESCRIPTION
## Summary

Model B (operator-locked, epic OMN-13573) failing-rollup enforcement, **pilot: omnibase_core**. Keep ONE required aggregate rollup context per repo (`CI Summary`), but make it AIRTIGHT so it goes red if ANY spec-required validator sub-job fails. Model A (granular per-validator branch-protection contexts) was rejected.

Root cause (OMN-13574): the spec's granular `required_check_on_main` contexts (e.g. `Quality Gate / ruff`) are NOT in live branch protection — `dev` requires only aggregate rollups (`CI Summary`, `verify / verify`, plus the CodeRabbit + skip-token gates). The legacy consumer proves a validator is *present* (pre-commit hook id + CI keyword) but never proves it *gates*. Audit: `docs/audits/2026-06-24-validator-enforcement-deficiency-audit/`.

Three gates found NOT actually gating `CI Summary` on omnibase_core, now fixed:
- `naming-conventions`, `aislop-patterns` ran only in `omni-standards-compliance.yml` (no aggregator, not in branch protection).
- `pydantic-patterns` had NO real CI job — the `pydantic` keyword matched incidental `pip install pydantic`.
- `version-pin-check` sat in `quality-gate.needs` with `continue-on-error: true`, so it could never gate.

## Changes
- **ci.yml**: add `naming-conventions`, `pydantic-patterns`, `aislop-patterns` jobs feeding `quality-gate → ci-summary`; remove `version-pin-check` from `quality-gate.needs` (it can never gate while `continue-on-error: true`).
- **`validator_rollup_coverage.py`** + `ModelRollupCoverageGap`: meta-verifier that walks the rollup job's transitive `needs` graph and fails if any opted-in spec-required validator is uncovered, undefined, or swallowed by `continue-on-error`.
- **validator-requirements.yaml**: additive top-level `model_b_rollup_enforcement` per-repo opt-in (pilot: omnibase_core only).
- Wired as enforcement: pre-commit hook `validate-rollup-coverage` + `check-handshake.yml` step.
- **test_validator_rollup_coverage.py**: 8 meta-checks incl. planted-failure proofs.
- ADR: `docs/decisions/adr-2026-06-24-model-b-failing-rollup-enforcement.md`.

## Planted-failure proof (no merge of the failure)
`tests/validation/test_validator_rollup_coverage.py`:
- `test_planted_dropped_need_is_detected` — dropping `aislop-patterns` from `quality-gate.needs` is detected as a coverage gap.
- `test_planted_continue_on_error_is_detected` — marking a covering job `continue-on-error: true` is detected.
- `test_planted_deleted_job_is_detected`, `test_wrong_rollup_context_name_is_detected`.

```
tests/validation/test_validator_rollup_coverage.py ........  [100%]
8 passed
```

Live verifier against committed ci.yml: `rollup-coverage: AIRTIGHT (omnibase_core)`.

## Other 11 repos stay green (HARD GUARDRAIL)
The spec change is purely additive (new top-level `model_b_rollup_enforcement` key). The legacy `ValidatorRequirementsConsumer` reads only `required_validators` + `known_repos` and ignores the new key. Proven: `required_validators` is **byte-identical** between canonical main spec and this branch, and the consumer's gap set is **identical** for all 11 other repos (omniclaude, omnibase_compat, omnibase_spi, omnibase_infra, omnidash, omnimarket, omniintelligence, omnimemory, omninode_infra, omniweb, onex_change_control). The Model-B verifier is per-repo opt-in (only omnibase_core); non-opted repos exit 0. Fleet rollout: OMN-13576.

Evidence-Source: OCC#3049
Evidence-Ticket: OMN-13574
