### PR TITLE
feat(OMN-13136): add util_omni_home_paths — canonical OMNI_HOME-derived path resolver

### DIFF
--- a/src/omnibase_core/utils/__init__.py
+++ b/src/omnibase_core/utils/__init__.py
@@ -32,6 +32,11 @@ from .util_hash import (
     deterministic_jitter,
     string_to_uuid,
 )
+from .util_omni_home_paths import (
+    resolve_evidence_root,
+    resolve_omnibase_infra_path,
+    resolve_worktrees_root,
+)
 from .util_validators import convert_dict_to_frozen_pairs, convert_list_to_tuple
 
 # Note: parse_datetime is lazy-loaded via __getattr__ to avoid circular imports
@@ -64,6 +69,9 @@ __all__ = [
     "get_contract_attr",
     "has_contract_attr",
     "parse_datetime",
+    "resolve_evidence_root",
+    "resolve_omnibase_infra_path",
+    "resolve_worktrees_root",
     "string_to_uuid",
 ]
 

--- a/src/omnibase_core/utils/util_omni_home_paths.py
+++ b/src/omnibase_core/utils/util_omni_home_paths.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Canonical resolver for OMNI_HOME-derived path configuration (OMN-13136).
+
+Root defect being fixed
+-----------------------
+``~/.omnibase/.env`` previously defined N derived path vars (e.g.
+``ONEX_WORKTREES_ROOT=${OMNI_HOME}/omni_worktrees``) as separate shell
+variables that were expanded at ``source`` time.  When ``OMNI_HOME`` was
+unset at that moment, every derived var baked a broken bare-root path
+(``/omni_worktrees``, ``/onex_change_control/evidence``, …).
+
+Two-layer canonical fix (per OMN-12803 / OMN-13136)
+----------------------------------------------------
+1. **Bootstrap seed (OMNI_HOME only):** ``OMNI_HOME`` is irreducible — it
+   locates the monorepo registry on disk.  It is the single env var that must
+   remain in ``~/.omnibase/.env``, set home-relative:
+   ``OMNI_HOME=${OMNI_HOME:-$HOME/Code/omni_home}``.
+
+2. **Derived paths → read-time resolution:** This module resolves all
+   ``OMNI_HOME``-derived paths at call time, reading ``OMNI_HOME`` fail-fast
+   via ``os.environ["OMNI_HOME"]``.  Callers that previously read
+   ``os.environ["ONEX_WORKTREES_ROOT"]`` etc. should migrate to the functions
+   below.  The derived env vars (``ONEX_WORKTREES_ROOT``,
+   ``ONEX_EVIDENCE_ROOT``, ``OMNIBASE_INFRA_PATH``) can then be removed from
+   ``~/.omnibase/.env`` as follow-up operator cleanup.
+
+Migration note
+--------------
+Existing readers of the legacy env vars are updated in follow-up PRs (one
+per repo):
+* ``omniclaude/plugins/onex/skills/_lib/dod-evidence-runner/dod_evidence_runner.py``
+  → migrate ``os.environ.get("ONEX_EVIDENCE_ROOT")`` to ``resolve_evidence_root()``.
+* ``omniclaude/plugins/onex/hooks/scripts/pre_tool_use_bash_guard.sh``
+  → already has ``OMNI_HOME``-derived fallback; remove the
+  ``ONEX_WORKTREES_ROOT`` override path and rely on ``OMNI_HOME`` only.
+* ``~/.omnibase/.env`` — operator cleanup: remove the three derived-path
+  lines (``ONEX_WORKTREES_ROOT``, ``ONEX_EVIDENCE_ROOT``,
+  ``OMNIBASE_INFRA_PATH``) once all readers are migrated.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+
+def _omni_home() -> Path:
+    """Return the canonical monorepo root from OMNI_HOME (fail-fast).
+
+    Raises:
+        KeyError: when OMNI_HOME is not set — never silently produces a wrong
+            default path.
+    """
+    return Path(os.environ["OMNI_HOME"])  # env-read-ok: bootstrap seed; OMN-13136
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_worktrees_root() -> Path:
+    """Return the canonical worktrees root: ``$OMNI_HOME/omni_worktrees``.
+
+    This is the canonical resolver that replaces direct reads of the
+    ``ONEX_WORKTREES_ROOT`` env var.  Reads ``OMNI_HOME`` fail-fast; callers
+    must ensure ``OMNI_HOME`` is set before invoking.
+
+    Returns:
+        Absolute path to the worktrees directory (not guaranteed to exist).
+
+    Raises:
+        KeyError: when ``OMNI_HOME`` is not set.
+    """
+    return _omni_home() / "omni_worktrees"
+
+
+def resolve_evidence_root() -> Path:
+    """Return the canonical DoD evidence root: ``$OMNI_HOME/onex_change_control/evidence``.
+
+    This is the canonical resolver that replaces direct reads of the
+    ``ONEX_EVIDENCE_ROOT`` env var.  Reads ``OMNI_HOME`` fail-fast; callers
+    must ensure ``OMNI_HOME`` is set before invoking.
+
+    Returns:
+        Absolute path to the evidence directory (not guaranteed to exist).
+
+    Raises:
+        KeyError: when ``OMNI_HOME`` is not set.
+    """
+    return _omni_home() / "onex_change_control" / "evidence"
+
+
+def resolve_omnibase_infra_path() -> Path:
+    """Return the canonical omnibase_infra clone path: ``$OMNI_HOME/omnibase_infra``.
+
+    This is the canonical resolver that replaces direct reads of the
+    ``OMNIBASE_INFRA_PATH`` env var.  Reads ``OMNI_HOME`` fail-fast; callers
+    must ensure ``OMNI_HOME`` is set before invoking.
+
+    Returns:
+        Absolute path to the omnibase_infra repository clone (not guaranteed
+        to exist).
+
+    Raises:
+        KeyError: when ``OMNI_HOME`` is not set.
+    """
+    return _omni_home() / "omnibase_infra"
+
+
+__all__ = [
+    "resolve_evidence_root",
+    "resolve_omnibase_infra_path",
+    "resolve_worktrees_root",
+]

--- a/tests/unit/utils/test_util_omni_home_paths.py
+++ b/tests/unit/utils/test_util_omni_home_paths.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for util_omni_home_paths (OMN-13136).
+
+Verifies that each resolver:
+- derives the correct sub-path from OMNI_HOME
+- raises KeyError (fail-fast) when OMNI_HOME is absent
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.utils.util_omni_home_paths import (
+    resolve_evidence_root,
+    resolve_omnibase_infra_path,
+    resolve_worktrees_root,
+)
+
+
+@pytest.mark.unit
+class TestResolveWorktreesRoot:
+    def test_derives_from_omni_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        result = resolve_worktrees_root()
+        assert str(result) == "/some/monorepo/omni_worktrees"
+
+    def test_raises_key_error_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OMNI_HOME", raising=False)
+        with pytest.raises(KeyError):
+            resolve_worktrees_root()
+
+    def test_returns_path_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from pathlib import Path
+
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        assert isinstance(resolve_worktrees_root(), Path)
+
+
+@pytest.mark.unit
+class TestResolveEvidenceRoot:
+    def test_derives_from_omni_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        result = resolve_evidence_root()
+        assert str(result) == "/some/monorepo/onex_change_control/evidence"
+
+    def test_raises_key_error_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OMNI_HOME", raising=False)
+        with pytest.raises(KeyError):
+            resolve_evidence_root()
+
+    def test_returns_path_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from pathlib import Path
+
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        assert isinstance(resolve_evidence_root(), Path)
+
+
+@pytest.mark.unit
+class TestResolveOmnibaseInfraPath:
+    def test_derives_from_omni_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        result = resolve_omnibase_infra_path()
+        assert str(result) == "/some/monorepo/omnibase_infra"
+
+    def test_raises_key_error_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OMNI_HOME", raising=False)
+        with pytest.raises(KeyError):
+            resolve_omnibase_infra_path()
+
+    def test_returns_path_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from pathlib import Path
+
+        monkeypatch.setenv("OMNI_HOME", "/some/monorepo")
+        assert isinstance(resolve_omnibase_infra_path(), Path)


### PR DESCRIPTION
## Summary

Adds `omnibase_core.utils.util_omni_home_paths` — a canonical read-time resolver for all `OMNI_HOME`-derived paths (OMN-13136).

**Root defect fixed:** `~/.omnibase/.env` defined `ONEX_WORKTREES_ROOT`, `ONEX_EVIDENCE_ROOT`, and `OMNIBASE_INFRA_PATH` as shell-expanded vars. When `OMNI_HOME` was unset at source-time, each derived var baked a broken bare-root path (e.g. `/omni_worktrees`). Callers that read those env vars got silently wrong paths.

**Fix:** Three public resolver functions (`resolve_worktrees_root()`, `resolve_evidence_root()`, `resolve_omnibase_infra_path()`) read `OMNI_HOME` fail-fast via `os.environ["OMNI_HOME"]` at call-time. The derived env vars are now migration debt to be removed from `~/.omnibase/.env` in follow-up operator cleanup.

### Changed files

- `src/omnibase_core/utils/util_omni_home_paths.py` — new module (3 public functions + `_omni_home()` helper)
- `src/omnibase_core/utils/__init__.py` — re-exports the 3 resolvers in `__all__`
- `tests/unit/utils/test_util_omni_home_paths.py` — 9 unit tests (derive-path, KeyError-when-unset, returns-Path)

### Deferred follow-up surfaces

- `omniclaude/plugins/onex/skills/_lib/dod-evidence-runner/dod_evidence_runner.py` — migrate `os.environ.get("ONEX_EVIDENCE_ROOT")` → `resolve_evidence_root()` (separate PR)
- `omniclaude/plugins/onex/hooks/scripts/pre_tool_use_bash_guard.sh` — remove `ONEX_WORKTREES_ROOT` override; rely on `OMNI_HOME` only (separate PR)
- Operator cleanup: remove 3 derived-path lines from `~/.omnibase/.env` once all readers migrated

## DoD evidence

- 9/9 unit tests pass: `uv run pytest tests/unit/utils/test_util_omni_home_paths.py -v`
- All pre-commit hooks pass on the 3 changed files
- `uv run mypy src/omnibase_core/utils/util_omni_home_paths.py --strict` → 0 errors
- `OMNI_HOME` is in the `validate_no_new_env_vars.py` bootstrap allowlist; hook exits 0

## Receipt Gate

Evidence-Ticket: OMN-13136
Evidence-Source: OCC#3221
