### PR TITLE
feat(OMN-14353): compute-golden equivalence oracle + non-vacuous canary

### DIFF
--- a/scripts/ci/compute_golden.py
+++ b/scripts/ci/compute_golden.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Compute-behavior golden recorder + equivalence comparator (OMN-14353 canary).
+
+A minimal, general recorder for a PURE COMPUTE node: it serializes a node's
+``input -> output`` as a golden and replays it, comparing the fresh output to the
+recorded one under a declared volatile-field mask. This is the equivalence-oracle
+primitive a self-verifying codegen factory (tier-4b) must generalize.
+
+NOTE — this is deliberately NOT ``omnibase_core.runtime.golden_chain.record_fixture``.
+That recorder freezes an LLM provider's *response bytes* over an HTTP transport
+seam (pinned to provider/model/endpoint/routing_contract/request_hash); it does
+not fit a pure COMPUTE node whose golden is ``typed input -> typed output`` with
+no provider/model/endpoint at all. See the OMN-14353 report for the full rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol
+
+
+class _JsonDumpable(Protocol):
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+
+
+def _canonical(payload: Any) -> str:
+    """Deterministic JSON string for structural comparison (sorted keys)."""
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False)
+
+
+def apply_mask(payload: dict[str, Any], volatile_mask: list[str]) -> dict[str, Any]:
+    """Return a deep copy of ``payload`` with each dotted-path volatile field removed.
+
+    Masking excludes non-deterministic fields (timestamps, uuids, ...) from the
+    equivalence compare. A path segment may address a dict key at any depth;
+    list elements are descended into transparently.
+    """
+    masked: dict[str, Any] = json.loads(json.dumps(payload))  # deep copy via round-trip
+    for dotted in volatile_mask:
+        _remove_path(masked, dotted.split("."))
+    return masked
+
+
+def _remove_path(node: Any, segments: list[str]) -> None:
+    if not segments:
+        return
+    head, rest = segments[0], segments[1:]
+    if isinstance(node, list):
+        for item in node:
+            _remove_path(item, segments)
+        return
+    if not isinstance(node, dict):
+        return
+    if not rest:
+        node.pop(head, None)
+        return
+    if head in node:
+        _remove_path(node[head], rest)
+
+
+def diff_paths(expected: Any, actual: Any, _prefix: str = "") -> list[str]:
+    """Return dotted paths where ``expected`` and ``actual`` structurally differ."""
+    diffs: list[str] = []
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        for key in sorted(set(expected) | set(actual)):
+            child = f"{_prefix}.{key}" if _prefix else key
+            if key not in expected:
+                diffs.append(f"{child} (added)")
+            elif key not in actual:
+                diffs.append(f"{child} (removed)")
+            else:
+                diffs.extend(diff_paths(expected[key], actual[key], child))
+    elif isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            diffs.append(f"{_prefix} (len {len(expected)}->{len(actual)})")
+        for i, (e, a) in enumerate(zip(expected, actual, strict=False)):
+            diffs.extend(diff_paths(e, a, f"{_prefix}[{i}]"))
+    elif expected != actual:
+        diffs.append(f"{_prefix}: {expected!r} != {actual!r}")
+    return diffs
+
+
+def record_golden(
+    *,
+    output: _JsonDumpable,
+    input_model: _JsonDumpable,
+    volatile_mask: list[str] | None = None,
+) -> dict[str, Any]:
+    """Serialize a compute node's input->output as a golden record."""
+    return {
+        "golden_version": "compute_golden.v1",
+        "input_type": type(input_model).__name__,
+        "output_type": type(output).__name__,
+        "input": input_model.model_dump(mode="json"),
+        "output": output.model_dump(mode="json"),
+        "volatile_mask": list(volatile_mask or []),
+    }
+
+
+def compare_output(golden: dict[str, Any], fresh_output: _JsonDumpable) -> list[str]:
+    """Compare a fresh output against a golden under the golden's volatile mask.
+
+    Returns the list of differing paths — EMPTY means equivalent.
+    """
+    mask = list(golden.get("volatile_mask", []))
+    expected = apply_mask(golden["output"], mask)
+    actual = apply_mask(fresh_output.model_dump(mode="json"), mask)
+    return diff_paths(expected, actual)
+
+
+def outputs_equivalent(
+    a: _JsonDumpable, b: _JsonDumpable, volatile_mask: list[str]
+) -> bool:
+    """True iff two outputs are byte-equal after masking + canonical normalization."""
+    ma = apply_mask(a.model_dump(mode="json"), volatile_mask)
+    mb = apply_mask(b.model_dump(mode="json"), volatile_mask)
+    return _canonical(ma) == _canonical(mb)
+
+
+__all__ = [
+    "apply_mask",
+    "compare_output",
+    "diff_paths",
+    "outputs_equivalent",
+    "record_golden",
+]

--- a/scripts/ci/compute_golden.py
+++ b/scripts/ci/compute_golden.py
@@ -21,7 +21,10 @@ from typing import Any, Protocol
 
 
 class _JsonDumpable(Protocol):
-    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]:
+        # Protocol stub body: never executed (structural typing only).
+        # `pass` (not `...`) avoids CodeQL py/ineffectual-statement (alert #2591).
+        pass
 
 
 def _canonical(payload: Any) -> str:

--- a/tests/unit/canary/__init__.py
+++ b/tests/unit/canary/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/canary/test_routing_authority_golden_canary.py
+++ b/tests/unit/canary/test_routing_authority_golden_canary.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Equivalence-oracle canary for a pure T1 COMPUTE node (OMN-14353).
+
+Proves the compute-golden oracle is NON-VACUOUS on a real node
+(``NodeRoutingAuthorityCheckCompute``): a golden recorded from its legacy
+input->output catches a behavior regression. This is the de-risking proof for
+the self-verifying codegen factory — the piece that makes "self-verifying" mean
+"behavior is pinned", not "a file exists".
+
+The canary is hermetic: it records goldens in-process, asserts replay
+equivalence + determinism, and proves the comparator discriminates by PERTURBING
+a recorded output field (never by editing handler source). The live
+source-mutation proof (off-by-one ``>``/``>=`` in the residue ratchet, caught by
+the ``residue_at_baseline`` golden) is documented in the OMN-14353 report.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.nodes.node_routing_authority_check_compute.handler import (
+    ModelResidueEntry,
+    ModelRoutingAuthorityCheckInput,
+    ModelRoutingContractEntry,
+    NodeRoutingAuthorityCheckCompute,
+)
+from scripts.ci.compute_golden import (
+    compare_output,
+    outputs_equivalent,
+    record_golden,
+)
+
+pytestmark = pytest.mark.unit
+
+_GOOD_CONTRACT = """\
+name: node_generation_consumer
+node_type: compute
+model_routing:
+  provider: "google"
+  served_model_id: "gemini-1.5-pro"
+  endpoint_ref: "gemini_pro"
+  routing_source: "bifrost_delegation.yaml"
+"""
+_MISSING_ROUTING = "name: node_bad\nnode_type: compute\n"
+_GOOD_BIFROST = """\
+backends:
+  - backend_id: "gemini_pro"
+    tier: "cloud"
+    endpoint_url_env: "GEMINI_PRO_URL"
+    endpoint_url: null
+"""
+_CLI_BIFROST = """\
+backends:
+  - backend_id: "cli-claude"
+    tier: "cli_agents"
+    endpoint_url: "cli://claude"
+"""
+_CLEAN_SOURCE = "def handle(p):\n    return p\n"
+_DIRTY_SOURCE = 'import os\nED = os.getenv("SERVICE_ENDPOINT")\n'
+# Two endpoint env reads; neither matches the api-key hints — so a residue
+# baseline of 2 is exactly at the ratchet edge (the off-by-one canary input).
+_RESIDUE_SRC = (
+    'import os\nA = os.getenv("SERVICE_ENDPOINT")\nB = os.getenv("PROVIDER_HOST")\n'
+)
+
+
+def _clean_input() -> ModelRoutingAuthorityCheckInput:
+    return ModelRoutingAuthorityCheckInput(
+        demo_path_contracts=(ModelRoutingContractEntry(contract_rel="c.yaml"),),
+        contract_contents={"c.yaml": _GOOD_CONTRACT},
+        bifrost_config_rel="bifrost.yaml",
+        bifrost_config_content=_GOOD_BIFROST,
+        demo_path_sources=("clean.py",),
+        source_contents={"clean.py": _CLEAN_SOURCE},
+        residue_entries=(),
+        residue_contents={},
+    )
+
+
+def _violations_input() -> ModelRoutingAuthorityCheckInput:
+    return ModelRoutingAuthorityCheckInput(
+        demo_path_contracts=(ModelRoutingContractEntry(contract_rel="bad.yaml"),),
+        contract_contents={"bad.yaml": _MISSING_ROUTING},
+        bifrost_config_rel="bifrost.yaml",
+        bifrost_config_content=_CLI_BIFROST,
+        demo_path_sources=("dirty.py",),
+        source_contents={"dirty.py": _DIRTY_SOURCE},
+        residue_entries=(),
+        residue_contents={},
+    )
+
+
+def _residue_at_baseline_input() -> ModelRoutingAuthorityCheckInput:
+    return ModelRoutingAuthorityCheckInput(
+        demo_path_contracts=(ModelRoutingContractEntry(contract_rel="c.yaml"),),
+        contract_contents={"c.yaml": _GOOD_CONTRACT},
+        bifrost_config_rel="bifrost.yaml",
+        bifrost_config_content=_GOOD_BIFROST,
+        demo_path_sources=("clean.py",),
+        source_contents={"clean.py": _CLEAN_SOURCE},
+        residue_entries=(
+            ModelResidueEntry(
+                file_rel="legacy.py",
+                baseline_count=2,
+                debt_ticket="OMN-0000",
+                description="known env-authority debt",
+            ),
+        ),
+        residue_contents={"legacy.py": _RESIDUE_SRC},
+    )
+
+
+_INPUTS = {
+    "clean": _clean_input,
+    "violations": _violations_input,
+    "residue_at_baseline": _residue_at_baseline_input,
+}
+
+
+@pytest.fixture
+def handler() -> NodeRoutingAuthorityCheckCompute:
+    return NodeRoutingAuthorityCheckCompute()
+
+
+@pytest.mark.parametrize("name", list(_INPUTS))
+def test_handler_is_deterministic(
+    handler: NodeRoutingAuthorityCheckCompute, name: str
+) -> None:
+    """Legacy handler is deterministic — a prerequisite for a stable golden."""
+    inp = _INPUTS[name]()
+    out1 = handler.check(inp)
+    out2 = handler.check(inp)
+    assert outputs_equivalent(out1, out2, volatile_mask=[])
+
+
+@pytest.mark.parametrize("name", list(_INPUTS))
+def test_record_then_replay_is_equivalent(
+    handler: NodeRoutingAuthorityCheckCompute, name: str
+) -> None:
+    """A recorded golden replays clean against the (unchanged) handler."""
+    inp = _INPUTS[name]()
+    golden = record_golden(input_model=inp, output=handler.check(inp), volatile_mask=[])
+    # Replay from the SERIALIZED input proves the golden is self-contained.
+    replayed_inp = ModelRoutingAuthorityCheckInput.model_validate(golden["input"])
+    assert compare_output(golden, handler.check(replayed_inp)) == []
+
+
+def test_comparator_discriminates_a_regression(
+    handler: NodeRoutingAuthorityCheckCompute,
+) -> None:
+    """THE oracle proof: a behavior change in the output is caught by the comparator.
+
+    Hermetic stand-in for the live source-mutation (off-by-one residue ratchet):
+    perturb the recorded verdict and confirm the comparator flags the exact path,
+    proving it is not vacuously empty.
+    """
+    inp = _residue_at_baseline_input()
+    golden = record_golden(input_model=inp, output=handler.check(inp), volatile_mask=[])
+    assert golden["output"]["residue_ok"] is True  # baseline pins clean
+    # Simulate the regressed verdict the off-by-one mutation produces.
+    golden["output"]["residue_ok"] = False
+    golden["output"]["passed"] = False
+    diffs = compare_output(golden, handler.check(inp))
+    assert diffs, (
+        "comparator MUST catch the regressed verdict (oracle is vacuous otherwise)"
+    )
+    assert any("residue_ok" in d for d in diffs)
+    assert any("passed" in d for d in diffs)
+
+
+def test_volatile_mask_excludes_declared_fields(
+    handler: NodeRoutingAuthorityCheckCompute,
+) -> None:
+    """A field named in the volatile mask is excluded from the compare."""
+    inp = _clean_input()
+    golden = record_golden(
+        input_model=inp, output=handler.check(inp), volatile_mask=["passed"]
+    )
+    # Corrupt the masked field in the recorded output; the mask must ignore it.
+    golden["output"]["passed"] = not golden["output"]["passed"]
+    assert compare_output(golden, handler.check(inp)) == []


### PR DESCRIPTION
## OMN-14353 — compute-golden equivalence oracle + non-vacuous canary

De-risks the self-verifying codegen factory by proving, on ONE real T1 COMPUTE node, that a golden recorded from legacy `input→output` **actually catches a regression** — the equivalence oracle is non-vacuous. Proves the RECORD + REPLAY + DISCRIMINATION half; the coverage-guided adequacy receipt was split to **#1426 (OMN-14354)** for dedicated verification of the fail-closed waiver; regeneration (tier-4b) is out of scope.

### Node
`NodeRoutingAuthorityCheckCompute.check(ModelRoutingAuthorityCheckInput) -> ModelRoutingAuthorityCheckOutput`.

### What lands here
- `scripts/ci/compute_golden.py` — the pure-COMPUTE typed `input→output` golden recorder + masked comparator (canonical-normalize + dotted-path volatile mask + path-level diff). **Complementary to** `omnibase_core.runtime.golden_chain.record_fixture` (LLM-delegation-specific; freezes model bytes over an httpx seam) — documented in-module.
- `tests/unit/canary/test_routing_authority_golden_canary.py` — hermetic canary: records goldens, asserts determinism + replay-equivalence, and proves the comparator **discriminates** via an output perturbation (never edits handler source).

### dod_evidence
- `uv run pytest tests/unit/canary/test_routing_authority_golden_canary.py` → 8 passed. ruff + mypy clean (incl. the `no-any-return` fix at compute_golden.py); pre-commit exit 0.
- Live source-mutation proof (off-by-one `>`→`>=` residue ratchet → `residue_at_baseline` golden RED, others GREEN, revert green) was demonstrated in the OMN-14353 report.

### Notes
- Rebased onto latest dev; adequacy receipt moved to #1426. No self-authored OCC companion (independent verifier per no-self-evidence rule).

---

Evidence-Source: OCC#3877
Evidence-Commit: 8075404e7bdb7bbd77d41b4d5977d6743594a599
Evidence-Ticket: OMN-14353