### PR TITLE
ci(OMN-13911): wire Handshake Policy Gate as a live merge_group check

### DIFF
--- a/.github/workflows/handshake-policy-gate.yml
+++ b/.github/workflows/handshake-policy-gate.yml
@@ -4,19 +4,26 @@
 name: Handshake Policy Gate
 # Checks that every active OmniNode repo has the architecture-handshake
 # CI workflow installed and passing on its default branch.
-# Runs weekly, on manual dispatch, and on PR/merge_group (OMN-13875) so the
-# check is a live, observable PR-time signal instead of only surfacing once a
-# week. NOT wired into required-status-checks here — the required-context
-# flip is a separate, staged decision (wedge-safety: this job depends on
-# POLICY_GATE_TOKEN, a cross-repo PAT not available to fork PRs).
+# Runs weekly, on manual dispatch, and on merge_group (OMN-13875) so the
+# check is a live, observable pre-merge signal instead of only surfacing
+# once a week. NOT wired into required-status-checks here — the
+# required-context flip is a separate, staged decision.
+#
+# Deliberately NOT triggered on `pull_request`: this job needs
+# POLICY_GATE_TOKEN (a cross-repo PAT), and this repo's OMNI_RUNNER_SELECTOR_V1
+# convention (see ci.yml) routes every `pull_request`-triggered job to the
+# public ubuntu-latest runner regardless of fork status, withholding trusted
+# secrets by design. Adding `pull_request` here would make this job
+# permanently red on every PR (confirmed live on PR #1381 — "ERROR: GitHub
+# CLI is not authenticated"), which is a worse, always-failing-but-ignorable
+# gate than the original silent one. `merge_group` is a distinct
+# `github.event_name` (not `pull_request`), so it correctly routes to the
+# trusted self-hosted runner where the token is available.
 
 on:
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: '0 8 * * 1'
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main, dev]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/handshake-policy-gate.yml
+++ b/.github/workflows/handshake-policy-gate.yml
@@ -4,12 +4,20 @@
 name: Handshake Policy Gate
 # Checks that every active OmniNode repo has the architecture-handshake
 # CI workflow installed and passing on its default branch.
-# Runs weekly and on manual dispatch.
+# Runs weekly, on manual dispatch, and on PR/merge_group (OMN-13875) so the
+# check is a live, observable PR-time signal instead of only surfacing once a
+# week. NOT wired into required-status-checks here — the required-context
+# flip is a separate, staged decision (wedge-safety: this job depends on
+# POLICY_GATE_TOKEN, a cross-repo PAT not available to fork PRs).
 
 on:
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: '0 8 * * 1'
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## OMN-13911 (child of OMN-13875) — omnibase_core finding: decorative CI gate

### Problem
`Handshake Policy Gate` (`.github/workflows/handshake-policy-gate.yml`) only triggered on `schedule` (weekly Monday 08:00 UTC) and `workflow_dispatch`. It never ran on `pull_request` or `merge_group`, so a broken architecture-handshake in any active OmniNode repo could go unnoticed for up to a week — the check existed but was never a live, observable pre-merge signal. Same decorative-gate class as the other four OMN-13875 findings (omnibase_infra #2188, omnibase_spi #254, omniintelligence #746 — all merged).

### Fix (revised after live evidence)
My first attempt added both `pull_request` and `merge_group` triggers, mirroring `url-authority-gate.yml`/`canonical-inference-gate.yml`. Live CI immediately showed "Check handshake compliance across repos" failing with "ERROR: GitHub CLI is not authenticated" — this job needs `POLICY_GATE_TOKEN`, and this repo's own `OMNI_RUNNER_SELECTOR_V1` convention (used throughout `ci.yml`) routes *every* `pull_request`-triggered job to the public `ubuntu-latest` runner regardless of fork status, withholding trusted secrets by design. `pull_request` would have made this job permanently red on every future PR.

Final fix drops `pull_request`, keeps `merge_group` only (a distinct, non-`pull_request` event_name, correctly reaching the trusted self-hosted runner where the token works):
```diff
 on:
   schedule:
     - cron: '0 8 * * 1'
+  merge_group:
   workflow_dispatch:
```

### Scope / wedge-safety
**Deliberately NOT added to required-status-checks** — that flip is a separate, staged decision.

### Verification
Workflow-YAML-only change, zero Python touched: `yaml.safe_load` OK both iterations; `uv run pre-commit run --files .github/workflows/handshake-policy-gate.yml` all applicable hooks Passed both iterations; `uv run pytest tests/ -v` (no `-k`) launched as the mandatory full-suite pre-push check (zero blast radius expected — no Python source/test file touched).

### OCC evidence
This is a child ticket (OMN-13911) of OMN-13875, carved out because the parent's shared contract already has 3 dod_evidence entries and cannot accept a 4th consumer without forcing a rewrite of already-merged receipts (OMN-13888 defect class).

Evidence-Source: OCC#3546
Evidence-Ticket: OMN-13911
