### PR TITLE
feat(OMN-13024): A-2 UI evidence-class gate — Receipt-Gate rejects ui/dashboard evidence without Playwright proxy-origin trace

### DIFF
--- a/src/omnibase_core/enums/governance/__init__.py
+++ b/src/omnibase_core/enums/governance/__init__.py
@@ -35,6 +35,7 @@ from omnibase_core.enums.governance.enum_drift_severity import EnumDriftSeverity
 from omnibase_core.enums.governance.enum_eval_metric_type import EnumEvalMetricType
 from omnibase_core.enums.governance.enum_eval_mode import EnumEvalMode
 from omnibase_core.enums.governance.enum_eval_verdict import EnumEvalVerdict
+from omnibase_core.enums.governance.enum_evidence_class import EnumEvidenceClass
 from omnibase_core.enums.governance.enum_evidence_kind import EnumEvidenceKind
 from omnibase_core.enums.governance.enum_finding_severity import EnumFindingSeverity
 from omnibase_core.enums.governance.enum_integration_surface import (
@@ -65,6 +66,7 @@ __all__ = [
     "EnumEvalMetricType",
     "EnumEvalMode",
     "EnumEvalVerdict",
+    "EnumEvidenceClass",
     "EnumEvidenceKind",
     "EnumFindingSeverity",
     "EnumIntegrationSurface",

--- a/src/omnibase_core/enums/governance/enum_evidence_class.py
+++ b/src/omnibase_core/enums/governance/enum_evidence_class.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumEvidenceClass — provenance class of a dod_evidence proof artifact.
+
+The receipt-gate uses the evidence class to decide *what kind of proof* is
+acceptable for a given dod_evidence check. UI / dashboard work cannot be
+proven by a direct HTTP probe (curl / wget / httpx) against a backend port —
+that proves the API responds, not that the dashboard renders the data through
+its proxy origin. UI-class evidence must come from a Playwright run whose
+captured network trace originates from the dashboard proxy origin, not a
+direct backend port (OMN-13024, A-2).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumEvidenceClass(StrEnum):
+    """Classification of a DoD receipt's proof surface.
+
+    Members
+    -------
+    UI_DASHBOARD
+        Evidence for UI / dashboard behavior. The receipt-gate requires this
+        class to be proven by a Playwright run with a proxy-origin network
+        trace; a direct ``curl``/``wget``/``httpx`` probe is rejected.
+    BACKEND
+        Evidence for backend / service behavior. A direct HTTP probe is an
+        acceptable proof surface; the UI proxy-origin requirement does not
+        apply. Set this explicitly to opt a legitimate HTTP-client receipt
+        out of the UI-class gate.
+    UNCLASSIFIED
+        No UI/backend distinction asserted or inferred. Treated as not
+        UI-class — the proxy-origin requirement does not apply.
+    """
+
+    UI_DASHBOARD = "ui_dashboard"
+    BACKEND = "backend"
+    UNCLASSIFIED = "unclassified"
+
+
+__all__ = ["EnumEvidenceClass"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -54,6 +54,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from omnibase_core.enums.governance.enum_evidence_class import EnumEvidenceClass
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 from omnibase_core.models.contracts.ticket.model_proof_packet import ModelProofPacket
 
@@ -249,6 +250,16 @@ class ModelDodReceipt(BaseModel):
             "the per-class tier requirement is enforced at the gate, not on every "
             "receipt unconditionally. F1 autobind (OMN-13317) fills the packet's "
             "source fields (evidence_source_sha, evidence_ticket, verifier)."
+        ),
+    )
+    evidence_class: EnumEvidenceClass | None = Field(
+        default=None,
+        description=(
+            "Provenance class of this proof surface (OMN-13024). When set to "
+            "UI_DASHBOARD the receipt-gate requires a Playwright proxy-origin "
+            "network trace and rejects direct curl/wget/httpx probes. When set "
+            "to BACKEND a direct HTTP probe is accepted (opt-out of the UI gate). "
+            "None lets the gate infer the class from the probe_command."
         ),
     )
 

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -28,6 +28,8 @@ Decision matrix:
     - Receipt missing probe_command/stdout → FAIL ("missing probe_command|probe_stdout")
     - Receipt verifier == runner          → FAIL ("self-attestation: ... ADVISORY")
     - Receipt status != PASS              → FAIL ("failing receipt (ADVISORY|FAIL|PENDING)")
+    - UI-class evidence w/o Playwright    → FAIL ("ui-class evidence requires Playwright proxy-origin trace")
+    - UI-class trace hits backend port    → FAIL ("ui-class evidence requires Playwright proxy-origin trace")
     - Override token: free-text reason   → FAIL (must use approved allowlist id)
     - Override token: unknown id         → FAIL ("unknown approval id")
     - Override token: expired            → FAIL ("approval expired")
@@ -92,6 +94,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
+from omnibase_core.enums.governance.enum_evidence_class import EnumEvidenceClass
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
 from omnibase_core.models.contracts.ticket.model_receipt_check_result import (
@@ -167,6 +170,119 @@ EVIDENCE_CLASS_PATTERN = re.compile(
     r"^Evidence-Class:\s+(promotion|hotfix)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+
+# UI evidence-class gate (OMN-13024, A-2)
+# ---------------------------------------
+# UI / dashboard evidence cannot be proven by a direct HTTP probe against a
+# backend port — that proves the API responds, not that the dashboard renders
+# the data through its proxy origin. UI-class receipts must come from a
+# Playwright run whose captured network trace originates from the dashboard
+# proxy origin, not a direct backend port.
+
+# Direct HTTP-client invocations that are inadequate proof for UI-class work.
+_HTTP_CLIENT_RE = re.compile(r"\b(?:curl|wget|httpx)\b", re.IGNORECASE)
+# A Playwright run reference in a probe_command.
+_PLAYWRIGHT_RE = re.compile(r"playwright", re.IGNORECASE)
+# An absolute http(s) URL in a captured network trace: captures (host[:port], path).
+_HTTP_URL_RE = re.compile(r"https?://([^/\s]+)(/\S*)?", re.IGNORECASE)
+# A logged HTTP request line (absolute or relative target) in a network trace.
+_REQUEST_LINE_RE = re.compile(
+    r"\b(?:GET|POST|PUT|PATCH|DELETE|HEAD)\b\s+\S+",
+    re.IGNORECASE,
+)
+# Message fragment shared by every UI evidence-class rejection so operators and
+# CI greps can match the gate by a single stable substring.
+_UI_EVIDENCE_FAILURE_PREFIX = "ui-class evidence requires Playwright proxy-origin trace"
+
+
+def classify_evidence_class(receipt: ModelDodReceipt) -> EnumEvidenceClass:
+    """Resolve the evidence class of a receipt (OMN-13024, A-2).
+
+    Precedence:
+
+    1. An explicit ``evidence_class`` field on the receipt always wins —
+       ``BACKEND`` opts a legitimate HTTP-client probe out of the UI gate,
+       ``UI_DASHBOARD`` forces full proxy-origin validation.
+    2. Otherwise infer from ``probe_command``: a direct ``curl``/``wget``/
+       ``httpx`` invocation that does **not** reference Playwright is
+       classified ``UI_DASHBOARD`` (the inadequate-proof shape this gate
+       exists to reject). Everything else is ``UNCLASSIFIED``.
+    """
+    if receipt.evidence_class is not None:
+        return receipt.evidence_class
+    command = receipt.probe_command
+    if _PLAYWRIGHT_RE.search(command):
+        return EnumEvidenceClass.UNCLASSIFIED
+    if _HTTP_CLIENT_RE.search(command):
+        return EnumEvidenceClass.UI_DASHBOARD
+    return EnumEvidenceClass.UNCLASSIFIED
+
+
+def _network_trace_status(probe_stdout: str) -> str:
+    """Classify a captured probe_stdout as a proxy-origin network trace.
+
+    Returns one of:
+
+    - ``"no_trace"`` — no HTTP request was captured at all.
+    - ``"cross_origin"`` — an ``/api`` request targets a host:port that is not
+      the page origin (a direct backend-port call that bypasses the proxy).
+    - ``"ok"`` — at least one request was captured and every absolute ``/api``
+      request shares the page origin (proxied / same-origin).
+
+    The page origin is inferred as any host:port that serves a non-``/api``
+    path (the document / asset load). Relative ``/api`` requests are
+    same-origin by construction and never count as cross-origin.
+    """
+    urls = _HTTP_URL_RE.findall(probe_stdout)
+    has_request = bool(urls) or bool(_REQUEST_LINE_RE.search(probe_stdout))
+    if not has_request:
+        return "no_trace"
+    page_origins = {host for host, path in urls if "api" not in (path or "").lower()}
+    api_origins = {host for host, path in urls if "api" in (path or "").lower()}
+    cross_origin = {host for host in api_origins if host not in page_origins}
+    if cross_origin:
+        return "cross_origin"
+    return "ok"
+
+
+def _check_ui_evidence_class(
+    receipt: ModelDodReceipt, receipt_path: Path
+) -> str | None:
+    """Reject UI/dashboard-class evidence lacking a Playwright proxy-origin trace.
+
+    Returns ``None`` when the receipt is not UI-class or satisfies the
+    proxy-origin requirement; otherwise an operator-facing failure reason.
+    """
+    if classify_evidence_class(receipt) is not EnumEvidenceClass.UI_DASHBOARD:
+        return None
+
+    if not _PLAYWRIGHT_RE.search(receipt.probe_command):
+        return (
+            f"{_UI_EVIDENCE_FAILURE_PREFIX}: receipt at {receipt_path} is "
+            f"ui/dashboard-class (probe_command={receipt.probe_command!r}) but does "
+            "not reference a Playwright run. UI/dashboard evidence cannot be proven "
+            "by a direct curl/wget/httpx probe against a backend port — re-run the "
+            "probe via `npx playwright test ...` against the dashboard proxy origin "
+            "and capture the network trace in probe_stdout."
+        )
+
+    trace_status = _network_trace_status(receipt.probe_stdout)
+    if trace_status == "no_trace":
+        return (
+            f"{_UI_EVIDENCE_FAILURE_PREFIX}: receipt at {receipt_path} is "
+            "ui/dashboard-class and references Playwright but probe_stdout contains "
+            "no captured network trace. Capture the Playwright network trace showing "
+            "proxy-origin requests."
+        )
+    if trace_status == "cross_origin":
+        return (
+            f"{_UI_EVIDENCE_FAILURE_PREFIX}: receipt at {receipt_path} network trace "
+            "targets a direct backend port instead of the dashboard proxy origin. "
+            "The trace must show same-origin proxied requests, not a cross-origin "
+            "backend-port call."
+        )
+    return None
+
 
 # The SHA of the commit that merged OMN-10419 (Task 9 / T6a). PRs opened after
 # this SHA are required to include Evidence-Source. PRs opened before it are
@@ -446,6 +562,13 @@ def _check_one_receipt(
     )
     if adversarial_validated_failure is not None:
         return fail(adversarial_validated_failure)
+
+    # UI evidence-class guard (OMN-13024, A-2): UI/dashboard-class receipts must
+    # carry a Playwright proxy-origin network trace; a direct curl/wget/httpx
+    # probe (or a trace that hits a direct backend port) is rejected.
+    ui_evidence_failure = _check_ui_evidence_class(receipt, receipt_path)
+    if ui_evidence_failure is not None:
+        return fail(ui_evidence_failure)
 
     if receipt.check_type == CHECK_TYPE_RUNTIME_SHA_MATCH:
         runtime_sha_result = classify_runtime_sha_match_receipt(receipt)
@@ -1142,6 +1265,7 @@ __all__ = [
     "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",
     "_CONTRACT_SHA256_REQUIRED_AFTER",
+    "classify_evidence_class",
     "compute_contract_sha256",
     "parse_evidence_source",
     "parse_pr_opened_at",

--- a/tests/unit/validation/test_receipt_gate_ui_evidence_class.py
+++ b/tests/unit/validation/test_receipt_gate_ui_evidence_class.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""UI evidence-class gate tests for the Receipt-Gate (OMN-13024, A-2).
+
+UI / dashboard evidence cannot be proven by a direct HTTP probe (curl / wget /
+httpx) against a backend port — that proves the API responds, not that the
+dashboard renders the data through its proxy origin. UI-class receipts must
+come from a Playwright run whose captured network trace originates from the
+dashboard proxy origin, not a direct backend port.
+
+These tests write a literal receipt YAML to disk and assert the literal gate
+output, per the "literal command + literal stdout assertions" acceptance
+criterion.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.governance.enum_evidence_class import EnumEvidenceClass
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.validation.validator_receipt_gate import (
+    classify_evidence_class,
+    validate_pr_receipts,
+)
+
+_UI_FAILURE_SUBSTRING = "ui-class evidence requires Playwright proxy-origin trace"
+
+# A Playwright network trace whose /api request shares the page origin
+# (localhost:3000) — i.e. proxied / same-origin, not a direct backend port.
+_PROXY_ORIGIN_TRACE = (
+    "Running 1 test using 1 worker\n"
+    "[doc] GET http://localhost:3000/dashboard 200\n"
+    "[xhr] GET http://localhost:3000/api/delegation/rows 200\n"
+    "  1 passed (3.2s)\n"
+)
+
+# A trace whose /api request targets a different port (3001) than the page
+# origin (3000) — a direct backend-port call that bypasses the proxy.
+_DIRECT_BACKEND_TRACE = (
+    "Running 1 test using 1 worker\n"
+    "[doc] GET http://localhost:3000/dashboard 200\n"
+    "[xhr] GET http://localhost:3001/api/delegation/rows 200\n"
+    "  1 passed (3.2s)\n"
+)
+
+
+def _write_contract(contracts_dir: Path, ticket_id: str) -> None:
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "ticket_id": ticket_id,
+        "schema_version": "1.0.0",
+        "summary": "test",
+        "dod_evidence": [
+            {
+                "id": "dod-001",
+                "description": "ui dashboard check",
+                "checks": [
+                    {"check_type": "command", "check_value": "render dashboard"}
+                ],
+            }
+        ],
+    }
+    (contracts_dir / f"{ticket_id}.yaml").write_text(yaml.safe_dump(body))
+
+
+def _receipt_dict(
+    *,
+    ticket_id: str = "OMN-13024",
+    probe_command: str,
+    probe_stdout: str,
+    evidence_class: str | None = None,
+    runner: str = "worker-A",
+    verifier: str = "foreground-claude-X",
+    status: str = "PASS",
+) -> dict[str, object]:
+    data: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": ticket_id,
+        "evidence_item_id": "dod-001",
+        "check_type": "command",
+        "check_value": "render dashboard",
+        "status": status,
+        "run_timestamp": datetime.now(tz=UTC).isoformat(),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": runner,
+        "verifier": verifier,
+        "probe_command": probe_command,
+        "probe_stdout": probe_stdout,
+    }
+    if evidence_class is not None:
+        data["evidence_class"] = evidence_class
+    return data
+
+
+def _write_receipt(receipts_dir: Path, ticket_id: str, data: dict[str, object]) -> Path:
+    p = receipts_dir / ticket_id / "dod-001" / "command.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data))
+    return p
+
+
+@pytest.mark.unit
+class TestUiEvidenceClassModelField:
+    """The receipt model carries an optional evidence_class field."""
+
+    def test_evidence_class_defaults_to_none(self) -> None:
+        receipt = ModelDodReceipt.model_validate(
+            _receipt_dict(
+                probe_command="echo ok",
+                probe_stdout="ok\n",
+            )
+        )
+        assert receipt.evidence_class is None
+
+    def test_evidence_class_parses_ui_dashboard(self) -> None:
+        receipt = ModelDodReceipt.model_validate(
+            _receipt_dict(
+                probe_command="npx playwright test",
+                probe_stdout=_PROXY_ORIGIN_TRACE,
+                evidence_class="ui_dashboard",
+            )
+        )
+        assert receipt.evidence_class is EnumEvidenceClass.UI_DASHBOARD
+
+
+@pytest.mark.unit
+class TestClassifyEvidenceClass:
+    """Classification precedence: explicit field wins, else infer from command."""
+
+    def test_curl_without_playwright_infers_ui_dashboard(self) -> None:
+        receipt = ModelDodReceipt.model_validate(
+            _receipt_dict(
+                probe_command="curl http://localhost:3001/api/delegation/rows",
+                probe_stdout='{"rows": []}\n',
+            )
+        )
+        assert classify_evidence_class(receipt) is EnumEvidenceClass.UI_DASHBOARD
+
+    def test_playwright_command_is_unclassified_without_explicit_field(self) -> None:
+        receipt = ModelDodReceipt.model_validate(
+            _receipt_dict(
+                probe_command="npx playwright test",
+                probe_stdout=_PROXY_ORIGIN_TRACE,
+            )
+        )
+        assert classify_evidence_class(receipt) is EnumEvidenceClass.UNCLASSIFIED
+
+    def test_explicit_backend_overrides_curl_heuristic(self) -> None:
+        receipt = ModelDodReceipt.model_validate(
+            _receipt_dict(
+                probe_command="curl http://localhost:8085/v1/introspection",
+                probe_stdout='{"ok": true}\n',
+                evidence_class="backend",
+            )
+        )
+        assert classify_evidence_class(receipt) is EnumEvidenceClass.BACKEND
+
+
+@pytest.mark.unit
+class TestUiEvidenceClassGate:
+    """The gate rejects UI-class evidence without a Playwright proxy-origin trace."""
+
+    def test_curl_ui_class_evidence_fails(self, tmp_path: Path) -> None:
+        """DoD: curl probe with no Playwright reference fails the gate."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="curl http://localhost:3001/api/delegation/rows",
+                probe_stdout='{"rows": [{"id": 1}]}\n',
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert not result.passed
+        assert _UI_FAILURE_SUBSTRING in result.message
+
+    def test_explicit_ui_class_curl_fails(self, tmp_path: Path) -> None:
+        """An explicit evidence_class=ui_dashboard curl receipt fails the gate."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="httpx http://localhost:3001/api/rows",
+                probe_stdout='{"rows": []}\n',
+                evidence_class="ui_dashboard",
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert not result.passed
+        assert _UI_FAILURE_SUBSTRING in result.message
+
+    def test_playwright_proxy_origin_trace_passes(self, tmp_path: Path) -> None:
+        """DoD: Playwright probe with a proxy-origin trace passes the gate."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="npx playwright test tests/dashboard/delegation.spec.ts",
+                probe_stdout=_PROXY_ORIGIN_TRACE,
+                evidence_class="ui_dashboard",
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed, result.message
+
+    def test_playwright_direct_backend_port_trace_fails(self, tmp_path: Path) -> None:
+        """A Playwright run whose trace hits a direct backend port fails."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="npx playwright test tests/dashboard/delegation.spec.ts",
+                probe_stdout=_DIRECT_BACKEND_TRACE,
+                evidence_class="ui_dashboard",
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert not result.passed
+        assert _UI_FAILURE_SUBSTRING in result.message
+
+    def test_backend_class_curl_escapes_ui_gate(self, tmp_path: Path) -> None:
+        """An explicit evidence_class=backend curl receipt is not UI-gated."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="curl http://localhost:8085/v1/introspection/manifest",
+                probe_stdout='{"manifest": {"version": "0.37.0"}}\n',
+                evidence_class="backend",
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed, result.message
+
+    def test_non_ui_command_receipt_unaffected(self, tmp_path: Path) -> None:
+        """A plain command receipt (no HTTP client) is not UI-gated."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13024")
+        _write_receipt(
+            receipts,
+            "OMN-13024",
+            _receipt_dict(
+                probe_command="uv run pytest tests/unit -q",
+                probe_stdout="120 passed\n",
+            ),
+        )
+
+        result = validate_pr_receipts(
+            pr_body="Closes OMN-13024",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed, result.message


### PR DESCRIPTION
## OMN-13024 — A-2: UI evidence-class gate in the Receipt-Gate

The Receipt-Gate now rejects ui/dashboard-class DoD evidence that lacks a Playwright proxy-origin network trace. UI/dashboard work cannot be proven by a direct HTTP probe (curl/wget/httpx) against a backend port — that proves the API responds, not that the dashboard renders the data through its proxy origin.

Evidence-Source: OCC#3265
Evidence-Ticket: OMN-13024
Implementation-Head: cd845a4801a858bca972290375b8fb0a2258f1a8

### What changed
- New `EnumEvidenceClass` (`UI_DASHBOARD` / `BACKEND` / `UNCLASSIFIED`) and an optional `evidence_class` field on `ModelDodReceipt`.
- `classify_evidence_class(receipt)`: explicit `evidence_class` wins; otherwise infer `UI_DASHBOARD` from a direct `curl`/`wget`/`httpx` `probe_command` that does not reference Playwright.
- `_check_ui_evidence_class` wired into `_check_one_receipt`: a ui/dashboard-class receipt fails unless `probe_command` references a Playwright run AND `probe_stdout` carries a network trace whose `/api` requests share the page (proxy) origin — a direct backend-port (cross-origin) call is rejected. `evidence_class: backend` opts a legitimate HTTP-client probe out of the gate.

### DoD evidence
- A receipt with `probe_command='curl http://localhost:3001/api/...'` and no Playwright reference fails with `ui-class evidence requires Playwright proxy-origin trace` (`test_curl_ui_class_evidence_fails`).
- A receipt with `probe_command='npx playwright test ...'` and a proxy-origin trace in `probe_stdout` passes (`test_playwright_proxy_origin_trace_passes`).
- A Playwright run whose trace hits a direct backend port fails (`test_playwright_direct_backend_port_trace_fails`).
- `tests/unit/validation/test_receipt_gate_ui_evidence_class.py` — 11 tests green.
- Receipt-gate + dod-receipt model suites green (no regression); `mypy --strict` clean; ruff clean.

### Notes
- Canonical-only: pure validation-library change to the Receipt-Gate validator + DoD receipt model + a new governance enum. No REST endpoint, no Plugin*/engine/router/daemon, no runtime/deploy mutation.
- OCC pairing: `onex_change_control` PR #3244 carries `contracts/OMN-13024.yaml` + 4 PASS DoD receipts (validated locally via `validate_pr_receipts`, 4/4 PASS).