### PR TITLE
ci(OMN-14104): force OCC preflight local wheel install

### DIFF
--- a/.github/workflows/occ-preflight.yml
+++ b/.github/workflows/occ-preflight.yml
@@ -409,13 +409,25 @@ jobs:
           wheel_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/occ-preflight-wheels.XXXXXX")"
           (cd "$core_path" && uv build --wheel --out-dir "$wheel_dir")
 
-          core_wheel="$(find "$wheel_dir" -maxdepth 1 -type f -name 'omnibase_core-*.whl' -print -quit)"
+          core_wheel="$(find "$wheel_dir" -maxdepth 1 -type f -name 'omnibase_core-*.whl' | sort | tail -n 1)"
           if [ -z "$core_wheel" ]; then
             echo "::error::omnibase_core wheel was not produced"
             exit 1
           fi
 
-          uv pip install --python "$venv_py" --no-deps --no-config --no-index --reinstall-package omnibase-core "$core_wheel"
+          uv pip uninstall --python "$venv_py" omnibase-core omnibase_core || true
+          uv pip install --python "$venv_py" --no-deps --no-config --no-index --no-cache --reinstall "$core_wheel"
+
+          "$venv_py" - <<'PY'
+          from importlib import metadata
+          import os
+          import omnibase_core
+
+          distribution_version = metadata.version("omnibase-core")
+          source_path = os.path.abspath(os.path.dirname(omnibase_core.__file__))
+          print(f"omnibase-core distribution version: {distribution_version}")
+          print(f"omnibase_core import path: {source_path}")
+          PY
 
           # Export the venv interpreter for the downstream gate steps so they run
           # against this install instead of bare `python` (the system interpreter).

--- a/tests/unit/validation/test_occ_preflight_workflow_shape.py
+++ b/tests/unit/validation/test_occ_preflight_workflow_shape.py
@@ -54,6 +54,39 @@ def test_install_step_disables_caller_config_for_core_wheel() -> None:
     )
 
 
+def test_install_step_avoids_package_name_reinstall_for_core_wheel() -> None:
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    install_lines = [
+        line.strip()
+        for line in joined.splitlines()
+        if line.strip().startswith("uv pip install") and '"$core_wheel"' in line
+    ]
+    assert install_lines, "final omnibase_core wheel install command not found"
+    for line in install_lines:
+        assert "--reinstall-package omnibase-core" not in line, (
+            "occ-preflight must install only the exact wheel path; naming "
+            "omnibase-core as a reinstall target has pulled stale published "
+            "distributions on self-hosted runners"
+        )
+
+
+def test_install_step_bypasses_uv_cache_for_core_wheel() -> None:
+    script = _install_step_script()
+    joined = re.sub(r"\\\n\s*", " ", script)
+    pattern = re.compile(r"uv pip install\b[^\n]*--no-cache[^\n]*\"\$core_wheel\"")
+    assert pattern.search(joined), (
+        "the final occ-preflight core install must bypass uv cache so runner "
+        "state cannot substitute a stale published omnibase-core wheel"
+    )
+
+
+def test_install_step_proves_installed_distribution() -> None:
+    script = _install_step_script()
+    assert 'metadata.version("omnibase-core")' in script
+    assert "omnibase_core import path:" in script
+
+
 def test_install_step_has_no_bare_pypi_core_install() -> None:
     script = _install_step_script()
     joined = re.sub(r"\\\n\s*", " ", script)


### PR DESCRIPTION
Evidence-Ticket: OMN-14104
Evidence-Source: OCC#3707
promotion-receipt: OCC-3707

## Summary
- install the exact locally built omnibase_core wheel in OCC preflight without naming omnibase-core as a reinstall target
- bypass uv cache for the final wheel install so runner state cannot substitute stale published wheels
- print the installed distribution version and import path before downstream OCC eligibility runs

## Verification
- uv run pytest tests/unit/validation/test_occ_preflight_workflow_shape.py tests/unit/validation/test_receipt_gate_workflow_shape.py -q
- uv run ruff format tests/unit/validation/test_occ_preflight_workflow_shape.py
- uv run ruff check --fix tests/unit/validation/test_occ_preflight_workflow_shape.py
- bash -n extracted Install omnibase_core workflow script
- git diff --check

