### PR TITLE
feat(OMN-13566): canonical no-new-os-environ AST validator + REQUIRED CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1211,6 +1211,45 @@ jobs:
           # shellcheck disable=SC2086
           uv run python -m omnibase_core.validation.doc_content_scan.runtime_doc_content_scan $files
 
+  # No-new-os-environ gate (OMN-13566) — canonical AST-based env-read enforcement.
+  # Blocks ALL os.environ/os.getenv reads outside KEEP_ALLOWLIST. Feeds quality-gate
+  # so a violation turns the single required CI Summary rollup red. The deliberate
+  # red-test corpus (test_deliberate_violation_corpus) is the DoD proof that CI
+  # would catch a real violation.
+  no-new-os-environ:
+    name: No New os.environ Reads (OMN-13566)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Scan src/ for os.environ/os.getenv reads outside KEEP_ALLOWLIST (OMN-13566)
+        run: |
+          uv run python -m omnibase_core.validators.no_new_os_environ --all --src src/
+
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
   # ---------------------------------------------------------------------------
@@ -1233,7 +1272,7 @@ jobs:
     # provide. naming-conventions / pydantic-patterns / aislop-patterns ARE
     # spec-required validators (validator-requirements.yaml) and are now needs so
     # a real violation turns the single required CI Summary rollup red.
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan, no-new-os-environ]
     if: always()
 
     steps:
@@ -1266,6 +1305,7 @@ jobs:
           pydantic="${{ needs.pydantic-patterns.result }}"
           aislop="${{ needs.aislop-patterns.result }}"
           doc_content="${{ needs.doc-content-scan.result }}"
+          no_new_os_environ="${{ needs.no-new-os-environ.result }}"
 
           # Report each check
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
@@ -1291,6 +1331,7 @@ jobs:
           echo "| Pydantic Patterns (OMN-13574) | $pydantic |" >> $GITHUB_STEP_SUMMARY
           echo "| AI Slop Patterns (OMN-13574) | $aislop |" >> $GITHUB_STEP_SUMMARY
           echo "| Doc-Content Scan (OMN-13572) | $doc_content |" >> $GITHUB_STEP_SUMMARY
+          echo "| No New os.environ Reads (OMN-13566) | $no_new_os_environ |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
           if [[ "$lint" == "success" ]] && \
@@ -1313,7 +1354,8 @@ jobs:
              [[ "$naming" == "success" ]] && \
              [[ "$pydantic" == "success" ]] && \
              [[ "$aislop" == "success" ]] && \
-             [[ "$doc_content" == "success" ]]; then
+             [[ "$doc_content" == "success" ]] && \
+             [[ "$no_new_os_environ" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY
             echo "All quality checks passed."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1395,6 +1395,16 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # OMN-13566: Canonical AST env-read gate replacing the regex ratchet.
+      - id: no-new-os-environ
+        name: No New os.environ/os.getenv Reads (OMN-13566)
+        entry: uv run python -m omnibase_core.validators.no_new_os_environ
+        language: system
+        types: [python]
+        exclude: ^(tests/|scripts/|examples/)
+        pass_filenames: true
+        stages: [pre-commit]
+
       # OMN-5063: Block untyped metadata dict fields
       # Centralized in onex_change_control (OMN-5135)
       - id: no-untyped-metadata

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -180,6 +180,21 @@
   pass_filenames: true
   stages: [pre-commit]
 
+- id: no-new-os-environ
+  name: No New os.environ/os.getenv Reads (OMN-13566)
+  description: >
+    Canonical AST-based gate: block ALL os.environ[KEY], os.environ.get(KEY), and os.getenv(KEY) reads
+    outside the explicit KEEP_ALLOWLIST of structurally required bootstrap/path/CI vars. This is the canonical
+    generalisation of check-env-reads.sh (OMN-11069/11186) deployed from omnibase_core as a pre-commit
+    hook + REQUIRED CI status check on all repos. Exempts test files (tests/), scripts/, and lines annotated
+    with `# env-read-ok: <reason>`. Extend KEEP_ALLOWLIST in omnibase_core.validators.no_new_os_environ
+    via a CODEOWNERS-reviewed PR. Suppression: # env-read-ok: <reason>. DoD: OMN-13566.
+  language: python
+  entry: python -m omnibase_core.validators.no_new_os_environ
+  types: [python]
+  pass_filenames: true
+  stages: [pre-commit]
+
 - id: check-hardcoded-topics-v2
   name: Hardcoded ONEX Topic Strings (contract-driven)
   description: >

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -601,6 +601,35 @@ required_validators:
     applies_to_repos:
       - omnibase_core
 
+  no-new-os-environ:
+    description: |
+      Canonical AST-based gate: block ALL os.environ[KEY], os.environ.get(KEY),
+      and os.getenv(KEY) reads outside the explicit KEEP_ALLOWLIST of
+      structurally required bootstrap/path/CI vars. Generalises the infra
+      check-env-reads.sh (OMN-11069/11186) as a single canonical implementation
+      deployed from omnibase_core. Converts the platform from "block new vs
+      frozen 685 baseline" to "zero env reads outside the named bootstrap set."
+      KEEP_ALLOWLIST is the only permitted escape, reviewed in CODEOWNERS.
+      Suppression: # env-read-ok: <reason> (structural bootstrap seams only).
+      Exempts tests/, scripts/, examples/. DoD proof: deliberate red-test corpus
+      in test_no_new_os_environ.py asserts the gate catches real violations.
+      OMN-13566 (Wave-4 env-read enforcement ratchet).
+    central_source: "omnibase_core.validators.no_new_os_environ"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "CI Summary"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "no-new-os-environ"
+    ci_workflow_keywords:
+      - "no_new_os_environ"
+      - "no-new-os-environ"
+    excludes:
+      allowed: ["^tests/", "^scripts/", "^examples/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omnibase_core
+
 # ---------------------------------------------------------------------------
 # Model B — failing-rollup enforcement (OMN-13574, epic OMN-13573)
 # ---------------------------------------------------------------------------
@@ -655,6 +684,7 @@ model_b_rollup_enforcement:
         pydantic-patterns: ["pydantic-patterns"]
         aislop-patterns: ["aislop-patterns"]
         doc-content-scan: ["doc-content-scan"]
+        no-new-os-environ: ["no-new-os-environ"]
       # Machine-checkable intentional omissions. These validators are
       # ci_workflow: required and apply to omnibase_core, but are currently
       # grandfathered in validator-requirements-baseline.yaml as

--- a/src/omnibase_core/models/validation/model_env_read_finding.py
+++ b/src/omnibase_core/models/validation/model_env_read_finding.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Finding model for no-new-os-environ validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ModelEnvReadFinding:
+    """One env-read violation found by the validator."""
+
+    path: Path
+    line: int
+    col: int
+    var_name: str
+    raw_line: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.col}: "
+            f"os.environ/os.getenv read of {self.var_name!r} "
+            f"outside KEEP_ALLOWLIST"
+        )

--- a/src/omnibase_core/validators/env_read_visitor.py
+++ b/src/omnibase_core/validators/env_read_visitor.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""AST visitor for no-new-os-environ validation."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Collection
+
+
+class EnvReadVisitor(ast.NodeVisitor):
+    """Walk an AST looking for os.environ / os.getenv reads."""
+
+    def __init__(
+        self,
+        source_lines: list[str],
+        *,
+        keep_allowlist: Collection[str],
+        suppression_marker: str,
+    ) -> None:
+        self._lines = source_lines
+        self._keep_allowlist = keep_allowlist
+        self._suppression_marker = suppression_marker
+        self.findings: list[tuple[int, int, str]] = []
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        """Detect os.environ[KEY]."""
+        if _is_os_environ_attr(node.value):
+            var_name = _extract_constant_string(node.slice)
+            if var_name is not None and self._should_flag(node.lineno, var_name):
+                self.findings.append((node.lineno, node.col_offset, var_name))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Detect os.environ.get(KEY) and os.getenv(KEY)."""
+        if _is_os_environ_get(node.func) or _is_os_getenv(node.func):
+            var_name = _first_arg_string(node)
+            if var_name is not None and self._should_flag(node.lineno, var_name):
+                self.findings.append((node.lineno, node.col_offset, var_name))
+        self.generic_visit(node)
+
+    def _should_flag(self, lineno: int, var_name: str) -> bool:
+        if var_name in self._keep_allowlist:
+            return False
+        raw = self._lines[lineno - 1] if lineno <= len(self._lines) else ""
+        return self._suppression_marker not in raw
+
+
+def _is_os_environ_attr(node: ast.expr) -> bool:
+    """Return True for the ``os.environ`` attribute expression."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "environ"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+    )
+
+
+def _is_os_environ_get(node: ast.expr) -> bool:
+    """Return True for ``os.environ.get`` attribute chain."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "get"
+        and _is_os_environ_attr(node.value)
+    )
+
+
+def _is_os_getenv(node: ast.expr) -> bool:
+    """Return True for ``os.getenv`` attribute expression."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "getenv"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+    )
+
+
+def _extract_constant_string(node: ast.expr) -> str | None:
+    """Extract a string constant from a subscript slice."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _first_arg_string(node: ast.Call) -> str | None:
+    """Extract the first positional argument as a string constant, if any."""
+    if node.args:
+        return _extract_constant_string(node.args[0])
+    return None

--- a/src/omnibase_core/validators/no_new_os_environ.py
+++ b/src/omnibase_core/validators/no_new_os_environ.py
@@ -1,0 +1,491 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical no-new-os-environ validator (OMN-13566).
+
+Blocks ALL ``os.environ[KEY]``, ``os.environ.get(KEY)``, and ``os.getenv(KEY)``
+reads outside the explicit ``KEEP_ALLOWLIST`` of structurally required bootstrap
+and CI variables.  This converts the platform from "block new vs frozen 685
+baseline" to "zero env reads outside the named bootstrap set."
+
+Generalises ``omnibase_infra/scripts/check-env-reads.sh`` (OMN-11069/11186) and
+the ``scripts/validation/validate_no_new_env_vars.py`` regex approach into a
+single canonical AST-based implementation deployed as a pre-commit hook and CI
+job from ``omnibase_core``.
+
+Allowlist policy
+----------------
+- ``KEEP_ALLOWLIST`` is the ONLY permitted escape.
+- Adding a new var requires a PR reviewed by CODEOWNERS.
+- Inline suppression (``# env-read-ok: <reason>``) is allowed for one-off
+  structural bootstrap lines that are not candidates for the global allowlist.
+- Test files (``tests/``) and tooling directories (``scripts/``, ``examples/``)
+  are skipped because they legitimately reference env var names as test data or
+  in operational bootstrap tooling.
+
+Usage
+-----
+Pre-commit (staged files)::
+
+    python -m omnibase_core.validators.no_new_os_environ file1.py file2.py ...
+
+CI — full repo scan::
+
+    python -m omnibase_core.validators.no_new_os_environ --all --src src/
+
+Suppression
+-----------
+Add ``# env-read-ok: <reason>`` on the offending line.
+
+DoD reference: OMN-13566 (Wave-4 env-read enforcement ratchet).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Keep allowlist — ONLY approved bootstrap / path-resolution / CI env vars.
+# Extend via PR reviewed by CODEOWNERS — never auto-expand.
+# ---------------------------------------------------------------------------
+KEEP_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Cross-machine identity / path resolution
+        "OMNI_HOME",
+        "OMNI_WORKTREES",
+        "OMNIMARKET_ROOT",
+        "ONEX_SRC_DIR",
+        "PATH",
+        "HOME",
+        "USER",
+        "HOSTNAME",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "XDG_RUNTIME_DIR",
+        # CI environment detection
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CI_RUNNER_TYPE",
+        "JENKINS_URL",
+        "GITHUB_TOKEN",
+        "GITHUB_SHA",
+        "GITHUB_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF",
+        "GITHUB_REPOSITORY",
+        "GITHUB_WORKSPACE",
+        "GITHUB_OUTPUT",
+        "GITHUB_STEP_SUMMARY",
+        "GITHUB_ENV",
+        "RUNNER_TEMP",
+        "RUNNER_TOOL_CACHE",
+        "RUNNER_OS",
+        "RUNNER_ARCH",
+        # ONEX runtime state roots
+        "ONEX_EVIDENCE_ROOT",
+        "ONEX_WORKTREES_ROOT",
+        "ONEX_STATE_ROOT",
+        "ONEX_STATE_DIR",
+        "ONEX_CORRELATION_ID",
+        "ONEX_HOOKS_MASK",
+        "ONEX_RUNTIME_CONTRACTS_DIR",
+        "ONEX_CONTEXT_SIZE_WARN_ON_CREATE",
+        "ONEX_DEBUG_THREAD_SAFETY",
+        "ONEX_VALIDATION_MODE",
+        # ONEX event bus config (grandfathered at OMN-11186 activation)
+        "ONEX_EVENT_BUS_BOOTSTRAP_SERVERS",
+        "ONEX_EVENT_BUS_TOPICS",
+        "ONEX_EVENT_BUS_ENABLE_AUTO_COMMIT",
+        "ONEX_EVENT_BUS_PARTITIONS",
+        "ONEX_EVENT_BUS_PRIORITY",
+        "ONEX_EVENT_BUS_REPLICATION_FACTOR",
+        "ONEX_EVENT_BUS_SASL_MECHANISM",
+        "ONEX_EVENT_BUS_SASL_PASSWORD",
+        "ONEX_EVENT_BUS_SASL_USERNAME",
+        "ONEX_EVENT_BUS_SECURITY_PROTOCOL",
+        "ONEX_EVENT_BUS_TIMEOUT_SECONDS",
+        # Kafka / event bus bootstrap (pre-existing; migrate to contract when feasible)
+        "KAFKA_BOOTSTRAP_SERVERS",
+        "EVENT_BUS_BOOTSTRAP_SERVERS",
+        "EVENT_BUS_TOPICS",
+        # Postgres (doctor + diagnostic tooling)
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_USER",
+        "POSTGRES_DB",
+        # Valkey / Redis diagnostic
+        "VALKEY_HOST",
+        "VALKEY_PORT",
+        "REDIS_URL",
+        # Infisical bootstrap
+        "INFISICAL_ADDR",
+        "INFISICAL_TOKEN",
+        "INFISICAL_CLIENT_ID",
+        "INFISICAL_CLIENT_SECRET",
+        # OMNIBASE_ALLOWED_NAMESPACES
+        "OMNIBASE_ALLOWED_NAMESPACES",
+        # OMNIBASE_CORE_PATH (used during pre-commit before install)
+        "OMNIBASE_CORE_PATH",
+        # Linear (doctor checks only)
+        "LINEAR_API_KEY",
+        # LLM endpoints (inference tooling)
+        "LLM_LOCAL_MODEL",
+        "LLM_LOCAL_URL",
+        # ONEX agent / plugin paths
+        "OMNICLAUDE_AGENTS_PATH",
+        # Contract enforcement overrides
+        "CONTRACT_REQUIRED_AFTER",
+        "PLAN_CONTRACT_REQUIRED_AFTER",
+        # DB circuit breaker tuning
+        "DB_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+        "DB_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS",
+        "DB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT",
+        # Generic config used in existing tests / validators
+        "DEBUG",
+        "DEBUG_MODE",
+        "ENVIRONMENT",
+        "NODE_ENV",
+        "LOG_LEVEL",
+        "NODE_ID",
+        "NODE_VERSION",
+        "SERVICE_PORT",
+        "MAX_WORKFLOWS",
+        "WORKFLOW_TIMEOUT",
+        "METRICS_ENABLED",
+        "METRICS_PORT",
+        "HEALTH_CHECK_ENABLED",
+        "HEALTH_CHECK_INTERVAL",
+        "HEALTH_CHECK_TIMEOUT",
+        # Scripts / validation tooling
+        "DETERMINISTIC_SKILL_ROOT",
+        "ZONE_DIFF_FILTER_FAKE_DIFF",
+        # PYTHONPATH (tooling launchers)
+        "PYTHONPATH",
+        # Artifact store (CLI seam; OMN-13537)
+        "ONEX_ARTIFACT_STORE_ROOT",
+        # Config discovery / overlay resolver (bootstrap seam)
+        "ONEX_OVERLAY_DIR",
+        "ONEX_RUNTIME_PROFILE",
+        "ONEX_CONFIG_DIR",
+        "ONEX_CONTRACTS_ROOT",
+        # OMNI_HOME-relative path roots
+        "OMNI_PROJECTS_ROOT",
+        "OMNI_SKILLS_ROOT",
+        # OpenTelemetry / tracing
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_SERVICE_NAME",
+        "OTEL_TRACES_EXPORTER",
+        "OTEL_RESOURCE_ATTRIBUTES",
+        # Phoenix / observability
+        "PHOENIX_HOST",
+        "PHOENIX_PORT",
+        # Google / ADC bootstrap
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_API_KEY",
+        # GitHub secondary PAT (hooks only — api_key_ref is the canonical route)
+        "GH_PAT",
+        "GH_TOKEN",
+        # Docker / container plumbing
+        "DOCKER_HOST",
+        "DOCKER_BUILDKIT",
+        "COMPOSE_FILE",
+        "COMPOSE_PROJECT_NAME",
+        # Python runtime / packaging tooling
+        "VIRTUAL_ENV",
+        "UV_PROJECT_ENVIRONMENT",
+        "PIP_INDEX_URL",
+        "PIP_NO_CACHE_DIR",
+        # SSL / TLS
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        # Pytest / test tooling
+        "PYTEST_CURRENT_TEST",
+        "PYTEST_XDIST_WORKER",
+        "PYTEST_XDIST_WORKER_COUNT",
+        # Kubernetes platform detection (structural bootstrap seam)
+        "KUBERNETES_SERVICE_HOST",
+        "KUBERNETES_SERVICE_PORT",
+        "KUBERNETES_NAMESPACE",
+        # Service host (infrastructure bootstrap)
+        "SERVICE_HOST",
+        # misc platform vars legitimately checked in cross-platform code
+        "USERPROFILE",  # Windows HOME equivalent
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PROGRAMFILES",
+        "SYSTEMROOT",
+        "COMSPEC",
+        "TERM",
+        "COLORTERM",
+        "FORCE_COLOR",
+        "NO_COLOR",
+        "CLICOLOR",
+        # ONEX test isolation
+        "ONEX_TEST_ISOLATION",
+        "ONEX_TEST_BUS_BACKEND",
+        "ONEX_SKIP_RUNTIME_CHECK",
+        # OMNI_HOME companion vars
+        "OMNI_RUNNER_SELECTOR_V1",
+    }
+)
+
+# Inline suppression annotation
+_SUPPRESSION_TOKEN = "# env-read-ok"
+
+# Directories to skip unconditionally (pre-commit passes individual files, but
+# validate_file is also called directly from validate_paths which walks dirs).
+_SKIP_DIR_SEGMENTS: frozenset[str] = frozenset({"tests", "scripts", "examples"})
+
+
+# ---------------------------------------------------------------------------
+# Finding dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvReadFinding:
+    """One env-read violation found by the validator."""
+
+    path: Path
+    line: int
+    col: int
+    var_name: str
+    raw_line: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.col}: "
+            f"os.environ/os.getenv read of {self.var_name!r} "
+            f"outside KEEP_ALLOWLIST"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AST visitor
+# ---------------------------------------------------------------------------
+
+
+class _EnvReadVisitor(ast.NodeVisitor):
+    """Walk an AST looking for os.environ / os.getenv reads."""
+
+    def __init__(self, source_lines: list[str]) -> None:
+        self._lines = source_lines
+        self.findings: list[tuple[int, int, str]] = []  # (line, col, var_name)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        """Detect os.environ[KEY]."""
+        if _is_os_environ_attr(node.value):
+            var_name = _extract_constant_string(node.slice)
+            if var_name is not None and self._should_flag(node.lineno, var_name):
+                self.findings.append((node.lineno, node.col_offset, var_name))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Detect os.environ.get(KEY) and os.getenv(KEY)."""
+        if _is_os_environ_get(node.func) or _is_os_getenv(node.func):
+            var_name = _first_arg_string(node)
+            if var_name is not None and self._should_flag(node.lineno, var_name):
+                self.findings.append((node.lineno, node.col_offset, var_name))
+        self.generic_visit(node)
+
+    def _should_flag(self, lineno: int, var_name: str) -> bool:
+        if var_name in KEEP_ALLOWLIST:
+            return False
+        raw = self._lines[lineno - 1] if lineno <= len(self._lines) else ""
+        return _SUPPRESSION_TOKEN not in raw
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_os_environ_attr(node: ast.expr) -> bool:
+    """Return True for the ``os.environ`` attribute expression."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "environ"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+    )
+
+
+def _is_os_environ_get(node: ast.expr) -> bool:
+    """Return True for ``os.environ.get`` attribute chain."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "get"
+        and _is_os_environ_attr(node.value)
+    )
+
+
+def _is_os_getenv(node: ast.expr) -> bool:
+    """Return True for ``os.getenv`` attribute expression."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "getenv"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+    )
+
+
+def _extract_constant_string(node: ast.expr) -> str | None:
+    """Extract a string constant from a subscript slice."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _first_arg_string(node: ast.Call) -> str | None:
+    """Extract the first positional argument as a string constant, if any."""
+    if node.args:
+        return _extract_constant_string(node.args[0])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Path skip logic
+# ---------------------------------------------------------------------------
+
+
+def _should_skip_path(path: Path) -> bool:
+    """Return True for non-Python files or files inside skipped directories."""
+    if path.suffix != ".py":
+        return True
+    return any(seg in _SKIP_DIR_SEGMENTS for seg in path.parts)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_file(path: Path) -> list[EnvReadFinding]:
+    """Return all env-read violations in *path*.
+
+    Returns an empty list when the file should be skipped (test/scripts dir,
+    non-Python, unreadable) or is clean.
+    """
+    if _should_skip_path(path):
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    visitor = _EnvReadVisitor(lines)
+    visitor.visit(tree)
+
+    return [
+        EnvReadFinding(
+            path=path,
+            line=lineno,
+            col=col,
+            var_name=var_name,
+            raw_line=lines[lineno - 1],
+        )
+        for lineno, col, var_name in visitor.findings
+    ]
+
+
+def validate_paths(paths: Sequence[Path]) -> list[EnvReadFinding]:
+    """Validate all Python files under the supplied paths."""
+    findings: list[EnvReadFinding] = []
+    for path in _iter_python_files(paths):
+        findings.extend(validate_file(path))
+    return findings
+
+
+def _iter_python_files(paths: Sequence[Path]) -> Iterator[Path]:
+    for path in paths:
+        if path.is_file() and path.suffix == ".py":
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                p for p in path.rglob("*.py") if "__pycache__" not in p.parts
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Block new os.environ/os.getenv reads outside the KEEP_ALLOWLIST. "
+            "All config must flow through contract YAML or the overlay resolver "
+            "(OMN-13566)."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Python files or directories to scan (pre-commit passes staged files).",
+    )
+    parser.add_argument(
+        "--all",
+        dest="scan_all",
+        action="store_true",
+        default=False,
+        help="Scan the entire --src directory (CI mode).",
+    )
+    parser.add_argument(
+        "--src",
+        type=Path,
+        default=Path("src"),
+        help="Source root for --all mode (default: src/).",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.scan_all:
+        findings = validate_paths([args.src])
+    elif args.paths:
+        findings = validate_paths(args.paths)
+    else:
+        return 0
+
+    if not findings:
+        return 0
+
+    sys.stderr.write(
+        "no-new-os-environ: os.environ/os.getenv reads outside KEEP_ALLOWLIST found\n"
+    )
+    sys.stderr.write(
+        "  All config must flow through contract YAML or the overlay resolver.\n"
+        "  Add '# env-read-ok: <reason>' to suppress a structural bootstrap line,\n"
+        "  or extend KEEP_ALLOWLIST in omnibase_core.validators.no_new_os_environ\n"
+        "  via a CODEOWNERS-reviewed PR.\n\n"
+    )
+    for finding in findings:
+        sys.stderr.write(f"  {finding.format()}\n")
+        sys.stderr.write(f"    {finding.raw_line.strip()}\n")
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/omnibase_core/validators/no_new_os_environ.py
+++ b/src/omnibase_core/validators/no_new_os_environ.py
@@ -45,8 +45,12 @@ import argparse
 import ast
 import sys
 from collections.abc import Iterator, Sequence
-from dataclasses import dataclass
 from pathlib import Path
+
+from omnibase_core.models.validation.model_env_read_finding import (
+    ModelEnvReadFinding,
+)
+from omnibase_core.validators.env_read_visitor import EnvReadVisitor
 
 # ---------------------------------------------------------------------------
 # Keep allowlist — ONLY approved bootstrap / path-resolution / CI env vars.
@@ -239,122 +243,11 @@ KEEP_ALLOWLIST: frozenset[str] = frozenset(
 )
 
 # Inline suppression annotation
-_SUPPRESSION_TOKEN = "# env-read-ok"
+_SUPPRESSION_MARKER = "# env-read-ok"
 
 # Directories to skip unconditionally (pre-commit passes individual files, but
 # validate_file is also called directly from validate_paths which walks dirs).
 _SKIP_DIR_SEGMENTS: frozenset[str] = frozenset({"tests", "scripts", "examples"})
-
-
-# ---------------------------------------------------------------------------
-# Finding dataclass
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class EnvReadFinding:
-    """One env-read violation found by the validator."""
-
-    path: Path
-    line: int
-    col: int
-    var_name: str
-    raw_line: str
-
-    def format(self) -> str:
-        return (
-            f"{self.path}:{self.line}:{self.col}: "
-            f"os.environ/os.getenv read of {self.var_name!r} "
-            f"outside KEEP_ALLOWLIST"
-        )
-
-
-# ---------------------------------------------------------------------------
-# AST visitor
-# ---------------------------------------------------------------------------
-
-
-class _EnvReadVisitor(ast.NodeVisitor):
-    """Walk an AST looking for os.environ / os.getenv reads."""
-
-    def __init__(self, source_lines: list[str]) -> None:
-        self._lines = source_lines
-        self.findings: list[tuple[int, int, str]] = []  # (line, col, var_name)
-
-    def visit_Subscript(self, node: ast.Subscript) -> None:
-        """Detect os.environ[KEY]."""
-        if _is_os_environ_attr(node.value):
-            var_name = _extract_constant_string(node.slice)
-            if var_name is not None and self._should_flag(node.lineno, var_name):
-                self.findings.append((node.lineno, node.col_offset, var_name))
-        self.generic_visit(node)
-
-    def visit_Call(self, node: ast.Call) -> None:
-        """Detect os.environ.get(KEY) and os.getenv(KEY)."""
-        if _is_os_environ_get(node.func) or _is_os_getenv(node.func):
-            var_name = _first_arg_string(node)
-            if var_name is not None and self._should_flag(node.lineno, var_name):
-                self.findings.append((node.lineno, node.col_offset, var_name))
-        self.generic_visit(node)
-
-    def _should_flag(self, lineno: int, var_name: str) -> bool:
-        if var_name in KEEP_ALLOWLIST:
-            return False
-        raw = self._lines[lineno - 1] if lineno <= len(self._lines) else ""
-        return _SUPPRESSION_TOKEN not in raw
-
-
-# ---------------------------------------------------------------------------
-# AST helpers
-# ---------------------------------------------------------------------------
-
-
-def _is_os_environ_attr(node: ast.expr) -> bool:
-    """Return True for the ``os.environ`` attribute expression."""
-    return (
-        isinstance(node, ast.Attribute)
-        and node.attr == "environ"
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "os"
-    )
-
-
-def _is_os_environ_get(node: ast.expr) -> bool:
-    """Return True for ``os.environ.get`` attribute chain."""
-    return (
-        isinstance(node, ast.Attribute)
-        and node.attr == "get"
-        and _is_os_environ_attr(node.value)
-    )
-
-
-def _is_os_getenv(node: ast.expr) -> bool:
-    """Return True for ``os.getenv`` attribute expression."""
-    return (
-        isinstance(node, ast.Attribute)
-        and node.attr == "getenv"
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "os"
-    )
-
-
-def _extract_constant_string(node: ast.expr) -> str | None:
-    """Extract a string constant from a subscript slice."""
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    return None
-
-
-def _first_arg_string(node: ast.Call) -> str | None:
-    """Extract the first positional argument as a string constant, if any."""
-    if node.args:
-        return _extract_constant_string(node.args[0])
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Path skip logic
-# ---------------------------------------------------------------------------
 
 
 def _should_skip_path(path: Path) -> bool:
@@ -369,7 +262,7 @@ def _should_skip_path(path: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def validate_file(path: Path) -> list[EnvReadFinding]:
+def validate_file(path: Path) -> list[ModelEnvReadFinding]:
     """Return all env-read violations in *path*.
 
     Returns an empty list when the file should be skipped (test/scripts dir,
@@ -389,11 +282,15 @@ def validate_file(path: Path) -> list[EnvReadFinding]:
         return []
 
     lines = source.splitlines()
-    visitor = _EnvReadVisitor(lines)
+    visitor = EnvReadVisitor(
+        lines,
+        keep_allowlist=KEEP_ALLOWLIST,
+        suppression_marker=_SUPPRESSION_MARKER,
+    )
     visitor.visit(tree)
 
     return [
-        EnvReadFinding(
+        ModelEnvReadFinding(
             path=path,
             line=lineno,
             col=col,
@@ -404,9 +301,9 @@ def validate_file(path: Path) -> list[EnvReadFinding]:
     ]
 
 
-def validate_paths(paths: Sequence[Path]) -> list[EnvReadFinding]:
+def validate_paths(paths: Sequence[Path]) -> list[ModelEnvReadFinding]:
     """Validate all Python files under the supplied paths."""
-    findings: list[EnvReadFinding] = []
+    findings: list[ModelEnvReadFinding] = []
     for path in _iter_python_files(paths):
         findings.extend(validate_file(path))
     return findings
@@ -488,4 +385,4 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # error-ok: validator CLI process exit

--- a/tests/unit/validators/test_no_new_os_environ.py
+++ b/tests/unit/validators/test_no_new_os_environ.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the canonical no-new-os-environ validator (OMN-13566).
+
+TDD test file written before the implementation. The validator must:
+
+1. Block os.environ[KEY], os.environ.get(KEY), and os.getenv(KEY) calls
+   outside the keep allowlist in source files.
+2. Pass reads of keys listed in KEEP_ALLOWLIST.
+3. Respect ``# env-read-ok: <reason>`` inline suppression.
+4. Skip test files and scripts/ directories.
+5. Parse multiline strings correctly (no false positives inside docstrings).
+6. Exit 0 / 1 via main() for CLI use.
+7. Contain a deliberate red-test corpus (used as DoD proof in CI).
+
+Red-test corpus (DoD item: "a new env read in any repo fails CI"):
+  The test ``test_deliberate_violation_corpus`` plants two known-bad snippets
+  and asserts that validate_file() flags both.  If the validator ever stops
+  flagging them, this test fails — proving the gate is live.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_new_os_environ import (
+    KEEP_ALLOWLIST,
+    validate_file,
+    validate_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Basic violation detection
+# ---------------------------------------------------------------------------
+
+
+def test_flags_os_environ_subscript(tmp_path: Path) -> None:
+    """os.environ[KEY] outside allowlist → violation."""
+    src = _write(
+        tmp_path,
+        "bad.py",
+        'import os\nVAL = os.environ["MY_SECRET_KEY"]\n',
+    )
+    findings = validate_file(src)
+    assert len(findings) == 1
+    assert findings[0].var_name == "MY_SECRET_KEY"
+    assert findings[0].line == 2
+
+
+def test_flags_os_environ_get(tmp_path: Path) -> None:
+    """os.environ.get(KEY) outside allowlist → violation."""
+    src = _write(
+        tmp_path,
+        "bad2.py",
+        'import os\nVAL = os.environ.get("UNLISTED_TOKEN")\n',
+    )
+    findings = validate_file(src)
+    assert len(findings) == 1
+    assert findings[0].var_name == "UNLISTED_TOKEN"
+
+
+def test_flags_os_getenv(tmp_path: Path) -> None:
+    """os.getenv(KEY) outside allowlist → violation."""
+    src = _write(
+        tmp_path,
+        "bad3.py",
+        'import os\nVAL = os.getenv("MYSTERY_PARAM")\n',
+    )
+    findings = validate_file(src)
+    assert len(findings) == 1
+    assert findings[0].var_name == "MYSTERY_PARAM"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "keep_var",
+    sorted(KEEP_ALLOWLIST)[:10],  # spot-check 10 entries
+)
+def test_allows_keep_allowlist_vars(tmp_path: Path, keep_var: str) -> None:
+    """Reads of vars in KEEP_ALLOWLIST must not produce findings."""
+    src = _write(
+        tmp_path,
+        "ok.py",
+        f'import os\nVAL = os.environ["{keep_var}"]\n',
+    )
+    assert validate_file(src) == []
+
+
+def test_allows_omni_home(tmp_path: Path) -> None:
+    src = _write(tmp_path, "ok2.py", 'import os\nroot = os.environ["OMNI_HOME"]\n')
+    assert validate_file(src) == []
+
+
+def test_allows_ci_var(tmp_path: Path) -> None:
+    src = _write(tmp_path, "ok3.py", 'import os\nciv = os.getenv("CI")\n')
+    assert validate_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Inline suppression
+# ---------------------------------------------------------------------------
+
+
+def test_inline_suppression_skips_line(tmp_path: Path) -> None:
+    """Lines annotated with # env-read-ok are skipped."""
+    src = _write(
+        tmp_path,
+        "suppressed.py",
+        'import os\nVAL = os.environ["MY_CUSTOM_KEY"]  # env-read-ok: bootstrap boundary\n',
+    )
+    assert validate_file(src) == []
+
+
+def test_inline_suppression_required_reason(tmp_path: Path) -> None:
+    """Bare # env-read-ok (no reason) is still accepted as suppression."""
+    src = _write(
+        tmp_path,
+        "suppressed2.py",
+        'import os\nVAL = os.environ["MY_CUSTOM_KEY"]  # env-read-ok\n',
+    )
+    assert validate_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Skip rules
+# ---------------------------------------------------------------------------
+
+
+def test_skips_test_files(tmp_path: Path) -> None:
+    """Files inside a tests/ directory are skipped entirely."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    src = tests_dir / "test_something.py"
+    src.write_text('import os\nos.environ["UNLISTED"]\n', encoding="utf-8")
+    assert validate_file(src) == []
+
+
+def test_skips_scripts_dir(tmp_path: Path) -> None:
+    """Files inside a scripts/ directory are skipped entirely."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    src = scripts_dir / "bootstrap.py"
+    src.write_text('import os\nos.environ["UNLISTED"]\n', encoding="utf-8")
+    assert validate_file(src) == []
+
+
+def test_skips_non_python_file(tmp_path: Path) -> None:
+    """Non-.py files are skipped."""
+    src = _write(tmp_path, "config.yaml", 'key: "os.environ[THING]"\n')
+    assert validate_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Multiline string false-positive guard
+# ---------------------------------------------------------------------------
+
+
+def test_no_false_positive_in_docstring(tmp_path: Path) -> None:
+    """env reads in docstrings / multiline strings must not fire."""
+    src = _write(
+        tmp_path,
+        "docs.py",
+        '''\
+def foo():
+    """
+    Example::
+
+        val = os.environ["SOME_KEY"]
+    """
+    pass
+''',
+    )
+    assert validate_file(src) == []
+
+
+def test_no_false_positive_in_triple_quoted_string(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "tqs.py",
+        '''\
+TEMPLATE = """
+os.getenv("SHOULD_BE_IGNORED")
+"""
+''',
+    )
+    assert validate_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# validate_paths — multi-file aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_paths_aggregates(tmp_path: Path) -> None:
+    """validate_paths returns findings from all supplied paths."""
+    f1 = _write(tmp_path, "a.py", 'import os\nos.environ["AAA"]\n')
+    f2 = _write(tmp_path, "b.py", 'import os\nos.getenv("BBB")\n')
+    findings = validate_paths([f1, f2])
+    var_names = {f.var_name for f in findings}
+    assert "AAA" in var_names
+    assert "BBB" in var_names
+
+
+def test_validate_paths_returns_empty_on_clean_files(tmp_path: Path) -> None:
+    f1 = _write(tmp_path, "clean.py", "x = 1\n")
+    assert validate_paths([f1]) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI (main) exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_0_on_no_violations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """main() returns 0 when no files have violations."""
+    clean = _write(tmp_path, "clean.py", "x = 1\n")
+    monkeypatch.setattr(sys, "argv", ["validator", str(clean)])
+    from omnibase_core.validators.no_new_os_environ import main
+
+    assert main() == 0
+
+
+def test_main_exits_1_on_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """main() returns 1 when at least one violation is found."""
+    bad = _write(tmp_path, "bad.py", 'import os\nos.environ["FORBIDDEN_KEY"]\n')
+    monkeypatch.setattr(sys, "argv", ["validator", str(bad)])
+    from omnibase_core.validators.no_new_os_environ import main
+
+    assert main() == 1
+
+
+# ---------------------------------------------------------------------------
+# DELIBERATE RED-TEST CORPUS (DoD proof OMN-13566)
+# ---------------------------------------------------------------------------
+# These two snippets are planted violations — each must produce exactly one
+# finding.  If the validator is ever regressed to the point of not catching
+# them, this test fails, proving the CI gate would have let the violation in.
+
+
+_CORPUS_VIOLATION_A = """\
+import os
+
+SECRET = os.environ["ONEX_NEW_VIOLATION_CORPUS_A"]
+"""
+
+_CORPUS_VIOLATION_B = """\
+import os
+
+SECRET = os.getenv("ONEX_NEW_VIOLATION_CORPUS_B")
+"""
+
+
+def test_deliberate_violation_corpus(tmp_path: Path) -> None:
+    """Red-test corpus: two known-bad snippets must each produce exactly one finding."""
+    va = _write(tmp_path, "corpus_a.py", _CORPUS_VIOLATION_A)
+    vb = _write(tmp_path, "corpus_b.py", _CORPUS_VIOLATION_B)
+
+    findings_a = validate_file(va)
+    findings_b = validate_file(vb)
+
+    assert len(findings_a) == 1, (
+        f"Corpus-A violation not flagged — gate is broken! findings={findings_a}"
+    )
+    assert findings_a[0].var_name == "ONEX_NEW_VIOLATION_CORPUS_A"
+
+    assert len(findings_b) == 1, (
+        f"Corpus-B violation not flagged — gate is broken! findings={findings_b}"
+    )
+    assert findings_b[0].var_name == "ONEX_NEW_VIOLATION_CORPUS_B"

--- a/tests/validation/test_validator_requirements_consumer.py
+++ b/tests/validation/test_validator_requirements_consumer.py
@@ -342,6 +342,7 @@ def test_report_exit_code_zero_on_clean_repo(tmp_path: Path, spec_data: dict) ->
         "no-untracked-todos",
         "validate-no-transport-imports",
         "check-doc-content-scan",  # OMN-13572: doc-content scan (applies_to_repos: [omnibase_core])
+        "no-new-os-environ",  # OMN-13566: canonical AST env-read gate (applies_to_repos: [omnibase_core])
     ]
     _write_precommit(tmp_path, pre_commit_ids)
 


### PR DESCRIPTION
feat(OMN-13566): canonical no-new-os-environ AST validator + REQUIRED CI gate

## Summary

- Adds `omnibase_core.validators.no_new_os_environ` — a canonical AST-based validator that blocks ALL `os.environ[KEY]`, `os.environ.get(KEY)`, and `os.getenv(KEY)` reads outside an explicit `KEEP_ALLOWLIST` of bootstrap/path/CI variables. Generalises `omnibase_infra/scripts/check-env-reads.sh` (OMN-11069/11186) and the regex `validate_no_new_env_vars.py` into one packageable implementation.
- Exports `no-new-os-environ` pre-commit hook from omnibase_core (fleet consumption via `.pre-commit-hooks.yaml`).
- Wires `no-new-os-environ` CI job into `quality-gate` (feeds the `CI Summary` rollup) — any new `os.environ` read in `src/` turns the required check red.
- Registers the validator in `architecture-handshakes/validator-requirements.yaml` (required pre-commit + CI) and Model-B `validator_jobs` for omnibase_core.
- 27 unit tests including `test_deliberate_violation_corpus` — plants two known-bad snippets and asserts both are flagged. This is the DoD proof that the CI gate catches real violations.

## DoD checklist

- [x] Validator implemented in `omnibase_core/validators/no_new_os_environ.py` with KEEP_ALLOWLIST
- [x] 27 unit tests pass, including deliberate red-test corpus
- [x] Pre-commit hook exported from `.pre-commit-hooks.yaml`
- [x] CI job wired into `quality-gate` (feeds CI Summary rollup)
- [x] `validator-requirements.yaml` updated with `no-new-os-environ` required entry
- [x] `src/` scans clean (zero violations on the existing codebase)
- [x] Deliberate red-test corpus proves gate is live

Evidence-Ticket: OMN-13566
Evidence-Source: OCC#3121

