### PR TITLE
ci(OMN-13914): add synchronize+reopened to pr-title-check trigger

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -6,7 +6,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   pr-title:


### PR DESCRIPTION
## Summary

Fan-out of the OMN-13909 canary fix (onex_change_control PR #3542, merged) to close the `pr-title / check-title` required-check merge-wedge in this repo. `types: [opened, edited]` never re-reports the required context on a push without a subsequent title edit, wedging `mergeStateStatus: BLOCKED` even when every other required check is green. Full root-cause analysis on OMN-13909; this repo is one of 9 fan-out targets tracked under the child ticket OMN-13914 (omnidash excluded — parked by operator directive).

## Fix

`.github/workflows/pr-title-check.yml`: `types: [opened, edited]` → `types: [opened, edited, synchronize, reopened]`. Identical one-line diff as the canary fix — no scope creep. No change to `pr-title-check-reusable.yml` needed (it already reads the live event payload title, which GitHub populates correctly on `synchronize`).

## Test plan

- [x] YAML parse check
- [x] `pre-commit run --files .github/workflows/pr-title-check.yml` — all applicable hooks passed
- Targeted verification per the #2188/#254 precedent for workflow-YAML-only diffs — full multi-hour local suite not required for a single-line CI trigger-type change with zero Python/runtime impact

Evidence-Ticket: OMN-13914

OMN-13914 (see OMN-13909 for full context)

Evidence-Source: OCC#3553
