### PR TITLE
feat(OMN-13609): port model-class-existence check into canonical validator platform (WS-C Phase 1.1)

### DIFF
--- a/.github/workflows/validator-generated-node-model-class-exists.yml
+++ b/.github/workflows/validator-generated-node-model-class-exists.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# generated-node model-class-existence gate [OMN-13609]
+#
+# Required status check context:
+#   "generated-node model-class-existence Validator / validate"
+#
+# WS-C Phase 1.1 (epic OMN-13604). Ported from the SEA generation pipeline's
+# model_types check, the authoritative logic lives in the canonical validator
+# platform (omnibase_core.validation.validator_contract_linter.validate_model_class_existence).
+# This gate runs the validator unit tests, then self-scans omnibase_core/src for
+# any generated node whose contract declares an inline input_model / output_model
+# class name that is not bound at the top level of the co-located handler.py.
+# Hand-authored nodes that declare a fully-qualified dotted importable model path
+# are deliberately out of scope. Consumer repos wire this by adding the
+# generated-node-model-class-exists pre-commit hook and a mirror of the `validate`
+# job in their own CI.
+
+name: generated-node model-class-existence Validator
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: validator-generated-node-model-class-exists-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validators/test_generated_node_model_class_exists.py \
+            tests/unit/validation/test_validator_contract_linter.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.generated_node_model_class_exists src/omnibase_core

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -341,6 +341,21 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # OMN-13609 (WS-C Phase 1.1): a generated node's contract-declared inline
+      # input_model / output_model class names must be bound at the top level of
+      # the co-located handler.py. Ported from the SEA pipeline model_types check;
+      # the authoritative logic lives in the canonical validator platform
+      # (omnibase_core.validation.validator_contract_linter.validate_model_class_existence)
+      # which this guard invokes. Only inline generated models are in scope —
+      # hand-authored nodes that declare a dotted importable model path are skipped.
+      - id: generated-node-model-class-exists
+        name: generated-node model-class-existence guard (OMN-13609)
+        entry: uv run python -m omnibase_core.validators.generated_node_model_class_exists src/omnibase_core
+        language: system
+        files: (^|/)contract\.yaml$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # CLASS vs FILE Naming Conventions:
       # - validate-naming-conventions: CLASS naming (ModelUser, EnumStatus, ProtocolEventBus)
       # - validate-file-naming-conventions: FILE naming (model_user.py, enum_status.py)
@@ -450,7 +465,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py|src/omnibase_core/validators/command_category_requires_event_model\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py|src/omnibase_core/validators/command_category_requires_event_model\.py|src/omnibase_core/validators/generated_node_model_class_exists\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
 

--- a/src/omnibase_core/validation/validator_contract_linter.py
+++ b/src/omnibase_core/validation/validator_contract_linter.py
@@ -46,6 +46,7 @@ See Also:
     - scripts/lint_contract.py: Original standalone linting script
 """
 
+import ast
 import logging
 import re
 import sys
@@ -88,6 +89,7 @@ RULE_REQUIRED_FIELDS = "required_fields"
 RULE_RECOMMENDED_FIELDS = "recommended_fields"
 RULE_NAMING_CONVENTION = "naming_convention"
 RULE_MODEL_PREFIX = "model_prefix"
+RULE_MODEL_CLASS_EXISTS = "model_class_exists"
 RULE_FINGERPRINT_FORMAT = "fingerprint_format"
 RULE_FINGERPRINT_MATCH = "fingerprint_match"
 RULE_SCHEMA_VALIDATION = "schema_validation"
@@ -195,6 +197,180 @@ def _detect_contract_type(data: dict[str, object]) -> str | None:
         return "orchestrator"
 
     return None
+
+
+# Sentinel module prefix used by the SEA generation pipeline for models that are
+# inlined into the single generated handler.py rather than living in a real,
+# importable package. A contract that points its model at this sentinel (or at no
+# module at all) declares an *inline* model whose existence can only be proven
+# against the handler source.
+_GENERATED_INLINE_MODULE_PREFIX = "generated"
+
+
+def _extract_declared_inline_model_class_name(model_field: object) -> str:
+    """Extract a contract-declared model class name *iff* it is an inline model.
+
+    The model-class-existence check (OMN-13609) is meaningful only for the
+    SEA-style generated-node form, where the model class is inlined into the
+    single generated ``handler.py``. Two declaration shapes occur:
+
+        * Nested mapping: ``input_model: {name: ModelFooInput, module: ...}``
+        * Flat string:    ``input_model: pkg.module.ModelFooInput`` (bare or dotted)
+
+    A model is treated as **inline** (in scope) only when it is NOT a
+    fully-qualified importable reference to a real package:
+
+        * flat bare name (no dot, e.g. ``ModelFooInput``) → inline;
+        * nested mapping whose ``module`` is absent or the ``generated`` inline
+          sentinel → inline;
+
+    A dotted importable path (``omnibase_core.models...ModelX``) or a nested
+    mapping with a real importable ``module`` is a hand-authored canonical node
+    whose model lives in its own module — out of scope (existence is proven by
+    import resolution / schema validation, not by scanning ``handler.py``).
+
+    Returns the bare class name when the model is inline, else the empty string.
+    """
+    if isinstance(model_field, dict):
+        name = model_field.get("name", "")
+        if not isinstance(name, str) or not name:
+            return ""
+        module = model_field.get("module", "")
+        module = module if isinstance(module, str) else ""
+        if not module or module.split(".")[0] == _GENERATED_INLINE_MODULE_PREFIX:
+            return name
+        return ""
+    if isinstance(model_field, str) and model_field:
+        # A dotted path is a real importable reference (hand-authored) — skip.
+        if "." in model_field:
+            return ""
+        return model_field
+    return ""
+
+
+def validate_model_class_existence(
+    contract_data: dict[str, object],
+    handler_source: str,
+    *,
+    path: Path,
+    severity: EnumSeverity = EnumSeverity.ERROR,
+) -> list[ModelValidationIssue]:
+    """Validate that contract-declared model classes exist in the handler source.
+
+    Canonical home (OMN-13609, WS-C Phase 1.1) for the model-class-existence
+    check ported from the SEA generation pipeline. A generated node inlines its
+    ``input_model`` / ``output_model`` classes into a single ``handler.py``; those
+    declared names must be bound at the top level of that handler. If an inline
+    model class is undefined in the handler, the contract is rejected.
+
+    Scope: the check applies ONLY to **inline** model declarations (the generated
+    form — a bare class name, or a nested mapping with no/`generated` module).
+    Hand-authored canonical nodes declare a fully-qualified dotted importable path
+    (``omnibase_core.models...ModelX``); those models live in their own module and
+    are resolved by import, so they are deliberately out of scope (see
+    :func:`_extract_declared_inline_model_class_name`).
+
+    Both the contract linter (file-based, via the co-located ``handler.py``) and
+    ``node_generation_consumer`` (string-based, on freshly generated source)
+    invoke this single function — the platform owns the logic, the node does not
+    re-implement it.
+
+    Args:
+        contract_data: Parsed contract YAML mapping.
+        handler_source: Generated handler module source code.
+        path: Contract file path used for issue attribution.
+        severity: Severity to assign to any violation found.
+
+    Returns:
+        List of ``ModelValidationIssue`` for inline model classes that are not
+        bound at the top level of the handler. Empty when all inline classes are
+        bound, no inline model is declared, or the handler source cannot be
+        AST-parsed (a syntax error is reported by the separate syntax check, not
+        masked here).
+    """
+    input_model_name = _extract_declared_inline_model_class_name(
+        contract_data.get("input_model")
+    )
+    output_model_name = _extract_declared_inline_model_class_name(
+        contract_data.get("output_model")
+    )
+
+    if not input_model_name and not output_model_name:
+        return []
+
+    try:
+        tree = ast.parse(handler_source)
+    except SyntaxError:
+        # Syntax errors are owned by the dedicated syntax check; do not mask
+        # them with a (misleading) model-class verdict here.
+        return []
+
+    handler_names = _collect_handler_top_level_names(tree)
+
+    issues: list[ModelValidationIssue] = []
+    for label, model_name in (
+        ("input_model", input_model_name),
+        ("output_model", output_model_name),
+    ):
+        if model_name and model_name not in handler_names:
+            issues.append(
+                ModelValidationIssue(
+                    severity=severity,
+                    message=(
+                        f"Contract-declared {label} '{model_name}' is not bound at "
+                        "the top level of the generated handler (no defining class, "
+                        "import, or assignment)"
+                    ),
+                    code=RULE_MODEL_CLASS_EXISTS,
+                    file_path=path,
+                    line_number=1,
+                    rule_name=RULE_MODEL_CLASS_EXISTS,
+                    suggestion=(
+                        f"Define or import {model_name} in the handler, or update "
+                        f"the contract's {label} to match the handler's class name"
+                    ),
+                    context={
+                        "declared_model": model_name,
+                        "model_field": label,
+                        "handler_names": ", ".join(sorted(handler_names)),
+                    },
+                )
+            )
+
+    return issues
+
+
+def _collect_handler_top_level_names(tree: ast.Module) -> set[str]:
+    """Collect every name bound at the top level of a handler module.
+
+    A contract-declared model class is "present" in the handler when its name is
+    bound at module scope by any of:
+
+        * a class definition (``class ModelFooInput: ...`` — the single-file
+          generated-node form, ported from the SEA pipeline);
+        * an import (``from generated.models import ModelFooInput`` /
+          ``import x as ModelFooInput`` — the canonical multi-module form used by
+          hand-authored nodes that keep models in separate modules);
+        * a module-level assignment (``ModelFooInput = ...`` — an alias).
+
+    All three make the declared name resolvable in the handler namespace, which
+    is the real invariant; restricting to ``ClassDef`` only (as the SEA check
+    did) would falsely reject canonical nodes that import their models.
+    """
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
 
 
 class ValidatorContractLinter(ValidatorBase):
@@ -675,6 +851,70 @@ class ValidatorContractLinter(ValidatorBase):
 
         return issues
 
+    def _validate_model_class_existence(
+        self,
+        data: dict[str, object],
+        path: Path,
+        contract: ModelValidatorSubcontract,
+    ) -> list[ModelValidationIssue]:
+        """Guardrail: contract-declared model classes must exist in the handler.
+
+        OMN-13609 (WS-C Phase 1.1): ported from the SEA generation pipeline. When
+        a contract is co-located with a generated handler module (the canonical
+        generated-node layout writes ``contract.yaml`` + ``handler.py`` in the
+        same directory), the contract's ``input_model`` / ``output_model`` class
+        names must be defined as top-level classes in that handler.
+
+        The check only runs when a sibling handler module is present; a
+        contract-only directory yields no issue (existence cannot be proven
+        either way, and absence of a handler is not a contract violation in the
+        linter's per-file model). All logic lives in the module-level
+        :func:`validate_model_class_existence` so node_generation_consumer can
+        invoke the same authority on freshly generated source.
+
+        Args:
+            data: Parsed contract YAML mapping.
+            path: Path to the contract file.
+            contract: The validator contract.
+
+        Returns:
+            List of validation issues for declared model classes absent from the
+            co-located handler.
+        """
+        handler_path = self._resolve_handler_path(path)
+        if handler_path is None:
+            return []
+
+        try:
+            handler_source = handler_path.read_text(encoding="utf-8")
+        except FILE_IO_ERRORS:
+            # fallback-ok: handler unreadable - the model-class check cannot run;
+            # other checks/tooling surface the read failure.
+            return []
+
+        severity = self._get_severity(
+            self._get_rule_by_id(RULE_MODEL_CLASS_EXISTS, contract),
+            contract,
+        )
+        return validate_model_class_existence(
+            data,
+            handler_source,
+            path=path,
+            severity=severity,
+        )
+
+    @staticmethod
+    def _resolve_handler_path(contract_path: Path) -> Path | None:
+        """Resolve the generated handler module co-located with a contract.
+
+        The canonical generated-node layout writes ``handler.py`` beside
+        ``contract.yaml``. Returns the handler path when it exists, else None.
+        """
+        handler_path = contract_path.parent / "handler.py"
+        if handler_path.is_file():
+            return handler_path
+        return None
+
     def _validate_fingerprint_format(
         self,
         data: dict[str, object],
@@ -908,12 +1148,15 @@ class ValidatorContractLinter(ValidatorBase):
         issues: list[ModelValidationIssue] = []
         severity = self._get_severity(rule, contract)
 
-        # Only warn on seam contracts (those with event wiring)
-        has_events = bool(
-            data.get("event_subscriptions")
-            or data.get("yaml_consumed_events")
-            or data.get("yaml_published_events")
+        # Only warn on seam contracts (those with event wiring). Explicit any()
+        # over the event-wiring fields — not an or-chain (check-no-fallbacks gate,
+        # OMN-13609 self-touch).
+        event_wiring_fields = (
+            "event_subscriptions",
+            "yaml_consumed_events",
+            "yaml_published_events",
         )
+        has_events = any(data.get(field) for field in event_wiring_fields)
         if not has_events:
             return issues
 
@@ -972,6 +1215,11 @@ class ValidatorContractLinter(ValidatorBase):
         # Run guardrail checks (always run, not rule-dependent)
         # These prevent regression from field name migrations
         issues.extend(self._validate_deprecated_field_names(data, path, contract))
+
+        # Guardrail (OMN-13609): contract-declared model classes must exist in
+        # the co-located generated handler. Always run when a sibling
+        # handler.py is present; a no-op otherwise.
+        issues.extend(self._validate_model_class_existence(data, path, contract))
 
         # Get rules
         required_rule = self._get_rule_by_id(RULE_REQUIRED_FIELDS, contract)
@@ -1042,6 +1290,7 @@ __all__ = [
     "RULE_FINGERPRINT_FORMAT",
     "RULE_FINGERPRINT_MATCH",
     "RULE_GOLDEN_PATH_RECOMMENDED",
+    "RULE_MODEL_CLASS_EXISTS",
     "RULE_MODEL_PREFIX",
     "RULE_NAMING_CONVENTION",
     "RULE_RECOMMENDED_FIELDS",
@@ -1050,4 +1299,5 @@ __all__ = [
     "RULE_YAML_SYNTAX",
     "SNAKE_CASE_PATTERN",
     "ValidatorContractLinter",
+    "validate_model_class_existence",
 ]

--- a/src/omnibase_core/validators/generated_node_model_class_exists.py
+++ b/src/omnibase_core/validators/generated_node_model_class_exists.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Enforce contract-declared model classes exist in the generated handler (OMN-13609).
+
+WS-C Phase 1.1 enforcement gate. Ported from the SEA generation pipeline's
+``model_types`` check, the authoritative logic lives in the canonical validator
+platform — :func:`omnibase_core.validation.validator_contract_linter.validate_model_class_existence`.
+This module is the thin pre-commit / CI enforcement wrapper around that platform
+authority: it does NOT re-implement the check, it invokes it.
+
+A generated ONEX node directory co-locates ``contract.yaml`` with ``handler.py``.
+The contract declares ``input_model`` / ``output_model`` class names; those classes
+must be defined as top-level classes in the generated handler. A contract that
+references an undefined model class is rejected.
+
+Scope: only ``contract.yaml`` files that have a sibling ``handler.py`` are
+checked — the existence of a model class can only be proven against a handler. A
+contract-only directory (no co-located handler) is out of scope.
+
+Usage::
+
+    python -m omnibase_core.validators.generated_node_model_class_exists src/
+
+When pre-commit supplies staged filenames, only ``contract.yaml`` files among
+them (that have a sibling ``handler.py``) are scanned. When no paths are
+supplied, ``src/`` is scanned recursively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import yaml  # ONEX_EXCLUDE: manual_yaml - validator reads adjacent contract.yaml files
+
+from omnibase_core.enums import EnumSeverity
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
+from omnibase_core.validation.validator_contract_linter import (
+    validate_model_class_existence,
+)
+
+DEFAULT_SCAN_ROOT = Path("src")
+CONTRACT_FILENAME = "contract.yaml"
+HANDLER_FILENAME = "handler.py"
+
+
+def validate_paths(paths: Sequence[Path]) -> list[ModelValidationIssue]:
+    """Validate every generated-node contract reachable from the provided paths."""
+    issues: list[ModelValidationIssue] = []
+    for contract_path in _iter_generated_node_contracts(paths):
+        issues.extend(validate_file(contract_path))
+    return issues
+
+
+def validate_file(contract_path: Path) -> list[ModelValidationIssue]:
+    """Validate one generated-node contract against its co-located handler.
+
+    Delegates the check to the canonical platform authority
+    (:func:`validate_model_class_existence`). Returns the platform issues for
+    declared model classes absent from the handler; empty otherwise.
+    """
+    handler_path = contract_path.parent / HANDLER_FILENAME
+    if not handler_path.is_file():
+        return []
+
+    try:
+        # ONEX_EXCLUDE: manual_yaml - reading adjacent node contract for validation
+        data = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, UnicodeDecodeError):
+        # YAML/encoding validity is the contract-linter's concern; this gate only
+        # asserts model-class existence on parseable contracts.
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    try:
+        handler_source = handler_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    return validate_model_class_existence(
+        data,
+        handler_source,
+        path=contract_path,
+        severity=EnumSeverity.ERROR,
+    )
+
+
+def _iter_generated_node_contracts(paths: Sequence[Path]) -> Iterator[Path]:
+    scan_paths = tuple(paths) or (DEFAULT_SCAN_ROOT,)
+    for path in scan_paths:
+        if path.is_file() and path.name == CONTRACT_FILENAME:
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob(CONTRACT_FILENAME)
+                if "__pycache__" not in candidate.parts
+            )
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Require that a generated node's contract-declared input_model / "
+            "output_model class names exist as top-level classes in the "
+            "co-located handler.py. Invokes the canonical validator platform "
+            "(validate_model_class_existence)."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SCAN_ROOT],
+        help="contract.yaml file or directory paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    issues = validate_paths(args.paths)
+    if not issues:
+        return 0
+
+    sys.stderr.write("generated-node model-class-existence guard failed:\n")
+    for issue in issues:
+        location = str(issue.file_path) if issue.file_path else "<unknown>"
+        sys.stderr.write(f"  {location}: {issue.message}\n")
+    sys.stderr.write(
+        "\nEvery generated node's contract-declared input_model / output_model "
+        "class name must be defined as a top-level class in the co-located "
+        "handler.py. Define the missing class in the handler, or update the "
+        "contract to match the handler's class name.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validation/test_validator_contract_linter.py
+++ b/tests/unit/validation/test_validator_contract_linter.py
@@ -365,5 +365,317 @@ class TestValidatorContractLinterInit:
         assert validator.registry is registry
 
 
+# =============================================================================
+# Model Class Existence Tests (OMN-13609 - WS-C Phase 1.1)
+#
+# Ported from SEA pipeline/validator.py model_types check: a generated node's
+# contract-declared input_model/output_model class names must exist as top-level
+# classes in the co-located generated handler. If a declared class name is
+# undefined in the handler, the validator rejects the contract.
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestValidateModelClassExistence:
+    """Tests for the model-class-existence check (OMN-13609)."""
+
+    def test_undefined_model_class_is_rejected(self, tmp_path: Path) -> None:
+        """Contract declaring a model class absent from the handler is rejected."""
+        from omnibase_core.validation.validator_contract_linter import (
+            RULE_MODEL_CLASS_EXISTS,
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": {"name": "ModelFooInput", "module": "generated.models"},
+            "output_model": {"name": "ModelFooOutput", "module": "generated.models"},
+        }
+        handler_source = (
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class ModelBarInput(BaseModel):\n"
+            "    value: int\n"
+            "\n"
+            "class ModelFooOutput(BaseModel):\n"
+            "    result: int\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': input_data.get('value', 0)}\n"
+        )
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert len(issues) == 1
+        assert issues[0].code == RULE_MODEL_CLASS_EXISTS
+        assert issues[0].severity == EnumSeverity.ERROR
+        assert "ModelFooInput" in issues[0].message
+
+    def test_all_model_classes_present_passes(self, tmp_path: Path) -> None:
+        """Contract whose declared model classes all exist in the handler passes."""
+        from omnibase_core.validation.validator_contract_linter import (
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": {"name": "ModelFooInput", "module": "generated.models"},
+            "output_model": {"name": "ModelFooOutput", "module": "generated.models"},
+        }
+        handler_source = (
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class ModelFooInput(BaseModel):\n"
+            "    value: int\n"
+            "\n"
+            "class ModelFooOutput(BaseModel):\n"
+            "    result: int\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': input_data.get('value', 0)}\n"
+        )
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert issues == []
+
+    def test_bare_flat_string_model_field_is_checked(self, tmp_path: Path) -> None:
+        """A bare (un-dotted) flat-string model name is the inline form: checked."""
+        from omnibase_core.validation.validator_contract_linter import (
+            RULE_MODEL_CLASS_EXISTS,
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": "ModelFlatInput",
+            "output_model": "ModelFlatOutput",
+        }
+        handler_source = (
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class ModelFlatInput(BaseModel):\n"
+            "    value: int\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': 0}\n"
+        )
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert len(issues) == 1
+        assert issues[0].code == RULE_MODEL_CLASS_EXISTS
+        assert "ModelFlatOutput" in issues[0].message
+
+    def test_dotted_importable_path_is_out_of_scope(self, tmp_path: Path) -> None:
+        """A fully-qualified dotted model path is a hand-authored reference whose
+        model lives in its own module: out of scope, never flagged here."""
+        from omnibase_core.validation.validator_contract_linter import (
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": "omnibase_core.models.nodes.foo.ModelFooInput",
+            "output_model": "omnibase_core.models.nodes.foo.ModelFooOutput",
+        }
+        # Handler does not define/import the model names at all — still no issue,
+        # because dotted references are resolved by import, not by handler scan.
+        handler_source = (
+            "def handle(input_data: dict) -> dict:\n    return {'result': 0}\n"
+        )
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert issues == []
+
+    def test_nested_model_imported_into_handler_passes(self, tmp_path: Path) -> None:
+        """Inline model declared with the generated sentinel, satisfied by an
+        import binding in the handler (not only a ClassDef)."""
+        from omnibase_core.validation.validator_contract_linter import (
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": {"name": "ModelFooInput", "module": "generated.models"},
+        }
+        handler_source = (
+            "from generated.models import ModelFooInput\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': 0}\n"
+        )
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert issues == []
+
+    def test_unparseable_handler_yields_no_class_existence_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """A handler that cannot be AST-parsed yields no model-class issue.
+
+        Syntax errors are owned by the separate syntax check; the model-class
+        check emits nothing rather than masking a syntax error.
+        """
+        from omnibase_core.validation.validator_contract_linter import (
+            validate_model_class_existence,
+        )
+
+        contract_data: dict[str, object] = {
+            "name": "node_foo",
+            "contract_version": "1.0.0",
+            "node_type": "compute",
+            "input_model": {"name": "ModelFooInput", "module": "generated.models"},
+        }
+        handler_source = "def handle(:\n    pass\n"  # invalid syntax
+
+        issues = validate_model_class_existence(
+            contract_data,
+            handler_source,
+            path=tmp_path / "contract.yaml",
+            severity=EnumSeverity.ERROR,
+        )
+
+        assert issues == []
+
+
+@pytest.mark.unit
+class TestModelClassExistenceWiredInLinter:
+    """The check is wired into the per-file linter loop via co-located handler."""
+
+    def test_contract_with_undefined_model_class_fails_linter(
+        self, tmp_path: Path
+    ) -> None:
+        """A generated node dir (contract.yaml + handler.py) with a mismatched
+        model class name is rejected by ValidatorContractLinter.validate()."""
+        from omnibase_core.validation.validator_contract_linter import (
+            RULE_MODEL_CLASS_EXISTS,
+        )
+
+        node_dir = tmp_path / "node_foo"
+        node_dir.mkdir()
+        (node_dir / "contract.yaml").write_text(
+            "name: node_foo\n"
+            'contract_version: "1.0.0"\n'
+            "node_type: compute\n"
+            "description: A foo node\n"
+            "input_model:\n"
+            "  name: ModelFooInput\n"
+            "  module: generated.models\n"
+            "output_model:\n"
+            "  name: ModelFooOutput\n"
+            "  module: generated.models\n",
+            encoding="utf-8",
+        )
+        (node_dir / "handler.py").write_text(
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class ModelWrongInput(BaseModel):\n"
+            "    value: int\n"
+            "\n"
+            "class ModelFooOutput(BaseModel):\n"
+            "    result: int\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': 0}\n",
+            encoding="utf-8",
+        )
+
+        contract = create_test_contract(target_patterns=["**/contract.yaml"])
+        validator = ValidatorContractLinter(contract=contract)
+        result = validator.validate(node_dir / "contract.yaml")
+
+        assert not result.is_valid
+        codes = {issue.code for issue in result.issues}
+        assert RULE_MODEL_CLASS_EXISTS in codes
+        assert any(
+            "ModelFooInput" in issue.message
+            for issue in result.issues
+            if issue.code == RULE_MODEL_CLASS_EXISTS
+        )
+
+    def test_contract_with_matching_model_classes_passes_linter(
+        self, tmp_path: Path
+    ) -> None:
+        """A generated node dir whose handler defines all declared model classes
+        produces no model-class-existence issue."""
+        from omnibase_core.validation.validator_contract_linter import (
+            RULE_MODEL_CLASS_EXISTS,
+        )
+
+        node_dir = tmp_path / "node_foo"
+        node_dir.mkdir()
+        (node_dir / "contract.yaml").write_text(
+            "name: node_foo\n"
+            'contract_version: "1.0.0"\n'
+            "node_type: compute\n"
+            "description: A foo node\n"
+            "input_model:\n"
+            "  name: ModelFooInput\n"
+            "  module: generated.models\n"
+            "output_model:\n"
+            "  name: ModelFooOutput\n"
+            "  module: generated.models\n",
+            encoding="utf-8",
+        )
+        (node_dir / "handler.py").write_text(
+            "from pydantic import BaseModel\n"
+            "\n"
+            "class ModelFooInput(BaseModel):\n"
+            "    value: int\n"
+            "\n"
+            "class ModelFooOutput(BaseModel):\n"
+            "    result: int\n"
+            "\n"
+            "def handle(input_data: dict) -> dict:\n"
+            "    return {'result': 0}\n",
+            encoding="utf-8",
+        )
+
+        contract = create_test_contract(target_patterns=["**/contract.yaml"])
+        validator = ValidatorContractLinter(contract=contract)
+        result = validator.validate(node_dir / "contract.yaml")
+
+        codes = {issue.code for issue in result.issues}
+        assert RULE_MODEL_CLASS_EXISTS not in codes
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/validators/test_generated_node_model_class_exists.py
+++ b/tests/unit/validators/test_generated_node_model_class_exists.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the generated-node model-class-existence enforcement gate (OMN-13609).
+
+This validator is the thin pre-commit / CI wrapper around the canonical platform
+authority ``validate_model_class_existence``. It scans generated-node
+``contract.yaml`` files (those with a co-located ``handler.py``) and fails when a
+contract declares a model class absent from the handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.generated_node_model_class_exists import (
+    main,
+    validate_file,
+    validate_paths,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_CONTRACT = """\
+name: node_foo
+contract_version: "1.0.0"
+node_type: compute
+input_model:
+  name: ModelFooInput
+  module: generated.models
+output_model:
+  name: ModelFooOutput
+  module: generated.models
+"""
+
+_HANDLER_MATCHING = """\
+from pydantic import BaseModel
+
+
+class ModelFooInput(BaseModel):
+    value: int
+
+
+class ModelFooOutput(BaseModel):
+    result: int
+
+
+def handle(input_data: dict) -> dict:
+    return {"result": 0}
+"""
+
+_HANDLER_MISMATCH = """\
+from pydantic import BaseModel
+
+
+class ModelWrongInput(BaseModel):
+    value: int
+
+
+class ModelFooOutput(BaseModel):
+    result: int
+
+
+def handle(input_data: dict) -> dict:
+    return {"result": 0}
+"""
+
+
+def _write_node(tmp_path: Path, contract: str, handler: str | None) -> Path:
+    node_dir = tmp_path / "node_foo"
+    node_dir.mkdir()
+    (node_dir / "contract.yaml").write_text(contract, encoding="utf-8")
+    if handler is not None:
+        (node_dir / "handler.py").write_text(handler, encoding="utf-8")
+    return node_dir / "contract.yaml"
+
+
+def test_matching_handler_passes(tmp_path: Path) -> None:
+    contract_path = _write_node(tmp_path, _CONTRACT, _HANDLER_MATCHING)
+    assert validate_file(contract_path) == []
+
+
+def test_mismatched_handler_fails(tmp_path: Path) -> None:
+    contract_path = _write_node(tmp_path, _CONTRACT, _HANDLER_MISMATCH)
+    issues = validate_file(contract_path)
+    assert len(issues) == 1
+    assert "ModelFooInput" in issues[0].message
+
+
+def test_contract_without_handler_is_out_of_scope(tmp_path: Path) -> None:
+    """No co-located handler.py => model-class existence cannot be proven => skip."""
+    contract_path = _write_node(tmp_path, _CONTRACT, handler=None)
+    assert validate_file(contract_path) == []
+
+
+def test_validate_paths_scans_directory(tmp_path: Path) -> None:
+    _write_node(tmp_path, _CONTRACT, _HANDLER_MISMATCH)
+    issues = validate_paths([tmp_path])
+    assert len(issues) == 1
+
+
+def test_main_returns_nonzero_on_violation(tmp_path: Path) -> None:
+    _write_node(tmp_path, _CONTRACT, _HANDLER_MISMATCH)
+    assert main([str(tmp_path)]) == 1
+
+
+def test_main_returns_zero_on_clean(tmp_path: Path) -> None:
+    _write_node(tmp_path, _CONTRACT, _HANDLER_MATCHING)
+    assert main([str(tmp_path)]) == 0


### PR DESCRIPTION
## OMN-13609 — WS-C Phase 1.1: port model-class-existence check into the canonical validator platform

Epic: OMN-13604 (SEA → canonical migration). Unblocked by the merged Phase-1 gate **OMN-13608**, which named the canonical validator authority as `omnibase_core.validation` / `ValidatorContractLinter`.

### What
Ports the SEA generation pipeline's `model_types` check (`onex-self-extending-agent/src/pipeline/validator.py` lines 69-90 — contract-declared `input_model`/`output_model` class names must exist in the generated handler) into the canonical validator platform. The node no longer owns this logic; it invokes the platform.

### Platform authority (omnibase_core.validation)
- New module-level **`validate_model_class_existence(contract_data, handler_source, *, path, severity)`** in `validator_contract_linter.py` — the single canonical function both the linter (file-based, via co-located `handler.py`) and `node_generation_consumer` (string-based, on generated source) invoke.
- New `_validate_model_class_existence` method on `ValidatorContractLinter`, wired as an always-run guardrail in the per-file loop (alongside `_validate_deprecated_field_names`), reading the co-located `handler.py`.
- `RULE_MODEL_CLASS_EXISTS` constant; both symbols exported in `__all__`.

### Scope (architecturally corrected vs the narrow SEA form)
The check applies **only to inline generated models** — a bare class name, or a nested mapping with no module / the `generated` sentinel module. Hand-authored canonical nodes declare a fully-qualified dotted importable model path (`omnibase_core.models...ModelX`) whose model lives in its own module; those are resolved by import and are **out of scope**. "Present" in the handler means bound at module top level by a class def, an **import**, OR a module-level assignment — restricting to `ClassDef`-only (the SEA form) would falsely reject canonical nodes that import their models. Self-scan over `src/omnibase_core` is clean.

### Enforcement (Rule 5 — gate, not detection)
- New thin enforcement wrapper `omnibase_core.validators.generated_node_model_class_exists` that **invokes the platform authority** (no re-implementation), scanning `contract.yaml` files with a co-located `handler.py`.
- Wired as **pre-commit hook** (`generated-node-model-class-exists`) + **CI gate** (`validator-generated-node-model-class-exists.yml`).

### Tests (TDD)
- The undefined-model-class test **FAILs before the port, PASSes after** (verified locally: 6 tests ImportError → green).
- 6 new linter/function tests + 6 new validator-module tests; all existing contract-linter tests pass.
- Also refactored a pre-existing or-chain in `_validate_golden_path_recommended` to explicit `any(...)` to satisfy the check-no-fallbacks gate on self-touch.

### dod_evidence
- Full local verify (no `-k`): linter + validator suites green (29 passed); `mypy src/ --strict` clean on changed modules; `ruff format`/`check --fix` clean; `pre-commit run` on all changed files PASS (exit 0); self-scan `python -m omnibase_core.validators.generated_node_model_class_exists src/omnibase_core` exit 0 (clean).
- The omnimarket invocation wiring (node_generation_consumer invokes this function) is a paired dependent PR gated on this PR's merge + the omnibase_core pin bump (the new symbol does not exist in omnimarket's currently pinned core rev).

Refs OMN-13609. Epic OMN-13604.

---
Evidence-Ticket: OMN-13609
Evidence-Source: OCC#3182