### PR TITLE
test(OMN-13721): cover error-path gaps in crypto_file_key_provider (85% → 98%)

### DIFF
--- a/contracts/OMN-13721.yaml
+++ b/contracts/OMN-13721.yaml
@@ -1,0 +1,30 @@
+---
+schema_version: "1.0.0"
+ticket_id: "OMN-13721"
+title: "test(coverage): fill error-path gaps in crypto_file_key_provider"
+summary: "Add tests for three uncovered error branches in FileKeyProvider: base64 TypeError (lines 103-104),
+  UnicodeDecodeError as ValueError (lines 117-123), and OSError atomic-write cleanup (lines 235-247).
+  No source changes."
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "pytest on tests/unit/crypto/test_crypto_file_key_provider.py reports 0 failures and
+      coverage >= 95% on crypto_file_key_provider.py."
+    command: "cd omnibase_core && uv run pytest tests/unit/crypto/test_crypto_file_key_provider.py --cov=omnibase_core.crypto.crypto_file_key_provider
+      --cov-report=term-missing -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "omnibase_core PR adds 6 new tests covering lines 103-104 (TypeError from non-string
+      base64 value), 117-123 (UnicodeDecodeError triggering outer ValueError handler), and 235-247 (OSError
+      cleanup in _save_keys). Coverage rises from 85.62% to 98.63%."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/crypto/test_crypto_file_key_provider.py --cov=omnibase_core.crypto.crypto_file_key_provider
+          -q 2>&1 | grep 'passed'"

--- a/tests/unit/crypto/test_crypto_file_key_provider.py
+++ b/tests/unit/crypto/test_crypto_file_key_provider.py
@@ -10,6 +10,7 @@ import json
 import os
 import stat
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -371,6 +372,132 @@ class TestFileKeyProviderValidation:
         assert provider.has_key("valid-runtime") is True
         assert provider.has_key("invalid-runtime") is False
         assert provider.get_public_key("valid-runtime") == valid_key
+
+
+@pytest.mark.unit
+class TestFileKeyProviderLoadKeyErrors:
+    """Error-path tests for _load_keys() — covers lines 103-104 and 117-123."""
+
+    def test_skips_non_string_key_value_on_load(self, tmp_path: Path) -> None:
+        """Key whose JSON value is not a string triggers TypeError in
+        base64.urlsafe_b64decode(), caught at lines 103-104.
+
+        base64.urlsafe_b64decode() requires a bytes-like object or str.
+        Passing None (JSON null) or an int raises TypeError, which is exactly
+        what the inner except (ValueError, TypeError) is designed to handle.
+        The provider must skip those entries and continue loading others.
+        """
+        key_file = tmp_path / "keys.json"
+        # JSON null -> Python None; JSON 42 -> Python int.
+        # Both cause TypeError when passed to base64.urlsafe_b64decode().
+        key_file.write_text('{"keys": {"null-runtime": null, "int-runtime": 42}}')
+        key_file.chmod(0o600)
+
+        provider = FileKeyProvider(key_file)
+
+        assert provider.has_key("null-runtime") is False
+        assert provider.has_key("int-runtime") is False
+        assert provider.list_runtime_ids() == []
+
+    def test_mixed_valid_and_non_string_key_value_on_load(self, tmp_path: Path) -> None:
+        """Valid keys are loaded; keys whose JSON value is a non-string are skipped
+        (lines 103-104).
+
+        Ensures the inner exception handler skips the bad entry without
+        preventing subsequent valid entries from loading.
+        """
+        key_file = tmp_path / "keys.json"
+        valid_key = generate_keypair().public_key_bytes
+        valid_b64 = base64.urlsafe_b64encode(valid_key).decode()
+        # Inline JSON so the 'bad' value is genuinely a non-string (integer).
+        key_file.write_text(
+            json.dumps({"keys": {"valid-runtime": valid_b64, "bad-runtime": 99}})
+        )
+        key_file.chmod(0o600)
+
+        provider = FileKeyProvider(key_file)
+
+        assert provider.has_key("valid-runtime") is True
+        assert provider.get_public_key("valid-runtime") == valid_key
+        assert provider.has_key("bad-runtime") is False
+
+    def test_handles_non_utf8_file_gracefully(self, tmp_path: Path) -> None:
+        """File with invalid UTF-8 bytes triggers UnicodeDecodeError, caught as
+        ValueError by the outer except (KeyError, ValueError) (lines 117-123).
+
+        Provider must start with an empty key set rather than raising.
+        """
+        key_file = tmp_path / "keys.json"
+        # 0xff 0xfe are invalid in UTF-8; read_text(encoding="utf-8") will raise
+        # UnicodeDecodeError which is a subclass of ValueError.
+        key_file.write_bytes(b"\xff\xfe\x80\x81 not valid utf-8")
+        key_file.chmod(0o600)
+
+        provider = FileKeyProvider(key_file)
+
+        assert provider.list_runtime_ids() == []
+
+
+@pytest.mark.unit
+class TestFileKeyProviderSaveOSError:
+    """Error-path tests for _save_keys() — covers lines 235-247.
+
+    The atomic write in _save_keys() wraps temp-file operations in an OSError
+    handler that cleans up the fd and temp file before re-raising.  Three
+    sub-paths need individual exercise:
+      235-239, 242-244, 247  — main cleanup (os.fsync raises)
+      240-241                — inner except for os.close failure
+      245-246                — inner except for Path.unlink failure
+    """
+
+    def test_save_keys_oserror_propagates(self, tmp_path: Path) -> None:
+        """OSError from os.fsync() during _save_keys() is re-raised after cleanup
+        (covers lines 235, 237-239, 242-244, 247).
+
+        Both fd and temp_path are non-None when fsync raises, so the cleanup
+        branches for fd-close and temp-unlink both execute before the re-raise.
+        """
+        key_file = tmp_path / "keys.json"
+        provider = FileKeyProvider(key_file)
+        keypair = generate_keypair()
+
+        with patch("os.fsync", side_effect=OSError("simulated disk error")):
+            with pytest.raises(OSError, match="simulated disk error"):
+                provider.register_key("runtime-001", keypair.public_key_bytes)
+
+    def test_save_keys_fd_close_failure_suppressed(self, tmp_path: Path) -> None:
+        """Inner OSError when os.close(fd) fails during cleanup is suppressed
+        (covers lines 240-241).
+
+        Simulates the case where the fd is already invalid when cleanup runs.
+        The outer OSError is still propagated; the inner one is silently ignored.
+        """
+        key_file = tmp_path / "keys.json"
+        provider = FileKeyProvider(key_file)
+        keypair = generate_keypair()
+
+        with patch("os.fsync", side_effect=OSError("disk full")):
+            with patch("os.close", side_effect=OSError("bad file descriptor")):
+                with pytest.raises(OSError, match="disk full"):
+                    provider.register_key("runtime-001", keypair.public_key_bytes)
+
+    def test_save_keys_temp_unlink_failure_suppressed(self, tmp_path: Path) -> None:
+        """Inner OSError when Path.unlink() fails during cleanup is suppressed
+        (covers lines 245-246).
+
+        Simulates the case where the temp file cannot be removed during cleanup.
+        The outer OSError is still propagated; the unlink failure is ignored.
+        """
+        key_file = tmp_path / "keys.json"
+        provider = FileKeyProvider(key_file)
+        keypair = generate_keypair()
+
+        with patch("os.fsync", side_effect=OSError("disk full")):
+            with patch.object(
+                Path, "unlink", side_effect=OSError("read-only filesystem")
+            ):
+                with pytest.raises(OSError, match="disk full"):
+                    provider.register_key("runtime-001", keypair.public_key_bytes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fills three clusters of uncovered exception-handling paths in `src/omnibase_core/crypto/crypto_file_key_provider.py`, raising coverage on that module from **85.62% → 98.63%** (0 missing statements). No source changes — tests only.

Ticket: OMN-13721

## Coverage gaps filled

| Lines | Handler | Trigger | Tests added |
|-------|---------|---------|-------------|
| 103-104 | `except (ValueError, TypeError)` inside `_load_keys()` | `base64.urlsafe_b64decode()` receives a non-string JSON value (`null` or integer) → `TypeError` | `test_skips_non_string_key_value_on_load`, `test_mixed_valid_and_non_string_key_value_on_load` |
| 117-123 | outer `except (KeyError, ValueError)` in `_load_keys()` | File contains non-UTF-8 bytes → `UnicodeDecodeError` (a `ValueError` subclass) from `read_text(encoding="utf-8")` | `test_handles_non_utf8_file_gracefully` |
| 235-247 | `except OSError` cleanup in `_save_keys()` | `os.fsync` raises during atomic temp-file write; inner `os.close` and `Path.unlink` failure sub-paths also exercised | `test_save_keys_oserror_propagates`, `test_save_keys_fd_close_failure_suppressed`, `test_save_keys_temp_unlink_failure_suppressed` |

All 6 new tests use `@pytest.mark.unit` and `tmp_path`. The two inner cleanup-failure tests (`os.close` raises, `Path.unlink` raises) are scoped to the mock context and restored immediately after.

## Test evidence

```
src/omnibase_core/crypto/crypto_file_key_provider.py   120  0  26  2  98.63%   237->242, 242->247
35 passed in 4.95s
```

(Remaining 2 partial branch items are the `fd is None` / `temp_path is None` short-circuit paths inside the OSError cleanup — branch-only, no missing statements.)

## OCC pair

Contract: `contracts/OMN-13721.yaml` (in this PR)

## DoD evidence

Evidence-Ticket: OMN-13721
Evidence-Source: OCC#3298

- `uv run pytest tests/unit/crypto/test_crypto_file_key_provider.py --cov=omnibase_core.crypto.crypto_file_key_provider --cov-report=term-missing -q` → 35 passed, 98.63% coverage
- Pre-commit hooks on changed file: all pass (pre-existing repo-wide failures are unrelated to this change)
- mypy: no new errors introduced (6 pre-existing errors in `contract_loader.py`, `cli_install.py`, `model_onex_container.py`)
