### PR TITLE
fix(OMN-13929): bump project.version 0.46.5 -> 0.46.6 (post-publish release-identity disarm)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.5"
+version = "0.46.6"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.5"
+version = "0.46.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Problem

The 0.46.5 release train just published (promotion PR #1387 merged to main as f873d830, tag v0.46.5, PyPI live — verified via https://pypi.org/pypi/omnibase-core/0.46.5/json HTTP 200). Dev's `project.version` still reads 0.46.5 == latest published, which arms the OMN-13411 release-identity gate: the first packaged-source merge to dev turns `validate` red on every subsequent dev PR. This is the exact failure mode that wedged core dev after the 0.46.4 train (OMN-13910, PR #1381 was the first victim, ~13h after publish).

## Fix

Mandatory post-publish disarm step (mechanics step 7, OMN-13912 principle: the event that arms a gate must perform its own disarm): bump `project.version` 0.46.5 -> 0.46.6 + regenerate `uv.lock` (embeds the self-version). No PyPI publish action here — 0.46.6 publishes on the next release train. Covered by the standing releases-autonomous grant (bump-to-unblock).

## Verification

- `uv run python scripts/check_release_identity.py` → `OK: version 0.46.6 is ahead of latest published 0.46.5.`
- `uv run pytest tests/scripts/test_check_release_identity.py -q` → 9/9 passed.
- `uv run pre-commit run --files pyproject.toml uv.lock` → all applicable hooks Passed, including "No code merged onto a published version without a bump (OMN-13411)".
- Targeted verification per the accepted OMN-13910/OMN-13875 precedent — this diff touches zero source files, only version metadata.

## DoD

- [x] Bump PR opened; `validate` (release-identity) green.
- [ ] Evidence commented on OMN-13929.

Evidence-Ticket: OMN-13929

Evidence-Source: OCC#3560