### PR TITLE
feat(OMN-14229): implement documented ModelFSMStateTransition.priority / guard-fallthrough in the FSM engine

### DIFF
--- a/src/omnibase_core/utils/util_fsm_executor.py
+++ b/src/omnibase_core/utils/util_fsm_executor.py
@@ -15,7 +15,7 @@ while maintaining type clarity for FSM-specific usage.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -125,9 +125,12 @@ async def execute_transition(
             context={"fsm": fsm.state_machine_name, "state": current_state},
         )
 
-    # 2. Find valid transition
-    transition = _find_transition(fsm, current_state, trigger)
-    if not transition:
+    # 2. Select the transition using priority-ordered guard fallthrough.
+    #    Implements the documented ModelFSMStateTransition.priority semantics:
+    #    among the transitions matching (current_state, trigger), guards are
+    #    evaluated in priority order and the first eligible one is chosen.
+    selection = await _select_transition(fsm, current_state, trigger, context)
+    if selection is None:
         raise ModelOnexError(
             error_code=EnumCoreErrorCode.VALIDATION_ERROR,
             message=f"No transition for trigger '{trigger}' from state '{current_state}'",
@@ -138,9 +141,14 @@ async def execute_transition(
             },
         )
 
-    # 3. Evaluate transition conditions
-    failed_conditions = await _evaluate_failed_conditions(transition, context)
-    if failed_conditions:
+    transition = selection.transition
+
+    # 3. Fail-closed guard evaluation. Selection already evaluated guards in
+    #    priority order; when no candidate is eligible (no guard passed and no
+    #    default edge is declared) the FSM stays in-state rather than silently
+    #    executing a transition whose guard is false.
+    if not selection.guard_passed:
+        failed_conditions = selection.failed_conditions
         # Create intent to log condition failure
         intents.append(
             ModelIntent(
@@ -415,21 +423,94 @@ def _get_state_definition(
     return None
 
 
-def _find_transition(
-    fsm: ModelFSMSubcontract, from_state: str, trigger: str
-) -> ModelFSMStateTransition | None:
-    """Find transition matching from_state and trigger."""
-    # First look for exact match
-    for transition in fsm.transitions:
-        if transition.from_state == from_state and transition.trigger == trigger:
-            return transition
+class _TransitionSelection(NamedTuple):
+    """Outcome of priority-ordered guard-fallthrough transition selection.
 
-    # Then look for wildcard transitions
-    for transition in fsm.transitions:
-        if transition.from_state == "*" and transition.trigger == trigger:
-            return transition
+    Attributes:
+        transition: The transition chosen for the (from_state, trigger) pair —
+            either the highest-priority candidate whose guard passed, or (when
+            no candidate is eligible) the highest-priority candidate whose guard
+            failed, so the caller can emit a fail-closed guard-rejection result.
+        guard_passed: True when ``transition`` is eligible to execute (its guard
+            passed, or it is an unconditional default edge). False when no
+            candidate was eligible and the FSM must stay in its current state.
+        failed_conditions: Names of the required conditions that rejected the
+            selected candidate; empty when ``guard_passed`` is True.
+    """
 
-    return None
+    transition: ModelFSMStateTransition
+    guard_passed: bool
+    failed_conditions: tuple[str, ...]
+
+
+async def _select_transition(
+    fsm: ModelFSMSubcontract,
+    from_state: str,
+    trigger: str,
+    context: FSMContextType,
+) -> _TransitionSelection | None:
+    """Select the transition to execute using priority-ordered guard fallthrough.
+
+    Implements the documented ``ModelFSMStateTransition.priority`` semantics
+    (see the model's "Priority Resolution" docstring):
+
+    1. Candidate set: transitions whose ``(from_state, trigger)`` match exactly.
+       Only when there is no exact match does the wildcard set
+       (``from_state == "*"``) apply — exact-state transitions always take
+       precedence over wildcard/global handlers (preserves prior behavior).
+    2. Candidates are evaluated in ``priority`` DESCENDING order; declaration
+       order is the stable tiebreak within equal priority.
+    3. The first candidate whose required conditions all pass is selected. A
+       transition with no required conditions is a trivially-passing "default
+       edge"; declared at the lowest priority it acts as the fallthrough once
+       every higher-priority guard has been rejected.
+    4. Fail-closed: if no candidate's guard passes (and no default edge is
+       declared), the highest-priority candidate is returned with
+       ``guard_passed=False``. The engine never silently executes a transition
+       whose guard is false; the caller emits a guard-rejection result and the
+       FSM stays in its current state.
+
+    Returns:
+        A ``_TransitionSelection``, or ``None`` when ``(from_state, trigger)``
+        matches no transition at all (the caller raises "no transition").
+    """
+    exact_candidates = [
+        transition
+        for transition in fsm.transitions
+        if transition.from_state == from_state and transition.trigger == trigger
+    ]
+    # Wildcard transitions apply only when no exact-state transition matches.
+    candidates = exact_candidates or [
+        transition
+        for transition in fsm.transitions
+        if transition.from_state == "*" and transition.trigger == trigger
+    ]
+    if not candidates:
+        return None
+
+    # Priority DESC; sorted() is stable, so equal-priority candidates keep
+    # their declaration order (the documented tiebreak).
+    ordered = sorted(
+        candidates, key=lambda transition: transition.priority, reverse=True
+    )
+
+    first_rejection: _TransitionSelection | None = None
+    for transition in ordered:
+        failed = await _evaluate_failed_conditions(transition, context)
+        if not failed:
+            # Guard passed (or unconditional default edge): the first eligible
+            # candidate in priority order wins.
+            return _TransitionSelection(transition, True, ())
+        if first_rejection is None:
+            # Remember the highest-priority guard failure for the fail-closed
+            # rejection result if no candidate turns out to be eligible.
+            first_rejection = _TransitionSelection(transition, False, failed)
+
+    # No candidate was eligible. ``first_rejection`` is guaranteed non-None here
+    # because the candidate list is non-empty and every candidate failed its
+    # guard (an eligible candidate would have returned above). Fail closed: the
+    # FSM stays in-state and no false-guard transition is silently executed.
+    return first_rejection
 
 
 async def _evaluate_conditions(

--- a/tests/unit/utils/test_fsm_executor.py
+++ b/tests/unit/utils/test_fsm_executor.py
@@ -1646,3 +1646,261 @@ class TestCorrelationIdPropagation:
         ]
         assert len(persist_intents) == 1
         assert persist_intents[0].payload.correlation_id == specific_uuid
+
+
+@pytest.mark.unit
+class TestFSMPriorityGuardFallthrough:
+    """Priority-ordered guard fallthrough (documented ModelFSMStateTransition.priority).
+
+    A single (from_state, trigger) pair may declare multiple transitions that
+    differ by guard and priority. The engine evaluates guards in priority order
+    and selects the first eligible one; an unconditional low-priority transition
+    acts as the fallthrough default edge; when nothing is eligible the FSM stays
+    in its current state (fail-closed) rather than silently taking the first
+    declaration.
+    """
+
+    @staticmethod
+    def _score_transition(
+        name: str, to_state: str, priority: int, minimum: int | None
+    ) -> ModelFSMStateTransition:
+        """A verifying -> ``to_state`` transition guarded by ``score >= minimum``.
+
+        ``minimum=None`` yields an unconditional (default-edge) transition.
+        """
+        conditions = (
+            []
+            if minimum is None
+            else [
+                ModelFSMTransitionCondition(
+                    condition_name=f"score_at_least_{minimum}",
+                    condition_type="field_check",
+                    expression=f"score >= {minimum}",
+                    required=True,
+                )
+            ]
+        )
+        return ModelFSMStateTransition(
+            transition_name=name,
+            from_state="verifying",
+            to_state=to_state,
+            trigger="verify_done",
+            priority=priority,
+            conditions=conditions,
+            version=ModelSemVer(major=1, minor=0, patch=0),
+        )
+
+    def _build_fsm(self, *, include_default: bool) -> ModelFSMSubcontract:
+        state_names = ["idle", "verifying", "accepted", "escalated"]
+        if include_default:
+            state_names.append("reviewed")
+        states = [
+            ModelFSMStateDefinition(
+                state_name=name,
+                state_type="operational",
+                description=f"{name} state",
+                is_terminal=False,
+                version=ModelSemVer(major=1, minor=0, patch=0),
+            )
+            for name in state_names
+        ]
+        transitions = [
+            ModelFSMStateTransition(
+                transition_name="begin",
+                from_state="idle",
+                to_state="verifying",
+                trigger="begin",
+                version=ModelSemVer(major=1, minor=0, patch=0),
+            ),
+            # Higher-priority guard: strong pass -> accepted.
+            self._score_transition("accept_on_high_score", "accepted", 20, 80),
+            # Lower-priority guard: partial pass -> escalated.
+            self._score_transition("escalate_on_mid_score", "escalated", 10, 50),
+        ]
+        if include_default:
+            # Unconditional default edge at the lowest priority: the fallthrough.
+            transitions.append(
+                self._score_transition("review_by_default", "reviewed", 0, None)
+            )
+        return ModelFSMSubcontract(
+            state_machine_name="branching_fsm",
+            state_machine_version=ModelSemVer(major=1, minor=0, patch=0),
+            description="FSM whose verify_done trigger branches on a score guard",
+            version=ModelSemVer(major=1, minor=0, patch=0),
+            states=states,
+            initial_state="idle",
+            terminal_states=[],
+            error_states=[],
+            transitions=transitions,
+            operations=[],
+            persistence_enabled=False,
+            recovery_enabled=False,
+        )
+
+    @pytest.fixture
+    def branching_fsm(self) -> ModelFSMSubcontract:
+        """Two guarded verify_done branches, no default edge."""
+        return self._build_fsm(include_default=False)
+
+    @pytest.fixture
+    def branching_fsm_with_default(self) -> ModelFSMSubcontract:
+        """Two guarded verify_done branches plus an unconditional default edge."""
+        return self._build_fsm(include_default=True)
+
+    @pytest.mark.asyncio
+    async def test_highest_priority_matching_guard_wins(
+        self, branching_fsm: ModelFSMSubcontract
+    ) -> None:
+        """When several guards pass, the highest-priority transition is chosen."""
+        # score 90 satisfies BOTH `>= 80` (priority 20) and `>= 50` (priority 10).
+        result = await execute_transition(
+            branching_fsm, "verifying", "verify_done", {"score": 90}
+        )
+        assert result.success
+        assert result.new_state == "accepted"
+        assert result.transition_name == "accept_on_high_score"
+
+    @pytest.mark.asyncio
+    async def test_fallthrough_to_lower_priority_guard(
+        self, branching_fsm: ModelFSMSubcontract
+    ) -> None:
+        """When the top guard fails, evaluation falls through to the next guard."""
+        # score 60 fails `>= 80` but satisfies `>= 50`.
+        result = await execute_transition(
+            branching_fsm, "verifying", "verify_done", {"score": 60}
+        )
+        assert result.success
+        assert result.new_state == "escalated"
+        assert result.transition_name == "escalate_on_mid_score"
+
+    @pytest.mark.asyncio
+    async def test_no_guard_matches_is_fail_closed(
+        self, branching_fsm: ModelFSMSubcontract
+    ) -> None:
+        """No guard matches and no default edge -> stay in-state (fail-closed)."""
+        # score 30 fails every guard; there is no default edge.
+        result = await execute_transition(
+            branching_fsm, "verifying", "verify_done", {"score": 30}
+        )
+        assert not result.success
+        # Fail-closed: did NOT silently take the first-declared transition.
+        assert result.new_state == "verifying"
+        assert result.failure_type == "guard_rejection"
+        assert result.error == "Transition conditions not met"
+        # Reports the highest-priority rejected guard's failed condition.
+        assert result.failed_conditions == ("score_at_least_80",)
+
+    @pytest.mark.asyncio
+    async def test_default_edge_fires_when_guards_fail(
+        self, branching_fsm_with_default: ModelFSMSubcontract
+    ) -> None:
+        """An unconditional low-priority default edge is the fallthrough."""
+        # score 30 fails both guards; the priority-0 unconditional edge fires.
+        result = await execute_transition(
+            branching_fsm_with_default, "verifying", "verify_done", {"score": 30}
+        )
+        assert result.success
+        assert result.new_state == "reviewed"
+        assert result.transition_name == "review_by_default"
+
+    @pytest.mark.asyncio
+    async def test_passing_guard_preferred_over_default_edge(
+        self, branching_fsm_with_default: ModelFSMSubcontract
+    ) -> None:
+        """A passing guard is preferred over the lower-priority default edge."""
+        result = await execute_transition(
+            branching_fsm_with_default, "verifying", "verify_done", {"score": 90}
+        )
+        assert result.success
+        assert result.new_state == "accepted"
+
+    @pytest.mark.asyncio
+    async def test_branching_fsm_passes_contract_validation(
+        self, branching_fsm: ModelFSMSubcontract
+    ) -> None:
+        """Multi-branch (same trigger, distinct priority) is a valid contract."""
+        errors = await validate_fsm_contract(branching_fsm)
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_exact_match_preempts_wildcard_on_guard_failure(self) -> None:
+        """An exact (state, trigger) match preempts a wildcard on the same trigger.
+
+        A failing exact guard rejects (stays in-state) rather than falling
+        through to the wildcard transition — preserving the pre-existing
+        exact-over-wildcard precedence.
+        """
+        fsm = ModelFSMSubcontract(
+            state_machine_name="exact_vs_wildcard_fsm",
+            state_machine_version=ModelSemVer(major=1, minor=0, patch=0),
+            description="Exact transition and wildcard sharing a trigger",
+            version=ModelSemVer(major=1, minor=0, patch=0),
+            states=[
+                ModelFSMStateDefinition(
+                    state_name="idle",
+                    state_type="operational",
+                    description="Idle state",
+                    is_terminal=False,
+                    version=ModelSemVer(major=1, minor=0, patch=0),
+                ),
+                ModelFSMStateDefinition(
+                    state_name="running",
+                    state_type="operational",
+                    description="Running state",
+                    is_terminal=False,
+                    version=ModelSemVer(major=1, minor=0, patch=0),
+                ),
+                ModelFSMStateDefinition(
+                    state_name="fallback",
+                    state_type="operational",
+                    description="Wildcard fallback state",
+                    is_terminal=False,
+                    version=ModelSemVer(major=1, minor=0, patch=0),
+                ),
+            ],
+            initial_state="idle",
+            terminal_states=[],
+            error_states=[],
+            transitions=[
+                ModelFSMStateTransition(
+                    transition_name="exact_guarded",
+                    from_state="idle",
+                    to_state="running",
+                    trigger="verify",
+                    priority=5,
+                    conditions=[
+                        ModelFSMTransitionCondition(
+                            condition_name="score_at_least_80",
+                            condition_type="field_check",
+                            expression="score >= 80",
+                            required=True,
+                        )
+                    ],
+                    version=ModelSemVer(major=1, minor=0, patch=0),
+                ),
+                ModelFSMStateTransition(
+                    transition_name="wildcard_fallback",
+                    from_state="*",
+                    to_state="fallback",
+                    trigger="verify",
+                    priority=1,
+                    version=ModelSemVer(major=1, minor=0, patch=0),
+                ),
+            ],
+            operations=[],
+            persistence_enabled=False,
+            recovery_enabled=False,
+        )
+
+        # Exact guard fails: reject and stay in idle; the wildcard is NOT taken.
+        result = await execute_transition(fsm, "idle", "verify", {"score": 10})
+        assert not result.success
+        assert result.new_state == "idle"
+        assert result.failure_type == "guard_rejection"
+        assert result.transition_name == "exact_guarded"
+
+        # Exact guard passes: exact transition fires.
+        result = await execute_transition(fsm, "idle", "verify", {"score": 90})
+        assert result.success
+        assert result.new_state == "running"
+        assert result.transition_name == "exact_guarded"


### PR DESCRIPTION
## Summary

`ModelFSMStateTransition.priority` is documented (the model's "Priority Resolution" docstring: higher priority wins, declaration order is the tiebreak, default `0`) but was **unwired**. The FSM engine's transition selection (`util_fsm_executor._find_transition`) picked the first `(from_state, trigger)` match by declaration order and evaluated that single transition's guard *after* selection. As a result a state could not branch on guards: from one `(state, trigger)` you could not declare two transitions differing only by guard and have the engine pick the one whose guard holds.

This wires the documented `priority` field and adds guard fallthrough.

## Change

`_select_transition` (replaces `_find_transition`):

1. Candidates matching `(from_state, trigger)` are ordered by `priority` **descending**, with declaration order as the stable tiebreak.
2. Guards are evaluated in that order; the **first** candidate whose required conditions all pass is selected.
3. A transition with **no required conditions** is a trivially-passing **default edge**; declared at the lowest priority it acts as the fallthrough after every higher-priority guard has been rejected.
4. **Fail-closed:** when no guard passes and no default edge is declared, the engine returns the existing `guard_rejection` result (stays in-state, `success=False`, `failed_conditions` populated) — it never silently executes a transition whose guard is false.
5. Exact-state matches still preempt wildcard (`from_state == "*"`) transitions, preserving prior precedence.

## Backward compatibility

- No existing FSM contract declares duplicate `(from_state, trigger)` transitions (scanned 996 contract YAMLs), so single-candidate selection is byte-identical — the fallthrough is purely additive.
- The `guard_rejection` / no-raise contract is preserved: the mixin state-mutation protection (OMN-604) and `node_reducer` 7-key FSM metadata mapping both rely on guard failure returning `success=False` without raising, and both continue to hold.

## Tests

New `TestFSMPriorityGuardFallthrough`: highest-priority passing guard wins, fallthrough to the next-priority guard, unconditional default-edge fallthrough, fail-closed no-eligible (stays in-state, not silent first-match), passing guard preferred over default edge, exact-over-wildcard precedence, and multi-branch contract validity.

## dod_evidence (local, worktree source with `PYTHONPATH` cleared)

- `tests/unit/utils/test_fsm_executor.py` + `tests/unit/mixins/test_mixin_fsm_execution.py`: **65 passed**.
- Reducer/orchestrator/FSM-model consumer tests (`test_reducer_integration.py`, `test_node_reducer_concurrency.py`, `test_action_creation.py`, `tests/unit/models/fsm/`): **507 passed, 1 xpassed**.
- `mypy src/omnibase_core/utils/util_fsm_executor.py`: clean.
- `ruff check` + `ruff format --check`: clean; `pre-commit run --files <changed>`: exit 0.

Evidence-Source: OCC#3779
Evidence-Ticket: OMN-14229

Closes OMN-14229

---

Draft: opened for review only. Not marked ready/merge — awaiting an independent OCC evidence companion and deploy-gate rerun.

