### PR TITLE
fix(OMN-13763): evacuate run_coro_sync compat->core, drop compat from spine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,16 +148,12 @@ node_contract_verify_replay_compute = "omnibase_core.nodes.node_contract_verify_
 
 [project.optional-dependencies]
 spi = ["omnibase-spi>=0.20.2"]
-# omnibase-compat provides run_coro_sync (OMN-9237) for sync-from-async bridging.
-# Optional so omnibase-core can be installed as a standalone SDK without it;
-# model_onex_container falls back to an inline equivalent when not installed.
-compat = ["omnibase-compat>=0.4.2,<1.0.0"]
 cli = ["psutil>=7.2.1"]
 kafka = ["aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0"]
 cache = ["redis>=5.0.0,<9.0.0"]
 metrics = ["prometheus-client>=0.21.0,<1.0.0"]
 sql-parser = ["sqlglot>=26.0.0,<31.0.0"]
-full = ["omnibase-spi>=0.20.2", "omnibase-compat>=0.4.2,<1.0.0", "psutil>=7.2.1", "aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<9.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
+full = ["omnibase-spi>=0.20.2", "psutil>=7.2.1", "aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<9.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
 
 [dependency-groups]
 dev = [
@@ -188,11 +184,6 @@ dev = [
 
 [tool.uv.sources]
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
-# Pinned to compat main while compat v0.4.2 (2026-05-31 release wave) is unpublished on PyPI.
-# Switch to a PyPI pin after omnibase-compat v0.4.2 publishes.
-# OMN-13522: compat main has diverged from compat dev (off-dev-line); the OMN-13509
-# gate landing in this same PR found this real divergence — re-pin tracked in OMN-13522.
-omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", branch = "main" }  # onex-allow-pin-hygiene OMN-13522
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/omnibase_core"]

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -77,7 +77,6 @@ if TYPE_CHECKING:
         ProtocolPerformanceMonitor,
     )
 
-import asyncio
 import os
 import tempfile
 import threading
@@ -87,25 +86,8 @@ from pathlib import Path
 # Import needed for type annotations
 from uuid import UUID, uuid4
 
-# OMN-9241: prefer the canonical helper from omnibase_compat (OMN-9237, PR #64)
-# when installed; fall back to an inline equivalent so omnibase-core works as a
-# standalone SDK without the optional compat extra.
-try:
-    from omnibase_compat.concurrency import run_coro_sync
-except ImportError:
-    import concurrent.futures
-    from collections.abc import Coroutine
-    from typing import Any, TypeVar
-
-    _RunT = TypeVar("_RunT")
-
-    def run_coro_sync(coro: "Coroutine[Any, Any, _RunT]") -> "_RunT":
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(coro)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            return executor.submit(asyncio.run, coro).result()
+# OMN-13763: run_coro_sync graduated from omnibase_compat into omnibase_core (OMN-9237).
+from omnibase_core.utils.util_run_coro_sync import run_coro_sync
 
 
 # Import context-based container management

--- a/src/omnibase_core/utils/util_run_coro_sync.py
+++ b/src/omnibase_core/utils/util_run_coro_sync.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Sync-from-async coroutine runner.
+
+Graduated from ``omnibase_compat.concurrency.util_run_coro_sync`` (OMN-13763)
+into ``omnibase_core`` so the core->spi->infra spine no longer depends on
+``omnibase_compat`` for this primitive.
+
+The underlying problem: ``asyncio.run()`` raises ``RuntimeError`` when invoked
+from inside a running event loop. That case arises during async auto-wiring
+when handler ``__init__`` methods (which are inherently sync -- Python does not
+allow ``async __init__``) call container helpers such as
+``get_service_sync(...)`` while the enclosing wiring coroutine is being
+awaited.
+
+See plan ``docs/plans/2026-04-19-runtime-permanent-fix-and-regression-guard-part-1.md``
+Task 2 and Linear ticket OMN-9237.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from collections.abc import Coroutine
+from typing import Any
+
+
+def run_coro_sync[T](coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine to completion from sync code, safe inside a running loop.
+
+    Returns the coroutine's result. Safe from both sync AND async contexts --
+    the coroutine is awaited exactly once.
+
+    When no event loop is running in the calling thread, the coroutine is
+    executed via ``asyncio.run()`` -- the cheap path. When a loop IS running,
+    the coroutine is dispatched to a short-lived worker thread with its own
+    event loop via ``concurrent.futures.ThreadPoolExecutor(max_workers=1)``,
+    and the calling thread blocks on the resulting future's ``.result()``
+    until the coroutine completes. This is O(thread-spawn); callers that can
+    await directly should prefer the async equivalent.
+
+    Exceptions raised inside ``coro`` propagate unchanged to the caller along
+    either path.
+
+    Args:
+        coro: A coroutine object (i.e. ``some_async_fn(...)``). The coroutine
+            is awaited exactly once by this helper; do not await it elsewhere.
+
+    Returns:
+        The value returned by awaiting ``coro``.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -- cheap path.
+        return asyncio.run(coro)
+
+    # Running loop detected -- dispatch to a worker thread with its own loop.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coro).result()

--- a/tests/unit/models/container/test_get_service_sync_from_async.py
+++ b/tests/unit/models/container/test_get_service_sync_from_async.py
@@ -10,8 +10,9 @@ asyncio.run() cannot be called from a running event loop`` in that scenario,
 breaking all auto-wiring.
 
 OMN-9241 Task 6 supersedes the inline ``_run_coro_sync`` helper (PR #853) with
-the canonical ``omnibase_compat.concurrency.run_coro_sync`` import. These tests
-lock in that contract:
+the canonical ``omnibase_compat.concurrency.run_coro_sync`` import. OMN-13763
+graduates ``run_coro_sync`` from omnibase_compat into omnibase_core so the
+spine no longer depends on compat at runtime. These tests lock in that contract:
 
 1. ``get_service_sync`` run inside ``asyncio.run`` does not raise the
    forbidden ``RuntimeError``.
@@ -19,9 +20,9 @@ lock in that contract:
    referenced in the plan) run inside ``asyncio.run`` returns a container
    without raising.
 3. ``model_onex_container.py`` imports ``run_coro_sync`` from
-   ``omnibase_compat.concurrency`` rather than shipping its own inline copy —
-   enforced via ``inspect.getsource`` grep so a future rebase cannot
-   silently reintroduce a duplicate helper.
+   ``omnibase_core.utils.util_run_coro_sync`` (OMN-13763) — not from
+   omnibase_compat — enforced via ``inspect.getsource`` grep so a future
+   rebase cannot silently reintroduce either an inline copy or a compat import.
 """
 
 from __future__ import annotations
@@ -148,23 +149,28 @@ def _collect_asyncio_run_lines_outside_except(source: str) -> list[int]:
 
 @pytest.mark.unit
 def test_container_delegates_to_compat_run_coro_sync() -> None:
-    """Source must use ``omnibase_compat.concurrency.run_coro_sync``, not an inline copy.
+    """Source must use ``omnibase_core.utils.util_run_coro_sync.run_coro_sync``, not compat or inline.
 
-    This lock-in prevents a future rebase from silently reintroducing the
-    inline ``_run_coro_sync`` helper (as existed in PR #853) — which would
-    defeat the purpose of extracting the helper into ``omnibase_compat``.
-
-    omnibase-compat is an optional dep (SDK boundary rule). The import is
-    wrapped in try/except ImportError with an inline fallback that calls
-    asyncio.run() internally — that one location is exempted by the AST check.
+    OMN-13763 graduates ``run_coro_sync`` from omnibase_compat into omnibase_core
+    so the spine no longer depends on compat at runtime. This lock-in prevents:
+    - Reintroducing the inline ``_run_coro_sync`` helper (as existed in PR #853)
+    - Re-adding the omnibase_compat import (compat is no longer a spine dep)
     """
     source = inspect.getsource(model_onex_container)
 
-    # Contract-first: the canonical try-import pattern is present.
-    assert "from omnibase_compat.concurrency import run_coro_sync" in source, (
-        "model_onex_container.py must attempt to import run_coro_sync from "
-        "omnibase_compat.concurrency (OMN-9237). The inline _run_coro_sync "
-        "helper from PR #853 is superseded and should be removed."
+    # Contract-first: the canonical core import is present (OMN-13763 graduation).
+    assert (
+        "from omnibase_core.utils.util_run_coro_sync import run_coro_sync" in source
+    ), (
+        "model_onex_container.py must import run_coro_sync from "
+        "omnibase_core.utils.util_run_coro_sync (OMN-13763). The compat import "
+        "is removed as part of evacuating run_coro_sync from omnibase_compat into core."
+    )
+
+    # The old compat import must be gone (OMN-13763: compat dep removed from spine).
+    assert "from omnibase_compat.concurrency import run_coro_sync" not in source, (
+        "model_onex_container.py must NOT import run_coro_sync from omnibase_compat "
+        "(OMN-13763): the function now lives in omnibase_core.utils.util_run_coro_sync."
     )
 
     # Explicitly assert no duplicate private inline helper definition remains.

--- a/tests/unit/utils/test_run_coro_sync.py
+++ b/tests/unit/utils/test_run_coro_sync.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util_run_coro_sync.
+
+Graduated from omnibase_compat into omnibase_core (OMN-13763).
+Covers the two execution paths: no running loop (asyncio.run) and
+running loop (ThreadPoolExecutor dispatch).
+"""
+
+import asyncio
+
+import pytest
+
+from omnibase_core.utils.util_run_coro_sync import run_coro_sync
+
+
+async def _return_value(value: int) -> int:
+    return value
+
+
+async def _raise_error() -> int:
+    raise ValueError("expected error")
+
+
+@pytest.mark.unit
+def test_run_coro_sync_no_loop_returns_value() -> None:
+    """run_coro_sync runs the cheap path when no event loop is active."""
+    result = run_coro_sync(_return_value(42))
+    assert result == 42
+
+
+@pytest.mark.unit
+def test_run_coro_sync_no_loop_propagates_exception() -> None:
+    """run_coro_sync propagates coroutine exceptions via the cheap path."""
+    with pytest.raises(ValueError, match="expected error"):
+        run_coro_sync(_raise_error())
+
+
+@pytest.mark.unit
+def test_run_coro_sync_inside_running_loop_returns_value() -> None:
+    """run_coro_sync dispatches to a worker thread when a loop is already running."""
+
+    async def _driver() -> int:
+        # run_coro_sync must not call asyncio.run on this thread --
+        # it detects the running loop and spawns a worker thread instead.
+        return run_coro_sync(_return_value(99))
+
+    result = asyncio.run(_driver())
+    assert result == 99
+
+
+@pytest.mark.unit
+def test_run_coro_sync_inside_running_loop_propagates_exception() -> None:
+    """run_coro_sync propagates coroutine exceptions via the thread-pool path."""
+
+    async def _driver() -> None:
+        run_coro_sync(_raise_error())
+
+    with pytest.raises(ValueError, match="expected error"):
+        asyncio.run(_driver())

--- a/uv.lock
+++ b/uv.lock
@@ -688,15 +688,6 @@ wheels = [
 ]
 
 [[package]]
-name = "omnibase-compat"
-version = "0.3.1"
-source = { git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main#d86ee00a8b585f9bf32b1ec7c8e785843e4957b0" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-
-[[package]]
 name = "omnibase-core"
 version = "0.46.1"
 source = { editable = "." }
@@ -722,13 +713,9 @@ cache = [
 cli = [
     { name = "psutil" },
 ]
-compat = [
-    { name = "omnibase-compat" },
-]
 full = [
     { name = "aiokafka" },
     { name = "confluent-kafka" },
-    { name = "omnibase-compat" },
     { name = "omnibase-spi" },
     { name = "prometheus-client" },
     { name = "psutil" },
@@ -788,8 +775,6 @@ requires-dist = [
     { name = "dependency-injector", specifier = ">=4.48.3,<5.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "jsonschema", specifier = ">=4.25.1,<5.0.0" },
-    { name = "omnibase-compat", marker = "extra == 'compat'", git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main" },
-    { name = "omnibase-compat", marker = "extra == 'full'", git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main" },
     { name = "omnibase-spi", marker = "extra == 'full'", specifier = ">=0.20.2" },
     { name = "omnibase-spi", marker = "extra == 'spi'", specifier = ">=0.20.2" },
     { name = "prometheus-client", marker = "extra == 'full'", specifier = ">=0.21.0,<1.0.0" },
@@ -806,7 +791,7 @@ requires-dist = [
     { name = "tree-sitter", specifier = ">=0.25.2,<0.26" },
     { name = "tree-sitter-python", specifier = ">=0.25.0,<0.26" },
 ]
-provides-extras = ["spi", "compat", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
+provides-extras = ["spi", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Evacuates `run_coro_sync` from `omnibase_compat` into `omnibase_core`, closing the only live compat runtime import in the core→spi→infra spine.

**Changes:**
- Add `src/omnibase_core/utils/util_run_coro_sync.py` — stdlib-only, graduated verbatim from `omnibase_compat.concurrency.util_run_coro_sync` (OMN-9237), with updated docstring citing OMN-13763
- Update `src/omnibase_core/models/container/model_onex_container.py` line ~91: replace the `try/except ImportError` compat fallback with a direct `from omnibase_core.utils.util_run_coro_sync import run_coro_sync`
- Remove `compat = ["omnibase-compat>=0.4.2,<1.0.0"]` optional extra from `pyproject.toml`
- Remove `omnibase-compat` from the `full` extra in `pyproject.toml`
- Remove the `omnibase-compat = { git = ... }` stanza from `[tool.uv.sources]`
- Refresh `uv.lock` — confirmed `Removed omnibase-compat v0.3.1 (d86ee00a)`
- Add `tests/unit/utils/test_run_coro_sync.py` — 4 unit tests covering both execution paths (no-loop via `asyncio.run`, running-loop via `ThreadPoolExecutor`) and exception propagation on each path

## Tickets

- OMN-13763 (this change)
- Epic: OMN-13762

## dod_evidence

```
$ grep -rnE "^[[:space:]]*(from|import) omnibase_compat" src/
# (no output — zero matches)

$ uv run pytest tests/unit/utils/test_run_coro_sync.py -q
4 passed in 0.38s

$ uv run pre-commit run --files src/omnibase_core/utils/util_run_coro_sync.py \
    src/omnibase_core/models/container/model_onex_container.py \
    tests/unit/utils/test_run_coro_sync.py pyproject.toml
# all hooks: Passed

$ uv lock
Removed omnibase-compat v0.3.1 (d86ee00a)
```

Pre-commit failures on `--all-files` are pre-existing on `dev` (confirmed via `git stash` baseline run — identical set of failures before this change).

## OCC Receipt

Evidence-Source: 1a1855634304c8adadfdb88dea3ead2a79128290
Evidence-Ticket: OMN-13763

