### PR TITLE
ci(OMN-14104): force occ-preflight to install local core wheel

### DIFF
--- a/.github/workflows/occ-preflight.yml
+++ b/.github/workflows/occ-preflight.yml
@@ -406,16 +406,16 @@ jobs:
             'blake3>=1.0.8,<2.0.0' \
             'ruamel-yaml>=0.18.0'
 
-          mkdir -p /tmp/occ-preflight-wheels
-          (cd "$core_path" && uv build --wheel --out-dir /tmp/occ-preflight-wheels)
+          wheel_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/occ-preflight-wheels.XXXXXX")"
+          (cd "$core_path" && uv build --wheel --out-dir "$wheel_dir")
 
-          core_wheel="$(find /tmp/occ-preflight-wheels -maxdepth 1 -type f -name 'omnibase_core-*.whl' | head -1)"
+          core_wheel="$(find "$wheel_dir" -maxdepth 1 -type f -name 'omnibase_core-*.whl' -print -quit)"
           if [ -z "$core_wheel" ]; then
             echo "::error::omnibase_core wheel was not produced"
             exit 1
           fi
 
-          uv pip install --python "$venv_py" --no-deps --reinstall-package omnibase-core "$core_wheel"
+          uv pip install --python "$venv_py" --no-deps --no-config --no-index --reinstall-package omnibase-core "$core_wheel"
 
           # Export the venv interpreter for the downstream gate steps so they run
           # against this install instead of bare `python` (the system interpreter).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.5"
+version = "0.46.6"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/tests/unit/validation/test_occ_preflight_workflow_shape.py
+++ b/tests/unit/validation/test_occ_preflight_workflow_shape.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Structural tests for .github/workflows/occ-preflight.yml install logic."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "occ-preflight.yml"
+)
+
+
+def _install_step_script() -> str:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"]["eligibility"]["steps"]
+    for step in steps:
+        if step.get("name") == "Install omnibase_core":
+            script: str = step["run"]
+            return script
+    raise AssertionError("Install omnibase_core step not found in occ-preflight.yml")
+
+
+def test_install_step_builds_wheel_from_source() -> None:
+    script = _install_step_script()
+    assert "uv build --wheel" in script
+    assert '"$core_wheel"' in script
+
+
+def test_install_step_uses_no_index_for_core_wheel() -> None:
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    pattern = re.compile(r"uv pip install\b[^\n]*--no-index[^\n]*\"\$core_wheel\"")
+    assert pattern.search(joined), (
+        'the final `uv pip install ... "$core_wheel"` must include --no-index '
+        "so uv cannot fall back to a stale published omnibase-core wheel"
+    )
+
+
+def test_install_step_disables_caller_config_for_core_wheel() -> None:
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    pattern = re.compile(r"uv pip install\b[^\n]*--no-config[^\n]*\"\$core_wheel\"")
+    assert pattern.search(joined), (
+        "the final occ-preflight core install must ignore the caller repo config; "
+        "downstream repos may pin an older omnibase-core version"
+    )
+
+
+def test_install_step_has_no_bare_pypi_core_install() -> None:
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    for line in joined.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uv pip install"):
+            continue
+        if "omnibase-core" not in stripped:
+            continue
+        if "--no-index" in stripped:
+            continue
+        pytest.fail(
+            f"bare `uv pip install omnibase-core` without --no-index found: {stripped!r}"
+        )
+
+
+def test_install_step_seeds_transitive_deps_before_no_index() -> None:
+    script = _install_step_script()
+    assert "pydantic>=" in script
+    assert "pyyaml>=" in script

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.5"
+version = "0.46.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Fixes the `occ-preflight` reusable workflow so it installs the freshly built local `omnibase_core` wheel instead of resolving a stale published wheel from the caller repo/index.

## Changes

- Build the core wheel into a temp directory and install the exact `"$core_wheel"` path with `--no-index --no-config`.
- Add an occ-preflight workflow-shape regression test mirroring the receipt-gate guard that already prevents this fallback class.
- Bump the main-line package identity to `0.46.6` so the main-release gate does not alias this workflow/test change onto already-published `0.46.5`.

## Test plan

- `uv run pytest tests/unit/validation/test_occ_preflight_workflow_shape.py tests/unit/validation/test_receipt_gate_workflow_shape.py -q`
- `uv run pytest tests/scripts/test_check_release_identity.py tests/unit/validation/test_occ_preflight_workflow_shape.py -q`
- `uv run ruff format tests/unit/validation/test_occ_preflight_workflow_shape.py`
- `uv run ruff check --fix tests/unit/validation/test_occ_preflight_workflow_shape.py`
- `git diff --check`

## Type safety checklist
- [x] No new `metadata["key"]` or `metadata.get("key")` string literal access on Pydantic model fields
- [x] No new `metadata: dict[str, Any]` fields without TypedDict or `# ONEX_EXCLUDE:` comment
- [x] No new bare `except Exception` — must use narrowed type, or minimal-scope boundary with `logger.exception(...)` + degrade comment, or typed wrap/re-raise
- [x] If adding a key to a metadata dict, the key is defined in the relevant TypedDict

## Related issues

OMN-14104

Evidence-Ticket: OMN-14104
Evidence-Source: OCC#3706
promotion-receipt: OCC-3706
