### PR TITLE
ci(OMN-14076): remove merge_group triggers from 22 non-required workflows (Lever 1 canary)

### DIFF
--- a/.github/workflows/call-occ-preflight.yml
+++ b/.github/workflows/call-occ-preflight.yml
@@ -21,8 +21,6 @@ on:
   pull_request:
     branches: [main, dev, "hotfix/**"]
     types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
-    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -8,8 +8,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/handshake-policy-gate.yml
+++ b/.github/workflows/handshake-policy-gate.yml
@@ -24,7 +24,6 @@ on:
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: '0 8 * * 1'
-  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -31,8 +31,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-backend-secret-discipline.yml
+++ b/.github/workflows/validator-backend-secret-discipline.yml
@@ -18,8 +18,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-banned-compose-vars.yml
+++ b/.github/workflows/validator-banned-compose-vars.yml
@@ -25,8 +25,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-bypass-token-blocklist.yml
+++ b/.github/workflows/validator-bypass-token-blocklist.yml
@@ -36,8 +36,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-command-category-event-model.yml
+++ b/.github/workflows/validator-command-category-event-model.yml
@@ -19,8 +19,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-dispatched-contract-operation.yml
+++ b/.github/workflows/validator-dispatched-contract-operation.yml
@@ -24,8 +24,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -27,8 +27,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-generated-node-model-class-exists.yml
+++ b/.github/workflows/validator-generated-node-model-class-exists.yml
@@ -24,8 +24,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-gitignore-baseline.yml
+++ b/.github/workflows/validator-gitignore-baseline.yml
@@ -16,8 +16,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-hardcoded-topic.yml
+++ b/.github/workflows/validator-hardcoded-topic.yml
@@ -23,8 +23,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-except-swallow.yml
+++ b/.github/workflows/validator-no-except-swallow.yml
@@ -16,8 +16,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-import-none-fallback.yml
+++ b/.github/workflows/validator-no-import-none-fallback.yml
@@ -16,8 +16,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-none-guard-publish.yml
+++ b/.github/workflows/validator-no-none-guard-publish.yml
@@ -16,8 +16,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-plugin-daemon-classes.yml
+++ b/.github/workflows/validator-no-plugin-daemon-classes.yml
@@ -39,8 +39,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-operation-match.yml
+++ b/.github/workflows/validator-operation-match.yml
@@ -20,8 +20,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-pin-hygiene.yml
+++ b/.github/workflows/validator-pin-hygiene.yml
@@ -24,8 +24,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-release-identity.yml
+++ b/.github/workflows/validator-release-identity.yml
@@ -25,8 +25,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -31,8 +31,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-todo-marker.yml
+++ b/.github/workflows/validator-todo-marker.yml
@@ -33,8 +33,6 @@ on:
     branches: [main, develop, dev, "hotfix/**"]
   pull_request:
     branches: [main, develop, dev]
-  merge_group:
-    branches: [main, develop, dev]
 
 env:
   PYTHON_VERSION: "3.12"


### PR DESCRIPTION
## Summary

Lever 1 from `docs/plans/2026-07-06-ci-streamlining-logjam-reduction-plan.md` §3 — **CANARY on omnibase_core ONLY** (per `feedback_canary_before_fanout`; fan-out to infra/market/occ/omniclaude is held until this canary is verified clean).

Removes the `merge_group:` trigger from the `on:` block of **22 non-required workflows**. The merge queue only waits on required status-check contexts; these 22 carry none, so every `merge_group` run they fire burns a shared self-hosted runner slot and gates nothing. `pull_request` and `push` triggers are **untouched** — these workflows still run pre-queue (PR) and post-merge (push), so nothing is un-enforced. No logic changes; 43 pure line deletions.

Expected impact (plan §3): core queue-wave load 32 → 10 workflow runs (−69%).

Closes OMN-14076

## dod_evidence — independent verification (done BEFORE any edit)

**Live required-status-check contexts on `omnibase_core` `dev`** (`gh api repos/OmniNode-ai/omnibase_core/branches/dev/protection/required_status_checks --jq '.contexts'`) — 10 total, each maps to a KEPT workflow:

| Required context | Kept workflow |
|---|---|
| `gate / CodeRabbit Thread Check` | cr-thread-gate-caller.yml |
| `call-reject-skip-token / scan / reject-skip-gate-token` | call-reject-skip.yml |
| `CI Summary` | ci.yml |
| `verify / verify` | call-receipt-gate.yml |
| `contract-validation` | contract-validation.yml |
| `URL Authority Gate` | url-authority-gate.yml |
| `deploy-gate / deploy-gate` | deploy-gate.yml |
| `Dep Provenance Gate` | dep-provenance-gate.yml |
| `Canonical Inference Gate` | canonical-inference-gate.yml |
| `No Faked Boundary Gate` | no-faked-boundary.yml |

**Ruleset check** (`gh api repos/OmniNode-ai/omnibase_core/rules/branches/dev --jq '[.[] | select(.type=="required_status_checks")]'`) → `[]`. Zero ruleset-based required checks; the only ruleset on dev is the Merge Queue itself (id 13269695). So the 10 legacy branch-protection contexts are the **complete** required set.

**Each of the 22 CUT workflows was proven (a) to carry a `merge_group` trigger and (b) to produce NO required context** (job names: `validate`, `fsm-handler-drift`, `no-plugin-daemon-classes`, `runtime-profiles`, `receipt-honesty`, `policy-gate`, `check-handshake`, `occ-preflight / eligibility`). `call-occ-preflight` specifically verified: it reports `occ-preflight / eligibility`, which is **NOT** a required context on omnibase_core dev (it is required only in onex_change_control). Cut count = 22, zero exclusions.

**Post-edit re-parse:** all 22 files remain valid YAML with jobs intact; `merge_group` gone; `pull_request`/`push`/`schedule`/`workflow_dispatch` preserved. A repo-wide grep for the top-level `merge_group:` trigger returns **exactly the 10 kept required-context carriers** — the cut is precisely complementary.

**Local lint:** `actionlint 1.7.12` on all 22 changed files → exit 0 (only pre-existing shellcheck style notes inside `validator-todo-marker.yml`'s untouched `run:` script). The repo's `.pre-commit-config.yaml` excludes `.github/workflows/` from all yamlfmt/hygiene hooks, so actionlint + YAML parse is the authoritative local gate for workflow edits.

## The 22 cut workflows

call-occ-preflight, check-handshake, handshake-policy-gate, receipt-honesty, + the 18 validator-* workflows (backend-secret-discipline, banned-compose-vars, bypass-token-blocklist, command-category-event-model, dispatched-contract-operation, fsm-handler-drift, generated-node-model-class-exists, gitignore-baseline, hardcoded-topic, no-except-swallow, no-import-none-fallback, no-none-guard-publish, no-plugin-daemon-classes, operation-match, pin-hygiene, release-identity, runtime-profiles, todo-marker).

## Risk

Cannot break a required gate by construction (the cut set = merge_group-triggered − required-context). Trivially revertible. Cross-PR-interaction residual (a non-required validator that would have caught a squash-combined violation on the queue SHA) is addressed by the plan: these are per-file static checks, and they still run on `pull_request` and `push: [dev]`.

Evidence-Source: OCC#3661
Evidence-Ticket: OMN-14076
