### PR TITLE
ci(OMN-14277): host canonical deploy-gate reusable in omnibase_core (additive Phase 1, no caller repoint)

### DIFF
--- a/.github/actions/deploy-gate/action.yml
+++ b/.github/actions/deploy-gate/action.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Composite action: run the deploy-gate validator.
+# Called by omnibase_core/.github/workflows/deploy-gate-reusable.yml
+# Canonical source for all repos.
+#
+# Relocated omniclaude -> omnibase_core (OMN-14277) to fix the inverted CI
+# layering: omnibase_core / omnibase_infra / omnimarket must not depend
+# up-layer on the omniclaude plugin. Original canonical source: OMN-9685
+# (validator), OMN-9734 (DGM-Phase6 centralisation).
+
+name: Deploy Gate Validator
+description: >
+  Validates that PRs touching runtime paths cite a ticket with deploy DoD evidence.
+  Canonical implementation: OMN-9685. Centralised: OMN-9734 (DGM-Phase6).
+  Relocated to omnibase_core: OMN-14277.
+
+inputs:
+  pr-number:
+    description: PR number to validate
+    required: true
+  github-token:
+    description: GitHub token for gh CLI access
+    required: true
+  contracts-dir:
+    description: >
+      Path to directory containing OMN-XXXX.yaml ticket contracts.
+      Canonical source is onex_change_control (OMN-11423); the reusable
+      workflow checks out OCC and passes _occ/contracts here.
+    required: false
+    default: _occ/contracts
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "0.8.3"
+
+    - name: Install pyyaml
+      shell: bash
+      run: python -m pip install pyyaml
+
+    - name: Run deploy gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        CONTRACTS_DIR: ${{ inputs.contracts-dir }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        if ! changed_files="$(gh pr diff "$PR_NUMBER" --name-only 2>/tmp/deploy-gate-gh-diff.err | tr '\n' ' ')"; then
+          base_ref="${GITHUB_BASE_REF:-main}"
+          echo "::notice::gh pr diff failed; falling back to local git diff against origin/${base_ref}"
+          cat /tmp/deploy-gate-gh-diff.err || true
+          git fetch origin "$base_ref" --no-tags
+          changed_files="$(git diff --name-only "origin/${base_ref}" HEAD | tr '\n' ' ')"
+        fi
+
+        python "$ACTION_PATH/validate_pr_deploy_required.py" \
+          --changed-files "$changed_files" \
+          --pr-body "$(gh pr view "$PR_NUMBER" --json body -q '.body')" \
+          --contracts-dir "$CONTRACTS_DIR"

--- a/.github/actions/deploy-gate/validate_pr_deploy_required.py
+++ b/.github/actions/deploy-gate/validate_pr_deploy_required.py
@@ -1,0 +1,530 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Wave D CI gate: runtime-change PRs must cite a ticket with deploy evidence.
+
+Ticket: OMN-8912
+Root cause: OMN-8841 — Dockerfile.runtime changed, deploy never dispatched,
+            deploy-agent inactive 2 days undetected.
+Canonical source: OMN-9685 (omnibase_core PR #902) — narrowed path patterns,
+                  removed skip-token bypass.
+DGM-Phase6: moved here for single-source reuse across all repos.
+
+Usage (CI):
+    python validate_pr_deploy_required.py \
+        --changed-files "docker/Dockerfile.runtime src/omnibase_infra/runtime/service_kernel.py" \
+        --pr-body "$(gh pr view $PR --json body -q .body)" \
+        --contracts-dir contracts/
+
+Exit codes:
+    0  - Gate passed (no runtime change, or deploy evidence found)
+    1  - Gate failed (runtime change detected but no deploy evidence)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from re import Pattern
+
+# ---------------------------------------------------------------------------
+# Runtime path patterns — ANY file matching these triggers the gate.
+# Extend this list when new runtime-touching paths are discovered.
+# ---------------------------------------------------------------------------
+RUNTIME_PATH_PATTERNS = [
+    # Docker layer
+    "docker/Dockerfile*",
+    "docker/docker-compose*.yml",
+    "docker/docker-compose*.yaml",
+    "docker/**/*.Dockerfile",
+    "Dockerfile*",
+    # Node handlers + contracts (omnibase_infra)
+    "src/omnibase_infra/nodes/*/handlers/*.py",
+    "src/omnibase_infra/nodes/*/handlers/*/*.py",
+    "src/omnibase_infra/nodes/*/contract.yaml",
+    "src/omnibase_infra/nodes/*/*/contract.yaml",
+    # Runtime kernel
+    "src/omnibase_infra/runtime/**/*.py",
+    # Alert daemon (today's incident path — OMN-8870/OMN-8841)
+    "scripts/monitor_logs.py",
+    # omnimarket node handlers + runtime-touching paths only
+    "src/omnimarket/nodes/*/handlers/*.py",
+    "src/omnimarket/nodes/*/contract.yaml",
+    "src/omnimarket/nodes/*/runtime/**/*.py",
+    "src/omnimarket/services/**/*.py",
+    # Cross-repo node handlers and runtime paths (OMN-9685: narrowed from catch-all)
+    # Use both flat and nested forms since ** requires at least one path segment
+    "src/*/nodes/*.py",
+    "src/*/nodes/**/*.py",
+    "src/*/runtime/*.py",
+    "src/*/runtime/**/*.py",
+    "src/*/handlers/*.py",
+    "src/*/handlers/**/*.py",
+    "src/*/services/*.py",
+    "src/*/services/**/*.py",
+    "src/*/cli/*.py",
+    "src/*/cli/**/*.py",
+    # Contract files trigger deploy (behavior change) — scoped to src/ to avoid
+    # matching test fixtures and example directories.
+    "src/**/contract.yaml",
+]
+
+# Deploy evidence: a dod_evidence check whose check_value contains one of these.
+DEPLOY_KEYWORDS = ["docker exec", "rpk topic produce", "deploy"]
+
+
+def _glob_to_regex(pattern: str) -> Pattern[str]:
+    """Convert a glob pattern (with ** support) to a compiled regex."""
+    # Escape everything except * and ?
+    parts = re.split(r"(\*\*|\*|\?)", pattern)
+    regex_parts: list[str] = []
+    for part in parts:
+        if part == "**":
+            regex_parts.append(".*")
+        elif part == "*":
+            regex_parts.append("[^/]*")
+        elif part == "?":
+            regex_parts.append("[^/]")
+        else:
+            regex_parts.append(re.escape(part))
+    return re.compile("^" + "".join(regex_parts) + "$")
+
+
+_COMPILED_RUNTIME_PATTERNS: list[Pattern[str]] = [
+    _glob_to_regex(p) for p in RUNTIME_PATH_PATTERNS
+]
+
+# Ticket ID pattern in PR body / commit messages
+TICKET_PATTERN = re.compile(r"\bOMN-(\d+)\b", re.IGNORECASE)
+EVIDENCE_SOURCE_PATTERN = re.compile(
+    r"^Evidence-Source:\s*(\S+)\s*$", re.IGNORECASE | re.MULTILINE
+)
+EVIDENCE_TICKET_PATTERN = re.compile(
+    r"^Evidence-Ticket:\s*(OMN-\d+)\s*$", re.IGNORECASE | re.MULTILINE
+)
+
+DEFAULT_OCC_REF = "dev"
+
+
+@dataclass
+class DeployGateResult:
+    passed: bool
+    skipped: bool = False
+    message: str = ""
+    runtime_paths_hit: list[str] = field(default_factory=list)
+    tickets_checked: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EvidenceMetadata:
+    source: str | None = None
+    ticket: str | None = None
+
+
+@dataclass(frozen=True)
+class OccEvidenceResolution:
+    passed: bool
+    occ_ref: str = DEFAULT_OCC_REF
+    deploy_gate_required: bool = False
+    skipped: bool = False
+    source_kind: str = "canonical"
+    evidence_ticket: str | None = None
+    message: str = ""
+
+
+def find_runtime_paths(changed_files: list[str]) -> list[str]:
+    """Return subset of changed_files that match runtime path patterns."""
+    hits: list[str] = []
+    for f in changed_files:
+        for regex in _COMPILED_RUNTIME_PATTERNS:
+            if regex.match(f):
+                hits.append(f)
+                break
+    return hits
+
+
+def parse_evidence_metadata(pr_body: str) -> EvidenceMetadata:
+    """Extract deploy-gate Evidence-* metadata from a PR body."""
+    source_match = EVIDENCE_SOURCE_PATTERN.search(pr_body)
+    ticket_match = EVIDENCE_TICKET_PATTERN.search(pr_body)
+    return EvidenceMetadata(
+        source=source_match.group(1).strip() if source_match else None,
+        ticket=ticket_match.group(1).upper() if ticket_match else None,
+    )
+
+
+def _run_gh_json(args: list[str]) -> dict | list | str | int | float | bool | None:
+    """Run gh and parse JSON output. Separated for focused unit tests."""
+    completed = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    output = completed.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return None
+
+
+def _resolve_occ_pr_source(source: str) -> tuple[str | None, str]:
+    occ_pr_num = re.sub(r"^OCC#", "", source, flags=re.IGNORECASE)
+    pr_json = _run_gh_json(
+        [
+            "pr",
+            "view",
+            occ_pr_num,
+            "--repo",
+            "OmniNode-ai/onex_change_control",
+            "--json",
+            "state,headRefOid,mergeCommit",
+        ]
+    )
+    if not isinstance(pr_json, dict):
+        return None, "open-pr"
+    if pr_json.get("state") == "MERGED":
+        merge_commit = pr_json.get("mergeCommit")
+        if isinstance(merge_commit, dict):
+            return merge_commit.get("oid"), "merged"
+        return None, "merged"
+    head_ref_oid = pr_json.get("headRefOid")
+    return head_ref_oid if isinstance(head_ref_oid, str) else None, "open-pr"
+
+
+def _resolve_occ_sha_source(source: str) -> tuple[str | None, str]:
+    compare_json = _run_gh_json(
+        [
+            "api",
+            f"repos/OmniNode-ai/onex_change_control/compare/HEAD...{source}",
+        ]
+    )
+    if isinstance(compare_json, dict) and compare_json.get("status") in {
+        "behind",
+        "identical",
+    }:
+        commit_json = _run_gh_json(
+            ["api", f"repos/OmniNode-ai/onex_change_control/commits/{source}"]
+        )
+        if isinstance(commit_json, dict):
+            commit_sha = commit_json.get("sha")
+            return commit_sha if isinstance(commit_sha, str) else None, "merged"
+        return None, "merged"
+
+    open_prs_json = _run_gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            "OmniNode-ai/onex_change_control",
+            "--state",
+            "open",
+            "--json",
+            "headRefOid",
+        ]
+    )
+    if isinstance(open_prs_json, list):
+        for item in open_prs_json:
+            if not isinstance(item, dict):
+                continue
+            head_ref_oid = item.get("headRefOid")
+            if isinstance(head_ref_oid, str) and head_ref_oid.startswith(source):
+                return head_ref_oid, "open-pr"
+    return None, "unknown"
+
+
+def resolve_occ_evidence_source(
+    changed_files: list[str],
+    pr_body: str,
+    default_occ_ref: str = DEFAULT_OCC_REF,
+) -> OccEvidenceResolution:
+    """Resolve deploy-gate OCC checkout ref from PR Evidence-* metadata."""
+    runtime_hits = find_runtime_paths(changed_files)
+    metadata = parse_evidence_metadata(pr_body)
+
+    if not runtime_hits:
+        return OccEvidenceResolution(
+            passed=True,
+            occ_ref=default_occ_ref,
+            skipped=True,
+            deploy_gate_required=False,
+            message="No runtime paths touched — deploy-gate OCC checkout skipped.",
+        )
+
+    if not metadata.source:
+        return OccEvidenceResolution(
+            passed=True,
+            occ_ref=default_occ_ref,
+            deploy_gate_required=True,
+            message=(
+                "Evidence-Source not present — using canonical OCC contract source."
+            ),
+        )
+
+    if not metadata.ticket:
+        return OccEvidenceResolution(
+            passed=False,
+            deploy_gate_required=True,
+            source_kind="invalid",
+            message=(
+                "DEPLOY GATE FAILED: PR body has Evidence-Source but is missing "
+                "Evidence-Ticket: OMN-XXXX. Add Evidence-Ticket so deploy-gate "
+                "can validate the contract at the pinned OCC source."
+            ),
+        )
+
+    if re.match(r"^OCC#[0-9]+$", metadata.source, re.IGNORECASE):
+        occ_ref, source_kind = _resolve_occ_pr_source(metadata.source)
+    elif re.match(r"^[0-9a-f]{7,40}$", metadata.source, re.IGNORECASE):
+        occ_ref, source_kind = _resolve_occ_sha_source(metadata.source.lower())
+    else:
+        return OccEvidenceResolution(
+            passed=False,
+            deploy_gate_required=True,
+            source_kind="invalid",
+            evidence_ticket=metadata.ticket,
+            message=(
+                f"DEPLOY GATE FAILED: Evidence-Source value {metadata.source!r} "
+                "is not valid. Accepted forms: OCC#<number> or a 7-40 "
+                "character OCC commit SHA."
+            ),
+        )
+
+    if not occ_ref:
+        return OccEvidenceResolution(
+            passed=False,
+            deploy_gate_required=True,
+            source_kind=source_kind,
+            evidence_ticket=metadata.ticket,
+            message=(
+                f"DEPLOY GATE FAILED: Evidence-Source {metadata.source!r} "
+                "could not be resolved to an OCC PR head or merged OCC commit."
+            ),
+        )
+
+    return OccEvidenceResolution(
+        passed=True,
+        occ_ref=occ_ref,
+        deploy_gate_required=True,
+        source_kind=source_kind,
+        evidence_ticket=metadata.ticket,
+        message=(
+            f"Evidence-Source resolved to OCC ref {occ_ref} "
+            f"for {metadata.ticket} ({source_kind})."
+        ),
+    )
+
+
+def has_deploy_evidence(contract_path: Path) -> bool:
+    """Return True if the ticket contract has at least one deploy DoD evidence item."""
+    if not contract_path.exists():
+        return False
+    import yaml
+
+    try:
+        with contract_path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError):
+        return False
+
+    dod_evidence = data.get("dod_evidence", []) if isinstance(data, dict) else []
+    for item in dod_evidence:
+        checks = item.get("checks", []) if isinstance(item, dict) else []
+        for check in checks:
+            value = check.get("check_value", "") if isinstance(check, dict) else ""
+            if isinstance(value, str):
+                if any(kw in value.lower() for kw in DEPLOY_KEYWORDS):
+                    return True
+    return False
+
+
+def validate_pr_deploy_gate(
+    changed_files: list[str],
+    pr_body: str,
+    contracts_dir: Path,
+) -> DeployGateResult:
+    """Check runtime-change PRs for deploy evidence in cited ticket contracts."""
+    runtime_hits = find_runtime_paths(changed_files)
+
+    if not runtime_hits:
+        return DeployGateResult(
+            passed=True,
+            skipped=True,
+            message="No runtime paths touched — deploy gate skipped.",
+        )
+
+    metadata = parse_evidence_metadata(pr_body)
+    if metadata.source and not metadata.ticket:
+        return DeployGateResult(
+            passed=False,
+            runtime_paths_hit=runtime_hits,
+            message=(
+                "DEPLOY GATE FAILED: PR body has Evidence-Source but is missing "
+                "Evidence-Ticket: OMN-XXXX. Add Evidence-Ticket so deploy-gate "
+                "can validate the contract at the pinned OCC source."
+            ),
+        )
+
+    # Extract cited ticket IDs from PR body
+    if metadata.source and metadata.ticket:
+        ticket_ids = [metadata.ticket]
+    else:
+        ticket_ids = [f"OMN-{m}" for m in TICKET_PATTERN.findall(pr_body)]
+
+    if not ticket_ids:
+        return DeployGateResult(
+            passed=False,
+            runtime_paths_hit=runtime_hits,
+            message=(
+                "DEPLOY GATE FAILED: PR touches runtime paths but cites no OMN-XXXX ticket. "
+                f"Runtime paths: {runtime_hits}. "
+                "Add a dod_evidence item with check_value containing 'deploy', "
+                "'docker exec', or 'rpk topic produce' to the ticket contract in "
+                "onex_change_control/contracts/OMN-XXXX.yaml. "
+                "See OMN-8912, OMN-9685, and OMN-11423."
+            ),
+        )
+
+    # Check each cited ticket for deploy evidence
+    tickets_checked: list[str] = []
+    for ticket_id in ticket_ids:
+        contract_path = contracts_dir / f"{ticket_id}.yaml"
+        tickets_checked.append(ticket_id)
+        if has_deploy_evidence(contract_path):
+            return DeployGateResult(
+                passed=True,
+                runtime_paths_hit=runtime_hits,
+                tickets_checked=tickets_checked,
+                message=(
+                    f"DEPLOY GATE PASSED: {ticket_id} has deploy evidence. "
+                    f"Runtime paths: {runtime_hits}."
+                ),
+            )
+
+    # No ticket had deploy evidence
+    missing = [t for t in ticket_ids if not (contracts_dir / f"{t}.yaml").exists()]
+    no_deploy = [
+        t
+        for t in ticket_ids
+        if (contracts_dir / f"{t}.yaml").exists()
+        and not has_deploy_evidence(contracts_dir / f"{t}.yaml")
+    ]
+
+    parts: list[str] = [
+        "DEPLOY GATE FAILED: PR touches runtime paths but no cited ticket has deploy DoD evidence.",
+        f"Runtime paths: {runtime_hits}.",
+    ]
+    if missing:
+        parts.append(
+            f"Tickets with no contract file in onex_change_control/contracts/: {missing}. "
+            "Create the contract YAML in the onex_change_control repo, not in the caller repo."
+        )
+    if no_deploy:
+        parts.append(
+            f"Tickets found but missing deploy evidence (check_value must contain "
+            f"'docker exec', 'rpk topic produce', or 'deploy'): {no_deploy}."
+        )
+    parts.append(
+        "Add a dod_evidence item with check_value containing 'deploy', 'docker exec', or "
+        "'rpk topic produce' to onex_change_control/contracts/OMN-XXXX.yaml. "
+        "Root cause: OMN-8841 (deploy-agent inactive 2 days post-Dockerfile change). "
+        "Gate: OMN-8912. Contract source fix: OMN-11423."
+    )
+
+    return DeployGateResult(
+        passed=False,
+        runtime_paths_hit=runtime_hits,
+        tickets_checked=tickets_checked,
+        message=" ".join(parts),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Wave D: validate that runtime-change PRs have deploy evidence.",
+    )
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Space-separated list of changed file paths (from gh pr diff --name-only)",
+    )
+    parser.add_argument(
+        "--pr-body",
+        required=True,
+        help="Full PR description text",
+    )
+    parser.add_argument(
+        "--contracts-dir",
+        default="contracts",
+        help="Directory containing OMN-XXXX.yaml ticket contracts (default: contracts/)",
+    )
+    parser.add_argument(
+        "--resolve-occ-ref",
+        action="store_true",
+        help=(
+            "Resolve deploy-gate Evidence-Source metadata to an OCC checkout ref "
+            "and exit without validating contracts."
+        ),
+    )
+    parser.add_argument(
+        "--default-occ-ref",
+        default=DEFAULT_OCC_REF,
+        help="Fallback OCC ref when no Evidence-Source is present (default: dev).",
+    )
+    parser.add_argument(
+        "--github-output",
+        default="",
+        help="Optional path to append GitHub Actions output values.",
+    )
+
+    args = parser.parse_args(argv)
+    changed = [f for f in args.changed_files.split() if f]
+    contracts_dir = Path(args.contracts_dir)
+
+    if args.resolve_occ_ref:
+        resolution = resolve_occ_evidence_source(
+            changed_files=changed,
+            pr_body=args.pr_body,
+            default_occ_ref=args.default_occ_ref,
+        )
+        if args.github_output:
+            with Path(args.github_output).open("a", encoding="utf-8") as fh:
+                fh.write(f"occ_ref={resolution.occ_ref}\n")
+                fh.write(
+                    "deploy_gate_required="
+                    f"{str(resolution.deploy_gate_required).lower()}\n"
+                )
+                fh.write(f"occ_source_kind={resolution.source_kind}\n")
+                if resolution.evidence_ticket:
+                    fh.write(f"evidence_ticket={resolution.evidence_ticket}\n")
+        if resolution.passed:
+            print(f"::notice::{resolution.message}")
+        else:
+            print(f"::error::{resolution.message}")
+        return 0 if resolution.passed else 1
+
+    result = validate_pr_deploy_gate(
+        changed_files=changed,
+        pr_body=args.pr_body,
+        contracts_dir=contracts_dir,
+    )
+
+    if result.passed:
+        print(f"::notice::{result.message}")
+    else:
+        print(f"::error::{result.message}")
+
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/deploy-gate/validate_pr_deploy_required.py
+++ b/.github/actions/deploy-gate/validate_pr_deploy_required.py
@@ -30,7 +30,6 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from re import Pattern
 
 # ---------------------------------------------------------------------------
 # Runtime path patterns — ANY file matching these triggers the gate.
@@ -78,7 +77,7 @@ RUNTIME_PATH_PATTERNS = [
 DEPLOY_KEYWORDS = ["docker exec", "rpk topic produce", "deploy"]
 
 
-def _glob_to_regex(pattern: str) -> Pattern[str]:
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     """Convert a glob pattern (with ** support) to a compiled regex."""
     # Escape everything except * and ?
     parts = re.split(r"(\*\*|\*|\?)", pattern)
@@ -95,7 +94,7 @@ def _glob_to_regex(pattern: str) -> Pattern[str]:
     return re.compile("^" + "".join(regex_parts) + "$")
 
 
-_COMPILED_RUNTIME_PATTERNS: list[Pattern[str]] = [
+_COMPILED_RUNTIME_PATTERNS: list[re.Pattern[str]] = [
     _glob_to_regex(p) for p in RUNTIME_PATH_PATTERNS
 ]
 

--- a/.github/workflows/deploy-gate-reusable.yml
+++ b/.github/workflows/deploy-gate-reusable.yml
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Reusable workflow: deploy-gate validator.
+# Canonical, org-wide source — all repos call this via uses: instead of
+# running their own copy of validate_pr_deploy_required.py.
+#
+# Relocated omniclaude -> omnibase_core (OMN-14277). Previously hosted in
+# omniclaude (the top plugin layer), which inverted the compat -> core ->
+# spi -> infra layering: omnibase_core / omnibase_infra / omnimarket must
+# not depend up-layer on omniclaude. The OMN-14260 incident (2026-07-10)
+# amplified its blast radius through exactly that inversion — a bad change
+# to the omniclaude@main reusable broke Deploy Gate on every core/infra
+# caller at once. omnibase_core is a low layer those repos may legitimately
+# depend on for CI gating.
+#
+# Lineage: canonical validator OMN-9685 (omnibase_core PR #902); centralised
+# OMN-9734 (DGM-Phase6); OCC contract resolution OMN-11423 (contracts read
+# from onex_change_control, not the caller repo).
+#
+# Usage in caller repos:
+#   jobs:
+#     deploy-gate:
+#       uses: OmniNode-ai/omnibase_core/.github/workflows/deploy-gate-reusable.yml@main
+#       secrets: inherit
+#
+# The caller job key and this reusable's job name are BOTH `deploy-gate`, so
+# the surfaced required-status-check context is `deploy-gate / deploy-gate`
+# (caller-job / reusable-job) — identical to the prior omniclaude-hosted
+# reusable. Do NOT rename either without a coordinated branch-protection
+# required-context update.
+
+name: Deploy Gate (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      pr-number:
+        description: PR number to validate (defaults to github.event.pull_request.number)
+        type: number
+        required: false
+        default: 0
+      contracts-dir:
+        description: >
+          Deprecated (OMN-11423). Contracts are now read from onex_change_control;
+          this input is ignored. Remove it from your caller workflow.
+        type: string
+        required: false
+        default: contracts
+
+jobs:
+  deploy-gate:
+    name: deploy-gate
+    # OMNI_RUNNER_SELECTOR_V1 - trusted CI defaults to self-hosted omnibase-ci; public forks default to ubuntu-latest
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v7
+
+      # OMN-12564 / OMN-14277: the OCC checkout logic lives in omnibase_core
+      # (this repo), but the job's GITHUB_WORKSPACE holds the *caller* repo's
+      # tree. Pull just the hardened checkout script + validator from
+      # omnibase_core@main into a side path so the steps below can invoke them
+      # without polluting the caller checkout.
+      - name: Fetch deploy-gate support scripts (omnibase_core)
+        if: github.event_name != 'merge_group'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OmniNode-ai/omnibase_core
+          ref: main
+          path: .deploy-gate-support
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/deploy-gate/checkout-occ-contracts.sh
+            .github/actions/deploy-gate/validate_pr_deploy_required.py
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve deploy-gate OCC evidence source
+        if: github.event_name != 'merge_group'
+        id: resolve_occ_evidence
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr-number != 0 && inputs.pr-number || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::OCC evidence-source resolution requires GITHUB_TOKEN"
+            exit 1
+          fi
+
+          if ! changed_files="$(gh pr diff "$PR_NUMBER" --name-only 2>/tmp/deploy-gate-gh-diff.err | tr '\n' ' ')"; then
+            base_ref="${GITHUB_BASE_REF:-main}"
+            echo "::notice::gh pr diff failed; falling back to local git diff against origin/${base_ref}"
+            cat /tmp/deploy-gate-gh-diff.err || true
+            git fetch origin "$base_ref" --no-tags
+            changed_files="$(git diff --name-only "origin/${base_ref}" HEAD | tr '\n' ' ')"
+          fi
+          pr_body="$(gh pr view "$PR_NUMBER" --json body -q '.body')"
+
+          python "${GITHUB_WORKSPACE}/.deploy-gate-support/.github/actions/deploy-gate/validate_pr_deploy_required.py" \
+            --changed-files "$changed_files" \
+            --pr-body "$pr_body" \
+            --resolve-occ-ref \
+            --default-occ-ref dev \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Checkout onex_change_control contracts (canonical contract source)
+        if: github.event_name != 'merge_group' && steps.resolve_occ_evidence.outputs.deploy_gate_required == 'true'
+        shell: bash
+        # OMN-12564: the OCC checkout is delegated to a standalone, unit-tested
+        # script that bounds BOTH the fetch AND the checkout with a hard
+        # `timeout`. The old inline step only bounded the fetch, so a wedged
+        # blobless-partial-clone checkout (`git -C _occ checkout --force
+        # FETCH_HEAD`) spun until the 25-min job timeout on #1786/#1788. The
+        # script drops `--filter=blob:none` for a deterministic full-ref
+        # checkout and, on stall, emits a diagnostic block (ref, fetch command,
+        # elapsed, last git subprocess, process tree) so future hangs are
+        # diagnosable from the log alone. The step-level `timeout-minutes` below
+        # is the outer bound; the script is the inner, self-diagnosing
+        # git-level bound.
+        timeout-minutes: 12
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OCC_REF: ${{ steps.resolve_occ_evidence.outputs.occ_ref }}
+          OCC_REPO_URL: https://github.com/OmniNode-ai/onex_change_control.git
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::OCC contracts checkout requires GITHUB_TOKEN"
+            exit 1
+          fi
+
+          bash "${GITHUB_WORKSPACE}/.deploy-gate-support/scripts/deploy-gate/checkout-occ-contracts.sh"
+
+      - name: Skip on merge_group
+        if: github.event_name == 'merge_group'
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::notice::deploy-gate: merge_group event — skipped (validated on PR branch)."
+
+      - name: Run deploy gate (canonical composite action)
+        if: github.event_name != 'merge_group'
+        uses: OmniNode-ai/omnibase_core/.github/actions/deploy-gate@main
+        with:
+          pr-number: ${{ inputs.pr-number != 0 && inputs.pr-number || github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          contracts-dir: _occ/contracts

--- a/scripts/deploy-gate/checkout-occ-contracts.sh
+++ b/scripts/deploy-gate/checkout-occ-contracts.sh
@@ -67,7 +67,9 @@ TIMEOUT_KILL_AFTER="${OCC_TIMEOUT_KILL_AFTER_SECS:-10}"
 
 # Build the HTTPS extraheader. We use the `x-access-token` basic scheme (works
 # for both GITHUB_TOKEN and a CROSS_REPO_PAT) — matching the deploy-gate
-# workflow. The header is kept out of the diagnostic block (token redaction).
+# workflow. The header carries the base64 token, so it is redacted before it can
+# reach the diagnostic block: FETCH_CMD_DISPLAY is token-free by construction,
+# and run_git_bounded scrubs the extraheader out of LAST_GIT_CMD (OMN-14277).
 git_auth_header=""
 if [ -n "$GH_TOKEN" ]; then
   git_auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
@@ -145,7 +147,23 @@ FETCH_CMD_DISPLAY="git -C ${OCC_CHECKOUT_DIR} -c http.version=HTTP/1.1 fetch --d
 run_git_bounded() {
   local tmo="$1"
   shift
-  LAST_GIT_CMD="git $*"
+  # Build the diagnostic command string with the git auth extraheader REDACTED.
+  # The fetch args carry `-c http.https://github.com/.extraheader=AUTHORIZATION:
+  # basic <base64>` where <base64> decodes to `x-access-token:$GH_TOKEN`. If that
+  # reaches the job log (emit_diagnostics prints LAST_GIT_CMD on every
+  # timeout/exhaustion path) the credential leaks — base64 is trivially
+  # reversible and GitHub log-masking does NOT match the encoded form
+  # (CodeRabbit Major, OMN-14277). Redact per-argument BEFORE `$*` flattening so
+  # the space inside "AUTHORIZATION: basic <b64>" cannot split the secret; git
+  # itself still runs below with the REAL, unredacted args.
+  local _redacted_args=() _a
+  for _a in "$@"; do
+    case "$_a" in
+      *extraheader=*) _redacted_args+=("${_a%%=*}=***REDACTED***") ;;
+      *) _redacted_args+=("$_a") ;;
+    esac
+  done
+  LAST_GIT_CMD="git ${_redacted_args[*]}"
   # Launch under timeout; capture the child pid so we can dump its tree if it
   # hangs. `timeout` forwards signals to the child group.
   "$TIMEOUT_BIN" -k "$TIMEOUT_KILL_AFTER" "$tmo" git "$@" &

--- a/scripts/deploy-gate/checkout-occ-contracts.sh
+++ b/scripts/deploy-gate/checkout-occ-contracts.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Bound + harden the OCC (onex_change_control) contract checkout used by the
+# deploy-gate reusable workflow [OMN-12564].
+#
+# Why this exists:
+#   Deploy Gate stalled inside the OCC partial-clone checkout
+#   (`git -C _occ checkout --force FETCH_HEAD`) on #1786 (runner-24) and #1788
+#   (runner-40). The hang was inside git itself — a filtered partial clone
+#   (`--filter=blob:none`) can lazily fetch missing blobs during checkout, and
+#   the previous inline workflow step only wrapped the *fetch* in `timeout`,
+#   not the checkout. A wedged checkout therefore spun until the 25-minute job
+#   timeout with no diagnostics.
+#
+# What this fixes:
+#   1. Hard timeout around BOTH the fetch AND the checkout (git-level via
+#      `timeout`, step-level via the caller's `timeout-minutes`).
+#   2. Deterministic full-ref checkout: drops `--filter=blob:none` so checkout
+#      never re-enters a lazy fetch / index-pack loop. We still shallow-fetch
+#      (`--depth=1`) and sparse-checkout `contracts/`, but all blobs for that
+#      single ref arrive in the one bounded fetch.
+#   3. On failure, emits a full diagnostic block (OCC ref, exact fetch command,
+#      elapsed time, last git subprocess, and a process/subprocess tree of the
+#      hung git PID) so future hangs are diagnosable from the job log alone.
+#
+# Tunable env (defaults are production values; tests override them):
+#   OCC_REF                  ref to fetch (default: dev)
+#   OCC_REPO_URL             OCC clone URL (default: GitHub OmniNode-ai/onex_change_control)
+#   OCC_CHECKOUT_DIR         working dir (default: _occ)
+#   OCC_SPARSE_PATH          sparse path to materialize (default: contracts)
+#   OCC_FETCH_TIMEOUT_SECS   per-fetch hard timeout (default: 90)
+#   OCC_CHECKOUT_TIMEOUT_SECS per-checkout hard timeout (default: 60)
+#   OCC_MAX_ATTEMPTS         attempts before giving up (default: 5)
+#   OCC_RETRY_BACKOFF_SECS   comma list of backoff delays (default: 0,10,20,30,45)
+#   GH_TOKEN                 token for the https extraheader (optional)
+set -uo pipefail
+
+OCC_REF="${OCC_REF:-dev}"
+OCC_REPO_URL="${OCC_REPO_URL:-https://github.com/OmniNode-ai/onex_change_control.git}"
+OCC_CHECKOUT_DIR="${OCC_CHECKOUT_DIR:-_occ}"
+OCC_SPARSE_PATH="${OCC_SPARSE_PATH:-contracts}"
+OCC_FETCH_TIMEOUT_SECS="${OCC_FETCH_TIMEOUT_SECS:-90}"
+OCC_CHECKOUT_TIMEOUT_SECS="${OCC_CHECKOUT_TIMEOUT_SECS:-60}"
+OCC_MAX_ATTEMPTS="${OCC_MAX_ATTEMPTS:-5}"
+OCC_RETRY_BACKOFF_SECS="${OCC_RETRY_BACKOFF_SECS:-0,10,20,30,45}"
+GH_TOKEN="${GH_TOKEN:-}"
+
+# Resolve a `timeout` binary. On macOS (local/dev) it is `gtimeout` from
+# coreutils; on Linux CI runners it is `timeout`. We require one — without it
+# we cannot bound git, which is the whole point.
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+else
+  echo "::error::checkout-occ-contracts: no 'timeout'/'gtimeout' binary available — cannot bound git" >&2
+  exit 3
+fi
+
+# -k <kill-after>: if the SIGTERM is ignored (e.g. git stuck in a syscall),
+# escalate to SIGKILL after a short grace window. Belt-and-suspenders against
+# a process that swallows TERM.
+TIMEOUT_KILL_AFTER="${OCC_TIMEOUT_KILL_AFTER_SECS:-10}"
+
+# Build the HTTPS extraheader. We use the `x-access-token` basic scheme (works
+# for both GITHUB_TOKEN and a CROSS_REPO_PAT) — matching the deploy-gate
+# workflow. The header is kept out of the diagnostic block (token redaction).
+git_auth_header=""
+if [ -n "$GH_TOKEN" ]; then
+  git_auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+fi
+
+# State captured for the diagnostic block.
+LAST_GIT_CMD=""
+LAST_GIT_PID=""
+
+# ---------------------------------------------------------------------------
+# emit_process_tree <root_pid>
+#   Best-effort process/subprocess tree. Prefer pstree; fall back to a
+#   `ps`-derived forest that always works on Linux + macOS CI images.
+# ---------------------------------------------------------------------------
+emit_process_tree() {
+  local root_pid="${1:-}"
+  echo "  Process tree (root pid: ${root_pid:-unknown}):"
+  if command -v pstree >/dev/null 2>&1 && [ -n "$root_pid" ]; then
+    pstree -p "$root_pid" 2>/dev/null | sed 's/^/    /' && return 0
+  fi
+  # Portable fallback: a bounded ps snapshot scoped to the wedged git's own
+  # process group / ancestry plus any git/timeout/sleep processes — enough to
+  # reconstruct the parent/child relationship of the hung git without dumping
+  # the entire host process table into the CI log.
+  echo "    (pstree unavailable — scoped ps snapshot:)"
+  # Match on the command basename (field 6) being exactly git/timeout/sleep, or
+  # the row being the wedged git itself, its child, or sharing its process
+  # group — never a substring match against full command lines (which pulls in
+  # unrelated host processes).
+  ps -eo pid,ppid,pgid,etime,stat,comm 2>/dev/null \
+    | awk -v root="${root_pid:-0}" '
+        NR==1 { print; next }
+        { n=split($6, p, "/"); base=p[n] }
+        $1==root || $2==root || $3==root \
+          || base=="git" || base=="timeout" || base=="gtimeout" || base=="sleep"' \
+    | head -n 60 \
+    | sed 's/^/    /' \
+    || ps -ef 2>/dev/null | head -n 60 | sed 's/^/    /' \
+    || echo "    (ps unavailable)"
+}
+
+# ---------------------------------------------------------------------------
+# emit_diagnostics <elapsed_secs> <phase> <root_pid>
+#   The full diagnostic block required by OMN-12564 acceptance criteria.
+# ---------------------------------------------------------------------------
+emit_diagnostics() {
+  local elapsed="${1:-?}" phase="${2:-unknown}" root_pid="${3:-}"
+  {
+    echo "::group::OCC checkout diagnostics (phase: ${phase})"
+    echo "OCC checkout diagnostics"
+    echo "  OCC ref:          ${OCC_REF}"
+    echo "  OCC repo:         ${OCC_REPO_URL}"
+    echo "  Checkout dir:     ${OCC_CHECKOUT_DIR}"
+    echo "  Sparse path:      ${OCC_SPARSE_PATH}"
+    echo "  Fetch command:    ${FETCH_CMD_DISPLAY:-<not yet built>}"
+    echo "  Elapsed:          ${elapsed}s"
+    echo "  Fetch timeout:    ${OCC_FETCH_TIMEOUT_SECS}s"
+    echo "  Checkout timeout: ${OCC_CHECKOUT_TIMEOUT_SECS}s"
+    echo "  Last git subprocess: ${LAST_GIT_CMD:-<none>}"
+    echo "  Last git pid:        ${LAST_GIT_PID:-<none>}"
+    emit_process_tree "${root_pid:-$LAST_GIT_PID}"
+    echo "::endgroup::"
+  } >&2
+}
+
+# Display-only fetch command (no token), built once OCC_REF is known.
+FETCH_CMD_DISPLAY="git -C ${OCC_CHECKOUT_DIR} -c http.version=HTTP/1.1 fetch --depth=1 origin ${OCC_REF}"
+
+# ---------------------------------------------------------------------------
+# run_git_bounded <timeout_secs> <git args...>
+#   Runs git under a hard timeout, recording the command + pid for diagnostics
+#   and distinguishing a timeout (exit 124/137) from an ordinary failure.
+#   Returns the git/timeout exit code.
+# ---------------------------------------------------------------------------
+run_git_bounded() {
+  local tmo="$1"
+  shift
+  LAST_GIT_CMD="git $*"
+  # Launch under timeout; capture the child pid so we can dump its tree if it
+  # hangs. `timeout` forwards signals to the child group.
+  "$TIMEOUT_BIN" -k "$TIMEOUT_KILL_AFTER" "$tmo" git "$@" &
+  LAST_GIT_PID=$!
+  wait "$LAST_GIT_PID"
+  return $?
+}
+
+# Parse backoff list into an array.
+IFS=',' read -r -a BACKOFFS <<<"$OCC_RETRY_BACKOFF_SECS"
+
+attempt=1
+while [ "$attempt" -le "$OCC_MAX_ATTEMPTS" ]; do
+  # Backoff (skip on first attempt; clamp to last value if list is short).
+  if [ "$attempt" -gt 1 ]; then
+    idx=$((attempt - 1))
+    delay="${BACKOFFS[$idx]:-${BACKOFFS[${#BACKOFFS[@]}-1]}}"
+    if [ "${delay:-0}" -gt 0 ] 2>/dev/null; then
+      echo "::notice::Retrying OCC contracts checkout in ${delay}s (attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+      sleep "$delay"
+    fi
+  fi
+
+  attempt_start="$(date +%s)"
+
+  rm -rf "$OCC_CHECKOUT_DIR"
+  git init "$OCC_CHECKOUT_DIR" >/dev/null
+  git -C "$OCC_CHECKOUT_DIR" remote add origin "$OCC_REPO_URL"
+  git -C "$OCC_CHECKOUT_DIR" sparse-checkout init --cone >/dev/null
+  git -C "$OCC_CHECKOUT_DIR" sparse-checkout set "$OCC_SPARSE_PATH" >/dev/null
+
+  # --- Bounded, deterministic fetch -------------------------------------
+  # NOTE: no `--filter=blob:none`. A blobless partial clone defers blob
+  # download to checkout time, which is exactly where #1786/#1788 wedged.
+  # A shallow (`--depth=1`) sparse fetch of one ref pulls every blob we need
+  # up front, so the subsequent checkout is a pure local index write.
+  fetch_args=(-C "$OCC_CHECKOUT_DIR" -c http.version=HTTP/1.1)
+  if [ -n "$git_auth_header" ]; then
+    fetch_args+=(-c "http.https://github.com/.extraheader=${git_auth_header}")
+  fi
+  fetch_args+=(fetch --depth=1 origin "$OCC_REF")
+
+  run_git_bounded "$OCC_FETCH_TIMEOUT_SECS" "${fetch_args[@]}"
+  fetch_rc=$?
+
+  if [ "$fetch_rc" -eq 124 ] || [ "$fetch_rc" -eq 137 ]; then
+    elapsed=$(($(date +%s) - attempt_start))
+    echo "::warning::OCC fetch timed out after ${OCC_FETCH_TIMEOUT_SECS}s (attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+    emit_diagnostics "$elapsed" "fetch-timeout" "$LAST_GIT_PID"
+    attempt=$((attempt + 1))
+    continue
+  fi
+  if [ "$fetch_rc" -ne 0 ]; then
+    echo "::warning::OCC fetch failed (rc=${fetch_rc}, attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  # --- Bounded checkout -------------------------------------------------
+  run_git_bounded "$OCC_CHECKOUT_TIMEOUT_SECS" -C "$OCC_CHECKOUT_DIR" checkout --force FETCH_HEAD
+  checkout_rc=$?
+
+  if [ "$checkout_rc" -eq 124 ] || [ "$checkout_rc" -eq 137 ]; then
+    elapsed=$(($(date +%s) - attempt_start))
+    echo "::warning::OCC checkout timed out after ${OCC_CHECKOUT_TIMEOUT_SECS}s (attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+    emit_diagnostics "$elapsed" "checkout-timeout" "$LAST_GIT_PID"
+    attempt=$((attempt + 1))
+    continue
+  fi
+  if [ "$checkout_rc" -ne 0 ]; then
+    echo "::warning::OCC checkout failed (rc=${checkout_rc}, attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  if [ -d "${OCC_CHECKOUT_DIR}/${OCC_SPARSE_PATH}" ]; then
+    echo "::notice::OCC contracts checkout succeeded on attempt ${attempt}"
+    exit 0
+  fi
+
+  echo "::warning::OCC checkout completed but ${OCC_CHECKOUT_DIR}/${OCC_SPARSE_PATH} is missing (attempt ${attempt}/${OCC_MAX_ATTEMPTS})"
+  attempt=$((attempt + 1))
+done
+
+elapsed=$(($(date +%s) - ${attempt_start:-$(date +%s)}))
+echo "::error::OCC contracts checkout failed after ${OCC_MAX_ATTEMPTS} attempts"
+emit_diagnostics "$elapsed" "exhausted" "$LAST_GIT_PID"
+exit 1


### PR DESCRIPTION
## OMN-14277 — relocate canonical deploy-gate reusable omniclaude → omnibase_core (Phase 1: additive)

Closes OMN-14277

### Why
`deploy-gate-reusable.yml` is the **canonical, org-wide deploy-gate**, but it currently lives in **omniclaude** (the top plugin layer) and is consumed up-layer by `omnibase_core`, `omnibase_infra`, and `omnimarket` via `uses: OmniNode-ai/omniclaude/...@main`. That inverts the `compat → core → spi → infra` layering (CLAUDE.md rule #7). The 2026-07-10 **OMN-14260** org-wide "Deploy Gate" `startup_failure` had its blast radius amplified by exactly this inversion — a bad change to the omniclaude@main reusable broke Deploy Gate on every core/infra caller at once.

### What this PR does (Phase 1 — ADDITIVE, no caller repoint, no deletion)
Adds the omnibase_core-hosted copies of all four deploy-gate surfaces:

| File | Note |
|------|------|
| `.github/workflows/deploy-gate-reusable.yml` | job name kept `deploy-gate` → surfaced context stays **`deploy-gate / deploy-gate`** (no branch-protection change) |
| `.github/actions/deploy-gate/action.yml` | composite action |
| `.github/actions/deploy-gate/validate_pr_deploy_required.py` | **verbatim** — zero omniclaude-internal deps (stdlib + pyyaml only) |
| `scripts/deploy-gate/checkout-occ-contracts.sh` | **verbatim** |

Only internal change vs the omniclaude copies: the reusable's sparse-checkout `repository:` and the composite-action `uses:` now point at `OmniNode-ai/omnibase_core` instead of `OmniNode-ai/omniclaude` (side-path renamed `.omniclaude-deploy-gate` → `.deploy-gate-support`).

**No caller is repointed here, and the omniclaude copy is untouched.** All existing consumers keep resolving `omniclaude@main` exactly as before — zero blast radius.

### Sequencing (why additive-first)
The reusable's internal sparse-checkout + composite-action references resolve at `omnibase_core@main`. Those files don't exist on core@main until this PR promotes (dev→main). So:
1. **This PR (Phase 1):** land the files on core dev → promote core dev→main.
2. **Phase 2 (separate PR):** repoint `omnibase_core/.github/workflows/deploy-gate.yml` (self, via relative `./`) and `omnibase_infra/.github/workflows/deploy-gate.yml` (via `OmniNode-ai/omnibase_core/...@main`) to the new reusable.
3. **Phase 3 (follow-up ticket):** migrate omnimarket's separate inline surface, then delete the omniclaude copy once all consumers are off it.

### Verification
- `.github/` + `scripts/*.sh` touch **no** runtime path patterns → this PR's own deploy-gate SKIPs (passes trivially).
- actionlint clean on the new reusable; YAML/py/bash syntax OK; scoped pre-commit green.
- No `# skip-*` tokens, no `--no-verify`, no hardcoded absolute paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Deploy Gate validation for pull requests that modify runtime-related files.
  * Added support for deploy evidence metadata and contract-based evidence checks.
  * Added reusable workflow support for resolving evidence sources and checking out required contracts.
  * Added resilient, bounded OCC contract checkout with retries and diagnostic reporting.
  * Automatically skips validation when no runtime files are changed or for merge-group events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

Evidence-Source: OCC#3825
Evidence-Commit: 6088c6804dd000e2ca8afb0023432a55f4df24d0
Evidence-Ticket: OMN-14277

