### PR TITLE
feat(OMN-13735): FSM YAML-vs-handler drift guard — validator + pre-commit hook + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1836,7 +1836,7 @@ jobs:
         with:
           checks: "boundary-parity"
           warn-only: "false"
-          repos: "omniclaude,omnidash,omniintelligence,omnibase_infra,omnibase_core,omnimemory,onex_change_control"
+          repos: "omniclaude,omnidash,omniintelligence,omnibase_infra,omnibase_core,omnimemory,omnimarket,onex_change_control"
 
   # API-STABLE check_name: "CI Summary"
   # Aggregates Quality Gate + Tests Gate into a single top-level status.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1832,7 +1832,7 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
-      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@552200ce4ac3dae5ac38d2fe1adf17adc7b8a7ac # main
+      - uses: OmniNode-ai/onex_change_control/.github/actions/validate-boundaries@77f63a25b67db14dbca603ed8f841c3c5c4ee93e # dev
         with:
           checks: "boundary-parity"
           warn-only: "false"

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# FSM Handler Drift Guard — YAML-vs-handler drift gate (OMN-13735)
+#
+# Canonical CI gate for `omnibase_core.validators.fsm_handler_drift`.
+# Required status check context: "fsm-handler-drift".
+#
+# The validator reconciles every reducer contract.yaml's state_machine.transitions
+# (filtered by fsm_handler_binding.state_filter for each declared FSM type) against
+# the handler module's exported VALID_TRANSITIONS and GUARD_CONDITIONS Python symbols
+# via AST literal evaluation — no import required, no allowlist.
+#
+# This workflow runs on omnibase_core:
+#   1. Unit pytest for the validator (regression guard, incl. synthetic divergence cases)
+#   2. Self-scan of omnibase_core's own src/ — must produce zero findings (omnibase_core
+#      has no reducer handlers with fsm_handler_binding, so the scan is a no-op that
+#      confirms the validator exits 0 on a clean repo)
+#
+# Consumer repos (omnimarket) wire the remote `check-fsm-handler-drift` pre-commit hook
+# and their own CI job that scans their src/ for real fsm_handler_binding contracts.
+
+name: FSM Handler Drift Guard
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: fsm-handler-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fsm-handler-drift:
+    name: fsm-handler-drift
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run fsm-handler-drift unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validators/test_fsm_handler_drift.py \
+            -v
+
+      - name: Self-scan omnibase_core src/ (must exit 0 — no fsm_handler_binding contracts here)
+        run: uv run python -m omnibase_core.validators.fsm_handler_drift src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,6 +301,20 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # OMN-13735: reconcile every reducer contract.yaml's state_machine.transitions
+      # (filtered by the declared fsm_handler_binding.state_filter) against the handler
+      # module's VALID_TRANSITIONS / GUARD_CONDITIONS symbols via AST literal eval. Any
+      # (from_state, trigger)->to_state or guard field/value divergence blocks; zero
+      # allowlist. Core dogfoods its own export (no fsm_handler_binding contracts here yet,
+      # so this scan exits 0 until one is added).
+      - id: check-fsm-handler-drift
+        name: FSM YAML-vs-handler drift guard (OMN-13735)
+        entry: uv run python -m omnibase_core.validators.fsm_handler_drift src/
+        language: system
+        files: (^|/)(contract\.yaml|handlers/handler_.*\.py)$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # OMN-13530: require an 'operation' field on operation_match handler entries.
       # A missing operation makes the contract fail closed at RuntimeLocal startup
       # ('handlers[i].operation is missing') — the 0.46.0 regression that took down

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -518,6 +518,22 @@
   pass_filenames: true
   stages: [pre-commit]
 
+- id: check-fsm-handler-drift
+  name: FSM YAML-vs-handler drift guard (OMN-13735)
+  description: >
+    Reconcile every reducer contract.yaml's state_machine.transitions (filtered by the fsm_handler_binding.state_filter
+    for each declared FSM type) against the handler module's exported VALID_TRANSITIONS and GUARD_CONDITIONS
+    Python symbols via AST literal evaluation — no import required. EXISTENCE (blocking): every contract
+    transition MUST appear in VALID_TRANSITIONS with the correct to_state; any handler transition not
+    in the contract is also a block; guard field/value mismatches block. Zero allowlist entries. Scans
+    the repo root (cwd); pass_filenames is false so it re-reconciles whenever a contract.yaml or a handler
+    .py changes.
+  language: python
+  entry: python -m omnibase_core.validators.fsm_handler_drift
+  files: (^|/)(contract\.yaml|handlers/handler_.*\.py)$
+  pass_filenames: false
+  stages: [pre-commit]
+
 - id: check-projection-exposure-drift
   name: Projection exposure-column drift (OMN-13663)
   description: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,11 @@ onex-demo-path-topic-gate = "omnibase_core.validation.validator_demo_path_topic_
 # node's migration DDL). Existence drift fails the build; identity/tier/cost
 # columns omitted from every exposure warn (the cost_tier_name class of bug).
 check-projection-exposure-drift = "omnibase_core.validators.projection_exposure_drift:main"
+# OMN-13735: FSM YAML-vs-handler drift validator. Reconciles every reducer
+# contract.yaml's state_machine.transitions (filtered by fsm_handler_binding.state_filter)
+# against the handler's VALID_TRANSITIONS and GUARD_CONDITIONS Python symbols via AST.
+# Fails on any (from_state, trigger)->to_state or guard divergence; zero allowlist entries.
+check-fsm-handler-drift = "omnibase_core.validators.fsm_handler_drift:main"
 
 [project.entry-points."onex.backends"]
 event_bus_inmemory = "omnibase_core.event_bus.event_bus_inmemory:EventBusInmemory"

--- a/src/omnibase_core/enums/enum_fsm_handler_drift.py
+++ b/src/omnibase_core/enums/enum_fsm_handler_drift.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""FSM handler drift severity and kind enums (OMN-13735)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumFsmHandlerDriftSeverity(StrEnum):
+    """Severity of a FSM handler drift finding."""
+
+    ERROR = "error"
+
+
+class EnumFsmHandlerDriftKind(StrEnum):
+    """Classification of a FSM handler drift finding."""
+
+    TRANSITION_MISSING_IN_HANDLER = "transition_missing_in_handler"
+    TRANSITION_EXTRA_IN_HANDLER = "transition_extra_in_handler"
+    TRANSITION_TO_STATE_MISMATCH = "transition_to_state_mismatch"
+    GUARD_MISSING_IN_HANDLER = "guard_missing_in_handler"
+    GUARD_FIELD_MISMATCH = "guard_field_mismatch"
+    GUARD_VALUE_MISMATCH = "guard_value_mismatch"
+    HANDLER_FILE_NOT_FOUND = "handler_file_not_found"
+    SYMBOL_NOT_FOUND = "symbol_not_found"
+    SYMBOL_PARSE_ERROR = "symbol_parse_error"
+    CONTRACT_SCHEMA_ERROR = "contract_schema_error"

--- a/src/omnibase_core/enums/enum_fsm_handler_drift.py
+++ b/src/omnibase_core/enums/enum_fsm_handler_drift.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """FSM handler drift severity and kind enums (OMN-13735)."""
 

--- a/src/omnibase_core/models/validation/model_fsm_handler_drift_finding.py
+++ b/src/omnibase_core/models/validation/model_fsm_handler_drift_finding.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Finding model for the FSM handler drift validator (OMN-13735).
 

--- a/src/omnibase_core/models/validation/model_fsm_handler_drift_finding.py
+++ b/src/omnibase_core/models/validation/model_fsm_handler_drift_finding.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Finding model for the FSM handler drift validator (OMN-13735).
+
+The validator reconciles every reducer ``contract.yaml``'s
+``state_machine.transitions`` (filtered to a declared FSM type's state set)
+against the handler module's exported ``VALID_TRANSITIONS`` and
+``GUARD_CONDITIONS`` Python symbols.
+
+Finding kinds:
+* ``TRANSITION_MISSING_IN_HANDLER`` (ERROR) — contract declares a transition
+  that the handler's VALID_TRANSITIONS dict does not contain.
+* ``TRANSITION_EXTRA_IN_HANDLER`` (ERROR) — handler's VALID_TRANSITIONS
+  contains a transition not declared in the contract.
+* ``TRANSITION_TO_STATE_MISMATCH`` (ERROR) — a shared (from_state, trigger)
+  key resolves to a different to_state in contract vs handler.
+* ``GUARD_MISSING_IN_HANDLER`` (ERROR) — contract declares a guard_condition
+  for a transition but handler's GUARD_CONDITIONS has no entry for it.
+* ``GUARD_FIELD_MISMATCH`` (ERROR) — guard's field name differs.
+* ``GUARD_VALUE_MISMATCH`` (ERROR) — guard's required value differs.
+* ``HANDLER_FILE_NOT_FOUND`` (ERROR) — the declared handler_module cannot be
+  resolved to a file on disk.
+* ``SYMBOL_NOT_FOUND`` (ERROR) — the handler file does not export the
+  declared symbol name.
+* ``SYMBOL_PARSE_ERROR`` (ERROR) — AST parsing of the handler file failed.
+* ``CONTRACT_SCHEMA_ERROR`` (ERROR) — the contract YAML does not conform to
+  the expected fsm_handler_binding schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from omnibase_core.enums.enum_fsm_handler_drift import (
+    EnumFsmHandlerDriftKind,
+    EnumFsmHandlerDriftSeverity,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelFsmHandlerDriftFinding:
+    """A single FSM handler drift finding."""
+
+    severity: EnumFsmHandlerDriftSeverity
+    kind: EnumFsmHandlerDriftKind
+    node: str
+    contract_path: Path
+    fsm_type: str
+    handler_module: str
+    detail: str
+    from_state: str | None = None
+    trigger: str | None = None
+    to_state_contract: str | None = None
+    to_state_handler: str | None = None
+
+    def format(self) -> str:
+        transition = ""
+        if self.from_state is not None and self.trigger is not None:
+            transition = f" ({self.from_state!r}, {self.trigger!r})"
+            if self.to_state_contract is not None:
+                transition += f" -> contract:{self.to_state_contract!r}"
+            if self.to_state_handler is not None:
+                transition += f" handler:{self.to_state_handler!r}"
+        return (
+            f"{self.contract_path}: [{self.severity.value}] "
+            f"node={self.node} fsm_type={self.fsm_type}{transition}: {self.detail}"
+        )

--- a/src/omnibase_core/validators/fsm_handler_drift.py
+++ b/src/omnibase_core/validators/fsm_handler_drift.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """FSM YAML-vs-handler drift validator (OMN-13735).

--- a/src/omnibase_core/validators/fsm_handler_drift.py
+++ b/src/omnibase_core/validators/fsm_handler_drift.py
@@ -1,0 +1,1000 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""FSM YAML-vs-handler drift validator (OMN-13735).
+
+Mechanically enforces the invariant described in
+``handler_pattern_lifecycle.py:61``: every ``VALID_TRANSITIONS`` and
+``GUARD_CONDITIONS`` entry in a reducer handler must exactly mirror the
+matching ``state_machine.transitions`` entries in the node's ``contract.yaml``.
+
+The contract opts in by declaring a ``fsm_handler_binding`` section:
+
+.. code-block:: yaml
+
+    fsm_handler_binding:
+      - fsm_type: "PATTERN_LIFECYCLE"
+        handler_module: "omnimarket.nodes.node_intelligence_reducer.handlers.handler_pattern_lifecycle"
+        valid_transitions_symbol: "VALID_TRANSITIONS"
+        guard_conditions_symbol: "GUARD_CONDITIONS"
+        state_filter:
+          - "candidate"
+          - "provisional"
+          - "validated"
+          - "deprecated"
+
+The validator:
+1. Finds all ``contract.yaml`` files with a ``fsm_handler_binding`` section.
+2. For each binding, locates the handler file by resolving the dotted module
+   path against the scan root's ``src/`` tree (no import required).
+3. Extracts ``VALID_TRANSITIONS`` and ``GUARD_CONDITIONS`` via AST literal
+   evaluation — no code execution, no dependency import.
+4. Filters the contract's ``state_machine.transitions`` to only those whose
+   ``from_state`` is in the binding's ``state_filter``.
+5. Compares the two tables; emits a ``ModelFsmHandlerDriftFinding`` for every
+   divergence — missing transitions, extra transitions, wrong to_state, guard
+   field/value mismatches.
+
+Zero allowlist entries. Every divergence is a hard block.
+
+Usage::
+
+    check-fsm-handler-drift [ROOT] [--src-subdir PATH]
+    python -m omnibase_core.validators.fsm_handler_drift src/
+
+ROOT defaults to the current working directory.
+``--src-subdir`` overrides the default ``src`` sub-directory that contains the
+Python package tree (used to locate handler files from dotted module paths).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.enums.enum_fsm_handler_drift import (
+    EnumFsmHandlerDriftKind,
+    EnumFsmHandlerDriftSeverity,
+)
+from omnibase_core.models.validation.model_fsm_handler_drift_finding import (
+    ModelFsmHandlerDriftFinding,
+)
+
+# Default sub-directory containing the Python package tree relative to repo root.
+DEFAULT_SRC_SUBDIR = "src"
+
+_ERROR = EnumFsmHandlerDriftSeverity.ERROR
+
+
+# --------------------------------------------------------------------------- #
+# Typed internal model for one fsm_handler_binding entry
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class _FsmHandlerBinding:
+    fsm_type: str
+    handler_module: str
+    valid_transitions_symbol: str
+    guard_conditions_symbol: str | None
+    state_filter: frozenset[str]
+
+
+# --------------------------------------------------------------------------- #
+# Contract discovery
+# --------------------------------------------------------------------------- #
+
+
+def _is_fsm_binding_contract(data: object) -> bool:
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("fsm_handler_binding"), list)
+        and len(data["fsm_handler_binding"]) > 0
+    )
+
+
+def discover_fsm_binding_contracts(root: Path) -> list[Path]:
+    """Return every ``contract.yaml`` under ``root`` that declares a fsm_handler_binding."""
+    found: list[Path] = []
+    for contract_path in sorted(root.rglob("contract.yaml")):
+        if any(
+            part in {"__pycache__", ".git", ".venv", "node_modules"}
+            for part in contract_path.parts
+        ):
+            continue
+        try:
+            data = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, UnicodeDecodeError, OSError):
+            continue
+        if _is_fsm_binding_contract(data):
+            found.append(contract_path)
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Binding schema parsing
+# --------------------------------------------------------------------------- #
+
+
+def _parse_bindings(
+    data: dict[str, object],
+    contract_path: Path,
+    node: str,
+) -> tuple[list[_FsmHandlerBinding], list[ModelFsmHandlerDriftFinding]]:
+    """Parse and validate the ``fsm_handler_binding`` list from a contract.
+
+    Returns (valid_bindings, schema_error_findings).
+    """
+    raw_bindings = data.get("fsm_handler_binding")
+    if not isinstance(raw_bindings, list):
+        return [], [
+            ModelFsmHandlerDriftFinding(
+                severity=_ERROR,
+                kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                node=node,
+                contract_path=contract_path,
+                fsm_type="",
+                handler_module="",
+                detail="fsm_handler_binding must be a list",
+            )
+        ]
+
+    bindings: list[_FsmHandlerBinding] = []
+    errors: list[ModelFsmHandlerDriftFinding] = []
+
+    for idx, entry in enumerate(raw_bindings):
+        if not isinstance(entry, dict):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type="",
+                    handler_module="",
+                    detail=f"fsm_handler_binding[{idx}] must be a dict",
+                )
+            )
+            continue
+
+        fsm_type = entry.get("fsm_type")
+        handler_module = entry.get("handler_module")
+        valid_transitions_symbol = entry.get("valid_transitions_symbol")
+        state_filter_raw = entry.get("state_filter")
+
+        if not isinstance(fsm_type, str) or not fsm_type:
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=str(fsm_type or ""),
+                    handler_module=str(handler_module or ""),
+                    detail=f"fsm_handler_binding[{idx}].fsm_type must be a non-empty string",
+                )
+            )
+            continue
+        if not isinstance(handler_module, str) or not handler_module:
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module="",
+                    detail=f"fsm_handler_binding[{idx}].handler_module must be a non-empty string",
+                )
+            )
+            continue
+        if (
+            not isinstance(valid_transitions_symbol, str)
+            or not valid_transitions_symbol
+        ):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"fsm_handler_binding[{idx}].valid_transitions_symbol "
+                        "must be a non-empty string"
+                    ),
+                )
+            )
+            continue
+        if not isinstance(state_filter_raw, list) or not state_filter_raw:
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"fsm_handler_binding[{idx}].state_filter "
+                        "must be a non-empty list of state name strings"
+                    ),
+                )
+            )
+            continue
+        if not all(isinstance(s, str) for s in state_filter_raw):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"fsm_handler_binding[{idx}].state_filter "
+                        "every entry must be a string"
+                    ),
+                )
+            )
+            continue
+
+        guard_symbol = entry.get("guard_conditions_symbol")
+        guard_symbol_str: str | None = None
+        if guard_symbol is not None:
+            if not isinstance(guard_symbol, str) or not guard_symbol:
+                errors.append(
+                    ModelFsmHandlerDriftFinding(
+                        severity=_ERROR,
+                        kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                        node=node,
+                        contract_path=contract_path,
+                        fsm_type=fsm_type,
+                        handler_module=handler_module,
+                        detail=(
+                            f"fsm_handler_binding[{idx}].guard_conditions_symbol "
+                            "must be a non-empty string when present"
+                        ),
+                    )
+                )
+                continue
+            guard_symbol_str = guard_symbol
+
+        bindings.append(
+            _FsmHandlerBinding(
+                fsm_type=fsm_type,
+                handler_module=handler_module,
+                valid_transitions_symbol=valid_transitions_symbol,
+                guard_conditions_symbol=guard_symbol_str,
+                state_filter=frozenset(str(s).lower() for s in state_filter_raw),
+            )
+        )
+
+    return bindings, errors
+
+
+# --------------------------------------------------------------------------- #
+# Handler file resolution
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_handler_file(
+    handler_module: str,
+    scan_root: Path,
+    src_subdir: str = DEFAULT_SRC_SUBDIR,
+) -> Path | None:
+    """Resolve a dotted module path to a ``.py`` file path.
+
+    Searches:
+      1. ``<scan_root>/<src_subdir>/<module_as_path>.py``
+      2. ``<scan_root>/<module_as_path>.py``
+
+    Returns the first matching path, or ``None`` if neither exists.
+    """
+    rel = Path(*handler_module.split("."))
+    candidates = [
+        scan_root / src_subdir / rel.with_suffix(".py"),
+        scan_root / rel.with_suffix(".py"),
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# AST symbol extraction
+# --------------------------------------------------------------------------- #
+
+
+def _extract_literal_symbol(
+    source_path: Path,
+    symbol_name: str,
+) -> tuple[object | None, str | None]:
+    """Extract a module-level literal constant by name via AST.
+
+    Uses ``ast.literal_eval`` — no code execution, no import required.
+
+    Returns (value, error_message). If successful, error_message is None.
+    """
+    try:
+        source = source_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, f"cannot read handler file: {exc}"
+
+    try:
+        tree = ast.parse(source, filename=str(source_path))
+    except SyntaxError as exc:
+        return None, f"syntax error in handler file: {exc}"
+
+    for node in ast.walk(tree):
+        # Match annotated assignment: VALID_TRANSITIONS: Final[...] = {...}
+        if isinstance(node, ast.AnnAssign):
+            if (
+                isinstance(node.target, ast.Name)
+                and node.target.id == symbol_name
+                and node.value is not None
+            ):
+                try:
+                    return ast.literal_eval(node.value), None
+                except (ValueError, TypeError) as exc:
+                    return None, (
+                        f"symbol {symbol_name!r} in {source_path} "
+                        f"is not a literal expression: {exc}"
+                    )
+        # Match plain assignment: VALID_TRANSITIONS = {...}
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == symbol_name:
+                    try:
+                        return ast.literal_eval(node.value), None
+                    except (ValueError, TypeError) as exc:
+                        return None, (
+                            f"symbol {symbol_name!r} in {source_path} "
+                            f"is not a literal expression: {exc}"
+                        )
+
+    return None, f"symbol {symbol_name!r} not found in {source_path}"
+
+
+# --------------------------------------------------------------------------- #
+# Transition table normalization from contract YAML
+# --------------------------------------------------------------------------- #
+
+
+def _normalize_contract_transitions(
+    state_machine: dict[str, object],
+    state_filter: frozenset[str],
+) -> dict[tuple[str, str], str]:
+    """Extract (from_state, trigger) -> to_state from contract YAML transitions.
+
+    Only includes transitions whose ``from_state`` is in ``state_filter``
+    (case-insensitive).
+    """
+    transitions_raw = state_machine.get("transitions")
+    if not isinstance(transitions_raw, list):
+        return {}
+
+    result: dict[tuple[str, str], str] = {}
+    for t in transitions_raw:
+        if not isinstance(t, dict):
+            continue
+        from_state = t.get("from_state")
+        to_state = t.get("to_state")
+        trigger = t.get("trigger")
+        if not (
+            isinstance(from_state, str)
+            and isinstance(to_state, str)
+            and isinstance(trigger, str)
+        ):
+            continue
+        from_lower = from_state.lower()
+        if from_lower not in state_filter:
+            continue
+        result[(from_lower, trigger.lower())] = to_state.lower()
+    return result
+
+
+def _normalize_contract_guards(
+    state_machine: dict[str, object],
+    state_filter: frozenset[str],
+) -> dict[tuple[str, str], tuple[str, str]]:
+    """Extract (from_state, trigger) -> (field, required_value) guards from contract YAML.
+
+    Only includes guards on transitions whose ``from_state`` is in ``state_filter``.
+    """
+    transitions_raw = state_machine.get("transitions")
+    if not isinstance(transitions_raw, list):
+        return {}
+
+    result: dict[tuple[str, str], tuple[str, str]] = {}
+    for t in transitions_raw:
+        if not isinstance(t, dict):
+            continue
+        from_state = t.get("from_state")
+        trigger = t.get("trigger")
+        guards = t.get("guard_conditions")
+        if not (isinstance(from_state, str) and isinstance(trigger, str)):
+            continue
+        from_lower = from_state.lower()
+        if from_lower not in state_filter:
+            continue
+        if not isinstance(guards, list) or not guards:
+            continue
+        # Take the first guard per transition (typical pattern)
+        first = guards[0]
+        if not isinstance(first, dict):
+            continue
+        field = first.get("field")
+        value = first.get("value")
+        if isinstance(field, str) and isinstance(value, str):
+            result[(from_lower, trigger.lower())] = (field, value)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Handler VALID_TRANSITIONS normalization
+# --------------------------------------------------------------------------- #
+
+
+def _normalize_handler_transitions(
+    raw: object,
+    source_path: Path,
+    node: str,
+    contract_path: Path,
+    fsm_type: str,
+    handler_module: str,
+) -> tuple[dict[tuple[str, str], str], list[ModelFsmHandlerDriftFinding]]:
+    """Normalize the raw value of VALID_TRANSITIONS from AST literal eval.
+
+    Expected shape: ``{(str, str): str, ...}``
+    Returns (transitions_dict, error_findings).
+    """
+    if not isinstance(raw, dict):
+        return {}, [
+            ModelFsmHandlerDriftFinding(
+                severity=_ERROR,
+                kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                node=node,
+                contract_path=contract_path,
+                fsm_type=fsm_type,
+                handler_module=handler_module,
+                detail=(
+                    f"VALID_TRANSITIONS in {source_path} is not a dict "
+                    f"(got {type(raw).__name__})"
+                ),
+            )
+        ]
+
+    result: dict[tuple[str, str], str] = {}
+    errors: list[ModelFsmHandlerDriftFinding] = []
+    for key, val in raw.items():
+        if not (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and isinstance(key[0], str)
+            and isinstance(key[1], str)
+        ):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"VALID_TRANSITIONS in {source_path}: "
+                        f"key {key!r} is not a (str, str) tuple"
+                    ),
+                )
+            )
+            continue
+        if not isinstance(val, str):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"VALID_TRANSITIONS in {source_path}: "
+                        f"value for key {key!r} is not a str (got {type(val).__name__})"
+                    ),
+                )
+            )
+            continue
+        result[(key[0].lower(), key[1].lower())] = val.lower()
+    return result, errors
+
+
+def _normalize_handler_guards(
+    raw: object,
+    source_path: Path,
+    node: str,
+    contract_path: Path,
+    fsm_type: str,
+    handler_module: str,
+) -> tuple[dict[tuple[str, str], tuple[str, str]], list[ModelFsmHandlerDriftFinding]]:
+    """Normalize the raw value of GUARD_CONDITIONS from AST literal eval.
+
+    Expected shape: ``{(str, str): (str, str, str), ...}``
+    (from_state, trigger) -> (field, required_value, error_message)
+    Returns (guards_dict, error_findings).
+    """
+    if not isinstance(raw, dict):
+        return {}, [
+            ModelFsmHandlerDriftFinding(
+                severity=_ERROR,
+                kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                node=node,
+                contract_path=contract_path,
+                fsm_type=fsm_type,
+                handler_module=handler_module,
+                detail=(
+                    f"GUARD_CONDITIONS in {source_path} is not a dict "
+                    f"(got {type(raw).__name__})"
+                ),
+            )
+        ]
+
+    result: dict[tuple[str, str], tuple[str, str]] = {}
+    errors: list[ModelFsmHandlerDriftFinding] = []
+    for key, val in raw.items():
+        if not (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and isinstance(key[0], str)
+            and isinstance(key[1], str)
+        ):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"GUARD_CONDITIONS in {source_path}: "
+                        f"key {key!r} is not a (str, str) tuple"
+                    ),
+                )
+            )
+            continue
+        if not (
+            isinstance(val, tuple)
+            and len(val) >= 2
+            and isinstance(val[0], str)
+            and isinstance(val[1], str)
+        ):
+            errors.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    detail=(
+                        f"GUARD_CONDITIONS in {source_path}: "
+                        f"value for key {key!r} must be a tuple of at least (str, str, ...)"
+                    ),
+                )
+            )
+            continue
+        result[(key[0].lower(), key[1].lower())] = (val[0], val[1])
+    return result, errors
+
+
+# --------------------------------------------------------------------------- #
+# Drift comparison
+# --------------------------------------------------------------------------- #
+
+
+def _diff_transitions(
+    contract_transitions: dict[tuple[str, str], str],
+    handler_transitions: dict[tuple[str, str], str],
+    node: str,
+    contract_path: Path,
+    fsm_type: str,
+    handler_module: str,
+) -> list[ModelFsmHandlerDriftFinding]:
+    findings: list[ModelFsmHandlerDriftFinding] = []
+
+    all_keys = set(contract_transitions.keys()) | set(handler_transitions.keys())
+    for key in sorted(all_keys):
+        from_state, trigger = key
+        in_contract = key in contract_transitions
+        in_handler = key in handler_transitions
+
+        if in_contract and not in_handler:
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.TRANSITION_MISSING_IN_HANDLER,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    to_state_contract=contract_transitions[key],
+                    detail=(
+                        f"contract declares ({from_state!r}, {trigger!r}) -> "
+                        f"{contract_transitions[key]!r} but VALID_TRANSITIONS "
+                        "has no such entry"
+                    ),
+                )
+            )
+        elif in_handler and not in_contract:
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.TRANSITION_EXTRA_IN_HANDLER,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    to_state_handler=handler_transitions[key],
+                    detail=(
+                        f"handler VALID_TRANSITIONS has ({from_state!r}, {trigger!r}) -> "
+                        f"{handler_transitions[key]!r} but contract has no such transition "
+                        f"for the {fsm_type} state_filter"
+                    ),
+                )
+            )
+        else:
+            # Both present — check to_state agreement
+            contract_to = contract_transitions[key]
+            handler_to = handler_transitions[key]
+            if contract_to != handler_to:
+                findings.append(
+                    ModelFsmHandlerDriftFinding(
+                        severity=_ERROR,
+                        kind=EnumFsmHandlerDriftKind.TRANSITION_TO_STATE_MISMATCH,
+                        node=node,
+                        contract_path=contract_path,
+                        fsm_type=fsm_type,
+                        handler_module=handler_module,
+                        from_state=from_state,
+                        trigger=trigger,
+                        to_state_contract=contract_to,
+                        to_state_handler=handler_to,
+                        detail=(
+                            f"({from_state!r}, {trigger!r}): contract says to_state="
+                            f"{contract_to!r} but handler says {handler_to!r}"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def _diff_guards(
+    contract_guards: dict[tuple[str, str], tuple[str, str]],
+    handler_guards: dict[tuple[str, str], tuple[str, str]],
+    node: str,
+    contract_path: Path,
+    fsm_type: str,
+    handler_module: str,
+) -> list[ModelFsmHandlerDriftFinding]:
+    findings: list[ModelFsmHandlerDriftFinding] = []
+
+    for key in sorted(contract_guards.keys()):
+        from_state, trigger = key
+        if key not in handler_guards:
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.GUARD_MISSING_IN_HANDLER,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    detail=(
+                        f"contract declares guard on ({from_state!r}, {trigger!r}) "
+                        "but GUARD_CONDITIONS has no such entry"
+                    ),
+                )
+            )
+            continue
+
+        contract_field, contract_value = contract_guards[key]
+        handler_field, handler_value = handler_guards[key]
+
+        if contract_field != handler_field:
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.GUARD_FIELD_MISMATCH,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    detail=(
+                        f"guard for ({from_state!r}, {trigger!r}): "
+                        f"contract field={contract_field!r} but handler field={handler_field!r}"
+                    ),
+                )
+            )
+        if contract_value != handler_value:
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.GUARD_VALUE_MISMATCH,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    detail=(
+                        f"guard for ({from_state!r}, {trigger!r}): "
+                        f"contract value={contract_value!r} but handler value={handler_value!r}"
+                    ),
+                )
+            )
+
+    # Extra guards in handler not in contract are also a drift
+    for key in sorted(handler_guards.keys()):
+        if key not in contract_guards:
+            from_state, trigger = key
+            handler_field, handler_value = handler_guards[key]
+            findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.GUARD_MISSING_IN_HANDLER,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=fsm_type,
+                    handler_module=handler_module,
+                    from_state=from_state,
+                    trigger=trigger,
+                    detail=(
+                        f"handler GUARD_CONDITIONS has ({from_state!r}, {trigger!r}) "
+                        f"with field={handler_field!r}/value={handler_value!r} "
+                        "but contract declares no guard for this transition"
+                    ),
+                )
+            )
+
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# Per-contract validation
+# --------------------------------------------------------------------------- #
+
+
+def validate_contract(
+    contract_path: Path,
+    scan_root: Path,
+    src_subdir: str = DEFAULT_SRC_SUBDIR,
+) -> list[ModelFsmHandlerDriftFinding]:
+    """Validate one contract's fsm_handler_binding entries."""
+    try:
+        data = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, UnicodeDecodeError, OSError):
+        return []
+
+    if not _is_fsm_binding_contract(data):
+        return []
+
+    node_dir = contract_path.parent
+    node = node_dir.name
+    all_findings: list[ModelFsmHandlerDriftFinding] = []
+
+    bindings, schema_errors = _parse_bindings(data, contract_path, node)
+    all_findings.extend(schema_errors)
+
+    state_machine = data.get("state_machine")
+    if not isinstance(state_machine, dict) and bindings:
+        all_findings.append(
+            ModelFsmHandlerDriftFinding(
+                severity=_ERROR,
+                kind=EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR,
+                node=node,
+                contract_path=contract_path,
+                fsm_type="",
+                handler_module="",
+                detail="contract has fsm_handler_binding but no state_machine section",
+            )
+        )
+        return all_findings
+
+    for binding in bindings:
+        # 1. Resolve handler file
+        handler_file = _resolve_handler_file(
+            binding.handler_module, scan_root, src_subdir
+        )
+        if handler_file is None:
+            all_findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.HANDLER_FILE_NOT_FOUND,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=binding.fsm_type,
+                    handler_module=binding.handler_module,
+                    detail=(
+                        f"handler_module {binding.handler_module!r} could not be resolved "
+                        f"to a file under {scan_root}/{src_subdir}/ or {scan_root}/"
+                    ),
+                )
+            )
+            continue
+
+        # 2. Extract VALID_TRANSITIONS via AST
+        raw_vt, vt_err = _extract_literal_symbol(
+            handler_file, binding.valid_transitions_symbol
+        )
+        if vt_err is not None:
+            all_findings.append(
+                ModelFsmHandlerDriftFinding(
+                    severity=_ERROR,
+                    kind=EnumFsmHandlerDriftKind.SYMBOL_NOT_FOUND
+                    if "not found" in vt_err
+                    else EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                    node=node,
+                    contract_path=contract_path,
+                    fsm_type=binding.fsm_type,
+                    handler_module=binding.handler_module,
+                    detail=vt_err,
+                )
+            )
+            continue
+
+        handler_transitions, norm_errors = _normalize_handler_transitions(
+            raw_vt,
+            handler_file,
+            node,
+            contract_path,
+            binding.fsm_type,
+            binding.handler_module,
+        )
+        all_findings.extend(norm_errors)
+        if norm_errors:
+            continue
+
+        # 3. Normalize contract transitions (filtered by state_filter)
+        assert isinstance(state_machine, dict)  # guaranteed above
+        contract_transitions = _normalize_contract_transitions(
+            state_machine, binding.state_filter
+        )
+
+        # 4. Diff transitions
+        all_findings.extend(
+            _diff_transitions(
+                contract_transitions,
+                handler_transitions,
+                node,
+                contract_path,
+                binding.fsm_type,
+                binding.handler_module,
+            )
+        )
+
+        # 5. Extract and diff GUARD_CONDITIONS if declared
+        if binding.guard_conditions_symbol:
+            raw_gc, gc_err = _extract_literal_symbol(
+                handler_file, binding.guard_conditions_symbol
+            )
+            if gc_err is not None:
+                all_findings.append(
+                    ModelFsmHandlerDriftFinding(
+                        severity=_ERROR,
+                        kind=EnumFsmHandlerDriftKind.SYMBOL_NOT_FOUND
+                        if "not found" in gc_err
+                        else EnumFsmHandlerDriftKind.SYMBOL_PARSE_ERROR,
+                        node=node,
+                        contract_path=contract_path,
+                        fsm_type=binding.fsm_type,
+                        handler_module=binding.handler_module,
+                        detail=gc_err,
+                    )
+                )
+            else:
+                handler_guards, guard_norm_errors = _normalize_handler_guards(
+                    raw_gc,
+                    handler_file,
+                    node,
+                    contract_path,
+                    binding.fsm_type,
+                    binding.handler_module,
+                )
+                all_findings.extend(guard_norm_errors)
+                if not guard_norm_errors:
+                    contract_guards = _normalize_contract_guards(
+                        state_machine, binding.state_filter
+                    )
+                    all_findings.extend(
+                        _diff_guards(
+                            contract_guards,
+                            handler_guards,
+                            node,
+                            contract_path,
+                            binding.fsm_type,
+                            binding.handler_module,
+                        )
+                    )
+
+    return all_findings
+
+
+def validate_root(
+    root: Path,
+    src_subdir: str = DEFAULT_SRC_SUBDIR,
+) -> list[ModelFsmHandlerDriftFinding]:
+    """Validate every contract with fsm_handler_binding discovered under ``root``."""
+    findings: list[ModelFsmHandlerDriftFinding] = []
+    for contract_path in discover_fsm_binding_contracts(root):
+        findings.extend(validate_contract(contract_path, root, src_subdir))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reconcile reducer node contract.yaml fsm_handler_binding declarations "
+            "against the handler module's VALID_TRANSITIONS and GUARD_CONDITIONS symbols."
+        )
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        default=Path(),
+        help="Repository root to scan for contracts (default: cwd).",
+    )
+    parser.add_argument(
+        "--src-subdir",
+        default=DEFAULT_SRC_SUBDIR,
+        help=(
+            "Sub-directory under root containing the Python package tree "
+            f"(default: {DEFAULT_SRC_SUBDIR!r})."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_root(args.root, args.src_subdir)
+
+    for finding in findings:
+        sys.stderr.write(f"ERROR {finding.format()}\n")
+
+    if findings:
+        sys.stderr.write(
+            f"\nfsm-handler-drift: {len(findings)} blocking error(s) — "
+            "the handler's VALID_TRANSITIONS or GUARD_CONDITIONS diverges from the "
+            "contract's state_machine.transitions. Fix the handler or the contract "
+            "to restore alignment.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -79,6 +79,7 @@ def test_cross_repo_boundary_validation_clones_all_boundary_repos() -> None:
         "omnibase_infra",
         "omnibase_core",
         "omnimemory",
+        "omnimarket",
         "onex_change_control",
     }
 

--- a/tests/unit/validators/test_fsm_handler_drift.py
+++ b/tests/unit/validators/test_fsm_handler_drift.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 """Unit tests for the FSM handler drift validator (OMN-13735).

--- a/tests/unit/validators/test_fsm_handler_drift.py
+++ b/tests/unit/validators/test_fsm_handler_drift.py
@@ -1,0 +1,414 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the FSM handler drift validator (OMN-13735).
+
+TDD — three mandatory cases:
+  1. Injected divergence (TRANSITION_MISSING_IN_HANDLER) asserts findings are raised.
+  2. Aligned handler passes with zero findings.
+  3. Hook script exits non-zero on divergence fixture, zero on aligned fixture.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.enums.enum_fsm_handler_drift import EnumFsmHandlerDriftKind
+from omnibase_core.validators.fsm_handler_drift import (
+    discover_fsm_binding_contracts,
+    main,
+    validate_root,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Fixture helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_node(
+    root: Path,
+    *,
+    node: str,
+    contract_yaml: str,
+    handler_py: str | None = None,
+    handler_subpath: str = "handlers/handler_fsm.py",
+    pkg: str = "mypkg",
+) -> tuple[Path, Path | None]:
+    """Write a minimal node directory with contract.yaml and optional handler.
+
+    The node directory is placed at ``root/src/<pkg>/nodes/<node>/`` so that
+    a handler_module of ``<pkg>.nodes.<node>.handlers.handler_fsm`` resolves via
+    the default src_subdir="src" lookup.
+
+    Returns (contract_path, handler_path_or_None).
+    """
+    node_dir = root / "src" / pkg / "nodes" / node
+    node_dir.mkdir(parents=True, exist_ok=True)
+    contract_path = node_dir / "contract.yaml"
+    contract_path.write_text(textwrap.dedent(contract_yaml), encoding="utf-8")
+
+    handler_path: Path | None = None
+    if handler_py is not None:
+        handler_full = node_dir / handler_subpath
+        handler_full.parent.mkdir(parents=True, exist_ok=True)
+        handler_full.write_text(textwrap.dedent(handler_py), encoding="utf-8")
+        handler_path = handler_full
+
+    return contract_path, handler_path
+
+
+_ALIGNED_CONTRACT = """\
+    state_machine:
+      state_machine_name: "test_fsm"
+      initial_state: "idle"
+      states:
+        - state_name: "active"
+        - state_name: "inactive"
+        - state_name: "deleted"
+      transitions:
+        - from_state: "active"
+          to_state: "inactive"
+          trigger: "deactivate"
+        - from_state: "inactive"
+          to_state: "active"
+          trigger: "reactivate"
+        - from_state: "active"
+          to_state: "deleted"
+          trigger: "delete"
+          guard_conditions:
+            - field: "actor_role"
+              operator: "eq"
+              value: "admin"
+              error_message: "delete requires admin"
+    fsm_handler_binding:
+      - fsm_type: "MY_FSM"
+        handler_module: "mypkg.nodes.node_test.handlers.handler_fsm"
+        valid_transitions_symbol: "VALID_TRANSITIONS"
+        guard_conditions_symbol: "GUARD_CONDITIONS"
+        state_filter:
+          - "active"
+          - "inactive"
+          - "deleted"
+"""
+
+_ALIGNED_HANDLER = """\
+    from typing import Final
+    VALID_TRANSITIONS: Final[dict[tuple[str, str], str]] = {
+        ("active", "deactivate"): "inactive",
+        ("inactive", "reactivate"): "active",
+        ("active", "delete"): "deleted",
+    }
+    GUARD_CONDITIONS: Final[dict[tuple[str, str], tuple[str, str, str]]] = {
+        ("active", "delete"): ("actor_role", "admin", "delete requires admin"),
+    }
+"""
+
+_DIVERGED_HANDLER = """\
+    from typing import Final
+    # INJECTED DRIFT: removed ("inactive", "reactivate") -> "active"
+    # and changed ("active", "delete") -> "archived" (wrong to_state)
+    VALID_TRANSITIONS: Final[dict[tuple[str, str], str]] = {
+        ("active", "deactivate"): "inactive",
+        ("active", "delete"): "archived",
+    }
+    GUARD_CONDITIONS: Final[dict[tuple[str, str], tuple[str, str, str]]] = {
+        ("active", "delete"): ("actor_role", "admin", "delete requires admin"),
+    }
+"""
+
+
+# --------------------------------------------------------------------------- #
+# TDD Case 1: Injected divergence raises findings
+# --------------------------------------------------------------------------- #
+
+
+def test_injected_divergence_raises_findings(tmp_path: Path) -> None:
+    """TDD case 1: validator fires on injected YAML-vs-handler divergence.
+
+    Divergence injected: handler VALID_TRANSITIONS is missing a transition that
+    the contract declares, and has a wrong to_state for another.
+    """
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_DIVERGED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+
+    findings = validate_root(tmp_path)
+    # Should find: TRANSITION_MISSING_IN_HANDLER for ("inactive", "reactivate")
+    # and TRANSITION_TO_STATE_MISMATCH for ("active", "delete")
+    assert len(findings) >= 2, (
+        f"Expected at least 2 findings for injected drift, got {len(findings)}: "
+        + "\n".join(f.format() for f in findings)
+    )
+    kinds = {f.kind for f in findings}
+    assert EnumFsmHandlerDriftKind.TRANSITION_MISSING_IN_HANDLER in kinds, (
+        f"Expected TRANSITION_MISSING_IN_HANDLER in {kinds}"
+    )
+    assert EnumFsmHandlerDriftKind.TRANSITION_TO_STATE_MISMATCH in kinds, (
+        f"Expected TRANSITION_TO_STATE_MISMATCH in {kinds}"
+    )
+
+
+def test_injected_divergence_main_exits_nonzero(tmp_path: Path) -> None:
+    """TDD case 1b: main() exits with code 1 on divergence."""
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_DIVERGED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    result = main([str(tmp_path)])
+    assert result == 1, f"Expected exit code 1, got {result}"
+
+
+# --------------------------------------------------------------------------- #
+# TDD Case 2: Aligned handler passes with zero findings
+# --------------------------------------------------------------------------- #
+
+
+def test_aligned_handler_zero_findings(tmp_path: Path) -> None:
+    """TDD case 2: zero findings when handler matches contract exactly."""
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_ALIGNED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    findings = validate_root(tmp_path)
+    assert findings == [], "\n".join(f.format() for f in findings)
+
+
+def test_aligned_handler_main_exits_zero(tmp_path: Path) -> None:
+    """TDD case 2b: main() exits with code 0 on aligned fixture."""
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_ALIGNED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    result = main([str(tmp_path)])
+    assert result == 0, f"Expected exit code 0, got {result}"
+
+
+# --------------------------------------------------------------------------- #
+# TDD Case 3: Hook script subprocess exit codes
+# --------------------------------------------------------------------------- #
+
+
+def test_hook_script_subprocess_nonzero_on_divergence(tmp_path: Path) -> None:
+    """TDD case 3a: subprocess invocation exits non-zero on divergence fixture."""
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_DIVERGED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validators.fsm_handler_drift",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, (
+        f"Expected exit code 1 (divergence), got {result.returncode}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "ERROR" in result.stderr, f"Expected ERROR in stderr, got: {result.stderr}"
+
+
+def test_hook_script_subprocess_zero_on_aligned(tmp_path: Path) -> None:
+    """TDD case 3b: subprocess invocation exits zero on aligned fixture."""
+    _make_node(
+        tmp_path,
+        node="node_test",
+        contract_yaml=_ALIGNED_CONTRACT,
+        handler_py=_ALIGNED_HANDLER,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "omnibase_core.validators.fsm_handler_drift",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Expected exit code 0 (aligned), got {result.returncode}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Additional edge cases
+# --------------------------------------------------------------------------- #
+
+
+def test_no_fsm_binding_skipped(tmp_path: Path) -> None:
+    """Contracts without fsm_handler_binding are silently skipped."""
+    node_dir = tmp_path / "src" / "mypkg" / "nodes" / "node_plain"
+    node_dir.mkdir(parents=True, exist_ok=True)
+    (node_dir / "contract.yaml").write_text(
+        "name: node_plain\nnode_type: COMPUTE\n", encoding="utf-8"
+    )
+    findings = validate_root(tmp_path)
+    assert findings == []
+
+
+def test_handler_file_not_found(tmp_path: Path) -> None:
+    """Missing handler file produces HANDLER_FILE_NOT_FOUND finding."""
+    contract_yaml = """\
+        state_machine:
+          state_machine_name: "x"
+          initial_state: "a"
+          states: []
+          transitions: []
+        fsm_handler_binding:
+          - fsm_type: "X"
+            handler_module: "nonexistent.module.handler"
+            valid_transitions_symbol: "VALID_TRANSITIONS"
+            state_filter: ["a"]
+    """
+    _make_node(
+        tmp_path,
+        node="node_nf",
+        contract_yaml=contract_yaml,
+    )
+    findings = validate_root(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].kind == EnumFsmHandlerDriftKind.HANDLER_FILE_NOT_FOUND
+
+
+def test_extra_transition_in_handler(tmp_path: Path) -> None:
+    """Handler with extra transition not in contract produces TRANSITION_EXTRA_IN_HANDLER."""
+    contract_yaml = """\
+        state_machine:
+          state_machine_name: "x"
+          initial_state: "a"
+          states:
+            - state_name: "a"
+            - state_name: "b"
+          transitions:
+            - from_state: "a"
+              to_state: "b"
+              trigger: "go"
+        fsm_handler_binding:
+          - fsm_type: "X"
+            handler_module: "mypkg.nodes.node_extra.handlers.handler_fsm"
+            valid_transitions_symbol: "VALID_TRANSITIONS"
+            state_filter: ["a", "b"]
+    """
+    handler_py = """\
+        from typing import Final
+        VALID_TRANSITIONS: Final[dict[tuple[str, str], str]] = {
+            ("a", "go"): "b",
+            ("b", "return"): "a",  # EXTRA: not in contract
+        }
+    """
+    _make_node(
+        tmp_path,
+        node="node_extra",
+        contract_yaml=contract_yaml,
+        handler_py=handler_py,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    findings = validate_root(tmp_path)
+    assert any(
+        f.kind == EnumFsmHandlerDriftKind.TRANSITION_EXTRA_IN_HANDLER for f in findings
+    ), "\n".join(f.format() for f in findings)
+
+
+def test_guard_value_mismatch(tmp_path: Path) -> None:
+    """Guard value mismatch between contract and handler raises GUARD_VALUE_MISMATCH."""
+    contract_yaml = """\
+        state_machine:
+          state_machine_name: "g"
+          initial_state: "a"
+          states:
+            - state_name: "a"
+            - state_name: "b"
+          transitions:
+            - from_state: "a"
+              to_state: "b"
+              trigger: "promote"
+              guard_conditions:
+                - field: "role"
+                  operator: "eq"
+                  value: "superadmin"
+                  error_message: "requires superadmin"
+        fsm_handler_binding:
+          - fsm_type: "G"
+            handler_module: "mypkg.nodes.node_guard.handlers.handler_fsm"
+            valid_transitions_symbol: "VALID_TRANSITIONS"
+            guard_conditions_symbol: "GUARD_CONDITIONS"
+            state_filter: ["a", "b"]
+    """
+    handler_py = """\
+        from typing import Final
+        VALID_TRANSITIONS: Final[dict[tuple[str, str], str]] = {
+            ("a", "promote"): "b",
+        }
+        GUARD_CONDITIONS: Final[dict[tuple[str, str], tuple[str, str, str]]] = {
+            ("a", "promote"): ("role", "admin", "requires admin"),  # wrong value: admin vs superadmin
+        }
+    """
+    _make_node(
+        tmp_path,
+        node="node_guard",
+        contract_yaml=contract_yaml,
+        handler_py=handler_py,
+        handler_subpath="handlers/handler_fsm.py",
+    )
+    findings = validate_root(tmp_path)
+    assert any(
+        f.kind == EnumFsmHandlerDriftKind.GUARD_VALUE_MISMATCH for f in findings
+    ), "\n".join(f.format() for f in findings)
+
+
+def test_discover_no_contracts(tmp_path: Path) -> None:
+    """Root with no contracts yields empty discovery list."""
+    contracts = discover_fsm_binding_contracts(tmp_path)
+    assert contracts == []
+
+
+def test_contract_schema_error_missing_state_filter(tmp_path: Path) -> None:
+    """fsm_handler_binding missing state_filter produces CONTRACT_SCHEMA_ERROR."""
+    contract_yaml = """\
+        state_machine:
+          state_machine_name: "x"
+          initial_state: "a"
+          states: []
+          transitions: []
+        fsm_handler_binding:
+          - fsm_type: "X"
+            handler_module: "mypkg.handler"
+            valid_transitions_symbol: "VALID_TRANSITIONS"
+    """
+    _make_node(tmp_path, node="node_schema", contract_yaml=contract_yaml)
+    findings = validate_root(tmp_path)
+    assert any(
+        f.kind == EnumFsmHandlerDriftKind.CONTRACT_SCHEMA_ERROR for f in findings
+    )


### PR DESCRIPTION
## OMN-13735 — FSM YAML-vs-handler drift guard (validator + pre-commit + CI) [omnibase_core]

Sub-issue (c) of OMN-12847. Converts the comment-only invariant at
`omnimarket/.../node_intelligence_reducer/handlers/handler_pattern_lifecycle.py:61`
("This table is the SINGLE SOURCE OF TRUTH … Any changes must be reflected in contract.yaml")
into a mechanical gate.

### What
- `omnibase_core/validators/fsm_handler_drift.py` — strongly-typed validator. A reducer contract opts in
  via a declared, typed `fsm_handler_binding` section (handler_module + `VALID_TRANSITIONS`/`GUARD_CONDITIONS`
  symbol names + `state_filter`). The validator filters the contract's `state_machine.transitions` to the
  declared slice and reconciles it against the handler's exported symbols via **AST literal evaluation**
  (no import, no string-grep heuristics). Any `(from_state, trigger) -> to_state` mismatch, missing/extra
  handler transition, or guard field/value divergence is a hard block. **Zero allowlist entries.**
- `enums/enum_fsm_handler_drift.py`, `models/validation/model_fsm_handler_drift_finding.py` — typed
  severity/kind enums + frozen finding model.
- Wired as a **local pre-commit hook** (`.pre-commit-config.yaml` → `check-fsm-handler-drift`), an
  **exported remote hook** (`.pre-commit-hooks.yaml` for consumer repos), a **console script**
  (`pyproject.toml`), and a **required CI gate** (`.github/workflows/validator-fsm-handler-drift.yml`,
  context `fsm-handler-drift`).

The reducer-side binding + omnimarket enforcement land in the paired omnimarket PR (the slice this guard
proves clean is `node_intelligence_reducer` PATTERN_LIFECYCLE).

### Pre-condition (DoD): zero existing drift
`grep -r 'VALID_TRANSITIONS|GUARD_CONDITIONS' omnimarket/src/` enumerated; only
`node_intelligence_reducer/handlers/handler_pattern_lifecycle.py` carries an active
`(from_state, trigger)->to_state` table, and it is a faithful projection of the contract slice
(the other hit, `node_memory_lifecycle_orchestrator`, is a different `state->frozenset[state]` shape with
no trigger — out of scope). Validator scan of the real contract exits 0.

### dod_evidence (failing→passing)
- Unit tests: `uv run pytest tests/unit/validators/test_fsm_handler_drift.py` → **12 passed**.
- Negative (injected divergence) proof:
  ```
  ERROR …/node_synth/contract.yaml: ('open','close') -> contract:'closed' handler:'suspended'
  fsm-handler-drift: 1 blocking error(s) …
  exit=1
  ```
- Positive: validator scan of the omnimarket worktree (with the binding) → `exit=0`.
- Self-scan of omnibase_core `src/` → `exit=0`.
- `ruff format --check` + `ruff check` → clean; `mypy --strict` on the new modules → `Success: no issues found`.

### OCC receipt pairing
Evidence-Ticket: OMN-13735
Evidence-Source: da14810b0b8c7e442aff846ce19d0267dbfd05d2
- Paired OCC receipt PR: OmniNode-ai/onex_change_control#3304 (`contracts/OMN-13735.yaml`)

Opened, not merged.