### PR TITLE
ci(OMN-13330): give core runtime-profiles a unique job id so it can be required

### DIFF
--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -1,10 +1,17 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 ---
-# Runtime Profiles — ValidatorRuntimeProfiles gate [OMN-9886]
+# Runtime Profiles — ValidatorRuntimeProfiles gate [OMN-9886 / OMN-13330 unique job id]
 #
 # Canonical CI gate for `omnibase_core.validation.validator_runtime_profiles`.
-# Required status check context: "Runtime Profiles / validate".
+# Required status check context: "runtime-profiles".
+#
+# The job id/name is deliberately unique ("runtime-profiles"), NOT the shared
+# "validate" used by core's other validator workflows. GitHub surfaces the
+# check-run context as the bare job name, so a shared "validate" name collides
+# across 14 unrelated core workflows and cannot be made a required status check
+# without forcing all 14. A unique job id yields a unique, safely-requirable
+# context so this gate can be flipped REQUIRED (OMN-13330).
 #
 # Plan: docs/plans/2026-04-26-runtime-lifecycle-hardening-plan.md (Task 4,
 # Wave 1 core enforcement).
@@ -13,9 +20,9 @@
 #   1. unit pytest for the validator (regression guard)
 #   2. self-scan of omnibase_core's own contract.yaml files; must exit 0
 #
-# Consumer repos (omnimarket, omnibase_infra) wire this by adding the
-# validate-runtime-profiles hook entry to their own .pre-commit-config.yaml
-# and mirroring the `validate` job in their own CI.
+# Consumer repos (omnimarket, omnibase_infra, omniclaude) wire this by adding
+# the validate-runtime-profiles hook entry to their own .pre-commit-config.yaml
+# and mirroring the `runtime-profiles` job in their own CI.
 
 name: Runtime Profiles
 
@@ -36,8 +43,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: validate
+  runtime-profiles:
+    name: runtime-profiles
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
       ${{


### PR DESCRIPTION
## Summary

Give core's `validator-runtime-profiles` workflow a unique check-run context so it can be made a REQUIRED status check on `dev` — the unblock prerequisite for OMN-13330 (epic, related OMN-9048). Partial: core pilot (the validator lives in core and self-scans core's own contracts).

## Root cause / verify-first findings

`validator-runtime-profiles` is required in **0** of the 4 repos that have it (core/infra/omniclaude/omnimarket), confirmed via `gh api .../required_status_checks/contexts` on every dev branch. The flip is blocked by the same collision fixed for receipt-honesty in OMN-13328: the workflow used job `name: validate`, which GitHub surfaces as the bare context `validate` — shared by 14 core validator workflows (11x `validate` on a single dev SHA). Requiring `validate` would force all 14 jobs.

Two of the ticket's original targets are no-ops and were dropped (see ticket comment): `omnidash` (Vite+React UI, no node `contract.yaml`/runtime profiles) and `onex_change_control` (no node contracts with `runtime_profiles`). `omniclaude` already has the GHA.

## Change

- `.github/workflows/validator-runtime-profiles.yml`: rename the job id/name from `validate` to `runtime-profiles`, yielding the unique check-run context `runtime-profiles`. Updated the documenting header + the consumer-repo comment.

No behavior change to the gate (same validator unit tests + core contract self-scan). No cross-workflow `needs:` references the job; the pre-commit hook id is independent of the job name.

## Follow-up (separate, serial, additive)

After this merges and `runtime-profiles` runs green on a `merge_group` SHA, flip `runtime-profiles` REQUIRED on core dev (verify-each, additive-only). The same rename + flip should then be mirrored to infra/omniclaude/omnimarket (the other 3 repos that declare runtime profiles).

Evidence-Source: OCC#3097
Evidence-Ticket: OMN-13330
