### PR TITLE
refactor(OMN-14221): retire constants→models import-layering back-edge in omnibase_core

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -58,8 +58,9 @@ ignore_imports =
     # OMN-3210 burn-down: errors -> models (~11 edges)
     omnibase_core.errors -> omnibase_core.models.**
     omnibase_core.errors.** -> omnibase_core.models.**
-    # OMN-3210 burn-down: constants -> models (~1 edge)
-    omnibase_core.constants.** -> omnibase_core.models.**
+    # OMN-3210 burn-down: constants -> models — RETIRED (OMN-14221):
+    # constants_handler_capabilities no longer imports ModelOnexError; the
+    # get_capabilities_by_node_kind boundary now raises the built-in ValueError.
 
 [importlinter:contract:core-models-no-upward]
 name = Models must not import behavioral/orchestration layers (direct)

--- a/src/omnibase_core/constants/constants_handler_capabilities.py
+++ b/src/omnibase_core/constants/constants_handler_capabilities.py
@@ -40,7 +40,6 @@ from omnibase_core.enums.enum_reducer_capability import EnumReducerCapability
 from omnibase_core.errors.exception_unsupported_capability_error import (
     UnsupportedCapabilityError,
 )
-from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
 if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
@@ -211,24 +210,18 @@ def get_capabilities_by_node_kind(node_kind: EnumNodeKind) -> frozenset[str]:
         # Raises ValueError
     """
     if node_kind == EnumNodeKind.RUNTIME_HOST:
-        raise ModelOnexError(
-            message=(
-                f"RUNTIME_HOST is an infrastructure type, not a core node type. "
-                f"It does not have a defined capability set. "
-                f"Use one of: {list(_NODE_KIND_TO_CAPABILITIES.keys())}"
-            ),
-            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-            context={"node_kind": str(node_kind)},
+        raise ValueError(  # error-ok: standard input validation at function boundary
+            f"RUNTIME_HOST is an infrastructure type, not a core node type. "
+            f"It does not have a defined capability set. "
+            f"Use one of: {list(_NODE_KIND_TO_CAPABILITIES.keys())} "
+            f"(error_code: VALIDATION_ERROR, context: node_kind={node_kind})"
         )
 
     if node_kind not in _NODE_KIND_TO_CAPABILITIES:
-        raise ModelOnexError(
-            message=(
-                f"Unknown node kind: {node_kind}. "
-                f"Expected one of: {list(_NODE_KIND_TO_CAPABILITIES.keys())}"
-            ),
-            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
-            context={"node_kind": str(node_kind)},
+        raise ValueError(  # error-ok: standard input validation at function boundary
+            f"Unknown node kind: {node_kind}. "
+            f"Expected one of: {list(_NODE_KIND_TO_CAPABILITIES.keys())} "
+            f"(error_code: VALIDATION_ERROR, context: node_kind={node_kind})"
         )
 
     return _NODE_KIND_TO_CAPABILITIES[node_kind]

--- a/tests/unit/constants/test_handler_capabilities.py
+++ b/tests/unit/constants/test_handler_capabilities.py
@@ -554,10 +554,9 @@ class TestGetCapabilitiesByNodeKind:
             get_capabilities_by_node_kind,
         )
 
-        # RUNTIME_HOST is infrastructure, not a core node type
-        from omnibase_core.errors import ModelOnexError
-
-        with pytest.raises(ModelOnexError):
+        # RUNTIME_HOST is infrastructure, not a core node type; the function
+        # raises the built-in ValueError per its docstring (boundary validation).
+        with pytest.raises(ValueError):
             get_capabilities_by_node_kind(EnumNodeKind.RUNTIME_HOST)
 
 


### PR DESCRIPTION
## Summary (mechanical)

Retire the single `constants → models` frozen import-layering back-edge in omnibase_core's import-linter oracle (`.importlinter`, `core-foundation-no-upward` contract).

`get_capabilities_by_node_kind()` in `constants_handler_capabilities.py` raised `ModelOnexError` while its own docstring declared `Raises: ValueError`. This PR makes the code match the docstring — and CLAUDE.md error-handling doctrine ("standard Python validation at function boundaries → `ValueError`"):

- Both boundary-validation `raise ModelOnexError(...)` sites → `raise ValueError(...)`, folding `error_code`/`context` into the message text, with the sanctioned `# error-ok:` boundary marker.
- Drop the now-unused `from omnibase_core.models.errors.model_onex_error import ModelOnexError` import — the **sole** `constants → models` edge in the package.
- Retire the frozen `constants → models` ignore line in `.importlinter`; the `unmatched_ignore_imports_alerting=ERROR` ratchet then keeps itself honest.
- Flip the test's expected exception (`test_get_capabilities_raises_for_runtime_host`) to `ValueError`, dropping its `ModelOnexError` import.

## Delegation authorship (RSD dogfood)

The substantive refactor of `get_capabilities_by_node_kind` was **authored by delegation** — `onex delegate --task-type refactor`, which routed **LOCAL** (Qwen3.6-35B-A3B) at **$0**, `quality_score=1.0`. The local model produced the exact `ValueError` refactor adopted here (recovered from the orchestrator capture log). Human/oracle finishing added only the repo-specific `# error-ok:` annotation (a convention the model could not infer from the prompt) and the mechanical consequences (import removal, ignore-line retirement, test flip).

## dod_evidence

- **Delegation payload** — `attempts[0]`: `tier=local`, `model_id=Qwen3.6-35B-A3B`, `quality_score=1.0`, `cost_usd=0.0`. Authored refactor == the code landed here.
- **lint-imports (PYTHONPATH-cleared)** — before: `Analyzed 4078 files, 10327 dependencies … 4 kept, 0 broken` (edge frozen via ignore). after: `Analyzed 4078 files, 10326 dependencies … 4 kept, 0 broken` (one edge removed; ignore line retired; no unmatched-ignore error).
- **grep guardrail (F18)** — `grep -rn "from omnibase_core.models" src/omnibase_core/constants/` → empty. The specific import is gone, not merely lint-imports green.
- **mypy** — `Success: no issues found in 1 source file`.
- **tests** — `tests/unit/constants/test_handler_capabilities.py` → 68 passed (includes the flipped `pytest.raises(ValueError)` assertion; `ModelOnexError` is `Exception`-derived, not a `ValueError` relative, so the assertion genuinely flips).
- **ruff format + check** — clean. **pre-commit (changed files)** — all hooks Passed, incl. `import-linter (intra-core dependency layering)` and `ONEX Error Raising Validation`.


## Independent verification (OCC companion)

An independent verifier (NOT the delegation author, NOT the implementer) reproduced this change end-to-end in an isolated worktree with PYTHONPATH cleared: lint-imports 4 kept / 0 broken (10326 deps) with the ignore line removed; negative control restoring the ModelOnexError import broke core-foundation-no-upward (l.43); ModelOnexError is not a ValueError subclass so the flipped test assertion is genuine; mypy clean; 68 tests passed; ruff + pre-commit (import-linter + ONEX Error Raising Validation) clean, with a marker-stripped negative control proving the `# error-ok:` markers are required.

Evidence-Source: OCC#3773
Evidence-Ticket: OMN-14221
Closes OMN-14221
Refs OMN-3210 (Platform Tech Debt Reduction — import-layering burn-down)