### PR TITLE
fix(OMN-13888): OCC per-entry receipt hashing + append-only + supersession + dual-accept

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.4"
+version = "0.46.5"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/enums/enum_append_only_violation_kind.py
+++ b/src/omnibase_core/enums/enum_append_only_violation_kind.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Append-only violation categories for the OCC append-only gate (OMN-13888)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumAppendOnlyViolationKind(StrEnum):
+    """Category of an OCC append-only violation."""
+
+    ENTRY_EDITED = "entry_edited"
+    ENTRY_REMOVED = "entry_removed"
+    RECEIPT_FILE_MUTATED = "receipt_file_mutated"
+
+
+__all__ = ["EnumAppendOnlyViolationKind"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -223,7 +223,23 @@ class ModelDodReceipt(BaseModel):
             "this receipt. The OCC-first eligibility gate requires this field "
             "and rejects receipts whose digest does not match the pinned OCC "
             "contract. Optional here only for staged migration of historical "
-            "Receipt Gate fixtures."
+            "Receipt Gate fixtures. Legacy WHOLE-FILE binding (OMN-13888): "
+            "grandfathered for receipts minted before per-entry hashing; new "
+            "mints bind ``contract_entry_sha256`` instead so appending a later "
+            "dod_evidence entry does not invalidate prior receipts."
+        ),
+    )
+    contract_entry_sha256: str | None = Field(
+        default=None,
+        description=(
+            "Per-entry SHA-256 digest (OMN-13888) binding this receipt to the "
+            "canonical JSON of its own dod_evidence item plus an immutable "
+            "contract header (ticket_id + schema_version), NOT the whole "
+            "contract file. Appending dod_evidence entry N+1 does not change "
+            "the hash of entries 1..N, so prior receipts remain valid. When "
+            "present it is the authoritative binding and takes precedence over "
+            "``contract_sha256`` (dual-accept transition). None on legacy "
+            "receipts that only bound the whole file."
         ),
     )
     branch: str | None = Field(
@@ -315,7 +331,7 @@ class ModelDodReceipt(BaseModel):
             raise ValueError(f"commit_sha must be 7-40 hex chars (git SHA), got: {v!r}")
         return v
 
-    @field_validator("contract_sha256")
+    @field_validator("contract_sha256", "contract_entry_sha256")
     @classmethod
     def _validate_contract_sha256(cls, v: str | None) -> str | None:
         if v is None:
@@ -323,7 +339,7 @@ class ModelDodReceipt(BaseModel):
         normalized = v.strip().lower()
         if not _SHA256_RE.match(normalized):
             raise ValueError(
-                "contract_sha256 must be a sha256:<64 lowercase hex> digest "
+                "contract hash must be a sha256:<64 lowercase hex> digest "
                 "or a bare 64-character lowercase hex digest"
             )
         if not normalized.startswith("sha256:"):

--- a/src/omnibase_core/models/contracts/ticket/model_receipt_supersession.py
+++ b/src/omnibase_core/models/contracts/ticket/model_receipt_supersession.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelReceiptSupersession — net-new correction record for a DoD receipt.
+
+OMN-13888 scope item 3: supersession / tombstone records let a prior receipt be
+re-bound or invalidated WITHOUT editing any merged file. A supersession is a
+net-new file appended alongside the base receipt at::
+
+    drift/dod_receipts/<TICKET>/<EVIDENCE_ITEM>/<CHECK_TYPE>.supersede.<NNNN>.yaml
+
+The highest ``NNNN`` in a key's chain is the authoritative record ("latest
+non-tombstoned record"). A record with ``tombstone: true`` and no
+``replacement`` invalidates the key (the key then has no active receipt). A
+record with a ``replacement`` re-binds the key to that receipt — and a later
+record can un-tombstone a key by supplying a replacement at a higher ``NNNN``.
+The base receipt file is never edited, honoring the append-only rule.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+
+_TICKET_ID_RE = re.compile(r"^OMN-\d+$")
+# SemVer 2.0.0 — mirrors ``_SEMVER_RE`` in model_dod_receipt.
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+
+class ModelReceiptSupersession(BaseModel):
+    """A net-new record that re-binds or tombstones a prior DoD receipt.
+
+    Frozen and ``extra="forbid"``: a supersession is durable evidence, not a
+    scratch object. ``replacement`` is required unless ``tombstone`` is set; a
+    present replacement must key-match the record (same ticket / evidence item /
+    check type) and must carry a per-entry ``contract_entry_sha256`` (new
+    scheme) so the correction cannot re-introduce a whole-file binding.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    schema_version: str = Field(
+        ..., description="SemVer 2.0.0 string for the supersession record schema."
+    )
+    ticket_id: str = Field(
+        ..., description="Linear ticket this record corrects (e.g. OMN-13899)."
+    )
+    # string-id-ok: evidence item IDs are human-readable slugs from the contract.
+    evidence_item_id: str = Field(
+        ..., min_length=1, description="dod_evidence[].id whose receipt is corrected."
+    )
+    check_type: str = Field(
+        ..., min_length=1, description="check_type of the receipt being corrected."
+    )
+    supersedes: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "OCC-root-relative path of the receipt or record this one replaces "
+            "(e.g. drift/dod_receipts/OMN-13899/dod-x/command.yaml)."
+        ),
+    )
+    reason: str = Field(
+        ..., min_length=1, description="Why the prior receipt is superseded."
+    )
+    superseder: str = Field(
+        ...,
+        min_length=1,
+        description="Identity that authored this correction (agent / login / CI).",
+    )
+    created_at: datetime = Field(
+        ..., description="UTC timestamp when this record was authored (tz-aware)."
+    )
+    tombstone: bool = Field(
+        default=False,
+        description=(
+            "When true the key is invalidated and has no active receipt unless a "
+            "later record supplies a replacement. Requires replacement to be None."
+        ),
+    )
+    replacement: ModelDodReceipt | None = Field(
+        default=None,
+        description=(
+            "The receipt that becomes active for the key. Required unless "
+            "tombstone is set. Must key-match this record and carry "
+            "contract_entry_sha256."
+        ),
+    )
+
+    @field_validator("ticket_id")
+    @classmethod
+    def _validate_ticket_id(cls, v: str) -> str:
+        if not _TICKET_ID_RE.match(v):
+            raise ValueError(f"ticket_id must match OMN-\\d+, got: {v!r}")
+        return v
+
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, v: str) -> str:
+        if not _SEMVER_RE.match(v):
+            raise ValueError(
+                f"schema_version must be valid SemVer (e.g. '1.0.0'), got: {v!r}"
+            )
+        return v
+
+    @field_validator("superseder", "reason")
+    @classmethod
+    def _non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("field must contain non-whitespace characters")
+        return v
+
+    @field_validator("created_at")
+    @classmethod
+    def _validate_tz_aware(cls, v: Any) -> datetime:
+        if not isinstance(v, datetime):
+            raise ValueError(f"created_at must be datetime, got {type(v).__name__}")
+        if v.tzinfo is None:
+            raise ValueError("created_at must be timezone-aware (UTC)")
+        return v.astimezone(UTC)
+
+    @model_validator(mode="after")
+    def _enforce_replacement_invariant(self) -> ModelReceiptSupersession:
+        if self.tombstone:
+            if self.replacement is not None:
+                raise ValueError(
+                    "a tombstone record must not carry a replacement receipt; "
+                    "set tombstone=false to re-bind the key"
+                )
+            return self
+        if self.replacement is None:
+            raise ValueError(
+                "a non-tombstone supersession must carry a replacement receipt "
+                "(or set tombstone=true to invalidate the key)"
+            )
+        replacement = self.replacement
+        key = (self.ticket_id, self.evidence_item_id, self.check_type)
+        replacement_key = (
+            replacement.ticket_id,
+            replacement.evidence_item_id,
+            replacement.check_type,
+        )
+        if key != replacement_key:
+            raise ValueError(
+                f"replacement receipt key {replacement_key} does not match the "
+                f"supersession record key {key}"
+            )
+        if replacement.contract_entry_sha256 is None:
+            raise ValueError(
+                "replacement receipt must carry a per-entry contract_entry_sha256 "
+                "(new scheme); whole-file-only bindings are not accepted in a "
+                "supersession replacement"
+            )
+        return self
+
+
+__all__ = ["ModelReceiptSupersession"]

--- a/src/omnibase_core/models/validation/model_occ_append_only_result.py
+++ b/src/omnibase_core/models/validation/model_occ_append_only_result.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Result model for the OCC append-only enforcement gate (OMN-13888)."""
+
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EnumAppendOnlyViolationKind(StrEnum):
+    """Category of an append-only violation."""
+
+    ENTRY_EDITED = "entry_edited"
+    ENTRY_REMOVED = "entry_removed"
+    RECEIPT_FILE_MUTATED = "receipt_file_mutated"
+
+
+class ModelAppendOnlyViolation(BaseModel):
+    """A single append-only violation with a human-readable detail."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: EnumAppendOnlyViolationKind
+    target: str = Field(
+        ..., description="dod_evidence item id or receipt file path that violated."
+    )
+    detail: str = Field(default="")
+
+
+class ModelOccAppendOnlyResult(BaseModel):
+    """Aggregate result of the append-only check over a contract + receipt diff."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ok: bool
+    reason: str = Field(
+        default="",
+        description="APPEND_ONLY_VIOLATION when ok is False, empty otherwise.",
+    )
+    violations: tuple[ModelAppendOnlyViolation, ...] = Field(default_factory=tuple)
+    detail: str = Field(default="")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "reason": self.reason,
+            "violations": [
+                {"kind": v.kind.value, "target": v.target, "detail": v.detail}
+                for v in self.violations
+            ],
+            "detail": self.detail,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = [
+    "EnumAppendOnlyViolationKind",
+    "ModelAppendOnlyViolation",
+    "ModelOccAppendOnlyResult",
+]

--- a/src/omnibase_core/models/validation/model_occ_append_only_result.py
+++ b/src/omnibase_core/models/validation/model_occ_append_only_result.py
@@ -6,17 +6,12 @@
 from __future__ import annotations
 
 import json
-from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
-class EnumAppendOnlyViolationKind(StrEnum):
-    """Category of an append-only violation."""
-
-    ENTRY_EDITED = "entry_edited"
-    ENTRY_REMOVED = "entry_removed"
-    RECEIPT_FILE_MUTATED = "receipt_file_mutated"
+from omnibase_core.enums.enum_append_only_violation_kind import (
+    EnumAppendOnlyViolationKind,
+)
 
 
 class ModelAppendOnlyViolation(BaseModel):

--- a/src/omnibase_core/validation/validator_occ_append_only.py
+++ b/src/omnibase_core/validation/validator_occ_append_only.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Append-only enforcement for OCC contracts + receipts (OMN-13888, scope 2).
+
+Per-entry hashing (scope 1) removes the *demand* to rewrite merged receipts; this
+gate removes the *ability*. Given the contract at the merge base and at the PR
+head, every dod_evidence item present at the base must exist at the head with an
+identical per-entry hash (editing an item is a violation; removing one is a
+violation). Appending a brand-new item id is allowed. A net-new contract
+(``base is None``) passes trivially. Separately, any ``M``/``D``/``R`` git diff
+of an existing receipt file under ``drift/dod_receipts/<TICKET>/`` is a
+violation — corrections must be net-new ``A`` (add) supersession files.
+
+The pure core (:func:`evaluate_append_only`) takes the two parsed contracts and
+a list of ``(git_status, path)`` diff tuples, so it is fully unit-testable. The
+:func:`main` CLI performs the git I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.models.validation.model_occ_append_only_result import (
+    EnumAppendOnlyViolationKind,
+    ModelAppendOnlyViolation,
+    ModelOccAppendOnlyResult,
+)
+from omnibase_core.validation.validator_receipt_gate import (
+    ContractEntryNotFoundError,
+    compute_contract_entry_sha256,
+)
+
+_APPEND_ONLY_VIOLATION = "APPEND_ONLY_VIOLATION"
+_RECEIPT_DIR_PREFIX = "drift/dod_receipts"
+
+
+def _entry_ids(contract: object) -> list[str]:
+    ids: list[str] = []
+    if isinstance(contract, dict):
+        items = contract.get("dod_evidence", [])
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict):
+                    item_id = item.get("id")
+                    if isinstance(item_id, str):
+                        ids.append(item_id)
+    return ids
+
+
+def evaluate_append_only(
+    base_contract: dict[str, object] | None,
+    head_contract: dict[str, object] | None,
+    receipt_diff: Iterable[tuple[str, str]] = (),
+) -> ModelOccAppendOnlyResult:
+    """Evaluate the append-only invariant. Pure — no I/O.
+
+    Args:
+        base_contract: Parsed contract at the merge base, or ``None`` when the
+            contract is net-new on this PR (nothing to protect → pass).
+        head_contract: Parsed contract at the PR head.
+        receipt_diff: ``(git_status, path)`` pairs from ``git diff
+            --name-status`` scoped to the receipt directory. Status letters:
+            ``A`` add (allowed), ``M`` modify, ``D`` delete, ``R``/``C`` rename/copy.
+    """
+    violations: list[ModelAppendOnlyViolation] = []
+
+    if base_contract is not None:
+        head = head_contract if isinstance(head_contract, dict) else {}
+        head_ids = set(_entry_ids(head))
+        for base_id in _entry_ids(base_contract):
+            if base_id not in head_ids:
+                violations.append(
+                    ModelAppendOnlyViolation(
+                        kind=EnumAppendOnlyViolationKind.ENTRY_REMOVED,
+                        target=base_id,
+                        detail=(
+                            f"dod_evidence item {base_id!r} present at base was "
+                            "removed at head; removals are forbidden (append-only)."
+                        ),
+                    )
+                )
+                continue
+            try:
+                base_hash = compute_contract_entry_sha256(base_contract, base_id)
+                head_hash = compute_contract_entry_sha256(head, base_id)
+            except ContractEntryNotFoundError:
+                # Defensive: id membership already checked above.
+                continue
+            if base_hash != head_hash:
+                violations.append(
+                    ModelAppendOnlyViolation(
+                        kind=EnumAppendOnlyViolationKind.ENTRY_EDITED,
+                        target=base_id,
+                        detail=(
+                            f"dod_evidence item {base_id!r} was edited "
+                            f"(entry hash {base_hash} -> {head_hash}); existing "
+                            "entries are immutable. Append a new item or file a "
+                            "supersession record instead."
+                        ),
+                    )
+                )
+
+    for status, path in receipt_diff:
+        code = status.strip().upper()[:1] if status.strip() else ""
+        if code in ("M", "D", "R", "C"):
+            violations.append(
+                ModelAppendOnlyViolation(
+                    kind=EnumAppendOnlyViolationKind.RECEIPT_FILE_MUTATED,
+                    target=path,
+                    detail=(
+                        f"receipt file {path!r} was {code!r} (modified/deleted/"
+                        "renamed); merged receipts are immutable. Corrections must "
+                        "be net-new '.supersede.<NNNN>.yaml' add-only files."
+                    ),
+                )
+            )
+
+    if violations:
+        return ModelOccAppendOnlyResult(
+            ok=False,
+            reason=_APPEND_ONLY_VIOLATION,
+            violations=tuple(violations),
+            detail=f"{len(violations)} append-only violation(s) detected.",
+        )
+    return ModelOccAppendOnlyResult(
+        ok=True,
+        detail="No append-only violations: existing entries and receipts unchanged.",
+    )
+
+
+def _load_yaml_from_git(
+    repo: Path, ref: str, rel_path: str
+) -> dict[str, object] | None:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{ref}:{rel_path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    parsed = yaml.safe_load(proc.stdout)
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _load_yaml_file(path: Path) -> dict[str, object] | None:
+    if not path.is_file():
+        return None
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _receipt_diff_from_git(
+    repo: Path, base_ref: str, ticket_id: str
+) -> list[tuple[str, str]]:
+    scope = f"{_RECEIPT_DIR_PREFIX}/{ticket_id}"
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--name-status", base_ref, "--", scope],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    diff: list[tuple[str, str]] = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        # Rename/copy lines carry the destination path last.
+        path = parts[-1]
+        diff.append((status, path))
+    return diff
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="OCC append-only enforcement gate (OMN-13888)"
+    )
+    parser.add_argument("--repo", required=True, help="Path to the OCC repo root.")
+    parser.add_argument("--ticket-id", required=True)
+    parser.add_argument(
+        "--base-ref",
+        default="origin/dev",
+        help="Merge-base ref to compare against (default origin/dev).",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo)
+    contract_rel = f"contracts/{args.ticket_id}.yaml"
+    base_contract = _load_yaml_from_git(repo, args.base_ref, contract_rel)
+    head_contract = _load_yaml_file(repo / contract_rel)
+    receipt_diff = _receipt_diff_from_git(repo, args.base_ref, args.ticket_id)
+
+    result = evaluate_append_only(base_contract, head_contract, receipt_diff)
+    sys.stdout.write(f"{result.to_json()}\n")
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "ModelOccAppendOnlyResult",
+    "evaluate_append_only",
+    "main",
+]

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -220,6 +220,24 @@ def validate_occ_merge_eligibility(
             # receipts grandfather so appending an entry does not invalidate
             # them). The None hard-fail (OMN-10421 / OMN-13061) fires only when
             # BOTH bindings are absent.
+            #
+            # Round-1 soft-spot (verifier PROBE6): `is_bound` keys on the
+            # receipt-controlled `pr_number`, so a NEW legacy-only receipt could
+            # in principle set a FOREIGN pr_number to reach the grandfather path
+            # and skip the whole-file check with a wrong hash. That path is NOT
+            # independently exploitable end-to-end: a receipt can only be
+            # introduced through an onex_change_control PR, and OCC's Receipt
+            # Honesty Gate (scripts/validation/check_receipt_hardening.py, a
+            # REQUIRED status check) validates every post-cutoff receipt's
+            # contract_sha256 == sha256(contracts/<ticket>.yaml) UNCONDITIONAL on
+            # pr_number — so a forged wrong-hash net-new receipt is rejected
+            # upstream before this grandfather is ever reached. The grandfather
+            # here is defense-in-depth behind that stricter gate; the terminal
+            # fix is the per-entry hash (scope 1), which makes every new receipt
+            # immune to appends without needing the whole-file grandfather at
+            # all. Full closure of the pure-function residual (an unforgeable
+            # "receipt file is net-new in this PR" git signal threaded from CI)
+            # is tracked as follow-up and is disproportionate to wire here.
             if (
                 receipt.contract_sha256 is None
                 and receipt.contract_entry_sha256 is None

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -31,6 +31,10 @@ from omnibase_core.validation.validator_receipt_gate import (
     _CONTRACT_SHA256_REQUIRED_AFTER,
     _extract_ticket_ids,
     _iter_dod_evidence,
+    check_receipt_contract_binding,
+)
+from omnibase_core.validation.validator_receipt_supersession import (
+    resolve_supersession,
 )
 
 EVIDENCE_TICKET_PATTERN = re.compile(
@@ -151,24 +155,51 @@ def validate_occ_merge_eligibility(
                 / f"{check_type}.yaml"
             )
             receipt_key = f"{ticket_id}:{evidence_item_id}:{check_type}"
-            if not receipt_path.exists():
-                missing_receipts.append(receipt_key)
-                continue
-            try:
-                receipt_raw = _load_yaml(receipt_path)
-                receipt = ModelDodReceipt.model_validate(receipt_raw)
-            except (OSError, yaml.YAMLError, ValidationError) as exc:
-                nonpass_receipts.append(receipt_key)
-                return ModelOccEligibilityResult(
-                    eligible=False,
-                    reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
-                    ticket_ids=ticket_ids,
-                    occ_commit_sha=snapshot.occ_commit_sha,
-                    contract_hashes=contract_hashes,
-                    receipt_ids=tuple(sorted(receipt_ids)),
-                    missing_or_nonpass_receipts=tuple(sorted(nonpass_receipts)),
-                    detail=f"receipt {receipt_path} is invalid: {exc}",
-                )
+
+            # OMN-13888 (scope 3): resolve the supersession chain first. A
+            # tombstone invalidates the key (no active receipt); a replacement
+            # re-binds it to a net-new receipt without editing the base file.
+            supersession = resolve_supersession(
+                snapshot.receipts_dir, ticket_id, evidence_item_id, check_type
+            )
+            if supersession is not None:
+                if supersession.error is not None:
+                    nonpass_receipts.append(receipt_key)
+                    return ModelOccEligibilityResult(
+                        eligible=False,
+                        reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
+                        ticket_ids=ticket_ids,
+                        occ_commit_sha=snapshot.occ_commit_sha,
+                        contract_hashes=contract_hashes,
+                        receipt_ids=tuple(sorted(receipt_ids)),
+                        missing_or_nonpass_receipts=tuple(sorted(nonpass_receipts)),
+                        detail=supersession.error,
+                    )
+                if supersession.tombstoned or supersession.receipt is None:
+                    missing_receipts.append(receipt_key)
+                    continue
+                receipt = supersession.receipt
+                receipt_source = supersession.source_path
+            else:
+                if not receipt_path.exists():
+                    missing_receipts.append(receipt_key)
+                    continue
+                try:
+                    receipt_raw = _load_yaml(receipt_path)
+                    receipt = ModelDodReceipt.model_validate(receipt_raw)
+                except (OSError, yaml.YAMLError, ValidationError) as exc:
+                    nonpass_receipts.append(receipt_key)
+                    return ModelOccEligibilityResult(
+                        eligible=False,
+                        reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
+                        ticket_ids=ticket_ids,
+                        occ_commit_sha=snapshot.occ_commit_sha,
+                        contract_hashes=contract_hashes,
+                        receipt_ids=tuple(sorted(receipt_ids)),
+                        missing_or_nonpass_receipts=tuple(sorted(nonpass_receipts)),
+                        detail=f"receipt {receipt_path} is invalid: {exc}",
+                    )
+                receipt_source = receipt_path
             if receipt.ticket_id != ticket_id:
                 return ModelOccEligibilityResult(
                     eligible=False,
@@ -178,17 +209,21 @@ def validate_occ_merge_eligibility(
                     contract_hashes=contract_hashes,
                     receipt_ids=tuple(sorted(receipt_ids)),
                     detail=(
-                        f"receipt {receipt_path} declares ticket_id={receipt.ticket_id}, "
+                        f"receipt {receipt_source} declares ticket_id={receipt.ticket_id}, "
                         f"expected {ticket_id}"
                     ),
                 )
-            # OMN-13061: hard-fail when contract_sha256 is None — mirrors
-            # validator_receipt_gate post-cutoff enforcement (OMN-10421).
-            # The migration window closed on _CONTRACT_SHA256_REQUIRED_AFTER
-            # (2026-04-30); all receipts authored after that date must bind
-            # a contract hash. Historical corpus scanners are ADVISORY only
-            # (OMN-13060 follow-through unchanged).
-            if receipt.contract_sha256 is None:
+            is_bound = _receipt_bound_to_pr(receipt, snapshot)
+            # OMN-13888 (scope 1/5): dual-accept contract binding. A receipt
+            # with a per-entry hash is checked strictly; a legacy receipt is
+            # whole-file-checked only when bound to THIS PR (prior merged
+            # receipts grandfather so appending an entry does not invalidate
+            # them). The None hard-fail (OMN-10421 / OMN-13061) fires only when
+            # BOTH bindings are absent.
+            if (
+                receipt.contract_sha256 is None
+                and receipt.contract_entry_sha256 is None
+            ):
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
@@ -197,13 +232,21 @@ def validate_occ_merge_eligibility(
                     contract_hashes=contract_hashes,
                     receipt_ids=tuple(sorted(receipt_ids)),
                     detail=(
-                        f"receipt {receipt_path} missing required contract_sha256 field "
-                        f"(OMN-10421 / OMN-13061): receipts produced after "
-                        f"{_CONTRACT_SHA256_REQUIRED_AFTER.date()} must record the "
-                        "contract hash. Rerun probes to produce a new receipt."
+                        f"receipt {receipt_source} missing both contract_sha256 and "
+                        f"contract_entry_sha256 (OMN-10421 / OMN-13061 / OMN-13888): "
+                        f"receipts produced after "
+                        f"{_CONTRACT_SHA256_REQUIRED_AFTER.date()} must bind the "
+                        "contract. Rerun probes to produce a new receipt."
                     ),
                 )
-            if receipt.contract_sha256 != contract_hash:
+            binding_error = check_receipt_contract_binding(
+                receipt=receipt,
+                contract_data=contract_data,
+                evidence_item_id=evidence_item_id,
+                whole_file_hash=contract_hash,
+                is_bound_to_this_pr=is_bound,
+            )
+            if binding_error is not None:
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
@@ -211,12 +254,9 @@ def validate_occ_merge_eligibility(
                     occ_commit_sha=snapshot.occ_commit_sha,
                     contract_hashes=contract_hashes,
                     receipt_ids=tuple(sorted(receipt_ids)),
-                    detail=(
-                        f"receipt {receipt_path} contract_sha256={receipt.contract_sha256} "
-                        f"does not match pinned contract hash {contract_hash}"
-                    ),
+                    detail=f"receipt {receipt_source}: {binding_error}",
                 )
-            if _receipt_bound_to_pr(receipt, snapshot):
+            if is_bound:
                 tickets_with_pr_bound_receipt.add(ticket_id)
             if receipt.status is not EnumReceiptStatus.PASS:
                 nonpass_receipts.append(receipt_key)

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -85,6 +85,7 @@ and scope for audit traceability.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -107,6 +108,9 @@ from omnibase_core.validation.completion_verify import verify as _completion_ver
 from omnibase_core.validation.runtime_sha_match import (
     CHECK_TYPE_RUNTIME_SHA_MATCH,
     classify_runtime_sha_match_receipt,
+)
+from omnibase_core.validation.validator_receipt_supersession import (
+    resolve_supersession,
 )
 
 # PRs opened after this UTC datetime must include contract_sha256 in receipts;
@@ -389,6 +393,114 @@ def _prefixed_contract_sha256(contract_path: Path) -> str:
     return f"sha256:{compute_contract_sha256(contract_path)}"
 
 
+# Immutable contract-identity fields folded into every per-entry hash
+# (OMN-13888). Deliberately excludes reworded fields such as ``title`` /
+# ``summary`` — including them would make the hash brittle without adding a real
+# integrity guarantee. ``ticket_id`` and ``schema_version`` are the invariant
+# contract identity.
+HEADER_FIELDS: tuple[str, ...] = ("ticket_id", "schema_version")
+
+
+class ContractEntryNotFoundError(LookupError):
+    """Raised when a dod_evidence item id is absent from the contract."""
+
+
+def compute_contract_entry_sha256(contract_data: object, evidence_item_id: str) -> str:
+    """Return the canonical per-entry contract hash for one dod_evidence item.
+
+    The hash binds a receipt to the parse-then-canonical-JSON of its own
+    dod_evidence item plus a pinned header subset (:data:`HEADER_FIELDS`), NOT
+    the whole contract file (OMN-13888). This is what makes appending a later
+    dod_evidence entry non-destructive: entry N+1 leaves the hashes of entries
+    1..N untouched.
+
+    The input is the **parsed** contract (``yaml.safe_load`` output), and the
+    output is canonical JSON (sorted keys, no whitespace). Folded scalars and
+    key ordering are normalised away, so a yamlfmt-style reflow/reindent/requote
+    of the contract file that preserves parsed semantics yields an identical
+    hash.
+
+    Raises:
+        ContractEntryNotFoundError: when no dod_evidence item has ``id ==
+            evidence_item_id``.
+    """
+    entry: dict[str, object] | None = None
+    if isinstance(contract_data, dict):
+        items = contract_data.get("dod_evidence", [])
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get("id") == evidence_item_id:
+                    entry = item
+                    break
+    if entry is None:
+        raise ContractEntryNotFoundError(
+            f"dod_evidence item {evidence_item_id!r} not found in contract"
+        )
+    header = {
+        key: (contract_data.get(key) if isinstance(contract_data, dict) else None)
+        for key in HEADER_FIELDS
+    }
+    canonical = {"header": header, "entry": entry}
+    blob = json.dumps(
+        canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return f"sha256:{hashlib.sha256(blob.encode('utf-8')).hexdigest()}"
+
+
+def check_receipt_contract_binding(
+    receipt: ModelDodReceipt,
+    contract_data: object,
+    evidence_item_id: str,
+    whole_file_hash: str,
+    is_bound_to_this_pr: bool,
+) -> str | None:
+    """Dual-accept contract-binding check shared by both OCC gates (OMN-13888).
+
+    Precedence:
+
+    1. ``contract_entry_sha256`` present → NEW scheme, always strict: the
+       receipt's entry hash must equal the recomputed per-entry hash. A forged
+       new receipt fails here.
+    2. Legacy (only ``contract_sha256``):
+       - bound to THIS PR → whole-file transition check (must match the current
+         whole-file hash).
+       - a PRIOR merged receipt → grandfathered: NOT re-hashed against the
+         (since-grown) whole-file hash, so appending an entry does not
+         retroactively invalidate it.
+
+    Returns ``None`` when the binding is valid, else an operator-facing failure
+    reason. The "both hashes absent" hard-fail is left to the caller because
+    the eligibility gate and receipt gate apply distinct cutoff policy to it.
+    """
+    if receipt.contract_entry_sha256 is not None:
+        try:
+            expected = compute_contract_entry_sha256(contract_data, evidence_item_id)
+        except ContractEntryNotFoundError as exc:
+            return (
+                f"contract_entry_sha256 present but {exc}; the receipt binds a "
+                "dod_evidence item that no longer exists in the contract"
+            )
+        if receipt.contract_entry_sha256 != expected:
+            return (
+                "entry hash mismatch: receipt "
+                f"contract_entry_sha256={receipt.contract_entry_sha256!r} does "
+                f"not match recomputed per-entry hash {expected!r} for "
+                f"{evidence_item_id!r}. The dod_evidence item mutated since the "
+                "receipt was produced (or the receipt is forged); rerun probes."
+            )
+        return None
+
+    if receipt.contract_sha256 is not None and is_bound_to_this_pr:
+        if receipt.contract_sha256 != whole_file_hash:
+            return (
+                "whole-file hash mismatch: receipt "
+                f"contract_sha256={receipt.contract_sha256!r} does not match "
+                f"pinned contract hash {whole_file_hash!r}. Contract mutated "
+                "post-receipt; rerun probes or mint a per-entry hash."
+            )
+    return None
+
+
 def _extract_ticket_ids(pr_body: str, pr_title: str | None = None) -> list[str]:
     """Return sorted unique ticket IDs cited by this PR.
 
@@ -574,6 +686,8 @@ def _check_one_receipt(
     receipts_dir: Path,
     contract_path: Path | None = None,
     pr_opened_at: datetime | None = None,
+    contract_data: object = None,
+    current_pr_number: int | None = None,
 ) -> ModelReceiptCheckResult:
     """Verify exactly one (ticket, evidence, check) has a PASS receipt on disk."""
     receipt_path = receipts_dir / ticket_id / evidence_item_id / f"{check_type}.yaml"
@@ -587,15 +701,35 @@ def _check_one_receipt(
             reason=reason,
         )
 
-    receipt, receipt_failure = _load_bound_receipt(
-        receipt_path,
-        ticket_id,
-        evidence_item_id,
-        check_type,
+    # OMN-13888 (scope 3): resolve the supersession chain before loading the
+    # base file. A tombstone means the key has no active receipt (fail as
+    # missing); a replacement re-binds the key without editing the base file.
+    supersession = resolve_supersession(
+        receipts_dir, ticket_id, evidence_item_id, check_type
     )
-    if receipt_failure is not None:
-        return fail(receipt_failure)
-    assert receipt is not None
+    receipt: ModelDodReceipt
+    if supersession is not None:
+        if supersession.error is not None:
+            return fail(supersession.error)
+        active_receipt = supersession.receipt
+        if supersession.tombstoned or active_receipt is None:
+            return fail(
+                f"receipt for {ticket_id}/{evidence_item_id}/{check_type} is "
+                f"tombstoned at {supersession.source_path}; the key has no "
+                "active receipt (supersession invalidated it)"
+            )
+        receipt = active_receipt
+        receipt_path = supersession.source_path
+    else:
+        loaded, receipt_failure = _load_bound_receipt(
+            receipt_path,
+            ticket_id,
+            evidence_item_id,
+            check_type,
+        )
+        if receipt_failure is not None or loaded is None:
+            return fail(receipt_failure or f"no receipt at {receipt_path}")
+        receipt = loaded
 
     # Post-schema adversarial guard: surface ADVISORY / PENDING / self-
     # attestation with a message that names the rule (OMN-9788).
@@ -620,23 +754,26 @@ def _check_one_receipt(
                 f"{runtime_sha_result.reason}"
             )
 
-    # Hash-binding check (OMN-10421, invariant I4): verify the contract has
-    # not mutated since this receipt was produced. Only active when the caller
-    # supplies pr_opened_at — callers that omit it get no hash enforcement
-    # (backward-compatible with pre-OMN-10421 call sites).
+    # Hash-binding check (OMN-10421 invariant I4; OMN-13888 dual-accept):
+    # verify the contract has not mutated since this receipt was produced. Only
+    # active when the caller supplies pr_opened_at — callers that omit it get no
+    # hash enforcement (backward-compatible with pre-OMN-10421 call sites).
     if (
         contract_path is not None
         and contract_path.exists()
         and pr_opened_at is not None
     ):
-        actual_sha = _prefixed_contract_sha256(contract_path)
-        if receipt.contract_sha256 is None:
+        # Both bindings absent: legacy None-handling (post-cutoff hard FAIL /
+        # pre-cutoff ADVISORY). Only fires when neither hash is present.
+        if receipt.contract_sha256 is None and receipt.contract_entry_sha256 is None:
             is_post_cutoff = pr_opened_at >= _CONTRACT_SHA256_REQUIRED_AFTER
             if is_post_cutoff:
                 return fail(
-                    f"receipt at {receipt_path} missing required contract_sha256 field "
-                    f"(OMN-10421): receipts produced after {_CONTRACT_SHA256_REQUIRED_AFTER.date()} "
-                    "must record the contract hash. Rerun probes to produce a new receipt."
+                    f"receipt at {receipt_path} missing required contract binding "
+                    f"(OMN-10421 / OMN-13888): receipts produced after "
+                    f"{_CONTRACT_SHA256_REQUIRED_AFTER.date()} must record "
+                    "contract_sha256 or contract_entry_sha256. Rerun probes to "
+                    "produce a new receipt."
                 )
             # Pre-cutoff PR: ADVISORY downgrade — field expected soon but not yet required.
             return ModelReceiptCheckResult(
@@ -645,17 +782,29 @@ def _check_one_receipt(
                 check_type=check_type,
                 passed=False,
                 reason=(
-                    f"receipt at {receipt_path} missing contract_sha256 (ADVISORY — "
+                    f"receipt at {receipt_path} missing contract binding (ADVISORY — "
                     "legacy receipt within 7-day migration window; rerun probes to bind "
                     "the receipt to the current contract hash)"
                 ),
             )
-        if receipt.contract_sha256 != actual_sha:
-            return fail(
-                f"contract mutated post-receipt; rerun probes. "
-                f"receipt contract_sha256={receipt.contract_sha256!r} but "
-                f"sha256({contract_path})={actual_sha!r}"
-            )
+        whole_file_hash = _prefixed_contract_sha256(contract_path)
+        # A legacy whole-file receipt is grandfathered when it binds a
+        # DIFFERENT (prior) PR — appending an entry must not invalidate it.
+        # Absent PR context, or a same-PR / pr_number-less receipt, stays strict.
+        is_bound_to_this_pr = (
+            current_pr_number is None
+            or receipt.pr_number is None
+            or receipt.pr_number == current_pr_number
+        )
+        binding_error = check_receipt_contract_binding(
+            receipt=receipt,
+            contract_data=contract_data,
+            evidence_item_id=evidence_item_id,
+            whole_file_hash=whole_file_hash,
+            is_bound_to_this_pr=is_bound_to_this_pr,
+        )
+        if binding_error is not None:
+            return fail(binding_error)
 
     return ModelReceiptCheckResult(
         ticket_id=ticket_id,
@@ -1045,6 +1194,7 @@ def _check_ticket(
     contracts_dir: Path,
     receipts_dir: Path,
     pr_opened_at: datetime | None,
+    current_pr_number: int | None = None,
 ) -> list[ModelReceiptCheckResult]:
     """Load a ticket contract and verify all its dod_evidence receipts.
 
@@ -1086,6 +1236,8 @@ def _check_ticket(
             receipts_dir,
             contract_path=contract_path,
             pr_opened_at=pr_opened_at,
+            contract_data=contract_data,
+            current_pr_number=current_pr_number,
         )
         for item_id, check_type, _check_value in triples
     ]
@@ -1275,7 +1427,13 @@ def validate_pr_receipts(
     all_checks: list[ModelReceiptCheckResult] = []
     for ticket_id in ticket_ids:
         all_checks.extend(
-            _check_ticket(ticket_id, contracts_dir, receipts_dir, pr_opened_at)
+            _check_ticket(
+                ticket_id,
+                contracts_dir,
+                receipts_dir,
+                pr_opened_at,
+                current_pr_number=current_pr_number,
+            )
         )
 
     failures = [c for c in all_checks if not c.passed]
@@ -1321,11 +1479,15 @@ __all__ = [
     "EVIDENCE_SOURCE_PATTERN",
     "EVIDENCE_SOURCE_SHA_PATTERN",
     "EVIDENCE_TICKET_PATTERN",
+    "HEADER_FIELDS",
     "OVERRIDE_PATTERN",
     "SKIP_TOKEN_PATTERN",
     "TICKET_PATTERN",
+    "ContractEntryNotFoundError",
     "_CONTRACT_SHA256_REQUIRED_AFTER",
+    "check_receipt_contract_binding",
     "classify_evidence_class",
+    "compute_contract_entry_sha256",
     "compute_contract_sha256",
     "parse_evidence_source",
     "parse_pr_opened_at",

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -471,6 +471,18 @@ def check_receipt_contract_binding(
     Returns ``None`` when the binding is valid, else an operator-facing failure
     reason. The "both hashes absent" hard-fail is left to the caller because
     the eligibility gate and receipt gate apply distinct cutoff policy to it.
+
+    Grandfather safety (OMN-13888 round-1 PROBE6). ``is_bound_to_this_pr`` is
+    derived by callers from the receipt-controlled ``pr_number``, so a NEW
+    legacy-only receipt could nominally set a foreign ``pr_number`` to reach the
+    grandfather branch and skip the whole-file check. This is defense-in-depth,
+    not the sole barrier: receipts are only introduced through onex_change_control
+    PRs, where the Receipt Honesty Gate (``check_receipt_hardening.py``) already
+    rejects any post-cutoff receipt whose ``contract_sha256`` != the CURRENT
+    ``sha256(contracts/<ticket>.yaml)`` — unconditional on ``pr_number`` — so a
+    forged wrong-hash net-new receipt never survives to this point. The per-entry
+    hash (branch 1) is the terminal fix that removes the grandfather's relevance
+    for all future receipts.
     """
     if receipt.contract_entry_sha256 is not None:
         try:

--- a/src/omnibase_core/validation/validator_receipt_supersession.py
+++ b/src/omnibase_core/validation/validator_receipt_supersession.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Supersession-chain resolution for DoD receipts (OMN-13888, scope item 3).
+
+A receipt key ``(<TICKET>, <EVIDENCE_ITEM>, <CHECK_TYPE>)`` maps to a base file::
+
+    drift/dod_receipts/<TICKET>/<EVIDENCE_ITEM>/<CHECK_TYPE>.yaml
+
+plus an append-only chain of net-new correction records::
+
+    drift/dod_receipts/<TICKET>/<EVIDENCE_ITEM>/<CHECK_TYPE>.supersede.<NNNN>.yaml
+
+The record with the highest zero-padded ``NNNN`` is authoritative. A tombstone
+record (``tombstone: true``, no replacement) invalidates the key; a replacement
+record re-binds the key to a new receipt embedded in the record. When no
+supersession file exists, the key resolves to its base receipt file. No merged
+file is ever edited — corrections are always net-new higher-numbered files.
+
+This module keeps the path-local O(1) glob the receipt tree was built for; it
+does not scan a global supersessions directory.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.models.contracts.ticket.model_receipt_supersession import (
+    ModelReceiptSupersession,
+)
+
+_SUPERSEDE_NNNN_RE = re.compile(r"\.supersede\.(\d+)\.yaml$")
+
+
+@dataclass(frozen=True)
+class SupersessionResolution:
+    """Outcome of resolving a receipt key's supersession chain.
+
+    Exactly one of ``receipt``, ``tombstoned``, or ``error`` is meaningful:
+
+    - ``receipt`` set → the key is re-bound to this replacement receipt.
+    - ``tombstoned`` True → the key is deliberately invalidated (no active
+      receipt); the caller must treat it as MISSING / non-satisfied.
+    - ``error`` set → the latest supersession record is unreadable/invalid; the
+      caller must fail closed.
+
+    ``source_path`` names the record used, for operator-facing messages.
+    """
+
+    receipt: ModelDodReceipt | None
+    tombstoned: bool
+    error: str | None
+    source_path: Path
+
+
+def resolve_supersession(
+    receipts_dir: Path,
+    ticket_id: str,
+    evidence_item_id: str,
+    check_type: str,
+) -> SupersessionResolution | None:
+    """Resolve the active receipt for a key from its supersession chain.
+
+    Returns ``None`` when no supersession file exists for the key — the caller
+    then proceeds with the base receipt file exactly as before (backward
+    compatible). Otherwise returns a :class:`SupersessionResolution` describing
+    the re-bind, the tombstone, or a load error from the authoritative record.
+    """
+    key_dir = receipts_dir / ticket_id / evidence_item_id
+    if not key_dir.is_dir():
+        return None
+
+    numbered: list[tuple[int, Path]] = []
+    for candidate in key_dir.glob(f"{check_type}.supersede.*.yaml"):
+        match = _SUPERSEDE_NNNN_RE.search(candidate.name)
+        if match is not None:
+            numbered.append((int(match.group(1)), candidate))
+    if not numbered:
+        return None
+
+    numbered.sort(key=lambda item: item[0])
+    _, latest_path = numbered[-1]
+
+    try:
+        with latest_path.open(encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+    except (yaml.YAMLError, OSError) as exc:
+        return SupersessionResolution(
+            receipt=None,
+            tombstoned=False,
+            error=f"supersession record {latest_path} is unreadable: {exc}",
+            source_path=latest_path,
+        )
+
+    try:
+        record = ModelReceiptSupersession.model_validate(raw)
+    except ValidationError as exc:
+        return SupersessionResolution(
+            receipt=None,
+            tombstoned=False,
+            error=f"supersession record {latest_path} is invalid: {exc}",
+            source_path=latest_path,
+        )
+
+    if (record.ticket_id, record.evidence_item_id, record.check_type) != (
+        ticket_id,
+        evidence_item_id,
+        check_type,
+    ):
+        return SupersessionResolution(
+            receipt=None,
+            tombstoned=False,
+            error=(
+                f"supersession record {latest_path} declares key "
+                f"({record.ticket_id}, {record.evidence_item_id}, "
+                f"{record.check_type}) but is filed under "
+                f"({ticket_id}, {evidence_item_id}, {check_type})"
+            ),
+            source_path=latest_path,
+        )
+
+    if record.tombstone:
+        return SupersessionResolution(
+            receipt=None,
+            tombstoned=True,
+            error=None,
+            source_path=latest_path,
+        )
+
+    return SupersessionResolution(
+        receipt=record.replacement,
+        tombstoned=False,
+        error=None,
+        source_path=latest_path,
+    )
+
+
+__all__ = ["SupersessionResolution", "resolve_supersession"]

--- a/tests/unit/validation/test_occ_per_entry_hashing.py
+++ b/tests/unit/validation/test_occ_per_entry_hashing.py
@@ -1,0 +1,596 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-13888 — per-entry hashing, append-only, supersession, dual-accept.
+
+These regression tests prove the OCC merge-eligibility redesign:
+
+* Class 1 — appending a dod_evidence entry does not invalidate prior receipts.
+* Class 2 — supersession/tombstone re-bind or invalidate a key without edits.
+* Class 3 — Nth-consumer lockout is gone; forgery + grandfather + dual-accept.
+* Determinism — the per-entry hash is invariant across a yamlfmt-style reflow.
+* Append-only — edit/remove of an entry or receipt file is a violation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.contracts.ticket.model_receipt_supersession import (
+    ModelReceiptSupersession,
+)
+from omnibase_core.validation.validator_occ_append_only import evaluate_append_only
+from omnibase_core.validation.validator_occ_merge_eligibility import (
+    EnumOccEligibilityReason,
+    ModelOccEligibilityInput,
+    validate_occ_merge_eligibility,
+)
+from omnibase_core.validation.validator_receipt_gate import (
+    compute_contract_entry_sha256,
+    parse_pr_opened_at,
+    validate_pr_receipts,
+)
+from omnibase_core.validation.validator_receipt_supersession import (
+    resolve_supersession,
+)
+
+TICKET = "OMN-13888"
+
+
+def _entry(item_id: str, value: str) -> dict:
+    return {
+        "id": item_id,
+        "description": f"entry {item_id}",
+        "checks": [{"check_type": "command", "check_value": value}],
+    }
+
+
+def _contract(item_ids: list[str]) -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "ticket_id": TICKET,
+        "title": "per-entry hashing",
+        "dod_evidence": [_entry(i, f"cmd-{i}") for i in item_ids],
+    }
+
+
+def _write_contract(root: Path, contract: dict) -> Path:
+    (root / "contracts").mkdir(parents=True, exist_ok=True)
+    path = root / "contracts" / f"{TICKET}.yaml"
+    path.write_text(yaml.safe_dump(contract, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _whole_file_hash(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _receipt_dict(
+    *,
+    item_id: str,
+    pr_number: int,
+    commit_sha: str,
+    contract_entry_sha256: str | None = None,
+    contract_sha256: str | None = None,
+    status: EnumReceiptStatus = EnumReceiptStatus.PASS,
+) -> dict:
+    data = {
+        "schema_version": "1.0.0",
+        "ticket_id": TICKET,
+        "evidence_item_id": item_id,
+        "check_type": "command",
+        "check_value": f"cmd-{item_id}",
+        "status": status.value,
+        "run_timestamp": datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+        "commit_sha": commit_sha,
+        "runner": "worker",
+        "verifier": "independent-ci",
+        "probe_command": f"run cmd-{item_id}",
+        "probe_stdout": "1 passed\n",
+        "exit_code": 0,
+        "pr_number": pr_number,
+    }
+    if contract_entry_sha256 is not None:
+        data["contract_entry_sha256"] = contract_entry_sha256
+    if contract_sha256 is not None:
+        data["contract_sha256"] = contract_sha256
+    return data
+
+
+def _write_receipt(root: Path, item_id: str, data: dict) -> Path:
+    path = root / "receipts" / TICKET / item_id / "command.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _snapshot(
+    root: Path, *, pr_number: int, commit_sha: str
+) -> ModelOccEligibilityInput:
+    return ModelOccEligibilityInput(
+        repo="omnibase_core",
+        pr_number=pr_number,
+        pr_title=f"fix({TICKET}): per-entry hashing",
+        pr_body=f"Closes: {TICKET}",
+        pr_branch=f"jonah/{TICKET.lower()}-x",
+        pr_commit_shas=(commit_sha,),
+        pr_commit_texts=(f"fix({TICKET}): work",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=root / "contracts",
+        receipts_dir=root / "receipts",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Determinism (scope 3a)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_entry_hash_deterministic_across_yamlfmt_reflow() -> None:
+    contract = _contract(["a", "b"])
+    baseline = compute_contract_entry_sha256(contract, "a")
+    # yamlfmt-style transform that preserves parsed semantics:
+    # reorder top-level keys, reorder nested keys, add a reworded title.
+    reflowed = {
+        "title": "COMPLETELY reworded title >- folded",
+        "dod_evidence": [
+            {
+                "checks": [{"check_value": "cmd-a", "check_type": "command"}],
+                "description": "entry a",
+                "id": "a",
+            },
+            _entry("b", "cmd-b"),
+        ],
+        "schema_version": "1.0.0",
+        "ticket_id": TICKET,
+    }
+    assert compute_contract_entry_sha256(reflowed, "a") == baseline
+
+
+# --------------------------------------------------------------------------- #
+# Class 1 — append non-destructive
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_append_entry_does_not_invalidate_prior_receipts_eligibility(
+    tmp_path: Path,
+) -> None:
+    # Grown contract [a, b, c]. a/b bound to PRIOR merged PRs; c bound to THIS PR.
+    contract = _contract(["a", "b", "c"])
+    _write_contract(tmp_path, contract)
+    for item, pr, sha in (("a", 101, "a" * 40), ("b", 102, "b" * 40)):
+        _write_receipt(
+            tmp_path,
+            item,
+            _receipt_dict(
+                item_id=item,
+                pr_number=pr,
+                commit_sha=sha,
+                contract_entry_sha256=compute_contract_entry_sha256(contract, item),
+            ),
+        )
+    this_sha = "c" * 40
+    prior_a_bytes = (tmp_path / "receipts" / TICKET / "a" / "command.yaml").read_bytes()
+    _write_receipt(
+        tmp_path,
+        "c",
+        _receipt_dict(
+            item_id="c",
+            pr_number=303,
+            commit_sha=this_sha,
+            contract_entry_sha256=compute_contract_entry_sha256(contract, "c"),
+        ),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha=this_sha)
+    )
+    assert result.eligible is True, result.detail
+    # prior receipt bytes untouched
+    assert (
+        tmp_path / "receipts" / TICKET / "a" / "command.yaml"
+    ).read_bytes() == prior_a_bytes
+
+
+@pytest.mark.unit
+def test_append_entry_receipt_gate_passes_without_rewrite(tmp_path: Path) -> None:
+    contract = _contract(["a", "b"])
+    contract_path = _write_contract(tmp_path, contract)
+    for item, pr, sha in (("a", 101, "a" * 40), ("b", 202, "b" * 40)):
+        _write_receipt(
+            tmp_path,
+            item,
+            _receipt_dict(
+                item_id=item,
+                pr_number=pr,
+                commit_sha=sha,
+                contract_entry_sha256=compute_contract_entry_sha256(contract, item),
+            ),
+        )
+    result = validate_pr_receipts(
+        pr_body=f"Closes: {TICKET}",
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+        pr_title=f"fix({TICKET}): x",
+        pr_opened_at=parse_pr_opened_at("2026-06-01T00:00:00Z"),
+        current_pr_number=202,
+    )
+    assert result.passed is True, result.message
+    assert contract_path.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Class 3 — forgery + grandfather + dual-accept
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_forged_entry_hash_fails_eligibility(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    forged = "sha256:" + "0" * 64
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=303,
+            commit_sha="c" * 40,
+            contract_entry_sha256=forged,
+        ),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha="c" * 40)
+    )
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+@pytest.mark.unit
+def test_legacy_prior_receipt_grandfathered_on_grown_contract(tmp_path: Path) -> None:
+    # a: legacy whole-file receipt bound to a PRIOR merged PR. b: current-PR
+    # receipt with per-entry hash. The whole-file hash of the grown [a,b]
+    # contract differs from a's recorded (stale) contract_sha256, but a is a
+    # prior receipt so it is grandfathered (not re-hashed).
+    contract = _contract(["a", "b"])
+    _write_contract(tmp_path, contract)
+    stale_whole = "sha256:" + "f" * 64
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=101,
+            commit_sha="a" * 40,
+            contract_sha256=stale_whole,
+        ),
+    )
+    this_sha = "c" * 40
+    _write_receipt(
+        tmp_path,
+        "b",
+        _receipt_dict(
+            item_id="b",
+            pr_number=303,
+            commit_sha=this_sha,
+            contract_entry_sha256=compute_contract_entry_sha256(contract, "b"),
+        ),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha=this_sha)
+    )
+    assert result.eligible is True, result.detail
+
+
+@pytest.mark.unit
+def test_entry_hash_wins_over_stale_whole_file(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    this_sha = "c" * 40
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=303,
+            commit_sha=this_sha,
+            contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+            contract_sha256="sha256:" + "f" * 64,  # stale whole-file, ignored
+        ),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha=this_sha)
+    )
+    assert result.eligible is True, result.detail
+
+
+@pytest.mark.unit
+def test_wrong_entry_hash_wins_over_matching_whole_file(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    contract_path = _write_contract(tmp_path, contract)
+    this_sha = "c" * 40
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=303,
+            commit_sha=this_sha,
+            contract_entry_sha256="sha256:" + "0" * 64,  # wrong entry hash
+            contract_sha256=_whole_file_hash(contract_path),  # matching whole-file
+        ),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha=this_sha)
+    )
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+@pytest.mark.unit
+def test_both_bindings_absent_hard_fails(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(item_id="a", pr_number=303, commit_sha="c" * 40),
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha="c" * 40)
+    )
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+# --------------------------------------------------------------------------- #
+# Class 2 — supersession + tombstone
+# --------------------------------------------------------------------------- #
+
+
+def _supersession_dict(
+    *, item_id: str, tombstone: bool, replacement: dict | None
+) -> dict:
+    data = {
+        "schema_version": "1.0.0",
+        "ticket_id": TICKET,
+        "evidence_item_id": item_id,
+        "check_type": "command",
+        "supersedes": f"drift/dod_receipts/{TICKET}/{item_id}/command.yaml",
+        "reason": "rebind to the actually-merged PR",
+        "superseder": "closeout-agent",
+        "created_at": datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        "tombstone": tombstone,
+    }
+    if replacement is not None:
+        data["replacement"] = replacement
+    return data
+
+
+@pytest.mark.unit
+def test_supersession_replacement_rebinds_key_eligibility(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    # base receipt binds a stale/superseded PR
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=101,
+            commit_sha="a" * 40,
+            contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+        ),
+    )
+    this_sha = "c" * 40
+    replacement = _receipt_dict(
+        item_id="a",
+        pr_number=303,
+        commit_sha=this_sha,
+        contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+    )
+    supersede_path = (
+        tmp_path / "receipts" / TICKET / "a" / "command.supersede.0001.yaml"
+    )
+    supersede_path.write_text(
+        yaml.safe_dump(
+            _supersession_dict(item_id="a", tombstone=False, replacement=replacement),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha=this_sha)
+    )
+    assert result.eligible is True, result.detail
+
+
+@pytest.mark.unit
+def test_tombstone_only_invalidates_key(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    _write_receipt(
+        tmp_path,
+        "a",
+        _receipt_dict(
+            item_id="a",
+            pr_number=303,
+            commit_sha="c" * 40,
+            contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+        ),
+    )
+    supersede_path = (
+        tmp_path / "receipts" / TICKET / "a" / "command.supersede.0001.yaml"
+    )
+    supersede_path.write_text(
+        yaml.safe_dump(
+            _supersession_dict(item_id="a", tombstone=True, replacement=None),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    result = validate_occ_merge_eligibility(
+        _snapshot(tmp_path, pr_number=303, commit_sha="c" * 40)
+    )
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
+
+
+@pytest.mark.unit
+def test_highest_nnnn_untombstones(tmp_path: Path) -> None:
+    contract = _contract(["a"])
+    _write_contract(tmp_path, contract)
+    key_dir = tmp_path / "receipts" / TICKET / "a"
+    key_dir.mkdir(parents=True, exist_ok=True)
+    (key_dir / "command.yaml").write_text("placeholder: true\n", encoding="utf-8")
+    (key_dir / "command.supersede.0001.yaml").write_text(
+        yaml.safe_dump(
+            _supersession_dict(item_id="a", tombstone=True, replacement=None),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    replacement = _receipt_dict(
+        item_id="a",
+        pr_number=303,
+        commit_sha="c" * 40,
+        contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+    )
+    (key_dir / "command.supersede.0002.yaml").write_text(
+        yaml.safe_dump(
+            _supersession_dict(item_id="a", tombstone=False, replacement=replacement),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    resolution = resolve_supersession(tmp_path / "receipts", TICKET, "a", "command")
+    assert resolution is not None
+    assert resolution.tombstoned is False
+    assert resolution.receipt is not None
+    assert resolution.receipt.pr_number == 303
+
+
+# --------------------------------------------------------------------------- #
+# Supersession model invariants
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_supersession_requires_replacement_unless_tombstone() -> None:
+    with pytest.raises(ValueError, match="must carry a replacement"):
+        ModelReceiptSupersession.model_validate(
+            _supersession_dict(item_id="a", tombstone=False, replacement=None)
+        )
+
+
+@pytest.mark.unit
+def test_supersession_replacement_must_carry_entry_hash() -> None:
+    contract = _contract(["a"])
+    replacement = _receipt_dict(
+        item_id="a",
+        pr_number=303,
+        commit_sha="c" * 40,
+        contract_sha256="sha256:" + "a" * 64,  # whole-file only, no entry hash
+    )
+    with pytest.raises(ValueError, match="contract_entry_sha256"):
+        ModelReceiptSupersession.model_validate(
+            _supersession_dict(item_id="a", tombstone=False, replacement=replacement)
+        )
+    del contract  # silence unused
+
+
+@pytest.mark.unit
+def test_supersession_tombstone_rejects_replacement() -> None:
+    contract = _contract(["a"])
+    replacement = _receipt_dict(
+        item_id="a",
+        pr_number=303,
+        commit_sha="c" * 40,
+        contract_entry_sha256=compute_contract_entry_sha256(contract, "a"),
+    )
+    with pytest.raises(ValueError, match="must not carry a replacement"):
+        ModelReceiptSupersession.model_validate(
+            _supersession_dict(item_id="a", tombstone=True, replacement=replacement)
+        )
+
+
+@pytest.mark.unit
+def test_supersession_replacement_key_must_match() -> None:
+    contract = _contract(["a", "b"])
+    replacement = _receipt_dict(
+        item_id="b",  # mismatched key
+        pr_number=303,
+        commit_sha="c" * 40,
+        contract_entry_sha256=compute_contract_entry_sha256(contract, "b"),
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        ModelReceiptSupersession.model_validate(
+            _supersession_dict(item_id="a", tombstone=False, replacement=replacement)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Append-only validator
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_append_only_allows_new_entry() -> None:
+    base = _contract(["a"])
+    head = _contract(["a", "b"])
+    result = evaluate_append_only(base, head, [])
+    assert result.ok is True, result.detail
+
+
+@pytest.mark.unit
+def test_append_only_rejects_edit() -> None:
+    base = _contract(["a"])
+    head = _contract(["a"])
+    # mutate entry a's check_value
+    head["dod_evidence"][0]["checks"][0]["check_value"] = "MUTATED"
+    result = evaluate_append_only(base, head, [])
+    assert result.ok is False
+    assert result.reason == "APPEND_ONLY_VIOLATION"
+    assert result.violations[0].kind.value == "entry_edited"
+
+
+@pytest.mark.unit
+def test_append_only_rejects_removal() -> None:
+    base = _contract(["a", "b"])
+    head = _contract(["a"])
+    result = evaluate_append_only(base, head, [])
+    assert result.ok is False
+    assert any(v.kind.value == "entry_removed" for v in result.violations)
+
+
+@pytest.mark.unit
+def test_append_only_rejects_receipt_file_mutation() -> None:
+    base = _contract(["a"])
+    head = _contract(["a"])
+    diff = [("M", f"drift/dod_receipts/{TICKET}/a/command.yaml")]
+    result = evaluate_append_only(base, head, diff)
+    assert result.ok is False
+    assert any(v.kind.value == "receipt_file_mutated" for v in result.violations)
+
+
+@pytest.mark.unit
+def test_append_only_allows_added_supersede_file() -> None:
+    base = _contract(["a"])
+    head = _contract(["a"])
+    diff = [("A", f"drift/dod_receipts/{TICKET}/a/command.supersede.0001.yaml")]
+    result = evaluate_append_only(base, head, diff)
+    assert result.ok is True, result.detail
+
+
+@pytest.mark.unit
+def test_append_only_net_new_contract_passes() -> None:
+    head = _contract(["a"])
+    result = evaluate_append_only(None, head, [])
+    assert result.ok is True

--- a/tests/unit/validation/test_occ_per_entry_hashing.py
+++ b/tests/unit/validation/test_occ_per_entry_hashing.py
@@ -492,7 +492,6 @@ def test_supersession_requires_replacement_unless_tombstone() -> None:
 
 @pytest.mark.unit
 def test_supersession_replacement_must_carry_entry_hash() -> None:
-    contract = _contract(["a"])
     replacement = _receipt_dict(
         item_id="a",
         pr_number=303,
@@ -503,7 +502,6 @@ def test_supersession_replacement_must_carry_entry_hash() -> None:
         ModelReceiptSupersession.model_validate(
             _supersession_dict(item_id="a", tombstone=False, replacement=replacement)
         )
-    del contract  # silence unused
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.4"
+version = "0.46.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-13888 — OCC per-entry hashing + append-only + supersession + dual-accept (Option A)

Implements the operator-approved Option A design for the OCC merge-eligibility
redesign. Root cause: `validator_occ_merge_eligibility` and
`validator_receipt_gate` bound each receipt to the **whole contract file** hash,
so appending one dod_evidence entry changed the file hash and invalidated every
prior merged receipt — the OCC#3521 / OMN-13875 Nth-consumer lockout.

### What changed (omnibase_core)
- `compute_contract_entry_sha256(contract_data, evidence_item_id)` — canonical
  parse-then-JSON hash of a single dod_evidence item + an immutable header
  (`ticket_id` + `schema_version`). yamlfmt-deterministic (reflow/reorder/requote
  yields an identical hash). Appending entry N+1 leaves 1..N hashes untouched.
- `ModelDodReceipt.contract_entry_sha256` — new per-entry binding field;
  `contract_sha256` retained for grandfathering.
- `check_receipt_contract_binding` — dual-accept: entry-hash present → strict;
  legacy whole-file checked only when bound to THIS PR; prior merged receipts
  grandfather (never re-hashed). Wired into eligibility + receipt-gate.
- `ModelReceiptSupersession` + `resolve_supersession` — append-only
  `.supersede.<NNNN>.yaml` chain, highest NNNN wins, tombstone invalidates a key,
  replacement re-binds without editing any merged file.
- `validator_occ_append_only` + `ModelOccAppendOnlyResult` — rejects edits/removals
  of existing entries and M/D/R of merged receipt files; appends allowed.
- pyproject 0.46.4 → 0.46.5 (release-identity gate).

### Merge-time binding (scope 4)
occ-preflight keeps open-or-merged acceptance (no gh call) — a code PR could never
pass otherwise. The MERGED requirement lives in omnimarket `DurableEvidenceGate`
Check 2 (unchanged) plus tombstone honoring (companion omnimarket PR).

### Tests
21 new regression tests in `tests/unit/validation/test_occ_per_entry_hashing.py`
(determinism, append non-destructive on both gates, forgery, grandfather,
dual-accept precedence, supersession rebind/tombstone/untombstone, model
invariants, append-only). 299 existing receipt-gate/occ tests pass unchanged.

Evidence-Source: OCC#3548
Evidence-Ticket: OMN-13888

Refs OMN-13888, OMN-13875, OMN-13899.
