### PR TITLE
ci(OMN-13762): exempt dependency-bot authors from receipt-gate + occ-preflight evidence gates

### DIFF
--- a/.github/workflows/occ-preflight.yml
+++ b/.github/workflows/occ-preflight.yml
@@ -66,11 +66,66 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      # OMN-13762: Dependency-bot PRs (Dependabot, Renovate) are authored by bots
+      # that structurally cannot cite a Linear ticket, an Evidence-Source, or an
+      # OCC receipt. Detect a trusted dependency-bot author up front from
+      # GitHub-verified PR metadata (never from caller-supplied body text) and
+      # skip the eligibility steps below. The job still concludes `success` (its
+      # remaining steps are skipped, not failed), so the
+      # `occ-preflight / eligibility` status check passes WITHOUT a skip token.
+      # The allowlist mirrors validator_receipt_gate.DEPENDENCY_BOT_AUTHORS.
+      - name: Detect dependency-bot author (occ-preflight exemption)
+        id: bot_exempt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the PR number for both pull_request and merge_group events.
+          if [ -n "${PR_NUMBER:-}" ]; then
+            resolved_pr_num="$PR_NUMBER"
+          elif [ -n "${MERGE_GROUP_HEAD_REF:-}" ]; then
+            resolved_pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
+            [ "$resolved_pr_num" = "$MERGE_GROUP_HEAD_REF" ] && resolved_pr_num=""
+          else
+            resolved_pr_num=""
+          fi
+
+          # GitHub-verified author identity. Prefer the API login; fall back to
+          # the event-payload login when the API is unavailable.
+          author_login=""
+          if [ -n "$resolved_pr_num" ]; then
+            author_login="$(gh pr view "$resolved_pr_num" --repo "${{ github.repository }}" --json author --jq '.author.login' 2>/dev/null || true)"
+          fi
+          if [ -z "$author_login" ]; then
+            author_login="${PR_EVENT_AUTHOR:-}"
+          fi
+
+          # Trusted dependency-bot allowlist. Matches the gh CLI login form
+          # ("app/dependabot") and the raw API/event login form
+          # ("dependabot[bot]"). Keep in sync with
+          # validator_receipt_gate.DEPENDENCY_BOT_AUTHORS.
+          exempt="false"
+          case "$author_login" in
+            "dependabot[bot]"|"app/dependabot"|"dependabot"|"renovate[bot]"|"app/renovate"|"renovate")
+              exempt="true"
+              ;;
+          esac
+
+          if [ "$exempt" = "true" ]; then
+            echo "::notice::OCC-preflight exemption (OMN-13762): PR authored by trusted dependency bot '${author_login}'. Dependency-bump PRs carry no Linear ticket or OCC receipt; the eligibility gate is not applicable. Eligibility steps are skipped; the job still reports success."
+          fi
+          echo "exempt=${exempt}" >> "$GITHUB_OUTPUT"
+
       # I1: Resolve all mutable GitHub state exactly once.
       # Writes /tmp/pr_{body,title,author,branch,number}.txt and
       # /tmp/pr_commit_{shas,texts}.txt for downstream steps.
       - name: Resolve PR snapshot
         id: resolve
+        if: steps.bot_exempt.outputs.exempt != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -138,7 +193,7 @@ jobs:
       # I4: OCC fetch failure is a hard FAIL — no fallback to stale/cached evidence.
       - name: Resolve Evidence-Source
         id: resolve_evidence_source
-        if: github.repository != 'OmniNode-ai/onex_change_control'
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -182,7 +237,7 @@ jobs:
       # I3: OCC's own PRs use in-tree checkout; other repos check out pinned OCC evidence.
       # I4: OCC fetch failure is a hard FAIL — no fallback to stale/cached evidence.
       - name: Check out onex_change_control (for contracts + receipts)
-        if: github.repository != 'OmniNode-ai/onex_change_control'
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/onex_change_control
@@ -194,6 +249,7 @@ jobs:
       # subsequent steps use this exact SHA — never re-fetching. (I1, I2)
       - name: Resolve OCC evidence SHA
         id: occ_sha
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           set -euo pipefail
           repo_short="${GITHUB_REPOSITORY##*/}"
@@ -220,11 +276,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.13
+        if: steps.bot_exempt.outputs.exempt != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install uv
+        if: steps.bot_exempt.outputs.exempt != 'true'
         uses: astral-sh/setup-uv@v7
 
       # OMN-12565: Runner Python write-contract preflight.
@@ -241,6 +299,7 @@ jobs:
       # on a fresh runner). This preflight asserts that contract up front and
       # fails loudly if it is violated, before any install or gate step runs.
       - name: Preflight runner Python write contract
+        if: steps.bot_exempt.outputs.exempt != 'true'
         env:
           OCC_PREFLIGHT_VENV: ${{ github.workspace }}/.occ-preflight-venv
         run: |
@@ -274,7 +333,7 @@ jobs:
       # Install omnibase_compat and omnibase_core from source so the validator
       # module is available. Pattern mirrors receipt-gate.yml install block.
       - name: Check out omnibase_compat (transitive dep)
-        if: "! hashFiles('./src/omnibase_compat/__init__.py') && ! hashFiles('./omnibase_compat/pyproject.toml')"
+        if: "steps.bot_exempt.outputs.exempt != 'true' && ! hashFiles('./src/omnibase_compat/__init__.py') && ! hashFiles('./omnibase_compat/pyproject.toml')"
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_compat
@@ -283,7 +342,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check out omnibase_core (for eligibility validator)
-        if: "! hashFiles('./src/omnibase_core/__init__.py') && ! hashFiles('./omnibase_core/pyproject.toml')"
+        if: "steps.bot_exempt.outputs.exempt != 'true' && ! hashFiles('./src/omnibase_core/__init__.py') && ! hashFiles('./omnibase_core/pyproject.toml')"
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
@@ -292,6 +351,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install omnibase_core
+        if: steps.bot_exempt.outputs.exempt != 'true'
         # OMN-12565: install into a uv-managed virtual environment under
         # $GITHUB_WORKSPACE instead of the system interpreter. `uv pip install
         # --system` wrote /usr/local/lib/python3.12/dist-packages, which a
@@ -362,6 +422,7 @@ jobs:
           echo "OCC_PREFLIGHT_PY=$venv_py" >> "$GITHUB_ENV"
 
       - name: Verify eligibility validator importable
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           "$OCC_PREFLIGHT_PY" -c "from omnibase_core.validation.validator_occ_merge_eligibility import validate_occ_merge_eligibility" || {
             echo "::error::validator_occ_merge_eligibility not importable after install"
@@ -373,6 +434,7 @@ jobs:
       # Auto-merge MUST NOT arm when this step exits non-zero.
       - name: Run OCC eligibility check
         id: occ_eligibility
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -116,6 +116,63 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "::notice::receipt-gate target_branch=${target_branch:-unknown} policy_mode=${policy_mode}"
 
+      # OMN-13762: Dependency-bot PRs (Dependabot, Renovate) are authored by bots
+      # that structurally cannot cite a Linear ticket, an Evidence-Source, or an
+      # OCC receipt — the receipt gate's premise (a human-authored, ticket-backed
+      # change) does not apply to an automated dependency bump. Detect a trusted
+      # dependency-bot author up front from GitHub-verified PR metadata (never
+      # from caller-supplied body text, so a human PR cannot spoof it) and skip
+      # the receipt-evidence steps below. The job still concludes `success` (its
+      # remaining steps are skipped, not failed), so the required
+      # `verify / verify` status check passes WITHOUT a skip token. The allowlist
+      # mirrors validator_receipt_gate.DEPENDENCY_BOT_AUTHORS.
+      - name: Detect dependency-bot author (receipt-gate exemption)
+        id: bot_exempt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the PR number for both pull_request and merge_group events.
+          if [ -n "${PR_NUMBER:-}" ]; then
+            resolved_pr_num="$PR_NUMBER"
+          elif [ -n "${MERGE_GROUP_HEAD_REF:-}" ]; then
+            resolved_pr_num="$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -E 's@^.*/pr-([0-9]+)-.*$@\1@')"
+            [ "$resolved_pr_num" = "$MERGE_GROUP_HEAD_REF" ] && resolved_pr_num=""
+          else
+            resolved_pr_num=""
+          fi
+
+          # GitHub-verified author identity. Prefer the API login; fall back to
+          # the event-payload login when the API is unavailable. Author identity
+          # is read from trusted GitHub metadata, never from PR body text.
+          author_login=""
+          if [ -n "$resolved_pr_num" ]; then
+            author_login="$(gh pr view "$resolved_pr_num" --repo "${{ github.repository }}" --json author --jq '.author.login' 2>/dev/null || true)"
+          fi
+          if [ -z "$author_login" ]; then
+            author_login="${PR_EVENT_AUTHOR:-}"
+          fi
+
+          # Trusted dependency-bot allowlist. Matches both the gh CLI login form
+          # ("app/dependabot") and the raw API/event login form
+          # ("dependabot[bot]"). Keep in sync with
+          # validator_receipt_gate.DEPENDENCY_BOT_AUTHORS.
+          exempt="false"
+          case "$author_login" in
+            "dependabot[bot]"|"app/dependabot"|"dependabot"|"renovate[bot]"|"app/renovate"|"renovate")
+              exempt="true"
+              ;;
+          esac
+
+          if [ "$exempt" = "true" ]; then
+            echo "::notice::Receipt-gate exemption (OMN-13762): PR authored by trusted dependency bot '${author_login}'. Dependency-bump PRs carry no Linear ticket or OCC receipt; the evidence gate is not applicable. Receipt-evidence steps are skipped; the job still reports success."
+          fi
+          echo "exempt=${exempt}" >> "$GITHUB_OUTPUT"
+
       # OMN-10419: Resolve Evidence-Source commit-ish to an exact OCC SHA before
       # checking out onex_change_control. Accepts two forms:
       #   OCC#<number> — open PR head SHA (resolved via GitHub API)
@@ -127,7 +184,7 @@ jobs:
       # cutoff commit's authored date from OCC's git log.
       - name: Resolve Evidence-Source
         id: resolve_evidence_source
-        if: github.repository != 'OmniNode-ai/onex_change_control'
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -270,7 +327,7 @@ jobs:
       # onex_change_control PRs are the only exception and validate evidence
       # inside the PR checkout to avoid circular "already on main" dependency.
       - name: Check out onex_change_control (for contracts + receipts)
-        if: github.repository != 'OmniNode-ai/onex_change_control'
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/onex_change_control
@@ -282,7 +339,7 @@ jobs:
       # at the pinned OCC SHA. A valid commit-ish with no contract for this
       # ticket (e.g., predates the ticket) is a hard FAIL.
       - name: Assert contract exists at pinned OCC SHA
-        if: github.repository != 'OmniNode-ai/onex_change_control'
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -335,11 +392,13 @@ jobs:
           exit "$fail"
 
       - name: Set up Python 3.13
+        if: steps.bot_exempt.outputs.exempt != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install uv
+        if: steps.bot_exempt.outputs.exempt != 'true'
         uses: astral-sh/setup-uv@v7
 
       # OMN-12565: Runner Python write-contract preflight.
@@ -356,6 +415,7 @@ jobs:
       # on a fresh runner). This preflight asserts that contract up front and
       # fails loudly if it is violated, before any install or gate step runs.
       - name: Preflight runner Python write contract
+        if: steps.bot_exempt.outputs.exempt != 'true'
         env:
           RECEIPT_GATE_VENV: ${{ github.workspace }}/.receipt-gate-venv
         run: |
@@ -391,7 +451,7 @@ jobs:
       # fallback where omnibase-core's published package references a git+https
       # URL for omnibase-compat that no longer resolves.
       - name: Check out omnibase_compat (transitive dep)
-        if: "! hashFiles('./src/omnibase_compat/__init__.py') && ! hashFiles('./omnibase_compat/pyproject.toml')"
+        if: "steps.bot_exempt.outputs.exempt != 'true' && ! hashFiles('./src/omnibase_compat/__init__.py') && ! hashFiles('./omnibase_compat/pyproject.toml')"
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_compat
@@ -400,7 +460,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check out omnibase_core (for receipt-gate deps)
-        if: "! hashFiles('./src/omnibase_core/__init__.py') && ! hashFiles('./omnibase_core/pyproject.toml')"
+        if: "steps.bot_exempt.outputs.exempt != 'true' && ! hashFiles('./src/omnibase_core/__init__.py') && ! hashFiles('./omnibase_core/pyproject.toml')"
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
@@ -409,6 +469,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install omnibase_core
+        if: steps.bot_exempt.outputs.exempt != 'true'
         # Install from the PR's in-tree checkout (omnibase_core repo itself),
         # or a sibling checkout, or the .receipt-gate-deps source checkouts.
         # Never fall back to PyPI — the published package has a broken transitive
@@ -547,6 +608,7 @@ jobs:
           echo "RECEIPT_GATE_PY=$venv_py" >> "$GITHUB_ENV"
 
       - name: Verify receipt_gate_cli importable
+        if: steps.bot_exempt.outputs.exempt != 'true'
         # Fail-fast check: the preceding install step claims success, but if uv
         # silently substituted a PyPI wheel for omnibase-core (OMN-9198), the
         # installed package won't contain recent modules. Catch that here so the
@@ -560,6 +622,7 @@ jobs:
 
       - name: Resolve PR snapshot
         id: resolve_body
+        if: steps.bot_exempt.outputs.exempt != 'true'
         # Resolve mutable GitHub state exactly once. All eligibility checks below
         # consume these files plus the pinned OCC SHA; they do not re-fetch PR
         # metadata or move the evidence ref during validation.
@@ -629,6 +692,7 @@ jobs:
 
       - name: Resolve evidence snapshot
         id: evidence
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           set -euo pipefail
           repo_short="${GITHUB_REPOSITORY##*/}"
@@ -657,6 +721,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run OCC Eligibility
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           set -euo pipefail
           PR_TITLE="$(cat /tmp/pr_title.txt)"
@@ -691,6 +756,7 @@ jobs:
             | tee /tmp/occ_eligibility.json
 
       - name: Run Receipt-Gate
+        if: steps.bot_exempt.outputs.exempt != 'true'
         run: |
           PR_BODY="$(cat /tmp/pr_body.txt)"
           PR_TITLE="$(cat /tmp/pr_title.txt)"

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -113,6 +113,41 @@ from omnibase_core.validation.runtime_sha_match import (
 # earlier PRs get ADVISORY downgrade for the 7-day legacy window (OMN-10421).
 _CONTRACT_SHA256_REQUIRED_AFTER = datetime(2026, 4, 30, 0, 0, 0, tzinfo=UTC)
 
+# OMN-13762: Trusted dependency-bot authors exempt from the receipt / OCC
+# evidence gates. A dependency-bump PR (Dependabot, Renovate) is opened by an
+# automated bot and structurally cannot cite a Linear ticket, an Evidence-Source,
+# or an OCC receipt — the receipt gate's premise (a human-authored, ticket-backed
+# change) does not apply. The receipt-gate and occ-preflight reusable workflows
+# short-circuit their evidence steps for these authors, identifying the author
+# from GitHub-verified PR metadata (never from PR body text). This frozenset is
+# the canonical allowlist mirrored by the bash `case` guards in
+# ``.github/workflows/receipt-gate.yml`` and ``.github/workflows/occ-preflight.yml``.
+# Both the gh CLI login form ("app/dependabot") and the raw API/event login form
+# ("dependabot[bot]") are listed because the two surfaces report differently.
+DEPENDENCY_BOT_AUTHORS: frozenset[str] = frozenset(
+    {
+        "dependabot[bot]",
+        "app/dependabot",
+        "dependabot",
+        "renovate[bot]",
+        "app/renovate",
+        "renovate",
+    }
+)
+
+
+def is_dependency_bot_author(author_login: str | None) -> bool:
+    """Return True when ``author_login`` is a trusted dependency-bot identity.
+
+    Used to decide whether the receipt / OCC evidence gates apply. The match is
+    exact against :data:`DEPENDENCY_BOT_AUTHORS`; a near-miss login (e.g.
+    ``dependabot-fork``) is NOT exempt. ``None``/empty is never exempt.
+    """
+    if not author_login:
+        return False
+    return author_login in DEPENDENCY_BOT_AUTHORS
+
+
 TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
 # Captures each ``omn-<n>(-<n>)*`` cluster on a branch name (OMN-13395). A single
 # PR branch may address several tickets via the ``omn-A-B(-C...)`` convention —

--- a/tests/unit/validation/test_receipt_gate_dependency_bot_exemption.py
+++ b/tests/unit/validation/test_receipt_gate_dependency_bot_exemption.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the dependency-bot author exemption (OMN-13762).
+
+The receipt-gate and occ-preflight reusable workflows skip their evidence
+steps for trusted dependency-bot authors (Dependabot, Renovate) because a
+dependency-bump PR cannot cite a Linear ticket or an OCC receipt. The canonical
+allowlist lives in ``validator_receipt_gate.DEPENDENCY_BOT_AUTHORS`` and is
+mirrored by the bash ``case`` guards in both workflow YAMLs. These tests pin the
+allowlist membership and the ``is_dependency_bot_author`` predicate so the
+Python source of truth and the YAML mirror cannot silently drift apart, and so a
+near-miss / spoofed login is never exempt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.validation.validator_receipt_gate import (
+    DEPENDENCY_BOT_AUTHORS,
+    is_dependency_bot_author,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "login",
+    [
+        "dependabot[bot]",  # raw API / event login form
+        "app/dependabot",  # gh CLI login form
+        "dependabot",
+        "renovate[bot]",
+        "app/renovate",
+        "renovate",
+    ],
+)
+def test_trusted_dependency_bots_are_exempt(login: str) -> None:
+    assert is_dependency_bot_author(login) is True
+    assert login in DEPENDENCY_BOT_AUTHORS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "login",
+    [
+        None,
+        "",
+        "jonah",
+        "jonahgabriel",
+        "dependabot-fork",  # near-miss must NOT be exempt
+        "evil-dependabot[bot]",
+        "DEPENDABOT[BOT]",  # case-sensitive: GitHub logins are lowercase
+        "app/dependabot-impersonator",
+    ],
+)
+def test_non_bot_or_near_miss_authors_are_not_exempt(login: str | None) -> None:
+    assert is_dependency_bot_author(login) is False
+
+
+@pytest.mark.unit
+def test_allowlist_is_frozen_and_exact() -> None:
+    """The allowlist must stay an immutable, explicit set (no wildcard match)."""
+    assert isinstance(DEPENDENCY_BOT_AUTHORS, frozenset)
+    # Membership must be exact-match only — guard against an accidental
+    # substring/prefix relaxation that would let a spoofed login through.
+    assert is_dependency_bot_author("dependabot[bot] ") is False
+    assert is_dependency_bot_author(" dependabot[bot]") is False


### PR DESCRIPTION
## OMN-13762 — Exempt dependency-bot authors from receipt-gate + occ-preflight

Part of the OMN-13762 real-release remediation umbrella: unblock the automated
dependency-bump PRs (e.g. omniclaude #1821 kafka-python, #1822 actions group)
that are wedged on the evidence gates.

### Problem
`receipt-gate.yml` (required status check `verify / verify`) and
`occ-preflight.yml` (`occ-preflight / eligibility`) hard-FAIL bot-authored
dependency-bump PRs at the **Resolve Evidence-Source** step:

```
RECEIPT GATE FAILED: PR body is missing required 'Evidence-Source:' line (OMN-10419)
OCC PREFLIGHT FAILED: PR body is missing required 'Evidence-Source:' line
```

Dependabot/Renovate PRs are opened by bots and structurally cannot cite a Linear
ticket, an `Evidence-Source`, or an OCC receipt — the gate's premise (a
human-authored, ticket-backed change) does not apply to an automated bump.

### Fix (gate fix, NOT a skip token)
An early **Detect dependency-bot author** step in each reusable workflow reads
the **GitHub-verified author login** (`gh pr view --json author`, falling back to
`github.event.pull_request.user.login`) — never PR body text, so a human PR
cannot spoof it. For a trusted dependency-bot identity it sets `exempt=true`;
every downstream evidence step is then gated with
`if: steps.bot_exempt.outputs.exempt != 'true'`. The job still concludes
**success** (its remaining steps are *skipped*, not failed), so the required
status checks pass without any `[skip-*]` token.

The canonical allowlist is `validator_receipt_gate.DEPENDENCY_BOT_AUTHORS`
(+ `is_dependency_bot_author`), mirrored by the bash `case` guards in both YAMLs.
Both the gh CLI login form (`app/dependabot`) and the raw API/event form
(`dependabot[bot]`) are matched. Match is exact — a near-miss like
`dependabot-fork` is **not** exempt.

### Scope / blast radius
Touches only the two reusable evidence-gate workflows + the validator allowlist
constant/predicate + its unit test. No change to evidence requirements for
human-authored PRs (for a non-bot author `exempt=false`, every step runs exactly
as before).

> Note: omniclaude's caller pins `receipt-gate.yml@main`, so the omniclaude
> dependabot PRs remain blocked until this exemption reaches omnibase_core
> **main** via the normal dev→main release promotion. This PR lands the fix on
> `dev` and is ready to ride that promotion.

### dod_evidence
```
$ uv run ruff format ... && uv run ruff check ...
1 file reformatted; All checks passed!

$ PYTHONPATH=<worktree>/src uv run pytest tests/unit/validation/test_receipt_gate_dependency_bot_exemption.py -q
15 passed

$ PYTHONPATH=<worktree>/src uv run mypy src/omnibase_core/validation/validator_receipt_gate.py
Success: no issues found in 1 source file

$ PYTHONPATH=<worktree>/src uv run pre-commit run --files <changed files>
all hooks: Passed   (incl. Receipt-gate substrate gates, validator-requirements,
                     Model-B rollup coverage, demo-path topic coherence)

$ python -c "import yaml; yaml.safe_load(open('.github/workflows/receipt-gate.yml')); yaml.safe_load(open('.github/workflows/occ-preflight.yml'))"
both workflows parse OK
```

### OCC receipt pairing
Evidence-Ticket: OMN-13762
Evidence-Source: OCC#3394
- OMN-13762 contract + 4 dod_evidence receipts (all PASS) at the pinned OCC SHA.