### PR TITLE
feat(OMN-13877): dep-provenance gate — omnibase_core

### DIFF
--- a/.github/workflows/dep-provenance-gate.yml
+++ b/.github/workflows/dep-provenance-gate.yml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-13873: dep-provenance gate — forbid first-party git-source overrides.
+#
+# Root cause this closes: omnibase_infra PR #2184 merged to dev carrying
+# [tool.uv.sources] git-rev overrides pinning omnibase-core / omnibase-spi to
+# UNRELEASED commits. All ~60 CI checks passed green because CI resolved
+# core/spi from those exact commits and tests ran against them — the breakage is
+# dependency *provenance*, not runtime behavior, so no test catches it.
+#
+# This gate is a pure static provenance check (no network calls). It FAILS if
+# any of omnibase-core / omnibase-spi / omnibase-compat (hyphen or underscore
+# spelling) has a git / rev / branch / tag source override in pyproject.toml's
+# [tool.uv.sources] block. onex-change-control is intentionally NOT checked (it
+# follows an immutable-main pin release model). A single line may be exempted
+# with an inline '# raw-override-ok: <ticket>' comment carrying a non-empty
+# token.
+#
+# Scoping: the whole-file gate runs only when a PR actually modifies
+# pyproject.toml (a forbidden override cannot be introduced without editing
+# pyproject.toml). This mirrors the precommit hook's `files: ^pyproject\.toml$`
+# scoping and the stale-todo-gate's changed-files approach, so a PR that does
+# not touch pyproject.toml is not re-flagged for pre-existing, separately-tracked
+# overrides.
+#
+# This job is intended to be a REQUIRED STATUS CHECK. The job name
+# "Dep Provenance Gate" must match branch protection rules (follow-up: add
+# `dep-provenance-gate` as a required context on dev + main — see OMN-13873).
+
+name: Dep Provenance Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  dep-provenance-gate:
+    name: Dep Provenance Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on merge_group
+        if: ${{ github.event_name == 'merge_group' }}
+        run: |
+          echo "merge_group event — provenance already proven at PR time; skipping."
+
+      - name: Checkout
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: astral-sh/setup-uv@v7
+
+      - name: Forbid first-party git-source overrides on dev/main
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_REF="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE_REF"...HEAD -- pyproject.toml || true)
+
+          if [ -z "$CHANGED" ]; then
+            echo "pyproject.toml unchanged in this PR — no new provenance surface. Skipping."
+            exit 0
+          fi
+
+          echo "pyproject.toml modified in this PR — verifying dependency provenance."
+          python3 scripts/check_dep_provenance.py --pyproject pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,18 @@ repos:
         files: ^(src/omnibase_core/enums/enum_hook_bit\.py|scripts/gen_hook_bits\.py|scripts/check_hook_bits_drift\.py)$
         stages: [pre-commit]
 
+      # Dep-provenance gate (OMN-13873)
+      # Forbid first-party git-source overrides (omnibase-core / omnibase-spi /
+      # omnibase-compat) in [tool.uv.sources]. onex-change-control is exempt
+      # (immutable-main pin model). Fires only when pyproject.toml changes.
+      - id: check-dep-provenance
+        name: Forbid first-party git-source overrides (OMN-13873)
+        entry: uv run --frozen python scripts/check_dep_provenance.py
+        language: system
+        files: ^pyproject\.toml$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # Substrate Gate: silent except-pass (OMN-wire-validators)
       # Baseline: 102 violations on 2026-05-10 — ratchet mode, threshold must decrease over time.
       # Annotate justified cases with: # substrate-allow: <reason>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,7 @@ ignore = [
 "scripts/validation/validate-check-names.py" = ["T201", "BLE001"]
 "scripts/validation/validate-stubbed-functionality.py" = ["T201", "BLE001"]
 "scripts/validation/validate-exception-handling.py" = ["T201", "BLE001"]
+"scripts/check_dep_provenance.py" = ["T201"]  # CLI output for dep-provenance gate (OMN-13873/OMN-13877)
 "src/omnibase_core/validation/validator_contracts.py" = ["T201"]
 "src/omnibase_core/validation/validator_routing_authority.py" = ["T201"]  # CLI output for routing-authority gate (OMN-13306)
 "src/omnibase_core/validation/delegation/validator_delegation_profile.py" = ["T201"]  # CLI output for delegation-profile hook (OMN-13306)

--- a/scripts/check_dep_provenance.py
+++ b/scripts/check_dep_provenance.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Dep-provenance gate — forbid first-party git-source overrides on dev/main.
+
+Root cause this closes (OMN-13873): omnibase_infra PR #2184 merged to dev
+carrying ``[tool.uv.sources]`` git-rev overrides pinning ``omnibase-core`` /
+``omnibase-spi`` to UNRELEASED commits. Every CI check passed because CI
+resolved those exact commits and ran green against them — the breakage is
+dependency *provenance*, not runtime behavior, so no test catches it. This is a
+pure static provenance gate: it FAILS closed if any PyPI-published first-party
+dependency is sourced from git instead of PyPI.
+
+Forbidden first-party deps (both hyphen and underscore spellings):
+
+    omnibase-core   omnibase-spi   omnibase-compat
+
+A ``[tool.uv.sources]`` entry for any of the above with a ``git`` / ``rev`` /
+``branch`` / ``tag`` key is a forbidden override and fails the gate.
+
+``onex-change-control`` is deliberately NOT checked — it follows an
+immutable-main pin release model (different from the three PyPI-released deps),
+so its git pin is intentional and must remain allowed.
+
+Escape hatch (Rule-10 style): a forbidden source line may carry an inline
+comment ``# raw-override-ok: <ticket>`` with a NON-EMPTY token. This exempts the
+single line. An empty token (``# raw-override-ok:`` with nothing after) does NOT
+exempt — the gate still fails. Because the TOML parser drops comments, the token
+is detected by reading the raw source line for each flagged package.
+
+Exit codes:
+    0  — no forbidden first-party git-source override present
+    1  — a forbidden override was found (or a hard error, e.g. missing file)
+
+This check is deterministic and offline — it makes no network calls.
+
+Usage::
+
+    uv run python scripts/check_dep_provenance.py
+    uv run python scripts/check_dep_provenance.py --pyproject pyproject.toml
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# First-party PyPI-published deps that must be resolved from PyPI, never git.
+# Names are stored in canonical hyphen form; underscore spellings are
+# normalized on lookup so both `omnibase-core` and `omnibase_core` are caught.
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_PACKAGES: frozenset[str] = frozenset(
+    {
+        "omnibase-core",
+        "omnibase-spi",
+        "omnibase-compat",
+    }
+)
+
+# Source-override keys that indicate a git provenance (any one is forbidden for
+# a first-party dep). A PyPI source has none of these.
+_GIT_SOURCE_KEYS: frozenset[str] = frozenset({"git", "rev", "branch", "tag"})
+
+# Inline escape token: `# raw-override-ok: <ticket>` with a non-empty token.
+_ESCAPE_TOKEN_RE = re.compile(r"#\s*raw-override-ok:\s*(\S+)")
+
+# ---------------------------------------------------------------------------
+# [tool.uv.sources] parsing — regex-based, adapted (with attribution) from
+# scripts/check-pinned-wheels.py::_parse_uv_sources. Copied rather than imported
+# because that module's filename contains a hyphen (not a clean import target).
+# We parse only the uv.sources block, which is sufficient for provenance.
+#
+# Note: the header pattern is anchored with ``^`` (start-of-line) so a commented
+# ``#   [tool.uv.sources]`` example elsewhere in the file (as this repo carries
+# in its dependency-guidance comments) does not shadow the real section.
+# ---------------------------------------------------------------------------
+
+_UVS_BLOCK_RE = re.compile(
+    r"^\[tool\.uv\.sources\](.*?)(?=^\[|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_UVS_ENTRY_RE = re.compile(
+    r"^(\S+)\s*=\s*\{([^}]+)\}",
+    re.MULTILINE,
+)
+_KV_RE = re.compile(r'(\w+)\s*=\s*"([^"]*)"')
+
+
+def _normalize(pkg: str) -> str:
+    """Canonicalize a package name to hyphen form for comparison."""
+    return pkg.strip().strip('"').strip("'").replace("_", "-").lower()
+
+
+def _uv_sources_block(text: str) -> str | None:
+    """Return the raw text of the [tool.uv.sources] block, or None if absent."""
+    block_m = _UVS_BLOCK_RE.search(text)
+    return block_m.group(1) if block_m else None
+
+
+def _parse_uv_source_entries(block: str) -> dict[str, dict[str, str]]:
+    """Return {normalized_pkg: {key: value}} for [tool.uv.sources] entries."""
+    sources: dict[str, dict[str, str]] = {}
+    for entry_m in _UVS_ENTRY_RE.finditer(block):
+        pkg = _normalize(entry_m.group(1))
+        kv_str = entry_m.group(2)
+        sources[pkg] = dict(_KV_RE.findall(kv_str))
+    return sources
+
+
+def _line_for_package(block: str, pkg: str) -> str | None:
+    """Return the raw source line (with any trailing comment) declaring `pkg`."""
+    for raw_line in block.splitlines():
+        stripped = raw_line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # Entry key is the text before the first '=' on the line.
+        key = stripped.split("=", 1)[0]
+        if _normalize(key) == pkg:
+            return raw_line
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+
+def find_violations(text: str) -> list[str]:
+    """Return diagnostic messages for each forbidden git-source override.
+
+    An empty list means the file is clean (exit 0). A non-empty list means the
+    gate fails (exit 1). Lines carrying a valid `# raw-override-ok: <token>`
+    escape are excluded.
+    """
+    block = _uv_sources_block(text)
+    if block is None:
+        # No [tool.uv.sources] block at all — nothing can be overridden.
+        return []
+
+    entries = _parse_uv_source_entries(block)
+    violations: list[str] = []
+
+    for pkg, attrs in entries.items():
+        if pkg not in _FORBIDDEN_PACKAGES:
+            continue
+        git_keys = sorted(_GIT_SOURCE_KEYS & set(attrs))
+        if not git_keys:
+            # A non-git source (unusual, but not a provenance violation).
+            continue
+
+        raw_line = _line_for_package(block, pkg)
+        if raw_line is not None:
+            escape_m = _ESCAPE_TOKEN_RE.search(raw_line)
+            if escape_m and escape_m.group(1).strip():
+                # Valid non-empty escape token — this line is exempt.
+                continue
+
+        keys_desc = ", ".join(f"{k}={attrs[k]!r}" for k in git_keys)
+        violations.append(
+            f"{pkg}: forbidden git-source override ({keys_desc}). "
+            f"First-party deps must resolve from PyPI, not git. "
+            f"line: {raw_line.strip() if raw_line else '<unresolved>'}"
+        )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to pyproject.toml (default: pyproject.toml)",
+    )
+    args = parser.parse_args(argv)
+
+    pyproject_path = Path(args.pyproject)
+    if not pyproject_path.exists():
+        print(
+            f"ERROR: pyproject.toml not found: {pyproject_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    violations = find_violations(pyproject_path.read_text())
+
+    if violations:
+        print(
+            "FAIL: forbidden first-party git-source override(s) in "
+            f"{pyproject_path} [tool.uv.sources]:",
+            file=sys.stderr,
+        )
+        for msg in violations:
+            print(f"  - {msg}", file=sys.stderr)
+        print(
+            "\nomnibase-core / omnibase-spi / omnibase-compat are PyPI-published "
+            "first-party deps and must NOT be pinned to git commits/branches/tags "
+            "on dev/main. Resolve them from PyPI (release the dep first if the "
+            "needed version is unpublished). If a temporary override is genuinely "
+            "unavoidable, annotate the exact line with "
+            "'# raw-override-ok: <ticket>' (non-empty token).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: no forbidden first-party git-source override in "
+        f"{pyproject_path} [tool.uv.sources]."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_dep_provenance.py
+++ b/tests/scripts/test_check_dep_provenance.py
@@ -65,9 +65,9 @@ def test_reject_core_spi_git_rev_override(mod, tmp_path: Path) -> None:
     block = (
         "[tool.uv.sources]\n"
         'omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
-        'rev = "2a07385dec0ff06903f62572c546ec201f964aaf" }\n'
+        'rev = "2a07385dec0ff06903f62572c546ec201f964aaf" }\n'  # pragma: allowlist secret
         'omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", '
-        'rev = "cdfe1a470e96cbe8414ba6b08bbc99a452f09018" }\n'
+        'rev = "cdfe1a470e96cbe8414ba6b08bbc99a452f09018" }\n'  # pragma: allowlist secret
     )
     path = _write_pyproject(tmp_path, block)
 
@@ -120,7 +120,7 @@ def test_allow_occ_only_override(mod, tmp_path: Path) -> None:
     block = (
         "[tool.uv.sources]\n"
         'onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", '
-        'rev = "2dd26ade7caaa7131e532473ec9d8a207d0e77ab" }\n'
+        'rev = "2dd26ade7caaa7131e532473ec9d8a207d0e77ab" }\n'  # pragma: allowlist secret
     )
     path = _write_pyproject(tmp_path, block)
 

--- a/tests/scripts/test_check_dep_provenance.py
+++ b/tests/scripts/test_check_dep_provenance.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the dep-provenance gate (OMN-13873).
+
+Recurrence guard for the omnibase_infra PR #2184 footgun: ``[tool.uv.sources]``
+git-rev overrides pinned ``omnibase-core`` / ``omnibase-spi`` to UNRELEASED
+commits, and every CI check passed green because the breakage is dependency
+*provenance*, not runtime behavior. This gate fails closed on any first-party
+git-source override on dev/main.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_dep_provenance.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_dep_provenance", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def _write_pyproject(tmp_path: Path, sources_block: str) -> Path:
+    """Write a minimal pyproject.toml with the given [tool.uv.sources] block."""
+    content = (
+        "[project]\n"
+        'name = "omnibase-infra"\n'
+        'version = "0.0.0"\n'
+        "dependencies = [\n"
+        "    # Example comment that also mentions [tool.uv.sources]\n"
+        '    #   omnibase-core = { git = "...", rev = "..." }\n'
+        '    "omnibase-core>=0.46.1,<0.47.0",\n'
+        '    "omnibase-spi>=0.23.0,<0.24.0",\n'
+        "]\n"
+        "\n"
+        f"{sources_block}"
+        "\n"
+        "[tool.ruff]\n"
+        'target-version = "py312"\n'
+    )
+    path = tmp_path / "pyproject.toml"
+    path.write_text(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# REJECT: reproduce #2184's L193-194 core/spi git-rev overrides
+# ---------------------------------------------------------------------------
+
+
+def test_reject_core_spi_git_rev_override(mod, tmp_path: Path) -> None:
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
+        'rev = "2a07385dec0ff06903f62572c546ec201f964aaf" }\n'
+        'omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", '
+        'rev = "cdfe1a470e96cbe8414ba6b08bbc99a452f09018" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+
+    violations = mod.find_violations(path.read_text())
+    assert len(violations) == 2
+    assert any("omnibase-core" in v for v in violations)
+    assert any("omnibase-spi" in v for v in violations)
+
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+def test_reject_underscore_spelling(mod, tmp_path: Path) -> None:
+    """Underscore spelling (omnibase_core) is caught the same as hyphen."""
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase_core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
+        'rev = "deadbeef" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+def test_reject_branch_override(mod, tmp_path: Path) -> None:
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", '
+        'branch = "dev" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+def test_reject_tag_override(mod, tmp_path: Path) -> None:
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", '
+        'tag = "v0.23.0" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# ALLOW: occ-only override (the current legitimate state)
+# ---------------------------------------------------------------------------
+
+
+def test_allow_occ_only_override(mod, tmp_path: Path) -> None:
+    """onex-change-control git pin is intentional (immutable-main model)."""
+    block = (
+        "[tool.uv.sources]\n"
+        'onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", '
+        'rev = "2dd26ade7caaa7131e532473ec9d8a207d0e77ab" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+
+    assert mod.find_violations(path.read_text()) == []
+    assert mod.main(["--pyproject", str(path)]) == 0
+
+
+def test_allow_no_uv_sources_block(mod, tmp_path: Path) -> None:
+    """A pyproject with no [tool.uv.sources] block cannot override anything."""
+    content = (
+        "[project]\n"
+        'name = "x"\n'
+        'version = "0.0.0"\n'
+        'dependencies = ["omnibase-core>=0.46.1,<0.47.0"]\n'
+        "[tool.ruff]\n"
+        'target-version = "py312"\n'
+    )
+    path = tmp_path / "pyproject.toml"
+    path.write_text(content)
+    assert mod.main(["--pyproject", str(path)]) == 0
+
+
+def test_allow_pypi_only(mod, tmp_path: Path) -> None:
+    """All first-party deps resolved from PyPI (no uv.sources entries) → clean."""
+    block = "[tool.uv.sources]\n"
+    path = _write_pyproject(tmp_path, block)
+    assert mod.main(["--pyproject", str(path)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# ESCAPE: `# raw-override-ok: <ticket>` exempts a line only with a non-empty token
+# ---------------------------------------------------------------------------
+
+
+def test_escape_valid_token(mod, tmp_path: Path) -> None:
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
+        'rev = "deadbeef" }  # raw-override-ok: OMN-12549\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+
+    assert mod.find_violations(path.read_text()) == []
+    assert mod.main(["--pyproject", str(path)]) == 0
+
+
+def test_escape_empty_token_still_fails(mod, tmp_path: Path) -> None:
+    """`# raw-override-ok:` with no token does NOT exempt — gate still fails."""
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
+        'rev = "deadbeef" }  # raw-override-ok:\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+
+    assert len(mod.find_violations(path.read_text())) == 1
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+def test_escape_is_per_line(mod, tmp_path: Path) -> None:
+    """An escape on one line does not exempt an un-annotated override on another."""
+    block = (
+        "[tool.uv.sources]\n"
+        'omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", '
+        'rev = "aaa" }  # raw-override-ok: OMN-12549\n'
+        'omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", '
+        'rev = "bbb" }\n'
+    )
+    path = _write_pyproject(tmp_path, block)
+
+    violations = mod.find_violations(path.read_text())
+    assert len(violations) == 1
+    assert "omnibase-spi" in violations[0]
+    assert mod.main(["--pyproject", str(path)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Missing file → hard error (exit 1, fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pyproject_fails_closed(mod, tmp_path: Path) -> None:
+    missing = tmp_path / "nope" / "pyproject.toml"
+    assert mod.main(["--pyproject", str(missing)]) == 1


### PR DESCRIPTION
Evidence-Ticket: OMN-13877
Evidence-Source: OCC#3519

## OMN-13877 — dep-provenance gate for omnibase_core

Adds the dep-provenance gate (root cause OMN-13873) to **omnibase_core**. The gate is a pure static, offline check that FAILS closed if any first-party PyPI-published dep (`omnibase-core` / `omnibase-spi` / `omnibase-compat`, hyphen or underscore spelling) is sourced from git (`git`/`rev`/`branch`/`tag`) in `[tool.uv.sources]`.

`onex-change-control`'s git pin is intentionally exempt (immutable-main pin release model), so **omnibase_core lands the gate with no pyproject dependency change** — the repo is already clean.

### Changes
- `scripts/check_dep_provenance.py` — the static provenance check (copied verbatim from the canonical OMN-13873 source in omnibase_infra)
- `.github/workflows/dep-provenance-gate.yml` — PR-time gate, scoped to run only when `pyproject.toml` changes; short-circuits on `merge_group`
- `tests/scripts/test_check_dep_provenance.py` — 11 recurrence-guard tests (reject core/spi git-rev, underscore/branch/tag overrides; allow occ-only + PyPI-only; per-line escape-token semantics; fail-closed on missing file)
- `.pre-commit-config.yaml` — `check-dep-provenance` local hook (`files: ^pyproject\.toml$`)
- `pyproject.toml` — T201 per-file-ignore for the CLI script (repo enforces no-print via ruff)

### dod_evidence
- `python3 scripts/check_dep_provenance.py` → exit 0: `OK: no forbidden first-party git-source override in pyproject.toml [tool.uv.sources].`
- `uv run pytest tests/scripts/test_check_dep_provenance.py -v` → **11 passed**
- `uv run ruff format . && uv run ruff check` → clean on new files
- `pre-commit run check-dep-provenance --all-files` → **Passed**
- Fast structural hooks (yamlfmt, trailing-whitespace, end-of-file-fixer, check-merge-conflict, ruff-format, ruff-fix) → all Passed
- `uv run mypy scripts/check_dep_provenance.py` → clean

Ready for merge as part of the OMN-13877 rollout sweep.
