### PR TITLE
perf(OMN-823): cache compiled PII regex patterns in sanitize_context_for_logging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -701,7 +701,7 @@
         "filename": "src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 464
+        "line_number": 485
       }
     ],
     "src/omnibase_core/services/replay/service_config_override_injector.py": [
@@ -1516,105 +1516,105 @@
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 218
+        "line_number": 219
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "1d278c7a5057bac15828468f030f52f07caf70bb",
         "is_verified": false,
-        "line_number": 219
+        "line_number": 220
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_verified": false,
-        "line_number": 232
+        "line_number": 233
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "c636e8e238fd7af97e2e500f8c6f0f4c0bedafb0",
         "is_verified": false,
-        "line_number": 233
+        "line_number": 234
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "418ee516f1cb095c50ff2f10a76192889c281f3a",
         "is_verified": false,
-        "line_number": 234
+        "line_number": 235
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 248
       },
       {
         "type": "AWS Access Key",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_verified": false,
-        "line_number": 456
+        "line_number": 457
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "4b872ea14c99c03e4b2944d84454f3ec200cefcc",
         "is_verified": false,
-        "line_number": 464
+        "line_number": 465
       },
       {
         "type": "GitHub Token",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
         "is_verified": false,
-        "line_number": 464
+        "line_number": 465
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "2558d4a3ab73d4491aa0a0315cb45e3ac6c15a66",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 473
       },
       {
         "type": "GitHub Token",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "ba29d6bfac4cd7b866a3d05103c38031a921ba88",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 473
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "5770b6b662095f2f933ff67eaa34e9b0e1c09ef2",
         "is_verified": false,
-        "line_number": 480
+        "line_number": 481
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "2d49ca40a3a462aa2d723aeb1ffe03473dc1025c",
         "is_verified": false,
-        "line_number": 550
+        "line_number": 551
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "5611f8e8c292a4e14de43e510c9c06286fe3495b",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 563
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py",
         "hashed_secret": "73195f23cc5c1b89bbd71a26a62e4a241a4cffc6",
         "is_verified": false,
-        "line_number": 569
+        "line_number": 570
       }
     ],
     "tests/unit/orchestrator/test_contract_versioning.py": [

--- a/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
+++ b/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
@@ -305,6 +305,27 @@ class ModelWorkflowStateSnapshot(BaseModel):
         ),
     ]
 
+    # Precompiled form of _PII_PATTERNS, built once at class-definition time so
+    # the hot sanitize/validate loops never recompile the default patterns on
+    # every call (OMN-823). _PII_PATTERNS above stays the raw source of truth
+    # (still referenced by docstrings/examples); this list is derived from it.
+    _COMPILED_PII_PATTERNS: ClassVar[list[tuple[re.Pattern[str], str]]] = [
+        (re.compile(pattern), replacement) for pattern, replacement in _PII_PATTERNS
+    ]
+
+    # Human-readable labels for the default PII patterns, in the SAME order as
+    # _PII_PATTERNS / _COMPILED_PII_PATTERNS. Used only by validate_no_pii() to
+    # describe detected violations; kept length-aligned with the compiled list.
+    _PII_PATTERN_LABELS: ClassVar[tuple[str, ...]] = (
+        "EMAIL",
+        "CREDIT_CARD",
+        "PHONE",
+        "SSN",
+        "IPV4",
+        "IPV6",
+        "API_KEY",
+    )
+
     # UUID pattern is SEPARATE from default PII patterns (opt-in redaction).
     # UUIDs are often NOT PII - they may be system-generated identifiers like
     # workflow_id, step_id, correlation_id, etc. that are useful for debugging.
@@ -504,14 +525,23 @@ class ModelWorkflowStateSnapshot(BaseModel):
               UUIDs are typically system-generated identifiers useful for debugging,
               not personally identifiable information.
         """
-        # Build pattern list: start with default PII patterns
-        patterns: list[tuple[str, str]] = list(cls._PII_PATTERNS)
-        # Optionally include UUID pattern
+        # Build the working list as COMPILED patterns. Start from the precompiled
+        # default PII set (OMN-823: compiled once at class load, not recompiled per
+        # call), then add the opt-in UUID pattern and any dynamic additional_patterns
+        # — both compiled per-call because they vary by call, not by class.
+        compiled_patterns: list[tuple[re.Pattern[str], str]] = list(
+            cls._COMPILED_PII_PATTERNS
+        )
+        # Optionally include UUID pattern (opt-in)
         if redact_uuids:
-            patterns.append(cls._UUID_PATTERN)
+            uuid_pattern, uuid_replacement = cls._UUID_PATTERN
+            compiled_patterns.append((re.compile(uuid_pattern), uuid_replacement))
         # Add any custom patterns
         if additional_patterns:
-            patterns.extend(additional_patterns)
+            compiled_patterns.extend(
+                (re.compile(pattern), replacement)
+                for pattern, replacement in additional_patterns
+            )
         redact_keys_lower = {k.lower() for k in (redact_keys or [])}
 
         def _sanitize_value(value: object, key: str | None = None) -> object:
@@ -522,8 +552,8 @@ class ModelWorkflowStateSnapshot(BaseModel):
 
             if isinstance(value, str):
                 result = value
-                for pattern, replacement in patterns:
-                    result = re.sub(pattern, replacement, result)
+                for compiled, replacement in compiled_patterns:
+                    result = compiled.sub(replacement, result)
                 return result
             elif isinstance(value, dict):
                 return {k: _sanitize_value(v, k) for k, v in value.items()}
@@ -592,62 +622,35 @@ class ModelWorkflowStateSnapshot(BaseModel):
             - For audit logging, consider using both methods: validate first, then
               sanitize before logging if PII is found.
         """
-        # Build pattern list with labels for reporting
-        pattern_labels: list[tuple[str, str, str]] = [
-            (r"\b[\w.+-]+@[\w.-]+\.\w{2,}\b", "EMAIL", "[EMAIL_REDACTED]"),
-            (r"\b(?:\d{4}[-\s]?){3}\d{4}\b", "CREDIT_CARD", "[CREDIT_CARD_REDACTED]"),
-            (
-                r"(?<!\d)(?:\+1[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}\b",
-                "PHONE",
-                "[PHONE_REDACTED]",
-            ),
-            (r"\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b", "SSN", "[SSN_REDACTED]"),
-            (r"\b(?:\d{1,3}\.){3}\d{1,3}\b", "IPV4", "[IP_REDACTED]"),
-            (
-                r"\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b"
-                r"|(?<![0-9a-fA-F:])::(?:[0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}\b"
-                r"|\b(?:[0-9a-fA-F]{1,4}:)+:(?:[0-9a-fA-F]{1,4}:)*[0-9a-fA-F]{1,4}\b"
-                r"|\b(?:[0-9a-fA-F]{1,4}:){1,7}:(?![0-9a-fA-F])"
-                r"|(?<![0-9a-fA-F:])::(?![0-9a-fA-F:])",
-                "IPV6",
-                "[IPV6_REDACTED]",
-            ),
-            (
-                r"\b(?:sk_(?:live|test)_[a-zA-Z0-9]{24,})\b"
-                r"|\b(?:pk_(?:live|test)_[a-zA-Z0-9]{24,})\b"
-                r"|\b(?:AKIA[0-9A-Z]{16})\b"
-                r"|\b(?:ghp_[a-zA-Z0-9]{36})\b"
-                r"|\b(?:gho_[a-zA-Z0-9]{36})\b"
-                r"|\b(?:github_pat_[a-zA-Z0-9_]{22,})\b"
-                r"|\b(?:xox[baprs]-[a-zA-Z0-9-]{10,})\b"
-                r"|\b(?:api[_-]?key[_-]?[a-zA-Z0-9]{20,})\b",
-                "API_KEY",
-                "[API_KEY_REDACTED]",
-            ),
+        # Reuse the precompiled default PII set (OMN-823) paired with reporting
+        # labels, in the same order. _PII_PATTERNS / _COMPILED_PII_PATTERNS is the
+        # single source of truth for the patterns; only the labels live separately.
+        # strict=True fails loudly if the labels ever drift out of length-alignment.
+        compiled_labels: list[tuple[re.Pattern[str], str]] = [
+            (compiled, label)
+            for (compiled, _replacement), label in zip(
+                cls._COMPILED_PII_PATTERNS, cls._PII_PATTERN_LABELS, strict=True
+            )
         ]
 
-        # Optionally include UUID pattern
+        # Optionally include UUID pattern (opt-in; compiled per-call)
         if check_uuids:
-            pattern_labels.append(
-                (
-                    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b",
-                    "UUID",
-                    "[UUID_REDACTED]",
-                )
-            )
+            uuid_pattern, _uuid_replacement = cls._UUID_PATTERN
+            compiled_labels.append((re.compile(uuid_pattern), "UUID"))
 
-        # Add any custom patterns
+        # Add any custom patterns (dynamic; compiled per-call)
         if additional_patterns:
-            for pattern, label in additional_patterns:
-                pattern_labels.append((pattern, label, f"[{label}_REDACTED]"))
+            compiled_labels.extend(
+                (re.compile(pattern), label) for pattern, label in additional_patterns
+            )
 
         violations: list[str] = []
 
         def _scan_value(value: object, path: str) -> None:
             """Recursively scan a value for PII patterns."""
             if isinstance(value, str):
-                for pattern, label, _replacement in pattern_labels:
-                    if re.search(pattern, value):
+                for compiled, label in compiled_labels:
+                    if compiled.search(value):
                         violations.append(
                             f"Detected PII pattern ({label}) at path: {path}"
                         )

--- a/tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py
+++ b/tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py
@@ -16,6 +16,7 @@ Tests the sanitize_context_for_logging() class method including:
 - Type preservation for non-string values
 """
 
+import re
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -736,3 +737,138 @@ class TestValidateNoPII:
         assert is_valid is False
         # Should report exactly one violation for this single value
         assert len(violations) == 1
+
+
+def _patch_re_compile_counter(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Patch ``re.compile`` with a counting wrapper and return the call log.
+
+    The module under test does ``import re`` and calls ``re.compile`` on that
+    shared ``re`` module object, so patching ``re.compile`` here is observed by
+    the code under test. The returned list records each compiled pattern string.
+    """
+    compiled: list[str] = []
+    real_compile = re.compile
+
+    def counting_compile(
+        pattern: str | re.Pattern[str],
+        flags: int | re.RegexFlag = 0,
+    ) -> re.Pattern[str]:
+        compiled.append(str(pattern))
+        return real_compile(pattern, flags)
+
+    monkeypatch.setattr(re, "compile", counting_compile)
+    return compiled
+
+
+@pytest.mark.unit
+class TestCompiledPiiPatternCaching:
+    """OMN-823: precompiled PII regex patterns.
+
+    Verifies that the default PII patterns are compiled once at class-load
+    time (cached in ``_COMPILED_PII_PATTERNS``) and that redaction / detection
+    output is byte-for-byte identical to the raw-string baseline.
+    """
+
+    def test_compiled_patterns_built_once_at_class_scope(self) -> None:
+        """The compiled-pattern list is a stable, class-level cache.
+
+        Accessing the ClassVar twice yields the same list object, proving it
+        was built once at class definition (not rebuilt per access/call).
+        """
+        first = ModelWorkflowStateSnapshot._COMPILED_PII_PATTERNS
+        second = ModelWorkflowStateSnapshot._COMPILED_PII_PATTERNS
+        assert first is second
+
+    def test_compiled_patterns_correspond_to_raw_source_of_truth(self) -> None:
+        """Each compiled pattern maps 1:1 to its raw ``_PII_PATTERNS`` entry.
+
+        ``_PII_PATTERNS`` stays the raw source of truth; the compiled list is
+        derived from it with identical pattern text and replacement strings.
+        """
+        raw = ModelWorkflowStateSnapshot._PII_PATTERNS
+        compiled = ModelWorkflowStateSnapshot._COMPILED_PII_PATTERNS
+        assert len(compiled) == len(raw)
+        for (raw_pattern, raw_replacement), (compiled_pattern, replacement) in zip(
+            raw, compiled, strict=True
+        ):
+            assert isinstance(compiled_pattern, re.Pattern)
+            assert compiled_pattern.pattern == raw_pattern
+            assert replacement == raw_replacement
+
+    def test_pattern_labels_align_with_compiled_patterns(self) -> None:
+        """validate_no_pii labels stay aligned 1:1 with the compiled patterns."""
+        assert len(ModelWorkflowStateSnapshot._PII_PATTERN_LABELS) == len(
+            ModelWorkflowStateSnapshot._COMPILED_PII_PATTERNS
+        )
+
+    @pytest.mark.parametrize(
+        ("raw_value", "expected"),
+        [
+            ("john.doe@example.com", "[EMAIL_REDACTED]"),
+            ("555-123-4567", "[PHONE_REDACTED]"),
+            ("123-45-6789", "[SSN_REDACTED]"),
+            ("192.168.1.1", "[IP_REDACTED]"),
+            ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", "[IPV6_REDACTED]"),
+        ],
+    )
+    def test_redaction_output_identical_for_each_pii_type(
+        self, raw_value: str, expected: str
+    ) -> None:
+        """Redaction output matches the raw-string baseline for every PII type."""
+        result = ModelWorkflowStateSnapshot.sanitize_context_for_logging(
+            {"field": raw_value}
+        )
+        assert result["field"] == expected
+
+    def test_additional_patterns_still_applied(self) -> None:
+        """Dynamic additional_patterns are compiled per-call and applied."""
+        result = ModelWorkflowStateSnapshot.sanitize_context_for_logging(
+            {"field": "internal-token-XYZ"},
+            additional_patterns=[(r"internal-token-\w+", "[CUSTOM_REDACTED]")],
+        )
+        assert result["field"] == "[CUSTOM_REDACTED]"
+
+    def test_default_path_does_not_recompile_patterns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The hot path uses precompiled patterns — no re.compile per call.
+
+        Sanitizing with only the default PII set must not invoke ``re.compile``;
+        that is the whole point of caching. Custom/UUID patterns (dynamic or
+        opt-in) are still compiled per-call and are exercised separately.
+        """
+        compiled = _patch_re_compile_counter(monkeypatch)
+
+        context = {
+            "email": "john.doe@example.com",
+            "phone": "555-123-4567",
+            "ssn": "123-45-6789",
+            "ip": "192.168.1.1",
+        }
+        ModelWorkflowStateSnapshot.sanitize_context_for_logging(context)
+        assert compiled == []
+
+    def test_uuid_opt_in_compiled_per_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """redact_uuids=True compiles exactly one extra (opt-in) pattern."""
+        compiled = _patch_re_compile_counter(monkeypatch)
+
+        context = {"user_id": "550e8400-e29b-41d4-a716-446655440000"}
+        result = ModelWorkflowStateSnapshot.sanitize_context_for_logging(
+            context, redact_uuids=True
+        )
+        assert result["user_id"] == "[UUID_REDACTED]"
+        assert len(compiled) == 1
+
+    def test_validate_no_pii_uses_compiled_patterns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """validate_no_pii reuses the precompiled set — no re.compile per call."""
+        compiled = _patch_re_compile_counter(monkeypatch)
+
+        is_valid, _violations = ModelWorkflowStateSnapshot.validate_no_pii(
+            {"email": "user@example.com", "ip": "10.0.0.1"}
+        )
+        assert is_valid is False
+        assert compiled == []


### PR DESCRIPTION
## Summary

Optimizes `ModelWorkflowStateSnapshot.sanitize_context_for_logging()` (and the sibling `validate_no_pii()`) by compiling the default PII regex patterns **once** at class-definition time instead of re-running the regex-string path (`re.sub` / `re.search`) for every string value on every call.

OMN-823: Cache compiled PII regex patterns for performance.

## Change

- New `ClassVar` `_COMPILED_PII_PATTERNS: list[tuple[re.Pattern[str], str]]`, derived once from `_PII_PATTERNS` at class scope (`re.compile(pattern)`).
- `_PII_PATTERNS` stays the **raw source of truth** (still referenced by docstrings/examples).
- `sanitize_context_for_logging` builds its working list from the precompiled defaults; the opt-in `_UUID_PATTERN` and dynamic `additional_patterns` are compiled per-call (they vary by call). Hot loop switched to `compiled.sub(replacement, result)`.
- `validate_no_pii` reuses the same precompiled set paired with a new `_PII_PATTERN_LABELS` tuple (length-aligned via `zip(..., strict=True)`); the inline raw-string pattern list it duplicated is removed. Hot loop switched to `compiled.search(value)`.
- **No behavioral change** to redaction or detection output — `_PII_PATTERNS` content, replacement strings, and `validate_no_pii` violation labels (incl. `IPV4`/`IPV6`) are unchanged.

## Tests / dod_evidence

New `TestCompiledPiiPatternCaching` in `tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py`:
- Redaction output identical to the raw-string baseline for email/phone/SSN/IPv4/IPv6 + `additional_patterns`.
- The compiled list is built once at class scope (identity-stable ClassVar) and corresponds 1:1 to `_PII_PATTERNS`.
- `_PII_PATTERN_LABELS` stays length-aligned with the compiled list.
- The default hot path performs no per-call `re.compile`; opt-in UUID compiles exactly one extra pattern per call.

Verification:
- `uv run pytest tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py -q` -> 86 passed.
- Blast radius (all model tests + every test importing the snapshot model): `tests/unit/models/ tests/unit/nodes/test_node_state_serialization.py tests/unit/concurrency/test_node_orchestrator_concurrency.py tests/integration/test_orchestrator_integration.py` -> 21355 passed, 4 skipped, 0 failed.
- `uv run mypy src/.../model_workflow_state_snapshot.py --strict` -> Success; pyright Passed; ruff clean; `pre-commit run --files` green.

Evidence-Ticket: OMN-823

Evidence-Source: OCC#3379
