### PR TITLE
feat(OMN-13411): release-identity gate for omnibase_core — block src/** merged onto a published version

### DIFF
--- a/.github/workflows/validator-release-identity.yml
+++ b/.github/workflows/validator-release-identity.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Release-identity gate [OMN-13411]
+#
+# Required status check context: "Release Identity Validator / validate"
+#
+# Blocks merging a packaged-source change (src/**) onto an already-published
+# version string. omnibase_core is a published PyPI package that downstream repos
+# pin and `uv sync` against; if src/ changes but project.version is NOT bumped
+# past the latest published tag, two distinct code states ship under one wheel
+# version. That is the literal meta-root-cause behind OMN-13402 (A3) / OMN-13405
+# (A6): core dev HEAD carried unreleased modules while still labelled 0.45.0 (==
+# the published wheel that lacked them), and a workspace build crash-looped on the
+# missing import because the version string could not disambiguate the two states.
+#
+# This is the omnibase_core port of the omnibase_infra release-identity gate
+# (OMN-13412, scripts/check_release_identity.py). Same blocking direction, same
+# src/**-only enforcement, same docs/tests/CI exemption.
+
+name: Release Identity Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-release-identity-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # Full history + tags so the gate can resolve the latest published tag
+          # and diff against the PR base.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run release-identity unit tests
+        run: |
+          uv run pytest tests/scripts/test_check_release_identity.py -v
+
+      - name: No code merged onto a published version without a bump
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.ref || 'dev' }}"
+          git fetch --quiet origin "${BASE}" || true
+          uv run python scripts/check_release_identity.py --base "origin/${BASE}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1262,6 +1262,22 @@ repos:
           - no:testmon
         stages: [pre-push]
 
+      # Release-Identity Gate (OMN-13411)
+      # Blocks merging a packaged-source (src/**) change onto an already-published
+      # version string. omnibase_core is a published PyPI package; if src/ changes
+      # but project.version is NOT bumped past the latest published tag, two code
+      # states ship under one wheel version (the OMN-13402/OMN-13405 crash). Port
+      # of the omnibase_infra release-identity gate (OMN-13412). The script does
+      # its own diff/tag resolution; pass_filenames=false because it inspects the
+      # whole worktree, not a per-file list.
+      - id: check-release-identity
+        name: No code merged onto a published version without a bump (OMN-13411)
+        entry: uv run python scripts/check_release_identity.py
+        language: system
+        files: ^(src/.*\.py|pyproject\.toml)$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # Enum Governance Validation (OMN-1313)
       # Enforces enum governance rules to prevent enum/status duplication:
       # - E001: Enum members must use UPPER_SNAKE_CASE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,6 +394,7 @@ ignore = [
 "scripts/emit_ts_types.py" = ["T201"]  # CLI output for omnidash-v2 TS type generation
 "scripts/validate_deterministic_skill_routing.py" = ["T201"]  # CLI output for CI gate report
 "scripts/migrate_dod_receipts.py" = ["T201"]  # CLI output for legacy DoD receipt migration [OMN-9790]
+"scripts/check_release_identity.py" = ["T201"]  # CLI output for release-identity gate report [OMN-13411]
 "scripts/validation/validate_no_new_env_vars.py" = ["T201"]  # CLI output for pre-commit hook report (OMN-11186)
 # Test files: print() used for debug output and test diagnostics — bulk removal deferred
 "tests/**/*.py" = ["T201"]

--- a/scripts/check_release_identity.py
+++ b/scripts/check_release_identity.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Release-identity gate: no importable-surface change merges onto a published
+version without a bump (OMN-13411).
+
+omnibase_core is a published PyPI package that downstream repos (omnibase_infra,
+omnimarket, ...) pin and ``uv sync`` against. If packaged source under ``src/``
+changes but ``pyproject.toml``'s ``project.version`` is NOT bumped past the most
+recently *published* version (the latest ``vX.Y.Z`` git tag), then two distinct
+code states ship under the SAME version string.
+
+This is the literal meta-root-cause behind OMN-13402 (A3) / OMN-13405 (A6): core
+dev HEAD carried unreleased modules (e.g. ``enum_correction_failure_axis``,
+OMN-13234) while still labelled 0.45.0 — the same version as the published wheel
+that LACKS them. A workspace build installed the released enum-LESS wheel and
+crash-looped on the missing import, because the version string could not
+distinguish the two code states. The sibling repo omnibase_infra closed the same
+gap with its own ``check_release_identity.py`` (OMN-13412); this is the
+omnibase_core port that this ticket (OMN-13411) requires.
+
+What it enforces
+----------------
+When the diff under inspection touches packaged source (``src/**``) AND any
+published tag exists, ``pyproject.toml``'s ``project.version`` MUST be strictly
+greater than the highest published version (latest ``v*`` / bare-semver tag).
+
+A docs-only / tests-only / CI-only diff (no ``src/**`` change) is exempt: the
+published wheel is unaffected, so no bump is required.
+
+Modes
+-----
+* ``--base <ref>``    Compare the working tree against ``<ref>`` (e.g. ``origin/dev``)
+                      to decide whether packaged source changed. CI passes the PR
+                      base. If omitted, the gate assumes source MAY have changed
+                      and always enforces the version-ahead invariant.
+* ``--changed-file``  Explicit changed-file list (repeatable / newline list on
+                      stdin via ``-``). Overrides ``--base`` diffing.
+
+Usage::
+
+    uv run python scripts/check_release_identity.py --base origin/dev
+    uv run python scripts/check_release_identity.py   # strict: always require ahead
+
+Exit codes:
+    0 — version is correctly ahead of the latest published tag (or exempt diff)
+    1 — packaged source changed without bumping past the latest published version
+    2 — configuration error (no pyproject version, malformed version/tag)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+# Packaged-source prefixes whose change requires a version bump.
+_PACKAGED_PREFIXES = ("src/",)
+
+
+def _read_pyproject_version() -> Version:
+    with _PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    raw = data.get("project", {}).get("version")
+    if not raw:
+        raise ValueError(f"no project.version in {_PYPROJECT}")
+    try:
+        return Version(str(raw))
+    except InvalidVersion as exc:
+        raise ValueError(f"malformed project.version {raw!r}: {exc}") from exc
+
+
+def _git(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+
+
+def _latest_published_version() -> Version | None:
+    """Return the highest published semver tag, or None if there are no tags."""
+    out = _git(["tag", "--list"])
+    if not out:
+        return None
+    best: Version | None = None
+    for line in out.splitlines():
+        tag = line.strip()
+        candidate = tag[1:] if tag.startswith("v") else tag
+        try:
+            ver = Version(candidate)
+        except InvalidVersion:
+            continue
+        if best is None or ver > best:
+            best = ver
+    return best
+
+
+def _packaged_source_changed(base: str | None, explicit: list[str]) -> bool:
+    """Decide whether packaged source changed relative to base / explicit list."""
+    if explicit:
+        files = explicit
+    elif base:
+        diff = _git(["diff", "--name-only", f"{base}...HEAD"])
+        files = [f for f in diff.splitlines() if f.strip()]
+        if not files:
+            # Fall back to a two-dot diff if the merge-base form yielded nothing.
+            diff = _git(["diff", "--name-only", base])
+            files = [f for f in diff.splitlines() if f.strip()]
+    else:
+        # No base and no explicit list: cannot prove the diff is exempt — enforce.
+        return True
+    return any(f.startswith(prefix) for f in files for prefix in _PACKAGED_PREFIXES)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Git ref to diff against (e.g. origin/dev) to detect src/ changes.",
+    )
+    parser.add_argument(
+        "--changed-file",
+        dest="changed_files",
+        action="append",
+        default=[],
+        help="Explicit changed file (repeatable). Overrides --base diffing.",
+    )
+    args = parser.parse_args(argv)
+
+    explicit = list(args.changed_files)
+    if explicit == ["-"]:
+        explicit = [ln.strip() for ln in sys.stdin.read().splitlines() if ln.strip()]
+
+    try:
+        pyproject_version = _read_pyproject_version()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    latest = _latest_published_version()
+    if latest is None:
+        print("OK: no published tag yet — release-identity bump not required.")
+        return 0
+
+    changed = _packaged_source_changed(args.base, explicit)
+    if not changed:
+        print(
+            "OK: no packaged src/** change in this diff — version bump not required "
+            f"(pyproject {pyproject_version}, latest published {latest})."
+        )
+        return 0
+
+    if pyproject_version > latest:
+        print(f"OK: version {pyproject_version} is ahead of latest published {latest}.")
+        return 0
+
+    print(
+        "FAIL: packaged source changed but pyproject version "
+        f"{pyproject_version} is NOT ahead of the latest published version "
+        f"{latest} (OMN-13411 release-identity gate).",
+        file=sys.stderr,
+    )
+    print(
+        "Merging code consumers import onto an already-published version aliases "
+        "two code states under one wheel version. Bump project.version in "
+        f"pyproject.toml past {latest} (e.g. "
+        f"{Version(f'{latest.major}.{latest.minor}.{latest.micro + 1}')}).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -117,16 +117,22 @@ def test_explicit_changed_file_overrides_base(mod, monkeypatch):
 def test_live_invocation_smoke():
     """Real subprocess run against the actual repo must succeed (version ahead).
 
-    The worktree pyproject is ahead of the latest published tag, so a real run
-    with no --base (strict mode) must exit 0 — proving the script is importable
-    and wired correctly end to end.
+    The subprocess sees a local published-version tag regardless of checkout tag
+    depth, so the strict-mode run proves the script is importable and wired
+    correctly end to end.
     """
-    result = subprocess.run(
-        ["python", str(_SCRIPT)],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=_SCRIPT.resolve().parents[1],
-    )
-    assert result.returncode == 0, result.stderr
-    assert "ahead of latest published" in result.stdout
+    repo = _SCRIPT.resolve().parents[1]
+    smoke_tag = "v0.45.999999"
+    subprocess.run(["git", "tag", "-f", smoke_tag, "HEAD"], cwd=repo, check=True)
+    try:
+        result = subprocess.run(
+            ["python", str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ahead of latest published" in result.stdout
+    finally:
+        subprocess.run(["git", "tag", "-d", smoke_tag], cwd=repo, check=False)

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the release-identity gate (OMN-13411).
+
+The gate forbids merging a packaged-source change onto an already-published
+version string. It is the omnibase_core port of the omnibase_infra release
+identity gate (OMN-13412) and the recurrence guard for the OMN-13402/OMN-13405
+"unreleased code on a published version" crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_release_identity.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_release_identity", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+@pytest.mark.unit
+def test_passes_when_version_ahead_of_published(mod, monkeypatch):
+    """src/** changed, but the version is strictly ahead — gate passes."""
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.46.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_packaged_source_changed", lambda base, explicit: True)
+    assert mod.main(["--base", "origin/dev"]) == 0
+
+
+@pytest.mark.unit
+def test_fails_when_src_changed_and_version_equals_published(mod, monkeypatch):
+    """src/** changed and the version equals the published wheel — gate FAILS.
+
+    This is the literal OMN-13405 footgun: core dev HEAD carried unreleased
+    modules while still labelled 0.45.0 (== the published wheel).
+    """
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_packaged_source_changed", lambda base, explicit: True)
+    assert mod.main(["--base", "origin/dev"]) == 1
+
+
+@pytest.mark.unit
+def test_fails_when_src_changed_and_version_behind_published(mod, monkeypatch):
+    """A version BEHIND the latest published tag is also a fail."""
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.44.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_packaged_source_changed", lambda base, explicit: True)
+    assert mod.main(["--base", "origin/dev"]) == 1
+
+
+@pytest.mark.unit
+def test_exempt_when_no_packaged_source_changed(mod, monkeypatch):
+    """A docs/tests/CI-only diff is exempt — the published wheel is unaffected."""
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_packaged_source_changed", lambda base, explicit: False)
+    assert mod.main(["--base", "origin/dev"]) == 0
+
+
+@pytest.mark.unit
+def test_passes_when_no_published_tag_yet(mod, monkeypatch):
+    """A repo with no published tags cannot alias a published version."""
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.1.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: None)
+    assert mod.main(["--base", "origin/dev"]) == 0
+
+
+@pytest.mark.unit
+def test_config_error_on_missing_version(mod, monkeypatch):
+    """A missing project.version is a config error (exit 2), not a pass."""
+
+    def _raise():
+        raise ValueError("no project.version")
+
+    monkeypatch.setattr(mod, "_read_pyproject_version", _raise)
+    assert mod.main(["--base", "origin/dev"]) == 2
+
+
+@pytest.mark.unit
+def test_packaged_source_changed_detects_src_prefix(mod):
+    """The src/ prefix triggers the bump requirement; non-src does not."""
+    assert mod._packaged_source_changed(None, ["src/omnibase_core/enums/enum_x.py"])
+    assert not mod._packaged_source_changed(
+        None, ["docs/foo.md", "tests/test_x.py", ".github/workflows/ci.yml"]
+    )
+
+
+@pytest.mark.unit
+def test_explicit_changed_file_overrides_base(mod, monkeypatch):
+    """An explicit --changed-file list bypasses git diffing entirely."""
+    monkeypatch.setattr(mod, "_read_pyproject_version", lambda: Version("0.45.0"))
+    monkeypatch.setattr(mod, "_latest_published_version", lambda: Version("0.45.0"))
+    # Explicit src file => changed => must be ahead => fails at 0.45.0.
+    assert mod.main(["--changed-file", "src/omnibase_core/foo.py"]) == 1
+    # Explicit docs file => not changed => exempt => passes.
+    assert mod.main(["--changed-file", "docs/foo.md"]) == 0
+
+
+@pytest.mark.unit
+def test_live_invocation_smoke():
+    """Real subprocess run against the actual repo must succeed (version ahead).
+
+    The worktree pyproject is ahead of the latest published tag, so a real run
+    with no --base (strict mode) must exit 0 — proving the script is importable
+    and wired correctly end to end.
+    """
+    result = subprocess.run(
+        ["python", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_SCRIPT.resolve().parents[1],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ahead of latest published" in result.stdout


### PR DESCRIPTION
## OMN-13411 — Release-identity gate for omnibase_core

Blocks merging a packaged-source (`src/**`) change onto an already-published version string. omnibase_core is a published PyPI package that downstream repos (omnibase_infra, omnimarket, ...) pin and `uv sync` against.

### Why
This is the literal meta-root-cause behind **OMN-13402** (A3) / **OMN-13405** (A6): omnibase_core dev HEAD carried unreleased modules (e.g. `enum_correction_failure_axis`, OMN-13234) while still labelled `0.45.0` — the same version as the published wheel that LACKED them. A workspace build installed the released enum-LESS wheel and crash-looped on the missing import, because the version string could not disambiguate the two code states.

The sibling repo omnibase_infra closed the same gap with its own `check_release_identity.py` (OMN-13412, PR #2067). This is the omnibase_core port that OMN-13411 requires.

### What
- `scripts/check_release_identity.py` — fails (exit 1) when packaged `src/**` changed since the PR base AND `project.version` is NOT strictly ahead of the latest published `v*` tag. Docs/tests/CI-only diffs are exempt; no-tag repos pass; missing version is a config error (exit 2).
- `tests/scripts/test_check_release_identity.py` — 9 cases: ahead-passes, equals-fails (the OMN-13405 footgun), behind-fails, exempt-diff, no-tag, config-error, src-prefix detection, explicit-changed-file override, and a live subprocess smoke test.
- `.github/workflows/validator-release-identity.yml` — standalone validator CI (runs the unit suite + the gate against `origin/<base>`), matching the 14 existing `validator-*.yml` workflows.
- `.pre-commit-config.yaml` — `check-release-identity` hook (pre-commit stage).
- `pyproject.toml` — T201 per-file-ignore for the CLI script (repo convention).

Making the workflow a **branch-protection-required** context is the deferred serial flip (additive, verify-on-merge_group-first), per the no-reflexive-live-mutation rule. The validator runs on every PR now; only the GitHub branch-protection registration is deferred.

### dod_evidence
- `uv run pytest tests/scripts/test_check_release_identity.py -q` → 9 passed
- `uv run ruff check` + `uv run mypy --strict scripts/check_release_identity.py` → clean
- `uv run pre-commit run --files ...` → all hooks pass incl. the new `check-release-identity` gate, `Verify Model-B rollup coverage (OMN-13574)`, `Enforce validator-requirements.yaml (OMN-9115)`
- Manual: src change @ equal version → exit 1; `0.46.0 > 0.45.0` strict → exit 0
- Head commit: `05de8fb9d903260c4fbd5aec3cb162df408775b2`

OCC receipt PR (Evidence-Source + Evidence-Ticket): onex_change_control — paired separately.

Evidence-Source: OCC#3086
Evidence-Ticket: OMN-13411