### PR TITLE
feat(OMN-13801): add Cursor hook contract models and enums

### DIFF
--- a/src/omnibase_core/enums/hooks/__init__.py
+++ b/src/omnibase_core/enums/hooks/__init__.py
@@ -17,9 +17,15 @@ from omnibase_core.enums.hooks.claude_code.enum_claude_code_session_outcome impo
 from omnibase_core.enums.hooks.claude_code.enum_claude_code_session_status import (
     EnumClaudeCodeSessionStatus,
 )
+from omnibase_core.enums.hooks.cursor.enum_cursor_hook_event_type import (
+    EnumCursorHookEventType,
+)
+from omnibase_core.enums.hooks.enum_agent_source import EnumAgentSource
 
 __all__ = [
+    "EnumAgentSource",
     "EnumClaudeCodeHookEventType",
     "EnumClaudeCodeSessionOutcome",
     "EnumClaudeCodeSessionStatus",
+    "EnumCursorHookEventType",
 ]

--- a/src/omnibase_core/enums/hooks/cursor/__init__.py
+++ b/src/omnibase_core/enums/hooks/cursor/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cursor IDE hook enumerations.
+
+Enums for Cursor IDE hook event types emitted by the OmniCursor plugin.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.hooks.cursor.enum_cursor_hook_event_type import (
+    EnumCursorHookEventType,
+)
+
+__all__ = [
+    "EnumCursorHookEventType",
+]

--- a/src/omnibase_core/enums/hooks/cursor/enum_cursor_hook_event_type.py
+++ b/src/omnibase_core/enums/hooks/cursor/enum_cursor_hook_event_type.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cursor hook event type.
+
+Cursor (OmniCursor) is an interchangeable dispatcher peer to Claude Code. To keep
+the two frontends behaviorally identical, Cursor shares Claude Code's canonical
+hook lifecycle vocabulary rather than introducing a parallel set of event names.
+
+OmniCursor normalizes its native hook names to the canonical values at emit time
+(see OmniCursor .cursor/hooks/scripts): for example ``beforeSubmitPrompt`` ->
+``UserPromptSubmit``, ``stop`` -> ``Stop``. Cursor's distinct identity is carried
+by its dedicated event model (ModelCursorHookEvent), its dedicated
+``cursor-hook-event.v1`` topic, its dedicated effect node, and the
+``agent_source="cursor"`` provenance stamped onto downstream events — not by a
+separate event-name enum.
+
+``EnumCursorHookEventType`` is therefore an alias of EnumClaudeCodeHookEventType.
+It exists as a named symbol so Cursor-side modules can import a Cursor-namespaced
+type, and so the relationship can later be specialized if Cursor diverges.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.hooks.claude_code.enum_claude_code_hook_event_type import (
+    EnumClaudeCodeHookEventType,
+)
+
+# Alias: Cursor shares Claude Code's canonical hook lifecycle vocabulary.
+EnumCursorHookEventType = EnumClaudeCodeHookEventType
+
+__all__ = ["EnumCursorHookEventType"]

--- a/src/omnibase_core/enums/hooks/enum_agent_source.py
+++ b/src/omnibase_core/enums/hooks/enum_agent_source.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Agent source for hook-derived events.
+
+Identifies which interchangeable dispatcher frontend produced a hook event.
+Claude Code and OmniCursor are behaviorally identical peers that share the same
+canonical hook lifecycle vocabulary (see EnumClaudeCodeHookEventType /
+EnumCursorHookEventType); ``EnumAgentSource`` is the provenance stamp that keeps
+their downstream events distinguishable once normalized onto the bus.
+
+This is the canonical type for the ``agent_source`` seam carried through hook
+dispatch and routing. It deliberately enumerates only the supported frontends —
+add a member when a new dispatcher peer is introduced.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumAgentSource(UtilStrValueHelper, str, Enum):
+    """Frontend dispatcher that produced a hook event.
+
+    Stamped onto downstream events as provenance so Claude Code and Cursor
+    paths remain distinguishable after normalization onto shared topics.
+    """
+
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+
+
+__all__ = ["EnumAgentSource"]

--- a/src/omnibase_core/models/hooks/__init__.py
+++ b/src/omnibase_core/models/hooks/__init__.py
@@ -20,6 +20,12 @@ from omnibase_core.models.hooks.claude_code.model_claude_code_session_outcome im
 from omnibase_core.models.hooks.claude_code.model_user_prompt_submit_payload import (
     ModelUserPromptSubmitPayload,
 )
+from omnibase_core.models.hooks.cursor.model_cursor_hook_event import (
+    ModelCursorHookEvent,
+)
+from omnibase_core.models.hooks.cursor.model_cursor_hook_event_payload import (
+    ModelCursorHookEventPayload,
+)
 from omnibase_core.utils.util_parse_hook_payload import (
     get_payload_type,
     parse_hook_payload,
@@ -29,6 +35,8 @@ __all__ = [
     "ModelClaudeCodeHookEvent",
     "ModelClaudeCodeHookEventPayload",
     "ModelClaudeCodeSessionOutcome",
+    "ModelCursorHookEvent",
+    "ModelCursorHookEventPayload",
     "ModelUserPromptSubmitPayload",
     "get_payload_type",
     "parse_hook_payload",

--- a/src/omnibase_core/models/hooks/cursor/__init__.py
+++ b/src/omnibase_core/models/hooks/cursor/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cursor IDE hook models.
+
+Models for Cursor IDE hook events and payloads emitted by the OmniCursor plugin.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.hooks.cursor.model_cursor_hook_event import (
+    ModelCursorHookEvent,
+)
+from omnibase_core.models.hooks.cursor.model_cursor_hook_event_payload import (
+    ModelCursorHookEventPayload,
+)
+
+__all__ = [
+    "ModelCursorHookEvent",
+    "ModelCursorHookEventPayload",
+]

--- a/src/omnibase_core/models/hooks/cursor/model_cursor_hook_event.py
+++ b/src/omnibase_core/models/hooks/cursor/model_cursor_hook_event.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cursor IDE hook event model.
+
+Raw input schema for Cursor hook events. This model represents the structure of
+events received from the OmniCursor plugin's hooks. It mirrors
+ModelClaudeCodeHookEvent so the two platforms are interchangeable dispatchers
+into the OmniNode stack, while remaining a distinct, first-class Cursor type.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.hooks.cursor.enum_cursor_hook_event_type import (
+    EnumCursorHookEventType,
+)
+from omnibase_core.models.hooks.cursor.model_cursor_hook_event_payload import (
+    ModelCursorHookEventPayload,
+)
+
+
+class ModelCursorHookEvent(BaseModel):
+    """Raw input schema for Cursor IDE hook events.
+
+    This model captures the essential fields from Cursor hook payloads. It is
+    the contract between the OmniCursor plugin and downstream processing in
+    omniintelligence. The shape intentionally matches ModelClaudeCodeHookEvent
+    (session_id, correlation_id, timestamp_utc, payload) so the shared
+    intelligence pipeline can be reused via event-type translation.
+
+    Attributes:
+        event_type: The type of Cursor hook event.
+        session_id: Cursor session/conversation identifier (string).
+        correlation_id: Optional ID for distributed tracing across services.
+        timestamp_utc: When the event occurred (timezone-aware UTC).
+        payload: Event-specific data as a ModelCursorHookEventPayload.
+
+    Example:
+        >>> from datetime import UTC, datetime
+        >>> event = ModelCursorHookEvent(
+        ...     event_type=EnumCursorHookEventType.USER_PROMPT_SUBMIT,
+        ...     session_id="abc123",
+        ...     timestamp_utc=datetime.now(UTC),
+        ...     payload=ModelCursorHookEventPayload(),
+        ... )
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    event_type: EnumCursorHookEventType = Field(
+        description="The type of Cursor IDE hook event"
+    )
+    session_id: str = Field(
+        description="Cursor session identifier (string per Cursor plugin API)"
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Optional correlation ID for distributed tracing",
+    )
+    timestamp_utc: datetime = Field(
+        description="When the event occurred (must be timezone-aware, e.g., datetime.now(UTC))"
+    )
+    payload: ModelCursorHookEventPayload = Field(
+        description="Event-specific data as a payload model"
+    )
+    agent_source: str = Field(
+        default="cursor",
+        description=(
+            "Originating dispatcher frontend; always 'cursor' for this model. "
+            "Propagated as provenance onto downstream events so Cursor and Claude "
+            "intents remain distinguishable on shared topics."
+        ),
+    )
+
+    @field_validator("timestamp_utc")
+    @classmethod
+    def validate_timezone_aware(cls, v: datetime) -> datetime:
+        """Validate that timestamp_utc is timezone-aware."""
+        if v.tzinfo is None:
+            raise ValueError(
+                "timestamp_utc must be timezone-aware (e.g., use datetime.now(UTC))"
+            )
+        return v
+
+    def __repr__(self) -> str:
+        """Return concise representation for debugging."""
+        session_display = (
+            self.session_id[:8] + "..." if len(self.session_id) > 8 else self.session_id
+        )
+        corr = " corr=..." if self.correlation_id else ""
+        return (
+            f"<CursorHookEvent {self.event_type.value} session={session_display}{corr}>"
+        )
+
+
+__all__ = ["ModelCursorHookEvent"]

--- a/src/omnibase_core/models/hooks/cursor/model_cursor_hook_event_payload.py
+++ b/src/omnibase_core/models/hooks/cursor/model_cursor_hook_event_payload.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Cursor hook event payload.
+
+Cursor (OmniCursor) is an interchangeable dispatcher peer to Claude Code and
+shares the same payload base so the two frontends can flow through the same
+intelligence pipeline. ``ModelCursorHookEventPayload`` is therefore an alias of
+ModelClaudeCodeHookEventPayload (extra="allow" base for event-specific payloads).
+
+Cursor's distinct identity is carried by ModelCursorHookEvent, its dedicated
+topic/node, and the ``agent_source="cursor"`` provenance — not by a separate
+payload base class. The alias exists so Cursor-side modules can import a
+Cursor-namespaced type and so it can later be specialized if Cursor diverges.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.hooks.claude_code.model_claude_code_hook_event_payload import (
+    ModelClaudeCodeHookEventPayload,
+)
+
+# Alias: Cursor shares Claude Code's hook payload base.
+ModelCursorHookEventPayload = ModelClaudeCodeHookEventPayload
+
+__all__ = ["ModelCursorHookEventPayload"]

--- a/tests/unit/enums/test_enum_agent_source.py
+++ b/tests/unit/enums/test_enum_agent_source.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for EnumAgentSource."""
+
+import json
+
+import pytest
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.hooks.enum_agent_source import EnumAgentSource
+
+
+@pytest.mark.unit
+class TestEnumAgentSource:
+    """Test basic enum structure and values."""
+
+    def test_claude_value(self) -> None:
+        assert EnumAgentSource.CLAUDE.value == "claude"
+
+    def test_cursor_value(self) -> None:
+        assert EnumAgentSource.CURSOR.value == "cursor"
+
+    def test_str_returns_value(self) -> None:
+        assert str(EnumAgentSource.CLAUDE) == "claude"
+        assert str(EnumAgentSource.CURSOR) == "cursor"
+
+    def test_enum_is_unique(self) -> None:
+        values = [m.value for m in EnumAgentSource.__members__.values()]
+        assert len(values) == len(set(values))
+
+    def test_enum_is_string_subclass(self) -> None:
+        assert isinstance(EnumAgentSource.CLAUDE, str)
+
+    def test_enum_equality_with_string(self) -> None:
+        assert EnumAgentSource.CLAUDE == "claude"
+        assert EnumAgentSource.CURSOR == "cursor"
+
+    def test_enum_membership(self) -> None:
+        assert EnumAgentSource.CLAUDE in list(EnumAgentSource)
+        assert EnumAgentSource.CURSOR in list(EnumAgentSource)
+
+    def test_enum_from_value(self) -> None:
+        assert EnumAgentSource("claude") is EnumAgentSource.CLAUDE
+        assert EnumAgentSource("cursor") is EnumAgentSource.CURSOR
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            EnumAgentSource("codex")
+
+    def test_reexported_from_hooks_package(self) -> None:
+        from omnibase_core.enums.hooks import EnumAgentSource as Reexported
+
+        assert Reexported is EnumAgentSource
+
+
+@pytest.mark.unit
+class TestEnumAgentSourceSerialization:
+    """Test serialization compatibility."""
+
+    def test_json_serialization_via_value(self) -> None:
+        data = {"agent_source": EnumAgentSource.CURSOR.value}
+        assert json.dumps(data) == '{"agent_source": "cursor"}'
+
+    def test_yaml_round_trip(self) -> None:
+        data = {"agent_source": EnumAgentSource.CURSOR.value}
+        loaded = yaml.safe_load(yaml.dump(data))
+        assert loaded["agent_source"] == "cursor"
+        assert EnumAgentSource(loaded["agent_source"]) is EnumAgentSource.CURSOR
+
+    def test_pydantic_field_assignment(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource
+
+        m = M(agent_source=EnumAgentSource.CURSOR)
+        assert m.agent_source is EnumAgentSource.CURSOR
+
+    def test_pydantic_string_coercion(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource
+
+        m = M(agent_source="cursor")
+        assert m.agent_source is EnumAgentSource.CURSOR
+
+    def test_pydantic_invalid_raises(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource
+
+        with pytest.raises(ValidationError):
+            M(agent_source="invalid")
+
+    def test_pydantic_model_dump(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource
+
+        m = M(agent_source=EnumAgentSource.CLAUDE)
+        assert m.model_dump() == {"agent_source": "claude"}
+
+    def test_pydantic_model_dump_json(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource
+
+        m = M(agent_source=EnumAgentSource.CLAUDE)
+        assert m.model_dump_json() == '{"agent_source":"claude"}'
+
+
+@pytest.mark.unit
+class TestEnumAgentSourceDefaultField:
+    """Test use as a defaulted field — the route_hook_event seam pattern."""
+
+    def test_default_is_claude(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource = EnumAgentSource.CLAUDE
+
+        assert M().agent_source is EnumAgentSource.CLAUDE
+
+    def test_default_overridden_with_cursor(self) -> None:
+        class M(BaseModel):
+            agent_source: EnumAgentSource = EnumAgentSource.CLAUDE
+
+        assert M(agent_source=EnumAgentSource.CURSOR).agent_source is (
+            EnumAgentSource.CURSOR
+        )


### PR DESCRIPTION
Ticket: OMN-13801
Evidence-Ticket: OMN-13801

Evidence-Source: OCC#3443

## Summary
- Add Cursor hook event contract models and payloads.
- Add EnumCursorHookEventType and EnumAgentSource.
- Re-export Cursor hook contracts from hooks packages.

## Verification
- env -u PYTHONPATH uv run pytest tests/unit/enums/test_enum_agent_source.py -v
- env -u PYTHONPATH uv run ruff check src/omnibase_core/enums/hooks src/omnibase_core/models/hooks tests/unit/enums/test_enum_agent_source.py
- env -u PYTHONPATH uv run python - <<PY (import smoke for EnumAgentSource, EnumCursorHookEventType, ModelCursorHookEvent, ModelCursorHookEventPayload)
