### PR TITLE
fix(OMN-13910): bump project.version 0.46.4 -> 0.46.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.4"
+version = "0.46.5"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.4"
+version = "0.46.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Problem (verified live 2026-07-03 ~17:30Z on core PR #1381)

`validate` fails on omnibase_core dev PRs with the OMN-13411 release-identity gate:
```
FAIL: packaged source changed but pyproject version 0.46.4 is NOT ahead of the latest published version 0.46.4 (OMN-13411 release-identity gate).
```
Since the 0.46.4 release train published earlier today, dev has accumulated packaged-source changes while `project.version` still reads 0.46.4 — so the gate fires on **every** PR to dev regardless of the PR's own content (the triggering PR, OMN-13875's #1381/#1383, touches only workflow YAML). This wedges all core dev work, including the in-flight OMN-13888 validator-redesign lane and OMN-13875/OMN-13911.

## Fix
Bump `project.version` 0.46.4 → 0.46.5 (the gate's own prescribed remedy) + regenerate `uv.lock` (embeds the self-version at `[[package]] name = "omnibase-core"`). No PyPI publish action here — 0.46.5 publishes on the next release train. Covered by the standing releases-autonomous grant (bump-to-unblock).

## Verification
- `python3 scripts/check_release_identity.py` → `OK: version 0.46.5 is ahead of latest published 0.46.4.`
- `uv run pytest tests/scripts/test_check_release_identity.py -v` → 9/9 passed, including the previously-failing `test_live_invocation_smoke`.
- `uv run pre-commit run --files pyproject.toml uv.lock` → all applicable hooks Passed, including "No code merged onto a published version without a bump (OMN-13411)".
- Targeted verification per the accepted OMN-13875 precedent (workflow/config-only diffs get targeted proof, not a full multi-hour local suite) — this diff touches zero source files, only version metadata.

## DoD
- [x] Bump PR merged to dev; `validate` (release-identity) green.
- [ ] Evidence commented on OMN-13910.
- [ ] omnibase_core#1383 (OMN-13911) rebased once this merges.

Evidence-Ticket: OMN-13910

Evidence-Source: OCC#3550
