### PR TITLE
fix(OMN-14298): RuntimeLocal calls initialize() before execute() + kills false-green over error-shaped returns

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -79,6 +79,32 @@ _KAFKA_EVENT_BUS_ENTRY_POINT: str = "event_bus_kafka"
 # the ``onex.backends`` entry-point group.
 SUPPORTED_EVENT_BUS_VALUES: frozenset[str] = frozenset({"inmemory", "kafka"})
 
+# Handler-result ``status`` values that unambiguously mean the run failed.
+# Effect/reducer handlers report failures in-band by returning an error-shaped
+# response envelope (``status="error"`` plus an ``error_message``) rather than
+# raising — e.g. the "Handler not initialized" envelope every init/execute
+# handler emits before ``initialize()`` has run. Before OMN-14298 the classifier
+# recognised only ``status == "failure"``, so such runs were misclassified
+# COMPLETED (exit 0) — a false green over a broken run.
+_FAILURE_STATUS_VALUES: frozenset[str] = frozenset({"failure", "failed", "error"})
+
+# Handler-result ``status`` values that unambiguously mean the run succeeded.
+# ``no_results`` in particular is a successful query that simply matched nothing
+# and must never be classified FAILED. An explicit success status short-circuits
+# the error-attribute heuristic below.
+_SUCCESS_STATUS_VALUES: frozenset[str] = frozenset(
+    {
+        "success",
+        "ok",
+        "completed",
+        "complete",
+        "no_results",
+        "healthy",
+        "passed",
+        "pass",
+    }
+)
+
 RawWorkflowMap = dict[str, object]
 RuntimeCallable = Callable[..., object]
 
@@ -377,6 +403,82 @@ class RuntimeLocal:
         )
         return None, ""
 
+    @staticmethod
+    def _handler_reports_initialized(handler_instance: object) -> bool:
+        """Return True if the handler already reports itself initialized.
+
+        Honors a public ``is_initialized`` property first, then the private
+        ``_initialized`` flag the ONEX init/execute handlers set. Anything else
+        (attribute absent, non-bool) is treated as "not initialized" so the
+        guard errs toward calling ``initialize()``.
+        """
+        is_init = getattr(handler_instance, "is_initialized", None)
+        if isinstance(is_init, bool):
+            return is_init
+        return getattr(handler_instance, "_initialized", None) is True
+
+    async def _ensure_handler_initialized(self, handler_instance: object) -> None:
+        """Call ``handler.initialize()`` before invoking its entry method (OMN-14298).
+
+        ONEX effect/reducer handlers use an ``initialize()`` / ``execute()``
+        lifecycle: ``execute()`` returns a "Handler not initialized" error
+        envelope until ``initialize()`` has run. RuntimeLocal previously invoked
+        the fallback ``execute()`` (or ``run()``) method WITHOUT ``initialize()``,
+        so every such node returned a not-initialized error that the runtime then
+        misclassified as COMPLETED — the systemic false-green this fix closes.
+
+        The call is guarded and idempotent:
+        - no-op when the handler declares no callable ``initialize``
+        - no-op when the handler already reports itself initialized
+          (``is_initialized`` / ``_initialized``); the handlers also guard
+          internally, so a redundant call is harmless
+        - no-op (with a warning) when ``initialize()`` declares required
+          parameters the runtime cannot supply (e.g. a graph ``connection_uri``);
+          ``execute()`` then surfaces the real not-initialized state, which
+          ``_classify_result`` maps to FAILED rather than a false COMPLETED.
+
+        Any exception raised *inside* a zero-argument ``initialize()`` propagates
+        so the run is recorded FAILED (via ``run_async``'s handler) rather than
+        silently green.
+        """
+        initialize = getattr(handler_instance, "initialize", None)
+        if not callable(initialize):
+            return
+        if self._handler_reports_initialized(handler_instance):
+            return
+
+        try:
+            sig = inspect.signature(initialize)
+        except (TypeError, ValueError):
+            sig = None
+        if sig is not None:
+            required = [
+                param.name
+                for param in sig.parameters.values()
+                if param.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+                and param.default is inspect.Parameter.empty
+            ]
+            if required:
+                logger.warning(
+                    "RuntimeLocal: %s.initialize() requires parameter(s) %s the "
+                    "runtime cannot supply — skipping initialize(); execute() will "
+                    "report its real lifecycle state",
+                    type(handler_instance).__name__,
+                    required,
+                )
+                return
+
+        logger.info(
+            "RuntimeLocal: calling %s.initialize() before invocation",
+            type(handler_instance).__name__,
+        )
+        await self._maybe_await(initialize())
+
     async def _invoke_handler_method(
         self,
         method: RuntimeCallable,
@@ -389,7 +491,12 @@ class RuntimeLocal:
         ``handle()`` receives a single positional payload argument.
         ``run_full_cycle()`` receives a typed command model as its first arg.
         ``run()`` and ``execute()`` are tried with payload first, then without.
+
+        Handlers exposing an ``initialize()`` lifecycle are initialized first via
+        ``_ensure_handler_initialized`` (OMN-14298) so ``execute()`` does not
+        return a spurious "Handler not initialized" error.
         """
+        await self._ensure_handler_initialized(handler_instance)
         try:
             result = await self._maybe_await(method(initial_payload))
         except TypeError as original_exc:
@@ -1716,7 +1823,24 @@ class RuntimeLocal:
 
     @staticmethod
     def _classify_result(result_obj: object | None) -> EnumWorkflowResult:
-        """Inspect handler return value to determine success or failure."""
+        """Inspect a handler return value to determine success or failure.
+
+        A handler that *returns* an error-shaped envelope — rather than raising —
+        must still be classified FAILED. Effect/reducer handlers never raise from
+        ``execute()``; they return a response with ``status="error"`` and an
+        ``error_message`` (e.g. the "Handler not initialized" or a downstream
+        connection failure). Before OMN-14298 only ``status == "failure"`` was
+        detected, so those runs surfaced a false-green COMPLETED / exit 0.
+
+        Decision order:
+        1. ``None`` → COMPLETED (compute handlers that return nothing succeeded).
+        2. positive ``cycles_failed`` → FAILED.
+        3. ``status`` in :data:`_FAILURE_STATUS_VALUES` → FAILED.
+        4. ``status`` in :data:`_SUCCESS_STATUS_VALUES` → COMPLETED (an explicit
+           success — notably ``no_results`` — short-circuits the heuristic below).
+        5. a populated ``error_message`` / ``error`` string → FAILED.
+        6. otherwise → COMPLETED.
+        """
         if result_obj is None:
             return EnumWorkflowResult.COMPLETED
         # Check for common failure indicators on result objects
@@ -1724,8 +1848,18 @@ class RuntimeLocal:
         if isinstance(cycles_failed, int | float) and cycles_failed > 0:
             return EnumWorkflowResult.FAILED
         status = getattr(result_obj, "status", None)
-        if status == "failure":
-            return EnumWorkflowResult.FAILED
+        if isinstance(status, str):
+            normalized = status.strip().lower()
+            if normalized in _FAILURE_STATUS_VALUES:
+                return EnumWorkflowResult.FAILED
+            if normalized in _SUCCESS_STATUS_VALUES:
+                return EnumWorkflowResult.COMPLETED
+        # No decisive status — a populated error message/attribute is an
+        # unambiguous failure signal even when the handler omits a status field.
+        for attr_name in ("error_message", "error"):
+            value = getattr(result_obj, attr_name, None)
+            if isinstance(value, str) and value.strip():
+                return EnumWorkflowResult.FAILED
         return EnumWorkflowResult.COMPLETED
 
     def _write_state(self) -> None:

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -25,7 +25,7 @@ import inspect
 import json
 import logging
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -265,10 +265,7 @@ class RuntimeLocal:
         status = payload.get("status", "success")
         logger.info("RuntimeLocal: terminal event received (status=%s)", status)
         self._terminal_payload = payload
-        if status == "failure":
-            self._result = EnumWorkflowResult.FAILED
-        else:
-            self._result = EnumWorkflowResult.COMPLETED
+        self._result = self._classify_result(payload)
 
         self._terminal_received.set()
 
@@ -1822,6 +1819,13 @@ class RuntimeLocal:
                 return None
 
     @staticmethod
+    def _result_field(result_obj: object, field_name: str) -> object | None:
+        """Read a status/error field from dict-style or attribute-style envelopes."""
+        if isinstance(result_obj, Mapping):
+            return result_obj.get(field_name)
+        return getattr(result_obj, field_name, None)
+
+    @staticmethod
     def _classify_result(result_obj: object | None) -> EnumWorkflowResult:
         """Inspect a handler return value to determine success or failure.
 
@@ -1844,10 +1848,10 @@ class RuntimeLocal:
         if result_obj is None:
             return EnumWorkflowResult.COMPLETED
         # Check for common failure indicators on result objects
-        cycles_failed = getattr(result_obj, "cycles_failed", None)
+        cycles_failed = RuntimeLocal._result_field(result_obj, "cycles_failed")
         if isinstance(cycles_failed, int | float) and cycles_failed > 0:
             return EnumWorkflowResult.FAILED
-        status = getattr(result_obj, "status", None)
+        status = RuntimeLocal._result_field(result_obj, "status")
         if isinstance(status, str):
             normalized = status.strip().lower()
             if normalized in _FAILURE_STATUS_VALUES:
@@ -1857,7 +1861,7 @@ class RuntimeLocal:
         # No decisive status — a populated error message/attribute is an
         # unambiguous failure signal even when the handler omits a status field.
         for attr_name in ("error_message", "error"):
-            value = getattr(result_obj, attr_name, None)
+            value = RuntimeLocal._result_field(result_obj, attr_name)
             if isinstance(value, str) and value.strip():
                 return EnumWorkflowResult.FAILED
         return EnumWorkflowResult.COMPLETED

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -830,3 +830,300 @@ def test_build_initial_payload_input_file_injects_only_missing_required_fields(
     assert isinstance(payload.correlation_id, _uuid_module.UUID)
     # task_name has a default — not injected, just uses the model default.
     assert payload.task_name == "default-task"
+
+
+# ---------------------------------------------------------------------------
+# OMN-14298 regression: RuntimeLocal must (1) call ``initialize()`` before the
+# fallback ``execute()`` for ONEX init/execute handlers, and (2) NOT surface a
+# false-green COMPLETED / exit 0 when a handler returns an error-shaped envelope
+# (``status="error"`` / "Handler not initialized"). These two defects together
+# produced ``onex node <name>`` runs that reported exit_code 0 over a broken run.
+# ---------------------------------------------------------------------------
+
+
+class _LifecycleResponse(BaseModel):
+    """Minimal stand-in for the effect/reducer response envelopes.
+
+    Mirrors ModelArchitectureGraphQueryResponseEvent / ModelNavigationHistoryResponse:
+    a ``status`` string (``"success"`` | ``"error"`` | ``"no_results"``) plus an
+    optional ``error_message`` populated on the error path.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: str
+    error_message: str | None = None
+
+
+class _InitExecuteLifecycleHandler:
+    """Mirrors the ONEX init/execute lifecycle with a zero-arg ``initialize()``.
+
+    ``execute()`` returns a ``status="error"`` envelope until ``initialize()`` has
+    run — exactly like HandlerArchitectureGraphQuery and
+    HandlerNavigationHistoryReducer. ``initialize()`` takes no required args, so
+    RuntimeLocal can and must call it before ``execute()``.
+    """
+
+    def __init__(self) -> None:
+        self._initialized = False
+        self.initialize_calls = 0
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    async def initialize(self) -> None:
+        # Idempotent, matching the real handlers' guarded initialize().
+        self.initialize_calls += 1
+        self._initialized = True
+
+    async def execute(self, request: object) -> _LifecycleResponse:
+        if not self._initialized:
+            return _LifecycleResponse(
+                status="error", error_message="Handler not initialized"
+            )
+        return _LifecycleResponse(status="success")
+
+
+class _RequiresArgInitHandler:
+    """Lifecycle handler whose ``initialize()`` needs an arg the runtime can't give.
+
+    Mirrors HandlerIntentQuery.initialize(connection_uri: str). RuntimeLocal must
+    skip ``initialize()`` (it cannot bind the required parameter) WITHOUT crashing,
+    and the resulting not-initialized error envelope must surface FAILED — never a
+    false-green COMPLETED.
+    """
+
+    def __init__(self) -> None:
+        self._initialized = False
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    async def initialize(self, connection_uri: str) -> None:
+        self._initialized = True
+
+    async def execute(self, request: object) -> _LifecycleResponse:
+        if not self._initialized:
+            return _LifecycleResponse(
+                status="error", error_message="Handler not initialized"
+            )
+        return _LifecycleResponse(status="success")
+
+
+class _AlwaysErrorExecuteHandler:
+    """Handler with no ``initialize()`` whose ``execute()`` always returns an error.
+
+    Stands in for a genuinely-failing handler (e.g. a downstream connection
+    failure returned in-band). Proves the false-green fix independently of the
+    initialize lifecycle: an error-shaped return must map to FAILED / exit 1.
+    """
+
+    async def execute(self, request: object) -> _LifecycleResponse:
+        return _LifecycleResponse(status="error", error_message="downstream boom")
+
+
+def _write_compute_handler_contract(target: Path, handler_class_name: str) -> None:
+    """Write a terminal-event-less compute contract → the ``_run_compute`` path.
+
+    This is the shape of the affected nodes (effect/reducer contracts declare a
+    top-level ``handler`` and no top-level ``terminal_event``), so RuntimeLocal
+    resolves the handler, falls back to ``execute()``, and classifies its return.
+    """
+    contract = {
+        "workflow_id": "omn-14298-init-lifecycle",
+        "handler": {
+            "module": _THIS_MODULE,
+            "class": handler_class_name,
+        },
+    }
+    target.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_local_initializes_handler_before_execute(
+    tmp_path: Path,
+) -> None:
+    """Proof (a): an init/execute handler now runs through initialize()→execute().
+
+    BEFORE OMN-14298: RuntimeLocal invoked the fallback ``execute()`` without
+    ``initialize()``, so ``execute()`` returned the "Handler not initialized"
+    envelope. AFTER: the runtime calls the zero-arg ``initialize()`` first, so
+    ``execute()`` runs its real body and returns ``status="success"`` → COMPLETED.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_compute_handler_contract(contract_path, "_InitExecuteLifecycleHandler")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+    )
+
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.COMPLETED
+    assert runtime.exit_code == 0
+    # initialize() ran before execute() — proven by the success status, since the
+    # handler returns "Handler not initialized" whenever the flag is unset.
+    handler_result = runtime.handler_result
+    assert isinstance(handler_result, _LifecycleResponse)
+    assert handler_result.status == "success"
+    assert handler_result.error_message is None
+
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    assert workflow_data["result"] == "completed"
+    assert workflow_data["exit_code"] == 0
+    assert workflow_data["handler_result"]["status"] == "success"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_local_error_envelope_surfaces_failed_not_false_green(
+    tmp_path: Path,
+) -> None:
+    """Proof (b): an error-shaped handler return must NOT be a false-green COMPLETED.
+
+    A handler whose ``execute()`` returns ``status="error"`` (the exact shape of
+    the "Handler not initialized" / downstream-failure envelope) must terminate
+    the workflow FAILED with exit_code 1. Before OMN-14298 the classifier only
+    recognised ``status == "failure"``, so this run reported exit_code 0.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_compute_handler_contract(contract_path, "_AlwaysErrorExecuteHandler")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+    )
+
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.FAILED
+    assert runtime.exit_code == 1
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    assert workflow_data["result"] == "failed"
+    assert workflow_data["exit_code"] == 1
+    assert workflow_data["handler_result"]["status"] == "error"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_runtime_local_skips_required_arg_initialize_and_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A handler whose initialize() needs an unsatisfiable arg fails closed, not green.
+
+    RuntimeLocal cannot supply ``connection_uri`` for the intent-query-shaped
+    handler, so it skips ``initialize()`` (without crashing). ``execute()`` then
+    returns the not-initialized error envelope, which must surface FAILED — never
+    a false COMPLETED.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_compute_handler_contract(contract_path, "_RequiresArgInitHandler")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+    )
+
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.FAILED
+    assert runtime.exit_code == 1
+    handler_result = runtime.handler_result
+    assert isinstance(handler_result, _LifecycleResponse)
+    assert handler_result.status == "error"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ensure_handler_initialized_is_idempotent_and_guarded(
+    workflow_path: Path,
+) -> None:
+    """``_ensure_handler_initialized`` calls initialize() once and is a no-op after.
+
+    Also verifies the two safe no-op branches: an already-initialized handler is
+    not re-initialized, and a handler with no ``initialize()`` is left untouched.
+    """
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+
+    handler = _InitExecuteLifecycleHandler()
+    await runtime._ensure_handler_initialized(handler)
+    assert handler.is_initialized is True
+    assert handler.initialize_calls == 1
+
+    # Second call is a no-op — the handler already reports initialized.
+    await runtime._ensure_handler_initialized(handler)
+    assert handler.initialize_calls == 1
+
+    # A handler exposing no initialize() must not raise.
+    await runtime._ensure_handler_initialized(_AlwaysErrorExecuteHandler())
+
+    # A handler with a required-arg initialize() is skipped, not called/crashed.
+    requires_arg = _RequiresArgInitHandler()
+    await runtime._ensure_handler_initialized(requires_arg)
+    assert requires_arg.is_initialized is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("status", "error_message", "expected"),
+    [
+        ("error", "Handler not initialized", EnumWorkflowResult.FAILED),
+        ("failure", None, EnumWorkflowResult.FAILED),
+        ("failed", None, EnumWorkflowResult.FAILED),
+        ("ERROR", None, EnumWorkflowResult.FAILED),
+        ("success", None, EnumWorkflowResult.COMPLETED),
+        # A successful query that matched nothing must NOT be classified FAILED.
+        ("no_results", None, EnumWorkflowResult.COMPLETED),
+        # Explicit success wins even if an error_message field lingers.
+        ("success", "", EnumWorkflowResult.COMPLETED),
+    ],
+)
+def test_classify_result_status_values(
+    status: str, error_message: str | None, expected: EnumWorkflowResult
+) -> None:
+    """``_classify_result`` maps error-ish statuses to FAILED and success to COMPLETED."""
+    result = _LifecycleResponse(status=status, error_message=error_message)
+    assert RuntimeLocal._classify_result(result) == expected
+
+
+@pytest.mark.unit
+def test_classify_result_none_is_completed() -> None:
+    """A ``None`` return (compute handler that returns nothing) is COMPLETED."""
+    assert RuntimeLocal._classify_result(None) == EnumWorkflowResult.COMPLETED
+
+
+@pytest.mark.unit
+def test_classify_result_populated_error_message_without_status_is_failed() -> None:
+    """A populated ``error_message`` is a failure signal even with no status field."""
+
+    class _ErrOnly(BaseModel):
+        model_config = ConfigDict(frozen=True, extra="forbid")
+
+        error_message: str
+
+    assert (
+        RuntimeLocal._classify_result(_ErrOnly(error_message="boom"))
+        == EnumWorkflowResult.FAILED
+    )
+
+
+@pytest.mark.unit
+def test_classify_result_plain_object_without_failure_markers_is_completed() -> None:
+    """An object with neither failure status nor error markers stays COMPLETED."""
+
+    class _Ok(BaseModel):
+        model_config = ConfigDict(frozen=True, extra="forbid")
+
+        value: int = 1
+
+    assert RuntimeLocal._classify_result(_Ok()) == EnumWorkflowResult.COMPLETED

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -1085,7 +1085,7 @@ async def test_ensure_handler_initialized_is_idempotent_and_guarded(
         # A successful query that matched nothing must NOT be classified FAILED.
         ("no_results", None, EnumWorkflowResult.COMPLETED),
         # Explicit success wins even if an error_message field lingers.
-        ("success", "", EnumWorkflowResult.COMPLETED),
+        ("success", "stale error from prior attempt", EnumWorkflowResult.COMPLETED),
     ],
 )
 def test_classify_result_status_values(
@@ -1100,6 +1100,41 @@ def test_classify_result_status_values(
 def test_classify_result_none_is_completed() -> None:
     """A ``None`` return (compute handler that returns nothing) is COMPLETED."""
     assert RuntimeLocal._classify_result(None) == EnumWorkflowResult.COMPLETED
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"status": "error"}, EnumWorkflowResult.FAILED),
+        ({"status": "failed"}, EnumWorkflowResult.FAILED),
+        ({"status": "success", "error": "stale error"}, EnumWorkflowResult.COMPLETED),
+        ({"error_message": "boom"}, EnumWorkflowResult.FAILED),
+        ({"cycles_failed": 1}, EnumWorkflowResult.FAILED),
+    ],
+)
+def test_classify_result_mapping_envelopes(
+    payload: dict[str, object], expected: EnumWorkflowResult
+) -> None:
+    """Dict-style response envelopes use the same status/error rules as objects."""
+    assert RuntimeLocal._classify_result(payload) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failure", "failed", "error", "ERROR"])
+async def test_terminal_event_uses_result_classifier(
+    tmp_path: Path, status: str
+) -> None:
+    """Terminal events classify every failure-ish status as FAILED."""
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event({"status": status})
+
+    assert runtime._result == EnumWorkflowResult.FAILED
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## OMN-14298 — RuntimeLocal init/execute lifecycle + kill the false-green

Closes OMN-14298.

`RuntimeLocal` never called `handler.initialize()` before falling back to
`execute()`. Every ONEX init/execute effect/reducer handler therefore returned a
`"Handler not initialized"` envelope (`status="error"`) — **while the runtime
reported the run COMPLETED / `exit_code: 0`**. That exit-0-over-a-broken-run is
the false-green class the operator bans, and it hit the documented local CLI
entrypoint (`onex node <name>`).

### Two defects fixed (both in `runtime/runtime_local.py`)

1. **Lifecycle.** `_invoke_handler_method` now calls a guarded, idempotent
   `_ensure_handler_initialized(handler)` before invoking the resolved entry
   method. It is a no-op when the handler has no `initialize()`, is already
   initialized (`is_initialized` / `_initialized`), or declares required
   parameters the runtime cannot supply (e.g. `node_intent_query_effect`'s
   `initialize(connection_uri: str)`) — in that last case `execute()` surfaces
   the real not-initialized state instead of the runtime crashing. Exceptions
   raised inside a zero-arg `initialize()` propagate → FAILED.

2. **False-green.** `_classify_result` now maps `status ∈ {failure, failed,
   error}` and a populated `error_message` / `error` string to **FAILED**. An
   explicit success status (incl. `no_results`) short-circuits so a
   matched-nothing query is not misread as a failure. Previously only
   `status == "failure"` was detected, so the `status="error"` envelope surfaced
   `exit_code: 0`.

### dod_evidence

**Real-node before/after** — `node_architecture_graph_query_effect/contract.yaml`
driven through `RuntimeLocal.run_async()` (omnimarket venv; installed core vs.
this branch's core on `PYTHONPATH`):

```
BEFORE (unfixed core):  result=completed  exit_code=SUCCESS(0)
                        handler_result.status='error' error_message='Handler not initialized'   ← false green
AFTER  (this branch):   result=failed     exit_code=ERROR(1)
```

**Automated tests** (`tests/unit/runtime/test_runtime_local.py`, +11):
- `test_runtime_local_initializes_handler_before_execute` — proof (a): init→execute runs, `status="success"`, COMPLETED/exit 0.
- `test_runtime_local_error_envelope_surfaces_failed_not_false_green` — proof (b): `status="error"` return → FAILED/exit 1.
- `test_runtime_local_skips_required_arg_initialize_and_fails_closed` — required-arg `initialize()` skipped without crash → FAILED.
- `test_ensure_handler_initialized_is_idempotent_and_guarded` — init called once; no-op for already-init / no-initialize / required-arg handlers.
- `test_classify_result_status_values` (7 params) + None / error_message-only / plain-object edge cases.

**Gate runs (local):**
- `uv run pytest tests/unit/runtime/test_runtime_local.py` → **47 passed**.
- All RuntimeLocal-adjacent tests (runtime, harness, node_base, spi, validators, contract/dod, localhost/local-path compute) → **413 passed** (no ripple in the changed surface).
- `ruff format` + `ruff check` clean; `mypy --strict src/.../runtime_local.py` clean; `pre-commit run --files <changed>` all Passed/Skipped.

> **Full-suite note:** the repo suite is 43,012 items and does not complete in the
> local shell window even parallel; CI runs the full matrix. The false-green fix
> is expected to *surface* previously-hidden failures in any node that only
> "passed" because `exit_code:0` masked an error return — that is the intent. No
> newly-RED node was observed in the 413-test adjacent surface; watch CI for
> broader ripple.

### Scope
Product PR only. No OCC companion authored here (build-verifier owns that). Not
merged (Codex lands).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow result classification across success, failure, and error responses.
  * Fixed handler execution so supported handlers are initialized before running.
  * Prevented initialization errors from being incorrectly reported as successful completion.
  * Gracefully handles handlers with unavailable initialization parameters.

* **Tests**
  * Added coverage for handler lifecycle execution, result classification, initialization safeguards, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-14298
Evidence-Source: OCC#3852
Evidence-Commit: 94d99052e17d962cfb4720ae95eba962ac58a498




