### PR TITLE
chore(OMN-13762): repin onex-change-control from branch=main to immutable SHA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
+onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", rev = "41054810a25db826a4c649f491a2d980bffb0c17" }  # pragma: allowlist secret  # OMN-13762: pinned to immutable SHA (was branch="main"; v0.1.0, last OCC version without omnibase-core circular dep)  # onex-allow-pin-hygiene OMN-13762
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/omnibase_core"]

--- a/uv.lock
+++ b/uv.lock
@@ -799,7 +799,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.150" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.19.1" },
-    { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
+    { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=41054810a25db826a4c649f491a2d980bffb0c17" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "prometheus-client", specifier = ">=0.21.0,<1.0.0" },
     { name = "psutil", specifier = ">=7.2.1" },
@@ -836,7 +836,7 @@ wheels = [
 [[package]]
 name = "onex-change-control"
 version = "0.1.0"
-source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main#41054810a25db826a4c649f491a2d980bffb0c17" }
+source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=41054810a25db826a4c649f491a2d980bffb0c17#41054810a25db826a4c649f491a2d980bffb0c17" }
 dependencies = [
     { name = "colorama" },
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Freeze the `onex-change-control` dev-dependency pin from the moving
`branch = "main"` source to the immutable `rev` SHA at OCC v0.1.0
(`41054810a25db826a4c649f491a2d980bffb0c17`), as part of the omnibase-core
0.46.1 R1 release preparation (OMN-13762).

**Change:**
```toml
# Before (moving pin):
onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }

# After (immutable pin + annotations):
onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", rev = "41054810a25db826a4c649f491a2d980bffb0c17" }  # pragma: allowlist secret  # onex-allow-pin-hygiene OMN-13762
```

OCC `41054810` = OCC v0.1.0, the SHA already frozen in uv.lock. This is the last
OCC version without a circular dep on omnibase_core in `[tool.uv.sources]`. The remote
HEAD at R1 cut (`2dd26ade`, v0.5.1) breaks `uv sync` in CI; `41054810` is the correct
freeze target. `# pragma: allowlist secret` suppresses detect-secrets false-positive
on the hex SHA; `# onex-allow-pin-hygiene` suppresses the pin-hygiene gate.

**uv.lock:** Source specifier updated from `branch=main#41054810...` to
`rev=41054810...#41054810...` — same package (v0.1.0), deps unchanged.
`uv lock` resolves cleanly (79 packages, 404ms).

## Scope

`onex-change-control` is in `[dependency-groups].dev` only — zero impact on
runtime or PyPI artifact.

## Evidence

Evidence-Ticket: OMN-13762
Evidence-Source: OCC#3385

## dod_evidence

- `dod-repin-core-occ-sha`: `pyproject.toml` updated from `branch = "main"` to
  `rev = "41054810..."` (OCC v0.1.0). `uv.lock` specifier updated to rev-based
  pin. `pragma: allowlist secret` + `onex-allow-pin-hygiene` annotations added.
  uv lock resolves cleanly. OCC is dev-only; no runtime or PyPI impact.
- `dod-deploy-gate`: no new contracts, no runtime topology change, no topic
  schema change. deploy-gate: not applicable (dev-dependency pin only).
- Paired OCC receipt PR: OmniNode-ai/onex_change_control#3385 (`contracts/OMN-13762.yaml` + PASS receipts for dod-repin-core-occ-sha, dod-core-dev-promotable-to-main, dod-occ-self).
