### PR TITLE
feat(OMN-14342): shadow-mode test-selection instrumentation on dev CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1671,6 +1671,37 @@ jobs:
           path: selection.json
           retention-days: 7
 
+      # OMN-14342: compute the COUNTERFACTUAL selection with the selector forced
+      # ON, independent of ENABLE_SMART_TESTS. Observational only — the full suite
+      # still runs on the boundary; this only records what the selector WOULD have
+      # skipped so shadow-compare can measure its real-world miss-rate.
+      - name: Shadow selection (forced on)
+        id: shadow
+        env:
+          BASE_SHA: ${{ steps.diff.outputs.base_sha }}
+        run: |
+          base_arg=()
+          if [ -n "$BASE_SHA" ]; then
+            base_arg=(--base-ref "$BASE_SHA")
+          fi
+          uv run python -m scripts.ci.detect_test_paths \
+            --changed-files-from changed.txt \
+            --ref-name "${{ github.ref_name }}" \
+            --event-name "${{ github.event_name }}" \
+            --feature-flag on \
+            "${base_arg[@]}" \
+            > shadow_selection.json
+          cat shadow_selection.json
+
+      - name: Upload shadow inputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: shadow-inputs
+          path: |
+            shadow_selection.json
+            changed.txt
+          retention-days: 7
+
   # ---------------------------------------------------------------------------
   # Phase 2 - Full Test Suite
   # ---------------------------------------------------------------------------
@@ -1798,6 +1829,84 @@ jobs:
           name: test-results-${{ matrix.split }}
           path: junit-${{ matrix.split }}.xml
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Shadow-mode test-selection compare (OMN-14342) — OBSERVATIONAL, non-blocking
+  # ---------------------------------------------------------------------------
+  # Compares the forced-on counterfactual selection against the full-suite junit
+  # to measure what the selector WOULD have skipped (escaped failures / selected
+  # fraction / wall-clock saved). Only meaningful when the ACTUAL run was a full
+  # suite (flag off, or is_full_suite escalation) — otherwise there is no full
+  # baseline to compare against, so it is gated on that condition. It never fails
+  # the build (continue-on-error) and never changes what runs. The record artifact
+  # is harvested to the durable ci-shadow-metrics branch by a separate workflow.
+  shadow-compare:
+    name: Shadow Selection Compare
+    needs: [detect-changes, test-parallel]
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    # Run whenever the actual test-parallel run was a full suite (the only case
+    # with a complete baseline). During rollout ENABLE_SMART_TESTS is off, so this
+    # is every non-docs dev PR.
+    if: >-
+      always()
+      && needs.detect-changes.result == 'success'
+      && (vars.ENABLE_SMART_TESTS != 'true' || needs.detect-changes.outputs.is_full_suite == 'true')
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Download shadow inputs
+        uses: actions/download-artifact@v7
+        with:
+          name: shadow-inputs
+          path: shadow-inputs
+
+      - name: Download full-suite junit
+        uses: actions/download-artifact@v7
+        with:
+          pattern: test-results-*
+          path: junit-artifacts
+
+      - name: Build shadow record
+        env:
+          SHADOW_PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHADOW_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHADOW_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          uv run python -m scripts.ci.test_selection_shadow \
+            --selection shadow-inputs/shadow_selection.json \
+            --changed-files-from shadow-inputs/changed.txt \
+            --junit-dir junit-artifacts \
+            --out shadow_record.json
+          echo "## Shadow test-selection record" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat shadow_record.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow record
+        uses: actions/upload-artifact@v7
+        with:
+          name: shadow-record-${{ github.run_id }}
+          path: shadow_record.json
+          retention-days: 14
 
   # ---------------------------------------------------------------------------
   # Integration Tests — always-run 4-split matrix (OMN-9851)

--- a/.github/workflows/shadow-metrics-harvest.yml
+++ b/.github/workflows/shadow-metrics-harvest.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Shadow test-selection metrics harvester (OMN-14342).
+#
+# Stage 2 of the two-stage durable store (Option A). CI's shadow-compare job
+# uploads an ephemeral `shadow-record-<run_id>` artifact on every dev PR. This
+# workflow runs in the trusted base-repo context after CI completes, downloads
+# that record, and appends it (dedup by repo+head_sha+pr_number) to an
+# append-only NDJSON on the dedicated `ci-shadow-metrics` orphan branch — a
+# durable, replayable log per the deterministic-truth doctrine, with no CI->LAN
+# coupling and no external infra/secrets. Promote to a Postgres projection later
+# if query volume justifies.
+name: Shadow Metrics Harvest
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: shadow-metrics-harvest
+  cancel-in-progress: false
+
+jobs:
+  harvest:
+    name: Harvest shadow records
+    runs-on: ubuntu-latest
+    # Harvest only from PR-triggered CI runs (the shadow record only exists there);
+    # workflow_dispatch is allowed for manual backfill.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Checkout product branch (for the append script)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Download shadow record(s) from the triggering run
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true # a run with no shadow record (docs-only PR) is normal
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          pattern: shadow-record-*
+          path: records
+
+      - name: Append records to ci-shadow-metrics NDJSON
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NDJSON_PATH: shadow_metrics.ndjson
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          records=(records/**/*.json)
+          if [ ${#records[@]} -eq 0 ]; then
+            echo "No shadow records to harvest (nothing uploaded by the triggering run)."
+            exit 0
+          fi
+
+          # Keep an absolute path to the append script before we clone the
+          # orphan branch into a subdirectory.
+          APPEND_SCRIPT="$PWD/scripts/ci/shadow_metrics_append.py"
+          RECORDS_DIR="$PWD/records"
+
+          AUTH="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads "$AUTH" ci-shadow-metrics >/dev/null 2>&1; then
+            git clone --branch ci-shadow-metrics --single-branch "$AUTH" _metrics
+          else
+            git clone --depth 1 "$AUTH" _metrics
+            (
+              cd _metrics
+              git checkout --orphan ci-shadow-metrics
+              git rm -rf . >/dev/null 2>&1 || true
+              printf '# CI shadow test-selection metrics (OMN-14342)\n\nAppend-only NDJSON log. One ModelShadowRecord per dev-PR CI run.\nSchema: scripts/ci/test_selection_shadow_models.py on the product branch.\n' > README.md
+            )
+          fi
+
+          python3 "$APPEND_SCRIPT" \
+            --records-dir "$RECORDS_DIR" \
+            --ndjson "$PWD/_metrics/${NDJSON_PATH}"
+
+          cd _metrics
+          git config user.name "onex-shadow-harvester[bot]"
+          git config user.email "shadow-harvester@omninode.ai"
+          git add "${NDJSON_PATH}" README.md
+          if git diff --cached --quiet; then
+            echo "No new records to commit."
+            exit 0
+          fi
+          git commit -m "chore(OMN-14342): harvest shadow test-selection record(s)"
+          git push "$AUTH" ci-shadow-metrics

--- a/scripts/ci/shadow_metrics_append.py
+++ b/scripts/ci/shadow_metrics_append.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Append harvested shadow records to the ci-shadow-metrics NDJSON (OMN-14342).
+
+Stage 2 of the durable store: dedup-append the per-run ``shadow_record.json``
+artifacts into the append-only ``shadow_metrics.ndjson`` on the
+``ci-shadow-metrics`` branch. Dedup key is (repo, head_sha, pr_number) so
+re-harvesting the same CI run is idempotent. Extracted from the harvester
+workflow so the append/dedup logic is unit-tested rather than inline shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _dedup_key(record: dict) -> tuple[object, object, object]:
+    return (record.get("repo"), record.get("head_sha"), record.get("pr_number"))
+
+
+def _load_existing_keys(ndjson: Path) -> set[tuple[object, object, object]]:
+    keys: set[tuple[object, object, object]] = set()
+    if not ndjson.exists():
+        return keys
+    for line in ndjson.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            keys.add(_dedup_key(json.loads(line)))
+        except json.JSONDecodeError:
+            continue
+    return keys
+
+
+def append_records(records_dir: Path, ndjson: Path) -> int:
+    """Append not-yet-seen records from ``records_dir`` into ``ndjson``.
+
+    Returns the number of records appended. Records are canonicalized
+    (``sort_keys=True``) so the NDJSON line is stable regardless of field order.
+    """
+    seen = _load_existing_keys(ndjson)
+    appended = 0
+    lines: list[str] = []
+    for path in sorted(records_dir.rglob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        key = _dedup_key(record)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(json.dumps(record, sort_keys=True))
+        appended += 1
+    if lines:
+        with ndjson.open("a", encoding="utf-8") as out:
+            out.write("\n".join(lines) + "\n")
+    return appended
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Append shadow records to NDJSON")
+    parser.add_argument("--records-dir", type=Path, required=True)
+    parser.add_argument("--ndjson", type=Path, required=True)
+    args = parser.parse_args(argv)
+    count = append_records(args.records_dir, args.ndjson)
+    sys.stdout.write(f"appended {count} new record(s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/shadow_premise_replay.py
+++ b/scripts/ci/shadow_premise_replay.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Reproduce the OMN-14342 premise-check number from merged dev-PR history.
+
+Replays the LIVE change-aware selector (``compute_selection``, forced
+``feature_flag_enabled=True``) over a set of merged dev PRs and reports what
+fraction would escalate to the full suite and which ``shared_module`` dominates.
+This is the evidence that justified building the shadow instrumentation.
+
+Reproduce end-to-end::
+
+    gh pr list --repo OmniNode-ai/omnibase_core --base dev --state merged \
+        --limit 120 --json number,headRefName,mergedAt,files > dev_prs.json
+    uv run python -m scripts.ci.shadow_premise_replay --prs-json dev_prs.json
+
+The 2026-07-10 baseline (120 merged omnibase_core dev PRs): 67-72% escalate to
+the full suite; ``shared_module`` dominates (44-63% of all PRs); ``models`` is the
+single dominant trigger (~29% of all PRs, ~2.2x the next module). The range is
+pyproject.toml fail-closed (worst case) vs metadata-only (best case).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+
+from scripts.ci.detect_test_paths import SRC_PREFIX, compute_selection
+from scripts.ci.test_selection_loader import load_adjacency_map
+
+_ADJ_DEFAULT = Path(__file__).parent / "test_selection_adjacency.yaml"
+
+
+def replay(prs: list[dict], adjacency_path: Path, *, pyproject_escalates: bool) -> dict:
+    """Replay the selector over PR change sets.
+
+    ``pyproject_escalates`` bounds the pyproject.toml effect: True = fail-closed
+    (worst case, matches CI when the base cannot be read); False = treat every
+    pyproject change as metadata-only (best case). The real number lies between.
+    """
+    config = load_adjacency_map(adjacency_path)
+    shared = set(config.shared_modules)
+    reason_hist: Counter[str] = Counter()
+    shared_module_hist: Counter[str] = Counter()
+    narrowed_paths: list[int] = []
+    full = 0
+    n = 0
+    for pr in prs:
+        files = [f["path"] for f in pr.get("files", [])]
+        if not files:
+            continue
+        n += 1
+        pyproj = None if ("pyproject.toml" in files and pyproject_escalates) else False
+        sel = compute_selection(
+            changed_files=files,
+            adjacency_path=adjacency_path,
+            ref_name=pr.get("headRefName", "feature-branch"),
+            event_name="pull_request",
+            feature_flag_enabled=True,
+            pyproject_dependency_relevant=pyproj,
+        )
+        if sel.is_full_suite:
+            full += 1
+            assert sel.full_suite_reason is not None
+            reason_hist[sel.full_suite_reason.value] += 1
+            if sel.full_suite_reason.value == "shared_module":
+                changed_modules = {
+                    p[len(SRC_PREFIX) :].split("/", 1)[0]
+                    for p in files
+                    if p.startswith(SRC_PREFIX)
+                } & set(config.adjacency.keys())
+                for m in sorted(changed_modules & shared):
+                    shared_module_hist[m] += 1
+        else:
+            narrowed_paths.append(len(sel.selected_paths))
+    return {
+        "n": n,
+        "full": full,
+        "narrowed": n - full,
+        "reason_hist": dict(reason_hist.most_common()),
+        "shared_module_hist": dict(shared_module_hist.most_common()),
+        "narrowed_median_paths": (
+            statistics.median(narrowed_paths) if narrowed_paths else 0
+        ),
+    }
+
+
+def _print_report(label: str, r: dict) -> None:
+    n = r["n"] or 1
+    lines = [
+        f"\n=== {label}: {r['n']} PRs ===",
+        f"  full-suite escalated : {r['full']}/{r['n']} ({100 * r['full'] / n:.0f}%)",
+        f"  narrowed (smart)     : {r['narrowed']}/{r['n']} "
+        f"({100 * r['narrowed'] / n:.0f}%), median selected_paths="
+        f"{r['narrowed_median_paths']:.0f}",
+        "  reason histogram:",
+    ]
+    lines += [
+        f"    {count:3} ({100 * count / n:2.0f}%) {reason}"
+        for reason, count in r["reason_hist"].items()
+    ]
+    if r["shared_module_hist"]:
+        lines.append("  which shared_module triggered SHARED_MODULE:")
+        lines += [
+            f"    {count:3}  {module}"
+            for module, count in r["shared_module_hist"].items()
+        ]
+    sys.stdout.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reproduce the OMN-14342 premise check"
+    )
+    parser.add_argument("--prs-json", type=Path, required=True)
+    parser.add_argument("--adjacency", type=Path, default=_ADJ_DEFAULT)
+    args = parser.parse_args(argv)
+
+    prs = json.loads(args.prs_json.read_text(encoding="utf-8"))
+    _print_report(
+        "WORST CASE (pyproject fail-closed)",
+        replay(prs, args.adjacency, pyproject_escalates=True),
+    )
+    _print_report(
+        "BEST CASE (pyproject metadata-only)",
+        replay(prs, args.adjacency, pyproject_escalates=False),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_selection_shadow.py
+++ b/scripts/ci/test_selection_shadow.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Build a shadow-mode test-selection record for a dev PR (OMN-14342).
+
+Observational only. The full unit suite runs unconditionally on the boundary;
+this compares the counterfactual selector output (forced ``--feature-flag on``)
+against the full-suite junit results to measure what the selector WOULD have
+skipped — its escaped-failure count, selected fraction, and wall-clock saved.
+
+Consumes:
+  * a ``ModelTestSelection`` JSON (the forced-on shadow selection),
+  * the change set (one path per line),
+  * every unit junit-*.xml from the full-suite matrix,
+  * the static adjacency map (for shared-module attribution).
+
+Emits one ``ModelShadowRecord`` JSON line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from scripts.ci.test_selection_loader import ModelAdjacencyMap, load_adjacency_map
+from scripts.ci.test_selection_models import ModelTestSelection
+from scripts.ci.test_selection_shadow_models import ModelShadowRecord
+
+SRC_PREFIX = "src/omnibase_core/"
+# Full-suite predicted marker: "tests/" (or "tests/unit/") selects everything.
+_FULL_MARKERS = frozenset({"tests/", "tests/unit/"})
+
+
+@dataclass(frozen=True)
+class TestCaseResult:
+    """One parsed junit <testcase>."""
+
+    file: str
+    name: str
+    failed: bool
+    time_s: float
+
+
+def _classname_to_path(classname: str) -> str | None:
+    """Best-effort fallback when a <testcase> has no ``file`` attribute.
+
+    pytest reliably emits ``file`` on every testcase, so this is only a guard.
+    A dotted classname like ``tests.unit.models.test_x`` maps back to
+    ``tests/unit/models/test_x.py`` (a trailing ``.ClassName`` is not
+    distinguishable from a module segment, so we accept coarse attribution).
+    """
+    if not classname:
+        return None
+    return classname.replace(".", "/") + ".py"
+
+
+def parse_junit_file(path: Path) -> list[TestCaseResult]:
+    """Parse one junit XML file into testcase results.
+
+    Tolerant of both ``<testsuites>`` and bare ``<testsuite>`` roots. A malformed
+    file yields an empty list rather than raising — a missing shard must not sink
+    the whole shadow record.
+    """
+    try:
+        root = ET.parse(path).getroot()  # noqa: S314 (trusted CI-produced junit)
+    except ET.ParseError:
+        return []
+    results: list[TestCaseResult] = []
+    for tc in root.iter("testcase"):
+        file = tc.get("file") or _classname_to_path(tc.get("classname", "")) or ""
+        # A testcase is a real failure on <failure> or <error>, not <skipped>.
+        failed = tc.find("failure") is not None or tc.find("error") is not None
+        try:
+            time_s = float(tc.get("time", "0") or 0)
+        except ValueError:
+            time_s = 0.0
+        results.append(
+            TestCaseResult(
+                file=file, name=tc.get("name", ""), failed=failed, time_s=time_s
+            )
+        )
+    return results
+
+
+def collect_unit_junit(junit_dir: Path) -> tuple[list[TestCaseResult], int]:
+    """Collect unit-suite testcases under ``junit_dir``.
+
+    Recurses (artifact downloads nest each shard in its own folder). Integration
+    shards (``junit-int-*.xml``) are excluded — the selector never narrows the
+    always-run integration job, so it is not part of the counterfactual.
+    """
+    results: list[TestCaseResult] = []
+    files_parsed = 0
+    for xml in sorted(junit_dir.rglob("junit-*.xml")):
+        if xml.name.startswith("junit-int-"):
+            continue
+        parsed = parse_junit_file(xml)
+        results.extend(parsed)
+        files_parsed += 1
+    return results, files_parsed
+
+
+def _is_selected(file_path: str, predicted_paths: list[str], is_full: bool) -> bool:
+    if is_full:
+        return True
+    norm = file_path.lstrip("./")
+    for pred in predicted_paths:
+        if pred in _FULL_MARKERS:
+            return True
+        if norm.startswith(pred):
+            return True
+    return False
+
+
+def changed_modules_for(
+    changed_files: list[str], config: ModelAdjacencyMap
+) -> list[str]:
+    """Top-level ``src/omnibase_core/<module>`` dirs touched by the change set."""
+    mods = {
+        path[len(SRC_PREFIX) :].split("/", 1)[0]
+        for path in changed_files
+        if path.startswith(SRC_PREFIX)
+    } & set(config.adjacency.keys())
+    return sorted(mods)
+
+
+def build_record(
+    *,
+    selection: ModelTestSelection,
+    changed_files: list[str],
+    config: ModelAdjacencyMap,
+    junit_results: list[TestCaseResult],
+    junit_files_parsed: int,
+    repo: str,
+    pr_number: int | None,
+    head_sha: str,
+    base_sha: str | None,
+    event: str,
+    ref_name: str,
+) -> ModelShadowRecord:
+    is_full = selection.is_full_suite
+    predicted = list(selection.selected_paths)
+
+    changed_mods = changed_modules_for(changed_files, config)
+    triggering = sorted(set(changed_mods) & set(config.shared_modules))
+
+    all_files = {r.file for r in junit_results if r.file}
+    selected_files = {f for f in all_files if _is_selected(f, predicted, is_full)}
+    total_test_files = len(all_files)
+    selected_test_files = len(selected_files)
+    selected_fraction = (
+        selected_test_files / total_test_files if total_test_files else 0.0
+    )
+
+    failures = [r for r in junit_results if r.failed]
+    escaped = sorted(
+        {r.file for r in failures if not _is_selected(r.file, predicted, is_full)}
+    )
+
+    wall_total = sum(r.time_s for r in junit_results)
+    wall_selected = sum(
+        r.time_s for r in junit_results if _is_selected(r.file, predicted, is_full)
+    )
+    wall_saved = 0.0 if is_full else max(0.0, wall_total - wall_selected)
+
+    return ModelShadowRecord(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        base_sha=base_sha,
+        event=event,
+        ref_name=ref_name,
+        created_at=datetime.now(UTC).isoformat(),
+        changed_file_count=len(changed_files),
+        changed_modules=changed_mods,
+        shadow_is_full_suite=is_full,
+        shadow_reason=(
+            selection.full_suite_reason.value
+            if selection.full_suite_reason is not None
+            else None
+        ),
+        triggering_shared_modules=triggering,
+        predicted_paths=predicted,
+        predicted_split_count=selection.split_count,
+        total_test_files=total_test_files,
+        selected_test_files=selected_test_files,
+        selected_fraction=selected_fraction,
+        full_suite_test_count=len(junit_results),
+        full_suite_failure_count=len(failures),
+        escaped_failures=escaped,
+        escaped_failure_count=len(escaped),
+        wall_clock_total_s=wall_total,
+        wall_clock_selected_s=wall_selected,
+        wall_clock_saved_s=wall_saved,
+        junit_files_parsed=junit_files_parsed,
+    )
+
+
+def _read_lines(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a shadow-mode test-selection record for a dev PR"
+    )
+    parser.add_argument("--selection", type=Path, required=True)
+    parser.add_argument("--changed-files-from", type=Path, required=True)
+    parser.add_argument("--junit-dir", type=Path, required=True)
+    parser.add_argument(
+        "--adjacency",
+        type=Path,
+        default=Path(__file__).parent / "test_selection_adjacency.yaml",
+    )
+    parser.add_argument("--out", type=Path, default=Path("shadow_record.json"))
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr-number", default=os.environ.get("SHADOW_PR_NUMBER", ""))
+    parser.add_argument("--head-sha", default=os.environ.get("SHADOW_HEAD_SHA", ""))
+    parser.add_argument("--base-sha", default=os.environ.get("SHADOW_BASE_SHA", ""))
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--ref-name", default=os.environ.get("GITHUB_REF_NAME", ""))
+    args = parser.parse_args(argv)
+
+    selection = ModelTestSelection.model_validate_json(
+        args.selection.read_text(encoding="utf-8")
+    )
+    changed_files = _read_lines(args.changed_files_from)
+    config = load_adjacency_map(args.adjacency)
+    junit_results, files_parsed = collect_unit_junit(args.junit_dir)
+
+    pr_number = int(args.pr_number) if str(args.pr_number).strip().isdigit() else None
+
+    record = build_record(
+        selection=selection,
+        changed_files=changed_files,
+        config=config,
+        junit_results=junit_results,
+        junit_files_parsed=files_parsed,
+        repo=args.repo,
+        pr_number=pr_number,
+        head_sha=args.head_sha,
+        base_sha=args.base_sha or None,
+        event=args.event,
+        ref_name=args.ref_name,
+    )
+    line = record.model_dump_json()
+    args.out.write_text(line + "\n", encoding="utf-8")
+    sys.stdout.write(line + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_selection_shadow_models.py
+++ b/scripts/ci/test_selection_shadow_models.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Frozen output contract for shadow-mode test-selection measurement (OMN-14342).
+
+A ``ModelShadowRecord`` is the per-PR counterfactual: what the change-aware
+selector WOULD have picked (forced on) versus what the full suite actually ran.
+It is observational only — the full suite still runs on the boundary; this record
+never changes what executes. One record per dev PR is appended to the durable
+``ci-shadow-metrics`` NDJSON log so the selector's real-world miss-rate can be
+measured before it is trusted as the dev default.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+SHADOW_RECORD_SCHEMA_VERSION = 1
+
+
+class ModelShadowRecord(BaseModel):
+    """One dev-PR shadow measurement, serialized as a single NDJSON line."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    schema_version: int = Field(default=SHADOW_RECORD_SCHEMA_VERSION, ge=1)
+
+    # Provenance
+    repo: str
+    pr_number: int | None = None
+    head_sha: str
+    base_sha: str | None = None
+    event: str
+    ref_name: str
+    created_at: str  # ISO-8601 UTC, when the record was built
+
+    # Change set
+    changed_file_count: int = Field(..., ge=0)
+    changed_modules: list[str] = Field(default_factory=list)
+
+    # What the selector (forced on) would have done
+    shadow_is_full_suite: bool
+    shadow_reason: str | None = None  # EnumFullSuiteReason value, or None when narrowed
+    triggering_shared_modules: list[str] = Field(default_factory=list)
+    predicted_paths: list[str] = Field(default_factory=list)
+    predicted_split_count: int = Field(..., ge=1, le=40)
+
+    # Full-suite actuals (unit job only — integration always runs, never narrowed)
+    total_test_files: int = Field(..., ge=0)
+    selected_test_files: int = Field(..., ge=0)
+    selected_fraction: float = Field(..., ge=0.0, le=1.0)
+    full_suite_test_count: int = Field(..., ge=0)
+    full_suite_failure_count: int = Field(..., ge=0)
+
+    # THE safety metric: full-suite failures whose test file the shadow set would
+    # have skipped. Must be 0 for the narrowed selection to be trustworthy.
+    escaped_failures: list[str] = Field(default_factory=list)
+    escaped_failure_count: int = Field(..., ge=0)
+
+    # Wall-clock accounting (seconds), summed from junit per-test timings
+    wall_clock_total_s: float = Field(..., ge=0.0)
+    wall_clock_selected_s: float = Field(..., ge=0.0)
+    wall_clock_saved_s: float = Field(..., ge=0.0)
+
+    junit_files_parsed: int = Field(..., ge=0)
+
+    @model_validator(mode="after")
+    def _check_internal_consistency(self) -> Self:
+        if self.selected_test_files > self.total_test_files:
+            raise ValueError(
+                f"selected_test_files ({self.selected_test_files}) exceeds "
+                f"total_test_files ({self.total_test_files})"
+            )
+        if self.escaped_failure_count != len(self.escaped_failures):
+            raise ValueError(
+                f"escaped_failure_count ({self.escaped_failure_count}) != "
+                f"len(escaped_failures) ({len(self.escaped_failures)})"
+            )
+        if self.escaped_failure_count > self.full_suite_failure_count:
+            raise ValueError(
+                f"escaped_failure_count ({self.escaped_failure_count}) exceeds "
+                f"full_suite_failure_count ({self.full_suite_failure_count})"
+            )
+        # When the shadow selection was itself a full suite, nothing is skipped:
+        # no failure can escape and no wall-clock is saved.
+        if self.shadow_is_full_suite:
+            if self.escaped_failure_count != 0:
+                raise ValueError(
+                    "escaped_failure_count must be 0 when shadow_is_full_suite=True"
+                )
+            if self.wall_clock_saved_s != 0.0:
+                raise ValueError(
+                    "wall_clock_saved_s must be 0 when shadow_is_full_suite=True"
+                )
+        return self

--- a/tests/unit/scripts/ci/test_shadow_metrics_append.py
+++ b/tests/unit/scripts/ci/test_shadow_metrics_append.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the shadow-metrics NDJSON dedup-append (OMN-14342)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.shadow_metrics_append import append_records
+
+pytestmark = pytest.mark.unit
+
+
+def _write_record(dirpath: Path, name: str, **fields: object) -> None:
+    base = {"repo": "OmniNode-ai/omnibase_core", "head_sha": "sha1", "pr_number": 1}
+    base.update(fields)
+    (dirpath / name).write_text(json.dumps(base), encoding="utf-8")
+
+
+def test_appends_new_record(tmp_path: Path) -> None:
+    records = tmp_path / "records"
+    records.mkdir()
+    _write_record(records, "shadow_record.json", head_sha="abc", pr_number=7)
+    ndjson = tmp_path / "shadow_metrics.ndjson"
+    assert append_records(records, ndjson) == 1
+    lines = ndjson.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["head_sha"] == "abc"
+
+
+def test_dedup_is_idempotent(tmp_path: Path) -> None:
+    records = tmp_path / "records"
+    records.mkdir()
+    _write_record(records, "shadow_record.json", head_sha="abc", pr_number=7)
+    ndjson = tmp_path / "shadow_metrics.ndjson"
+    assert append_records(records, ndjson) == 1
+    # Second harvest of the same run appends nothing.
+    assert append_records(records, ndjson) == 0
+    assert len(ndjson.read_text(encoding="utf-8").strip().splitlines()) == 1
+
+
+def test_distinct_head_shas_both_appended(tmp_path: Path) -> None:
+    records = tmp_path / "records"
+    (records / "a").mkdir(parents=True)
+    (records / "b").mkdir(parents=True)
+    _write_record(records / "a", "shadow_record.json", head_sha="aaa", pr_number=1)
+    _write_record(records / "b", "shadow_record.json", head_sha="bbb", pr_number=2)
+    ndjson = tmp_path / "shadow_metrics.ndjson"
+    assert append_records(records, ndjson) == 2
+
+
+def test_malformed_record_skipped(tmp_path: Path) -> None:
+    records = tmp_path / "records"
+    records.mkdir()
+    (records / "bad.json").write_text("{not json", encoding="utf-8")
+    _write_record(records, "good.json", head_sha="ok", pr_number=3)
+    ndjson = tmp_path / "shadow_metrics.ndjson"
+    assert append_records(records, ndjson) == 1
+
+
+def test_appended_line_is_canonical(tmp_path: Path) -> None:
+    records = tmp_path / "records"
+    records.mkdir()
+    # keys deliberately out of order in the source file
+    (records / "r.json").write_text(
+        '{"pr_number": 9, "head_sha": "z", "repo": "r", "escaped_failure_count": 0}',
+        encoding="utf-8",
+    )
+    ndjson = tmp_path / "shadow_metrics.ndjson"
+    append_records(records, ndjson)
+    line = ndjson.read_text(encoding="utf-8").strip()
+    # sort_keys=True → keys alphabetical, stable regardless of source order
+    assert line.startswith('{"escaped_failure_count": 0, "head_sha": "z"')

--- a/tests/unit/scripts/ci/test_test_selection_shadow.py
+++ b/tests/unit/scripts/ci/test_test_selection_shadow.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the shadow-mode test-selection record builder (OMN-14342)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.test_selection_loader import load_adjacency_map
+from scripts.ci.test_selection_models import EnumFullSuiteReason, ModelTestSelection
+from scripts.ci.test_selection_shadow import (
+    build_record,
+    collect_unit_junit,
+    main,
+    parse_junit_file,
+)
+from scripts.ci.test_selection_shadow_models import ModelShadowRecord
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+CONFIG = load_adjacency_map(ADJ)
+
+
+def _junit(cases: list[tuple[str, float, bool]]) -> str:
+    """Render a junit XML from (file, time_s, failed) tuples."""
+    rows = []
+    for i, (file, time_s, failed) in enumerate(cases):
+        classname = file.removesuffix(".py").replace("/", ".")
+        body = '<failure message="boom"/>' if failed else ""
+        rows.append(
+            f'<testcase classname="{classname}" name="test_{i}" '
+            f'file="{file}" time="{time_s}">{body}</testcase>'
+        )
+    inner = "".join(rows)
+    return f'<testsuite name="pytest" tests="{len(cases)}">{inner}</testsuite>'
+
+
+def _narrowed_selection() -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/unit/models/"],
+        split_count=1,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=[1],
+    )
+
+
+def _full_selection() -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=40,
+        is_full_suite=True,
+        full_suite_reason=EnumFullSuiteReason.SHARED_MODULE,
+        matrix=list(range(1, 41)),
+    )
+
+
+def _write_junit(
+    dirpath: Path, name: str, cases: list[tuple[str, float, bool]]
+) -> None:
+    (dirpath / name).write_text(_junit(cases), encoding="utf-8")
+
+
+def _build(
+    junit_dir: Path,
+    selection: ModelTestSelection,
+    changed_files: list[str],
+) -> ModelShadowRecord:
+    results, parsed = collect_unit_junit(junit_dir)
+    return build_record(
+        selection=selection,
+        changed_files=changed_files,
+        config=CONFIG,
+        junit_results=results,
+        junit_files_parsed=parsed,
+        repo="OmniNode-ai/omnibase_core",
+        pr_number=1234,
+        head_sha="deadbeef",
+        base_sha="cafef00d",
+        event="pull_request",
+        ref_name="jonah/feature",
+    )
+
+
+def test_escaped_failure_detected_outside_predicted_set(tmp_path: Path) -> None:
+    # models test passes; a cli test FAILS but is NOT under the predicted
+    # tests/unit/models/ set -> that failure "escapes" the narrowed selection.
+    _write_junit(
+        tmp_path,
+        "junit-1.xml",
+        [
+            ("tests/unit/models/test_a.py", 2.0, False),
+            ("tests/unit/cli/test_b.py", 0.5, True),
+        ],
+    )
+    rec = _build(tmp_path, _narrowed_selection(), ["src/omnibase_core/models/x.py"])
+    assert rec.full_suite_failure_count == 1
+    assert rec.escaped_failure_count == 1
+    assert rec.escaped_failures == ["tests/unit/cli/test_b.py"]
+    assert rec.shadow_is_full_suite is False
+
+
+def test_failure_inside_predicted_set_does_not_escape(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path,
+        "junit-1.xml",
+        [
+            ("tests/unit/models/test_a.py", 2.0, True),
+            ("tests/unit/cli/test_b.py", 0.5, False),
+        ],
+    )
+    rec = _build(tmp_path, _narrowed_selection(), ["src/omnibase_core/models/x.py"])
+    assert rec.full_suite_failure_count == 1
+    assert rec.escaped_failure_count == 0
+    # 1 of 2 test files selected; cli test (0.5s) is skipped by the shadow set.
+    assert rec.total_test_files == 2
+    assert rec.selected_test_files == 1
+    assert rec.selected_fraction == 0.5
+    assert rec.wall_clock_total_s == 2.5
+    assert rec.wall_clock_selected_s == 2.0
+    assert rec.wall_clock_saved_s == 0.5
+
+
+def test_full_suite_shadow_saves_nothing_and_escapes_nothing(tmp_path: Path) -> None:
+    _write_junit(
+        tmp_path,
+        "junit-1.xml",
+        [
+            ("tests/unit/models/test_a.py", 2.0, True),
+            ("tests/unit/cli/test_b.py", 0.5, True),
+        ],
+    )
+    rec = _build(tmp_path, _full_selection(), ["src/omnibase_core/models/x.py"])
+    assert rec.shadow_is_full_suite is True
+    assert rec.shadow_reason == "shared_module"
+    assert rec.escaped_failure_count == 0
+    assert rec.wall_clock_saved_s == 0.0
+    assert rec.selected_fraction == 1.0
+    assert rec.triggering_shared_modules == ["models"]
+
+
+def test_integration_junit_is_excluded(tmp_path: Path) -> None:
+    _write_junit(tmp_path, "junit-1.xml", [("tests/unit/models/test_a.py", 1.0, False)])
+    _write_junit(
+        tmp_path, "junit-int-1.xml", [("tests/integration/test_z.py", 9.0, True)]
+    )
+    results, parsed = collect_unit_junit(tmp_path)
+    assert parsed == 1  # only the unit shard
+    assert all("integration" not in r.file for r in results)
+
+
+def test_collect_recurses_nested_artifact_dirs(tmp_path: Path) -> None:
+    # Artifact downloads nest each shard in its own directory.
+    (tmp_path / "test-results-1").mkdir()
+    (tmp_path / "test-results-2").mkdir()
+    _write_junit(
+        tmp_path / "test-results-1",
+        "junit-1.xml",
+        [("tests/unit/models/test_a.py", 1.0, False)],
+    )
+    _write_junit(
+        tmp_path / "test-results-2",
+        "junit-2.xml",
+        [("tests/unit/cli/test_b.py", 1.0, True)],
+    )
+    results, parsed = collect_unit_junit(tmp_path)
+    assert parsed == 2
+    assert len(results) == 2
+
+
+def test_parse_junit_tolerates_malformed(tmp_path: Path) -> None:
+    bad = tmp_path / "junit-1.xml"
+    bad.write_text("<not-closed", encoding="utf-8")
+    assert parse_junit_file(bad) == []
+
+
+def test_missing_file_attr_falls_back_to_classname(tmp_path: Path) -> None:
+    (tmp_path / "junit-1.xml").write_text(
+        '<testsuite tests="1"><testcase classname="tests.unit.cli.test_b" '
+        'name="test_x" time="0.1"/></testsuite>',
+        encoding="utf-8",
+    )
+    results = parse_junit_file(tmp_path / "junit-1.xml")
+    assert results[0].file == "tests/unit/cli/test_b.py"
+
+
+def test_empty_junit_dir_yields_zero_fraction_no_crash(tmp_path: Path) -> None:
+    rec = _build(tmp_path, _narrowed_selection(), ["src/omnibase_core/models/x.py"])
+    assert rec.total_test_files == 0
+    assert rec.selected_fraction == 0.0
+    assert rec.junit_files_parsed == 0
+
+
+def test_model_rejects_escaped_when_full_suite() -> None:
+    with pytest.raises(ValueError, match="escaped_failure_count must be 0"):
+        ModelShadowRecord(
+            repo="r",
+            head_sha="h",
+            event="pull_request",
+            ref_name="b",
+            created_at="2026-07-10T00:00:00+00:00",
+            changed_file_count=1,
+            shadow_is_full_suite=True,
+            predicted_split_count=40,
+            total_test_files=1,
+            selected_test_files=1,
+            selected_fraction=1.0,
+            full_suite_test_count=1,
+            full_suite_failure_count=1,
+            escaped_failures=["tests/unit/cli/test_b.py"],
+            escaped_failure_count=1,
+            wall_clock_total_s=1.0,
+            wall_clock_selected_s=1.0,
+            wall_clock_saved_s=0.0,
+            junit_files_parsed=1,
+        )
+
+
+def test_cli_main_writes_record(tmp_path: Path) -> None:
+    _write_junit(tmp_path, "junit-1.xml", [("tests/unit/models/test_a.py", 1.0, False)])
+    selection_path = tmp_path / "selection.json"
+    selection_path.write_text(_narrowed_selection().model_dump_json(), encoding="utf-8")
+    changed = tmp_path / "changed.txt"
+    changed.write_text("src/omnibase_core/models/x.py\n", encoding="utf-8")
+    out = tmp_path / "shadow_record.json"
+    rc = main(
+        [
+            "--selection",
+            str(selection_path),
+            "--changed-files-from",
+            str(changed),
+            "--junit-dir",
+            str(tmp_path),
+            "--adjacency",
+            str(ADJ),
+            "--out",
+            str(out),
+            "--repo",
+            "OmniNode-ai/omnibase_core",
+            "--pr-number",
+            "42",
+            "--head-sha",
+            "abc",
+        ]
+    )
+    assert rc == 0
+    rec = ModelShadowRecord.model_validate_json(out.read_text(encoding="utf-8"))
+    assert rec.pr_number == 42
+    assert rec.repo == "OmniNode-ai/omnibase_core"


### PR DESCRIPTION
## OMN-14342 — Shadow-mode test-selection instrumentation (child of OMN-13969)

Observational-only instrumentation for the change-aware test selector
(`scripts/ci/detect_test_paths.py`). On every dev PR it records the **counterfactual**
(what the selector WOULD pick, forced on) alongside the full-suite results that
actually run, so the selector's real-world **miss-rate** can be measured before it
is trusted as the dev default. **Nothing about what runs changes** — the full suite
still runs on the boundary; `ENABLE_SMART_TESTS` is untouched.

### Why (premise-check — already validated)
Replaying the live selector over 120 merged omnibase_core dev PRs (forced `--feature-flag on`,
reproducible via `scripts/ci/shadow_premise_replay.py`):
- **67–72% of dev PRs escalate to the full suite** (only 28% narrow).
- **`shared_module` is the dominant escalation reason (44–63% of all PRs).**
- **`models` is the single dominant trigger — ~29% of all PRs, ~2.2× the next module.**

Demoting `models` out of `shared_modules` would nearly triple the narrowed fraction
(28% → ~57%) — but that demotion needs shadow data proving models-changes don't surface
broad regressions. **This PR produces that data**, tying the OMN-3210 seam program to the CI-time win.

### What
1. **Capture** — `detect-changes` gains a `Shadow selection (forced on)` step (runs the
   selector with `--feature-flag on` regardless of `ENABLE_SMART_TESTS`) + a `shadow-inputs` artifact.
2. **Compare** — new **observational, non-blocking** `shadow-compare` job (`continue-on-error: true`,
   gated to runs where the actual suite was full) aggregates the full-suite junit vs the shadow
   prediction into a `ModelShadowRecord`:
   - `escaped_failure_count` — full-suite failures the shadow set would have skipped (**the safety metric**).
   - `selected_fraction`, `wall_clock_saved_s`, `triggering_shared_modules`, escalation reason.
3. **Durable store (Option A, operator-approved)** — `shadow-metrics-harvest.yml` runs in the
   trusted base-repo context after CI, downloads the `shadow-record` artifact, and appends dedup'd
   records to an append-only NDJSON on the dedicated `ci-shadow-metrics` orphan branch. No CI→LAN
   coupling (works on GitHub-hosted PR runners), no infra/secrets, replayable log per the
   deterministic-truth doctrine. Promotable to a Postgres projection later.

### Files
- `scripts/ci/test_selection_shadow_models.py` — frozen `ModelShadowRecord`.
- `scripts/ci/test_selection_shadow.py` — junit aggregation + record builder + CLI.
- `scripts/ci/shadow_metrics_append.py` — dedup NDJSON appender (harvester stage 2).
- `scripts/ci/shadow_premise_replay.py` — reproducible premise-check.
- `tests/unit/scripts/ci/test_test_selection_shadow.py`, `test_shadow_metrics_append.py` — 15 unit tests.
- `.github/workflows/ci.yml` — shadow-selection step + shadow-compare job.
- `.github/workflows/shadow-metrics-harvest.yml` — trusted harvester → orphan-branch NDJSON.

### dod_evidence
- `uv run pytest tests/unit/scripts/ci/` → **133 passed** (15 new).
- `uv run ruff format/check` on all new files → clean; `uv run mypy -m scripts.ci.*` → Success (0 issues).
- `uv run pre-commit run --files <changed>` → exit 0 (SPDX, ruff, mypy, all gates pass).
- End-to-end smoke: real selector (cli-only change → `tests/unit/cli/`) fed to the builder against a
  synthetic junit with a `models` failure → `escaped_failure_count=1`, `wall_clock_saved_s=3.0`,
  `selected_fraction=0.5` — proves the escaped-failure safety metric fires on a real miss.
- Both workflow YAMLs parse; `shadow-compare` is `continue-on-error` and never changes what runs.

### Notes
- **No self-authored OCC companion** — comes from an independent verifier per the no-self-evidence rule.
- Canary on `omnibase_core` first; fan-out to `omnibase_infra` is a fast-follow (canary-before-fanout).
- `ci-shadow-metrics` is a metrics-only orphan branch (not dev/main); harvester pushes there, not to protected branches.


---

Evidence-Source: OCC#3859
Evidence-Commit: 28938d5e207dfb9456d20ebc37c0dada8a70e56f
Evidence-Ticket: OMN-14342