### PR TITLE
fix(OMN-14081): make pyproject.toml test-selector trigger content-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1550,6 +1550,10 @@ jobs:
             base="${{ github.event.pull_request.base.sha }}"
             git fetch --no-tags --depth=1 origin "$base" || true
             git diff --name-only "$base"...HEAD > changed.txt
+            # Emit the base SHA so the selector can classify a pyproject.toml diff
+            # content-aware (base-vs-head TOML). Only meaningful on pull_request;
+            # push/merge_group escalate before the pyproject check regardless.
+            echo "base_sha=$base" >> "$GITHUB_OUTPUT"
           else
             git diff --name-only HEAD~1 HEAD > changed.txt || echo "" > changed.txt
           fi
@@ -1560,12 +1564,21 @@ jobs:
         id: detect
         env:
           FLAG: ${{ vars.ENABLE_SMART_TESTS == 'true' && 'on' || 'off' }}
+          BASE_SHA: ${{ steps.diff.outputs.base_sha }}
         run: |
+          # Pass --base-ref only when we have a base SHA (pull_request). When
+          # pyproject.toml is in the diff and no base ref is supplied, the selector
+          # fails closed and escalates — the safe default.
+          base_arg=()
+          if [ -n "$BASE_SHA" ]; then
+            base_arg=(--base-ref "$BASE_SHA")
+          fi
           uv run python -m scripts.ci.detect_test_paths \
             --changed-files-from changed.txt \
             --ref-name "${{ github.ref_name }}" \
             --event-name "${{ github.event_name }}" \
             --feature-flag "$FLAG" \
+            "${base_arg[@]}" \
             > selection.json
           cat selection.json
           is_full=$(jq -r '.is_full_suite' selection.json)

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 import argparse
 import math
+import subprocess
 import sys
+import tomllib
 from pathlib import Path
+from typing import Any
 
 from scripts.ci.test_selection_loader import (
     ModelAdjacencyMap,
@@ -23,6 +26,37 @@ TEST_UNIT_PREFIX = "tests/unit/"
 TEST_INTEGRATION_PREFIX = "tests/integration/"
 
 FULL_SUITE_BRANCHES = {"main"}
+
+# pyproject.toml is handled content-aware (not as a bare path-prefix trigger).
+# See classify_pyproject_dependency_relevant / step 2 in compute_selection.
+PYPROJECT_PATH = "pyproject.toml"
+
+# Keys under [project] whose change is metadata-only — it cannot alter dependency
+# resolution, build inputs, or test behavior, so a diff confined to these must NOT
+# escalate to the full suite. Everything else in pyproject.toml (the `dependencies`
+# array, [project.optional-dependencies], [dependency-groups], [build-system],
+# [tool.*] including [tool.pytest.ini_options]/[tool.coverage], requires-python)
+# is treated as escalation-worthy. This is deliberately an allow-list of SAFE keys
+# (not a block-list of dependency tables): an unrecognized/new pyproject key
+# escalates by default, keeping the selector fail-closed.
+_PYPROJECT_SAFE_PROJECT_KEYS = frozenset(
+    {
+        "version",
+        "name",
+        "description",
+        "readme",
+        "authors",
+        "maintainers",
+        "keywords",
+        "classifiers",
+        "urls",
+        "license",
+        "license-files",
+        "entry-points",
+        "scripts",
+        "gui-scripts",
+    }
+)
 
 # Volume-aware split sizing (OMN-11026).
 # Main-branch full-suite uses 40 splits over the whole tree (~1,500 test files,
@@ -86,7 +120,17 @@ def compute_selection(
     ref_name: str,
     event_name: str = "pull_request",
     feature_flag_enabled: bool = True,
+    pyproject_dependency_relevant: bool | None = None,
 ) -> ModelTestSelection:
+    """Resolve the test selection for a change set.
+
+    ``pyproject_dependency_relevant`` carries the content-aware classification of a
+    ``pyproject.toml`` change (computed by the CLI via a base-vs-head TOML diff):
+    ``True`` = a dependency-bearing table changed (escalate), ``False`` = the change
+    is metadata-only (do not escalate on ``pyproject.toml`` alone), ``None`` = not
+    classified. When ``pyproject.toml`` is in the change set and this is not
+    ``False`` (i.e. ``True`` or ``None``), the selector fails closed and escalates.
+    """
     config = load_adjacency_map(adjacency_path)
 
     # 0. Feature flag short-circuit: off → legacy 40-split full suite.
@@ -103,6 +147,16 @@ def compute_selection(
 
     # 2. Test infrastructure escalation.
     for changed in changed_files:
+        if changed == PYPROJECT_PATH:
+            # Content-aware: pyproject.toml escalates only when a dependency-bearing
+            # table changed, OR when classification is unavailable (None) — fail
+            # closed. A bare `version` bump / entry-point registration / metadata
+            # edit must NOT force the full suite. `pyproject.toml` is intentionally
+            # NOT in `test_infrastructure_paths` (it would be a bare path-prefix
+            # trigger); it is handled here instead.
+            if pyproject_dependency_relevant is None or pyproject_dependency_relevant:
+                return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+            continue
         if any(
             changed == infra or changed.startswith(infra.rstrip("/") + "/")
             for infra in config.test_infrastructure_paths
@@ -210,6 +264,93 @@ def _count_test_files(selected_paths: list[str], repo_root: Path) -> int:
     return total
 
 
+def _pyproject_without_safe_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed pyproject with metadata-only ``[project]`` keys removed.
+
+    Two revisions compare equal iff their escalation-worthy content — the
+    ``dependencies`` array, ``[project.optional-dependencies]``,
+    ``[dependency-groups]``, ``[build-system]``, ``[tool.*]``, ``requires-python``,
+    and any other non-safe key — is identical. Only the metadata-only ``[project]``
+    keys in ``_PYPROJECT_SAFE_PROJECT_KEYS`` are stripped.
+    """
+    reduced = dict(data)
+    project = reduced.get("project")
+    if isinstance(project, dict):
+        reduced["project"] = {
+            key: value
+            for key, value in project.items()
+            if key not in _PYPROJECT_SAFE_PROJECT_KEYS
+        }
+    return reduced
+
+
+def classify_pyproject_dependency_relevant(
+    old_content: str | None,
+    new_content: str | None,
+) -> bool:
+    """Classify whether a ``pyproject.toml`` change should escalate to the full suite.
+
+    Returns ``True`` (escalate) when the change touches any escalation-worthy content
+    OR cannot be proven metadata-only. Returns ``False`` (safe to narrow) only when
+    both revisions parse as TOML and differ solely in metadata-only ``[project]``
+    keys (``version``, ``entry-points``, ``scripts``, ``urls``, ``description``, …).
+
+    Fail-closed by construction: missing base or head content, or a TOML parse
+    failure, all return ``True``. This is a governed safety selector — it never
+    narrows on ambiguity.
+    """
+    if old_content is None or new_content is None:
+        return True
+    try:
+        old_data = tomllib.loads(old_content)
+        new_data = tomllib.loads(new_content)
+    except tomllib.TOMLDecodeError:
+        return True
+    return _pyproject_without_safe_keys(old_data) != _pyproject_without_safe_keys(
+        new_data
+    )
+
+
+def _git_show(ref: str, rel_path: str, repo_root: Path) -> str | None:
+    """Return the content of ``rel_path`` at ``ref`` via ``git show``, or None.
+
+    None signals the caller to fail closed (the base revision could not be read —
+    e.g. the ref is unfetched, or the file did not exist at the base).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"{ref}:{rel_path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _resolve_pyproject_dependency_relevant(
+    base_ref: str | None,
+    repo_root: Path,
+) -> bool | None:
+    """Classify the working-tree ``pyproject.toml`` against its ``base_ref`` revision.
+
+    Returns ``None`` when classification is impossible (no base ref supplied, or the
+    head file can't be read) so the caller escalates (fail closed). Otherwise returns
+    the classifier's bool — which itself fails closed on parse/retrieval errors.
+    """
+    if not base_ref:
+        return None
+    try:
+        new_content = (repo_root / PYPROJECT_PATH).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    old_content = _git_show(base_ref, PYPROJECT_PATH, repo_root)
+    return classify_pyproject_dependency_relevant(old_content, new_content)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Resolve change-aware test paths")
     parser.add_argument(
@@ -231,6 +372,21 @@ def main(argv: list[str] | None = None) -> int:
         default="on",
         help="When 'off', emit a FEATURE_FLAG_OFF full-suite selection regardless of changed files.",
     )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help=(
+            "Base git ref/SHA for content-aware pyproject.toml classification. When "
+            "pyproject.toml is in the diff and this is omitted (or the base cannot be "
+            "read), the selector fails closed and escalates to the full suite."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root used to read the working-tree pyproject.toml and run git show.",
+    )
     args = parser.parse_args(argv)
 
     changed = [
@@ -238,12 +394,20 @@ def main(argv: list[str] | None = None) -> int:
         for line in args.changed_files_from.read_text().splitlines()
         if line.strip()
     ]
+    # Content-aware pyproject.toml classification (only when it is in the diff, to
+    # avoid a spurious git call otherwise). None → compute_selection fails closed.
+    pyproject_dependency_relevant: bool | None = None
+    if PYPROJECT_PATH in changed:
+        pyproject_dependency_relevant = _resolve_pyproject_dependency_relevant(
+            args.base_ref, args.repo_root
+        )
     selection = compute_selection(
         changed_files=changed,
         adjacency_path=args.adjacency,
         ref_name=args.ref_name,
         event_name=args.event_name,
         feature_flag_enabled=(args.feature_flag == "on"),
+        pyproject_dependency_relevant=pyproject_dependency_relevant,
     )
     sys.stdout.write(selection.model_dump_json())
     sys.stdout.write("\n")

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -26,15 +26,28 @@ shared_modules:
 thresholds:
   modules_changed_for_full_suite: 8
 
-# Test infrastructure — any change forces the full suite.
+# Test infrastructure — any change to these paths forces the full suite via a
+# bare path-prefix match in detect_test_paths.py step 2.
+#
+# Two triggers are handled specially and are intentionally ABSENT from this list
+# (OMN-14081):
+#   * pyproject.toml — handled CONTENT-AWARE in detect_test_paths.py
+#     (classify_pyproject_dependency_relevant): it escalates only when a
+#     dependency-bearing table changed (dependencies / optional-dependencies /
+#     dependency-groups / build-system / tool.* / requires-python), not on a bare
+#     `version` bump, entry-point registration, or metadata edit. Fail-closed:
+#     unparseable/unavailable TOML still escalates.
+#   * .github/workflows/ — removed to align with omnibase_infra (which omits it).
+#     A workflow-only change carries zero test-code delta, is exercised by the PR's
+#     own CI run, and is backstopped by the unconditional merge_group -> main full
+#     suite (root CLAUDE.md Rule #4). scripts/ci/ is KEPT (conservative — it houses
+#     the selector itself).
 test_infrastructure_paths:
-  - .github/workflows/
   - scripts/ci/
   - tests/conftest.py
   - tests/fixtures/
   - tests/pytest.ini
   - pytest.ini
-  - pyproject.toml
 
 # Reverse dependency edges. Key = changed module; value = modules that import it.
 # When `models` changes, also run tests for everything in `models.reverse_deps`.

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -111,19 +111,25 @@ def test_test_infrastructure_change_escalates_to_full_suite() -> None:
     assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
 
 
-def test_workflow_change_escalates_to_distributed_full_suite() -> None:
+def test_workflow_only_change_no_longer_escalates() -> None:
+    # OMN-14081: .github/workflows/ was removed from test_infrastructure_paths to
+    # align with omnibase_infra. A workflow-only change carries zero test-code delta,
+    # is exercised on the PR's own CI run, and is backstopped by the unconditional
+    # merge_group -> main full suite (root CLAUDE.md Rule #4). It now falls to the
+    # conservative tests/unit/ fallback instead of forcing the distributed full suite.
     selection = compute_selection(
         changed_files=[".github/workflows/receipt-gate.yml"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
     )
-    assert selection.is_full_suite is True
-    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
-    assert selection.split_count == 40
-    assert selection.matrix == list(range(1, 41))
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert selection.selected_paths == ["tests/unit/"]
 
 
 def test_selector_change_escalates_to_distributed_full_suite() -> None:
+    # scripts/ci/ is KEPT as a test-infrastructure trigger (conservative — it houses
+    # the selector itself), so a change here still escalates.
     selection = compute_selection(
         changed_files=["scripts/ci/detect_test_paths.py"],
         adjacency_path=ADJ,
@@ -133,6 +139,214 @@ def test_selector_change_escalates_to_distributed_full_suite() -> None:
     assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
     assert selection.split_count == 40
     assert selection.matrix == list(range(1, 41))
+
+
+# ---------------------------------------------------------------------------
+# OMN-14081: content-aware pyproject.toml classification
+# ---------------------------------------------------------------------------
+
+from scripts.ci.detect_test_paths import classify_pyproject_dependency_relevant
+
+_BASE_PYPROJECT = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "omnibase-core"
+version = "0.46.5"
+description = "Core models"
+requires-python = ">=3.12"
+dependencies = ["pydantic>=2.0", "pyyaml>=6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[project.entry-points."onex.nodes"]
+foo = "omnibase_core.nodes.foo"
+
+[project.urls]
+Homepage = "https://example.com"
+
+[dependency-groups]
+test = ["pytest-xdist"]
+
+[tool.uv.sources]
+omnibase-compat = { workspace = true }
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+
+[tool.ruff]
+line-length = 88
+"""
+
+
+def _mutate(base: str, old: str, new: str) -> str:
+    assert old in base, f"fixture missing marker: {old!r}"
+    return base.replace(old, new, 1)
+
+
+def test_classify_version_bump_is_not_dependency_relevant() -> None:
+    # The dominant core case: a bare version bump must NOT escalate.
+    new = _mutate(_BASE_PYPROJECT, 'version = "0.46.5"', 'version = "0.46.6"')
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is False
+
+
+def test_classify_entry_point_registration_is_not_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT,
+        'foo = "omnibase_core.nodes.foo"',
+        'foo = "omnibase_core.nodes.foo"\nbar = "omnibase_core.nodes.bar"',
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is False
+
+
+def test_classify_metadata_edit_is_not_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT,
+        'description = "Core models"',
+        'description = "Core models and contracts"',
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is False
+
+
+def test_classify_dependency_add_is_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT,
+        'dependencies = ["pydantic>=2.0", "pyyaml>=6.0"]',
+        'dependencies = ["pydantic>=2.0", "pyyaml>=6.0", "httpx>=0.27"]',
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_optional_dependency_change_is_dependency_relevant() -> None:
+    new = _mutate(_BASE_PYPROJECT, 'dev = ["pytest>=8.0"]', 'dev = ["pytest>=8.1"]')
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_dependency_group_change_is_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT,
+        'test = ["pytest-xdist"]',
+        'test = ["pytest-xdist", "pytest-cov"]',
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_build_system_change_is_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT, 'requires = ["hatchling"]', 'requires = ["setuptools"]'
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_uv_sources_change_is_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT,
+        "omnibase-compat = { workspace = true }",
+        'omnibase-compat = { git = "https://example.com/compat" }',
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_requires_python_change_is_dependency_relevant() -> None:
+    new = _mutate(
+        _BASE_PYPROJECT, 'requires-python = ">=3.12"', 'requires-python = ">=3.13"'
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_pytest_config_change_is_dependency_relevant() -> None:
+    # [tool.pytest.ini_options] is genuine test infrastructure — it MUST escalate.
+    new = _mutate(
+        _BASE_PYPROJECT, 'addopts = "-ra"', 'addopts = "-ra -p no:cacheprovider"'
+    )
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, new) is True
+
+
+def test_classify_malformed_new_toml_fails_closed() -> None:
+    assert (
+        classify_pyproject_dependency_relevant(_BASE_PYPROJECT, "this = = broken")
+        is True
+    )
+
+
+def test_classify_malformed_old_toml_fails_closed() -> None:
+    assert (
+        classify_pyproject_dependency_relevant("this = = broken", _BASE_PYPROJECT)
+        is True
+    )
+
+
+def test_classify_missing_base_content_fails_closed() -> None:
+    assert classify_pyproject_dependency_relevant(None, _BASE_PYPROJECT) is True
+
+
+def test_classify_missing_head_content_fails_closed() -> None:
+    assert classify_pyproject_dependency_relevant(_BASE_PYPROJECT, None) is True
+
+
+def test_pyproject_version_bump_narrows_via_compute_selection() -> None:
+    # End-to-end at the compute_selection layer: pyproject.toml in the diff, classified
+    # metadata-only (relevant=False) → narrow, not full suite.
+    selection = compute_selection(
+        changed_files=["pyproject.toml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        pyproject_dependency_relevant=False,
+    )
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert selection.selected_paths == ["tests/unit/"]
+
+
+def test_pyproject_dependency_change_escalates_via_compute_selection() -> None:
+    selection = compute_selection(
+        changed_files=["pyproject.toml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        pyproject_dependency_relevant=True,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_pyproject_unclassified_fails_closed_via_compute_selection() -> None:
+    # relevant=None (base ref unavailable / unsupplied) → escalate, fail closed.
+    selection = compute_selection(
+        changed_files=["pyproject.toml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        pyproject_dependency_relevant=None,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_pyproject_metadata_only_does_not_suppress_shared_module_escalation() -> None:
+    # A metadata-only pyproject change bundled with a shared-module source change must
+    # still escalate — via SHARED_MODULE, not TEST_INFRASTRUCTURE.
+    selection = compute_selection(
+        changed_files=["pyproject.toml", "src/omnibase_core/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        pyproject_dependency_relevant=False,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+
+
+def test_pyproject_relevance_ignored_when_pyproject_not_in_diff() -> None:
+    # The classification param only matters when pyproject.toml is in the change set.
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        pyproject_dependency_relevant=None,
+    )
+    assert selection.is_full_suite is False
+    assert "tests/unit/cli/" in selection.selected_paths
 
 
 def test_threshold_module_count_escalates() -> None:

--- a/tests/unit/scripts/ci/test_detect_test_paths_cli.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_cli.py
@@ -64,3 +64,133 @@ def test_cli_full_suite_on_main(tmp_path: Path) -> None:
     assert payload["is_full_suite"] is True
     assert payload["full_suite_reason"] == "main_branch"
     assert payload["split_count"] == 40
+
+
+# ---------------------------------------------------------------------------
+# OMN-14081: content-aware pyproject.toml classification via --base-ref
+# ---------------------------------------------------------------------------
+
+_BASE_PYPROJECT = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "omnibase-core"
+version = "0.46.5"
+dependencies = ["pydantic>=2.0"]
+"""
+
+
+def _init_repo_with_base_pyproject(repo: Path) -> str:
+    """git-init ``repo`` with a committed base pyproject.toml; return the base SHA."""
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "pyproject.toml").write_text(_BASE_PYPROJECT)
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    for args in (
+        ["init", "-q"],
+        ["add", "pyproject.toml"],
+        ["commit", "-q", "-m", "base"],
+    ):
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            env={**env},
+            capture_output=True,
+        )
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_cli(diff_file: Path, base_ref: str, repo_root: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.ci.detect_test_paths",
+            "--changed-files-from",
+            str(diff_file),
+            "--ref-name",
+            "feature-branch",
+            "--event-name",
+            "pull_request",
+            "--base-ref",
+            base_ref,
+            "--repo-root",
+            str(repo_root),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_cli_pyproject_version_bump_narrows(tmp_path: Path) -> None:
+    # Real git repo: base pyproject at 0.46.5, working tree bumped to 0.46.6.
+    # The CLI reads base via `git show` and head from the working tree, classifies
+    # it metadata-only, and must NOT escalate.
+    repo = tmp_path / "repo"
+    base_sha = _init_repo_with_base_pyproject(repo)
+    (repo / "pyproject.toml").write_text(
+        _BASE_PYPROJECT.replace('version = "0.46.5"', 'version = "0.46.6"')
+    )
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text("pyproject.toml\n")
+
+    payload = _run_cli(diff_file, base_sha, repo)
+    assert payload["is_full_suite"] is False
+    assert payload["full_suite_reason"] is None
+
+
+def test_cli_pyproject_dependency_add_escalates(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    base_sha = _init_repo_with_base_pyproject(repo)
+    (repo / "pyproject.toml").write_text(
+        _BASE_PYPROJECT.replace(
+            'dependencies = ["pydantic>=2.0"]',
+            'dependencies = ["pydantic>=2.0", "httpx>=0.27"]',
+        )
+    )
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text("pyproject.toml\n")
+
+    payload = _run_cli(diff_file, base_sha, repo)
+    assert payload["is_full_suite"] is True
+    assert payload["full_suite_reason"] == "test_infrastructure"
+
+
+def test_cli_pyproject_without_base_ref_fails_closed(tmp_path: Path) -> None:
+    # No --base-ref → classification unavailable → escalate (fail closed).
+    diff_file = tmp_path / "diff.txt"
+    diff_file.write_text("pyproject.toml\n")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.ci.detect_test_paths",
+            "--changed-files-from",
+            str(diff_file),
+            "--ref-name",
+            "feature-branch",
+            "--event-name",
+            "pull_request",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["is_full_suite"] is True
+    assert payload["full_suite_reason"] == "test_infrastructure"


### PR DESCRIPTION
## Summary

Closes OMN-14081 (parent epic OMN-13969, WS-T selective-testing revival).

omnibase_core's governed change-aware test selector escalated **every** PR to the full 40-shard suite (~22.5 min, 40 runner slots) with `full_suite_reason=test_infrastructure`, because `pyproject.toml` was a **bare path-prefix trigger** in `test_selection_adjacency.yaml` with zero content inspection. Since core is the foundational released package, nearly every PR touches `pyproject.toml` for a version bump or entry-point registration, so nearly every PR escalated. `ENABLE_SMART_TESTS=true` is **live**, so this was production CI behavior — the single biggest demand-reduction lever on core's queue.

## Changes

- **Content-aware `pyproject.toml` classification** (`detect_test_paths.py`): a base-vs-head TOML diff (`classify_pyproject_dependency_relevant`) narrows **only** when the change is confined to metadata-only `[project]` keys (`version`, `entry-points`, `scripts`, `urls`, `description`, `classifiers`, license, authors, …). It escalates on any change to the `dependencies` array, `[project.optional-dependencies]`, `[dependency-groups]`, `[build-system]`, `[tool.*]` (incl. `[tool.pytest.ini_options]`/`[tool.coverage]`), `requires-python`, or **any unrecognized key**.
- **FAIL-CLOSED by construction**: missing base/head content, a TOML parse failure, or no `--base-ref` supplied all escalate. This is an allow-list of SAFE keys, **not** a block-list of dep tables — an unknown/new pyproject key escalates by default. Shared-module / test-infra / threshold escalation is unchanged.
- **Remove `.github/workflows/` from `test_infrastructure_paths`** (align to omnibase_infra, which omits it). A workflow-only change carries zero test-code delta, is exercised on the PR's own CI run, and is backstopped by the unconditional `merge_group` → `main` full suite (root CLAUDE.md Rule #4). **`scripts/ci/` is KEPT** (conservative — it houses the selector itself). This addresses the merge_group-trim workflow-only PR case.
- **Wire `--base-ref`** (from `github.event.pull_request.base.sha`) into `ci.yml`'s detect-changes step so the classifier can read the base `pyproject.toml`.

## Before / after proof (real version-bump PR #1388, `0.46.5 -> 0.46.6`)

| | selector | result |
|---|---|---|
| **BEFORE** (origin/dev) | pyproject = blanket trigger | `is_full_suite=true`, reason=`test_infrastructure`, **40 shards** |
| **AFTER** (this PR) | content-aware | `is_full_suite=false`, narrowed |

Dominant real-world case (1-module fix + version bump + lockfile): **40 shards → 1 shard** (`tests/unit/cli/`).
Control — a real dependency add: **still escalates** (fail-closed preserved).

## Tests

Adds 24 tests: classification unit tests (version bump, entry-point, metadata, real dep add, optional-deps, dependency-groups, build-system, uv.sources, requires-python, pytest-config, malformed/missing → fail-closed); `compute_selection` escalation paths (relevant True/False/None, shared-module non-suppression, ignored-when-absent); and CLI end-to-end tests against a real tmp git repo (`--base-ref` + `git show` chain).

Local gates green: `ruff format` + `ruff check`, `mypy --strict`, `pre-commit` (97 hooks), `pytest tests/unit/scripts/ci/` (87 passed).

## dod_evidence

- Before/after selection output on real PR #1388 diff captured in the implementing session (OLD=40-shard `test_infrastructure`, NEW=narrowed).
- `pytest tests/unit/scripts/ci/` — 87 passed.
- OCC companion flows from the occ-build mechanism (not self-authored).

Evidence-Source: OCC#3664
Evidence-Ticket: OMN-14081