### PR TITLE
feat(OMN-13646): add context_pack_hash to ModelDelegationResult wire DTO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.0"
+version = "0.46.1"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -115,6 +115,14 @@ class ModelDelegationResult(BaseModel):
         ge=0.0,
         description="Estimated cost of the final attempt.",
     )
+    context_pack_hash: str = Field(
+        default="",
+        description=(
+            "Stable sha256 hash of the context pack injected into the delegated "
+            "prompt, propagated onto the terminal result for ROI correlation. "
+            "Empty string means the OFF arm or no context pack."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_total_tokens(self) -> Self:

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -282,6 +282,39 @@ class TestModelDelegationResult:
         assert r.terminal_failure_reason is None
         assert r.attempts_count == 1
 
+    def test_context_pack_hash_defaults_to_off_arm(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+        assert r.context_pack_hash == ""
+
+    def test_context_pack_hash_round_trips(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+            context_pack_hash="sha256:ctxpack",
+        )
+        dumped = r.model_dump()
+        assert dumped["context_pack_hash"] == "sha256:ctxpack"
+        restored = ModelDelegationResult.model_validate(dumped)
+        assert restored.context_pack_hash == "sha256:ctxpack"
+        assert restored == r
+
     def test_rejects_invalid_metric_ranges(self) -> None:
         with pytest.raises(ValidationError):
             ModelDelegationResult(

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.0"
+version = "0.46.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Evidence-Source: OCC#3188
Evidence-Ticket: OMN-13646

## OMN-13646 — add context_pack_hash to ModelDelegationResult wire DTO

Additive core wire-DTO change. Adds a `context_pack_hash: str = ""` field to
`ModelDelegationResult` so the omnimarket delegation orchestrator can attach the
injected context-pack hash onto the canonical terminal result for ROI
correlation. The sibling wire DTOs (`ModelTaskDelegatedEvent`,
`ModelDelegationWireRequest`) already carry the field; the terminal result was
the missing link — root cause of OMN-13407's empty hash on the failed/escalated
terminal.

### Change
- `src/omnibase_core/models/delegation/wire/model_delegation_result.py`: add
  `context_pack_hash: str = Field(default="", ...)`. Keeps `frozen=True` +
  `extra="forbid"`, strongly typed, no behavior change. Empty-string default
  preserves back-compat with existing emitters.
- `pyproject.toml` + `uv.lock`: patch-bump `0.46.0` -> `0.46.1` so omnimarket can
  pin the new git-rev (OMN-13644 / B2b pins omnibase_core to this merge SHA).
- `tests/unit/models/delegation/wire/test_delegation_wire_models.py`: two new
  tests — field defaults to `""`, and round-trips through
  `model_dump`/`model_validate`.

### dod_evidence
- Targeted suite green: `uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -q` → 88 passed (includes 2 new).
- Broader delegation models subtree green: `tests/unit/models/delegation/` → 179 passed.
- `uv run ruff format` + `ruff check --fix` clean.
- `pre-commit run --files <changed files>` → all hooks Passed (incl. version-bump gate OMN-13411).
- mypy `--strict`: the only errors are 3 pre-existing ones in untouched files (`contract_loader.py`, `cli_install.py`), confirmed present on `origin/dev` baseline; none introduced by this change.

Layering: compat->core->spi->infra respected (core-only wire DTO). No Plugin*, no behavior change, no redeploy.

---

Evidence-Source: OCC#3188
Evidence-Ticket: OMN-13646

OCC#3188 carries `contracts/OMN-13646.yaml` + PASS receipts (core #1348: 88 delegation wire-model tests; deploy assessment: additive field, no runtime deploy; self-binding OCC receipt).