### PR TITLE
feat(OMN-13576): wire spdx-headers as a required CI gate (burn down baseline ratchet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1211,6 +1211,64 @@ jobs:
           # shellcheck disable=SC2086
           uv run python -m omnibase_core.validation.doc_content_scan.runtime_doc_content_scan $files
 
+  # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
+  # SPDX Headers (OMN-13576: burn down validator-requirements baseline ratchet)
+  # validator-requirements.yaml requires `spdx-headers` (ci_workflow: required) on
+  # all repos. The pre-commit hook (validate-spdx-headers) was wired but no CI job
+  # ran it — it was grandfathered in validator-requirements-baseline.yaml as a
+  # MISSING_CI_WORKFLOW gap. This job runs the SAME validator the pre-commit hook
+  # runs, over the full tracked tree mirroring the hook's files:/exclude: scope,
+  # and feeds quality-gate so a missing/incorrect SPDX header turns the single
+  # required CI Summary rollup red. Full-tree scan (not changed-files) avoids the
+  # merge_group / no-diff exit-0 hole on the required path.
+  spdx-headers:
+    name: SPDX Headers
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Validate SPDX headers (OMN-13576)
+        run: |
+          # Mirror the pre-commit hook (validate-spdx-headers) file scope:
+          # files: ^(src|tests|scripts|examples)/.*\.(py|sh|bash|yml|yaml|toml)$
+          # exclude: ^(archived/|archive/)
+          files=$(git ls-files \
+            'src/**/*.py' 'src/**/*.sh' 'src/**/*.bash' 'src/**/*.yml' 'src/**/*.yaml' 'src/**/*.toml' \
+            'tests/**/*.py' 'tests/**/*.sh' 'tests/**/*.bash' 'tests/**/*.yml' 'tests/**/*.yaml' 'tests/**/*.toml' \
+            'scripts/**/*.py' 'scripts/**/*.sh' 'scripts/**/*.bash' 'scripts/**/*.yml' 'scripts/**/*.yaml' 'scripts/**/*.toml' \
+            'examples/**/*.py' 'examples/**/*.sh' 'examples/**/*.bash' 'examples/**/*.yml' 'examples/**/*.yaml' 'examples/**/*.toml' \
+            | grep -vE '^(archived/|archive/)' || true)
+          if [ -z "$files" ]; then
+            echo "No SPDX-eligible files to validate."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          uv run python scripts/validation/validate_spdx_headers.py $files
+
   # No-new-os-environ gate (OMN-13566) — canonical AST-based env-read enforcement.
   # Blocks ALL os.environ/os.getenv reads outside KEEP_ALLOWLIST. Feeds quality-gate
   # so a violation turns the single required CI Summary rollup red. The deliberate
@@ -1272,7 +1330,7 @@ jobs:
     # provide. naming-conventions / pydantic-patterns / aislop-patterns ARE
     # spec-required validators (validator-requirements.yaml) and are now needs so
     # a real violation turns the single required CI Summary rollup red.
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan, no-new-os-environ]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan, no-new-os-environ, spdx-headers]
     if: always()
 
     steps:
@@ -1306,6 +1364,7 @@ jobs:
           aislop="${{ needs.aislop-patterns.result }}"
           doc_content="${{ needs.doc-content-scan.result }}"
           no_new_os_environ="${{ needs.no-new-os-environ.result }}"
+          spdx_headers="${{ needs.spdx-headers.result }}"
 
           # Report each check
           echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
@@ -1332,6 +1391,7 @@ jobs:
           echo "| AI Slop Patterns (OMN-13574) | $aislop |" >> $GITHUB_STEP_SUMMARY
           echo "| Doc-Content Scan (OMN-13572) | $doc_content |" >> $GITHUB_STEP_SUMMARY
           echo "| No New os.environ Reads (OMN-13566) | $no_new_os_environ |" >> $GITHUB_STEP_SUMMARY
+          echo "| SPDX Headers (OMN-13576) | $spdx_headers |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
           if [[ "$lint" == "success" ]] && \
@@ -1355,7 +1415,8 @@ jobs:
              [[ "$pydantic" == "success" ]] && \
              [[ "$aislop" == "success" ]] && \
              [[ "$doc_content" == "success" ]] && \
-             [[ "$no_new_os_environ" == "success" ]]; then
+             [[ "$no_new_os_environ" == "success" ]] && \
+             [[ "$spdx_headers" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY
             echo "All quality checks passed."

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -110,9 +110,10 @@ classification:
   single-class-per-file:
     ci_workflow: backlog
     tracking: OMN-9048
-  spdx-headers:
-    ci_workflow: backlog
-    tracking: OMN-9048
+  # spdx-headers: WIRED + REMOVED 2026-06-25 (OMN-13576). The `spdx-headers` CI
+  # job in ci.yml now runs the validator over the full tree and feeds
+  # quality-gate → CI Summary, so the MISSING_CI_WORKFLOW gap no longer
+  # reproduces. Keeping a stale entry here would fail the gate.
   stub-implementations:
     ci_workflow: backlog
     tracking: OMN-9048
@@ -151,9 +152,8 @@ gaps:
   - repo: omnibase_core
     validator: single-class-per-file
     kind: MISSING_CI_WORKFLOW
-  - repo: omnibase_core
-    validator: spdx-headers
-    kind: MISSING_CI_WORKFLOW
+  # spdx-headers MISSING_CI_WORKFLOW removed 2026-06-25 (OMN-13576) — now WIRED
+  # as the `spdx-headers` CI job feeding quality-gate → CI Summary.
   - repo: omnibase_core
     validator: stub-implementations
     kind: MISSING_CI_WORKFLOW

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -738,6 +738,7 @@ model_b_rollup_enforcement:
         aislop-patterns: ["aislop-patterns"]
         doc-content-scan: ["doc-content-scan"]
         no-new-os-environ: ["no-new-os-environ"]
+        spdx-headers: ["spdx-headers"]
       # Machine-checkable intentional omissions. These validators are
       # ci_workflow: required and apply to omnibase_core, but are currently
       # grandfathered in validator-requirements-baseline.yaml as
@@ -748,7 +749,11 @@ model_b_rollup_enforcement:
       # starts applying to omnibase_core cannot silently escape Model B: it
       # must be added to validator_jobs (covered) or here (explicitly deferred).
       grandfathered_validators:
-        - spdx-headers
+        # OMN-13576: spdx-headers graduated from grandfathered → validator_jobs.
+        # The `spdx-headers` CI job in ci.yml runs the same validator the
+        # pre-commit hook runs (full-tree, mirroring the hook's files:/exclude:
+        # scope) and feeds quality-gate → ci-summary, so a missing/incorrect SPDX
+        # header turns the single required CI Summary rollup red.
         - stub-implementations
         - single-class-per-file
         - bandit-security

--- a/scripts/validation/validate-single-class-per-file.py
+++ b/scripts/validation/validate-single-class-per-file.py
@@ -200,6 +200,7 @@ def should_exclude_file(filepath: Path) -> bool:
         "model_routing_config.py",  # ModelTierModel + ModelRoutingTier + ModelDelegationConfig (hierarchy)
         "model_quality_gate.py",  # ModelQualityGateInput + ModelQualityGateResult (paired gate DTOs)
         "model_bifrost_delegation_config.py",  # 7 tightly-coupled Bifrost gateway config DTOs
+        "model_golden_chain_fixture.py",  # ModelGoldenChainProvenance + ModelGoldenChainFixture (fixture + embedded provenance); pre-existing OMN-13499 file surfaced by spdx-headers CI gate wiring (OMN-13576); split tracked separately
     }
 
     # Exclude validator files with small helper classes

--- a/src/omnibase_core/models/runtime/golden_chain/__init__.py
+++ b/src/omnibase_core/models/runtime/golden_chain/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Models for the canonical recorded-from-real golden-chain harness (OMN-13499)."""
 

--- a/src/omnibase_core/models/runtime/golden_chain/model_golden_chain_fixture.py
+++ b/src/omnibase_core/models/runtime/golden_chain/model_golden_chain_fixture.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Provenance-stamped golden-chain replay fixture model (OMN-13499).
 

--- a/src/omnibase_core/models/validation/model_rollup_coverage_gap.py
+++ b/src/omnibase_core/models/validation/model_rollup_coverage_gap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """Model-B rollup-coverage gap model (OMN-13574).

--- a/src/omnibase_core/runtime/golden_chain/record_guard.py
+++ b/src/omnibase_core/runtime/golden_chain/record_guard.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Record-mode authority guard for the canonical golden-chain harness (OMN-13499).
 
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
 _RECORD_ENV = "OMN_RECORD_GOLDEN"
 _NIGHTLY_RECORD_ENV = "OMN_GOLDEN_NIGHTLY_RECORD"
@@ -58,12 +61,16 @@ def require_record_mode_disabled(env: Mapping[str, str] | None = None) -> None:
     if not record_mode_enabled(source):
         return
     if _in_ci(source) and not _approved_nightly(source):
-        raise RuntimeError(
-            "Golden-chain RECORD mode (OMN_RECORD_GOLDEN=1) was requested inside a "
-            "CI run that is not an approved nightly record job. PR CI must REPLAY "
-            "fixtures only and must never mint/refresh a fixture (no accidental "
-            "regeneration). Record fixtures manually with a real endpoint, or via "
-            "the gated nightly record workflow (OMN_GOLDEN_NIGHTLY_RECORD=1)."
+        raise ModelOnexError(
+            message=(
+                "Golden-chain RECORD mode (OMN_RECORD_GOLDEN=1) was requested inside "
+                "a CI run that is not an approved nightly record job. PR CI must "
+                "REPLAY fixtures only and must never mint/refresh a fixture (no "
+                "accidental regeneration). Record fixtures manually with a real "
+                "endpoint, or via the gated nightly record workflow "
+                "(OMN_GOLDEN_NIGHTLY_RECORD=1)."
+            ),
+            error_code=EnumCoreErrorCode.INVALID_STATE,
         )
 
 

--- a/src/omnibase_core/validation/validator_rollup_coverage.py
+++ b/src/omnibase_core/validation/validator_rollup_coverage.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """Model-B rollup-coverage verifier for validator-requirements.yaml (OMN-13574).
@@ -70,11 +70,15 @@ class RollupCoverageVerifier:
     """Verify that a repo's required rollup transitively covers every opted-in
     spec-required validator, with no failure-swallowing on the covering jobs."""
 
-    def __init__(self, spec: dict[str, Any]) -> None:
+    def __init__(
+        self, spec: dict[str, Any]
+    ) -> None:  # ONEX_EXCLUDE: dict_str_any — raw validator-requirements.yaml document
         self._spec = spec
         enforcement = spec.get("model_b_rollup_enforcement")
         repos = enforcement.get("repos", {}) if isinstance(enforcement, dict) else {}
-        self._repos: dict[str, Any] = repos if isinstance(repos, dict) else {}
+        self._repos: dict[str, Any] = (
+            repos if isinstance(repos, dict) else {}
+        )  # ONEX_EXCLUDE: dict_str_any — opt-in block keyed by repo name
 
     @classmethod
     def from_spec_path(cls, spec_path: Path) -> RollupCoverageVerifier:
@@ -232,7 +236,9 @@ class RollupCoverageVerifier:
         return gaps
 
     @staticmethod
-    def _swallows_failure(job: dict[str, Any]) -> bool:
+    def _swallows_failure(
+        job: dict[str, Any],
+    ) -> bool:  # ONEX_EXCLUDE: dict_str_any — raw workflow job mapping from YAML
         # continue-on-error: true makes the job result "success" even when its
         # steps fail, so an aggregator reading needs.<job>.result can never go
         # red on it. Treat literal true and the string "true".
@@ -240,7 +246,9 @@ class RollupCoverageVerifier:
         return value is True or (isinstance(value, str) and value.strip() == "true")
 
     @staticmethod
-    def _transitive_needs(jobs: dict[str, Any], start: str) -> set[str]:
+    def _transitive_needs(
+        jobs: dict[str, Any], start: str
+    ) -> set[str]:  # ONEX_EXCLUDE: dict_str_any — raw workflow jobs mapping from YAML
         """All jobs transitively reachable through ``needs`` edges from ``start``."""
         seen: set[str] = set()
         queue: deque[str] = deque(_as_list(jobs.get(start, {}).get("needs")))

--- a/tests/unit/runtime/golden_chain/__init__.py
+++ b/tests/unit/runtime/golden_chain/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/runtime/golden_chain/test_recorded_replay_transport.py
+++ b/tests/unit/runtime/golden_chain/test_recorded_replay_transport.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Unit tests for the canonical golden-chain replay harness (OMN-13499).
 
@@ -20,6 +20,7 @@ from typing import Any
 
 import pytest
 
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.runtime.golden_chain.model_golden_chain_fixture import (
     ModelGoldenChainFixture,
 )
@@ -189,7 +190,7 @@ def test_record_mode_disabled_passes_outside_ci() -> None:
 
 
 def test_record_mode_fails_closed_in_pr_ci() -> None:
-    with pytest.raises(RuntimeError, match="must REPLAY fixtures only"):
+    with pytest.raises(ModelOnexError, match="must REPLAY fixtures only"):
         require_record_mode_disabled({"OMN_RECORD_GOLDEN": "1", "CI": "true"})
 
 
@@ -200,7 +201,7 @@ def test_record_mode_allowed_in_nightly() -> None:
 
 
 def test_record_fixture_blocked_in_pr_ci(tmp_path: Path) -> None:
-    with pytest.raises(RuntimeError, match="must REPLAY fixtures only"):
+    with pytest.raises(ModelOnexError, match="must REPLAY fixtures only"):
         record_fixture(
             output_path=tmp_path / "x.json",
             provider="zai",

--- a/tests/validation/test_validator_rollup_coverage.py
+++ b/tests/validation/test_validator_rollup_coverage.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """Meta-check tests for Model-B rollup coverage (OMN-13574, epic OMN-13573).
@@ -191,6 +191,25 @@ def test_meta_full_equality_no_silent_escape(spec: dict[str, Any]) -> None:
     assert not stale, (
         f"validator_jobs/grandfathered_validators reference validators that are "
         f"not ci_workflow:required for {PILOT_REPO}: {sorted(stale)}"
+    )
+
+
+def test_spdx_headers_is_wired_not_grandfathered(spec: dict[str, Any]) -> None:
+    """OMN-13576: spdx-headers graduated from grandfathered → validator_jobs.
+
+    Locks the burn-down: spdx-headers must be a covered rollup validator (its CI
+    job feeds quality-gate → CI Summary) and must NOT be listed as a deferred
+    grandfathered gap. A revert that re-grandfathers spdx-headers turns this red.
+    """
+    cfg = spec["model_b_rollup_enforcement"]["repos"][PILOT_REPO]
+    assert "spdx-headers" in cfg["validator_jobs"], (
+        "spdx-headers must be covered in validator_jobs (OMN-13576 wiring)"
+    )
+    assert "spdx-headers" not in cfg.get("grandfathered_validators", []), (
+        "spdx-headers must NOT be grandfathered — it is now a wired CI gate"
+    )
+    assert cfg["validator_jobs"]["spdx-headers"] == ["spdx-headers"], (
+        "spdx-headers must map to the 'spdx-headers' ci.yml job"
     )
 
 


### PR DESCRIPTION
## OMN-13576 — Burn down the validator-requirements baseline ratchet (first batch: wire `spdx-headers`)

Graduates the **`spdx-headers`** validator from a grandfathered baseline gap into a real, rollup-covered, required CI gate, following the OMN-13574 Model B failing-rollup pattern. Serial-per-validator per the CLAUDE.md constraint — this PR wires exactly one validator end-to-end; the remaining baseline entries graduate in their own follow-on PRs.

### What changed
- **`.github/workflows/ci.yml`**: new `spdx-headers` job runs `validate_spdx_headers.py` over the full tracked tree (mirroring the pre-commit hook's `files:`/`exclude:` scope) and is added to `quality-gate.needs` + the gate conditional, so a missing/incorrect SPDX header turns the single required **CI Summary** rollup red.
- **`validator-requirements.yaml`**: `spdx-headers -> ["spdx-headers"]` added to `model_b_rollup_enforcement.repos.omnibase_core.validator_jobs`; removed from `grandfathered_validators`. Rollup-coverage stays **AIRTIGHT**.
- **`validator-requirements-baseline.yaml`**: removed the `spdx-headers` `MISSING_CI_WORKFLOW` gap + classification entry. Consumer now reports `baseline-clean` (11 accepted gaps, was 12) **without** grandfathering spdx-headers.
- **7 pre-existing SPDX year-drift files** fixed (`2026 -> 2025`, the canonical-frozen creation year per `cli_spdx.py` / FILE_HEADERS.md) surfaced by the new full-tree gate, incl. one empty `__init__.py`.
- **3 pre-existing hook violations** those touched files carried, resolved so the gate ships green: `record_guard` `RuntimeError -> ModelOnexError(INVALID_STATE)`; two `dict[str, Any]` YAML-parse params annotated `# ONEX_EXCLUDE: dict_str_any`; `model_golden_chain_fixture.py` added to the path-scoped single-class legacy-exemption list.
- New regression test `test_spdx_headers_is_wired_not_grandfathered` locks the graduation.

### dod_evidence
- `validate-validator-requirements` consumer: `baseline-clean (omnibase_core — 11 accepted gap(s))` — spdx-headers gap no longer reproduced, no stale-baseline failure, **no grandfathering of spdx-headers**.
- `validator_rollup_coverage --repo omnibase_core`: `rollup-coverage: AIRTIGHT`.
- `pytest tests/validation/test_validator_rollup_coverage.py tests/validation/test_validator_requirements_spec.py tests/unit/runtime/golden_chain/test_recorded_replay_transport.py` → **48 passed**.
- **Planted-violation proof** (DoD): a file with a bad SPDX header makes `validate_spdx_headers.py` (the `spdx-headers` job's command) exit `1`; removing it returns exit `0`. So a real SPDX violation now turns the required CI Summary rollup red.
- `mypy --strict` clean on touched src.

Evidence-Source: OCC#3140
Evidence-Ticket: OMN-13576
