### PR TITLE
fix(OMN-14127): pin reusable zone-filter to ubuntu-latest (cross-repo wedge fix)

### DIFF
--- a/.github/workflows/zone-filter.yml
+++ b/.github/workflows/zone-filter.yml
@@ -36,12 +36,16 @@ on:
 jobs:
   classify:
     name: Zone Filter (docs-only check)
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
+    # OMN-14127: run UNCONDITIONALLY on the GitHub-hosted ubuntu-latest runner.
+    # This reusable workflow is a lightweight, docs-only path classifier —
+    # checkout + setup-python + `git diff` + a pure-stdlib zone classifier, with
+    # ZERO self-hosted/LAN dependency (no Kafka/Postgres/Valkey, no .201). The
+    # previous selector sent non-`pull_request` events (push / merge_group) to the
+    # self-hosted fleet, so under fleet saturation this classifier could never
+    # post and every downstream job that consumes `docs_only` wedged. Every repo
+    # that calls this reusable workflow (e.g. omnimarket) inherited that latent
+    # wedge; pinning it to ubuntu-latest removes it for ALL callers at once.
+    runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.zone.outputs.docs_only }}
 


### PR DESCRIPTION
## Summary

The reusable **`zone-filter.yml`** `classify` job selected the **self-hosted fleet** for every non-`pull_request` event (`push` / `merge_group`). It is a lightweight **docs-only path classifier** — `actions/checkout` + `setup-python` + `git diff` + a **pure-stdlib** zone classifier — with **zero self-hosted/LAN dependency** (no Kafka/Postgres/Valkey, no `.201`). Under fleet saturation it could never post its check-run, and every downstream job that consumes its `docs_only` output wedged.

Fix: pin `runs-on: ubuntu-latest` **unconditionally**.

## Cross-repo blast radius (flagged prominently)

This is a **SHARED reusable workflow** (`OmniNode-ai/omnibase_core/.github/workflows/zone-filter.yml`). Every repo that calls it inherits the latent wedge:

- **omnimarket** has a latent zone-filter wedge that this fixes **transitively**.
- The self-hosted wedge surface **shrinks for every caller at once** — a single change hardens the whole fleet.

## Isolation

Kept a **SEPARATE PR** from the CI Summary poller (both OMN-14127) precisely because this is a shared reusable workflow — isolated review and revert. See the poller PR #1397.

## Verification

- `zone-filter.yml` parses (`yaml.safe_load`).
- Change is a pure `runs-on` pin; no step/logic change. The classifier's steps already have no self-hosted dependency (confirmed by inspection).

## Receipt-gate

Independent OCC evidence companion is **NOT self-authored** (per policy) — Evidence-Source OCC# pending from the independent path. `Evidence-Ticket: OMN-14127`.

Closes OMN-14127

Evidence-Ticket: OMN-14127
Evidence-Source: OCC#3685
