### PR TITLE
feat(OMN-14280): add optional tenant_id to inference wire DTOs (isolation-ready wire)

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -76,6 +76,24 @@ class ModelInferenceIntent(BaseModel):
             "provider-call boundary after core fields are constructed."
         ),
     )
+    # string-id-ok: tenant identity is a named slug (e.g. "omninode"), not a UUID.
+    # OMN-14280 (OMN-14208 slice-2 A-now): the orchestrator stamps the workflow
+    # tenant onto the inference intent so the inference effect can independently
+    # attribute its own side effects (tenant-tagged logging/metrics, per-tenant
+    # credential/quota/cost) to the owning tenant instead of trusting a shared
+    # correlation_id -> tenant lookup. Optional now (backward-compatible wire);
+    # the fail-closed wire==topic-tenant guard + required-flip is A-enforce,
+    # gated behind the gateway topic-tenant stamp (deferred, not this slice).
+    tenant_id: str | None = Field(
+        default=None,
+        description=(
+            "Owning tenant for this inference call. Set by the delegation "
+            "orchestrator from the workflow tenant identity; the inference "
+            "effect reads it to tenant-tag its logs/metrics and round-trips it "
+            "onto ModelInferenceResponseData. Isolation-ready wire (not yet "
+            "isolation-enforced)."
+        ),
+    )
 
 
 class ModelQualityGateIntent(BaseModel):
@@ -135,6 +153,18 @@ class ModelInferenceResponseData(BaseModel):
     error_message: str = Field(
         default="",
         description="Failure reason when inference could not produce content.",
+    )
+    # string-id-ok: tenant identity is a named slug (e.g. "omninode"), not a UUID.
+    # OMN-14280 (OMN-14208 slice-2 A-now): round-tripped from ModelInferenceIntent
+    # by the inference effect so the tenant that owned the call is auditable on
+    # the response and the orchestrator can observability-cross-check it against
+    # the workflow tenant. Optional now; required-flip is A-enforce (deferred).
+    tenant_id: str | None = Field(
+        default=None,
+        description=(
+            "Owning tenant echoed back from the inference intent by the "
+            "inference effect. Isolation-ready wire (not yet isolation-enforced)."
+        ),
     )
 
 

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -467,6 +467,31 @@ class TestModelInferenceIntent:
                 correlation_id=uuid.uuid4(),
             )
 
+    def test_tenant_id_optional_and_settable(self) -> None:
+        # OMN-14280: tenant_id is an optional, top-level, str|None slug that
+        # defaults to None (backward-compatible wire) and round-trips verbatim.
+        default_intent = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=uuid.uuid4(),
+        )
+        assert default_intent.tenant_id is None
+
+        tenant_intent = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=uuid.uuid4(),
+            tenant_id="tenant-alpha",
+        )
+        assert tenant_intent.tenant_id == "tenant-alpha"
+        assert tenant_intent.model_dump()["tenant_id"] == "tenant-alpha"
+
 
 @pytest.mark.unit
 class TestModelRoutingTier:
@@ -945,6 +970,24 @@ class TestModelInferenceResponseData:
                 model_used="qwen3-14b",
                 prompt_tokens=-1,
             )
+
+    def test_tenant_id_optional_and_settable(self) -> None:
+        # OMN-14280: tenant_id round-trips the owning tenant back to the
+        # orchestrator; optional + defaults to None for backward compatibility.
+        default_resp = ModelInferenceResponseData(
+            correlation_id=uuid.uuid4(),
+            content="Generated response.",
+            model_used="qwen3-14b",
+        )
+        assert default_resp.tenant_id is None
+
+        tenant_resp = ModelInferenceResponseData(
+            correlation_id=uuid.uuid4(),
+            content="Generated response.",
+            model_used="qwen3-14b",
+            tenant_id="tenant-alpha",
+        )
+        assert tenant_resp.tenant_id == "tenant-alpha"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## OMN-14280 (OMN-14208 slice-2, A-now) — core half

Adds an optional top-level `tenant_id: str | None` to `ModelInferenceIntent` and `ModelInferenceResponseData` (`model_orchestrator_intents.py`).

**Label: isolation-READY wire, NOT isolation proven.** Real isolation (the fail-closed `wire tenant == topic-tenant` guard + optional→required flip) is a later slice (A-enforce), gated behind the gateway topic-tenant stamp. This PR ships only the backward-compatible wire field.

### Why (functional)
The delegation orchestrator needs to stamp the owning tenant onto the inference leg so the inference effect can independently attribute its own side effects (per-tenant logging/metrics, and later per-tenant credential/quota/cost) instead of relying solely on a shared correlation_id→tenant lookup. This is the wire half of a coordinated `omnibase_core → omnimarket` change; the producer + consumer behavior and the cross-boundary regression test land in the paired omnimarket PR against this core version.

### Backward compatibility
Optional-with-default (`None`) — existing producers/consumers keep working and old serialized payloads still validate. No hash re-record needed (the delegation `request_hash`/`prompt_hash` are computed over the inference POST body only; `tenant_id` is not a hashed key).

### Tests
- `tests/unit/models/delegation/wire/test_delegation_wire_models.py`: added `tenant_id` optional/default/settable coverage on both models. Full wire-model suite green (92 passed).
- Local: `uv run ruff format`/`ruff check` clean; `mypy` clean on the touched module.

### DoD evidence
- dod_evidence: focused wire-model unit tests green (92 passed); the observable-consumer-effect proof lives in the paired omnimarket PR's cross-boundary test (mutation-verified: dropping the round-trip fails the test).
- Design doc (authoritative): `docs/plans/2026-07-10-omn-14208-slice2-wire-tenant-isolation-design.md` (private).

### Sequencing / coordination
This is core-first. After merge + a core release carrying this field (`0.46.8`), the paired omnimarket PR bumps/relocks onto it and goes green.

`Evidence-Source: OCC#3830`


Evidence-Source: OCC#3830
Evidence-Commit: 70dbbfdf42e1e6e028446fde6ece4f662030280e
Evidence-Ticket: OMN-14280
