### PR TITLE
fix(OMN-14082): close argv false-green in 3 no-* validator gates (scanned 0 files, now full tree + fail-closed empty scope)

### DIFF
--- a/scripts/validation/validate_no_except_swallow.py
+++ b/scripts/validation/validate_no_except_swallow.py
@@ -102,16 +102,28 @@ def _should_skip(path: Path) -> bool:
     return any(part in SKIP_PATH_PARTS for part in path.parts)
 
 
-def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
-    all_violations: list[tuple[str, int, str]] = []
+def _resolve_scan_files(scan_roots: list[Path]) -> list[Path]:
+    """Return the concrete, non-skipped ``*.py`` files a default-scope scan opens.
+
+    Single source of truth for both driving the scan and for the fail-closed
+    empty-scope guard: a required gate that resolves zero files is a silent
+    false-green, not a clean result. [OMN-14082]
+    """
+    files: list[Path] = []
     for root in scan_roots:
         if not root.exists():
             continue
         for path in sorted(root.rglob("*.py")):
-            if not path.is_file() or _should_skip(path):
-                continue
-            for lineno, line_text in scan_python_source(path):
-                all_violations.append((str(path), lineno, line_text))
+            if path.is_file() and not _should_skip(path):
+                files.append(path)
+    return files
+
+
+def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
+    all_violations: list[tuple[str, int, str]] = []
+    for path in _resolve_scan_files(scan_roots):
+        for lineno, line_text in scan_python_source(path):
+            all_violations.append((str(path), lineno, line_text))
     return all_violations
 
 
@@ -125,20 +137,54 @@ def run_on_files(files: list[Path]) -> list[tuple[str, int, str]]:
     return all_violations
 
 
-def main() -> int:
-    repo_root = Path(__file__).resolve().parent.parent.parent
+def main(argv: list[str] | None = None, repo_root: Path | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
 
-    if len(sys.argv) > 1:
-        files = [Path(f) for f in sys.argv[1:]]
+    report_mode = "--report" in args
+    # Positional (non-flag) args are explicit file paths — pre-commit passes the
+    # staged filenames after the flags. Flags like --report must NOT be treated
+    # as file paths (the OMN-14082 false-green bug). [OMN-14082]
+    file_args = [a for a in args if not a.startswith("--")]
+
+    if file_args:
+        files = [Path(f) for f in file_args]
+        # FAIL-CLOSED: paths were listed but none exist as files — a broken
+        # invocation (e.g. a flag leaked in as a path). Never report PASS on an
+        # empty scan scope. [OMN-14082]
+        if not any(f.is_file() for f in files):
+            print(
+                f"ERROR: {len(files)} path(s) listed but none exist as files: "
+                f"{[str(f) for f in files]}. Refusing to PASS on an empty scan "
+                "scope. [OMN-14082]"
+            )
+            return 1
         violations = run_on_files(files)
+        scanned = sum(1 for f in files if f.is_file() and not _should_skip(f))
+        scope_note = f"{scanned} of {len(files)} listed file(s)"
     else:
+        # Default self-scan (CI `--report` with no filenames): whole src/ + scripts/.
         scan_roots = [repo_root / "src", repo_root / "scripts"]
+        scanned_files = _resolve_scan_files(scan_roots)
+        # FAIL-CLOSED: a required gate that resolves zero files is a silent
+        # false-green, not a clean result (wrong CWD / repo layout). [OMN-14082]
+        if not scanned_files:
+            print(
+                "ERROR: empty scan scope — resolved 0 Python files under "
+                f"{[str(r) for r in scan_roots]}. A required validator that scans "
+                "nothing is a false-green; check the working directory / repo "
+                "layout. [OMN-14082]"
+            )
+            return 1
         violations = run(scan_roots)
-
-    report_mode = "--report" in sys.argv
+        scope_note = f"{len(scanned_files)} file(s) under src/ + scripts/"
 
     if violations:
-        print(f"FAIL: {len(violations)} except-log-no-reraise violation(s) found:\n")
+        print(
+            f"FAIL: {len(violations)} except-log-no-reraise violation(s) found "
+            f"(scanned {scope_note}):\n"
+        )
         for filepath, lineno, line_text in violations:
             print(f"  {filepath}:{lineno}")
             print(f"    {line_text}\n")
@@ -148,7 +194,7 @@ def main() -> int:
         )
         return 0 if report_mode else 1
 
-    print("PASS: No except-log-no-reraise violations found.")
+    print(f"PASS: No except-log-no-reraise violations found (scanned {scope_note}).")
     return 0
 
 

--- a/scripts/validation/validate_no_import_none_fallback.py
+++ b/scripts/validation/validate_no_import_none_fallback.py
@@ -98,16 +98,28 @@ def _should_skip(path: Path) -> bool:
     return any(part in SKIP_PATH_PARTS for part in path.parts)
 
 
-def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
-    all_violations: list[tuple[str, int, str]] = []
+def _resolve_scan_files(scan_roots: list[Path]) -> list[Path]:
+    """Return the concrete, non-skipped ``*.py`` files a default-scope scan opens.
+
+    Single source of truth for both driving the scan and for the fail-closed
+    empty-scope guard: a required gate that resolves zero files is a silent
+    false-green, not a clean result. [OMN-14082]
+    """
+    files: list[Path] = []
     for root in scan_roots:
         if not root.exists():
             continue
         for path in sorted(root.rglob("*.py")):
-            if not path.is_file() or _should_skip(path):
-                continue
-            for lineno, line_text in scan_python_source(path):
-                all_violations.append((str(path), lineno, line_text))
+            if path.is_file() and not _should_skip(path):
+                files.append(path)
+    return files
+
+
+def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
+    all_violations: list[tuple[str, int, str]] = []
+    for path in _resolve_scan_files(scan_roots):
+        for lineno, line_text in scan_python_source(path):
+            all_violations.append((str(path), lineno, line_text))
     return all_violations
 
 
@@ -121,21 +133,53 @@ def run_on_files(files: list[Path]) -> list[tuple[str, int, str]]:
     return all_violations
 
 
-def main() -> int:
-    repo_root = Path(__file__).resolve().parent.parent.parent
+def main(argv: list[str] | None = None, repo_root: Path | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
 
-    if len(sys.argv) > 1:
-        files = [Path(f) for f in sys.argv[1:] if not f.startswith("--")]
+    report_mode = "--report" in args
+    # Positional (non-flag) args are explicit file paths — pre-commit passes the
+    # staged filenames after the flags. Flags like --report must NOT be treated
+    # as file paths (the OMN-14082 false-green bug). [OMN-14082]
+    file_args = [a for a in args if not a.startswith("--")]
+
+    if file_args:
+        files = [Path(f) for f in file_args]
+        # FAIL-CLOSED: paths were listed but none exist as files — a broken
+        # invocation (e.g. a flag leaked in as a path). Never report PASS on an
+        # empty scan scope. [OMN-14082]
+        if not any(f.is_file() for f in files):
+            print(
+                f"ERROR: {len(files)} path(s) listed but none exist as files: "
+                f"{[str(f) for f in files]}. Refusing to PASS on an empty scan "
+                "scope. [OMN-14082]"
+            )
+            return 1
         violations = run_on_files(files)
+        scanned = sum(1 for f in files if f.is_file() and not _should_skip(f))
+        scope_note = f"{scanned} of {len(files)} listed file(s)"
     else:
+        # Default self-scan (CI `--report` with no filenames): whole src/ + scripts/.
         scan_roots = [repo_root / "src", repo_root / "scripts"]
+        scanned_files = _resolve_scan_files(scan_roots)
+        # FAIL-CLOSED: a required gate that resolves zero files is a silent
+        # false-green, not a clean result (wrong CWD / repo layout). [OMN-14082]
+        if not scanned_files:
+            print(
+                "ERROR: empty scan scope — resolved 0 Python files under "
+                f"{[str(r) for r in scan_roots]}. A required validator that scans "
+                "nothing is a false-green; check the working directory / repo "
+                "layout. [OMN-14082]"
+            )
+            return 1
         violations = run(scan_roots)
-
-    report_mode = "--report" in sys.argv
+        scope_note = f"{len(scanned_files)} file(s) under src/ + scripts/"
 
     if violations:
         print(
-            f"FAIL: {len(violations)} ImportError-assigned-to-None fallback(s) found:\n"
+            f"FAIL: {len(violations)} ImportError-assigned-to-None fallback(s) found "
+            f"(scanned {scope_note}):\n"
         )
         for filepath, lineno, line_text in violations:
             print(f"  {filepath}:{lineno}")
@@ -147,7 +191,9 @@ def main() -> int:
         )
         return 0 if report_mode else 1
 
-    print("PASS: No ImportError-assigned-to-None fallbacks found.")
+    print(
+        f"PASS: No ImportError-assigned-to-None fallbacks found (scanned {scope_note})."
+    )
     return 0
 
 

--- a/scripts/validation/validate_no_none_guard_publish.py
+++ b/scripts/validation/validate_no_none_guard_publish.py
@@ -105,16 +105,28 @@ def _should_skip(path: Path) -> bool:
     return any(part in SKIP_PATH_PARTS for part in path.parts)
 
 
-def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
-    all_violations: list[tuple[str, int, str]] = []
+def _resolve_scan_files(scan_roots: list[Path]) -> list[Path]:
+    """Return the concrete, non-skipped ``*.py`` files a default-scope scan opens.
+
+    Single source of truth for both driving the scan and for the fail-closed
+    empty-scope guard: a required gate that resolves zero files is a silent
+    false-green, not a clean result. [OMN-14082]
+    """
+    files: list[Path] = []
     for root in scan_roots:
         if not root.exists():
             continue
         for path in sorted(root.rglob("*.py")):
-            if not path.is_file() or _should_skip(path):
-                continue
-            for lineno, line_text in scan_python_source(path):
-                all_violations.append((str(path), lineno, line_text))
+            if path.is_file() and not _should_skip(path):
+                files.append(path)
+    return files
+
+
+def run(scan_roots: list[Path]) -> list[tuple[str, int, str]]:
+    all_violations: list[tuple[str, int, str]] = []
+    for path in _resolve_scan_files(scan_roots):
+        for lineno, line_text in scan_python_source(path):
+            all_violations.append((str(path), lineno, line_text))
     return all_violations
 
 
@@ -128,21 +140,53 @@ def run_on_files(files: list[Path]) -> list[tuple[str, int, str]]:
     return all_violations
 
 
-def main() -> int:
-    repo_root = Path(__file__).resolve().parent.parent.parent
+def main(argv: list[str] | None = None, repo_root: Path | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
 
-    if len(sys.argv) > 1:
-        files = [Path(f) for f in sys.argv[1:] if not f.startswith("--")]
+    report_mode = "--report" in args
+    # Positional (non-flag) args are explicit file paths — pre-commit passes the
+    # staged filenames after the flags. Flags like --report must NOT be treated
+    # as file paths (the OMN-14082 false-green bug). [OMN-14082]
+    file_args = [a for a in args if not a.startswith("--")]
+
+    if file_args:
+        files = [Path(f) for f in file_args]
+        # FAIL-CLOSED: paths were listed but none exist as files — a broken
+        # invocation (e.g. a flag leaked in as a path). Never report PASS on an
+        # empty scan scope. [OMN-14082]
+        if not any(f.is_file() for f in files):
+            print(
+                f"ERROR: {len(files)} path(s) listed but none exist as files: "
+                f"{[str(f) for f in files]}. Refusing to PASS on an empty scan "
+                "scope. [OMN-14082]"
+            )
+            return 1
         violations = run_on_files(files)
+        scanned = sum(1 for f in files if f.is_file() and not _should_skip(f))
+        scope_note = f"{scanned} of {len(files)} listed file(s)"
     else:
+        # Default self-scan (CI `--report` with no filenames): whole src/ + scripts/.
         scan_roots = [repo_root / "src", repo_root / "scripts"]
+        scanned_files = _resolve_scan_files(scan_roots)
+        # FAIL-CLOSED: a required gate that resolves zero files is a silent
+        # false-green, not a clean result (wrong CWD / repo layout). [OMN-14082]
+        if not scanned_files:
+            print(
+                "ERROR: empty scan scope — resolved 0 Python files under "
+                f"{[str(r) for r in scan_roots]}. A required validator that scans "
+                "nothing is a false-green; check the working directory / repo "
+                "layout. [OMN-14082]"
+            )
+            return 1
         violations = run(scan_roots)
-
-    report_mode = "--report" in sys.argv
+        scope_note = f"{len(scanned_files)} file(s) under src/ + scripts/"
 
     if violations:
         print(
-            f"FAIL: {len(violations)} event-bus none-guard-before-publish violation(s) found:\n"
+            f"FAIL: {len(violations)} event-bus none-guard-before-publish violation(s) found "
+            f"(scanned {scope_note}):\n"
         )
         for filepath, lineno, line_text in violations:
             print(f"  {filepath}:{lineno}")
@@ -154,7 +198,9 @@ def main() -> int:
         )
         return 0 if report_mode else 1
 
-    print("PASS: No event-bus none-guard-before-publish violations found.")
+    print(
+        f"PASS: No event-bus none-guard-before-publish violations found (scanned {scope_note})."
+    )
     return 0
 
 

--- a/tests/validation/test_validator_scan_scope_omn14082.py
+++ b/tests/validation/test_validator_scan_scope_omn14082.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI scan-scope regression tests for the three no-* validators (OMN-14082).
+
+Guards the argv false-green bug: the CI invocation `<script> --report` (no
+filenames) used to resolve an EMPTY file set and print `PASS` having scanned
+zero files. These tests prove the fixed `main()`:
+
+* scans the intended ``src/`` + ``scripts/`` tree on the report-mode CI
+  invocation (files_scanned > 0, not the old zero);
+* flags a planted violation and passes on clean input;
+* FAILS CLOSED when the resolved scan scope is empty (exit 1, never a silent
+  exit-0 PASS) — even in `--report` mode;
+* preserves the pre-commit staged-file path and fails closed when the listed
+  paths do not exist (the generalized form of the `--report`-parsed-as-a-file
+  bug).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts" / "validation"))
+
+import validate_no_except_swallow as m_except
+import validate_no_import_none_fallback as m_import
+import validate_no_none_guard_publish as m_none
+
+# (module, planted-violation source, clean source) per validator.
+CASES = {
+    "no_except_swallow": (
+        m_except,
+        'try:\n    do()\nexcept Exception:\n    logger.warning("swallowed")\n',
+        'try:\n    do()\nexcept ValueError:\n    logger.warning("handled")\n',
+    ),
+    "no_import_none_fallback": (
+        m_import,
+        "try:\n    from foo import Bar\nexcept ImportError:\n    Bar = None\n",
+        "try:\n    from foo import Bar\nexcept ImportError:\n    raise\n",
+    ),
+    "no_none_guard_publish": (
+        m_none,
+        'def f(event_bus):\n    if event_bus is not None:\n        event_bus.publish("x")\n',
+        "def f(x):\n    if x is not None:\n        do_something(x)\n",
+    ),
+}
+
+CASE_IDS = list(CASES)
+CASE_VALUES = list(CASES.values())
+
+
+def _plant(repo_root: Path, source: str) -> Path:
+    pkg = repo_root / "src" / "pkg"
+    pkg.mkdir(parents=True, exist_ok=True)
+    f = pkg / "subject.py"
+    f.write_text(source, encoding="utf-8")
+    return f
+
+
+@pytest.mark.parametrize(("mod", "bad", "clean"), CASE_VALUES, ids=CASE_IDS)
+class TestScanScopeOMN14082:
+    def test_default_scan_flags_planted_violation(
+        self, mod, bad, clean, tmp_path, capsys
+    ):
+        """Enforce mode (no --report) flags a planted in-scope violation."""
+        _plant(tmp_path, bad)
+        rc = mod.main([], repo_root=tmp_path)
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "FAIL" in out
+        assert "subject.py" in out
+
+    def test_default_scan_passes_on_clean_input(
+        self, mod, bad, clean, tmp_path, capsys
+    ):
+        """Enforce mode passes when the in-scope file is clean."""
+        _plant(tmp_path, clean)
+        rc = mod.main([], repo_root=tmp_path)
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "PASS" in out
+
+    def test_report_mode_scans_nonzero_files(self, mod, bad, clean, tmp_path, capsys):
+        """Regression: `--report` with no filenames scans the tree, not zero files.
+
+        Before OMN-14082 the `--report` token was parsed as a file path and the
+        scan resolved zero files, printing a false-green PASS. The fixed main
+        must self-report a non-zero scanned count and still surface the planted
+        violation (report mode keeps exit 0 for the staged rollout).
+        """
+        _plant(tmp_path, bad)
+        rc = mod.main(["--report"], repo_root=tmp_path)
+        out = capsys.readouterr().out
+        assert rc == 0, out  # report mode: violation is non-fatal
+        assert "FAIL" in out  # ...but the violation is surfaced
+        m = re.search(r"scanned (\d+) file", out)
+        assert m is not None, out
+        assert int(m.group(1)) >= 1, out  # proves >0 files scanned (bug fixed)
+
+    def test_empty_scope_fails_closed_even_in_report_mode(
+        self, mod, bad, clean, tmp_path, capsys
+    ):
+        """A required gate that resolves zero files must ERROR, not exit-0 PASS."""
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+        rc = mod.main(["--report"], repo_root=empty_root)
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "empty scan scope" in out
+
+    def test_staged_file_mode_flags_and_passes(self, mod, bad, clean, tmp_path, capsys):
+        """Pre-commit staged-file path: explicit file list is scanned correctly."""
+        bad_f = tmp_path / "bad.py"
+        bad_f.write_text(bad, encoding="utf-8")
+        rc_bad = mod.main(["--report", str(bad_f)])
+        out_bad = capsys.readouterr().out
+        assert "FAIL" in out_bad, out_bad
+
+        clean_f = tmp_path / "ok.py"
+        clean_f.write_text(clean, encoding="utf-8")
+        rc_clean = mod.main([str(clean_f)])
+        out_clean = capsys.readouterr().out
+        assert rc_clean == 0, out_clean
+        assert "PASS" in out_clean
+
+    def test_staged_file_mode_nonexistent_paths_fail_closed(
+        self, mod, bad, clean, tmp_path, capsys
+    ):
+        """Listed paths that don't exist -> fail closed (the flag-as-file bug class)."""
+        rc = mod.main(["--report", str(tmp_path / "does_not_exist.py")])
+        out = capsys.readouterr().out
+        assert rc == 1, out
+        assert "none exist as files" in out

--- a/tests/validation/test_validator_scan_scope_omn14082.py
+++ b/tests/validation/test_validator_scan_scope_omn14082.py
@@ -117,6 +117,7 @@ class TestScanScopeOMN14082:
         bad_f.write_text(bad, encoding="utf-8")
         rc_bad = mod.main(["--report", str(bad_f)])
         out_bad = capsys.readouterr().out
+        assert rc_bad == 0, out_bad
         assert "FAIL" in out_bad, out_bad
 
         clean_f = tmp_path / "ok.py"


### PR DESCRIPTION
## OMN-14082 (WS-E) — fix validators that scan ZERO files and silently pass (argv false-green)

Closes OMN-14082.

### The hole
Three omnibase_core CI gates print `PASS` on **every PR having scanned zero files** — a silent false-green on required-looking checks:

| Workflow | Script | Bug |
|---|---|---|
| `validator-no-except-swallow.yml` | `validate_no_except_swallow.py --report` | `files=[Path("--report")]` → `is_file()` False → **0 files** |
| `validator-no-import-none-fallback.yml` | `validate_no_import_none_fallback.py --report` | filters `--`-args → `run_on_files([])` → **0 files** |
| `validator-no-none-guard-publish.yml` | `validate_no_none_guard_publish.py --report` | same empty-list path → **0 files** |

Root cause: the CI self-scan step invokes `<script> --report` with **no filenames**, and each script treated `sys.argv[1:]` as a file-path list. The `--report` token is a flag, not a path, so the resolved file set was empty and the intended whole-`src/` scan in the `else` branch was never reached. Verified in `docs/analyses/2026-07-06-validator-diff-scope-and-test-load-audit.md` §1.4.

### The fix (per the ticket's staged-rollout plan)
1. **Parse flags vs positional file args** — `--report` (and any `--flag`) is never treated as a path.
2. **No positional files → default self-scan of `src/` + `scripts/`** (the original intended scope; **not broadened**), via a new `_resolve_scan_files()` that is the single source of truth for the scan set (also used to refactor `run()`).
3. **FAIL-CLOSED on empty scope** — if the default scan resolves **zero** `.py` files (wrong CWD / broken repo layout), or if explicit paths are listed but none exist, the validator now **ERRORs (exit 1)** instead of exit-0 PASS — **even in `--report` mode**. An empty scope is a bug, not a clean result.
4. **Self-report the scanned file count** in PASS/FAIL output so the scope is always visible.
5. **`--report` stays violation-nonfatal** (staged rollout). Flipping straight to enforcing would wedge every core PR on the latent backlog this now surfaces. Steps 3–4 of the ticket (clear the backlog, then flip to enforcing) are follow-ups; this PR closes the **false-green** (the actual correctness hole) without wedging PRs.

Pre-commit staged-file path (which already worked because real filenames were passed) is preserved and covered by tests.

### Before / after (verified on a real invocation)
| Validator | BEFORE `--report` | AFTER `--report` | AFTER empty scope |
|---|---|---|---|
| no_except_swallow | **0 files**, exit 0 PASS | **4169 files** scanned, 35 latent findings surfaced, exit 0 | exit 1 (fail-closed) |
| no_import_none_fallback | **0 files**, exit 0 PASS | **4169 files**, 8 findings, exit 0 | exit 1 |
| no_none_guard_publish | **0 files**, exit 0 PASS | **4169 files**, 5 findings, exit 0 | exit 1 |

Latent backlog (48 findings, many carrying `# fallback-ok:`/`# noqa: BLE001` that these validators do **not** honor) confirms the ticket's staged-rollout rationale — hence report-mode is retained for violations while empty-scope is made fatal.

### dod_evidence
- `tests/validation/test_validator_scan_scope_omn14082.py` — 18 cases (6 × 3 validators): planted-violation flagged (enforce mode exit 1), clean input passes, **non-zero-scan regression** (`--report` scans ≥1 file, the exact bug), **fail-closed empty scope** (exit 1 + "empty scan scope"), staged-file mode flag+pass, nonexistent-path fail-closed.
- Full validator suite green: `pytest tests/validation/test_validate_no_*.py test_validator_scan_scope_omn14082.py` → **60 passed**.
- Local gates: `ruff format`, `ruff check --fix`, `mypy` on the 3 scripts, `pre-commit run --files` (52 passed, 0 failed, exit 0).
- CI invocation end-to-end from repo root: all three now report `scanned 4169 file` (was `0`).

### Scope note
All three affected validators live in **omnibase_core** — no cross-repo canary needed; this PR fixes the complete OMN-14082 set. Scan scope is unchanged from the original intent (`src/` + `scripts/`, AST-only, `timeout-minutes: 10`), not over-broadened.

Note: OMN-14082 was previously flipped to Done with an unrelated omniweb PR (#209) as its only attachment — a false-Done; the live gate was still scanning zero files on `origin/dev` when this work started. This PR is the actual fix.

---

### OCC evidence companion — OWED FROM AUTOGEN (not self-authored, per OMN-14055)
`verify / verify` (Receipt-Gate) and `occ-preflight / eligibility` require an `Evidence-Source: OCC#<PR>` / `<occ-sha>` line backed by an onex_change_control evidence companion. Per rule OMN-14055 / memory `feedback_no_self_authored_evidence`, the implementing agent must **not** author its own OCC evidence companion — it comes from the autogen/merge-sweep tick or an independent verifier. This PR is therefore intentionally left **armed (`--auto`) + blocked on the OCC companion** — an accepted terminal state. Once the autogen tick mints the companion and adds the `Evidence-Source:` line, receipt-gate + occ-preflight clear and the queue takes it.

All three validator self-scan CI jobs (`No Except/Import None/None Guard ... / validate`) are **green** on this PR (report mode surfaces the latent backlog and exits 0 — the false-green is closed without wedging the merge).


Evidence-Source: OCC#3670
Evidence-Ticket: OMN-14082
