### PR TITLE
feat(OMN-13927): receipt-attestation diff-consistency gate (pure core + CLI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,6 +346,7 @@ ignore = [
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_gate_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_reprobe.py" = ["T201"]  # CLI output for re-probe verification (OMN-9789)
+"src/omnibase_core/validation/validator_receipt_diff_consistency.py" = ["T201"]  # CLI output for the attestation diff-consistency gate (OMN-13927)
 "scripts/analysis/co_change_dark_matter.py" = ["T201"]
 "scripts/validation/validate_pr_receipts.py" = ["T201"]
 "scripts/validation/validate_pr_deploy_required.py" = ["T201"]

--- a/src/omnibase_core/enums/ticket/enum_diff_attestation.py
+++ b/src/omnibase_core/enums/ticket/enum_diff_attestation.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""EnumDiffAttestation — diff-falsifiable claims a receipt may assert (OMN-13927).
+
+A receipt's free-text ``actual_output`` can *claim* things about its own PR diff
+("net-new-only", "no existing receipts modified"). The per-receipt honesty gate
+(:mod:`omnibase_core.validation.validator_receipt_honesty`) has zero diff context
+and structurally cannot catch a receipt that lies about its own diff — the class
+that produced the OMN-13917 incident (OCC #3551 attested net-new-only while its
+diff modified a merged contract + 4 merged receipts).
+
+This enum is the closed v1 vocabulary of claims that are mechanically falsifiable
+against ``git diff --name-status <base>...<head>``. General free-text claim
+extraction is explicitly descoped (unbounded NLP, false-positive prone); only the
+three members below plus two high-precision legacy regexes are honored by
+:func:`omnibase_core.validation.validator_receipt_diff_consistency.check_diff_consistency`.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDiffAttestation(StrEnum):
+    """A diff-falsifiable attestation a receipt may declare.
+
+    Each member has an exact predicate over the PR's ``--name-status`` diff; a
+    contradicted attestation is a hard FAIL (blocks merge). See
+    :func:`omnibase_core.validation.validator_receipt_diff_consistency.check_diff_consistency`.
+
+    Members
+    -------
+    NET_NEW_ONLY
+        Every diff entry under ``drift/dod_receipts/**`` and ``contracts/**``
+        has status ``A`` (add). Any ``M``/``D``/``R``/``C`` under those prefixes
+        contradicts the claim. This is the append-only claim at the diff level —
+        it composes with ``validator_occ_append_only`` (per-entry hashing makes
+        "appending never touches merged files" the normal case).
+    RECEIPTS_UNMODIFIED
+        No ``M``/``D``/``R``/``C`` entries under ``drift/dod_receipts/**``.
+        Adding new receipt files is allowed; touching a merged one is not.
+    CONTRACT_UNMODIFIED
+        ``contracts/<ticket_id>.yaml`` is absent from the diff, or present with
+        status ``A``. Any ``M``/``D``/``R``/``C`` of the ticket's own contract
+        contradicts the claim.
+    """
+
+    NET_NEW_ONLY = "NET_NEW_ONLY"
+    RECEIPTS_UNMODIFIED = "RECEIPTS_UNMODIFIED"
+    CONTRACT_UNMODIFIED = "CONTRACT_UNMODIFIED"
+
+
+__all__ = ["EnumDiffAttestation"]

--- a/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_receipt.py
@@ -55,6 +55,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.governance.enum_evidence_class import EnumEvidenceClass
+from omnibase_core.enums.ticket.enum_diff_attestation import EnumDiffAttestation
 from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
 from omnibase_core.models.contracts.ticket.model_proof_packet import ModelProofPacket
 
@@ -266,6 +267,20 @@ class ModelDodReceipt(BaseModel):
             "the per-class tier requirement is enforced at the gate, not on every "
             "receipt unconditionally. F1 autobind (OMN-13317) fills the packet's "
             "source fields (evidence_source_sha, evidence_ticket, verifier)."
+        ),
+    )
+    diff_attestations: list[EnumDiffAttestation] = Field(
+        default_factory=list,
+        description=(
+            "Diff-falsifiable claims this receipt asserts about its own PR "
+            "(OMN-13927). Each declared attestation is validated at merge time "
+            "against `git diff --name-status <base>...<head>` by "
+            "`validator_receipt_diff_consistency`; a contradicted attestation "
+            "hard-fails the OCC honesty gate. This is the authoritative, "
+            "forward-looking trigger — the gate also honors two high-precision "
+            "legacy regexes over `actual_output` for receipts that only carry a "
+            "free-text net-new-only claim. Empty (the default) means the receipt "
+            "makes no diff-falsifiable claim and the check does not fire."
         ),
     )
     evidence_class: EnumEvidenceClass | None = Field(

--- a/src/omnibase_core/validation/validator_receipt_diff_consistency.py
+++ b/src/omnibase_core/validation/validator_receipt_diff_consistency.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Receipt-attestation diff-consistency gate (OMN-13927).
+
+A DoD receipt may *claim* things about its own PR diff — "net-new-only", "no
+existing receipts or the contract are modified". The per-receipt honesty gate
+(:mod:`omnibase_core.validation.validator_receipt_honesty`, rules A-E) is a pure
+``f(receipt) -> violations`` with **zero diff context**, so it structurally
+cannot catch a receipt that lies about its own diff. That gap produced the
+OMN-13917 incident: OCC #3551 merged a self-binding receipt attesting
+net-new-only while the same PR's diff modified ``contracts/OMN-13501.yaml`` and
+four pre-existing merged receipts.
+
+This module closes the residual **attestation-honesty** class. It is deliberately
+kept out of ``check_receipt_honesty`` (which must stay pure per-receipt); a
+diff-consistency check needs the PR ``--name-status`` diff, so it lives here with
+its own pure core (:func:`check_diff_consistency`) and a thin git-free CLI.
+
+Relationship to append-only (OMN-13888,
+:mod:`omnibase_core.validation.validator_occ_append_only`): append-only removes
+the *ability* to rewrite a merged contract entry or receipt file. Diff-consistency
+closes a different gap — a receipt that *lies about its diff* staying a trusted
+forensic artifact. The ``NET_NEW_ONLY`` attestation is the append-only claim at
+the receipt-attestation level: it asserts the diff touched nothing pre-existing.
+
+Scope (v1 — closed enum, NOT NLP). Two trigger paths:
+
+* **Structured (authoritative):** ``diff_attestations: list[EnumDiffAttestation]``
+  on :class:`~omnibase_core.models.contracts.ticket.model_dod_receipt.ModelDodReceipt`.
+* **Legacy free-text (high-precision only):** two regexes over ``actual_output`` of
+  a receipt ADDED in the PR ⇒ enforce ``NET_NEW_ONLY``. No match ⇒ no check.
+
+General free-text claim extraction is explicitly descoped (unbounded NLP,
+false-positive prone). A contradicted attestation is a hard FAIL (exit 1, blocks
+merge). No skip token, no allowlist — a merged false receipt is corrected via the
+OMN-13888 supersession model, never edited.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from omnibase_core.enums.ticket.enum_diff_attestation import EnumDiffAttestation
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+
+_RECEIPT_PREFIX = "drift/dod_receipts/"
+_CONTRACT_PREFIX = "contracts/"
+# git --name-status status letters that mean "touched a pre-existing file".
+_MUTATION_CODES = frozenset({"M", "D", "R", "C"})
+
+# Legacy free-text triggers (high-precision, deliberately narrow). Both imply a
+# NET_NEW_ONLY obligation. The first catches the verbatim OMN-13917 #3551 phrasing
+# ("No existing receipts or the OMN-13501 contract are modified"); the second the
+# canonical "net-new-only" shorthand.
+_NET_NEW_CLAIM_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"no existing (receipts?|contracts?)[^.]{0,80}(are )?modif", re.IGNORECASE
+    ),
+    re.compile(r"net[- ]new[- ]only", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class DiffConsistencyViolation:
+    """One attestation contradicted by the PR diff.
+
+    Attributes:
+        attestation: The diff-falsifiable claim that was contradicted.
+        detail: Human-readable explanation naming the offending diff entries.
+        receipt_path: Path to the receipt on disk (empty when checked in-memory).
+    """
+
+    attestation: EnumDiffAttestation
+    detail: str
+    receipt_path: Path = field(default_factory=Path)
+
+
+def _normalize_name_status(
+    name_status: Iterable[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """Reduce ``(git_status, path)`` pairs to ``(single-letter-code, path)``.
+
+    ``git diff --name-status`` emits rename/copy scores (``R100``); only the
+    leading letter carries the class, so it is normalized to a single uppercase
+    character. Blank statuses are dropped.
+    """
+    normalized: list[tuple[str, str]] = []
+    for status, path in name_status:
+        code = status.strip().upper()[:1] if status.strip() else ""
+        if code:
+            normalized.append((code, path))
+    return normalized
+
+
+def _enforced_attestations(receipt: ModelDodReceipt) -> set[EnumDiffAttestation]:
+    """Resolve which attestations this receipt must satisfy.
+
+    Union of the structured ``diff_attestations`` field (authoritative) and the
+    legacy free-text NET_NEW_ONLY triggers over ``actual_output``. A receipt with
+    neither makes no diff-falsifiable claim and is exempt from this gate.
+    """
+    enforced: set[EnumDiffAttestation] = set(receipt.diff_attestations)
+    text = receipt.actual_output or ""
+    if any(pattern.search(text) for pattern in _NET_NEW_CLAIM_RES):
+        enforced.add(EnumDiffAttestation.NET_NEW_ONLY)
+    return enforced
+
+
+def _check_net_new_only(
+    entries: list[tuple[str, str]],
+) -> str | None:
+    """Every receipt/contract diff entry must be an add (``A``)."""
+    offenders = [
+        f"{code} {path}"
+        for code, path in entries
+        if path.startswith((_RECEIPT_PREFIX, _CONTRACT_PREFIX))
+        and code in _MUTATION_CODES
+    ]
+    if not offenders:
+        return None
+    return (
+        "receipt attests NET_NEW_ONLY but the diff modifies/deletes/renames "
+        f"{len(offenders)} pre-existing receipt/contract file(s): "
+        + ", ".join(sorted(offenders))
+    )
+
+
+def _check_receipts_unmodified(
+    entries: list[tuple[str, str]],
+) -> str | None:
+    """No mutation of any file under ``drift/dod_receipts/``."""
+    offenders = [
+        f"{code} {path}"
+        for code, path in entries
+        if path.startswith(_RECEIPT_PREFIX) and code in _MUTATION_CODES
+    ]
+    if not offenders:
+        return None
+    return (
+        "receipt attests RECEIPTS_UNMODIFIED but the diff modifies/deletes/"
+        f"renames {len(offenders)} merged receipt file(s): "
+        + ", ".join(sorted(offenders))
+    )
+
+
+def _check_contract_unmodified(
+    entries: list[tuple[str, str]],
+    ticket_id: str,
+) -> str | None:
+    """The ticket's own ``contracts/<ticket_id>.yaml`` must be absent or added."""
+    target = f"{_CONTRACT_PREFIX}{ticket_id}.yaml"
+    offenders = [
+        f"{code} {path}"
+        for code, path in entries
+        if path == target and code in _MUTATION_CODES
+    ]
+    if not offenders:
+        return None
+    return (
+        "receipt attests CONTRACT_UNMODIFIED but the diff modifies/deletes/"
+        "renames its own contract: " + ", ".join(sorted(offenders))
+    )
+
+
+def check_diff_consistency(
+    receipt: ModelDodReceipt,
+    name_status: Iterable[tuple[str, str]],
+    ticket_id: str | None = None,
+) -> list[DiffConsistencyViolation]:
+    """Validate a receipt's diff-falsifiable attestations against the PR diff.
+
+    Pure — no I/O. The caller supplies the parsed ``git diff --name-status``
+    output as ``(status, path)`` pairs (repo-relative paths).
+
+    Args:
+        receipt: The receipt whose attestations are being checked. Only receipts
+            ADDED in the PR should be passed for the legacy free-text trigger to
+            be meaningful; the structured trigger is always honored.
+        name_status: ``(git_status, path)`` pairs for the whole PR diff. Status
+            letters: ``A`` add, ``M`` modify, ``D`` delete, ``R``/``C`` rename/copy.
+        ticket_id: Ticket whose contract the ``CONTRACT_UNMODIFIED`` predicate
+            targets. Defaults to ``receipt.ticket_id`` when omitted.
+
+    Returns:
+        One :class:`DiffConsistencyViolation` per contradicted attestation. Empty
+        when the receipt makes no claim or every claim holds.
+    """
+    resolved_ticket = ticket_id if ticket_id is not None else receipt.ticket_id
+    enforced = _enforced_attestations(receipt)
+    if not enforced:
+        return []
+
+    entries = _normalize_name_status(name_status)
+    violations: list[DiffConsistencyViolation] = []
+
+    if EnumDiffAttestation.NET_NEW_ONLY in enforced:
+        detail = _check_net_new_only(entries)
+        if detail is not None:
+            violations.append(
+                DiffConsistencyViolation(
+                    attestation=EnumDiffAttestation.NET_NEW_ONLY, detail=detail
+                )
+            )
+
+    if EnumDiffAttestation.RECEIPTS_UNMODIFIED in enforced:
+        detail = _check_receipts_unmodified(entries)
+        if detail is not None:
+            violations.append(
+                DiffConsistencyViolation(
+                    attestation=EnumDiffAttestation.RECEIPTS_UNMODIFIED, detail=detail
+                )
+            )
+
+    if EnumDiffAttestation.CONTRACT_UNMODIFIED in enforced:
+        detail = _check_contract_unmodified(entries, resolved_ticket)
+        if detail is not None:
+            violations.append(
+                DiffConsistencyViolation(
+                    attestation=EnumDiffAttestation.CONTRACT_UNMODIFIED, detail=detail
+                )
+            )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# File-scanning helpers (used by the CLI, pre-commit, and CI wiring)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReceiptDiffFinding:
+    """All diff-consistency violations found for one receipt file on disk."""
+
+    receipt_path: Path
+    violations: list[DiffConsistencyViolation]
+
+
+def parse_name_status(text: str) -> list[tuple[str, str]]:
+    """Parse ``git diff --name-status`` output into ``(status, path)`` pairs.
+
+    Rename/copy lines carry the destination path last (``R100\told\tnew``); the
+    destination is the one that exists at head, so it is taken as the path.
+    """
+    pairs: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        pairs.append((parts[0], parts[-1]))
+    return pairs
+
+
+def _load_receipt(receipt_path: Path) -> ModelDodReceipt | None:
+    """Parse + validate one receipt file, or ``None`` if not a valid receipt.
+
+    Structurally invalid receipts are skipped here — the receipt-gate owns those
+    failures; this gate only speaks to attestation honesty.
+    """
+    try:
+        raw = yaml.safe_load(receipt_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return ModelDodReceipt.model_validate(raw)
+    except (ValidationError, ValueError):
+        return None
+
+
+def scan_receipt_files_with_diff(
+    receipt_paths: Iterable[Path],
+    name_status: Iterable[tuple[str, str]],
+) -> list[ReceiptDiffFinding]:
+    """Run :func:`check_diff_consistency` over explicit receipt files.
+
+    This is the mode used by pre-commit and PR CI: it checks only the receipts
+    changed on the PR without making historical receipts a prerequisite for every
+    unrelated PR. Each receipt's ``CONTRACT_UNMODIFIED`` predicate targets its own
+    ``ticket_id``.
+    """
+    entries = list(name_status)
+    findings: list[ReceiptDiffFinding] = []
+    for receipt_path in sorted(set(receipt_paths)):
+        if not receipt_path.exists() or receipt_path.suffix not in {".yaml", ".yml"}:
+            continue
+        receipt = _load_receipt(receipt_path)
+        if receipt is None:
+            continue
+        violations = check_diff_consistency(receipt, entries)
+        if violations:
+            stamped = [
+                DiffConsistencyViolation(
+                    attestation=v.attestation,
+                    detail=v.detail,
+                    receipt_path=receipt_path,
+                )
+                for v in violations
+            ]
+            findings.append(
+                ReceiptDiffFinding(receipt_path=receipt_path, violations=stamped)
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI: check changed receipts' attestations against a name-status diff.
+
+    Usage::
+
+        git diff --name-status "origin/dev"...HEAD > /tmp/diff_name_status.txt
+        python -m omnibase_core.validation.validator_receipt_diff_consistency \\
+            --diff-file /tmp/diff_name_status.txt \\
+            drift/dod_receipts/OMN-XXXX/item/command.yaml ...
+
+    Exit codes:
+        0 — no contradicted attestations
+        1 — one or more contradicted attestations, or a missing/unreadable diff file
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Receipt-attestation diff-consistency gate (OMN-13927): fail when a "
+            "receipt attests a diff-falsifiable claim (NET_NEW_ONLY, "
+            "RECEIPTS_UNMODIFIED, CONTRACT_UNMODIFIED) that its own PR diff "
+            "contradicts."
+        )
+    )
+    parser.add_argument(
+        "--diff-file",
+        required=True,
+        help="Path to a file containing `git diff --name-status <base>...<head>` output.",
+    )
+    parser.add_argument(
+        "receipt_paths",
+        nargs="*",
+        help="Receipt YAML files changed on this PR (the receipts to check).",
+    )
+    args = parser.parse_args(argv)
+
+    diff_path = Path(args.diff_file)
+    try:
+        diff_text = diff_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"ERROR: cannot read --diff-file {diff_path}: {exc}", file=sys.stderr)
+        return 1
+    name_status = parse_name_status(diff_text)
+
+    explicit_paths = [Path(p) for p in args.receipt_paths]
+    if not explicit_paths:
+        print("RECEIPT DIFF-CONSISTENCY GATE PASSED: no changed receipt files to check")
+        return 0
+
+    findings = scan_receipt_files_with_diff(explicit_paths, name_status)
+    if not findings:
+        print(
+            "RECEIPT DIFF-CONSISTENCY GATE PASSED: "
+            f"0 contradicted attestations across {len(explicit_paths)} receipt(s)"
+        )
+        return 0
+
+    total = sum(len(f.violations) for f in findings)
+    print(
+        f"RECEIPT DIFF-CONSISTENCY GATE FAILED: {total} contradicted attestation(s) "
+        f"across {len(findings)} receipt(s):\n"
+    )
+    for finding in findings:
+        for v in finding.violations:
+            print(f"  [{v.attestation}] {finding.receipt_path}")
+            print(f"    {v.detail}")
+            print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "DiffConsistencyViolation",
+    "EnumDiffAttestation",
+    "ReceiptDiffFinding",
+    "check_diff_consistency",
+    "main",
+    "parse_name_status",
+    "scan_receipt_files_with_diff",
+]

--- a/tests/unit/validation/test_validator_receipt_diff_consistency.py
+++ b/tests/unit/validation/test_validator_receipt_diff_consistency.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for validator_receipt_diff_consistency — attestation-vs-diff gate (OMN-13927).
+
+The receipt-honesty gate (rules A-E) is pure per-receipt and cannot catch a
+receipt that lies about its own PR diff. This gate closes that class. Golden
+fixtures reproduce the OMN-13917 incident: a receipt attesting net-new-only while
+its diff modified a merged contract + four merged receipts (must-FAIL), and a true
+net-new-only PR whose diff is all-add (must-PASS).
+
+Covers: both trigger paths (structured `diff_attestations` + legacy free-text
+regexes), all three attestation predicates, the no-claim no-op, rename/copy status
+normalization, and the CLI.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from omnibase_core.enums.ticket.enum_diff_attestation import EnumDiffAttestation
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.models.contracts.ticket.model_dod_receipt import ModelDodReceipt
+from omnibase_core.validation.validator_receipt_diff_consistency import (
+    check_diff_consistency,
+    main,
+    parse_name_status,
+    scan_receipt_files_with_diff,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_receipt(**overrides: object) -> ModelDodReceipt:
+    """A valid PASS receipt that makes no diff claim unless overridden.
+
+    ``check_type`` is a non-executable, non-weak type so no adversarial downgrade
+    fires and the status stays PASS without a probe_stdout obligation.
+    """
+    base: dict[str, object] = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-13501",
+        "evidence_item_id": "dod-self-binding",
+        "check_type": "attestation",
+        "check_value": "net-new-only self-binding receipt",
+        "status": EnumReceiptStatus.PASS,
+        "run_timestamp": datetime.now(tz=UTC),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "codex-worker",
+        "verifier": "foreground-claude",
+        "probe_command": "git diff --name-status origin/dev...HEAD",
+        "probe_stdout": "A\tcontracts/OMN-13501.yaml",
+    }
+    base.update(overrides)
+    return ModelDodReceipt.model_validate(base)
+
+
+# The #3551 free-text claim, verbatim to the OMN-13917 incident.
+_INCIDENT_CLAIM = (
+    "No existing receipts or the OMN-13501 contract are modified "
+    "(OMN-13888 net-new-only)."
+)
+
+# The #3551 diff: one modified contract + four modified merged receipts.
+_INCIDENT_DIFF: list[tuple[str, str]] = [
+    ("M", "contracts/OMN-13501.yaml"),
+    ("M", "drift/dod_receipts/OMN-13501/dod-a/command.yaml"),
+    ("M", "drift/dod_receipts/OMN-13501/dod-b/command.yaml"),
+    ("M", "drift/dod_receipts/OMN-13501/dod-c/command.yaml"),
+    ("M", "drift/dod_receipts/OMN-13501/dod-d/command.yaml"),
+    ("A", "drift/dod_receipts/OMN-13501/dod-self-binding/command.yaml"),
+]
+
+# A true net-new-only diff (#3548-style): only adds.
+_NET_NEW_DIFF: list[tuple[str, str]] = [
+    ("A", "contracts/OMN-13501.yaml"),
+    ("A", "drift/dod_receipts/OMN-13501/dod-self-binding/command.yaml"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Golden regression: the OMN-13917 / #3551 incident
+# ---------------------------------------------------------------------------
+
+
+class TestIncidentGolden:
+    def test_3551_freetext_claim_against_mutating_diff_FAILS(self) -> None:
+        """#3551: free-text net-new-only claim + a diff that modifies pre-existing files."""
+        receipt = _make_receipt(actual_output=_INCIDENT_CLAIM)
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.attestation is EnumDiffAttestation.NET_NEW_ONLY
+        assert "contracts/OMN-13501.yaml" in v.detail
+        # All four modified receipts are named.
+        assert v.detail.count("drift/dod_receipts/OMN-13501/") == 4
+
+    def test_3548_net_new_only_diff_PASSES(self) -> None:
+        """#3548: identical claim, but the diff is genuinely all-add."""
+        receipt = _make_receipt(actual_output=_INCIDENT_CLAIM)
+        assert check_diff_consistency(receipt, _NET_NEW_DIFF) == []
+
+
+# ---------------------------------------------------------------------------
+# Trigger paths
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerPaths:
+    def test_structured_attestation_FAILS_on_mutation(self) -> None:
+        receipt = _make_receipt(
+            actual_output="clean run",
+            diff_attestations=[EnumDiffAttestation.NET_NEW_ONLY],
+        )
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert [v.attestation for v in violations] == [EnumDiffAttestation.NET_NEW_ONLY]
+
+    def test_no_claim_receipt_is_noop(self) -> None:
+        """A receipt with neither structured nor free-text claim is exempt."""
+        receipt = _make_receipt(actual_output="42 passed in 1.23s")
+        assert check_diff_consistency(receipt, _INCIDENT_DIFF) == []
+
+    def test_none_actual_output_is_noop(self) -> None:
+        receipt = _make_receipt(actual_output=None)
+        assert check_diff_consistency(receipt, _INCIDENT_DIFF) == []
+
+    def test_bare_net_new_only_phrase_triggers(self) -> None:
+        receipt = _make_receipt(actual_output="This PR is net-new-only.")
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert [v.attestation for v in violations] == [EnumDiffAttestation.NET_NEW_ONLY]
+
+    def test_structured_and_freetext_union_not_double_counted(self) -> None:
+        """Both triggers imply NET_NEW_ONLY; it is enforced once, not twice."""
+        receipt = _make_receipt(
+            actual_output=_INCIDENT_CLAIM,
+            diff_attestations=[EnumDiffAttestation.NET_NEW_ONLY],
+        )
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-attestation predicates
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptsUnmodified:
+    def test_fails_on_modified_receipt(self) -> None:
+        receipt = _make_receipt(
+            actual_output="x",
+            diff_attestations=[EnumDiffAttestation.RECEIPTS_UNMODIFIED],
+        )
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert [v.attestation for v in violations] == [
+            EnumDiffAttestation.RECEIPTS_UNMODIFIED
+        ]
+
+    def test_passes_when_only_adds_under_receipts(self) -> None:
+        receipt = _make_receipt(
+            actual_output="x",
+            diff_attestations=[EnumDiffAttestation.RECEIPTS_UNMODIFIED],
+        )
+        # A modified contract does NOT violate RECEIPTS_UNMODIFIED.
+        diff = [
+            ("A", "drift/dod_receipts/OMN-13501/dod-x/command.yaml"),
+            ("M", "contracts/OMN-13501.yaml"),
+        ]
+        assert check_diff_consistency(receipt, diff) == []
+
+
+class TestContractUnmodified:
+    def test_fails_on_modified_own_contract(self) -> None:
+        receipt = _make_receipt(
+            actual_output="x",
+            diff_attestations=[EnumDiffAttestation.CONTRACT_UNMODIFIED],
+        )
+        violations = check_diff_consistency(receipt, _INCIDENT_DIFF)
+        assert [v.attestation for v in violations] == [
+            EnumDiffAttestation.CONTRACT_UNMODIFIED
+        ]
+
+    def test_passes_when_contract_absent(self) -> None:
+        receipt = _make_receipt(
+            actual_output="x",
+            diff_attestations=[EnumDiffAttestation.CONTRACT_UNMODIFIED],
+        )
+        diff = [("M", "drift/dod_receipts/OMN-13501/dod-a/command.yaml")]
+        assert check_diff_consistency(receipt, diff) == []
+
+    def test_explicit_ticket_id_override_targets_other_contract(self) -> None:
+        receipt = _make_receipt(
+            actual_output="x",
+            diff_attestations=[EnumDiffAttestation.CONTRACT_UNMODIFIED],
+        )
+        diff = [("M", "contracts/OMN-99999.yaml")]
+        # Default (receipt.ticket_id == OMN-13501) does not fire.
+        assert check_diff_consistency(receipt, diff) == []
+        # Explicit override targeting OMN-99999 fires.
+        violations = check_diff_consistency(receipt, diff, ticket_id="OMN-99999")
+        assert [v.attestation for v in violations] == [
+            EnumDiffAttestation.CONTRACT_UNMODIFIED
+        ]
+
+
+class TestStatusNormalization:
+    def test_rename_score_counts_as_mutation(self) -> None:
+        receipt = _make_receipt(actual_output=_INCIDENT_CLAIM)
+        diff = [("R100", "drift/dod_receipts/OMN-13501/dod-a/command.yaml")]
+        violations = check_diff_consistency(receipt, diff)
+        assert [v.attestation for v in violations] == [EnumDiffAttestation.NET_NEW_ONLY]
+
+    def test_unrelated_paths_ignored(self) -> None:
+        receipt = _make_receipt(actual_output=_INCIDENT_CLAIM)
+        diff = [("M", "src/omnibase_core/foo.py"), ("M", "README.md")]
+        assert check_diff_consistency(receipt, diff) == []
+
+
+# ---------------------------------------------------------------------------
+# name-status parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseNameStatus:
+    def test_parses_add_and_modify(self) -> None:
+        text = "A\tcontracts/OMN-1.yaml\nM\tdrift/dod_receipts/OMN-1/x/command.yaml\n"
+        assert parse_name_status(text) == [
+            ("A", "contracts/OMN-1.yaml"),
+            ("M", "drift/dod_receipts/OMN-1/x/command.yaml"),
+        ]
+
+    def test_rename_takes_destination_path(self) -> None:
+        text = "R100\tcontracts/old.yaml\tcontracts/OMN-1.yaml\n"
+        assert parse_name_status(text) == [("R100", "contracts/OMN-1.yaml")]
+
+    def test_blank_and_malformed_lines_skipped(self) -> None:
+        text = "\nA\tcontracts/OMN-1.yaml\ngarbage-no-tab\n"
+        assert parse_name_status(text) == [("A", "contracts/OMN-1.yaml")]
+
+
+# ---------------------------------------------------------------------------
+# File scanning + CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_receipt(tmp_path, actual_output: str):  # type: ignore[no-untyped-def]
+    import yaml
+
+    receipt_dir = tmp_path / "drift" / "dod_receipts" / "OMN-13501" / "dod-self-binding"
+    receipt_dir.mkdir(parents=True)
+    receipt_path = receipt_dir / "command.yaml"
+    payload = {
+        "schema_version": "1.0.0",
+        "ticket_id": "OMN-13501",
+        "evidence_item_id": "dod-self-binding",
+        "check_type": "attestation",
+        "check_value": "net-new-only self-binding receipt",
+        "status": "PASS",
+        "run_timestamp": datetime.now(tz=UTC).isoformat(),
+        "commit_sha": "a1b2c3d4e5f6",  # pragma: allowlist secret
+        "runner": "codex-worker",
+        "verifier": "foreground-claude",
+        "probe_command": "git diff",
+        "probe_stdout": "output",
+        "actual_output": actual_output,
+    }
+    receipt_path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return receipt_path
+
+
+class TestScanAndCli:
+    def test_scan_flags_lying_receipt(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        receipt_path = _write_receipt(tmp_path, _INCIDENT_CLAIM)
+        findings = scan_receipt_files_with_diff([receipt_path], _INCIDENT_DIFF)
+        assert len(findings) == 1
+        assert findings[0].receipt_path == receipt_path
+        assert findings[0].violations[0].receipt_path == receipt_path
+
+    def test_scan_clean_receipt_no_finding(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        receipt_path = _write_receipt(tmp_path, _INCIDENT_CLAIM)
+        findings = scan_receipt_files_with_diff([receipt_path], _NET_NEW_DIFF)
+        assert findings == []
+
+    def test_cli_fails_on_lying_receipt(self, tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+        receipt_path = _write_receipt(tmp_path, _INCIDENT_CLAIM)
+        diff_file = tmp_path / "diff.txt"
+        diff_file.write_text(
+            "".join(f"{code}\t{path}\n" for code, path in _INCIDENT_DIFF),
+            encoding="utf-8",
+        )
+        rc = main(["--diff-file", str(diff_file), str(receipt_path)])
+        assert rc == 1
+        assert "FAILED" in capsys.readouterr().out
+
+    def test_cli_passes_on_clean_diff(self, tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+        receipt_path = _write_receipt(tmp_path, _INCIDENT_CLAIM)
+        diff_file = tmp_path / "diff.txt"
+        diff_file.write_text(
+            "".join(f"{code}\t{path}\n" for code, path in _NET_NEW_DIFF),
+            encoding="utf-8",
+        )
+        rc = main(["--diff-file", str(diff_file), str(receipt_path)])
+        assert rc == 0
+        assert "PASSED" in capsys.readouterr().out
+
+    def test_cli_no_receipts_passes(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        diff_file = tmp_path / "diff.txt"
+        diff_file.write_text("M\tcontracts/OMN-13501.yaml\n", encoding="utf-8")
+        assert main(["--diff-file", str(diff_file)]) == 0
+
+    def test_cli_missing_diff_file_errors(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        assert main(["--diff-file", str(tmp_path / "nope.txt")]) == 1


### PR DESCRIPTION
## What

Closes the residual **attestation-honesty** class left open after OMN-13888: a DoD receipt can *claim* net-new-only / receipts-unmodified / contract-unmodified about its own PR while the diff contradicts it — the OMN-13917 / OCC #3551 incident (a self-binding receipt attested net-new-only while its PR modified `contracts/OMN-13501.yaml` + 4 merged receipts). The per-receipt honesty gate (`validator_receipt_honesty`, rules A-E) is pure `f(receipt) -> violations` with zero diff context and structurally cannot catch this.

## Changes (omnibase_core half of OMN-13927)

- `EnumDiffAttestation` — closed v1 vocabulary: `NET_NEW_ONLY`, `RECEIPTS_UNMODIFIED`, `CONTRACT_UNMODIFIED`.
- Optional `diff_attestations: list[EnumDiffAttestation]` on `ModelDodReceipt` (authoritative, forward-looking trigger). Backward compatible — default empty; all 95 existing `ModelDodReceipt` tests + 105 receipt/honesty tests pass unchanged.
- `validator_receipt_diff_consistency.py` — **pure** `check_diff_consistency(receipt, name_status, ticket_id)` (no I/O) + git-free CLI (`--diff-file`). Two triggers: structured field (authoritative) + two high-precision legacy regexes over `actual_output` (`/no existing (receipts?|contracts?)…modif/i`, `/net[- ]new[- ]only/i`) ⇒ enforce `NET_NEW_ONLY`. General NLP claim extraction is explicitly **descoped**.
- 23 unit tests incl. the golden regression: **#3551 receipt/diff pair FAILS, #3548 net-new pair PASSES**, per-attestation predicates, rename/copy status normalization, and CLI exit codes.

Composes with (does not re-implement) `validator_occ_append_only` (OMN-13888): append-only removes the *ability* to rewrite merged entries; this closes the different gap of a receipt *lying about its diff* remaining a trusted artifact.

## Follow-up (separate PRs, this validator is the dependency)

CI/pre-commit wiring — OCC `ci.yml` honesty-gate extension + omniclaude `receipt-honesty.yml` mirror + OCC pre-commit hook — lands in the companion OCC PR that pins this validator ref. Per CLAUDE.md rule 5 (enforcement, not detection), the gate + hook wiring ships with the fixtures.

## Verification

- `env -u PYTHONPATH uv run pytest tests/unit/validation/test_validator_receipt_diff_consistency.py` → 23 passed
- receipt/honesty + `ModelDodReceipt` regression: 200 passed
- ruff format + check clean, mypy clean (3 files), pre-commit green on changed files

dod_evidence: 23 golden/unit tests (incl. #3551 must-FAIL / #3548 must-PASS) — `tests/unit/validation/test_validator_receipt_diff_consistency.py`.

Ticket: OMN-13927

Evidence-Source: OCC#3618
Evidence-Ticket: OMN-13927
