### PR TITLE
refactor(OMN-14217): retire types→validation import-layering back-edge in omnibase_core

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -60,8 +60,6 @@ ignore_imports =
     omnibase_core.errors.** -> omnibase_core.models.**
     # OMN-3210 burn-down: constants -> models (~1 edge)
     omnibase_core.constants.** -> omnibase_core.models.**
-    # OMN-3210 burn-down: types -> validation (~1 edge)
-    omnibase_core.types.** -> omnibase_core.validation.**
 
 [importlinter:contract:core-models-no-upward]
 name = Models must not import behavioral/orchestration layers (direct)

--- a/src/omnibase_core/types/typed_dict_validator_info.py
+++ b/src/omnibase_core/types/typed_dict_validator_info.py
@@ -11,7 +11,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
-    from omnibase_core.validation.validator_utils import ModelValidationResult
+    from omnibase_core.models.common.model_validation_result import (
+        ModelValidationResult,
+    )
 
 
 class TypedDictValidatorInfo(TypedDict):


### PR DESCRIPTION
## Summary

Burn down one frozen import-layering back-edge in `omnibase_core`, verified by the `.importlinter` oracle (the **Import Layering Oracle** CI job + pre-commit hook installed under OMN-14216, merged `3807a3c1`).

The `core-foundation-no-upward` contract froze a 1-edge family:

```
# OMN-3210 burn-down: types -> validation (~1 edge)
omnibase_core.types.** -> omnibase_core.validation.**
```

The single offending edge was a `TYPE_CHECKING`-only import in `types/typed_dict_validator_info.py`:

```python
from omnibase_core.validation.validator_utils import ModelValidationResult
```

`ModelValidationResult` is actually **defined** in `models/common/model_validation_result.py`; `validation/validator_utils.py` merely re-exports it. This change repoints the import at its canonical definition site, removing the foundation→behavioral back-edge, and drops the now-unmatched ignore line so the ratchet (`unmatched_ignore_imports_alerting = ERROR`) stays clean.

**Zero runtime behavior change** — the import is `TYPE_CHECKING`-only, used solely in a string forward-reference annotation. The resulting `types -> models` edge is already covered by the frozen `types.** -> models.**` allowlist, so `lint-imports` stays green.

## Changes

- `src/omnibase_core/types/typed_dict_validator_info.py` — repoint the `TYPE_CHECKING` import to `omnibase_core.models.common.model_validation_result`.
- `.importlinter` — remove the retired `types.** -> validation.**` ignore line (+ its comment).

## dod_evidence

**Oracle before (origin/dev `3807a3c1`, ignore line present):** `env -u PYTHONPATH uv run lint-imports` → `Contracts: 4 kept, 0 broken`.

**Oracle after (ignore line removed):** `env -u PYTHONPATH uv run lint-imports` (grimp built the worktree src: `file:///.../omni_worktrees/OMN-14217/omnibase_core`) → `Contracts: 4 kept, 0 broken`. The `core-foundation-no-upward` contract stays **KEPT** without the allowlist entry, proving the edge is genuinely gone (no unmatched-ignore error).

**grep proof the specific import is gone (not just wildcard-covered):**
```
$ grep -rn "omnibase_core.validation" src/omnibase_core/types/
  (no matches — family fully removed)
```

**Removed edge:** `omnibase_core.types.typed_dict_validator_info` → `omnibase_core.validation.validator_utils` (import repointed to `models.common.model_validation_result`).

**Other gates (worktree, PYTHONPATH cleared):**
- `mypy src/omnibase_core/` → `Success: no issues found in 4079 source files` (forward-ref `"ModelValidationResult[None]"` resolves from the new location).
- Affected tests (`test_init_exports`, `test_init_fast`, `test_backwards_compatibility_omn1071`, `validation/test_cli`, `cli/test_commands`) → `148 passed`.
- `ruff format --check` + `ruff check` → clean.
- `pre-commit run` (changed files) → 98 hooks, 0 failed; `import-linter (intra-core dependency layering)... Passed`.

Closes OMN-14217
Refs OMN-3210

Evidence-Source: OCC#3771
Evidence-Ticket: OMN-14217
