### PR TITLE
fix(OMN-13395): receipt-gate identity-binding rejects dual-ticket branch names (omn-A-B fails to match OMN-B)

### DIFF
--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -114,6 +114,13 @@ from omnibase_core.validation.runtime_sha_match import (
 _CONTRACT_SHA256_REQUIRED_AFTER = datetime(2026, 4, 30, 0, 0, 0, tzinfo=UTC)
 
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
+# Captures each ``omn-<n>(-<n>)*`` cluster on a branch name (OMN-13395). A single
+# PR branch may address several tickets via the ``omn-A-B(-C...)`` convention —
+# e.g. ``jonah/omn-13234-13362-...`` — where only the leading id sits behind the
+# literal ``OMN-`` prefix. The branch axis uses this to test the Evidence-Ticket's
+# number for membership in the cluster. Operates on an upper-cased branch string,
+# matching the case discipline of ``_verify_ticket_identity``.
+DUAL_TICKET_BRANCH_CLUSTER_PATTERN = re.compile(r"(?<![A-Z0-9])OMN-(\d+(?:-\d+)*)")
 CLOSING_KEYWORD_PATTERN = re.compile(
     r"\b(?:Closes|Fixes|Resolves|Implements)\b[:\s]+OMN-(\d+)\b",
     re.IGNORECASE,
@@ -856,7 +863,25 @@ def _verify_ticket_identity(
 
     # Axis 2: Branch name.
     if branch_name is not None:
-        if exact_ticket_pattern.search(branch_name.upper()) is None:
+        branch_upper = branch_name.upper()
+        branch_matches = exact_ticket_pattern.search(branch_upper) is not None
+        if not branch_matches:
+            # Dual-ticket branch convention (OMN-13395): a branch addressing
+            # multiple tickets encodes them as one ``omn-<n>(-<n>)*`` cluster
+            # (e.g. ``jonah/omn-13234-13362-...``). The exact-token pattern above
+            # only matches a literal ``OMN-<n>``, so a trailing id in such a
+            # cluster (preceded by ``-``, not ``OMN-``) never matches. Test the
+            # Evidence-Ticket's number for membership in each cluster's run.
+            ticket_number = re.search(r"(\d+)$", ticket_upper)
+            if ticket_number is not None:
+                target = ticket_number.group(1)
+                branch_matches = any(
+                    target in cluster.split("-")
+                    for cluster in DUAL_TICKET_BRANCH_CLUSTER_PATTERN.findall(
+                        branch_upper
+                    )
+                )
+        if not branch_matches:
             return (
                 f"IDENTITY BINDING FAILED: branch name does not reference {evidence_ticket}. "
                 f"branch={branch_name!r}, Evidence-Ticket={evidence_ticket!r}. "

--- a/tests/unit/validation/test_receipt_gate_identity_binding.py
+++ b/tests/unit/validation/test_receipt_gate_identity_binding.py
@@ -381,3 +381,147 @@ class TestTicketIdentityBinding:
 
         # Gate should proceed to receipt verification, not fail on missing Evidence-Ticket
         assert result.passed, result.message
+
+
+@pytest.mark.unit
+class TestDualTicketBranchBinding:
+    """Branch-axis matcher tolerates dual-ticket branch names (OMN-13395).
+
+    A single PR branch may address two (or more) tickets, encoded by the
+    ``omn-A-B(-C...)`` convention — e.g. ``jonah/omn-13234-13362-...``. The
+    full-token identity pattern only matches a literal ``OMN-<n>`` token, so a
+    trailing id in such a cluster (``13362``, preceded by ``-`` rather than
+    ``OMN-``) never matched the branch axis. The fix scans every ``omn-<cluster>``
+    run on the branch and tests the Evidence-Ticket's number for membership.
+
+    Axis 1 (PR title) is left unchanged — titles use the comma form
+    ``OMN-A, OMN-B`` that the existing token pattern already handles — so each
+    case below references the Evidence-Ticket in the PR title directly.
+    """
+
+    def _pr_body(self, ticket: str) -> str:
+        return f"Closes {ticket}\n\nEvidence-Source: abc123\nEvidence-Ticket: {ticket}"
+
+    def test_dual_ticket_branch_omn_a_b_passes(self, tmp_path: Path) -> None:
+        """omn-A-B branch with Evidence-Ticket=OMN-B passes the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13362")
+        _write_receipt(receipts, "OMN-13362")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13362"),
+            pr_title="feat(OMN-13362): typed tier cost and dual table",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13234-13362-typed-tier-cost-and-dual-table",
+        )
+
+        assert result.passed, result.message
+
+    def test_dual_ticket_branch_omn_b_a_passes(self, tmp_path: Path) -> None:
+        """omn-B-A branch (Evidence-Ticket leads) passes the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13362")
+        _write_receipt(receipts, "OMN-13362")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13362"),
+            pr_title="feat(OMN-13362): typed tier cost and dual table",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13362-13234-typed-tier-cost-and-dual-table",
+        )
+
+        assert result.passed, result.message
+
+    def test_dual_ticket_branch_first_ticket_passes(self, tmp_path: Path) -> None:
+        """Either member of an omn-A-B branch satisfies the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13234")
+        _write_receipt(receipts, "OMN-13234")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13234"),
+            pr_title="feat(OMN-13234): typed tier cost and dual table",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13234-13362-typed-tier-cost-and-dual-table",
+        )
+
+        assert result.passed, result.message
+
+    def test_triple_ticket_branch_member_passes(self, tmp_path: Path) -> None:
+        """A middle member of an omn-A-B-C cluster satisfies the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13200")
+        _write_receipt(receipts, "OMN-13200")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13200"),
+            pr_title="feat(OMN-13200): three ticket cluster",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13100-13200-13300-three-ticket-cluster",
+        )
+
+        assert result.passed, result.message
+
+    def test_single_ticket_branch_still_passes(self, tmp_path: Path) -> None:
+        """Regression: a plain single-ticket branch keeps passing the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13362")
+        _write_receipt(receipts, "OMN-13362")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13362"),
+            pr_title="feat(OMN-13362): typed tier cost",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13362-typed-tier-cost",
+        )
+
+        assert result.passed, result.message
+
+    def test_dual_ticket_branch_non_member_fails(self, tmp_path: Path) -> None:
+        """A ticket absent from the branch cluster still fails the branch axis."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-9999")
+        _write_receipt(receipts, "OMN-9999")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-9999"),
+            pr_title="feat(OMN-9999): unrelated ticket",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13234-13362-typed-tier-cost-and-dual-table",
+        )
+
+        assert not result.passed
+        assert "branch" in result.message.lower()
+        assert "omn-9999" in result.message.lower()
+
+    def test_dual_ticket_branch_numeric_prefix_non_member_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """A numeric-prefix near-miss (omn-133621) is not a cluster member."""
+        contracts = tmp_path / "contracts"
+        receipts = tmp_path / "receipts"
+        _write_contract(contracts, "OMN-13362")
+        _write_receipt(receipts, "OMN-13362")
+
+        result = validate_pr_receipts(
+            pr_body=self._pr_body("OMN-13362"),
+            pr_title="feat(OMN-13362): typed tier cost",
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            branch_name="jonah/omn-13234-133621-wrong-suffix",
+        )
+
+        assert not result.passed
+        assert "branch" in result.message.lower()


### PR DESCRIPTION
## OMN-13395 — Receipt-gate branch axis tolerates dual-ticket branch names

Closes OMN-13395.

### Problem
The identity-binding **branch axis** in
`src/omnibase_core/validation/validator_receipt_gate.py::_verify_ticket_identity`
matched only a literal `OMN-<n>` token via `exact_ticket_pattern`
(`(?<![A-Z0-9])OMN-<ticket>(?![A-Z0-9])`). A dual-ticket branch following the
`omn-A-B(-C...)` convention — e.g. `jonah/omn-13234-13362-typed-tier-cost-and-dual-table`
with `Evidence-Ticket: OMN-13362` — never contains the literal token `OMN-13362`
(the trailing `13362` is preceded by `-`, not `OMN-`), so the branch axis FAILED even
though the PR title and the receipt binding both referenced OMN-13362. Verified live on
omnibase_infra #2051: `IDENTITY BINDING FAILED: branch name does not reference OMN-13362`.

### Fix (scoped to the branch axis only)
When the exact-token match fails, scan the branch for every `omn-<n>(-<n>)*` cluster
(`DUAL_TICKET_BRANCH_CLUSTER_PATTERN`) and test the Evidence-Ticket's numeric id for
membership in any cluster's `-`-split run. Axis 1 (PR title) is unchanged — titles use
the `OMN-A, OMN-B` comma form the existing token pattern already handles. A numeric-prefix
near-miss (`omn-133621` vs `13362`) is still a non-member and still FAILS.

### dod_evidence
- **Unit (`dod-branch-axis-unit`)**: new `TestDualTicketBranchBinding` — `omn-A-B`, `omn-B-A`,
  triple-cluster, and single-ticket branches PASS; non-member + `omn-133621` near-miss FAIL.
  `uv run pytest tests/unit/validation/test_receipt_gate_identity_binding.py -q` → **20 passed**.
- **Blast radius (`dod-blast-radius`)**: every test referencing the changed code (17 files incl.
  the integration cascade test) → **355 passed**. `mypy --strict` on the changed module → clean.
- **Full suite**: ran `uv run pytest -q -n auto`; the one run that completed reported **9399 passed /
  2 failed**, but the failing-test names were lost to an xdist loadscope teardown crash
  (`KeyError: <WorkerController gwN>`) and the machine was externally CPU-saturated
  (Chrome/mediaanalysisd/ChatGPT), so I could not re-enumerate them locally — every retry timed out.
  The change is pure validator logic (no I/O), its complete blast radius is green, and the
  authoritative full suite runs on CI here.
- **Deploy assessment (`dod-deploy-assessment`)**: validator-logic + unit-test change only; no live
  deploy, restart, .201 mutation, or runtime lane mutation.

### OCC receipt pairing
Evidence-Ticket: OMN-13395
Evidence-Source: OCC#3380
- Paired OCC receipt PR: OmniNode-ai/onex_change_control#3380 (`contracts/OMN-13395.yaml` + 4 PASS receipts).
- Local gate proof: `validate_pr_receipts` against the OCC checkout →
  `RECEIPT GATE PASSED: 4 check(s) across 1 ticket(s) all have PASS receipts.`
