### PR TITLE
fix(OMN-13762): receipt-gate caller passes branch-policy-mode for main-release PRs

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -31,3 +31,5 @@ permissions:
 jobs:
   verify:
     uses: ./.github/workflows/receipt-gate.yml
+    with:
+      branch-policy-mode: ${{ (github.event.pull_request.base.ref == 'main' || github.event.merge_group.base_ref == 'refs/heads/main') && 'main-release' || 'legacy' }}


### PR DESCRIPTION
## OMN-13762

The `call-receipt-gate.yml` caller job passed **no** `with:` inputs, so the reusable `receipt-gate.yml` defaulted `branch-policy-mode` to `legacy`. Legacy mode runs the Axis-2 branch-name identity check, which FAILS on `dev`->`main` promotion PRs because their head branch is literally `dev` and cannot contain the ticket id. core's validator has a promotion exemption that skips the branch axis, but ONLY when `policy_mode == 'main-release'`.

### Change
Add a `with:` block so main-targeted PRs (and `merge_group` against `refs/heads/main`) run in `main-release` mode, while dev-targeted PRs stay `legacy`:

```yaml
jobs:
  verify:
    uses: ./.github/workflows/receipt-gate.yml
    with:
      branch-policy-mode: ${{ (github.event.pull_request.base.ref == 'main' || github.event.merge_group.base_ref == 'refs/heads/main') && 'main-release' || 'legacy' }}
```

The reusable `receipt-gate.yml` already declares the `branch-policy-mode` input (default `legacy`, accepts `legacy`/`dev-preflight`/`main-release`), so this is a valid input. The `uses:` ref, triggers, and permissions are unchanged.

### Evidence
OMN-13762 carries merged OCC receipts: #3382 / #3385 / #3384 / #3386.

This PR targets `dev`, so `base.ref == dev` -> the expression yields `legacy` (unchanged behavior for this PR); the branch name contains `omn-13762` so the Axis-2 check passes regardless.


Evidence-Ticket: OMN-13762
Evidence-Source: OCC#3387
