### PR TITLE
feat(OMN-14187): add 4 canonical OCC PR stamp-model core models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.7"
+version = "0.46.8"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/scripts/validation/validate-string-versions.py
+++ b/scripts/validation/validate-string-versions.py
@@ -295,6 +295,12 @@ class PythonASTValidator(ast.NodeVisitor):
             "run_id",  # Pipeline run correlation string (human-readable, not UUID)
             "ticket_id",  # Linear ticket identifier (e.g. "OMN-1234", not UUID)
             "epic_id",  # Linear epic identifier (e.g. "OMN-4392", not UUID)
+            # OCC_STAMP_IDENTIFIERS (OMN-14187 canonical OCC stamp-model)
+            #   allowlist_receipt_id: user-issued approval receipt handle captured
+            #   from the out-of-band "# skip-token-allowed: <id>" companion line
+            #   (validator_receipt_gate.ALLOWLIST_PATTERN captures a raw \S+ token,
+            #   not a UUID).
+            "allowlist_receipt_id",  # User-issued skip-token approval handle (not UUID)
         }
 
     def visit_Import(self, node: ast.Import):

--- a/src/omnibase_core/enums/enum_pr_evidence_source_kind.py
+++ b/src/omnibase_core/enums/enum_pr_evidence_source_kind.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Kind discriminator for a PR OCC evidence source (OMN-14187).
+
+An ``Evidence-Source:`` line in a PR body references either an open OCC PR by
+number (``OCC#<n>``) or a merged commit by SHA (a 7-40 char hex string). This
+enum captures that binary distinction as the typed discriminator for
+``ModelPrEvidenceSource``, replacing the ad-hoc regex branching in
+``validator_receipt_gate.py`` (``EVIDENCE_SOURCE_OCC_PR_PATTERN`` vs
+``EVIDENCE_SOURCE_SHA_PATTERN``).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumPrEvidenceSourceKind(StrEnum):
+    """Whether a PR evidence source points at an OCC PR or a merged commit."""
+
+    OCC_PR = "occ_pr"
+    COMMIT_SHA = "commit_sha"
+
+
+__all__ = ["EnumPrEvidenceSourceKind"]

--- a/src/omnibase_core/models/validation/model_pr_body_section.py
+++ b/src/omnibase_core/models/validation/model_pr_body_section.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""One structural segment of a decomposed PR body (OMN-14187).
+
+Piece 1/5 of the canonical OCC stamp-model (parent epic OMN-14180). When a
+parser (Piece 2 / OMN-14188) decomposes an existing PR body, each segment
+becomes one of these. ``content`` is retained byte-identical to the source so
+an idempotent re-render preserves human-authored prose verbatim instead of
+clobbering the PR description. Section order is carried by position in the
+containing tuple, not by a field. Pure Pydantic domain model: zero I/O.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPrBodySection(BaseModel):
+    """A heading + raw content span of a PR body.
+
+    ``heading`` is ``None`` for the leading, un-headed segment. ``content`` is
+    preserved byte-for-byte (including embedded/trailing whitespace) so the
+    round-trip is lossless. ``is_stamp_section`` is ``True`` only for the
+    canonical Evidence-Source/Evidence-Ticket block the renderer owns; ``False``
+    marks human-authored prose the renderer must preserve verbatim.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    heading: str | None = Field(default=None)
+    content: str = Field(default="")
+    is_stamp_section: bool = Field(default=False)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "heading": self.heading,
+            "content": self.content,
+            "is_stamp_section": self.is_stamp_section,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["ModelPrBodySection"]

--- a/src/omnibase_core/models/validation/model_pr_evidence_source.py
+++ b/src/omnibase_core/models/validation/model_pr_evidence_source.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed capture of a PR ``Evidence-Source:`` line (OMN-14187).
+
+Piece 1/5 of the canonical OCC stamp-model (parent epic OMN-14180). This model
+is the single typed vocabulary for the two independent regex/f-string
+implementations that parse and render evidence sources today:
+
+* ``omnibase_core.validation.validator_receipt_gate`` — ``EVIDENCE_SOURCE_OCC_PR_PATTERN``
+  (``^Evidence-Source:\\s+OCC#(\\d+)\\s*$``) and ``EVIDENCE_SOURCE_SHA_PATTERN``
+  (``^Evidence-Source:\\s+([0-9a-f]{7,40})\\s*$``).
+* ``omnimarket`` ``adapter_occ_autobind._patch_evidence_source`` — the ``OCC#<n>``
+  f-string it PATCHes back onto the product PR body.
+
+Pure Pydantic domain model: zero I/O, zero renderer/parser logic. The
+deterministic renderer/parser that consumes this vocabulary is deferred to
+Piece 2 (OMN-14188).
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_pr_evidence_source_kind import EnumPrEvidenceSourceKind
+
+
+class ModelPrEvidenceSource(BaseModel):
+    """A single ``Evidence-Source:`` reference — an OCC PR or a commit SHA.
+
+    Exactly one of ``occ_pr_number`` / ``commit_sha`` is populated, and which
+    one is populated must agree with ``kind``. The ``commit_sha`` pattern
+    mirrors ``validator_receipt_gate.EVIDENCE_SOURCE_SHA_PATTERN`` (7-40 hex).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: EnumPrEvidenceSourceKind
+    occ_pr_number: int | None = Field(default=None, ge=1)
+    commit_sha: str | None = Field(default=None, pattern=r"^[0-9a-f]{7,40}$")
+    url: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _check_kind_consistency(self) -> ModelPrEvidenceSource:
+        if self.kind is EnumPrEvidenceSourceKind.OCC_PR:
+            if self.occ_pr_number is None:
+                raise ValueError("kind=OCC_PR requires occ_pr_number to be set")
+            if self.commit_sha is not None:
+                raise ValueError("kind=OCC_PR requires commit_sha to be None")
+        else:  # EnumPrEvidenceSourceKind.COMMIT_SHA
+            if self.commit_sha is None:
+                raise ValueError("kind=COMMIT_SHA requires commit_sha to be set")
+            if self.occ_pr_number is not None:
+                raise ValueError("kind=COMMIT_SHA requires occ_pr_number to be None")
+        return self
+
+    def render_token(self) -> str:
+        """Return the source token as it appears after ``Evidence-Source: ``.
+
+        ``OCC#<n>`` for an OCC PR, or the raw commit SHA. Matches the f-string
+        emitted by ``adapter_occ_autobind`` today.
+        """
+        if self.occ_pr_number is not None:
+            return f"OCC#{self.occ_pr_number}"
+        if self.commit_sha is not None:
+            return self.commit_sha
+        # Unreachable: the after-validator guarantees exactly one is set.
+        # error-ok: defensive invariant guard for an impossible state.
+        raise ValueError("evidence source has neither occ_pr_number nor commit_sha")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "occ_pr_number": self.occ_pr_number,
+            "commit_sha": self.commit_sha,
+            "url": self.url,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["ModelPrEvidenceSource"]

--- a/src/omnibase_core/models/validation/model_pr_occ_metadata_stamp.py
+++ b/src/omnibase_core/models/validation/model_pr_occ_metadata_stamp.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aggregate OCC evidence-stamp for a PR (OMN-14187).
+
+Piece 1/5 of the canonical OCC stamp-model (parent epic OMN-14180). This is the
+top-level typed vocabulary that both the receipt-gate
+(``validator_receipt_gate`` / ``occ-preflight.yml``) and the omnimarket OCC
+autobind effect (``adapter_occ_autobind`` / ``adapter_occ_contract``) will
+consume, replacing today's independent regex/f-string implementations.
+
+* ``evidence_tickets`` are normalized to the ``OMN-<n>`` shape parsed today by
+  ``validator_receipt_gate.EVIDENCE_TICKET_PATTERN`` / ``TICKET_PATTERN``, then
+  de-duplicated preserving first-seen order (deliberately NOT sorted, unlike the
+  ad-hoc ``_extract_ticket_ids`` helper).
+* ``body_sections`` is empty when constructing a fresh stamp to render, and
+  populated when a parser decomposes an existing body — the structural
+  round-trip surface Piece 2's render()/parse() pair operates over.
+
+Pure Pydantic domain model: zero I/O, zero renderer/parser logic (deferred to
+Piece 2 / OMN-14188).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.validation.model_pr_body_section import ModelPrBodySection
+from omnibase_core.models.validation.model_pr_evidence_source import (
+    ModelPrEvidenceSource,
+)
+from omnibase_core.models.validation.model_pr_receipt_gate_skip_token import (
+    ModelPrReceiptGateSkipToken,
+)
+
+# Case-insensitive by construction: tokens are upper-cased before matching.
+# Mirrors the OMN-<n> shape of validator_receipt_gate.TICKET_PATTERN /
+# EVIDENCE_TICKET_PATTERN.
+_TICKET_RE = re.compile(r"^OMN-\d+$")
+
+
+class ModelPrOccMetadataStamp(BaseModel):
+    """The full typed OCC evidence-stamp decomposed from (or rendered to) a PR."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    repo: str = Field(default="")
+    pr_number: int | None = Field(default=None, ge=1)
+    head_sha: str | None = Field(default=None, pattern=r"^[0-9a-f]{7,40}$")
+    evidence_source: ModelPrEvidenceSource | None = Field(default=None)
+    evidence_tickets: tuple[str, ...] = Field(default_factory=tuple)
+    skip_tokens: tuple[ModelPrReceiptGateSkipToken, ...] = Field(default_factory=tuple)
+    body_sections: tuple[ModelPrBodySection, ...] = Field(default_factory=tuple)
+
+    @field_validator("evidence_tickets", mode="before")
+    @classmethod
+    def _normalize_tickets(cls, value: object) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str) or not isinstance(value, (list, tuple)):
+            raise ValueError(
+                "evidence_tickets must be a sequence of OMN-<n> ticket ids, "
+                f"got {type(value).__name__}"
+            )
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for raw in value:
+            if not isinstance(raw, str):
+                raise ValueError(
+                    f"evidence ticket must be a string, got {type(raw).__name__}"
+                )
+            token = raw.strip().upper()
+            if not _TICKET_RE.fullmatch(token):
+                raise ValueError(
+                    f"evidence ticket {raw!r} does not match OMN-<n> (e.g. OMN-14187)"
+                )
+            if token not in seen:
+                seen.add(token)
+                normalized.append(token)
+        return tuple(normalized)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "repo": self.repo,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "evidence_source": (
+                self.evidence_source.as_dict()
+                if self.evidence_source is not None
+                else None
+            ),
+            # Order-preserving, not sorted — first-seen ticket order is meaningful.
+            "evidence_tickets": list(self.evidence_tickets),
+            "skip_tokens": [token.as_dict() for token in self.skip_tokens],
+            "body_sections": [section.as_dict() for section in self.body_sections],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["ModelPrOccMetadataStamp"]

--- a/src/omnibase_core/models/validation/model_pr_receipt_gate_skip_token.py
+++ b/src/omnibase_core/models/validation/model_pr_receipt_gate_skip_token.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed capture of a ``[skip-<gate>: <reason>]`` bypass token (OMN-14187).
+
+Piece 1/5 of the canonical OCC stamp-model (parent epic OMN-14180). This model
+is the single typed vocabulary for the skip-token detection that lives in two
+places today:
+
+* ``omniclaude/.pre-commit-hooks/reject-deploy-gate-skip-token.sh`` —
+  ``SKIP_PATTERN='\\[skip-[a-zA-Z]'`` and
+  ``ALLOWLIST_PATTERN='#\\s*skip-token-allowed:\\s*\\S'``.
+* ``omnibase_core.validation.validator_receipt_gate`` — ``SKIP_TOKEN_PATTERN``
+  (``\\[skip-[a-zA-Z][^\\]<>]*\\]``) and ``ALLOWLIST_PATTERN``
+  (``#\\s*skip-token-allowed:\\s*(\\S+)``).
+
+The allowlist receipt id is captured from the separate, out-of-band
+``# skip-token-allowed: <id>`` companion line — it is NOT nested inside the
+bracket token. Pure Pydantic domain model: zero I/O.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPrReceiptGateSkipToken(BaseModel):
+    """A ``[skip-<gate_name>: <reason>]`` bypass token and its allowlist state.
+
+    ``gate_name`` is the identifier after ``skip-`` (e.g. ``receipt-gate``,
+    ``deploy-gate``); its pattern mirrors the leading-alpha requirement of the
+    hook's ``SKIP_PATTERN`` while pinning the full safe-identifier shape.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    gate_name: str = Field(min_length=1, pattern=r"^[a-zA-Z][a-zA-Z0-9_-]*$")
+    reason: str = Field(default="")
+    allowlist_receipt_id: str | None = Field(default=None)
+
+    @property
+    def is_allowlisted(self) -> bool:
+        """True when an out-of-band ``# skip-token-allowed: <id>`` id is bound."""
+        return self.allowlist_receipt_id is not None
+
+    def render_token(self) -> str:
+        """Return the bracket token as it appears in a PR body / commit message."""
+        return f"[skip-{self.gate_name}: {self.reason}]"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "gate_name": self.gate_name,
+            "reason": self.reason,
+            "allowlist_receipt_id": self.allowlist_receipt_id,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["ModelPrReceiptGateSkipToken"]

--- a/tests/unit/enums/test_enum_pr_evidence_source_kind.py
+++ b/tests/unit/enums/test_enum_pr_evidence_source_kind.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for EnumPrEvidenceSourceKind (OMN-14187)."""
+
+from __future__ import annotations
+
+from enum import Enum, StrEnum
+
+import pytest
+
+from omnibase_core.enums.enum_pr_evidence_source_kind import EnumPrEvidenceSourceKind
+
+
+@pytest.mark.unit
+class TestEnumPrEvidenceSourceKind:
+    def test_members_exist_with_expected_values(self) -> None:
+        assert EnumPrEvidenceSourceKind.OCC_PR == "occ_pr"
+        assert EnumPrEvidenceSourceKind.COMMIT_SHA == "commit_sha"
+
+    def test_exactly_two_members(self) -> None:
+        assert {member.value for member in EnumPrEvidenceSourceKind} == {
+            "occ_pr",
+            "commit_sha",
+        }
+
+    def test_strenum_inheritance(self) -> None:
+        assert issubclass(EnumPrEvidenceSourceKind, StrEnum)
+        assert issubclass(EnumPrEvidenceSourceKind, str)
+        assert issubclass(EnumPrEvidenceSourceKind, Enum)
+
+    def test_string_equality_with_plain_strings(self) -> None:
+        # StrEnum members compare equal to their plain-string value.
+        assert EnumPrEvidenceSourceKind.OCC_PR == "occ_pr"
+        assert EnumPrEvidenceSourceKind("occ_pr") is EnumPrEvidenceSourceKind.OCC_PR
+        assert str(EnumPrEvidenceSourceKind.COMMIT_SHA) == "commit_sha"

--- a/tests/unit/models/validation/test_model_pr_body_section.py
+++ b/tests/unit/models/validation/test_model_pr_body_section.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPrBodySection (OMN-14187)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_pr_body_section import ModelPrBodySection
+
+
+@pytest.mark.unit
+class TestModelPrBodySection:
+    def test_leading_unheaded_segment(self) -> None:
+        section = ModelPrBodySection(heading=None, content="intro text")
+        assert section.heading is None
+        assert section.content == "intro text"
+        assert section.is_stamp_section is False
+
+    def test_headed_segment(self) -> None:
+        section = ModelPrBodySection(heading="---", content="## Evidence\n")
+        assert section.heading == "---"
+        assert section.content == "## Evidence\n"
+
+    def test_defaults(self) -> None:
+        section = ModelPrBodySection()
+        assert section.heading is None
+        assert section.content == ""
+        assert section.is_stamp_section is False
+
+    def test_content_preserved_byte_for_byte(self) -> None:
+        raw = "  leading spaces\n\ttab-indented\nline with trailing space   \n\n"
+        section = ModelPrBodySection(content=raw)
+        # Round-trip fidelity is the entire point of this model.
+        assert section.content == raw
+        restored = ModelPrBodySection.model_validate(section.model_dump())
+        assert restored.content == raw
+
+    def test_is_stamp_section_flag(self) -> None:
+        section = ModelPrBodySection(
+            heading="Evidence-Source",
+            content="Evidence-Source: OCC#7\n",
+            is_stamp_section=True,
+        )
+        assert section.is_stamp_section is True
+
+    def test_serialization_roundtrip(self) -> None:
+        section = ModelPrBodySection(
+            heading="## Summary", content="body", is_stamp_section=False
+        )
+        assert ModelPrBodySection.model_validate(section.model_dump()) == section
+        assert (
+            ModelPrBodySection.model_validate_json(section.model_dump_json()) == section
+        )
+
+    def test_frozen_attribute_mutation_raises(self) -> None:
+        section = ModelPrBodySection(content="x")
+        with pytest.raises(ValidationError):
+            section.content = "y"  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrBodySection(content="x", order=1)  # type: ignore[call-arg]
+
+    def test_to_json_deterministic(self) -> None:
+        section = ModelPrBodySection(heading="h", content="c")
+        assert section.to_json() == section.to_json()

--- a/tests/unit/models/validation/test_model_pr_evidence_source.py
+++ b/tests/unit/models/validation/test_model_pr_evidence_source.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPrEvidenceSource (OMN-14187)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_pr_evidence_source_kind import EnumPrEvidenceSourceKind
+from omnibase_core.models.validation.model_pr_evidence_source import (
+    ModelPrEvidenceSource,
+)
+
+_VALID_SHA_40 = "a" * 40
+_VALID_SHA_7 = "0123abc"
+
+
+@pytest.mark.unit
+class TestModelPrEvidenceSource:
+    def test_valid_occ_pr_variant(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=123
+        )
+        assert src.occ_pr_number == 123
+        assert src.commit_sha is None
+
+    def test_valid_commit_sha_variant(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.COMMIT_SHA, commit_sha=_VALID_SHA_40
+        )
+        assert src.commit_sha == _VALID_SHA_40
+        assert src.occ_pr_number is None
+
+    def test_occ_pr_with_commit_sha_also_set_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(
+                kind=EnumPrEvidenceSourceKind.OCC_PR,
+                occ_pr_number=123,
+                commit_sha=_VALID_SHA_40,
+            )
+
+    def test_occ_pr_without_number_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(kind=EnumPrEvidenceSourceKind.OCC_PR)
+
+    def test_commit_sha_without_sha_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(kind=EnumPrEvidenceSourceKind.COMMIT_SHA)
+
+    def test_commit_sha_kind_with_occ_number_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(
+                kind=EnumPrEvidenceSourceKind.COMMIT_SHA,
+                commit_sha=_VALID_SHA_40,
+                occ_pr_number=5,
+            )
+
+    def test_occ_pr_number_zero_raises_ge1(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=0)
+
+    @pytest.mark.parametrize(
+        "bad_sha",
+        [
+            "z" * 40,  # invalid hex chars
+            "abc",  # too short (<7)
+            "a" * 41,  # too long (>40)
+            "ABCDEF0",  # uppercase not permitted by [0-9a-f]
+        ],
+    )
+    def test_invalid_commit_sha_pattern_raises(self, bad_sha: str) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(
+                kind=EnumPrEvidenceSourceKind.COMMIT_SHA, commit_sha=bad_sha
+            )
+
+    def test_valid_short_sha_boundary_7(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.COMMIT_SHA, commit_sha=_VALID_SHA_7
+        )
+        assert src.commit_sha == _VALID_SHA_7
+
+    def test_render_token_occ_pr(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=123
+        )
+        assert src.render_token() == "OCC#123"
+
+    def test_render_token_commit_sha(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.COMMIT_SHA, commit_sha=_VALID_SHA_40
+        )
+        assert src.render_token() == _VALID_SHA_40
+
+    def test_url_optional_field(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR,
+            occ_pr_number=7,
+            url="https://github.com/OmniNode-ai/onex_change_control/pull/7",
+        )
+        assert src.url is not None
+
+    def test_roundtrip_model_dump(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=999
+        )
+        restored = ModelPrEvidenceSource.model_validate(src.model_dump())
+        assert restored == src
+
+    def test_roundtrip_model_dump_json(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.COMMIT_SHA, commit_sha=_VALID_SHA_40
+        )
+        restored = ModelPrEvidenceSource.model_validate_json(src.model_dump_json())
+        assert restored == src
+
+    def test_frozen_attribute_mutation_raises(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=1
+        )
+        with pytest.raises(ValidationError):
+            src.occ_pr_number = 2  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrEvidenceSource(
+                kind=EnumPrEvidenceSourceKind.OCC_PR,
+                occ_pr_number=1,
+                bogus="x",  # type: ignore[call-arg]
+            )
+
+    def test_to_json_deterministic(self) -> None:
+        src = ModelPrEvidenceSource(
+            kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=42
+        )
+        assert src.to_json() == src.to_json()
+        assert '"kind":"occ_pr"' in src.to_json()

--- a/tests/unit/models/validation/test_model_pr_occ_metadata_stamp.py
+++ b/tests/unit/models/validation/test_model_pr_occ_metadata_stamp.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPrOccMetadataStamp (OMN-14187)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_pr_evidence_source_kind import EnumPrEvidenceSourceKind
+from omnibase_core.models.validation.model_pr_body_section import ModelPrBodySection
+from omnibase_core.models.validation.model_pr_evidence_source import (
+    ModelPrEvidenceSource,
+)
+from omnibase_core.models.validation.model_pr_occ_metadata_stamp import (
+    ModelPrOccMetadataStamp,
+)
+from omnibase_core.models.validation.model_pr_receipt_gate_skip_token import (
+    ModelPrReceiptGateSkipToken,
+)
+
+_VALID_SHA_40 = "a" * 40
+
+
+@pytest.mark.unit
+class TestModelPrOccMetadataStampTickets:
+    def test_ticket_order_preserved_not_sorted(self) -> None:
+        stamp = ModelPrOccMetadataStamp(
+            evidence_tickets=("OMN-456", "OMN-123"),
+        )
+        # Order preserved as given (NOT sorted to OMN-123, OMN-456).
+        assert stamp.evidence_tickets == ("OMN-456", "OMN-123")
+        assert stamp.model_dump()["evidence_tickets"] == ("OMN-456", "OMN-123")
+
+    def test_ticket_dedupe_preserves_first_occurrence(self) -> None:
+        stamp = ModelPrOccMetadataStamp(
+            evidence_tickets=("OMN-123", "OMN-456", "OMN-123"),
+        )
+        assert stamp.evidence_tickets == ("OMN-123", "OMN-456")
+
+    def test_ticket_case_normalized(self) -> None:
+        stamp = ModelPrOccMetadataStamp(evidence_tickets=("omn-123", "OMN-123"))
+        # Case-normalized then de-duped -> a single canonical entry.
+        assert stamp.evidence_tickets == ("OMN-123",)
+
+    @pytest.mark.parametrize("bad_ticket", ["JIRA-123", "OMN-abc", "omn123"])
+    def test_malformed_ticket_raises(self, bad_ticket: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ModelPrOccMetadataStamp(evidence_tickets=(bad_ticket,))
+        assert "OMN-<n>" in str(exc_info.value)
+
+    def test_bare_string_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrOccMetadataStamp(evidence_tickets="OMN-123")  # type: ignore[arg-type]
+
+    def test_empty_tickets_default(self) -> None:
+        stamp = ModelPrOccMetadataStamp()
+        assert stamp.evidence_tickets == ()
+
+
+@pytest.mark.unit
+class TestModelPrOccMetadataStampFields:
+    def test_defaults(self) -> None:
+        stamp = ModelPrOccMetadataStamp()
+        assert stamp.repo == ""
+        assert stamp.pr_number is None
+        assert stamp.head_sha is None
+        assert stamp.evidence_source is None
+        assert stamp.evidence_tickets == ()
+        assert stamp.skip_tokens == ()
+        assert stamp.body_sections == ()
+
+    def test_pr_number_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrOccMetadataStamp(pr_number=0)
+
+    def test_invalid_head_sha_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrOccMetadataStamp(head_sha="not-a-sha")
+
+    def test_valid_head_sha(self) -> None:
+        stamp = ModelPrOccMetadataStamp(head_sha=_VALID_SHA_40)
+        assert stamp.head_sha == _VALID_SHA_40
+
+    def test_frozen_attribute_mutation_raises(self) -> None:
+        stamp = ModelPrOccMetadataStamp(repo="omnibase_core")
+        with pytest.raises(ValidationError):
+            stamp.repo = "other"  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrOccMetadataStamp(unexpected="x")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestModelPrOccMetadataStampComposition:
+    @staticmethod
+    def _full_stamp() -> ModelPrOccMetadataStamp:
+        return ModelPrOccMetadataStamp(
+            repo="omnibase_core",
+            pr_number=1774,
+            head_sha=_VALID_SHA_40,
+            evidence_source=ModelPrEvidenceSource(
+                kind=EnumPrEvidenceSourceKind.OCC_PR, occ_pr_number=42
+            ),
+            evidence_tickets=("OMN-14187", "OMN-14180"),
+            skip_tokens=(
+                ModelPrReceiptGateSkipToken(gate_name="receipt-gate", reason="r"),
+            ),
+            body_sections=(
+                ModelPrBodySection(heading=None, content="intro\n"),
+                ModelPrBodySection(
+                    heading="Evidence-Source",
+                    content="Evidence-Source: OCC#42\n",
+                    is_stamp_section=True,
+                ),
+            ),
+        )
+
+    def test_nested_roundtrip_model_dump(self) -> None:
+        stamp = self._full_stamp()
+        restored = ModelPrOccMetadataStamp.model_validate(stamp.model_dump())
+        assert restored == stamp
+
+    def test_nested_roundtrip_model_dump_json(self) -> None:
+        stamp = self._full_stamp()
+        restored = ModelPrOccMetadataStamp.model_validate_json(stamp.model_dump_json())
+        assert restored == stamp
+
+    def test_as_dict_ticket_order_preserved(self) -> None:
+        stamp = self._full_stamp()
+        assert stamp.as_dict()["evidence_tickets"] == ["OMN-14187", "OMN-14180"]
+
+    def test_to_json_deterministic_byte_identical(self) -> None:
+        stamp = self._full_stamp()
+        assert stamp.to_json() == stamp.to_json()
+
+    def test_to_json_is_sorted_keys(self) -> None:
+        stamp = self._full_stamp()
+        payload = stamp.to_json()
+        # sort_keys=True => top-level keys emitted in sorted order.
+        parsed = json.loads(payload)
+        assert list(parsed.keys()) == sorted(parsed.keys())
+        # Nested evidence_source composed cleanly.
+        assert parsed["evidence_source"]["kind"] == "occ_pr"

--- a/tests/unit/models/validation/test_model_pr_receipt_gate_skip_token.py
+++ b/tests/unit/models/validation/test_model_pr_receipt_gate_skip_token.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelPrReceiptGateSkipToken (OMN-14187)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.validation.model_pr_receipt_gate_skip_token import (
+    ModelPrReceiptGateSkipToken,
+)
+
+# Regression pins copied verbatim from
+# omniclaude/.pre-commit-hooks/reject-deploy-gate-skip-token.sh so that any drift
+# in the rendered token / allowlist companion shape breaks this test.
+_HOOK_SKIP_PATTERN = re.compile(r"\[skip-[a-zA-Z]", re.IGNORECASE)
+_HOOK_ALLOWLIST_PATTERN = re.compile(r"#\s*skip-token-allowed:\s*\S", re.IGNORECASE)
+
+
+@pytest.mark.unit
+class TestModelPrReceiptGateSkipToken:
+    def test_valid_construction(self) -> None:
+        token = ModelPrReceiptGateSkipToken(
+            gate_name="receipt-gate", reason="docs only"
+        )
+        assert token.gate_name == "receipt-gate"
+        assert token.reason == "docs only"
+
+    @pytest.mark.parametrize("bad_name", ["has space", "1leading-digit", "-dash"])
+    def test_invalid_gate_name_pattern_raises(self, bad_name: str) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrReceiptGateSkipToken(gate_name=bad_name)
+
+    def test_empty_gate_name_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrReceiptGateSkipToken(gate_name="")
+
+    def test_allowlist_default_none_not_allowlisted(self) -> None:
+        token = ModelPrReceiptGateSkipToken(gate_name="deploy-gate")
+        assert token.allowlist_receipt_id is None
+        assert token.is_allowlisted is False
+
+    def test_allowlist_set_is_allowlisted(self) -> None:
+        token = ModelPrReceiptGateSkipToken(
+            gate_name="deploy-gate", allowlist_receipt_id="approval-abc123"
+        )
+        assert token.is_allowlisted is True
+
+    def test_render_token_exact_format(self) -> None:
+        token = ModelPrReceiptGateSkipToken(
+            gate_name="deploy-gate", reason="correctness fix"
+        )
+        assert token.render_token() == "[skip-deploy-gate: correctness fix]"
+
+    def test_rendered_token_matches_hook_skip_pattern(self) -> None:
+        # The rendered token must be detectable by the pre-commit / CI hook.
+        token = ModelPrReceiptGateSkipToken(gate_name="receipt-gate", reason="x")
+        assert _HOOK_SKIP_PATTERN.search(token.render_token()) is not None
+
+    def test_allowlist_companion_line_matches_hook_pattern(self) -> None:
+        # The out-of-band companion line the hook scans for.
+        companion = "# skip-token-allowed: approval-abc123"
+        assert _HOOK_ALLOWLIST_PATTERN.search(companion) is not None
+
+    def test_serialization_roundtrip(self) -> None:
+        token = ModelPrReceiptGateSkipToken(
+            gate_name="receipt-gate",
+            reason="ticketless chore",
+            allowlist_receipt_id="rid-1",
+        )
+        restored = ModelPrReceiptGateSkipToken.model_validate(token.model_dump())
+        assert restored == token
+        restored_json = ModelPrReceiptGateSkipToken.model_validate_json(
+            token.model_dump_json()
+        )
+        assert restored_json == token
+
+    def test_frozen_attribute_mutation_raises(self) -> None:
+        token = ModelPrReceiptGateSkipToken(gate_name="receipt-gate")
+        with pytest.raises(ValidationError):
+            token.reason = "changed"  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPrReceiptGateSkipToken(
+                gate_name="receipt-gate",
+                nested_allowlist="x",  # type: ignore[call-arg]
+            )
+
+    def test_to_json_deterministic(self) -> None:
+        token = ModelPrReceiptGateSkipToken(gate_name="receipt-gate", reason="r")
+        assert token.to_json() == token.to_json()

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.7"
+version = "0.46.8"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-14187 — Piece 1/5 of the canonical OCC stamp-model

Parent epic: **OMN-14180** (canonical OCC evidence-stamp model + deterministic renderer/handler, decomposed into 5 sequential children OMN-14187→14191).
This PR: **OMN-14187**, child 1/5 — the 4 core Pydantic models only.

### What this adds
A single typed vocabulary in `omnibase_core` that both the receipt-gate
(`validator_receipt_gate` / `occ-preflight.yml`) and the omnimarket OCC autobind
effect (`adapter_occ_autobind` / `adapter_occ_contract`) will consume, replacing
today's independent regex/f-string implementations.

New enum + 4 models (all `frozen=True, extra="forbid"`, tuple-based, deterministic
`as_dict()`/`to_json()` with `sort_keys=True`, direct-import only — following the
`model_occ_eligibility_*` sibling precedent, deliberately excluded from the
`models/validation/__init__.py` barrel):

- **`EnumPrEvidenceSourceKind`** (`enums/enum_pr_evidence_source_kind.py`) — `OCC_PR | COMMIT_SHA`, StrEnum.
- **`ModelPrEvidenceSource`** — an `Evidence-Source:` reference (`OCC#<n>` or a 7-40 hex SHA);
  after-validator enforces exactly-one-of + kind agreement; `render_token()` reproduces the
  `OCC#<n>`/sha token the autobind f-string emits today. `commit_sha` pattern mirrors
  `validator_receipt_gate.EVIDENCE_SOURCE_SHA_PATTERN`.
- **`ModelPrReceiptGateSkipToken`** — a `[skip-<gate>: <reason>]` token + its out-of-band
  `# skip-token-allowed: <id>` allowlist state; `gate_name` pattern mirrors
  `reject-deploy-gate-skip-token.sh` `SKIP_PATTERN`.
- **`ModelPrBodySection`** — heading + byte-identical `content` span for lossless PR-body
  round-trip (the surface Piece 2's render/parse preserves verbatim).
- **`ModelPrOccMetadataStamp`** — the aggregate; `evidence_tickets` normalized to case-folded
  `OMN-<n>` and de-duped preserving first-seen order (deliberately **not** sorted), composing
  the three leaf models.

Each field is grounded in the two live ad-hoc call sites (verbatim regex/format cross-checked in
tests as regression pins). No renderer/parser logic — that is explicitly deferred to **Piece 2 (OMN-14188)**.

### Supporting changes
- `pyproject.toml` / `uv.lock`: patch bump `0.46.7 → 0.46.8` (OMN-13411 release-identity gate: packaged source changed).
- `scripts/validation/validate-string-versions.py`: add `allowlist_receipt_id` to the curated
  intentionally-`str` id exceptions (it holds a user-issued approval receipt handle / raw `\S+`
  token, not a UUID) alongside the existing `ticket_id`/`epic_id`/`handler_id` entries.

### Local gates (proof_class=code-only)
- New tests: **66 passed** (`test_enum_pr_evidence_source_kind` + 4 `test_model_pr_*`).
- Adjacent suite (`tests/unit/models/validation/` + `tests/unit/enums/`): **4574 passed, 1 skipped**.
- `ruff format` + `ruff check --fix`: clean.
- `mypy --strict` on new files: **Success: no issues found in 5 source files** (the 5 pre-existing
  errors are in untouched transitively-imported modules — byte-identical to `origin/dev`).
- `pre-commit run` on all touched files: **all passed**.

### Notes
- Draft PR — Codex owns the merge queue; not arming auto-merge, not undrafting.
- OCC evidence companion is intentionally **not** self-authored here (no-self-authored-evidence rule);
  the independent verifier / autobind tick supplies it.

Closes OMN-14187
Refs OMN-14180

---
Evidence-Source: OCC#3762
Evidence-Ticket: OMN-14187
