### PR TITLE
ci(OMN-14100): gut 7 duplicate/superseded jobs from omni-standards-compliance.yml

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -1,6 +1,19 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 ---
+# OMN-14100 (child of OMN-13979): this workflow is NOT in required_status_checks
+# on `dev` or `main` — none of its job names ever gate merge. The 7 jobs that
+# duplicated (or were superseded by) REQUIRED `ci.yml` jobs feeding the
+# `quality-gate` -> `CI Summary` rollup were removed to stop burning runner
+# compute on a non-authoritative green:
+#   naming-conventions   -> ci.yml `naming-conventions` (same validate_class_naming.py)
+#   node-purity-check     -> ci.yml `node-purity-check` (same check_node_purity.py --verbose)
+#   transport-boundary    -> ci.yml `core-infra-boundary` (same validate-no-transport-imports.sh)
+#   type-safety (mypy)    -> ci.yml `lint` (mypy src/omnibase_core auto-discovers mypy.ini)
+#   type-union-check      -> ci.yml `lint` (ruff selects the full UP family incl. UP006/UP007)
+#   ai-slop-check         -> ci.yml `aislop-patterns` (same check_ai_slop.py --strict, full tree)
+#   no-new-env-vars       -> ci.yml `no-new-os-environ` (canonical AST validator supersedes the regex script)
+# The jobs below have no `ci.yml` equivalent and are kept.
 name: Omni* Ecosystem Standards Compliance
 
 on:
@@ -15,104 +28,6 @@ env:
   REPO_NAME: "omnibase_core"
 
 jobs:
-  naming-conventions:
-    name: Naming Convention Validation
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Validate class naming conventions
-        run: uv run python scripts/validate_class_naming.py
-
-  type-safety:
-    name: Type Safety Validation
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Load cached venv
-        id: cached-uv-dependencies
-        uses: actions/cache@v6
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-uv-dependencies.outputs.cache-hit != 'true'
-        run: uv sync --all-extras
-
-      - name: Install project (ensure editable install)
-        run: uv sync --all-extras
-
-      - name: Run MyPy type checking
-        run: uv run mypy src/ --config-file=mypy.ini
-
-  type-union-check:
-    name: PEP 604 Type Union Check (UP007)
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Check for Optional/Union usage (PEP 604)
-        run: uv run ruff check src/ --select UP007,UP006
-
   onex-compliance:
     name: ONEX Architecture Compliance
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
@@ -216,51 +131,6 @@ jobs:
 
           echo "Ecosystem integration validation completed"
 
-  node-purity-check:
-    name: Node Purity Check
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run node purity check
-        run: uv run python scripts/check_node_purity.py
-
-  transport-boundary:
-    name: Transport/I/O Import Boundary
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Check transport imports (ADR-005)
-        run: bash scripts/validate-no-transport-imports.sh
-
   forbidden-pattern-scan:
     name: Decommissioned Pattern Scanner (OMN-4801)
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
@@ -280,42 +150,6 @@ jobs:
           echo "Decommissioned Pattern Scanner (OMN-4801)"
           echo "================================================================"
           bash scripts/check_forbidden_patterns.sh
-
-  ai-slop-check:
-    name: AI-Slop Pattern Check (strict, PR diff)
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Compute changed Python/Markdown files vs PR base
-        id: changed
-        run: |
-          if [ -n "${{ github.base_ref }}" ]; then
-            git fetch origin "${{ github.base_ref }}" --no-tags --depth=1
-            git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.py' '*.md' \
-              | grep -v '^CHANGELOG\.md$' \
-              > /tmp/changed_files.txt || true
-          else
-            git diff --name-only HEAD~1 -- '*.py' '*.md' 2>/dev/null \
-              | grep -v '^CHANGELOG\.md$' \
-              > /tmp/changed_files.txt || true
-          fi
-          echo "count=$(wc -l < /tmp/changed_files.txt)" >> "$GITHUB_OUTPUT"
-      - name: Check changed files for AI-slop patterns (strict)
-        run: |
-          if [ "$(cat /tmp/changed_files.txt | wc -l)" -eq 0 ]; then exit 0; fi
-          xargs -a /tmp/changed_files.txt python scripts/validation/check_ai_slop.py --strict
 
   ci-naming-convention:
     name: CI Naming Convention
@@ -347,25 +181,3 @@ jobs:
             fi
           done
           echo "CI naming convention: PASS"
-
-  no-new-env-vars:
-    name: No New os.environ/os.getenv Additions (OMN-11186)
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Check for new env var additions
-        run: |
-          find src/ -name "*.py" -print0 | xargs -0 python scripts/validation/validate_no_new_env_vars.py


### PR DESCRIPTION
Evidence-Source: OCC#3671
Evidence-Ticket: OMN-14100

## OMN-14100 — gut duplicate/superseded jobs from `omni-standards-compliance.yml`

Child of OMN-13979 (CI validation-surface inventory), burn-down candidate #1.
Source finding: `docs/analyses/2026-07-07-ci-validation-surface-inventory-OMN-13979.md`.

**MERGE HELD FOR OPERATOR REVIEW (CI-surface change).** Auto-merge is armed, but this
touches the CI enforcement surface and is intentionally held for an operator merge call.

### What this changes
`omnibase_core/.github/workflows/omni-standards-compliance.yml` had 12 top-level jobs.
This removes the **7 confirmed duplicate/superseded** jobs and keeps the **5 unique** jobs.
No `needs:`/`uses:` edges exist between the removed and kept jobs (all jobs are independent),
so gutting the 7 leaves a valid 5-job workflow (actionlint clean, YAML parses).

**Removed (7):** `naming-conventions`, `type-safety`, `type-union-check`,
`node-purity-check`, `transport-boundary`, `ai-slop-check`, `no-new-env-vars`
**Kept (5):** `onex-compliance`, `legacy-compatibility-check`, `ecosystem-validation`,
`forbidden-pattern-scan`, `ci-naming-convention`

### Non-required proof (why removal loses no gate authority)
This workflow is **not in `required_status_checks`** on `dev` or `main`. Verified live 2026-07-07:

```
$ gh api repos/OmniNode-ai/omnibase_core/branches/dev/protection/required_status_checks --jq '.contexts'
["gate / CodeRabbit Thread Check","call-reject-skip-token / scan / reject-skip-gate-token",
 "CI Summary","verify / verify","contract-validation","URL Authority Gate",
 "deploy-gate / deploy-gate","Dep Provenance Gate","Canonical Inference Gate","No Faked Boundary Gate"]

$ gh api repos/OmniNode-ai/omnibase_core/branches/main/protection/required_status_checks --jq '.contexts'
["gate / CodeRabbit Thread Check","call-reject-skip-token / scan / reject-skip-gate-token",
 "CI Summary","verify / verify","main-target-guard"]
```

None of the 12 job names, nor the workflow name, appear in either list. Its green
checkmark was decorative — it never blocked a merge.

### Per-job coverage proof (every removed job still enforced by a REQUIRED `ci.yml` job)
Each covering job feeds `quality-gate → ci-summary` = the **required** `CI Summary` context
(`ci.yml` ci-summary `needs: [quality-gate, tests-gate, contract-compliance, boundary-validation]`).

| Removed job | Verdict | Covering REQUIRED `ci.yml` job | Evidence |
|---|---|---|---|
| `naming-conventions` | DUPLICATE | `naming-conventions` | same `scripts/validate_class_naming.py` (`ci.yml:1055`); `ci.yml:1023` comment self-documents the dup |
| `node-purity-check` | DUPLICATE | `node-purity-check` | same `scripts/check_node_purity.py` — required job runs it with `--verbose` (superset) (`ci.yml:535`) |
| `transport-boundary` | DUPLICATE | `core-infra-boundary` | same `scripts/validate-no-transport-imports.sh` (`ci.yml:381`) |
| `type-safety` (mypy) | DUPLICATE | `lint` | `mypy src/omnibase_core` (`ci.yml:127`); `src/` holds only the `omnibase_core` pkg and `mypy.ini` exists at repo root (mypy discovers `mypy.ini` before `pyproject.toml`), so `--config-file=mypy.ini` was redundant |
| `type-union-check` (UP007/UP006) | DUPLICATE | `lint` | `ruff check src/ tests/` (`ci.yml:124`); `pyproject.toml [tool.ruff.lint] select` includes the full `"UP"` family and its `ignore` list contains neither `UP006` nor `UP007` — strict superset (also covers `tests/`) |
| `ai-slop-check` | DUPLICATE | `aislop-patterns` | same `scripts/validation/check_ai_slop.py --strict` over the full tracked tree (`ci.yml:1156`, superset of PR-diff scope); `ci.yml:1108-1112` documents the migration from this workflow |
| `no-new-env-vars` | SUPERSEDED | `no-new-os-environ` | `omnibase_core.validators.no_new_os_environ` (OMN-13566, `ci.yml:1309`); its docstring states it "generalises … the `scripts/validation/validate_no_new_env_vars.py` regex approach into a single canonical AST-based implementation" |

### Coverage-preserved proof (mechanical)
- `Verify Model-B rollup coverage (OMN-13574)` pre-commit hook **passes** post-change — the
  rollup verifier maps every required validator to jobs in **`ci.yml`** (`model_b_rollup_enforcement.repos.omnibase_core.rollup_workflow: ci.yml`), never to this workflow, so removing these jobs cannot reduce required coverage.
- `CI Summary` (`ci-summary` in `ci.yml`) consumes **none** of this workflow's outputs.

### Kept jobs — why (no `ci.yml` equivalent)
- `onex-compliance` — vacuous/informational src-dir + protocol-count check; no equivalent.
- `legacy-compatibility-check` — warning-only `/model/` vs `/models/` check; no equivalent.
- `ecosystem-validation` — warning-only `CLAUDE.md` presence check; no equivalent.
- `forbidden-pattern-scan` (OMN-4801) — `scripts/check_forbidden_patterns.sh`; also a pre-commit
  hook, but core has **no required `Pre-commit` CI context** (unlike OCC), so this is the only
  CI-level backstop today.
- `ci-naming-convention` — meta-check on `ci.yml`'s own name / legacy-file absence; no equivalent.

### No-dangling-reference grep
```
# no workflow uses:/needs: the removed jobs or this workflow
$ grep -rnE "uses:.*omni-standards-compliance|needs:.*(naming-conventions|type-safety|type-union-check|node-purity-check|transport-boundary|ai-slop-check|no-new-env-vars)" .github/
(only historical ci.yml comments + the required ci.yml needs graph reference the SAME-NAMED ci.yml jobs, not this workflow's)
```

### Local gates
- `actionlint` on the workflow: PASS (0 issues)
- `python -c "yaml.safe_load(...)"`: PASS — jobs = the 5 kept
- `pre-commit run --files .github/workflows/omni-standards-compliance.yml`: exit 0 (Model-B rollup coverage Passed)

Closes OMN-14100

