### PR TITLE
fix(OMN-13502): exempt canonical recorded-replay seam in no-faked-boundary detector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.2"
+version = "0.46.4"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/validation/no_faked_boundary/handler.py
+++ b/src/omnibase_core/validation/no_faked_boundary/handler.py
@@ -28,8 +28,25 @@ routing-contract resolution, registry, or dispatch surface) that returns canned 
 prompt-echoed output, or a ``patch("httpx.Client")`` / ``MagicMock`` substituting
 that egress inside a real-dispatch test, is a FAKE of our architecture" — turns
 the ``feedback_real_dispatch_path_tests`` failure ("handler-isolation tests pass
-while live fails") into a BLOCKING gate. The ``onex-allow-faked-boundary``
-suppression marker is the per-line escape hatch.
+while live fails") into a BLOCKING gate.
+
+Suppression / exemption (OMN-13500/13502):
+
+* ``onex-allow-faked-boundary`` — per-LINE marker; the annotated line is skipped.
+* ``onex-allow-file-faked-boundary`` — FILE-level marker; a file carrying it
+  anywhere is skipped whole. Reserved for sources whose SUBJECT *is* the fake
+  pattern (this detector's own docstring, and the acceptance-corpus test), which
+  must quote the banned idioms verbatim. This module itself carries the marker
+  below for exactly that reason: onex-allow-file-faked-boundary OMN-13497
+  reason="detector source documents verbatim the patterns it bans".
+* Canonical recorded-replay seam — a ``patch("httpx.Client")`` /
+  ``patch("httpx.AsyncClient")`` that INJECTS a
+  ``RecordedReplayInferenceTransport`` (OMN-13499) as the replacement is the
+  canonical golden-chain seam, NOT a fake: live routing / model-selection /
+  request construction still run, only recorded bytes are replayed, and the
+  transport fails closed on route/hash drift. Such a patch is exempt from
+  ``patch_httpx_egress``; a bare ``patch("httpx.Client") as mock`` (which then
+  hand-sets canned bytes) or one injecting a ``MagicMock`` still flags.
 """
 
 from __future__ import annotations
@@ -54,6 +71,36 @@ __all__ = ["HandlerNoFakedBoundaryCompute", "scan_source"]
 # exists for the corpus / test-fixture sources whose SUBJECT is the fake pattern
 # the scanner must flag, and for genuinely-approved boundary doubles.
 _SUPPRESSION_MARKER: Final[str] = "onex-allow-faked-boundary"
+
+# A file carrying this marker ANYWHERE is skipped whole. Reserved for sources
+# whose subject IS the fake pattern (this detector's own docstring; the
+# acceptance-corpus test). Distinct substring from _SUPPRESSION_MARKER — the
+# per-line "onex-allow-faked-boundary" is NOT a substring of this token.
+_FILE_SUPPRESSION_MARKER: Final[str] = "onex-allow-file-faked-boundary"
+
+# The canonical recorded-from-real replay transport (OMN-13499). A ``patch`` of
+# the httpx egress that injects THIS as the replacement is the canonical
+# golden-chain seam (live routing/selection/request construction still run; only
+# recorded bytes are replayed and the transport fails closed on drift), so it is
+# NOT a boundary fake. See OMN-13500/13502.
+_CANONICAL_REPLAY_TRANSPORT: Final[str] = "RecordedReplayInferenceTransport"
+
+# Names bound to a RecordedReplayInferenceTransport(...) construction anywhere in
+# the file (e.g. ``transport = RecordedReplayInferenceTransport([fixture])``).
+_REPLAY_BINDING: Final[re.Pattern[str]] = re.compile(
+    r"(\w+)\s*=\s*" + _CANONICAL_REPLAY_TRANSPORT + r"\s*\(",
+)
+
+# A ``patch("httpx.Client"|"httpx.AsyncClient", <replacement>)`` that injects a
+# replacement object (positional ``new`` or ``new=``/``return_value=`` keyword),
+# capturing the injected NAME. A bare ``patch("httpx.Client") as mock`` (no
+# injected replacement — the mock is captured to hand-set canned bytes) does NOT
+# match here and therefore still flags.
+_PATCH_INJECTED: Final[re.Pattern[str]] = re.compile(
+    r"""patch\s*\(\s*["']httpx\.(?:Client|AsyncClient)["']\s*,\s*"""
+    r"""(?:(?:new|return_value)\s*=\s*)?([A-Za-z_]\w*)""",
+    re.IGNORECASE,
+)
 
 # === GENERATED SCANNING REGEXES (OMN-13497) — preserved verbatim from the
 # corpus-accepted artifact. Each pattern is one fake-boundary signature. ===
@@ -94,15 +141,38 @@ _PATTERN_COMPLETION_FSTRING: Final[re.Pattern[str]] = re.compile(
 )
 
 
+def _patch_injects_canonical_replay(line: str, replay_names: set[str]) -> bool:
+    """True iff ``line`` patches the httpx egress with the canonical replay transport.
+
+    The canonical golden-chain seam is ``patch("httpx.Client", return_value=x)``
+    (or positional ``new``) where ``x`` is a ``RecordedReplayInferenceTransport``.
+    A bare ``patch("httpx.Client") as mock`` or one injecting a ``MagicMock`` does
+    NOT match and is therefore still flagged as a boundary fake.
+    """
+    match = _PATCH_INJECTED.search(line)
+    return match is not None and match.group(1) in replay_names
+
+
 def scan_source(content: str, path: str = "<input>") -> ModelNoFakedBoundaryScanResult:
     """Scan ``content`` line by line for fakes of an inference/routing/dispatch boundary.
 
-    Pure and deterministic. A line carrying the ``onex-allow-faked-boundary``
-    suppression marker is skipped; otherwise each of the four generated
-    fake-boundary signatures is matched. Findings are emitted in source order
-    (line number) so the verdict is order-independent regardless of dispatch
-    backend.
+    Pure and deterministic. A file carrying the ``onex-allow-file-faked-boundary``
+    marker is skipped whole; a line carrying the ``onex-allow-faked-boundary``
+    marker is skipped; a ``patch`` that injects the canonical
+    ``RecordedReplayInferenceTransport`` is exempt from ``patch_httpx_egress``.
+    Otherwise each of the generated fake-boundary signatures is matched. Findings
+    are emitted in source order (line number) so the verdict is order-independent
+    regardless of dispatch backend.
     """
+    # File-level escape hatch: the whole file is exempt (subject IS the pattern).
+    if _FILE_SUPPRESSION_MARKER in content:
+        return ModelNoFakedBoundaryScanResult(path=path, flagged=False, findings=())
+
+    # Names bound to the canonical recorded-replay transport anywhere in the file,
+    # plus the class name itself (for inline ``return_value=Recorded...([f])``).
+    replay_names: set[str] = set(_REPLAY_BINDING.findall(content))
+    replay_names.add(_CANONICAL_REPLAY_TRANSPORT)
+
     findings: list[ModelNoFakedBoundaryFinding] = []
     for lineno, line in enumerate(content.splitlines(), start=1):
         if _SUPPRESSION_MARKER in line:
@@ -120,7 +190,9 @@ def scan_source(content: str, path: str = "<input>") -> ModelNoFakedBoundaryScan
                     matched_text=stripped,
                 )
             )
-        if _PATTERN_PATCH.search(line):
+        if _PATTERN_PATCH.search(line) and not _patch_injects_canonical_replay(
+            line, replay_names
+        ):
             findings.append(
                 ModelNoFakedBoundaryFinding(
                     path=path,

--- a/tests/unit/validation/no_faked_boundary/test_handler_no_faked_boundary_compute.py
+++ b/tests/unit/validation/no_faked_boundary/test_handler_no_faked_boundary_compute.py
@@ -123,6 +123,79 @@ def test_suppression_marker_skips_line() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Canonical recorded-replay seam exemption + file-level marker (OMN-13500/13502)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_canonical_replay_patch_seam_is_not_flagged() -> None:
+    # The canonical golden-chain seam: patch httpx.Client with a recorded-replay
+    # transport (live routing/request construction still run; only bytes replayed).
+    # The binding lives on a prior line, so the scanner must be content-aware.
+    src = (
+        "    transport = RecordedReplayInferenceTransport([fixture])\n"
+        '    with patch("httpx.Client", return_value=transport):\n'
+        "        run_chain()\n"
+    )
+    assert scan_source(src).flagged is False
+
+
+@pytest.mark.unit
+def test_canonical_replay_patch_seam_inline_construction_is_not_flagged() -> None:
+    src = (
+        '    with patch("httpx.AsyncClient",'
+        " return_value=RecordedReplayInferenceTransport([f])):\n"
+        "        run_chain()\n"
+    )
+    assert scan_source(src).flagged is False
+
+
+@pytest.mark.unit
+def test_bare_patch_httpx_still_flags_even_with_replay_binding_present() -> None:
+    # A bare ``patch("httpx.Client") as mock`` captures the mock to hand-set canned
+    # bytes — a fake — even in a file that also builds a real replay transport.
+    src = (
+        "    transport = RecordedReplayInferenceTransport([fixture])\n"
+        '    with patch("httpx.Client") as mock_client:\n'
+        "        mock_client.return_value.post.return_value = _canned\n"
+    )
+    result = scan_source(src)
+    assert result.flagged is True
+    assert any(f.pattern == "patch_httpx_egress" for f in result.findings)
+
+
+@pytest.mark.unit
+def test_patch_httpx_injecting_magicmock_still_flags() -> None:
+    src = '    with patch("httpx.Client", return_value=MagicMock()):'
+    assert scan_source(src).flagged is True
+
+
+@pytest.mark.unit
+def test_file_level_marker_skips_whole_file() -> None:
+    src = (
+        "# onex-allow-file-faked-boundary OMN-13497 reason=corpus subject\n"
+        "class _FakeBridge(ModelInferenceAdapter):\n"
+        '    with patch("httpx.Client") as mock_client:\n'
+        "    inference_bridge = MagicMock()\n"
+    )
+    result = scan_source(src)
+    assert result.flagged is False
+    assert result.findings == ()
+
+
+@pytest.mark.unit
+def test_file_level_marker_is_distinct_from_line_marker() -> None:
+    # The per-line marker must NOT be a substring of the file-level marker, so a
+    # file-level marker does not accidentally suppress only the line it is on.
+    from omnibase_core.validation.no_faked_boundary.handler import (
+        _FILE_SUPPRESSION_MARKER,
+        _SUPPRESSION_MARKER,
+    )
+
+    assert _SUPPRESSION_MARKER not in _FILE_SUPPRESSION_MARKER
+
+
+# ---------------------------------------------------------------------------
 # Canonical COMPUTE handler shape + two-transport (in-memory bus) dispatch
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.2"
+version = "0.46.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Evidence-Ticket: OMN-13502
Evidence-Source: OCC#3530

## OMN-13502 (F-ENABLE step 1) — no-faked-boundary detector false-positive fix

The `check-no-faked-boundary` detector (OMN-13497) `patch_httpx_egress` signature
false-flagged the **canonical golden-chain replay seam** — the exact pattern the
de-fake migration is supposed to produce:

```python
transport = RecordedReplayInferenceTransport([fixture])   # OMN-13499 canonical harness
with patch("httpx.Client", return_value=transport):       # live routing/request-construction still runs
    run_chain()
```

Live rescan showed 5 false positives in the one migrated golden-chain file, and
the detector also flagged its own source and the acceptance-corpus test (whose
subject IS the banned idiom). Left unfixed, fully-migrated files still flag and
the gate can never flip blocking (OMN-13500/13501/13502 blocker).

### Fix (both in the pure COMPUTE `scan_source`)
1. **File-level marker** `onex-allow-file-faked-boundary` — already *declared* by
   the corpus test (line 3) but never implemented. Now honored: a file carrying it
   anywhere is skipped whole. Applied to the detector`s own `handler.py`.
2. **Content-aware canonical-seam exemption** — a `patch("httpx.Client"/"httpx.AsyncClient", ...=x)`
   that injects a `RecordedReplayInferenceTransport` (bound name **or** inline
   construction) is exempt from `patch_httpx_egress`. A bare `patch("httpx.Client") as mock`
   (then hand-sets canned bytes) or one injecting a `MagicMock` still flags —
   proven by new regression tests.

Result: `omnibase_core` src+tests are now **clean** under the detector (0 findings),
which is the prerequisite for the wedge-safe required-gate flip in step 2.

### dod_evidence
- New/updated regression tests in `test_handler_no_faked_boundary_compute.py`:
  canonical seam exempt (bound + inline), bare-patch still flags, MagicMock-inject
  still flags, file-level marker skips whole file, marker-substring-distinctness.
- Focused: `pytest tests/unit/validation/no_faked_boundary/` → 29 passed.
- Blast radius: `pytest tests/unit/validation/ tests/unit/runtime/golden_chain/ -n auto` → 4668 passed, 5 skipped.
- Detector re-run: migrated omnimarket golden-chain file drops from 5 patch_httpx findings to 1 (a docstring-prose reference, a burn-down item); core src+tests → 0 findings.
- ruff format+check clean; mypy clean on handler.
- Version bump 0.46.2 → 0.46.4 (release-identity gate OMN-13411: latest published 0.46.3).

Part of WS-F boundary-fake burn-down (F-ENABLE). Unblocks OMN-13500/OMN-13501/OMN-13502.
