### PR TITLE
feat(OMN-12549): MixinNodeDispatch node-owned dispatch-selection seam (S0-seam, epic OMN-12525)

### DIFF
--- a/src/omnibase_core/nodes/node_effect.py
+++ b/src/omnibase_core/nodes/node_effect.py
@@ -568,10 +568,10 @@ class NodeEffect(
                     "circuit_breaker": op_cb.model_dump(),
                     "transaction_config": op_tx.model_dump(),
                 }
-                # TODO(OMN-5746): [v2.0] Per-operation configs (response_handling, retry_policy,
+                # TODO(OMN-5746): [v2.0] Per-operation configs (response_handling, retry_policy,  # onex-allow-todo-marker
                 # circuit_breaker) are serialized into operation_data but NOT YET
                 # wired to the execution pipeline. Only subcontract-level defaults
-                # are honored. See process() docstring "v1.0 Limitation" note.  [NEEDS TICKET]
+                # are honored. See process() docstring "v1.0 Limitation" note.
                 operations.append(op_dict)
 
             # Create new input_data with operations populated

--- a/src/omnibase_core/nodes/node_effect.py
+++ b/src/omnibase_core/nodes/node_effect.py
@@ -46,6 +46,7 @@ from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.resolution.resolver_handler import (
     HandlerCallable,
 )
+from omnibase_core.runtime.mixin_node_dispatch import MixinNodeDispatch
 
 # Error messages
 _ERR_EFFECT_SUBCONTRACT_NOT_LOADED = "Effect subcontract not loaded"
@@ -74,7 +75,9 @@ _per_op_circuit_breaker_warning_emitted: bool = False
 _per_op_response_handling_warning_emitted: bool = False
 
 
-class NodeEffect(NodeCoreBase, MixinEffectExecution, MixinHandlerRouting):
+class NodeEffect(
+    NodeCoreBase, MixinEffectExecution, MixinHandlerRouting, MixinNodeDispatch
+):
     """
     Contract-driven effect node for external I/O operations.
 

--- a/src/omnibase_core/nodes/node_orchestrator.py
+++ b/src/omnibase_core/nodes/node_orchestrator.py
@@ -38,6 +38,7 @@ from omnibase_core.models.workflow import (
     WORKFLOW_STATE_SNAPSHOT_SCHEMA_VERSION,
     ModelWorkflowStateSnapshot,
 )
+from omnibase_core.runtime.mixin_node_dispatch import MixinNodeDispatch
 from omnibase_core.utils.util_workflow_executor import WorkflowExecutionResult
 
 # Clock skew tolerance for snapshot timestamp validation
@@ -75,7 +76,9 @@ _WARN_WORKFLOW_ALL_STEPS_FAILED = (
 )
 
 
-class NodeOrchestrator(NodeCoreBase, MixinWorkflowExecution, MixinHandlerRouting):
+class NodeOrchestrator(
+    NodeCoreBase, MixinWorkflowExecution, MixinHandlerRouting, MixinNodeDispatch
+):
     """
     Workflow-driven orchestrator node for coordination.
 

--- a/src/omnibase_core/runtime/__init__.py
+++ b/src/omnibase_core/runtime/__init__.py
@@ -15,8 +15,10 @@ Components:
 Related:
     - OMN-229: FileRegistry for contract file loading
     - OMN-13444: RuntimeLocal relocated from omnibase_infra (local-first re-convergence)
+    - OMN-12549: MixinNodeDispatch node-owned dispatch-selection seam (epic OMN-12525)
 """
 
+from omnibase_core.runtime.mixin_node_dispatch import MixinNodeDispatch
 from omnibase_core.runtime.runtime_file_registry import FileRegistry
 from omnibase_core.runtime.runtime_local import (
     ResolvedRoutingEntry,
@@ -29,6 +31,7 @@ from omnibase_core.runtime.runtime_local_adapter import LocalRuntimeBusAdapter
 __all__ = [
     "FileRegistry",
     "LocalRuntimeBusAdapter",
+    "MixinNodeDispatch",
     "ResolvedRoutingEntry",
     "RuntimeLocal",
     "load_workflow_contract",

--- a/src/omnibase_core/runtime/mixin_node_dispatch.py
+++ b/src/omnibase_core/runtime/mixin_node_dispatch.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 from uuid import UUID, uuid4
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
@@ -95,7 +95,9 @@ class _NodeDispatchEntry:
         self.dispatcher_id = dispatcher_id
         self.dispatcher = dispatcher
         self.category = category
-        self.message_types = message_types  # None means "all message types"
+        self.message_types = (
+            set(message_types) if message_types is not None else None
+        )  # None means "all message types"
         self.node_kind = node_kind
         # None means "not type-scoped" — legacy string-only matching applies.
         self.payload_type_matcher = payload_type_matcher
@@ -111,6 +113,11 @@ class _NodeDispatchState:
         self.dispatchers: dict[str, _NodeDispatchEntry] = {}
         self.frozen: bool = False
         self.dlq_topic_deriver: DlqTopicDeriver | None = None
+
+
+class _NodeDispatchMatch(NamedTuple):
+    route_id: str
+    entry: _NodeDispatchEntry
 
 
 class MixinNodeDispatch:
@@ -178,6 +185,9 @@ class MixinNodeDispatch:
                 message=f"Route with ID '{route.route_id}' is already registered.",
                 error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
             )
+        entry = state.dispatchers.get(route.handler_id)
+        if entry is not None:
+            self._validate_route_dispatcher_category(route, entry)
         state.routes[route.route_id] = route
 
     def register_dispatcher(
@@ -221,7 +231,7 @@ class MixinNodeDispatch:
                 message=f"Dispatcher with ID '{dispatcher_id}' is already registered.",
                 error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
             )
-        state.dispatchers[dispatcher_id] = _NodeDispatchEntry(
+        entry = _NodeDispatchEntry(
             dispatcher_id=dispatcher_id,
             dispatcher=dispatcher,
             category=category,
@@ -229,6 +239,10 @@ class MixinNodeDispatch:
             node_kind=node_kind,
             payload_type_matcher=payload_type_matcher,
         )
+        for route in state.routes.values():
+            if route.handler_id == dispatcher_id:
+                self._validate_route_dispatcher_category(route, entry)
+        state.dispatchers[dispatcher_id] = entry
 
     def freeze(self) -> None:
         """Freeze the table for dispatch. Validates every route references a
@@ -244,12 +258,27 @@ class MixinNodeDispatch:
                     f"'{rid}' which is not registered.",
                     error_code=EnumCoreErrorCode.ITEM_NOT_REGISTERED,
                 )
+            self._validate_route_dispatcher_category(route, state.dispatchers[rid])
         state.frozen = True
 
     @property
     def is_frozen(self) -> bool:
         """True once :meth:`freeze` has been called."""
         return self._state().frozen
+
+    @staticmethod
+    def _validate_route_dispatcher_category(
+        route: ModelDispatchRoute, entry: _NodeDispatchEntry
+    ) -> None:
+        """Reject routes whose declared category disagrees with their dispatcher."""
+        if route.message_category == entry.category:
+            return
+        raise ModelOnexError(
+            message=f"Route '{route.route_id}' category "
+            f"'{route.message_category.value}' does not match dispatcher "
+            f"'{entry.dispatcher_id}' category '{entry.category.value}'.",
+            error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+        )
 
     # -- selection ------------------------------------------------------------
 
@@ -260,7 +289,7 @@ class MixinNodeDispatch:
         category: EnumMessageCategory,
         message_type: str,
         payload: object | None,
-    ) -> list[_NodeDispatchEntry]:
+    ) -> list[_NodeDispatchMatch]:
         """Port of the engine's ``_find_matching_dispatchers`` (selection only).
 
         Iterates routes in registration (insertion) order — the fan-out order the
@@ -269,7 +298,7 @@ class MixinNodeDispatch:
         the dispatcher's own message-type filter admits ``message_type``, and, for
         type-scoped dispatchers, the payload matches the declared event_model.
         """
-        matching: list[_NodeDispatchEntry] = []
+        matching: list[_NodeDispatchMatch] = []
         seen: set[str] = set()
         state = self._state()
         for route in state.routes.values():
@@ -288,23 +317,24 @@ class MixinNodeDispatch:
             if entry is None:
                 # Should be impossible after freeze() validation; skip defensively.
                 continue
+            if entry.category != route.message_category:
+                # Should be impossible after registration/freeze validation.
+                continue
             if (
                 entry.message_types is not None
                 and message_type not in entry.message_types
             ):
                 continue
-            if (
-                payload is not None
-                and entry.payload_type_matcher is not None
-                and not self._payload_matches(entry, payload)
+            if entry.payload_type_matcher is not None and not self._payload_matches(
+                entry, payload
             ):
                 continue
-            matching.append(entry)
+            matching.append(_NodeDispatchMatch(route.route_id, entry))
             seen.add(dispatcher_id)
         return matching
 
     @staticmethod
-    def _payload_matches(entry: _NodeDispatchEntry, payload: object) -> bool:
+    def _payload_matches(entry: _NodeDispatchEntry, payload: object | None) -> bool:
         """True when ``payload`` matches a type-scoped dispatcher's event_model.
 
         A raising matcher means "not my type" (never selected), mirroring the
@@ -417,10 +447,8 @@ class MixinNodeDispatch:
                 output_events=[],
             )
 
-        ordered_ids = [entry.dispatcher_id for entry in matching]
-        matched_route_id = self._first_matching_route_id(
-            topic, topic_category, message_type
-        )
+        ordered_ids = [match.entry.dispatcher_id for match in matching]
+        matched_route_id = matching[0].route_id
         return ModelDispatchResult(
             dispatch_id=dispatch_id,
             status=EnumDispatchStatus.SUCCESS,
@@ -447,19 +475,6 @@ class MixinNodeDispatch:
             return deriver(event_type, topic)
         except Exception:  # noqa: BLE001 — DLQ derivation must never crash selection
             return None
-
-    def _first_matching_route_id(
-        self,
-        topic: str,
-        category: EnumMessageCategory,
-        message_type: str,
-    ) -> str | None:
-        """First route (insertion order) fully matching topic/category/type, for
-        logging parity with the engine's ``matched_route_id``."""
-        for route in self._state().routes.values():
-            if route.matches(topic, category, message_type):
-                return route.route_id
-        return None
 
     @staticmethod
     def _extract_routing_inputs(envelope: object) -> tuple[object | None, object]:

--- a/src/omnibase_core/runtime/mixin_node_dispatch.py
+++ b/src/omnibase_core/runtime/mixin_node_dispatch.py
@@ -325,8 +325,17 @@ class MixinNodeDispatch:
                 and message_type not in entry.message_types
             ):
                 continue
-            if entry.payload_type_matcher is not None and not self._payload_matches(
-                entry, payload
+            # Engine-fidelity guard (OMN-12549): type-scope ONLY when a payload is
+            # available. The live engine's _find_matching_dispatchers gates this on
+            # ``payload is not None`` — with no payload it skips type-scoping and
+            # keeps the dispatcher. Dropping the guard would drive the matcher with
+            # payload=None (a spurious non-match) and diverge from the engine on the
+            # payload-less path (untested by the S0 harness, which always supplies a
+            # payload). Keep parity exact.
+            if (
+                payload is not None
+                and entry.payload_type_matcher is not None
+                and not self._payload_matches(entry, payload)
             ):
                 continue
             matching.append(_NodeDispatchMatch(route.route_id, entry))

--- a/src/omnibase_core/runtime/mixin_node_dispatch.py
+++ b/src/omnibase_core/runtime/mixin_node_dispatch.py
@@ -1,0 +1,487 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Node-owned dispatch-selection seam (OMN-12549, epic OMN-12525).
+
+``MixinNodeDispatch`` is the core-side, node-owned successor to the routing that
+today lives inside :class:`omnibase_infra.runtime.message_dispatch_engine.MessageDispatchEngine`.
+It ports the engine's *selection* semantics — the ``_find_matching_dispatchers``
+algorithm plus the surrounding ``dispatch()`` category/message-type derivation —
+using **core-only symbols** so orchestrator and effect nodes can own dispatch
+selection without depending on ``omnibase_infra``.
+
+Scope (design D4 / OMN-12549):
+    This mixin performs **selection only**. It resolves which registered
+    dispatchers a ``(topic, envelope)`` pair routes to and returns a
+    :class:`~omnibase_core.models.dispatch.model_dispatch_result.ModelDispatchResult`
+    whose equivalence tuple
+
+        (status, ordered dispatcher_ids, message_category, message_type, dlq_topic)
+
+    matches the live engine's for the same input. Handler *execution*, metrics,
+    binding resolution, and context injection remain the runtime's job and are
+    intentionally out of scope here — the engine stays live (no behavior change)
+    until the S5 cutover retires it.
+
+Parity contract (OMN-12548 S0 gate):
+    ``tests/integration/runtime/test_dispatch_selection_parity.py`` in
+    ``omnibase_infra`` drives the same probe corpus through both this mixin and
+    the engine behind ``ProtocolDispatchEngine`` and asserts tuple equality. The
+    only engine behavior this mixin cannot reproduce with core-only symbols is
+    DLQ-topic derivation (``omnibase_infra.event_bus.topic_constants``); that is
+    injected as a callable via :meth:`set_dlq_topic_deriver`, keeping the mixin
+    infra-free while preserving the ``dlq_topic`` element of the tuple.
+
+Usage as a node mixin:
+    ``__init__`` is cooperative (``super().__init__(**kwargs)``) so the mixin
+    slots into a node MRO exactly like :class:`MixinHandlerRouting`. State is
+    lazily materialized, so a node that never registers routes carries no
+    dispatch table and pays nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_dispatch_status import EnumDispatchStatus
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_core.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_core.models.errors import ModelOnexError
+
+if TYPE_CHECKING:
+    from omnibase_core.enums.enum_node_kind import EnumNodeKind
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+__all__ = ["MixinNodeDispatch"]
+
+# A dispatcher is any callable the node registers; selection never invokes it, so
+# its precise signature is irrelevant to this mixin (execution lives elsewhere).
+_DispatcherCallable = Callable[..., object]
+
+# Injected DLQ-topic deriver: ``(event_type | None, original_topic) -> dlq_topic | None``.
+# The infra runtime injects ``message_dispatch_engine._derive_dlq_topic`` so the
+# NO_DISPATCHER tuple's ``dlq_topic`` element matches the live engine. When absent,
+# derivation yields ``None`` (the mixin never imports infra topic constants).
+DlqTopicDeriver = Callable[[str | None, str], str | None]
+
+
+class _NodeDispatchEntry:
+    """Selection metadata for one registered dispatcher (core-only mirror of the
+    engine's ``DispatchEntryInternal``, minus the execution-only fields)."""
+
+    __slots__ = (
+        "category",
+        "dispatcher",
+        "dispatcher_id",
+        "message_types",
+        "node_kind",
+        "payload_type_matcher",
+    )
+
+    def __init__(
+        self,
+        *,
+        dispatcher_id: str,
+        dispatcher: _DispatcherCallable,
+        category: EnumMessageCategory,
+        message_types: set[str] | None,
+        node_kind: EnumNodeKind | None,
+        payload_type_matcher: Callable[[object], bool] | None,
+    ) -> None:
+        self.dispatcher_id = dispatcher_id
+        self.dispatcher = dispatcher
+        self.category = category
+        self.message_types = message_types  # None means "all message types"
+        self.node_kind = node_kind
+        # None means "not type-scoped" — legacy string-only matching applies.
+        self.payload_type_matcher = payload_type_matcher
+
+
+class _NodeDispatchState:
+    """Per-instance selection table. Materialized lazily so an unused mixin is inert."""
+
+    __slots__ = ("dispatchers", "dlq_topic_deriver", "frozen", "routes")
+
+    def __init__(self) -> None:
+        self.routes: dict[str, ModelDispatchRoute] = {}
+        self.dispatchers: dict[str, _NodeDispatchEntry] = {}
+        self.frozen: bool = False
+        self.dlq_topic_deriver: DlqTopicDeriver | None = None
+
+
+class MixinNodeDispatch:
+    """Contract-table dispatch **selection** owned by the node (OMN-12549).
+
+    Public surface mirrors the engine's registration + dispatch API so the same
+    probe corpus can drive both behind ``ProtocolDispatchEngine``:
+    :meth:`register_dispatcher`, :meth:`register_route`, :meth:`freeze`, and the
+    async :meth:`dispatch`. Selection is stateless and deterministic: the same
+    frozen table and input always yield the same dispatcher selection and tuple.
+    """
+
+    # Class-level annotation only (no assignment) so mypy sees the attribute while
+    # the value is materialized lazily via ``_state``. Mirrors MixinHandlerRouting.
+    _node_dispatch_state: _NodeDispatchState
+
+    def __init__(self, **kwargs: object) -> None:
+        """Cooperative MRO init. State is created here for standalone use and is
+        also (re)materialized lazily so node subclasses that skip kwargs are safe."""
+        super().__init__(**kwargs)
+        self._node_dispatch_state = _NodeDispatchState()
+
+    # -- internal state access ------------------------------------------------
+
+    def _state(self) -> _NodeDispatchState:
+        """Return the selection table, materializing it on first use.
+
+        Lazy creation keeps the mixin inert when a node never registers routes and
+        tolerates instantiation paths that bypass ``__init__`` (defensive)."""
+        state = getattr(self, "_node_dispatch_state", None)
+        if state is None:
+            state = _NodeDispatchState()
+            self._node_dispatch_state = state
+        return state
+
+    # -- configuration --------------------------------------------------------
+
+    def set_dlq_topic_deriver(self, deriver: DlqTopicDeriver | None) -> None:
+        """Inject the DLQ-topic deriver used on the NO_DISPATCHER path.
+
+        The mixin stays infra-free by never importing DLQ topic constants; the
+        runtime injects ``message_dispatch_engine._derive_dlq_topic`` so the
+        ``dlq_topic`` element of the selection tuple matches the live engine.
+        """
+        self._state().dlq_topic_deriver = deriver
+
+    # -- registration ---------------------------------------------------------
+
+    def register_route(self, route: ModelDispatchRoute) -> None:
+        """Register a routing rule (duplicate ``route_id`` is rejected)."""
+        if route is None:
+            raise ModelOnexError(
+                message="Cannot register None route. ModelDispatchRoute is required.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+        state = self._state()
+        if state.frozen:
+            raise ModelOnexError(
+                message="Cannot register route: MixinNodeDispatch is frozen. "
+                "Registration is not allowed after freeze().",
+                error_code=EnumCoreErrorCode.INVALID_STATE,
+            )
+        if route.route_id in state.routes:
+            raise ModelOnexError(
+                message=f"Route with ID '{route.route_id}' is already registered.",
+                error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
+            )
+        state.routes[route.route_id] = route
+
+    def register_dispatcher(
+        self,
+        dispatcher_id: str,
+        dispatcher: _DispatcherCallable,
+        category: EnumMessageCategory,
+        message_types: set[str] | None = None,
+        node_kind: EnumNodeKind | None = None,
+        payload_type_matcher: Callable[[object], bool] | None = None,
+    ) -> None:
+        """Register a dispatcher (duplicate ``dispatcher_id`` is rejected).
+
+        ``payload_type_matcher`` makes the dispatcher type-scoped: it is selected
+        only when the matcher accepts the message payload (OMN-12416), so a
+        multi-handler contract routes each message to the single handler whose
+        declared ``event_model`` matches instead of fanning out to every sibling.
+        ``node_kind`` is retained for parity with the engine registration surface
+        but does not influence selection (it drives execution-time context only).
+        """
+        if not dispatcher_id or not dispatcher_id.strip():
+            raise ModelOnexError(
+                message="Dispatcher ID cannot be empty or whitespace.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+        if dispatcher is None or not callable(dispatcher):
+            raise ModelOnexError(
+                message=f"Dispatcher for '{dispatcher_id}' must be callable. "
+                f"Got {type(dispatcher).__name__}.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+        state = self._state()
+        if state.frozen:
+            raise ModelOnexError(
+                message="Cannot register dispatcher: MixinNodeDispatch is frozen. "
+                "Registration is not allowed after freeze().",
+                error_code=EnumCoreErrorCode.INVALID_STATE,
+            )
+        if dispatcher_id in state.dispatchers:
+            raise ModelOnexError(
+                message=f"Dispatcher with ID '{dispatcher_id}' is already registered.",
+                error_code=EnumCoreErrorCode.DUPLICATE_REGISTRATION,
+            )
+        state.dispatchers[dispatcher_id] = _NodeDispatchEntry(
+            dispatcher_id=dispatcher_id,
+            dispatcher=dispatcher,
+            category=category,
+            message_types=message_types,
+            node_kind=node_kind,
+            payload_type_matcher=payload_type_matcher,
+        )
+
+    def freeze(self) -> None:
+        """Freeze the table for dispatch. Validates every route references a
+        registered dispatcher; idempotent once frozen."""
+        state = self._state()
+        if state.frozen:
+            return
+        for route in state.routes.values():
+            rid = route.handler_id
+            if rid not in state.dispatchers:
+                raise ModelOnexError(
+                    message=f"Route '{route.route_id}' references dispatcher "
+                    f"'{rid}' which is not registered.",
+                    error_code=EnumCoreErrorCode.ITEM_NOT_REGISTERED,
+                )
+        state.frozen = True
+
+    @property
+    def is_frozen(self) -> bool:
+        """True once :meth:`freeze` has been called."""
+        return self._state().frozen
+
+    # -- selection ------------------------------------------------------------
+
+    def _find_matching_dispatchers(
+        self,
+        *,
+        topic: str,
+        category: EnumMessageCategory,
+        message_type: str,
+        payload: object | None,
+    ) -> list[_NodeDispatchEntry]:
+        """Port of the engine's ``_find_matching_dispatchers`` (selection only).
+
+        Iterates routes in registration (insertion) order — the fan-out order the
+        tuple pins — and keeps each route's dispatcher when: the route is enabled
+        and matches the topic + category (+ optional route message-type filter),
+        the dispatcher's own message-type filter admits ``message_type``, and, for
+        type-scoped dispatchers, the payload matches the declared event_model.
+        """
+        matching: list[_NodeDispatchEntry] = []
+        seen: set[str] = set()
+        state = self._state()
+        for route in state.routes.values():
+            if not route.enabled:
+                continue
+            if not route.matches_topic(topic):
+                continue
+            if route.message_category != category:
+                continue
+            if route.message_type is not None and route.message_type != message_type:
+                continue
+            dispatcher_id = route.handler_id
+            if dispatcher_id in seen:
+                continue
+            entry = state.dispatchers.get(dispatcher_id)
+            if entry is None:
+                # Should be impossible after freeze() validation; skip defensively.
+                continue
+            if (
+                entry.message_types is not None
+                and message_type not in entry.message_types
+            ):
+                continue
+            if (
+                payload is not None
+                and entry.payload_type_matcher is not None
+                and not self._payload_matches(entry, payload)
+            ):
+                continue
+            matching.append(entry)
+            seen.add(dispatcher_id)
+        return matching
+
+    @staticmethod
+    def _payload_matches(entry: _NodeDispatchEntry, payload: object) -> bool:
+        """True when ``payload`` matches a type-scoped dispatcher's event_model.
+
+        A raising matcher means "not my type" (never selected), mirroring the
+        engine — a malformed/wrong-type payload never selects a type-scoped
+        dispatcher. Callers only invoke this when a matcher is present.
+        """
+        matcher = entry.payload_type_matcher
+        if matcher is None:
+            return True
+        try:
+            return bool(matcher(payload))
+        except Exception:  # noqa: BLE001 — a raising matcher means "not my type"
+            return False
+
+    async def dispatch(
+        self,
+        topic: str,
+        envelope: ModelEventEnvelope[object],
+    ) -> ModelDispatchResult:
+        """Select the dispatchers a ``(topic, envelope)`` routes to.
+
+        Returns a :class:`ModelDispatchResult` whose equivalence tuple matches the
+        live engine's for the same input:
+
+        * ``INVALID_MESSAGE`` when the topic yields no message category;
+        * ``NO_DISPATCHER`` (with an injected ``dlq_topic``) when nothing matches;
+        * ``SUCCESS`` with the ordered matched dispatcher ids otherwise.
+
+        Selection performs no handler execution; ``dispatcher_id`` carries the
+        comma-joined ordered selection, exactly as the engine records the executed
+        fan-out for an inert (side-effect-free) dispatcher.
+        """
+        state = self._state()
+        if not state.frozen:
+            raise ModelOnexError(
+                message="dispatch() called before freeze(). "
+                "Registration MUST complete and freeze() MUST be called before dispatch.",
+                error_code=EnumCoreErrorCode.INVALID_STATE,
+            )
+        if not topic or not topic.strip():
+            raise ModelOnexError(
+                message="Topic cannot be empty or whitespace.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+        if envelope is None:
+            raise ModelOnexError(
+                message="Cannot dispatch None envelope. ModelEventEnvelope is required.",
+                error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            )
+
+        dispatch_id = uuid4()
+        started_at = datetime.now(UTC)
+        correlation_id = self._extract_correlation_id(envelope)
+
+        # Step 1: parse topic -> category. No category => INVALID_MESSAGE (no DLQ,
+        # no message_category/type recorded), matching the engine's early return.
+        topic_category = EnumMessageCategory.from_topic(topic)
+        if topic_category is None:
+            return ModelDispatchResult(
+                dispatch_id=dispatch_id,
+                status=EnumDispatchStatus.INVALID_MESSAGE,
+                topic=topic,
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                error_message=(
+                    f"Cannot infer message category from topic '{topic}'. "
+                    "Topic must contain .events, .commands, .intents, or .projections segment."
+                ),
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                correlation_id=correlation_id,
+                output_events=[],
+            )
+
+        # Step 2: routing key from event_type (preferred) or payload class name.
+        event_type, payload = self._extract_routing_inputs(envelope)
+        normalized_event_type = (
+            str(event_type).strip() if event_type is not None else ""
+        )
+        message_type = (
+            normalized_event_type if normalized_event_type else type(payload).__name__
+        )
+
+        # Step 3: selection.
+        matching = self._find_matching_dispatchers(
+            topic=topic,
+            category=topic_category,
+            message_type=message_type,
+            payload=payload,
+        )
+
+        if not matching:
+            dlq_topic = self._derive_dlq_topic(
+                normalized_event_type if normalized_event_type else None, topic
+            )
+            return ModelDispatchResult(
+                dispatch_id=dispatch_id,
+                status=EnumDispatchStatus.NO_DISPATCHER,
+                topic=topic,
+                message_category=topic_category,
+                message_type=message_type,
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                dlq_topic=dlq_topic,
+                error_message=(
+                    f"No dispatcher registered for category '{topic_category}' "
+                    f"and message type '{message_type}' matching topic '{topic}'."
+                ),
+                error_code=EnumCoreErrorCode.ITEM_NOT_REGISTERED,
+                correlation_id=correlation_id,
+                output_events=[],
+            )
+
+        ordered_ids = [entry.dispatcher_id for entry in matching]
+        matched_route_id = self._first_matching_route_id(
+            topic, topic_category, message_type
+        )
+        return ModelDispatchResult(
+            dispatch_id=dispatch_id,
+            status=EnumDispatchStatus.SUCCESS,
+            route_id=matched_route_id,
+            dispatcher_id=", ".join(ordered_ids),
+            topic=topic,
+            message_category=topic_category,
+            message_type=message_type,
+            started_at=started_at,
+            completed_at=datetime.now(UTC),
+            output_count=0,
+            output_events=[],
+            correlation_id=correlation_id,
+        )
+
+    # -- helpers --------------------------------------------------------------
+
+    def _derive_dlq_topic(self, event_type: str | None, topic: str) -> str | None:
+        """Delegate to the injected deriver; ``None`` when none is configured."""
+        deriver = self._state().dlq_topic_deriver
+        if deriver is None:
+            return None
+        try:
+            return deriver(event_type, topic)
+        except Exception:  # noqa: BLE001 — DLQ derivation must never crash selection
+            return None
+
+    def _first_matching_route_id(
+        self,
+        topic: str,
+        category: EnumMessageCategory,
+        message_type: str,
+    ) -> str | None:
+        """First route (insertion order) fully matching topic/category/type, for
+        logging parity with the engine's ``matched_route_id``."""
+        for route in self._state().routes.values():
+            if route.matches(topic, category, message_type):
+                return route.route_id
+        return None
+
+    @staticmethod
+    def _extract_routing_inputs(envelope: object) -> tuple[object | None, object]:
+        """Extract ``(event_type, payload)`` from dict or model envelopes, matching
+        the engine's field-presence handling.
+
+        ``envelope`` is typed ``object`` (not ``ModelEventEnvelope``) because the
+        runtime may hand this mixin a raw dict envelope on some paths; the dict
+        branch would otherwise be statically unreachable.
+        """
+        if isinstance(envelope, dict):
+            return envelope.get("event_type"), envelope.get("payload", envelope)
+        return getattr(envelope, "event_type", None), getattr(envelope, "payload", None)
+
+    @staticmethod
+    def _extract_correlation_id(envelope: object) -> UUID:
+        """Correlation id from the envelope, auto-generated when absent (parity
+        with the engine's ``envelope.correlation_id or uuid4()``)."""
+        if isinstance(envelope, dict):
+            existing = envelope.get("correlation_id")
+        else:
+            existing = getattr(envelope, "correlation_id", None)
+        if isinstance(existing, UUID):
+            return existing
+        return uuid4()

--- a/tests/unit/runtime/test_mixin_node_dispatch.py
+++ b/tests/unit/runtime/test_mixin_node_dispatch.py
@@ -272,21 +272,20 @@ async def test_type_scoped_matcher_rejects_nonmatching_payload() -> None:
 
 
 @pytest.mark.asyncio
-async def test_type_scoped_matcher_rejects_none_payload() -> None:
+async def test_none_payload_skips_type_scoping_keeps_dispatcher() -> None:
+    """Engine-fidelity: with no payload, type-scoping is SKIPPED and the
+    type-scoped dispatcher is KEPT (selected), matching the live engine's
+    ``_find_matching_dispatchers`` guard ``payload is not None``.
+
+    The matcher is never invoked on a ``None`` payload — a matcher that would
+    reject ``None`` must NOT drop the dispatcher, because the engine does not run
+    it in the payload-less path. This pins parity on the edge the S0 harness does
+    not probe (it always supplies a payload).
+    """
     mixin = MixinNodeDispatch()
+    # A matcher that rejects everything except _AlphaPayload — it must NOT be
+    # consulted when payload is None, so the dispatcher stays selected.
     _register_single(mixin, payload_type_matcher=lambda p: isinstance(p, _AlphaPayload))
-    mixin.freeze()
-
-    result = await mixin.dispatch(
-        _EVENTS_TOPIC, _envelope(event_type=None, payload=None)
-    )
-    assert _selection_tuple(result)[0] == "no_dispatcher"
-
-
-@pytest.mark.asyncio
-async def test_type_scoped_matcher_can_accept_none_payload() -> None:
-    mixin = MixinNodeDispatch()
-    _register_single(mixin, payload_type_matcher=lambda p: p is None)
     mixin.freeze()
 
     result = await mixin.dispatch(

--- a/tests/unit/runtime/test_mixin_node_dispatch.py
+++ b/tests/unit/runtime/test_mixin_node_dispatch.py
@@ -16,6 +16,8 @@ and stay stable, using only core symbols.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import BaseModel
 
@@ -81,6 +83,8 @@ def _register_single(
         dispatcher=_noop_dispatcher,
         category=EnumMessageCategory.EVENT,
         message_types=message_types,
+        # NOTE(OMN-12549): tests pass matcher callables with narrower payload
+        # assumptions to pin runtime behavior around rejected payloads.
         payload_type_matcher=payload_type_matcher,  # type: ignore[arg-type]
     )
     mixin.register_route(
@@ -268,6 +272,30 @@ async def test_type_scoped_matcher_rejects_nonmatching_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_type_scoped_matcher_rejects_none_payload() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, payload_type_matcher=lambda p: isinstance(p, _AlphaPayload))
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=None)
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+@pytest.mark.asyncio
+async def test_type_scoped_matcher_can_accept_none_payload() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, payload_type_matcher=lambda p: p is None)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=None)
+    )
+    assert _selection_tuple(result)[0] == "success"
+
+
+@pytest.mark.asyncio
 async def test_raising_matcher_is_treated_as_non_match() -> None:
     def _raises(_payload: object) -> bool:
         raise ValueError("not my type")
@@ -309,6 +337,42 @@ async def test_route_message_type_filter_excludes_mismatch() -> None:
         _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
     )
     assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_message_types_are_snapshotted_on_registration() -> None:
+    message_types = {"_AlphaPayload"}
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, message_types=message_types)
+    message_types.clear()
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "success"
+
+
+@pytest.mark.asyncio
+async def test_route_id_comes_from_selected_dispatcher_route() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(
+        mixin,
+        dispatcher_id="d_reject",
+        payload_type_matcher=lambda p: isinstance(p, _BetaPayload),
+    )
+    _register_single(
+        mixin,
+        dispatcher_id="d_accept",
+        payload_type_matcher=lambda p: isinstance(p, _AlphaPayload),
+    )
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert result.route_id == "r-d_accept"
+    assert _selection_tuple(result)[1] == ("d_accept",)
 
 
 # ---------------------------------------------------------------------------
@@ -383,6 +447,64 @@ def test_freeze_validates_route_references_dispatcher() -> None:
     with pytest.raises(ModelOnexError) as exc:
         mixin.freeze()
     assert exc.value.error_code == EnumCoreErrorCode.ITEM_NOT_REGISTERED
+
+
+def test_register_route_rejects_existing_dispatcher_category_mismatch() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_dispatcher(
+        dispatcher_id="d1",
+        dispatcher=_noop_dispatcher,
+        category=EnumMessageCategory.COMMAND,
+    )
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_route(
+            ModelDispatchRoute(
+                route_id="r1",
+                topic_pattern="onex.evt.platform.*.v1",
+                message_category=EnumMessageCategory.EVENT,
+                handler_id="d1",
+            )
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER
+
+
+def test_register_dispatcher_rejects_existing_route_category_mismatch() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_route(
+        ModelDispatchRoute(
+            route_id="r1",
+            topic_pattern="onex.evt.platform.*.v1",
+            message_category=EnumMessageCategory.EVENT,
+            handler_id="d1",
+        )
+    )
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_dispatcher(
+            dispatcher_id="d1",
+            dispatcher=_noop_dispatcher,
+            category=EnumMessageCategory.COMMAND,
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER
+
+
+def test_freeze_rejects_route_dispatcher_category_mismatch() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_route(
+        ModelDispatchRoute(
+            route_id="r1",
+            topic_pattern="onex.evt.platform.*.v1",
+            message_category=EnumMessageCategory.EVENT,
+            handler_id="d1",
+        )
+    )
+    state = mixin._state()
+    state.dispatchers["d1"] = SimpleNamespace(
+        category=EnumMessageCategory.COMMAND,
+        dispatcher_id="d1",
+    )  # type: ignore[assignment]
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.freeze()
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER
 
 
 def test_empty_dispatcher_id_rejected() -> None:

--- a/tests/unit/runtime/test_mixin_node_dispatch.py
+++ b/tests/unit/runtime/test_mixin_node_dispatch.py
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Selection-semantics tests for ``MixinNodeDispatch`` (OMN-12549, epic OMN-12525).
+
+These pin the core-side seam's selection tuple
+
+    (status, ordered dispatcher_ids, message_category, message_type, dlq_topic)
+
+against the behavior it ports from the live
+``omnibase_infra.runtime.message_dispatch_engine`` ``_find_matching_dispatchers`` +
+``dispatch()`` selection path. The cross-repo dual-implementation parity gate
+(OMN-12548 Mode B, in omnibase_infra) asserts tuple equality against the engine
+itself; these tests are the in-repo proof that the ported semantics are correct
+and stay stable, using only core symbols.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_core.models.errors import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.nodes.node_effect import NodeEffect
+from omnibase_core.nodes.node_orchestrator import NodeOrchestrator
+from omnibase_core.runtime.mixin_node_dispatch import MixinNodeDispatch
+
+pytestmark = pytest.mark.unit
+
+_EVENTS_TOPIC = "onex.evt.platform.thing-happened.v1"  # onex-topic-allow: test fixture
+
+
+def _noop_dispatcher(_envelope: object) -> None:
+    """Inert dispatcher — selection never invokes it."""
+    return
+
+
+class _AlphaPayload(BaseModel):
+    value: int = 0
+
+
+class _BetaPayload(BaseModel):
+    value: int = 0
+
+
+def _selection_tuple(result: object) -> tuple[object, ...]:
+    """Extract the design-D2 equivalence tuple from a ModelDispatchResult."""
+    raw = getattr(result, "dispatcher_id", None) or ""
+    ordered = [d for d in (p.strip() for p in raw.split(",")) if d]
+    category = getattr(result, "message_category", None)
+    return (
+        result.status.value,
+        tuple(ordered),
+        category.value if category is not None else None,
+        getattr(result, "message_type", None),
+        getattr(result, "dlq_topic", None),
+    )
+
+
+def _envelope(*, event_type: str | None, payload: object) -> ModelEventEnvelope[object]:
+    kwargs: dict[str, object] = {"payload": payload}
+    if event_type is not None:
+        kwargs["event_type"] = event_type
+    return ModelEventEnvelope(**kwargs)
+
+
+def _register_single(
+    mixin: MixinNodeDispatch,
+    *,
+    dispatcher_id: str = "d1",
+    message_types: set[str] | None = None,
+    payload_type_matcher: object = None,
+    topic_pattern: str = "onex.evt.platform.*.v1",
+    route_message_type: str | None = None,
+) -> None:
+    mixin.register_dispatcher(
+        dispatcher_id=dispatcher_id,
+        dispatcher=_noop_dispatcher,
+        category=EnumMessageCategory.EVENT,
+        message_types=message_types,
+        payload_type_matcher=payload_type_matcher,  # type: ignore[arg-type]
+    )
+    mixin.register_route(
+        ModelDispatchRoute(
+            route_id=f"r-{dispatcher_id}",
+            topic_pattern=topic_pattern,
+            message_category=EnumMessageCategory.EVENT,
+            message_type=route_message_type,
+            handler_id=dispatcher_id,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path + fan-out ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_single_dispatcher_selection_tuple() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result) == (
+        "success",
+        ("d1",),
+        "event",
+        "_AlphaPayload",
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fanout_preserves_registration_order() -> None:
+    """Multiple dispatchers on one topic fan out in route registration order."""
+    mixin = MixinNodeDispatch()
+    for did in ("d_a", "d_b", "d_c"):
+        _register_single(mixin, dispatcher_id=did)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    status, ordered, *_ = _selection_tuple(result)
+    assert status == "success"
+    assert ordered == ("d_a", "d_b", "d_c")
+
+
+@pytest.mark.asyncio
+async def test_event_type_overrides_payload_class_for_message_type() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, message_types={"platform.thing.v1"})
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC,
+        _envelope(event_type="platform.thing.v1", payload=_AlphaPayload()),
+    )
+    status, ordered, _cat, message_type, _dlq = _selection_tuple(result)
+    assert status == "success"
+    assert ordered == ("d1",)
+    assert message_type == "platform.thing.v1"
+
+
+# ---------------------------------------------------------------------------
+# NO_DISPATCHER + DLQ deriver injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_dispatcher_without_deriver_has_none_dlq() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, topic_pattern="onex.evt.other.*.v1")
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    status, ordered, category, _mt, dlq = _selection_tuple(result)
+    assert status == "no_dispatcher"
+    assert ordered == ()
+    assert category == "event"
+    assert dlq is None
+
+
+@pytest.mark.asyncio
+async def test_no_dispatcher_uses_injected_deriver() -> None:
+    """The injected deriver supplies the ``dlq_topic`` element of the tuple."""
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, topic_pattern="onex.evt.other.*.v1")
+
+    seen: list[tuple[str | None, str]] = []
+
+    def _deriver(event_type: str | None, topic: str) -> str | None:
+        seen.append((event_type, topic))
+        return "onex.dlq.omnibase-infra.platform.v1"  # onex-topic-allow: test fixture
+
+    mixin.set_dlq_topic_deriver(_deriver)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC,
+        _envelope(event_type="platform.x.v1", payload=_AlphaPayload()),
+    )
+    assert _selection_tuple(result)[4] == "onex.dlq.omnibase-infra.platform.v1"
+    # event_type is forwarded normalized (non-empty), topic verbatim.
+    assert seen == [("platform.x.v1", _EVENTS_TOPIC)]
+
+
+@pytest.mark.asyncio
+async def test_deriver_raise_is_swallowed_to_none() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, topic_pattern="onex.evt.other.*.v1")
+
+    def _bad(_event_type: str | None, _topic: str) -> str | None:
+        raise RuntimeError("boom")
+
+    mixin.set_dlq_topic_deriver(_bad)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+    assert _selection_tuple(result)[4] is None
+
+
+# ---------------------------------------------------------------------------
+# INVALID_MESSAGE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uncategorizable_topic_is_invalid_message() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin)
+    mixin.freeze()
+
+    # No category segment (events/commands/intents/evt/cmd/intent) -> None category.
+    result = await mixin.dispatch(
+        "weird.random.topic", _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result) == (
+        "invalid_message",
+        (),
+        None,
+        None,
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Payload type-scoping (OMN-12416)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_type_scoped_matcher_accepts_matching_payload() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, payload_type_matcher=lambda p: isinstance(p, _AlphaPayload))
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "success"
+
+
+@pytest.mark.asyncio
+async def test_type_scoped_matcher_rejects_nonmatching_payload() -> None:
+    """A type-scoped dispatcher whose matcher rejects the payload is dropped ->
+    NO_DISPATCHER, not an error (OMN-12416)."""
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, payload_type_matcher=lambda p: isinstance(p, _AlphaPayload))
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_BetaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+@pytest.mark.asyncio
+async def test_raising_matcher_is_treated_as_non_match() -> None:
+    def _raises(_payload: object) -> bool:
+        raise ValueError("not my type")
+
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, payload_type_matcher=_raises)
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# Message-type filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_message_types_filter_excludes_mismatch() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, message_types={"SomethingElse"})
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+@pytest.mark.asyncio
+async def test_route_message_type_filter_excludes_mismatch() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin, route_message_type="OnlyThisType")
+    mixin.freeze()
+
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle / guard rails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_before_freeze_raises_invalid_state() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin)
+    with pytest.raises(ModelOnexError) as exc:
+        await mixin.dispatch(
+            _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+
+def test_register_after_freeze_raises() -> None:
+    mixin = MixinNodeDispatch()
+    _register_single(mixin)
+    mixin.freeze()
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_dispatcher(
+            dispatcher_id="d2",
+            dispatcher=_noop_dispatcher,
+            category=EnumMessageCategory.EVENT,
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_STATE
+
+
+def test_duplicate_dispatcher_id_rejected() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_dispatcher(
+        dispatcher_id="d1",
+        dispatcher=_noop_dispatcher,
+        category=EnumMessageCategory.EVENT,
+    )
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_dispatcher(
+            dispatcher_id="d1",
+            dispatcher=_noop_dispatcher,
+            category=EnumMessageCategory.EVENT,
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.DUPLICATE_REGISTRATION
+
+
+def test_duplicate_route_id_rejected() -> None:
+    mixin = MixinNodeDispatch()
+    route = ModelDispatchRoute(
+        route_id="r1",
+        topic_pattern="onex.evt.platform.*.v1",
+        message_category=EnumMessageCategory.EVENT,
+        handler_id="d1",
+    )
+    mixin.register_route(route)
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_route(route)
+    assert exc.value.error_code == EnumCoreErrorCode.DUPLICATE_REGISTRATION
+
+
+def test_freeze_validates_route_references_dispatcher() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_route(
+        ModelDispatchRoute(
+            route_id="r1",
+            topic_pattern="onex.evt.platform.*.v1",
+            message_category=EnumMessageCategory.EVENT,
+            handler_id="missing_dispatcher",
+        )
+    )
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.freeze()
+    assert exc.value.error_code == EnumCoreErrorCode.ITEM_NOT_REGISTERED
+
+
+def test_empty_dispatcher_id_rejected() -> None:
+    mixin = MixinNodeDispatch()
+    with pytest.raises(ModelOnexError) as exc:
+        mixin.register_dispatcher(
+            dispatcher_id="  ",
+            dispatcher=_noop_dispatcher,
+            category=EnumMessageCategory.EVENT,
+        )
+    assert exc.value.error_code == EnumCoreErrorCode.INVALID_PARAMETER
+
+
+# ---------------------------------------------------------------------------
+# Node MRO placement (additive; engine stays live)
+# ---------------------------------------------------------------------------
+
+
+def test_mixin_is_in_orchestrator_and_effect_mro() -> None:
+    assert MixinNodeDispatch in NodeOrchestrator.__mro__
+    assert MixinNodeDispatch in NodeEffect.__mro__
+
+
+@pytest.mark.asyncio
+async def test_disabled_route_is_skipped() -> None:
+    mixin = MixinNodeDispatch()
+    mixin.register_dispatcher(
+        dispatcher_id="d1",
+        dispatcher=_noop_dispatcher,
+        category=EnumMessageCategory.EVENT,
+    )
+    mixin.register_route(
+        ModelDispatchRoute(
+            route_id="r1",
+            topic_pattern="onex.evt.platform.*.v1",
+            message_category=EnumMessageCategory.EVENT,
+            handler_id="d1",
+            enabled=False,
+        )
+    )
+    mixin.freeze()
+    result = await mixin.dispatch(
+        _EVENTS_TOPIC, _envelope(event_type=None, payload=_AlphaPayload())
+    )
+    assert _selection_tuple(result)[0] == "no_dispatcher"


### PR DESCRIPTION
Evidence-Ticket: OMN-12549
Evidence-Source: OCC#3498
## OMN-12549 — S0-seam: MixinNodeDispatch (node-owned dispatch selection)

Epic **OMN-12525** (dispatch-chain unification), stage **S0-seam**. Prerequisite S0-gate parity test (OMN-12548) is already on `dev` in omnibase_infra.

### What this PR does
Adds `omnibase_core.runtime.mixin_node_dispatch.MixinNodeDispatch` — the core-only, node-owned successor to `MessageDispatchEngine` **selection**. It ports the live infra engine's `_find_matching_dispatchers` plus the surrounding `dispatch()` category/message-type derivation, using **core symbols only**, so orchestrator/effect nodes can own dispatch selection without importing `omnibase_infra`.

- **Selection only** (no handler execution). `dispatch(topic, envelope) -> ModelDispatchResult` whose equivalence tuple `(status, ordered dispatcher_ids, message_category, message_type, dlq_topic)` matches the live engine for the same input.
- **DLQ derivation injected**: the one infra-specific step (`event_bus.topic_constants`) is supplied via `set_dlq_topic_deriver`, keeping the mixin infra-free while preserving the `dlq_topic` tuple element for the OMN-12548 Mode-B gate.
- **Additive MRO placement** on `NodeOrchestrator` + `NodeEffect` (cooperative `super().__init__`, lazy state). No behavior change — the engine stays live; nodes don't call the mixin yet. `NodeCompute` is **untouched**: the ticket said "NodeCompute loses routing," but `MixinHandlerRouting._init_handler_routing` has live callers (`node_compute.py:182`, `node_orchestrator.py:371`, infra `node_registration_orchestrator`), so that removal is a separate follow-up rather than a silent behavior change here.

### Cross-repo sequencing (release-gated)
This is one slice of a 3-repo seam. The infra Mode-B parity flip cannot go green until this lands + omnibase-core is **released** and infra bumps its `omnibase-core` pin (infra consumes core from PyPI, not a workspace path). Order: **core (this) → spi (ProtocolDispatchEngine move) → infra (couplings + Mode-B flip)**.

### dod_evidence
- New `tests/unit/runtime/test_mixin_node_dispatch.py` (20 tests) pins the selection tuple: success + fan-out ordering, NO_DISPATCHER with/without injected DLQ deriver, INVALID_MESSAGE, payload type-scoping accept/reject/raising-matcher, dispatcher + route message-type filters, freeze/registration guard rails, disabled-route skip, and MRO placement. `20 passed`.
- `mypy src/omnibase_core/` (strict): `Success: no issues found in 4066 source files`.
- Node/runtime/mixin suites: orchestrator+effect `112 passed`; runtime+mixins `925 passed` (no MRO regression).
- `ruff format` + `ruff check` clean; pre-commit clean at commit.

Do not merge until the merge/release lane sequences the core→spi→infra release train.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dispatch selection support for nodes, enabling them to route events to the appropriate dispatcher with deterministic ordering and filtering.

* **Bug Fixes**
  * Improved handling for unmatched or invalid messages, including clearer no-dispatch and invalid-message outcomes.
  * Added safeguards for registration and freeze behavior to prevent duplicate or invalid dispatch setup.
  * Disabled routes are now skipped during dispatch selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

