### PR TITLE
ci(OMN-13328): give core receipt-honesty a unique job id so it can be a required status check

### DIFF
--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -1,9 +1,16 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 ---
-# Receipt-Honesty Gate [OMN-12791 validator / OMN-12825 CI wiring]
+# Receipt-Honesty Gate [OMN-12791 validator / OMN-12825 CI wiring / OMN-13328 unique job id]
 #
-# Required status check context: "Receipt Honesty / validate"
+# Required status check context: "receipt-honesty"
+#
+# The job id/name is deliberately unique ("receipt-honesty"), NOT the shared
+# "validate" used by core's other validator workflows. GitHub surfaces the
+# check-run context as the bare job name, so a shared "validate" name collides
+# across 14 unrelated core workflows and cannot be made a required status check
+# without forcing all 14. A unique job id yields a unique, safely-requirable
+# context (OMN-13328).
 #
 # Runs the receipt-honesty validator unit tests (proves the validator is
 # importable and behaving on the runner), then scans any in-repo DoD receipt
@@ -36,8 +43,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: validate
+  receipt-honesty:
+    name: receipt-honesty
     runs-on: >-
       ${{
         github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

Make core's `receipt-honesty` workflow's check-run context unique so it can be made a REQUIRED status check on `dev` (closing the OMN-13328 core blocker). The 3 other receipt-producing repos (omnibase_infra, omniclaude, omnimarket) were already flipped; core was DEFERRED because its context collides.

OMN-13328 (epic OMN-13325, related OMN-12649).

## Root cause

`receipt-honesty` was built because agents game receipts (PASS-with-PENDING, fake `verifier=user`), yet it was required nowhere. The core flip was blocked because the workflow used job `name: validate`. GitHub surfaces the check-run context as the bare **job name**, and `validate` is shared by 14 unrelated core validator workflows — confirmed `11x validate` check-runs on a single core dev HEAD SHA. Requiring `validate` would force all 14 jobs (and is not specific to receipt-honesty), so the context could not be safely made required.

## Change

- `.github/workflows/receipt-honesty.yml`: rename the job id and `name` from `validate` to `receipt-honesty`, yielding the unique check-run context `receipt-honesty`. Updated the documenting header comment to record the rationale.

No behavior change to the gate itself (same validator unit tests + `drift/dod_receipts/` scan). No cross-workflow `needs:` references this job, and the pre-commit hook id (`check-receipt-honesty`) is independent of the job name, so the rename is isolated.

## Follow-up (separate, serial, additive)

After this PR merges and `receipt-honesty` runs green on a `merge_group` SHA, the branch-protection flip on core `dev` adds the `receipt-honesty` context to `required_status_checks` — verify-each, additive-only. This is the operator-gated branch-protection step; it cannot run until the renamed context exists on a merged SHA.

## Evidence

OMN-13328 contract: onex_change_control `contracts/OMN-13328.yaml`.

Evidence-Source: OCC#3085
Evidence-Ticket: OMN-13328
