### PR TITLE
feat(OMN-13028): require event_model on command-category handler_routing entries (commit-time validator)

### DIFF
--- a/.github/workflows/validator-command-category-event-model.yml
+++ b/.github/workflows/validator-command-category-event-model.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# command-category handler 'event_model' gate [OMN-13028]
+#
+# Required status check context: "command-category Event Model Validator / validate"
+#
+# Runs the validator unit tests, then self-scans omnibase_core/src for any
+# handler_routing entry tagged 'message_category: command' that omits 'event_model'.
+# A command entry with no event_model is the OMN-13003 failure (command handler with
+# no event_model) — ladder layer 1 of the OMN-13003/13005 top-10 failure. Consumer
+# repos wire this by adding the command-category-requires-event-model pre-commit hook
+# and a mirror of the `validate` job in their own CI.
+
+name: command-category Event Model Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-command-category-event-model-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_command_category_requires_event_model.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.command_category_requires_event_model src/omnibase_core

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -327,6 +327,20 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # OMN-13028: require an 'event_model' on command-category handler entries.
+      # A handler_routing entry tagged 'message_category: command' names a typed
+      # command payload; the dispatcher resolves that type from the entry's
+      # 'event_model' block. A command entry with no event_model is the OMN-13003
+      # failure (command handler with no event_model) — ladder layer 1 of the
+      # OMN-13003/13005 top-10 failure. Core dogfoods its own export.
+      - id: command-category-requires-event-model
+        name: command-category handler 'event_model' guard (OMN-13028)
+        entry: uv run python -m omnibase_core.validators.command_category_requires_event_model src/omnibase_core
+        language: system
+        files: (^|/)contract\.yaml$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # CLASS vs FILE Naming Conventions:
       # - validate-naming-conventions: CLASS naming (ModelUser, EnumStatus, ProtocolEventBus)
       # - validate-file-naming-conventions: FILE naming (model_user.py, enum_status.py)
@@ -436,7 +450,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py|src/omnibase_core/validators/command_category_requires_event_model\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 

--- a/src/omnibase_core/models/validation/model_command_event_model_finding.py
+++ b/src/omnibase_core/models/validation/model_command_event_model_finding.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelCommandEventModelFinding — finding from the command-category event_model guard (OMN-13028)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCommandEventModelFinding:
+    """A ``handler_routing`` entry whose ``message_category`` is ``command`` but lacks an ``event_model``.
+
+    A command-category handler entry that omits ``event_model`` is the failure mode
+    behind OMN-13003 (handler with no event_model) and the ladder layer this guard
+    closes. A command message names a typed payload model; without a declared
+    ``event_model`` the dispatcher cannot resolve the payload type for the command
+    handler, and the node fails closed (or worse, silently degenerates) at runtime.
+
+    This guard makes that contract state mechanically impossible at commit time:
+    every ``handler_routing`` entry tagged ``message_category: command`` MUST declare
+    a non-empty ``event_model`` (a nested ``{name, module}`` block).
+    """
+
+    path: Path
+    handler_index: int
+    handler_name: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}: handlers[{self.handler_index}] "
+            f"(handler={self.handler_name}) has message_category=command "
+            f"but is missing 'event_model'"
+        )

--- a/src/omnibase_core/validators/command_category_requires_event_model.py
+++ b/src/omnibase_core/validators/command_category_requires_event_model.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Require an ``event_model`` on command-category handler_routing entries (OMN-13028).
+
+A ``handler_routing.handlers[]`` entry tagged ``message_category: command`` names a
+typed command payload. The dispatcher resolves that payload type from the entry's
+``event_model`` block (``{name, module}``). When a command entry omits
+``event_model``, the contract is the exact failure behind OMN-13003 — a command
+handler with no event_model — and the node fails closed (or silently degenerates,
+attempt_count=0) at runtime. This is ladder layer 1 of the OMN-13003/13005 top-10
+failure (Wall of Shame row 14).
+
+This validator is the commit-time enforcement gate: it scans ``contract.yaml``
+files and fails if any handler_routing entry with ``message_category: command``
+lacks a non-empty ``event_model``. Wire it as a pre-commit hook AND a required CI
+status check in every repo that carries ONEX node contracts so the regression can
+never re-land silently.
+
+Scope: only entries explicitly tagged ``message_category: command`` are checked.
+Entries with category ``event``/``intent``, or no ``message_category`` at all, are
+out of scope here — they are governed by other routing guards (e.g. the
+operation_match operation-field guard, OMN-13530). The boot-time half of OMN-13028
+(auto-wiring raising on a no-op/None-returning injected consumer) is tracked as a
+separate follow-up; this module is the commit-time, pure-code deliverable.
+
+Usage::
+
+    python -m omnibase_core.validators.command_category_requires_event_model src/
+
+When pre-commit supplies staged filenames, only ``contract.yaml`` files among them
+are scanned. When no paths are supplied, ``src/`` is scanned recursively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent contract.yaml files
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.models.validation.model_command_event_model_finding import (
+    ModelCommandEventModelFinding,
+)
+
+DEFAULT_SCAN_ROOT = Path("src")
+CONTRACT_FILENAME = "contract.yaml"
+COMMAND_CATEGORY = EnumMessageCategory.COMMAND.value  # "command"
+
+
+def validate_paths(paths: Sequence[Path]) -> list[ModelCommandEventModelFinding]:
+    """Validate the contract.yaml files reachable from the provided paths."""
+    findings: list[ModelCommandEventModelFinding] = []
+    for path in _iter_contract_files(paths):
+        findings.extend(validate_file(path))
+    return findings
+
+
+def validate_file(path: Path) -> list[ModelCommandEventModelFinding]:
+    """Validate one contract.yaml for command entries missing ``event_model``."""
+    try:
+        # ONEX_EXCLUDE: manual_yaml - reading adjacent node contract for validation
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, UnicodeDecodeError):
+        # YAML/encoding validity is a separate contract-linter concern; this gate
+        # only asserts event_model on parseable command-category routing entries.
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    routing = data.get("handler_routing")
+    if not isinstance(routing, dict):
+        return []
+
+    handlers = routing.get("handlers")
+    if not isinstance(handlers, list):
+        return []
+
+    findings: list[ModelCommandEventModelFinding] = []
+    for index, entry in enumerate(handlers):
+        if not isinstance(entry, dict):
+            continue
+        if not _is_command_category(entry):
+            continue
+        if _has_event_model(entry):
+            continue
+        findings.append(
+            ModelCommandEventModelFinding(
+                path=path,
+                handler_index=index,
+                handler_name=_handler_name(entry),
+            )
+        )
+    return findings
+
+
+def _is_command_category(entry: dict[str, object]) -> bool:
+    category = entry.get("message_category")
+    if not isinstance(category, str):
+        return False
+    return category.strip().lower() == COMMAND_CATEGORY
+
+
+def _has_event_model(entry: dict[str, object]) -> bool:
+    event_model = entry.get("event_model")
+    if isinstance(event_model, dict):
+        # A nested {name, module} block must carry a non-empty name to be real.
+        name = event_model.get("name")
+        return isinstance(name, str) and bool(name.strip())
+    if isinstance(event_model, str):
+        return bool(event_model.strip())
+    return False
+
+
+def _handler_name(entry: dict[str, object]) -> str:
+    handler = entry.get("handler")
+    if isinstance(handler, dict):
+        name = handler.get("name")
+        if isinstance(name, str) and name:
+            return name
+    handler_key = entry.get("handler_key")
+    if isinstance(handler_key, str) and handler_key:
+        return handler_key
+    handler_class = entry.get("handler_class")
+    if isinstance(handler_class, str) and handler_class:
+        return handler_class
+    return "<unnamed>"
+
+
+def _iter_contract_files(paths: Sequence[Path]) -> Iterator[Path]:
+    scan_paths = tuple(paths) or (DEFAULT_SCAN_ROOT,)
+    for path in scan_paths:
+        if path.is_file() and path.name == CONTRACT_FILENAME:
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob(CONTRACT_FILENAME)
+                if "__pycache__" not in candidate.parts
+            )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Require a non-empty 'event_model' on every handler_routing entry "
+            "tagged message_category: command. A missing event_model is the "
+            "OMN-13003 failure — a command handler with no payload model — and "
+            "makes the node fail closed (or degenerate) at runtime."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SCAN_ROOT],
+        help="contract.yaml file or directory paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_paths(args.paths)
+    if not findings:
+        return 0
+
+    sys.stderr.write("command-category handler 'event_model' guard failed:\n")
+    for finding in findings:
+        sys.stderr.write(f"  {finding.format()}\n")
+    sys.stderr.write(
+        "\nEvery handler_routing entry tagged 'message_category: command' must "
+        "declare a non-empty 'event_model' (a nested {name, module} block naming "
+        "the command payload model). Without it the dispatcher cannot resolve the "
+        "command payload type (OMN-13003), and the node fails closed or degenerates "
+        "at runtime. Add the 'event_model:' block alongside the command handler.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validators/test_command_category_requires_event_model.py
+++ b/tests/unit/validators/test_command_category_requires_event_model.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the command-category 'event_model' field guard (OMN-13028).
+
+A handler_routing entry tagged ``message_category: command`` must declare a
+non-empty ``event_model`` block. This closes ladder layer 1 of OMN-13003/13005
+(a command handler whose contract omitted ``event_model``) at commit time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.command_category_requires_event_model import (
+    main,
+    validate_file,
+    validate_paths,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_COMPLIANT_COMMAND = """\
+name: example_orchestrator
+node_type: orchestrator
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - message_category: command
+      event_model:
+        name: ModelExampleCommand
+        module: pkg.nodes.node_example.models.model_example_command
+      handler:
+        name: HandlerExample
+        module: pkg.nodes.node_example.handlers.handler_example
+"""
+
+_MISSING_EVENT_MODEL = """\
+name: example_broken
+node_type: orchestrator
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - message_category: command
+      handler:
+        name: HandlerBroken
+        module: pkg.nodes.node_broken.handlers.handler_broken
+"""
+
+_EVENT_CATEGORY_NO_EVENT_MODEL = """\
+name: example_event
+node_type: orchestrator
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - message_category: event
+      handler:
+        name: HandlerEvent
+        module: pkg.handlers.handler_event
+"""
+
+_NO_CATEGORY = """\
+name: example_no_category
+node_type: compute
+handler_routing:
+  routing_strategy: operation_match
+  handlers:
+    - operation: scan
+      handler:
+        name: HandlerScan
+        module: pkg.handlers.handler_scan
+"""
+
+_COMMAND_EMPTY_EVENT_MODEL = """\
+name: example_empty
+node_type: orchestrator
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - message_category: command
+      event_model: {}
+      handler:
+        name: HandlerEmpty
+        module: pkg.handlers.handler_empty
+"""
+
+_MULTI_HANDLER_PARTIAL = """\
+name: example_multi
+node_type: orchestrator
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - message_category: command
+      event_model:
+        name: ModelGoodCommand
+        module: pkg.models.model_good_command
+      handler:
+        name: HandlerGood
+        module: pkg.handlers.handler_good
+    - message_category: command
+      handler:
+        name: HandlerBad
+        module: pkg.handlers.handler_bad
+"""
+
+_LEGACY_FLAT_COMMAND_MISSING = """\
+name: example_flat
+node_type: compute
+handler_routing:
+  routing_strategy: payload_type_match
+  handlers:
+    - routing_key: ModelExampleCommand
+      handler_key: handle_example
+      message_category: command
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text(body, encoding="utf-8")
+    return contract
+
+
+def test_compliant_command_has_no_findings(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _COMPLIANT_COMMAND)
+    assert validate_file(contract) == []
+
+
+def test_command_missing_event_model_is_flagged(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _MISSING_EVENT_MODEL)
+    findings = validate_file(contract)
+    assert len(findings) == 1
+    assert findings[0].handler_index == 0
+    assert findings[0].handler_name == "HandlerBroken"
+
+
+def test_event_category_is_exempt(tmp_path: Path) -> None:
+    # Only command-category entries require event_model; event-category does not.
+    contract = _write(tmp_path, _EVENT_CATEGORY_NO_EVENT_MODEL)
+    assert validate_file(contract) == []
+
+
+def test_absent_category_is_exempt(tmp_path: Path) -> None:
+    # An entry with no message_category at all is out of scope for this guard.
+    contract = _write(tmp_path, _NO_CATEGORY)
+    assert validate_file(contract) == []
+
+
+def test_command_with_empty_event_model_is_flagged(tmp_path: Path) -> None:
+    # An empty event_model block is as bad as an absent one.
+    contract = _write(tmp_path, _COMMAND_EMPTY_EVENT_MODEL)
+    findings = validate_file(contract)
+    assert len(findings) == 1
+    assert findings[0].handler_name == "HandlerEmpty"
+
+
+def test_multi_handler_only_flags_missing_entries(tmp_path: Path) -> None:
+    contract = _write(tmp_path, _MULTI_HANDLER_PARTIAL)
+    findings = validate_file(contract)
+    assert len(findings) == 1
+    assert findings[0].handler_index == 1
+    assert findings[0].handler_name == "HandlerBad"
+
+
+def test_legacy_flat_command_missing_event_model_is_flagged(tmp_path: Path) -> None:
+    # Legacy routing_key/handler_key shape still requires event_model when the
+    # entry is tagged message_category: command.
+    contract = _write(tmp_path, _LEGACY_FLAT_COMMAND_MISSING)
+    findings = validate_file(contract)
+    assert len(findings) == 1
+    assert findings[0].handler_name == "handle_example"
+
+
+def test_main_returns_nonzero_on_violation(tmp_path: Path) -> None:
+    _write(tmp_path, _MISSING_EVENT_MODEL)
+    assert main([str(tmp_path)]) == 1
+
+
+def test_main_returns_zero_when_clean(tmp_path: Path) -> None:
+    _write(tmp_path, _COMPLIANT_COMMAND)
+    assert main([str(tmp_path)]) == 0
+
+
+def test_validate_paths_scans_directory_recursively(tmp_path: Path) -> None:
+    nested = tmp_path / "nodes" / "node_broken"
+    nested.mkdir(parents=True)
+    (nested / "contract.yaml").write_text(_MISSING_EVENT_MODEL, encoding="utf-8")
+    good = tmp_path / "nodes" / "node_ok"
+    good.mkdir(parents=True)
+    (good / "contract.yaml").write_text(_COMPLIANT_COMMAND, encoding="utf-8")
+    findings = validate_paths([tmp_path])
+    assert len(findings) == 1
+    assert findings[0].handler_name == "HandlerBroken"
+
+
+def test_non_dict_yaml_is_ignored(tmp_path: Path) -> None:
+    contract = _write(tmp_path, "- just\n- a\n- list\n")
+    assert validate_file(contract) == []
+
+
+def test_invalid_yaml_is_ignored(tmp_path: Path) -> None:
+    contract = _write(tmp_path, "name: [unterminated\n")
+    assert validate_file(contract) == []


### PR DESCRIPTION
## OMN-13028 — A-9: command-category handler_routing entries MUST declare event_model (commit-time fail-fast)

Closes ladder layer 1 of the OMN-13003/13005 top-10 failure (Wall of Shame row 14): a command handler whose contract omitted `event_model`. This adds the commit-time, pure-code guard that makes that contract state mechanically impossible.

### What this does
A `handler_routing.handlers[]` entry tagged `message_category: command` names a typed command payload; the dispatcher resolves that payload type from the entry's `event_model` block (`{name, module}`). When a command entry omits `event_model`, the contract is the exact OMN-13003 failure — a command handler with no event_model — and the node fails closed (or silently degenerates, attempt_count=0) at runtime. This guard fails the commit instead.

### Changes
- `src/omnibase_core/validators/command_category_requires_event_model.py` — scans `contract.yaml`, flags any handler_routing entry with `message_category=command` that lacks a non-empty `event_model` (nested `{name, module}` block with a non-empty name, or non-empty string). Mirrors the `operation_match_requires_operation` (OMN-13530) precedent.
- `src/omnibase_core/models/validation/model_command_event_model_finding.py` — frozen `ModelCommandEventModelFinding` dataclass.
- `tests/unit/validators/test_command_category_requires_event_model.py` — 12 unit tests.
- `.pre-commit-config.yaml` — wire `command-category-requires-event-model` hook (Operating Rule #5: enforcement, not detection).
- `.github/workflows/validator-command-category-event-model.yml` — required CI gate (runs unit tests + self-scans `src/omnibase_core`).

### Scope note
The boot-time half of OMN-13028 (auto-wiring raising on a no-op/None-returning injected consumer, the OMN-13005 leg) is scoped as a follow-up per the ticket DoD ("the boot-time no-op-consumer half can be scoped as a follow-up; the commit-time validator is the tractable pure-code deliverable"). This PR delivers the commit-time validator.

### dod_evidence
- **TDD red->green proof**: the guard fires only when active (proven by monkeypatch — `_is_command_category` off → 0 findings, on → 1 finding for the missing-event_model fixture).
- **DoD: command entry missing event_model fails, compliant one passes** — `test_command_missing_event_model_is_flagged` (fails) + `test_compliant_command_has_no_findings` (passes).
- **Unit tests**: `uv run pytest tests/unit/validators/test_command_category_requires_event_model.py -q` → 12 passed. Full `tests/unit/validators/` → 210 passed.
- **Self-scan clean**: `uv run python -m omnibase_core.validators.command_category_requires_event_model src/omnibase_core` → exit 0 (no core contract uses `message_category`, so no pre-existing violations).
- **mypy --strict**: clean on both changed modules.
- **ruff format + check --fix**: clean.
- **pre-commit run** on changed files: all hooks Passed (exit 0), no `--no-verify`.
- **Wired as gate**: pre-commit hook + required CI workflow added in the same PR.

### Deploy assessment
This PR adds a validator module, a Pydantic finding model, unit tests, a pre-commit hook, and a CI workflow only. No live service deploy, runtime restart, Kafka topic mutation, or database migration is required before merge.

Evidence-Source and OCC receipt binding tracked in the paired `onex_change_control` PR (contract `contracts/OMN-13028.yaml`).


Evidence-Source: OCC#3110
Evidence-Ticket: OMN-13028