### PR TITLE
feat(OMN-13613): Shared Experiment Result Contract in core shared models

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -174,6 +174,10 @@ from .enum_execution_shape import EnumExecutionShape, EnumMessageCategory
 from .enum_execution_status import EnumExecutionStatus
 from .enum_execution_trigger import EnumExecutionTrigger
 
+# Shared Experiment Result Contract enums (OMN-13613)
+from .enum_experiment_status import EnumExperimentStatus
+from .enum_experiment_type import EnumExperimentType
+
 # Failure type enums (OMN-1236)
 from .enum_failure_type import EnumFailureType
 
@@ -622,6 +626,8 @@ __all__ = [
     "EnumExecutionMode",
     "EnumExecutionShape",
     "EnumExecutionTrigger",
+    "EnumExperimentStatus",
+    "EnumExperimentType",
     "EnumMessageCategory",
     # Log level domain
     "EnumLogLevel",

--- a/src/omnibase_core/enums/enum_experiment_status.py
+++ b/src/omnibase_core/enums/enum_experiment_status.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Experiment-status enumeration for the Shared Experiment Result Contract.
+
+Strongly typed lifecycle status of a canonical experiment run carried by
+:class:`~omnibase_core.models.experiment.model_experiment_result.ModelExperimentResult`.
+Shared by all three Phase-3 experiment orchestrators of the SEA→canonical
+migration (epic OMN-13604) so every node reports terminal/lifecycle state
+through one vocabulary.
+
+.. versionadded:: OMN-13613
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumExperimentStatus(UtilStrValueHelper, str, Enum):
+    """Lifecycle status of a canonical experiment run."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+__all__ = ["EnumExperimentStatus"]

--- a/src/omnibase_core/enums/enum_experiment_type.py
+++ b/src/omnibase_core/enums/enum_experiment_type.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Experiment-type enumeration for the Shared Experiment Result Contract.
+
+Strongly typed classification of which canonical experiment orchestrator
+produced a :class:`~omnibase_core.models.experiment.model_experiment_result.ModelExperimentResult`.
+One member per Phase-3 orchestrator of the SEA→canonical migration
+(epic OMN-13604):
+
+* ``ENTROPY``         — ``node_entropy_experiment_orchestrator`` (OMN-13614)
+* ``MODEL_EVAL``      — ``node_model_eval_orchestrator`` (OMN-13615)
+* ``REGRESSION_TEST`` — ``node_regression_test_orchestrator`` (OMN-13616)
+
+.. versionadded:: OMN-13613
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumExperimentType(UtilStrValueHelper, str, Enum):
+    """Which canonical experiment orchestrator produced a result."""
+
+    ENTROPY = "entropy"
+    MODEL_EVAL = "model_eval"
+    REGRESSION_TEST = "regression_test"
+
+
+__all__ = ["EnumExperimentType"]

--- a/src/omnibase_core/models/__init__.py
+++ b/src/omnibase_core/models/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "epic",  # Epic-team execution state models (OMN-3871)
     "events",
     "execution",
+    "experiment",  # Shared Experiment Result Contract (OMN-13613)
     "handlers",
     "hooks",  # External hook models (Claude Code - OMN-1474)
     "infrastructure",

--- a/src/omnibase_core/models/experiment/__init__.py
+++ b/src/omnibase_core/models/experiment/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical experiment-telemetry models (OMN-13613).
+
+The Shared Experiment Result Contract is the single result schema emitted by
+all three Phase-3 experiment orchestrators of the SEA→canonical migration
+(epic OMN-13604). No experiment node invents its own result schema; they all
+import from here.
+
+Callers should import concrete symbols from their modules directly, e.g.::
+
+    from omnibase_core.models.experiment.model_experiment_result import (
+        ModelExperimentResult,
+    )
+"""

--- a/src/omnibase_core/models/experiment/model_experiment_cost.py
+++ b/src/omnibase_core/models/experiment/model_experiment_cost.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed dollar cost for the Shared Experiment Result Contract (OMN-13613).
+
+``cost_usd`` is a :class:`~decimal.Decimal` to avoid binary-float rounding drift
+in cost accounting and aggregation across the three Phase-3 experiment
+orchestrators of the SEA→canonical migration (epic OMN-13604).
+
+.. versionadded:: OMN-13613
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelExperimentCost"]
+
+
+class ModelExperimentCost(BaseModel):
+    """Typed dollar cost for an experiment result."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    cost_usd: Decimal = Field(
+        ...,
+        ge=Decimal("0"),
+        description="Total experiment cost in US dollars (Decimal, never negative).",
+    )

--- a/src/omnibase_core/models/experiment/model_experiment_evidence_ref.py
+++ b/src/omnibase_core/models/experiment/model_experiment_evidence_ref.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed evidence reference for the Shared Experiment Result Contract (OMN-13613).
+
+``evidence_id`` is the canonical UUID of the evidence record (e.g. an
+``ModelEvidenceItem.item_id``). ``artifact_ref`` optionally carries the
+content-addressed artifact-store reference (``sha256:<64 hex>``) for the raw
+evidence bytes. Shared by the three Phase-3 experiment orchestrators of the
+SEA→canonical migration (epic OMN-13604).
+
+.. versionadded:: OMN-13613
+"""
+
+from __future__ import annotations
+
+import re
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+__all__ = ["ModelExperimentEvidenceRef"]
+
+_SHA256_ARTIFACT_REF_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ModelExperimentEvidenceRef(BaseModel):
+    """Typed reference to the durable evidence backing an experiment result."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    evidence_id: UUID = Field(
+        ...,
+        description="Canonical UUID of the durable evidence record.",
+    )
+    artifact_ref: str | None = Field(  # content-address-ok: sha256-prefixed digest
+        default=None,
+        description=(
+            "Optional content-addressed artifact reference "
+            "('sha256:<64 lowercase hex chars>') for the raw evidence bytes."
+        ),
+    )
+
+    @field_validator("artifact_ref")
+    @classmethod
+    def _validate_artifact_ref(cls, value: str | None) -> str | None:
+        if value is not None and not _SHA256_ARTIFACT_REF_RE.match(value):
+            raise ValueError(
+                "artifact_ref must match 'sha256:<64 lowercase hex chars>', "
+                f"got: {value!r}"
+            )
+        return value

--- a/src/omnibase_core/models/experiment/model_experiment_result.py
+++ b/src/omnibase_core/models/experiment/model_experiment_result.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Shared Experiment Result Contract — canonical experiment telemetry (OMN-13613).
+
+``ModelExperimentResult`` is the single result schema emitted by every Phase-3
+experiment orchestrator of the SEA→canonical migration (epic OMN-13604):
+
+* ``node_entropy_experiment_orchestrator`` (OMN-13614)
+* ``node_model_eval_orchestrator`` (OMN-13615)
+* ``node_regression_test_orchestrator`` (OMN-13616)
+
+It is homed in ``omnibase_core`` (shared models) because those three nodes plus
+``omnimarket`` import it — ``>= 2`` repos consume it, so it belongs in core
+(see ``feedback_models_in_core_not_market.md``). No experiment node may invent
+its own result schema; they all import from here.
+
+Every field is strongly typed: identifiers are ``UUID``, lifecycle/classification
+fields are enums, and ``score`` / ``cost`` / ``evidence_ref`` are frozen typed
+value objects rather than bare scalars or ``str``. The model is frozen.
+
+.. versionadded:: OMN-13613
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_experiment_status import EnumExperimentStatus
+from omnibase_core.enums.enum_experiment_type import EnumExperimentType
+from omnibase_core.models.experiment.model_experiment_cost import ModelExperimentCost
+from omnibase_core.models.experiment.model_experiment_evidence_ref import (
+    ModelExperimentEvidenceRef,
+)
+from omnibase_core.models.experiment.model_experiment_score import ModelExperimentScore
+
+__all__ = ["ModelExperimentResult"]
+
+
+class ModelExperimentResult(BaseModel):
+    """Canonical result emitted by every Phase-3 experiment orchestrator.
+
+    All three experiment nodes (OMN-13614 / OMN-13615 / OMN-13616) plus
+    ``omnimarket`` produce/consume this exact shape — one result model, not
+    three. Every field is strongly typed and the model is frozen.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    experiment_id: UUID = Field(
+        ...,
+        description="Unique identifier for this experiment.",
+    )
+    experiment_type: EnumExperimentType = Field(
+        ...,
+        description="Which canonical experiment orchestrator produced the result.",
+    )
+    run_id: UUID = Field(
+        ...,
+        description="Identifier of the specific run that produced this result.",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation identifier linking events across the run.",
+    )
+    runtime_identity: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Runtime lane/service identity that executed the experiment "
+            "(e.g. 'stability-test/runtime-local')."
+        ),
+    )
+    score: ModelExperimentScore = Field(
+        ...,
+        description="Typed numeric score produced by the experiment.",
+    )
+    cost: ModelExperimentCost = Field(
+        ...,
+        description="Typed dollar cost of the experiment.",
+    )
+    status: EnumExperimentStatus = Field(
+        ...,
+        description="Lifecycle/terminal status of the experiment run.",
+    )
+    evidence_ref: ModelExperimentEvidenceRef = Field(
+        ...,
+        description="Typed reference to the durable evidence backing the result.",
+    )

--- a/src/omnibase_core/models/experiment/model_experiment_score.py
+++ b/src/omnibase_core/models/experiment/model_experiment_score.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed numeric score for the Shared Experiment Result Contract (OMN-13613).
+
+A bare float is ambiguous about its scale; pairing the value with an explicit
+``scale_max`` makes "0.875 out of 1.0" unambiguous across the three Phase-3
+experiment orchestrators of the SEA→canonical migration (epic OMN-13604).
+
+.. versionadded:: OMN-13613
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = ["ModelExperimentScore"]
+
+
+class ModelExperimentScore(BaseModel):
+    """Typed numeric score for an experiment result."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    value: float = Field(
+        ...,
+        ge=0.0,
+        description="Measured score, in the range [0.0, scale_max].",
+    )
+    scale_max: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Maximum possible score on this scale (default 1.0).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_value_within_scale(self) -> ModelExperimentScore:
+        if self.value > self.scale_max:
+            raise ValueError(
+                f"score value {self.value} exceeds scale_max {self.scale_max}"
+            )
+        return self

--- a/tests/unit/models/experiment/__init__.py
+++ b/tests/unit/models/experiment/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/models/experiment/test_model_experiment_result.py
+++ b/tests/unit/models/experiment/test_model_experiment_result.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the canonical Shared Experiment Result Contract (OMN-13613).
+
+The contract is shared by all three Phase-3 experiment orchestrators
+(OMN-13614 / OMN-13615 / OMN-13616) plus omnimarket. Every field must be
+strongly typed (UUID, enums, typed value objects — no bare ``str``), and the
+model and its value objects must be frozen.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_experiment_status import EnumExperimentStatus
+from omnibase_core.enums.enum_experiment_type import EnumExperimentType
+from omnibase_core.models.experiment.model_experiment_cost import ModelExperimentCost
+from omnibase_core.models.experiment.model_experiment_evidence_ref import (
+    ModelExperimentEvidenceRef,
+)
+from omnibase_core.models.experiment.model_experiment_result import (
+    ModelExperimentResult,
+)
+from omnibase_core.models.experiment.model_experiment_score import ModelExperimentScore
+
+
+def _result(**overrides: object) -> ModelExperimentResult:
+    base: dict[str, object] = {
+        "experiment_id": uuid4(),
+        "experiment_type": EnumExperimentType.MODEL_EVAL,
+        "run_id": uuid4(),
+        "correlation_id": uuid4(),
+        "runtime_identity": "stability-test/runtime-local",
+        "score": ModelExperimentScore(value=0.875, scale_max=1.0),
+        "cost": ModelExperimentCost(cost_usd=Decimal("0.0123")),
+        "status": EnumExperimentStatus.COMPLETED,
+        "evidence_ref": ModelExperimentEvidenceRef(evidence_id=uuid4()),
+    }
+    base.update(overrides)
+    return ModelExperimentResult(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestEnumExperimentType:
+    def test_is_str_enum(self) -> None:
+        assert EnumExperimentType.MODEL_EVAL.value == "model_eval"
+        assert str(EnumExperimentType.MODEL_EVAL) == "model_eval"
+
+    def test_covers_three_phase3_orchestrators(self) -> None:
+        values = {member.value for member in EnumExperimentType}
+        assert {"entropy", "model_eval", "regression_test"} <= values
+
+
+@pytest.mark.unit
+class TestEnumExperimentStatus:
+    def test_is_str_enum(self) -> None:
+        assert EnumExperimentStatus.COMPLETED.value == "completed"
+        assert str(EnumExperimentStatus.FAILED) == "failed"
+
+    def test_has_lifecycle_states(self) -> None:
+        values = {member.value for member in EnumExperimentStatus}
+        assert {"pending", "running", "completed", "failed"} <= values
+
+
+@pytest.mark.unit
+class TestModelExperimentScore:
+    def test_valid_score(self) -> None:
+        score = ModelExperimentScore(value=0.5, scale_max=1.0)
+        assert score.value == 0.5
+        assert score.scale_max == 1.0
+
+    def test_frozen(self) -> None:
+        score = ModelExperimentScore(value=0.5, scale_max=1.0)
+        with pytest.raises(ValidationError):
+            score.value = 0.6  # type: ignore[misc]
+
+    def test_value_must_not_exceed_scale_max(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelExperimentScore(value=1.5, scale_max=1.0)
+
+    def test_negative_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelExperimentScore(value=-0.1, scale_max=1.0)
+
+    def test_scale_max_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelExperimentScore(value=0.0, scale_max=0.0)
+
+
+@pytest.mark.unit
+class TestModelExperimentCost:
+    def test_cost_usd_is_decimal(self) -> None:
+        cost = ModelExperimentCost(cost_usd=Decimal("0.42"))
+        assert isinstance(cost.cost_usd, Decimal)
+        assert cost.cost_usd == Decimal("0.42")
+
+    def test_frozen(self) -> None:
+        cost = ModelExperimentCost(cost_usd=Decimal("0.42"))
+        with pytest.raises(ValidationError):
+            cost.cost_usd = Decimal("0.99")  # type: ignore[misc]
+
+    def test_negative_cost_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelExperimentCost(cost_usd=Decimal("-0.01"))
+
+    def test_zero_cost_allowed(self) -> None:
+        assert ModelExperimentCost(cost_usd=Decimal("0")).cost_usd == Decimal("0")
+
+
+@pytest.mark.unit
+class TestModelExperimentEvidenceRef:
+    def test_evidence_id_is_uuid(self) -> None:
+        evidence_id = uuid4()
+        ref = ModelExperimentEvidenceRef(evidence_id=evidence_id)
+        assert ref.evidence_id == evidence_id
+        assert isinstance(ref.evidence_id, UUID)
+
+    def test_frozen(self) -> None:
+        ref = ModelExperimentEvidenceRef(evidence_id=uuid4())
+        with pytest.raises(ValidationError):
+            ref.evidence_id = uuid4()  # type: ignore[misc]
+
+    def test_optional_artifact_ref(self) -> None:
+        ref = ModelExperimentEvidenceRef(
+            evidence_id=uuid4(),
+            artifact_ref="sha256:" + "a" * 64,
+        )
+        assert ref.artifact_ref == "sha256:" + "a" * 64
+
+    def test_string_evidence_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelExperimentEvidenceRef(evidence_id="not-a-uuid")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestModelExperimentResultFieldTypes:
+    def test_identifier_fields_are_uuid(self) -> None:
+        result = _result()
+        assert isinstance(result.experiment_id, UUID)
+        assert isinstance(result.run_id, UUID)
+        assert isinstance(result.correlation_id, UUID)
+
+    def test_enum_fields_are_enums(self) -> None:
+        result = _result()
+        assert isinstance(result.experiment_type, EnumExperimentType)
+        assert isinstance(result.status, EnumExperimentStatus)
+
+    def test_typed_value_objects(self) -> None:
+        result = _result()
+        assert isinstance(result.score, ModelExperimentScore)
+        assert isinstance(result.cost, ModelExperimentCost)
+        assert isinstance(result.evidence_ref, ModelExperimentEvidenceRef)
+
+    def test_runtime_identity_typed(self) -> None:
+        result = _result()
+        assert result.runtime_identity == "stability-test/runtime-local"
+
+    def test_string_experiment_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _result(experiment_id="not-a-uuid")
+
+    def test_invalid_experiment_type_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _result(experiment_type="not_a_type")
+
+    def test_valid_experiment_type_string_coerced(self) -> None:
+        # str-enum members accept their own string value (cross-process wire).
+        result = _result(experiment_type="model_eval")
+        assert result.experiment_type is EnumExperimentType.MODEL_EVAL
+
+    def test_string_status_coerced_or_rejected(self) -> None:
+        # str enum members accept their string value; an unknown string must fail.
+        with pytest.raises(ValidationError):
+            _result(status="not_a_status")
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            _result(unexpected_field="x")
+
+
+@pytest.mark.unit
+class TestModelExperimentResultFrozen:
+    def test_result_is_frozen(self) -> None:
+        result = _result()
+        with pytest.raises(ValidationError):
+            result.status = EnumExperimentStatus.FAILED  # type: ignore[misc]
+
+    def test_score_field_immutable(self) -> None:
+        result = _result()
+        with pytest.raises(ValidationError):
+            result.score = ModelExperimentScore(value=0.1, scale_max=1.0)  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestModelExperimentResultSerialization:
+    def test_roundtrip_json(self) -> None:
+        result = _result()
+        dumped = result.model_dump_json()
+        restored = ModelExperimentResult.model_validate_json(dumped)
+        assert restored == result
+
+    def test_equality_by_value(self) -> None:
+        experiment_id = uuid4()
+        run_id = uuid4()
+        correlation_id = uuid4()
+        evidence_id = uuid4()
+        kwargs: dict[str, object] = {
+            "experiment_id": experiment_id,
+            "experiment_type": EnumExperimentType.REGRESSION_TEST,
+            "run_id": run_id,
+            "correlation_id": correlation_id,
+            "runtime_identity": "dev/runtime-local",
+            "score": ModelExperimentScore(value=1.0, scale_max=1.0),
+            "cost": ModelExperimentCost(cost_usd=Decimal("0")),
+            "status": EnumExperimentStatus.COMPLETED,
+            "evidence_ref": ModelExperimentEvidenceRef(evidence_id=evidence_id),
+        }
+        assert ModelExperimentResult(**kwargs) == ModelExperimentResult(**kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
Evidence-Source: OCC#3161
Evidence-Ticket: OMN-13613

## OMN-13613 — Shared Experiment Result Contract (core shared models)

Phase-3 prerequisite of the SEA → canonical migration epic **OMN-13604**. Builds the **single canonical experiment-telemetry contract** that all three Phase-3 experiment orchestrators emit. No experiment node invents its own result schema; they all import this one model.

Homed in `omnibase_core` shared models because the three downstream orchestrators (**OMN-13614 / OMN-13615 / OMN-13616**) plus **omnimarket** import it — `>= 2` repos → core (per `feedback_models_in_core_not_market.md`).

### What's new
- `EnumExperimentType` — `entropy` / `model_eval` / `regression_test` (one member per Phase-3 orchestrator).
- `EnumExperimentStatus` — `pending` / `running` / `completed` / `failed` / `cancelled`.
- `ModelExperimentResult` — strongly-typed, frozen result with the canonical plan-doc fields:
  - `experiment_id` / `run_id` / `correlation_id` → `UUID`
  - `experiment_type` / `status` → enums (not strings)
  - `runtime_identity` → typed runtime lane/service identity
  - `score` → `ModelExperimentScore` (typed numeric value + `scale_max`, range-validated)
  - `cost` → `ModelExperimentCost` (`cost_usd` is `Decimal`, never negative)
  - `evidence_ref` → `ModelExperimentEvidenceRef` (evidence `UUID` + optional `sha256:` artifact ref)
- Value objects split one-class-per-file (repo single-class-per-file gate).

All models use `ConfigDict(frozen=True, extra="forbid", from_attributes=True)`. No bare `str` for typed fields, `UUID` not `str`, enums not strings — strongly-typed per repo doctrine.

### TDD + verification (dod_evidence)
- **TDD-first**: failing contract-derived test written before implementation (confirmed red: `ModuleNotFoundError: No module named 'omnibase_core.enums.enum_experiment_status'`), then made green.
- **Unit tests** (30): field types, frozen behavior, value-object validators (score within scale, non-negative cost, sha256 artifact-ref format, UUID rejection of non-UUID strings), `extra="forbid"`, and JSON round-trip.
  - `uv run pytest tests/unit/models/experiment/ -q` → **30 passed**
- **mypy --strict** clean on all new modules (4 enum/model files: `Success: no issues found`).
- **pre-commit run** on all changed files: **0 failures** (ruff format, ruff check, single-class-per-file, enum-casing, mypy strict hook, all gates Passed/Skipped).

### Scope / safety
- Pure additive shared-model build. No topic schema / envelope / contract-API change; no runtime-lane mutation; no live deploy.
- Does NOT bump any cross-repo pin (core/compat spine stays stable).
- No `Plugin*` base, no bespoke engine/router/daemon; no hardcoded paths/IPs; no env-encoded endpoints.

Blocks: OMN-13614, OMN-13615, OMN-13616 (Phase 3.1/3.2/3.3) — unblocked once this merges.

<!-- receipt-gate: paired with onex_change_control OCC PR (Evidence-Source repointed after both merge) -->
