### PR TITLE
fix(OMN-14245): preserve handler_routing + yaml event decls through ContractMergeEngine merge

### DIFF
--- a/src/omnibase_core/merge/contract_merge_engine.py
+++ b/src/omnibase_core/merge/contract_merge_engine.py
@@ -63,8 +63,17 @@ if TYPE_CHECKING:
     from omnibase_core.models.contracts.model_capability_provided import (
         ModelCapabilityProvided,
     )
+    from omnibase_core.models.contracts.model_consumed_event_entry import (
+        ModelConsumedEventEntry,
+    )
     from omnibase_core.models.contracts.model_descriptor_patch import (
         ModelDescriptorPatch,
+    )
+    from omnibase_core.models.contracts.model_published_event_entry import (
+        ModelPublishedEventEntry,
+    )
+    from omnibase_core.models.contracts.subcontracts.model_handler_routing_subcontract import (
+        ModelHandlerRoutingSubcontract,
     )
     from omnibase_core.protocols.protocol_contract_profile_factory import (
         ProtocolContractProfileFactory,
@@ -377,6 +386,13 @@ class ContractMergeEngine:
             base_output_model=base.output_model,
             base_behavior=base.behavior,
             base_tags=list(base.tags) if base.tags else [],
+            base_handler_routing=base.handler_routing,
+            base_yaml_consumed_events=list(base.yaml_consumed_events)
+            if base.yaml_consumed_events
+            else [],
+            base_yaml_published_events=list(base.yaml_published_events)
+            if base.yaml_published_events
+            else [],
             patch=patch,
             changes_applied=changes_applied,
         )
@@ -436,6 +452,9 @@ class ContractMergeEngine:
         base_output_model: str,
         base_behavior: ModelHandlerBehavior | None,
         base_tags: list[str],
+        base_handler_routing: ModelHandlerRoutingSubcontract | None,
+        base_yaml_consumed_events: list[ModelConsumedEventEntry],
+        base_yaml_published_events: list[ModelPublishedEventEntry],
         patch: ModelContractPatch,
         changes_applied: list[str],
     ) -> tuple[ModelHandlerContract, list[str]]:
@@ -448,6 +467,12 @@ class ContractMergeEngine:
         caller is responsible for extracting the appropriate behavior field
         (``base.behavior`` for ModelContractBase, ``base.descriptor`` for
         ModelHandlerContract).
+
+        ``ModelContractPatch`` has no override fields for handler_routing or
+        the consumed/published event declarations (OMN-14245), so
+        ``base_handler_routing``/``base_yaml_consumed_events``/
+        ``base_yaml_published_events`` are carried through unchanged rather
+        than merged against a patch value.
 
         Returns the merged contract and an updated changes list.
         """
@@ -557,6 +582,9 @@ class ContractMergeEngine:
             input_model=merged_input_model,
             output_model=merged_output_model,
             tags=list(base_tags) if base_tags else [],
+            handler_routing=base_handler_routing,
+            yaml_consumed_events=list(base_yaml_consumed_events),
+            yaml_published_events=list(base_yaml_published_events),
         )
         return result, changes
 
@@ -595,6 +623,9 @@ class ContractMergeEngine:
             base_output_model=current.output_model,
             base_behavior=current.descriptor,
             base_tags=list(current.tags) if current.tags else [],
+            base_handler_routing=current.handler_routing,
+            base_yaml_consumed_events=list(current.yaml_consumed_events),
+            base_yaml_published_events=list(current.yaml_published_events),
             patch=entry.overlay_patch,
             changes_applied=changes,
         )

--- a/src/omnibase_core/models/contracts/model_handler_contract.py
+++ b/src/omnibase_core/models/contracts/model_handler_contract.py
@@ -64,8 +64,17 @@ from omnibase_core.models.runtime.model_handler_behavior import (
 )
 
 if TYPE_CHECKING:
+    from omnibase_core.models.contracts.model_consumed_event_entry import (
+        ModelConsumedEventEntry,
+    )
+    from omnibase_core.models.contracts.model_published_event_entry import (
+        ModelPublishedEventEntry,
+    )
     from omnibase_core.models.contracts.subcontracts.model_context_integrity_subcontract import (
         ModelContextIntegritySubcontract,
+    )
+    from omnibase_core.models.contracts.subcontracts.model_handler_routing_subcontract import (
+        ModelHandlerRoutingSubcontract,
     )
     from omnibase_core.models.routing.model_trust_domain_config import (
         ModelTrustDomainConfig,
@@ -346,6 +355,32 @@ class ModelHandlerContract(BaseModel):
         ),
     )
 
+    # ==========================================================================
+    # Handler Routing and Event Declarations (OMN-14245)
+    # ==========================================================================
+    # Carried over unchanged from the base ModelContractBase profile by
+    # ContractMergeEngine._apply_patch_to_base. ModelContractPatch has no
+    # override for these fields, so a merge only preserves what the base
+    # profile declared — it never invents or mutates routing/event data.
+
+    handler_routing: ModelHandlerRoutingSubcontract | None = Field(
+        default=None,
+        description="Handler routing configuration carried over from the base "
+        "contract profile. See ModelContractBase.handler_routing.",
+    )
+
+    yaml_consumed_events: list[ModelConsumedEventEntry] = Field(
+        default_factory=list,
+        description="Events consumed by this node, carried over from the base "
+        "contract profile. See ModelContractBase.yaml_consumed_events.",
+    )
+
+    yaml_published_events: list[ModelPublishedEventEntry] = Field(
+        default_factory=list,
+        description="Events published by this node, carried over from the base "
+        "contract profile. See ModelContractBase.yaml_published_events.",
+    )
+
     model_config = ConfigDict(
         frozen=True,
         extra="ignore",
@@ -562,8 +597,17 @@ __all__ = [
 
 def _rebuild_model_handler_contract() -> None:
     """Rebuild ModelHandlerContract to resolve forward references."""
+    from omnibase_core.models.contracts.model_consumed_event_entry import (
+        ModelConsumedEventEntry,
+    )
+    from omnibase_core.models.contracts.model_published_event_entry import (
+        ModelPublishedEventEntry,
+    )
     from omnibase_core.models.contracts.subcontracts.model_context_integrity_subcontract import (
         ModelContextIntegritySubcontract,
+    )
+    from omnibase_core.models.contracts.subcontracts.model_handler_routing_subcontract import (
+        ModelHandlerRoutingSubcontract,
     )
     from omnibase_core.models.routing.model_trust_domain_config import (
         ModelTrustDomainConfig,
@@ -571,7 +615,10 @@ def _rebuild_model_handler_contract() -> None:
 
     ModelHandlerContract.model_rebuild(
         _types_namespace={
+            "ModelConsumedEventEntry": ModelConsumedEventEntry,
             "ModelContextIntegritySubcontract": ModelContextIntegritySubcontract,
+            "ModelHandlerRoutingSubcontract": ModelHandlerRoutingSubcontract,
+            "ModelPublishedEventEntry": ModelPublishedEventEntry,
             "ModelTrustDomainConfig": ModelTrustDomainConfig,
         }
     )

--- a/src/omnibase_core/models/contracts/model_handler_contract_extended.py
+++ b/src/omnibase_core/models/contracts/model_handler_contract_extended.py
@@ -51,13 +51,14 @@ class ModelHandlerContractExtended(ModelHandlerContract):
         str_strip_whitespace=True,
     )
 
-    handler_routing: (
-        dict[str, object] | None
-    ) = (  # ONEX_EXCLUDE: dict_str_any - infra routing config has variable schema
-        Field(
-            default=None,
-            description="Infra-specific handler routing configuration",
-        )
+    # ONEX_EXCLUDE: dict_str_any - infra routing config has variable schema.
+    # OMN-14245: the parent ModelHandlerContract.handler_routing became a typed
+    # ModelHandlerRoutingSubcontract | None field (so ContractMergeEngine can
+    # carry it through a merge); this subclass keeps the widened dict-form for
+    # infra handler_contract.yaml variable-schema compatibility.
+    handler_routing: dict[str, object] | None = Field(  # type: ignore[assignment]  # OMN-14245: widened in subclass for infra YAML dict-form compatibility
+        default=None,
+        description="Infra-specific handler routing configuration",
     )
 
     operation_bindings: (

--- a/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
+++ b/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
@@ -517,6 +517,12 @@ class NodeContractVerifyReplayCompute:
         synthetic_base.capability_outputs = []
         synthetic_base.handlers = []
         synthetic_base.dependencies = []
+        # OMN-14245: ContractMergeEngine now threads these through to the
+        # merged ModelHandlerContract; an un-set MagicMock attribute here
+        # fails Pydantic validation instead of being treated as absent.
+        synthetic_base.handler_routing = None
+        synthetic_base.yaml_consumed_events = []
+        synthetic_base.yaml_published_events = []
         synthetic_base.consumed_events = []
 
         synthetic_factory = MagicMock()

--- a/tests/unit/merge/test_contract_merge_engine.py
+++ b/tests/unit/merge/test_contract_merge_engine.py
@@ -118,6 +118,9 @@ def mock_base_contract() -> Mock:
     mock.capability_outputs = []
     mock.behavior = None
     mock.tags = []  # Required by merge engine for list(base.tags)
+    mock.handler_routing = None
+    mock.yaml_consumed_events = []
+    mock.yaml_published_events = []
 
     # Add model_dump method for serialization
     mock.model_dump = Mock(
@@ -1067,6 +1070,151 @@ class TestProfileResolution:
 
         # Factory should be called
         mock_profile_factory.get_profile.assert_called()
+
+
+class TestHandlerRoutingAndEventPreservation:
+    """Tests that handler_routing and event declarations survive a merge.
+
+    OMN-14245: ``_apply_patch_to_base`` previously constructed its output
+    ``ModelHandlerContract`` from only 9 named fields, silently dropping
+    ``handler_routing``, ``yaml_consumed_events``, and ``yaml_published_events``
+    even when the base ``ModelContractBase`` (from the profile factory) declared
+    them. ``ModelContractPatch`` has no override for these fields, so this is
+    pure preservation, not a new merge policy.
+    """
+
+    def test_handler_routing_preserved_through_merge(
+        self,
+        mock_profile_factory: Mock,
+        minimal_patch: ModelContractPatch,
+    ) -> None:
+        """A handler_routing block declared on the base profile must survive merge."""
+        from omnibase_core.merge.contract_merge_engine import ContractMergeEngine
+        from omnibase_core.models.contracts.subcontracts.model_handler_routing_entry import (
+            ModelHandlerRoutingEntry,
+        )
+        from omnibase_core.models.contracts.subcontracts.model_handler_routing_subcontract import (
+            ModelHandlerRoutingSubcontract,
+        )
+        from omnibase_core.models.dispatch.model_handler_ref import ModelHandlerRef
+
+        routing = ModelHandlerRoutingSubcontract(
+            version=ModelSemVer(major=1, minor=0, patch=0),
+            handlers=[
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerLedgerStats",
+                        module="omnimarket.nodes.node_ledger_stats_compute.handlers.handler_ledger_stats",
+                    ),
+                    operation="aggregate",
+                )
+            ],
+        )
+        mock_base = mock_profile_factory.get_profile.return_value
+        mock_base.handler_routing = routing
+
+        engine = ContractMergeEngine(mock_profile_factory)
+        result = engine.merge(minimal_patch)
+
+        assert result.handler_routing == routing
+
+    def test_yaml_consumed_events_preserved_through_merge(
+        self,
+        mock_profile_factory: Mock,
+        minimal_patch: ModelContractPatch,
+    ) -> None:
+        """A yaml_consumed_events list declared on the base profile must survive merge."""
+        from omnibase_core.merge.contract_merge_engine import ContractMergeEngine
+        from omnibase_core.models.contracts.model_consumed_event_entry import (
+            ModelConsumedEventEntry,
+        )
+
+        consumed = [ModelConsumedEventEntry(event_type="jobs.events.created.v1")]
+        mock_base = mock_profile_factory.get_profile.return_value
+        mock_base.yaml_consumed_events = consumed
+
+        engine = ContractMergeEngine(mock_profile_factory)
+        result = engine.merge(minimal_patch)
+
+        assert result.yaml_consumed_events == consumed
+
+    def test_yaml_published_events_preserved_through_merge(
+        self,
+        mock_profile_factory: Mock,
+        minimal_patch: ModelContractPatch,
+    ) -> None:
+        """A yaml_published_events list declared on the base profile must survive merge."""
+        from omnibase_core.merge.contract_merge_engine import ContractMergeEngine
+        from omnibase_core.models.contracts.model_published_event_entry import (
+            ModelPublishedEventEntry,
+        )
+
+        published = [
+            ModelPublishedEventEntry(
+                topic="jobs.events.started.v1", event_type="jobs.events.started.v1"
+            )
+        ]
+        mock_base = mock_profile_factory.get_profile.return_value
+        mock_base.yaml_published_events = published
+
+        engine = ContractMergeEngine(mock_profile_factory)
+        result = engine.merge(minimal_patch)
+
+        assert result.yaml_published_events == published
+
+    def test_handler_routing_survives_overlay_chaining(
+        self,
+        mock_profile_factory: Mock,
+        sample_profile_reference: ModelProfileReference,
+    ) -> None:
+        """handler_routing declared on the base must survive an overlay merge too.
+
+        ``_apply_overlay_entry`` re-enters ``_apply_patch_to_base`` using the
+        *current* (already-merged) contract as the new base — verifies the
+        preservation also holds across that second call site.
+        """
+        from omnibase_core.enums.enum_overlay_scope import EnumOverlayScope
+        from omnibase_core.merge.contract_merge_engine import ContractMergeEngine
+        from omnibase_core.models.contracts.subcontracts.model_handler_routing_entry import (
+            ModelHandlerRoutingEntry,
+        )
+        from omnibase_core.models.contracts.subcontracts.model_handler_routing_subcontract import (
+            ModelHandlerRoutingSubcontract,
+        )
+        from omnibase_core.models.dispatch.model_handler_ref import ModelHandlerRef
+        from omnibase_core.models.merge.model_overlay_stack_entry import (
+            ModelOverlayStackEntry,
+        )
+
+        routing = ModelHandlerRoutingSubcontract(
+            version=ModelSemVer(major=1, minor=0, patch=0),
+            handlers=[
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerX", module="pkg.handlers.handler_x"
+                    ),
+                    operation="tick",
+                )
+            ],
+        )
+        mock_base = mock_profile_factory.get_profile.return_value
+        mock_base.handler_routing = routing
+
+        base_patch = ModelContractPatch(extends=sample_profile_reference)
+        overlay = ModelOverlayStackEntry(
+            overlay_id="session-override",
+            overlay_patch=ModelContractPatch(
+                extends=sample_profile_reference,
+                description="Session-scoped override",
+            ),
+            scope=EnumOverlayScope.SESSION,
+            version="1.0.0",
+        )
+
+        engine = ContractMergeEngine(mock_profile_factory)
+        result = engine.merge_with_overlays(base_patch, overlays=[overlay])
+
+        assert result.handler_routing == routing
 
 
 class TestModuleExports:

--- a/tests/unit/merge/test_contract_merge_engine_events.py
+++ b/tests/unit/merge/test_contract_merge_engine_events.py
@@ -86,6 +86,9 @@ def create_mock_base_contract() -> Mock:
     mock.capability_outputs = []
     mock.behavior = None
     mock.tags = []
+    mock.handler_routing = None
+    mock.yaml_consumed_events = []
+    mock.yaml_published_events = []
 
     mock.model_dump = Mock(
         return_value={

--- a/tests/unit/merge/test_overlay_stacking.py
+++ b/tests/unit/merge/test_overlay_stacking.py
@@ -63,6 +63,9 @@ def mock_base_contract() -> Mock:
     mock.output_model = "BaseOutput"
     mock.behavior = None
     mock.tags = []
+    mock.handler_routing = None
+    mock.yaml_consumed_events = []
+    mock.yaml_published_events = []
     return mock
 
 

--- a/tests/unit/models/contracts/test_handler_contract_extended.py
+++ b/tests/unit/models/contracts/test_handler_contract_extended.py
@@ -82,11 +82,22 @@ def test_extended_contract_accepts_dict_output_model() -> None:
 
 @pytest.mark.unit
 def test_base_contract_ignores_extra_fields() -> None:
-    """Base contract silently ignores extra fields (extra='ignore')."""
-    data = {**_base_data(), "handler_routing": {"strategy": "round-robin"}}
+    """Base contract silently ignores extra fields (extra='ignore').
+
+    Uses a field name that is genuinely unknown to ModelHandlerContract.
+    ``handler_routing`` itself became a declared field on the base model
+    (OMN-14245, typed ``ModelHandlerRoutingSubcontract | None`` so it
+    survives ContractMergeEngine merges) and is exercised by
+    ``test_extended_contract_accepts_handler_routing`` above via the
+    infra-widened dict-form override on ModelHandlerContractExtended.
+    """
+    data = {
+        **_base_data(),
+        "some_infra_specific_extra_field": {"strategy": "round-robin"},
+    }
     contract = ModelHandlerContract(**data)
     # extra="ignore" means the field is accepted but not stored
-    assert not hasattr(contract, "handler_routing")
+    assert not hasattr(contract, "some_infra_specific_extra_field")
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_contract_validation_pipeline_events.py
+++ b/tests/unit/validation/test_contract_validation_pipeline_events.py
@@ -75,6 +75,9 @@ def create_mock_base_contract() -> Mock:
     mock.capability_outputs = []
     mock.behavior = None
     mock.tags = []
+    mock.handler_routing = None
+    mock.yaml_consumed_events = []
+    mock.yaml_published_events = []
     # Use valid handler_id format (dot-separated, each segment starting with letter/underscore)
     mock.handler_id = "node.base.contract"
     mock.descriptor = None


### PR DESCRIPTION
## Summary

Fixes **Bug 2 of OMN-14245** (the SAFE-BOUNDED half): `ContractMergeEngine` silently dropped `handler_routing` and the YAML event declarations on every merge.

`ContractMergeEngine._apply_patch_to_base` constructed its output `ModelHandlerContract` from only 9 named fields (name/version/description/input_model/output_model/behavior→descriptor/capability_inputs/capability_outputs/tags). `ModelHandlerContract` had **no** `handler_routing`, `yaml_consumed_events`, or `yaml_published_events` fields at all — so it was structurally unable to carry those facts even though the base `ModelContractBase` from `ContractProfileFactory.get_profile()` declares them. Any base profile that declares routing/events had them silently dropped on `merge()` and across overlay chaining.

## Changes

- **`model_handler_contract.py`**: add `handler_routing: ModelHandlerRoutingSubcontract | None`, `yaml_consumed_events: list[ModelConsumedEventEntry]`, `yaml_published_events: list[ModelPublishedEventEntry]` (additive; model is `frozen=True, extra="ignore"` → backward compatible). Forward refs resolved in `_rebuild_model_handler_contract()`.
- **`contract_merge_engine.py`**: thread `base.handler_routing` / `base.yaml_consumed_events` / `base.yaml_published_events` through `_apply_patch_to_base()` and both call sites (`_merge_internal`, `_apply_overlay_entry`). Pure preservation — `ModelContractPatch` has no override for these fields, so this is not a new merge policy.
- **`model_handler_contract_extended.py`**: the infra subclass re-widens `handler_routing` to dict-form; annotate the now-incompatible override with `# type: ignore[assignment]`, matching the existing `input_model`/`output_model` override idiom.
- **`node_contract_verify_replay_compute/handler.py`**: set the three fields on the synthetic `MagicMock` base so it validates against the widened model.

## Test evidence (RED→GREEN)

New `TestHandlerRoutingAndEventPreservation` (4 tests) proves the fields survive `merge()` and `merge_with_overlays()`:
- **RED** (engine change reverted, model+tests present): all 4 fail — `handler_routing == None`, `yaml_consumed_events == []`, `yaml_published_events == []` (fields dropped).
- **GREEN** (fix present): all 4 pass.

Local verification: 3364 tests in the affected dirs (merge / models.contracts / validation-pipeline-events / node_contract_verify_replay_compute) pass; contract-hash registry + diff-computer (154) and contract-yaml-schema (42) pass; mypy clean on changed modules + the widened subclass; ruff format + check clean; pre-commit passed at commit time. Full 43k suite runs in CI (shared-model change → governed selector escalates to full).

## Out of scope (design-gated)

**Bug 1 of OMN-14245** — the public contract-model schema drift (flat `descriptor` / `terminal_event` / `event_bus` / `handler` / `metadata`, plus the `input_model`/`output_model` retype and the `dependencies` name collision) — is explicitly **RISKY-RIPPLE, not fixed here** per the ticket. It needs a design decision first (breaking change across ~17 non-model files; `dependencies` PyPI-vs-protocol-DI name collision; `descriptor` vs. existing `behavior`/`behavior_spec` overlap). No live call site parses real `contract.yaml` through these models today, so this drift causes no runtime breakage.

Closes OMN-14245 (Bug 2). Bug 1 recommended as a follow-up design ticket.

Evidence-Ticket: OMN-14245
Evidence-Source: OCC#3829
Evidence-Commit: 5babd215b841290d67040e6ff16a36ef469d38d9
