### PR TITLE
fix(OMN-13857): onex run-node fails fast with an actionable message on missing/unreachable Kafka

### DIFF
--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -43,6 +43,28 @@ def _emit_error(node_id: str, message: str, **extra: str | int) -> NoReturn:
     sys.exit(1)
 
 
+def _resolve_bootstrap_servers(node_id: str) -> str:
+    """Return the Kafka bootstrap servers for ``run-node``, or fail fast clearly.
+
+    ``onex run-node`` dispatches over Kafka, so it needs a reachable broker.
+    Before OMN-13857 an unset ``KAFKA_BOOTSTRAP_SERVERS`` raised a bare
+    ``KeyError`` traceback and an empty value produced an opaque
+    ``_TRANSPORT`` failure. Both now emit a single actionable SkillRoutingError:
+    point the variable at a reachable lane broker, or run the node locally
+    (bus-less) with ``onex run <node>``.
+    """
+    bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "").strip()
+    if not bootstrap:
+        _emit_error(
+            node_id,
+            "KAFKA_BOOTSTRAP_SERVERS is not set. `onex run-node` dispatches over "
+            "Kafka and needs a reachable broker — export "
+            "KAFKA_BOOTSTRAP_SERVERS=<host:port> for your lane. To execute this "
+            f"node locally without a bus, use `onex run {node_id}` instead.",
+        )
+    return bootstrap
+
+
 def _coerce_contract_metadata(
     contract: ModelGenericYaml | dict[str, object],
 ) -> dict[str, object]:
@@ -196,7 +218,22 @@ def publish_and_poll(
     try:
         # Explicit assignment is more reliable than ephemeral group rebalances
         # for one-shot request/response flows.
-        metadata = consumer.list_topics(response_topic, timeout=10.0)
+        try:
+            metadata = consumer.list_topics(response_topic, timeout=10.0)
+        except Exception as exc:
+            # OMN-13857: the first broker touch fails with a raw
+            # confluent_kafka.KafkaException (_TRANSPORT) when the bootstrap
+            # address is unreachable. Convert it into an actionable error
+            # instead of surfacing an opaque traceback.
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.RUNTIME_ERROR,
+                message=(
+                    f"Kafka broker unreachable at {bootstrap_servers!r}: {exc}. "
+                    "Verify KAFKA_BOOTSTRAP_SERVERS points at a reachable lane "
+                    f"broker, or run the node locally (bus-less) with `onex run "
+                    f"{node_id}`."
+                ),
+            ) from exc
         topic_metadata = metadata.topics.get(response_topic)
         if topic_metadata is None or getattr(topic_metadata, "error", None) is not None:
             raise ModelOnexError(
@@ -287,7 +324,7 @@ def run_node(node_id: str, input_json: str, timeout: int) -> None:
     except json.JSONDecodeError as exc:
         _emit_error(node_id, f"Invalid JSON input: {exc}")
 
-    bootstrap_servers = os.environ["KAFKA_BOOTSTRAP_SERVERS"]
+    bootstrap_servers = _resolve_bootstrap_servers(node_id)
 
     try:
         (

--- a/tests/unit/cli/test_omn_13857_run_node_bootstrap.py
+++ b/tests/unit/cli/test_omn_13857_run_node_bootstrap.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-13857: ``onex run-node`` fails fast with an actionable message.
+
+Before this fix, an unset ``KAFKA_BOOTSTRAP_SERVERS`` raised a bare ``KeyError``
+traceback and an unreachable broker surfaced an opaque
+``confluent_kafka.KafkaException`` (``_TRANSPORT``). Both now emit a single
+actionable error that points the operator at the reachable-lane env var or the
+bus-less ``onex run <node>`` fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+
+_PATCH_PRODUCER = "confluent_kafka.Producer"
+_PATCH_CONSUMER = "confluent_kafka.Consumer"
+_PATCH_TOPIC_PARTITION = "confluent_kafka.TopicPartition"
+
+
+class _FakeTopicPartition:
+    def __init__(self, topic: str, partition: int, offset: int | None = None) -> None:
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
+
+
+class TestResolveBootstrapServers:
+    def test_returns_value_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from omnibase_core.cli.cli_run_node import _resolve_bootstrap_servers
+
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "lane-host:39092")
+        assert _resolve_bootstrap_servers("node_x") == "lane-host:39092"
+
+    def test_unset_exits_with_actionable_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from omnibase_core.cli.cli_run_node import run_node
+
+        monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+        result = CliRunner().invoke(run_node, ["node_dod_verify", "--input", "{}"])
+        assert result.exit_code == 1
+        assert "KAFKA_BOOTSTRAP_SERVERS is not set" in result.output
+        assert "onex run node_dod_verify" in result.output
+
+    def test_empty_exits_with_actionable_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from omnibase_core.cli.cli_run_node import run_node
+
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "   ")
+        result = CliRunner().invoke(run_node, ["node_dod_verify", "--input", "{}"])
+        assert result.exit_code == 1
+        assert "KAFKA_BOOTSTRAP_SERVERS is not set" in result.output
+
+
+class TestUnreachableBrokerWrapped:
+    def test_transport_failure_wrapped_as_actionable_error(self) -> None:
+        from omnibase_core.cli.cli_run_node import publish_and_poll
+        from omnibase_core.errors import OnexError
+
+        # Simulate the raw confluent_kafka.KafkaException (_TRANSPORT) the first
+        # broker touch raises when the bootstrap address is unreachable.
+        consumer = MagicMock()
+        consumer.list_topics.side_effect = RuntimeError(
+            "KafkaError{code=_TRANSPORT,val=-195,str=Broker transport failure}"
+        )
+
+        with (
+            patch(_PATCH_TOPIC_PARTITION, side_effect=_FakeTopicPartition),
+            patch(_PATCH_PRODUCER, return_value=MagicMock()),
+            patch(_PATCH_CONSUMER, return_value=consumer),
+        ):
+            with pytest.raises(OnexError, match="unreachable") as exc_info:
+                publish_and_poll(
+                    node_id="node_dod_verify",
+                    payload={},
+                    timeout=5,
+                    bootstrap_servers="unreachable-host:19092",
+                    command_topic="onex.cmd.test.command.v1",
+                    response_topic="onex.evt.test.completed.v1",
+                )
+        message = str(exc_info.value)
+        assert "unreachable-host:19092" in message
+        assert "onex run node_dod_verify" in message
+        # The consumer must still be closed on the failure path.
+        consumer.close.assert_called_once()


### PR DESCRIPTION
## Summary

Cites **OMN-13857** (finding 1). `onex run-node` dispatches over Kafka. Before this fix an unset `KAFKA_BOOTSTRAP_SERVERS` raised a bare `KeyError` traceback, and an unreachable broker surfaced an opaque `confluent_kafka.KafkaException` (`_TRANSPORT`, `val=-195`) — neither told the operator what to do. Both now emit a single actionable `SkillRoutingError`.

## What changed

`src/omnibase_core/cli/cli_run_node.py`:
- New `_resolve_bootstrap_servers(node_id)` — an unset/blank `KAFKA_BOOTSTRAP_SERVERS` emits a clear error naming the env var and the bus-less `onex run <node>` fallback, instead of a `KeyError`.
- `publish_and_poll` — the first broker touch (`consumer.list_topics`) is wrapped so a transport failure becomes a `ModelOnexError` citing the bootstrap address and the `onex run <node>` fallback, instead of a raw traceback. The consumer is still closed on the failure path.

**No hardcoded lane address** is introduced (CLAUDE.md rule #6): the reachable bootstrap stays operator-supplied via `KAFKA_BOOTSTRAP_SERVERS`; core only fails *clearly* when it is missing or unreachable. The success path (command names, flags, dispatch) is unchanged — this is stable-SDK-surface-safe.

## dod_evidence

- **`tests/unit/cli/test_omn_13857_run_node_bootstrap.py` (4 tests)**: resolver returns the value when set; unset and blank both exit 1 with the actionable message + `onex run node_dod_verify` hint; an unreachable-broker `list_topics` failure is wrapped as an `OnexError` citing the bootstrap address + fallback, with the consumer closed.
- **Independent live repro**: `onex run-node node_dod_verify` with `KAFKA_BOOTSTRAP_SERVERS` unset now prints the `SkillRoutingError` JSON (no traceback).
- Existing `tests/unit/cli` suite: **578 passed** (incl. 15 pre-existing `cli_run_node` tests). Whole suite collects cleanly (42,794 tests, no import breakage). `mypy src/omnibase_core/cli/cli_run_node.py` clean; ruff clean. The full omnibase_core suite runs on CI (it exceeds the local harness time cap on this machine).

## Scope note

This is the omnibase_core half of OMN-13857 (finding 1). The `$CONTRACT_REPO_DIR` determinism fix (finding 2) is a separate omnimarket PR on the same ticket/branch. Finding 3 (stale remote consumer OCC mirror + missing `pre-commit` on remote PATH) is operational/deploy — diagnosed and filed as a follow-up; no remote runtime touched.

Evidence-Ticket: OMN-13857
Evidence-Source: OCC#3506
