### PR TITLE
fix(OMN-1690): log silent exception catch in MixinContractPublisher heartbeat loop

### DIFF
--- a/src/omnibase_core/mixins/mixin_contract_publisher.py
+++ b/src/omnibase_core/mixins/mixin_contract_publisher.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -59,6 +60,8 @@ from omnibase_core.protocols.event_bus.protocol_event_bus_publisher import (
 
 if TYPE_CHECKING:
     from omnibase_core.models.container.model_onex_container import ModelONEXContainer
+
+logger = logging.getLogger(__name__)
 
 
 class MixinContractPublisher:
@@ -300,9 +303,15 @@ class MixinContractPublisher:
                 await asyncio.sleep(interval_seconds)
             except asyncio.CancelledError:
                 raise  # Propagate cancellation
-            except Exception:  # noqa: BLE001  # fallback-ok: heartbeat transient errors must not stop liveness signals
-                # Swallow error and continue heartbeating - transient errors shouldn't
-                # stop liveness signals. Consumers can detect issues via heartbeat gaps.
+            except Exception as exc:  # noqa: BLE001  # fallback-ok: heartbeat transient errors must not stop liveness signals
+                # Log-and-continue heartbeating - transient errors shouldn't stop
+                # liveness signals. Consumers can detect issues via heartbeat gaps,
+                # but the failure must be observable instead of silently swallowed.
+                logger.warning(
+                    "contract heartbeat emit failed; continuing liveness loop: %s",
+                    exc,
+                    exc_info=True,
+                )
                 await asyncio.sleep(interval_seconds)
 
     async def _emit_heartbeat(self) -> None:

--- a/tests/unit/mixins/test_mixin_contract_publisher.py
+++ b/tests/unit/mixins/test_mixin_contract_publisher.py
@@ -10,6 +10,7 @@ Validates ONEX standards for contract lifecycle events (OMN-1655).
 import asyncio
 import hashlib
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -649,6 +650,69 @@ capabilities:
 
         # Publisher should not have been called
         contract_publisher.mock_publisher_ref.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(90)
+    async def test_heartbeat_loop_logs_on_emit_failure(
+        self,
+        contract_publisher: MockNodeWithContractPublisher,
+        temp_contract_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Heartbeat loop logs a warning when an emit fails, then keeps looping.
+
+        Regression for OMN-1690: the transient-error branch previously swallowed
+        the exception silently. It must now emit an observable warning (with the
+        exception message and traceback) before continuing the liveness loop.
+        """
+        await contract_publisher.publish_contract(temp_contract_file)
+
+        emit_calls = 0
+
+        async def failing_then_succeeding_emit() -> None:
+            nonlocal emit_calls
+            emit_calls += 1
+            if emit_calls == 1:
+                raise RuntimeError("transient publish failure")
+
+        monkeypatch.setattr(
+            contract_publisher, "_emit_heartbeat", failing_then_succeeding_emit
+        )
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="omnibase_core.mixins.mixin_contract_publisher",
+        ):
+            # Drive the loop directly with a tiny interval so the failing emit,
+            # the warning log, and a subsequent successful emit all occur quickly.
+            loop_task = asyncio.create_task(contract_publisher._heartbeat_loop(0.01))
+            # Wait until the failing emit has been observed and logged.
+            for _ in range(100):
+                await asyncio.sleep(0.01)
+                if emit_calls >= 2:
+                    break
+            loop_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await loop_task
+
+        # The failing emit was retried (loop continued, not aborted).
+        assert emit_calls >= 2
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and record.name == "omnibase_core.mixins.mixin_contract_publisher"
+        ]
+        assert warnings, "expected a warning log from the heartbeat loop"
+        assert any(
+            "contract heartbeat emit failed" in record.getMessage()
+            and "transient publish failure" in record.getMessage()
+            for record in warnings
+        )
+        # Traceback must be attached so the failure is fully observable.
+        assert any(record.exc_info is not None for record in warnings)
 
     # ========================================================================
     # Event Field Tests


### PR DESCRIPTION
## Summary

Fixes **OMN-1690**: `MixinContractPublisher._heartbeat_loop` previously caught `Exception` and
silently slept, hiding production issues (transient Kafka publish failures, serialization errors)
behind heartbeat gaps. This change makes the failure observable:

- Adds a module-level `import logging` + `logger = logging.getLogger(__name__)` to
  `src/omnibase_core/mixins/mixin_contract_publisher.py`, matching the established convention in
  sibling mixins (`mixin_caching`, `mixin_service_registry`, `mixin_debug_discovery_logging`).
- Changes the transient-error branch to `except Exception as exc:` and emits
  `logger.warning("contract heartbeat emit failed; continuing liveness loop: %s", exc, exc_info=True)`
  before the existing `await asyncio.sleep(interval_seconds)`. The comment is updated to
  "log-and-continue". The `except asyncio.CancelledError: raise` branch is unchanged, so liveness
  signals still continue across transient failures.

## Test plan

- [x] New regression test `test_heartbeat_loop_logs_on_emit_failure` in
  `tests/unit/mixins/test_mixin_contract_publisher.py` monkeypatches `_emit_heartbeat` to raise once,
  drives `_heartbeat_loop` briefly then cancels, and asserts `caplog` captured the WARNING (message +
  exception text + `exc_info`) and that the loop kept retrying.
- [x] TDD red-check: reverting the source change makes the new test FAIL ("expected a warning log
  from the heartbeat loop"); with the fix it passes.
- [x] `uv run pytest tests/ -k contract_publisher -q` → **37 passed, 4 skipped**.
- [x] `uv run mypy src/omnibase_core` (CI config) → **Success: no issues found in 4058 source files**.
- [x] `uv run ruff format` + `uv run ruff check --fix` → clean; pre-commit commit-stage hooks pass on
  the changed files.
- [ ] Full `uv run pytest tests/` (no `-k`) is the authoritative CI gate; the local full run was green
  through the portion completed before this PR was opened (no failures), CI runs it to completion.

Ticket: OMN-1690
Evidence-Source: OCC#3375
Evidence-Ticket: OMN-1690
promotion-receipt: OCC-3375

dod_evidence: OCC#3375 carries contracts/OMN-1690.yaml + 3 PASS receipts (dod-001 tests, dod-deploy
assessment, dod-occ-self) for OMN-1690, each bound to contract hash
sha256:e5c5460c2db0961869498e4aebc09f6724a4b511112f944deccada9f124afdcc. Code-only logging change — no
deploy, no runtime mutation.
