### PR TITLE
feat(OMN-13649): carry resolved cost_tier_name onto ModelDelegationResult terminal

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -123,6 +123,17 @@ class ModelDelegationResult(BaseModel):
             "Empty string means the OFF arm or no context pack."
         ),
     )
+    cost_tier_name: str = Field(
+        default="",
+        description=(
+            "Resolved routing/cost tier that served this delegation (e.g. "
+            "'local', 'cheap_cloud', 'cheap_frontier', 'claude'). This is the "
+            "authoritative tier from the routing decision, carried onto the "
+            "terminal so the delegation projection persists it instead of "
+            "reconstructing it. Empty string when no serving tier was resolved "
+            "(e.g. a remote-agent A2A terminal). OMN-13649."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_total_tokens(self) -> Self:

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -315,6 +315,39 @@ class TestModelDelegationResult:
         assert restored.context_pack_hash == "sha256:ctxpack"
         assert restored == r
 
+    def test_cost_tier_name_defaults_empty(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+        assert r.cost_tier_name == ""
+
+    def test_cost_tier_name_round_trips(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+            cost_tier_name="local",
+        )
+        dumped = r.model_dump()
+        assert dumped["cost_tier_name"] == "local"
+        restored = ModelDelegationResult.model_validate(dumped)
+        assert restored.cost_tier_name == "local"
+        assert restored == r
+
     def test_rejects_invalid_metric_ranges(self) -> None:
         with pytest.raises(ValidationError):
             ModelDelegationResult(


### PR DESCRIPTION
## OMN-13649 (G2) — carry routing tier onto the delegation terminal event

**Part of the G2 cross-repo stack** (delegation dashboard data-gap plan §6 G2). This is the omnibase_core leg: add the authoritative routing/cost tier to the canonical delegation terminal wire DTO so the omnimarket delegation projection can persist it instead of reconstructing it client-side.

### Change
- `ModelDelegationResult`: add `cost_tier_name: str = Field(default="")` — the resolved serving tier from the routing decision (`local` / `cheap_cloud` / `cheap_frontier` / `claude`), carried onto the terminal so the projection writes a real column rather than guessing the tier from the model name.
- Additive optional field with `default=""`, so existing serialized terminals (no field) still parse under `extra="forbid"` and existing constructors are unaffected. Follows the `context_pack_hash` precedent landed in #1348.

### Why
Doctrine: tier is authoritative truth from the routing decision → durable terminal event → projection column → dashboard reads it. The orchestrator already knows `workflow.current_tier_name` but the canonical `ModelDelegationResult` did not carry it, so the projection dropped the tier at the boundary and the dashboard fell back to a client-side model-name regex (`modelTier.ts`). This field closes the emitter-side gap.

### Tests
- `tests/unit/models/delegation/wire/test_delegation_wire_models.py::TestModelDelegationResult::test_cost_tier_name_defaults_empty`
- `...::test_cost_tier_name_round_trips`
- Full wire-model suite green (90 passed); ruff + mypy --strict clean on the changed file.

### Stack / merge order
The omnimarket leg (emitter carry + projection read + contract exposure, branch `jonah/omn-13649-carry-tier-to-projection`) pins omnibase_core at this branch and must be re-pinned to the dev merge SHA after this PR lands.

dod_evidence: OMN-13649. Evidence-Source OCC SHA to be appended in the OCC pairing PR.
Evidence-Source: OCC#3192
Evidence-Ticket: OMN-13649
