### PR TITLE
ci(OMN-14127): scope CI Summary poller to run attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1938,6 +1938,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           # Bounded poll window (minutes) — kept under the run-cancel window so
           # the required context always reaches a terminal state first.
           DEADLINE_MINUTES: "90"
@@ -1959,7 +1960,7 @@ jobs:
               sleep "${POLL_INTERVAL_SECONDS}"
               continue
             fi
-            python3 scripts/ci/ci_summary_gate.py --jobs-file jobs.json
+            python3 scripts/ci/ci_summary_gate.py --jobs-file jobs.json --run-attempt "${RUN_ATTEMPT}"
             rc=$?
             case "${rc}" in
               0) echo "::notice::CI Summary = SUCCESS (all gating jobs provably passed)"; exit 0 ;;
@@ -1969,7 +1970,7 @@ jobs:
             esac
             if [ "$(date +%s)" -ge "${deadline}" ]; then
               echo "::error::CI Summary poll deadline (${DEADLINE_MINUTES}m) reached with gating jobs still pending — failing closed"
-              python3 scripts/ci/ci_summary_gate.py --jobs-file jobs.json --report-only || true
+              python3 scripts/ci/ci_summary_gate.py --jobs-file jobs.json --run-attempt "${RUN_ATTEMPT}" --report-only || true
               exit 1
             fi
             sleep "${POLL_INTERVAL_SECONDS}"

--- a/scripts/ci/ci_summary_gate.py
+++ b/scripts/ci/ci_summary_gate.py
@@ -142,13 +142,16 @@ class JobState:
     run_attempt: int
 
 
-def dedup_latest(jobs: list[dict[str, object]]) -> dict[str, JobState]:
+def dedup_latest(
+    jobs: list[dict[str, object]],
+    *,
+    run_attempt: int | None = None,
+) -> dict[str, JobState]:
     """Collapse the raw ``/runs/{id}/jobs`` array to one entry per job name.
 
-    Uses the highest ``run_attempt`` so partial re-runs (``gh run rerun
-    --failed``, which re-runs a subset in a new attempt) evaluate the freshest
-    conclusion for each job while still seeing jobs that passed in an earlier
-    attempt (fetch the endpoint with ``?filter=all``).
+    When ``run_attempt`` is provided, only rows from that workflow attempt are
+    considered. This prevents stale failed/cancelled rows from an earlier
+    attempt from becoming authoritative for a current rerun.
     """
 
     latest: dict[str, JobState] = {}
@@ -161,6 +164,8 @@ def dedup_latest(jobs: list[dict[str, object]]) -> dict[str, JobState]:
             attempt = int(raw_attempt) if isinstance(raw_attempt, (int, str)) else 1
         except (TypeError, ValueError):
             attempt = 1
+        if run_attempt is not None and attempt != run_attempt:
+            continue
         prev = latest.get(name)
         if prev is not None and attempt < prev.run_attempt:
             continue
@@ -177,6 +182,7 @@ def dedup_latest(jobs: list[dict[str, object]]) -> dict[str, JobState]:
 def evaluate(
     jobs: list[dict[str, object]],
     *,
+    run_attempt: int | None = None,
     self_name: str = SELF_JOB_NAME,
     gate_jobs: tuple[str, ...] = GATE_JOBS,
     allowlist: frozenset[str] = SOFT_ALLOWLIST,
@@ -184,7 +190,7 @@ def evaluate(
 ) -> tuple[int, str]:
     """Return ``(exit_code, human_report)`` for the current job snapshot."""
 
-    latest = dedup_latest(jobs)
+    latest = dedup_latest(jobs, run_attempt=run_attempt)
 
     # (1) Default-deny failure sweep over every present+completed job.
     sweep_failures = sorted(
@@ -331,10 +337,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print the verdict report and exit 0 regardless (diagnostics only).",
     )
+    parser.add_argument(
+        "--run-attempt",
+        type=int,
+        default=None,
+        help="Evaluate only rows for this GitHub Actions run_attempt.",
+    )
     args = parser.parse_args(argv)
 
     jobs = _load_jobs(args.jobs_file)
-    code, report = evaluate(jobs)
+    code, report = evaluate(jobs, run_attempt=args.run_attempt)
     print(report)  # noqa: T201 — CLI verdict report to stdout for the poll loop
     if args.report_only:
         return EXIT_SUCCESS

--- a/scripts/ci/ci_summary_gate.py
+++ b/scripts/ci/ci_summary_gate.py
@@ -142,19 +142,24 @@ class JobState:
     run_attempt: int
 
 
-def dedup_latest(
+def _job_states(
     jobs: list[dict[str, object]],
     *,
     run_attempt: int | None = None,
-) -> dict[str, JobState]:
-    """Collapse the raw ``/runs/{id}/jobs`` array to one entry per job name.
+) -> list[JobState]:
+    """Return authoritative job rows while preserving same-attempt duplicates.
 
     When ``run_attempt`` is provided, only rows from that workflow attempt are
     considered. This prevents stale failed/cancelled rows from an earlier
     attempt from becoming authoritative for a current rerun.
+
+    Without ``run_attempt``, only the latest observed attempt for each job name
+    is authoritative. Multiple rows for the same job name and same attempt are
+    preserved so the default-deny sweep cannot hide a failed duplicate behind a
+    later successful duplicate row.
     """
 
-    latest: dict[str, JobState] = {}
+    states: list[JobState] = []
     for raw in jobs:
         name = str(raw.get("name") or "")
         if not name:
@@ -166,16 +171,47 @@ def dedup_latest(
             attempt = 1
         if run_attempt is not None and attempt != run_attempt:
             continue
-        prev = latest.get(name)
-        if prev is not None and attempt < prev.run_attempt:
-            continue
         conclusion = raw.get("conclusion")
-        latest[name] = JobState(
-            name=name,
-            status=str(raw.get("status") or ""),
-            conclusion=None if conclusion is None else str(conclusion),
-            run_attempt=attempt,
+        states.append(
+            JobState(
+                name=name,
+                status=str(raw.get("status") or ""),
+                conclusion=None if conclusion is None else str(conclusion),
+                run_attempt=attempt,
+            )
         )
+
+    if run_attempt is not None:
+        return states
+
+    latest_attempt_by_name: dict[str, int] = {}
+    for state in states:
+        latest_attempt_by_name[state.name] = max(
+            latest_attempt_by_name.get(state.name, 0),
+            state.run_attempt,
+        )
+    return [
+        state
+        for state in states
+        if state.run_attempt == latest_attempt_by_name[state.name]
+    ]
+
+
+def dedup_latest(
+    jobs: list[dict[str, object]],
+    *,
+    run_attempt: int | None = None,
+) -> dict[str, JobState]:
+    """Collapse authoritative job rows to one entry per job name.
+
+    This is used for aggregate gate completeness reporting. The default-deny
+    failure sweep intentionally uses :func:`_job_states` directly so duplicate
+    same-attempt rows remain visible.
+    """
+
+    latest: dict[str, JobState] = {}
+    for state in _job_states(jobs, run_attempt=run_attempt):
+        latest[state.name] = state
     return latest
 
 
@@ -191,15 +227,18 @@ def evaluate(
     """Return ``(exit_code, human_report)`` for the current job snapshot."""
 
     latest = dedup_latest(jobs, run_attempt=run_attempt)
+    observed = _job_states(jobs, run_attempt=run_attempt)
 
     # (1) Default-deny failure sweep over every present+completed job.
     sweep_failures = sorted(
-        j.name
-        for name, j in latest.items()
-        if name != self_name
-        and name not in allowlist
-        and j.status == "completed"
-        and j.conclusion not in GOOD_CONCLUSIONS
+        {
+            state.name
+            for state in observed
+            if state.name != self_name
+            and state.name not in allowlist
+            and state.status == "completed"
+            and state.conclusion not in GOOD_CONCLUSIONS
+        }
     )
 
     # (2) Spec-required-validator anchor (OMN-14127 load-bearing): each covering

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -201,6 +201,20 @@ class TestCiSummaryGate:
         code, _ = evaluate(jobs)
         assert code == EXIT_FAILURE
 
+    def test_run_attempt_filters_stale_failure_from_previous_attempt(self) -> None:
+        jobs = [_job(j["name"], "failure", attempt=1) for j in _all_good()]
+        jobs.extend(_job(j["name"], "success", attempt=2) for j in _all_good())
+        code, _ = evaluate(jobs, run_attempt=2)
+        assert code == EXIT_SUCCESS
+
+    def test_current_attempt_missing_gate_is_pending_not_stale_failure(self) -> None:
+        jobs = [_job(j["name"], "failure", attempt=1) for j in _all_good()]
+        current_attempt = _all_good()[:-1]
+        jobs.extend(_job(j["name"], "success", attempt=2) for j in current_attempt)
+        code, report = evaluate(jobs, run_attempt=2)
+        assert code == EXIT_PENDING
+        assert _all_good()[-1]["name"] in report
+
     def test_neutral_conclusion_is_fail_closed(self) -> None:
         jobs = _all_good() + [_job("Some New Job", "neutral")]
         code, _ = evaluate(jobs)
@@ -278,3 +292,9 @@ class TestCiSummaryGateCli:
         jobs[0] = _job(GATE_JOBS[0], "failure")
         result = self._run(jobs, "--report-only")
         assert result.returncode == EXIT_SUCCESS
+
+    def test_cli_run_attempt_ignores_stale_failure(self) -> None:
+        jobs = [_job(j["name"], "failure", attempt=1) for j in _all_good()]
+        jobs.extend(_job(j["name"], "success", attempt=2) for j in _all_good())
+        result = self._run(jobs, "--run-attempt", "2")
+        assert result.returncode == EXIT_SUCCESS, result.stdout + result.stderr

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -201,6 +201,24 @@ class TestCiSummaryGate:
         code, _ = evaluate(jobs)
         assert code == EXIT_FAILURE
 
+    def test_same_attempt_duplicate_failure_is_not_hidden_by_success(self) -> None:
+        jobs = _all_good()
+        jobs.extend(
+            [
+                _job("Duplicate Job", "failure", attempt=2),
+                _job("Duplicate Job", "success", attempt=2),
+            ]
+        )
+        code, report = evaluate(jobs, run_attempt=2)
+        assert code == EXIT_FAILURE
+        assert "Duplicate Job" in report
+
+    def test_older_attempt_duplicate_failure_is_ignored(self) -> None:
+        jobs = [_job(j["name"], "success", attempt=2) for j in _all_good()]
+        jobs.append(_job("Duplicate Job", "failure", attempt=1))
+        code, _ = evaluate(jobs, run_attempt=2)
+        assert code == EXIT_SUCCESS
+
     def test_run_attempt_filters_stale_failure_from_previous_attempt(self) -> None:
         jobs = [_job(j["name"], "failure", attempt=1) for j in _all_good()]
         jobs.extend(_job(j["name"], "success", attempt=2) for j in _all_good())


### PR DESCRIPTION
## Summary

Scopes the OMN-14127 CI Summary poller to the current GitHub Actions `run_attempt` so reruns cannot be held red by stale failed/cancelled rows from an earlier attempt.

Evidence-Ticket: OMN-14127
Evidence-Source: OCC#3710

## Changes

- Adds `--run-attempt` to `scripts/ci/ci_summary_gate.py` and filters job rows before deduping.
- Passes `${{ github.run_attempt }}` from `.github/workflows/ci.yml` into the poller and report-only deadline path.
- Adds regression coverage for stale prior-attempt failures and current-attempt pending behavior.

## Test plan

- `uv run pytest tests/unit/scripts/ci/test_ci_summary_gate.py -q` (29 passed)
- `uv run ruff format scripts/ci/ci_summary_gate.py tests/unit/scripts/ci/test_ci_summary_gate.py`
- `uv run ruff check --fix scripts/ci/ci_summary_gate.py tests/unit/scripts/ci/test_ci_summary_gate.py`
- `git diff --check`

## Type safety checklist
- [x] No new `metadata["key"]` or `metadata.get("key")` string literal access on Pydantic model fields
- [x] No new `metadata: dict[str, Any]` fields without TypedDict or `# ONEX_EXCLUDE:` comment
- [x] No new bare `except Exception` — must use narrowed type, or minimal-scope boundary with `logger.exception(...)` + degrade comment, or typed wrap/re-raise
- [x] If adding a key to a metadata dict, the key is defined in the relevant TypedDict

## Related issues

OMN-14127



