### PR TITLE
fix(OMN-14248): scope mypy ignore_missing_imports per-module (stop masking unresolvable imports)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -45,9 +45,6 @@ extra_checks = True
 show_error_codes = True
 enable_error_code = unused-awaitable
 
-# Handle third-party imports
-ignore_missing_imports = True
-
 # Exclude archived directories and duplicate scripts to avoid module conflicts
 exclude = (?x)(
     ^archived/.*$ |
@@ -59,6 +56,137 @@ exclude = (?x)(
     ^scripts/validate-string-versions\.py$ |
     ^scripts/validate-union-usage\.py$
     )
+
+# =============================================================================
+# THIRD-PARTY OPTIONAL DEPENDENCIES (OMN-14248)
+# =============================================================================
+# These packages are genuine optional/soft dependencies (lazy-imported behind
+# try/except ImportError or function-local imports) and are NOT declared in
+# pyproject.toml. They ship no type stubs mypy can find. Scoped per-module so
+# the blanket `ignore_missing_imports = True` removed below (OMN-14248) does
+# not mask unresolvable imports anywhere else in the tree.
+# =============================================================================
+
+# Optional: CLI scaffold template rendering (cli/openclaw_scaffold.py, cli/cli_scaffold_channel.py)
+[mypy-jinja2.*]
+ignore_missing_imports = True
+
+# Optional: AWS Secrets Manager fetch (cli/cli_refresh_credentials.py)
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+# Optional: .env loading (models/security/model_secret_config.py, model_secret_manager.py)
+[mypy-dotenv.*]
+ignore_missing_imports = True
+
+# Optional: jsonpath extraction (mixins/mixin_effect_execution.py)
+[mypy-jsonpath_ng.*]
+ignore_missing_imports = True
+
+# =============================================================================
+# LEGACY MISSING FIRST-PARTY MODULES (OMN-14248)
+# =============================================================================
+# Surfaced by removing the blanket `ignore_missing_imports = True`. Each entry
+# below is a real unresolvable first-party import (stale-refactor leftovers,
+# TYPE_CHECKING-only forward refs to deleted/never-shipped modules, or
+# try/except-guarded optional first-party features). None of these are new
+# code; all pre-date this ticket. See PR body for the full triage: which of
+# these are confirmed dead/orphaned (zero consumers) vs. which have a
+# plausible real target (candidate follow-up fixes).
+#
+# RULES:
+# 1. DO NOT add new modules to this list - fix the import instead.
+# 2. When touching a file in this list, resolve the real import path (or
+#    delete the dead reference) and remove its entry here.
+# =============================================================================
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; real class moved to omnibase_core.models.workflow.execution.model_workflow_state_snapshot  # onex-allow-todo-marker
+[mypy-omnibase_core.models.state.model_workflow_state_snapshot]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): module does not exist under enums/; triage against models/core/model_tool_manifest.py  # onex-allow-todo-marker
+[mypy-omnibase_core.enums.enum_tool_manifest]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): module does not exist under utils/; no equivalent found anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.utils.util_semver_parser]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): stale path (missing "models." segment); real module is omnibase_core.models.core.model_generic_yaml  # onex-allow-todo-marker
+[mypy-omnibase_core.core.model_generic_yaml]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): orphaned - ModelRegistryModeConfig has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.models.registry.model_registry_mode_config]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): orphaned - ModelRegistryCacheEntry has no definition anywhere; model_registry_factory.py is dead code, zero consumers  # onex-allow-todo-marker
+[mypy-omnibase_core.models.core.model_registry_cache_entry]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): orphaned - ModelLLMAgentConfig has no definition anywhere; model_agent_instance.py is dead code, zero consumers  # onex-allow-todo-marker
+[mypy-omnibase_core.models.agent.model_llm_agent_config]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; real class moved to omnibase_core.protocols.base.protocol_has_model_dump  # onex-allow-todo-marker
+[mypy-omnibase_core.mixins.protocol_has_model_dump]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; InjectorRNG has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.services.replay.injector_rng]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; InjectorTime has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.services.replay.injector_time]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; RecorderEffect has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.services.replay.recorder_effect]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; ProtocolOnexValidation has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.models.protocols.protocol_onex_validation]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded optional feature (fallback-ok); MemoryMappedToolCache was never implemented  # onex-allow-todo-marker
+[mypy-omnibase_core.cache.memory_mapped_tool_cache]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded optional feature; PerformanceMonitor was never implemented  # onex-allow-todo-marker
+[mypy-omnibase_core.monitoring.performance_monitor]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded; real class moved to omnibase_core.protocols.protocol_context_aware_output_handler  # onex-allow-todo-marker
+[mypy-omnibase_core.nodes.node_logger.protocols.protocol_context_aware_output_handler]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded; real class moved to omnibase_core.protocols.protocol_smart_log_formatter (also duplicated at protocols/logging/)  # onex-allow-todo-marker
+[mypy-omnibase_core.nodes.node_logger.protocols.protocol_smart_log_formatter]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded; ProtocolEventBusFactory has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.nodes.node_runtime.protocols.protocol_event_bus_factory]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded (_NODE_MODELS_AVAILABLE); real class moved to omnibase_core.models.node_metadata.model_node_capability  # onex-allow-todo-marker
+[mypy-omnibase_core.models.core.model_node_capability]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded (_NODE_MODELS_AVAILABLE); real class moved to omnibase_core.models.node_metadata.model_node_information  # onex-allow-todo-marker
+[mypy-omnibase_core.models.core.model_node_information]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): try/except-guarded (_NODE_MODELS_AVAILABLE); real class moved to omnibase_core.models.node_metadata.model_node_type  # onex-allow-todo-marker
+[mypy-omnibase_core.models.core.model_node_type]
+ignore_missing_imports = True
+
+# TODO(OMN-14248): TYPE_CHECKING-only forward ref; BaseDiscoveryRegistry has no definition anywhere in the tree  # onex-allow-todo-marker
+[mypy-omnibase_core.discovery.base_discovery_registry]
+ignore_missing_imports = True
+
+# =============================================================================
+# END LEGACY MISSING FIRST-PARTY MODULES
+# =============================================================================
 
 # Per-module overrides for specific patterns
 # Tests are allowed to be less strict for rapid development and mocking

--- a/src/omnibase_core/models/core/model_execution_capabilities.py
+++ b/src/omnibase_core/models/core/model_execution_capabilities.py
@@ -15,8 +15,7 @@ from omnibase_core.models.configuration.model_performance_constraints import (
     ModelPerformanceConstraints,
 )
 from omnibase_core.models.infrastructure.model_duration import ModelDuration
-
-from .model_node_type import ModelNodeType
+from omnibase_core.models.node_metadata.model_node_type import ModelNodeType
 
 
 class ModelExecutionCapabilities(BaseModel):

--- a/src/omnibase_core/models/core/model_onex_batch_result.py
+++ b/src/omnibase_core/models/core/model_onex_batch_result.py
@@ -4,19 +4,17 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from omnibase_core.enums.enum_onex_status import EnumOnexStatus
-    from omnibase_core.models.core.model_protocol_metadata import ModelGenericMetadata
+from omnibase_core.enums.enum_onex_status import EnumOnexStatus
+from omnibase_core.models.core.model_protocol_metadata import ModelGenericMetadata
+from omnibase_core.models.results.model_onex_message import ModelOnexMessage
+from omnibase_core.models.results.model_onex_result import ModelOnexResult
+from omnibase_core.models.results.model_unified_summary import ModelUnifiedSummary
+from omnibase_core.models.results.model_unified_version import ModelUnifiedVersion
 
-    from .model_onex_message import ModelOnexMessage
-    from .model_onex_result import ModelOnexResult
-    from .model_unified_run_metadata import ModelUnifiedRunMetadata
-    from .model_unified_summary import ModelUnifiedSummary
-    from .model_unified_version import ModelUnifiedVersion
+from .model_unified_run_metadata import ModelUnifiedRunMetadata
 
 
 class ModelOnexBatchResult(BaseModel):

--- a/src/omnibase_core/models/core/model_onex_message_result.py
+++ b/src/omnibase_core/models/core/model_onex_message_result.py
@@ -4,17 +4,19 @@
 from __future__ import annotations
 
 from omnibase_core.models.core.model_orchestrator_info import ModelOrchestratorInfo
+from omnibase_core.models.results.model_onex_message import ModelOnexMessage
+from omnibase_core.models.results.model_onex_result import ModelOnexResult
+from omnibase_core.models.results.model_unified_summary import ModelUnifiedSummary
+from omnibase_core.models.results.model_unified_summary_details import (
+    ModelUnifiedSummaryDetails,
+)
+from omnibase_core.models.results.model_unified_version import ModelUnifiedVersion
 
 from .model_onex_batch_result import ModelOnexBatchResult
-from .model_onex_message import ModelOnexMessage
 
 # Import separated models
-from .model_onex_result import ModelOnexResult
 from .model_onex_result_metadata import ModelOnexResultMetadata
 from .model_unified_run_metadata import ModelUnifiedRunMetadata
-from .model_unified_summary import ModelUnifiedSummary
-from .model_unified_summary_details import ModelUnifiedSummaryDetails
-from .model_unified_version import ModelUnifiedVersion
 
 # Compatibility aliases (maintain old names for any existing imports)
 UnifiedSummaryDetailsModel = ModelUnifiedSummaryDetails

--- a/src/omnibase_core/models/core/model_service_resolution_result.py
+++ b/src/omnibase_core/models/core/model_service_resolution_result.py
@@ -9,7 +9,7 @@ Pydantic model for service resolution operation results.
 
 from pydantic import BaseModel, Field
 
-from .model_service import ModelService
+from omnibase_core.models.container.model_service import ModelService
 
 
 class ModelServiceResolutionResult(BaseModel):

--- a/src/omnibase_core/models/core/model_template_validation_result.py
+++ b/src/omnibase_core/models/core/model_template_validation_result.py
@@ -5,7 +5,7 @@
 
 from pydantic import BaseModel
 
-from .model_validation_issue import ModelValidationIssue
+from omnibase_core.models.common.model_validation_issue import ModelValidationIssue
 
 
 class ModelTemplateValidationResult(BaseModel):

--- a/src/omnibase_core/models/core/model_unified_run_metadata.py
+++ b/src/omnibase_core/models/core/model_unified_run_metadata.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 
 class ModelUnifiedRunMetadata(BaseModel):


### PR DESCRIPTION
Evidence-Source: OCC#3793
Evidence-Ticket: OMN-14248
Evidence-Commit: 3dc017c44c14c239c601043fbf8863efb49112f4

## Summary

`omnibase_core/mypy.ini` set `ignore_missing_imports = True` as a blanket **global**, masking every unresolvable import repo-wide — including genuinely broken first-party imports, not just unstubbed third-party packages. This scopes it per-module (mirroring `pyproject.toml`'s existing `jsonpath_ng.*`/`sqlglot.*` pattern, though `pyproject.toml`'s `[tool.mypy]` section is actually **dead config** — confirmed via `mypy --verbose` that the repo's canonical `uv run mypy src/omnibase_core` invocation (used by pre-commit's `mypy-type-check` hook and CI's `lint` job) reads `mypy.ini` exclusively; mypy only consults one config file).

Closes OMN-14248.

## Baseline vs after

- **Baseline** (`origin/dev` unchanged): `uv run mypy src/omnibase_core` → `Success: no issues found in 4074 source files` (green only because of the blanket ignore).
- **After removing the blanket ignore, before any scoping**: 40 `import-not-found` errors across 26 files — 4 third-party module targets (`jinja2`, `boto3`, `dotenv`, `jsonpath_ng`), ~28 unique first-party module targets.
- **Final state**: `Success: no issues found in 4074 source files` — green again, but now via 25 narrow, exact-match per-module overrides instead of one repo-wide blanket.
- **Blind spot verified closed**: a synthetic new broken import (`from omnibase_core.this_module_totally_does_not_exist import Whatever`) dropped into the tree is correctly flagged by mypy post-change (was previously silently swallowed).

## Blast-radius classification

**Third party (4 unique modules)** — genuine lazy/optional soft dependencies, not declared in `pyproject.toml`, all guarded by function-local imports or `try/except ImportError`: `jinja2` (CLI scaffold templating), `boto3` (AWS Secrets Manager fetch), `dotenv` (`.env` loading), `jsonpath_ng` (jsonpath extraction). `sqlglot` needed no entry — it ships its own `py.typed`, so `pyproject.toml`'s override for it was already unnecessary. Scoped `ignore_missing_imports` per-module.

**First-party — fixed (6 files, confirmed live bugs, not just type debt):**
Stale-refactor leftovers pointing at deleted relative-import paths, where the real target module was confirmed to exist elsewhere in the tree by grep + `git worktree`-local runtime reproduction (`env -u PYTHONPATH uv run python3 -c "import ..."`):

| File | Was importing (broken) | Fixed to |
|---|---|---|
| `model_template_validation_result.py` | `.model_validation_issue` (deleted) | `omnibase_core.models.common.model_validation_issue` |
| `model_service_resolution_result.py` | `.model_service` (deleted) | `omnibase_core.models.container.model_service` |
| `model_execution_capabilities.py` | `.model_node_type` (deleted) | `omnibase_core.models.node_metadata.model_node_type` |
| `model_onex_message_result.py` | `.model_onex_message`/`.model_onex_result`/`.model_unified_summary`/`.model_unified_summary_details`/`.model_unified_version` (all deleted from `models/core/`) | `omnibase_core.models.results.*` |
| `model_onex_batch_result.py` | same 5-module cluster, but `TYPE_CHECKING`-only | moved out of `TYPE_CHECKING` into real imports at `omnibase_core.models.results.*` |
| `model_unified_run_metadata.py` | `from datetime import datetime` behind `TYPE_CHECKING`, used as a real field type | moved `datetime` to a real runtime import |

Three of these (`model_template_validation_result.py`, `model_service_resolution_result.py`, `model_execution_capabilities.py`) raised `ModuleNotFoundError` on plain `import` — dead on arrival. `model_onex_message_result.py` likewise failed to import. `model_onex_batch_result.py` imported fine (its broken refs were `TYPE_CHECKING`-only) but **`ModelOnexBatchResult(results=[])` raised `PydanticUserError: not fully defined`** — a real, live instantiation crash, since `from __future__ import annotations` + `TYPE_CHECKING`-only imports means Pydantic can never resolve the field types at schema-build time.

**Correction from an earlier revision of this PR**: my first pass fixed `model_onex_batch_result.py`'s direct broken imports but claimed the instantiation crash was resolved without re-verifying after the fix — it wasn't. Independent review caught that `ModelOnexBatchResult(results=[])` still raised `PydanticUserError`, now complaining about `datetime` instead of `ModelOnexResult`. Root cause was one level deeper: the nested `ModelUnifiedRunMetadata` (used via `ModelOnexBatchResult.run_metadata`) hid `from datetime import datetime` behind the same `TYPE_CHECKING` anti-pattern while using it as a real field type. Fixed with the same move-out-of-`TYPE_CHECKING` shape as the other 5 files. Re-verified end to end:

```
>>> ModelOnexBatchResult(results=[])
results=[] messages=[] summary=None status=None version=None run_metadata=None metadata=None

>>> ModelOnexBatchResult(results=[ModelOnexResult(status=EnumOnexStatus.SUCCESS)], run_metadata=ModelUnifiedRunMetadata(start_time=datetime.now(timezone.utc)))
results=[ModelOnexResult(status=<EnumOnexStatus.SUCCESS: 'success'>, ...)] ... run_metadata=ModelUnifiedRunMetadata(start_time=..., end_time=None, duration=None, run_id=None) ...
```

No further issues surfaced deeper in the chain (`ModelOnexResult` itself instantiates cleanly with real nested data). All 6 fixes now verified via direct `import` + real instantiate reproduction before and after. None had test coverage (`grep -rl` across `tests/` found zero references to any of the 6 files) — flagging this as its own gap.

**First-party — tracked, not fixed this PR (21 unique modules across 15 files):** scoped `ignore_missing_imports` with `# TODO(OMN-14248)` (plus the mandatory `# onex-allow-todo-marker` suppression token required by this repo's own `check-todo-fixme-marker-compute` pre-commit gate) documenting either the real target (where found via `grep -rln "^class X"`) or confirmed-orphaned status (zero consumers anywhere in `src/`). Breakdown:
- **9 have a findable real target** (moved/renamed, `TYPE_CHECKING`-only or `try/except`-guarded so not import-time-fatal today): `model_workflow_state_snapshot`, `protocol_has_model_dump`, `protocol_context_aware_output_handler`, `protocol_smart_log_formatter`, `model_node_capability`, `model_node_information`, `model_node_type` (in `models/core/__init__.py`'s optional re-export block), `model_generic_yaml` (stale path missing a `models.` segment).
- **12 are genuinely orphaned** — the referenced class has no definition anywhere in the tree: `enum_tool_manifest`, `util_semver_parser`, `model_registry_mode_config`, `model_registry_cache_entry` (→ `model_registry_factory.py` is fully dead code, zero consumers repo-wide), `model_llm_agent_config` (→ `model_agent_instance.py` likewise fully dead, zero consumers), `protocol_has_model_dump`'s siblings `injector_rng`/`injector_time`/`recorder_effect` (replay-safety-enforcer feature was never completed), `protocol_onex_validation`, `memory_mapped_tool_cache`/`performance_monitor` (optional perf features guarded by `fallback-ok`, never implemented), `protocol_event_bus_factory`, `base_discovery_registry`.

None of these 21 are regressions from this PR — they were already unresolvable before this change (silently, via the blanket ignore). This PR's job was scoping the config; burning down 21 pre-existing dead/stale references (several of which need real implementation, not just an import fix) is follow-up work, not squeezed into tonight. I did NOT do a repo-wide sweep for the `TYPE_CHECKING`-hidden-stdlib-import pattern beyond the one instance nested directly under `ModelOnexBatchResult` — recommend a dedicated follow-up ticket (OMN-14250 covers this class) to sweep Pydantic models repo-wide for it; this PR only fixed the minimal instance blocking the claim above.

## Verification

- `uv run mypy src/omnibase_core` → green (0 errors, 4074 files).
- `pre-commit run --files mypy.ini <6 touched .py files>` → all hooks pass, including `check-todo-fixme-marker-compute` (required the `# onex-allow-todo-marker` token on each TODO line — first attempt without it correctly failed the gate).
- `pre-commit run --hook-stage pre-push --files <6 touched .py files>` → `mypy (type checking - strict)` + `pyright (type checking - basic)` pass.
- Governed test selector (`scripts/ci/detect_test_paths.py`) against the changed file set returned `is_full_suite: true, reason: shared_module` (touching `models/core/*` is a shared-module trigger). Ran targeted-but-broad local slice covering the affected surface: `tests/unit/models/{core,results,container,services}` + `tests/unit/test_smoke_high_dependency_exports.py` → **1914 passed, 0 failed** (re-run after the `model_unified_run_metadata.py` fix, still 1914/0). A full 43k-test unconstrained local run is multi-hour at this repo's current size; CI's `test-parallel` job (which also escalates to the full suite per the same governed selector) is the authoritative full-suite gate per repo policy and will run on this PR.
- No `--no-verify`, no skip tokens, no bypass — every gate that fired was fixed at the root (the TODO-marker gate) rather than bypassed.

## Test plan

- [ ] `gh pr checks` green (mypy/lint, full test-parallel suite, deploy-gate)
- [ ] CodeRabbit threads resolved if any
- [ ] Independent OCC companion evidence (not self-authored)

