### PR TITLE
feat(OMN-14354): coverage-guided adequacy receipt + fail-closed uncovered-waiver

### DIFF
--- a/scripts/ci/adequacy_receipt.py
+++ b/scripts/ci/adequacy_receipt.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Coverage-guided compute-golden adequacy receipt (OMN-14353 f/u, Task #41).
+
+Turns the proven ``compute_golden`` primitive into the load-bearing feature: a
+recorder whose golden set is chosen to MEASURE UP TO its promise. The canary
+showed a golden set at 49.9% branch coverage let 2 of 3 goldens miss a
+regression, so a happy-path golden must not be enough to mark a node canonical.
+
+This module:
+  * greedily selects, from a candidate input pool, the minimal subset that
+    maximizes the legacy handler's BRANCH coverage (Fable gap #1);
+  * stamps provenance (handler-module sha256, recorded_at, per-input hash) —
+    porting ``golden_chain.record_fixture``'s one genuinely reusable idea;
+  * applies a DENY-BY-DEFAULT scrub over recorded payloads (gap #5);
+  * emits a ``ModelAdequacyReceipt`` (coverage % + target + volatile mask +
+    provenance + explicit uncovered waiver) — the artifact the canonical-shape
+    ratchet-gate flip consumes, so "canonical" means coverage-measured.
+
+Property-based / contract-driven synthesis of NEW inputs for branches live
+traffic never reaches is the remaining half (design reported separately); this
+module consumes whatever candidate pool it is given and proves how much of the
+handler that pool actually exercises.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import io
+import json
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, Self
+
+import coverage
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RECEIPT_VERSION = "adequacy_receipt.v1"
+DEFAULT_COVERAGE_TARGET = 80.0
+
+# Deny-by-default scrub: any dict key whose lowercased name contains one of these
+# substrings has its value redacted before the payload is persisted.
+_DEFAULT_SCRUB_SUBSTRINGS = (
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "api_key",
+    "apikey",
+    "private_key",
+    "credential",
+    "authorization",
+)
+_SCRUBBED = "<scrubbed>"
+
+
+class _JsonDumpable(Protocol):
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+
+
+class ModelUncoveredWaiver(BaseModel):
+    """Explicit, reviewed acknowledgement that coverage fell short of target."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reason: str = Field(..., min_length=1)
+    uncovered_branch_count: int = Field(..., ge=0)
+
+
+class ModelAdequacyReceipt(BaseModel):
+    """The adequacy artifact the canonical-shape gate consumes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    # Schema discriminator tags (NOT semver) — the recorder's on-disk format id.
+    receipt_schema: str = Field(default=RECEIPT_VERSION)
+    node_id: str
+    handler_module: str
+    handler_module_sha256: str
+    recorded_at: str
+    recorder_schema: str = Field(default=RECEIPT_VERSION)
+
+    candidate_count: int = Field(..., ge=0)
+    selected_count: int = Field(..., ge=0)
+    selected_input_hashes: list[str] = Field(default_factory=list)
+
+    # coverage.py's total percent with branch=True: statements + branches
+    # (branch-inclusive), scoped to the handler module only.
+    branch_coverage_pct: float = Field(..., ge=0.0, le=100.0)
+    coverage_target: float = Field(default=DEFAULT_COVERAGE_TARGET, ge=0.0, le=100.0)
+    meets_target: bool
+    uncovered_waiver: ModelUncoveredWaiver | None = None
+
+    volatile_mask: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check(self) -> Self:
+        if self.selected_count > self.candidate_count:
+            raise ValueError("selected_count exceeds candidate_count")
+        if self.selected_count != len(self.selected_input_hashes):
+            raise ValueError("selected_count != len(selected_input_hashes)")
+        if self.meets_target and self.uncovered_waiver is not None:
+            raise ValueError("uncovered_waiver forbidden when meets_target=True")
+        if not self.meets_target and self.uncovered_waiver is None:
+            raise ValueError(
+                "meets_target=False requires an explicit uncovered_waiver "
+                "(a node below target cannot be marked canonical silently)"
+            )
+        return self
+
+
+def handler_module_sha256(module_file: str | Path) -> str:
+    """Hash the handler's source file — pins the receipt to the exact legacy code."""
+    return "sha256:" + hashlib.sha256(Path(module_file).read_bytes()).hexdigest()
+
+
+def input_hash(input_model: _JsonDumpable) -> str:
+    """Canonical sha256 of a serialized input (stable regardless of key order)."""
+    canon = json.dumps(input_model.model_dump(mode="json"), sort_keys=True)
+    return "sha256:" + hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def scrub(payload: Any, substrings: Sequence[str] = _DEFAULT_SCRUB_SUBSTRINGS) -> Any:
+    """Deep deny-by-default redaction of sensitive-looking dict values."""
+    if isinstance(payload, dict):
+        out: dict[str, Any] = {}
+        for key, value in payload.items():
+            if isinstance(key, str) and any(s in key.lower() for s in substrings):
+                out[key] = _SCRUBBED
+            else:
+                out[key] = scrub(value, substrings)
+        return out
+    if isinstance(payload, list):
+        return [scrub(item, substrings) for item in payload]
+    return payload
+
+
+def _measured_arcs(
+    run: Callable[[], object], source_match: str
+) -> set[tuple[str, int, int]]:
+    """Branch arcs exercised by ``run()``, restricted to files matching ``source_match``."""
+    # config_file=False so the repo's [tool.coverage] source/omit does not scope us.
+    cov = coverage.Coverage(branch=True, config_file=False)
+    cov.start()
+    try:
+        run()
+    finally:
+        cov.stop()
+    data = cov.get_data()
+    arcs: set[tuple[str, int, int]] = set()
+    for filename in data.measured_files():
+        if source_match not in filename:
+            continue
+        for a0, a1 in data.arcs(filename) or []:
+            arcs.add((filename, a0, a1))
+    return arcs
+
+
+def select_covering(
+    *,
+    handler_call: Callable[[Any], Any],
+    candidates: Sequence[Any],
+    source_match: str,
+) -> tuple[list[int], set[tuple[str, int, int]]]:
+    """Greedily pick the minimal candidate subset maximizing branch arcs.
+
+    Returns (selected indices in pick order, the union of arcs they cover).
+    Deterministic: ties broken by candidate index.
+    """
+    per_candidate: list[set[tuple[str, int, int]]] = [
+        _measured_arcs(functools.partial(handler_call, c), source_match)
+        for c in candidates
+    ]
+    covered: set[tuple[str, int, int]] = set()
+    selected: list[int] = []
+    remaining = set(range(len(candidates)))
+    while remaining:
+        best_idx = -1
+        best_gain = 0
+        for idx in sorted(remaining):
+            gain = len(per_candidate[idx] - covered)
+            if gain > best_gain:
+                best_gain = gain
+                best_idx = idx
+        if best_idx < 0 or best_gain == 0:
+            break
+        selected.append(best_idx)
+        covered |= per_candidate[best_idx]
+        remaining.discard(best_idx)
+    return selected, covered
+
+
+def coverage_pct_for(*, run: Callable[[], object], source_match: str) -> float:
+    """Overall branch-coverage percent for ``run()`` over files matching source_match.
+
+    Uses coverage.py's documented ``report()`` return value (the total percent,
+    branch-inclusive when ``branch=True``), scoped via an ``include`` glob.
+    """
+    # config_file=False so the repo's [tool.coverage] source does not scope us;
+    # report() is then given the explicit measured handler files (morfs) so the
+    # percent is for the handler alone, not diluted across the package.
+    cov = coverage.Coverage(branch=True, config_file=False)
+    cov.start()
+    try:
+        run()
+    finally:
+        cov.stop()
+    morfs = [f for f in cov.get_data().measured_files() if source_match in f]
+    if not morfs:
+        return 0.0
+    sink = io.StringIO()
+    try:
+        return round(float(cov.report(morfs=morfs, file=sink)), 2)
+    except coverage.exceptions.NoDataError:
+        return 0.0
+
+
+def build_receipt(
+    *,
+    node_id: str,
+    handler_module_file: str | Path,
+    handler_call: Callable[[Any], Any],
+    candidates: Sequence[_JsonDumpable],
+    source_match: str,
+    volatile_mask: list[str] | None = None,
+    coverage_target: float = DEFAULT_COVERAGE_TARGET,
+    waiver_reason: str | None = None,
+) -> ModelAdequacyReceipt:
+    """Coverage-guided selection → adequacy receipt for one COMPUTE node."""
+    selected_idx, _covered_arcs = select_covering(
+        handler_call=handler_call, candidates=candidates, source_match=source_match
+    )
+    selected = [candidates[i] for i in selected_idx]
+
+    def _run_selected() -> None:
+        for candidate in selected:
+            handler_call(candidate)
+
+    pct = coverage_pct_for(run=_run_selected, source_match=source_match)
+    meets = pct >= coverage_target
+    waiver = None
+    if not meets:
+        waiver = ModelUncoveredWaiver(
+            reason=waiver_reason
+            or (
+                f"candidate pool reaches only {pct:.1f}% branch coverage "
+                f"(< {coverage_target:.0f}% target); pool needs coverage-guided "
+                "synthesis for the uncovered branches"
+            ),
+            uncovered_branch_count=0,
+        )
+    return ModelAdequacyReceipt(
+        node_id=node_id,
+        handler_module=str(handler_module_file),
+        handler_module_sha256=handler_module_sha256(handler_module_file),
+        recorded_at=datetime.now(UTC).isoformat(),
+        candidate_count=len(candidates),
+        selected_count=len(selected),
+        selected_input_hashes=[input_hash(c) for c in selected],
+        branch_coverage_pct=pct,
+        coverage_target=coverage_target,
+        meets_target=meets,
+        uncovered_waiver=waiver,
+        volatile_mask=list(volatile_mask or []),
+    )
+
+
+__all__ = [
+    "DEFAULT_COVERAGE_TARGET",
+    "ModelAdequacyReceipt",
+    "ModelUncoveredWaiver",
+    "build_receipt",
+    "handler_module_sha256",
+    "input_hash",
+    "scrub",
+    "select_covering",
+]

--- a/scripts/ci/adequacy_receipt.py
+++ b/scripts/ci/adequacy_receipt.py
@@ -107,6 +107,14 @@ class ModelAdequacyReceipt(BaseModel):
                 "meets_target=False requires an explicit uncovered_waiver "
                 "(a node below target cannot be marked canonical silently)"
             )
+        if self.meets_target and self.selected_count == 0:
+            # Degenerate pass: coverage cannot be certified met over zero inputs
+            # (e.g. target=0 with an empty pool). Flagged by canon-inventory's
+            # seam review — the gate must not accept an input-less "pass".
+            raise ValueError(
+                "meets_target=True requires selected_count >= 1 "
+                "(coverage cannot be certified over zero inputs)"
+            )
         return self
 
 

--- a/scripts/ci/adequacy_receipt.py
+++ b/scripts/ci/adequacy_receipt.py
@@ -100,6 +100,13 @@ class ModelAdequacyReceipt(BaseModel):
             raise ValueError("selected_count exceeds candidate_count")
         if self.selected_count != len(self.selected_input_hashes):
             raise ValueError("selected_count != len(selected_input_hashes)")
+        # meets_target must be DERIVED from the numbers, not asserted. Without this,
+        # a persisted/hand-edited receipt could claim meets_target=True at 10%
+        # coverage with no waiver and slip through the gate (verify-1705 MEDIUM).
+        if self.meets_target != (self.branch_coverage_pct >= self.coverage_target):
+            raise ValueError(
+                "meets_target must equal branch_coverage_pct >= coverage_target"
+            )
         if self.meets_target and self.uncovered_waiver is not None:
             raise ValueError("uncovered_waiver forbidden when meets_target=True")
         if not self.meets_target and self.uncovered_waiver is None:

--- a/scripts/ci/adequacy_receipt.py
+++ b/scripts/ci/adequacy_receipt.py
@@ -57,7 +57,10 @@ _SCRUBBED = "<scrubbed>"
 
 
 class _JsonDumpable(Protocol):
-    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]:
+        # Protocol stub body: never executed (structural typing only).
+        # `pass` (not `...`) avoids CodeQL py/ineffectual-statement (alert #2590).
+        pass
 
 
 class ModelUncoveredWaiver(BaseModel):

--- a/scripts/ci/compute_golden.py
+++ b/scripts/ci/compute_golden.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Compute-behavior golden recorder + equivalence comparator (OMN-14353 canary).
+
+A minimal, general recorder for a PURE COMPUTE node: it serializes a node's
+``input -> output`` as a golden and replays it, comparing the fresh output to the
+recorded one under a declared volatile-field mask. This is the equivalence-oracle
+primitive a self-verifying codegen factory (tier-4b) must generalize.
+
+NOTE — this is deliberately NOT ``omnibase_core.runtime.golden_chain.record_fixture``.
+That recorder freezes an LLM provider's *response bytes* over an HTTP transport
+seam (pinned to provider/model/endpoint/routing_contract/request_hash); it does
+not fit a pure COMPUTE node whose golden is ``typed input -> typed output`` with
+no provider/model/endpoint at all. See the OMN-14353 report for the full rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol
+
+
+class _JsonDumpable(Protocol):
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+
+
+def _canonical(payload: Any) -> str:
+    """Deterministic JSON string for structural comparison (sorted keys)."""
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False)
+
+
+def apply_mask(payload: dict[str, Any], volatile_mask: list[str]) -> dict[str, Any]:
+    """Return a deep copy of ``payload`` with each dotted-path volatile field removed.
+
+    Masking excludes non-deterministic fields (timestamps, uuids, ...) from the
+    equivalence compare. A path segment may address a dict key at any depth;
+    list elements are descended into transparently.
+    """
+    masked: dict[str, Any] = json.loads(json.dumps(payload))  # deep copy via round-trip
+    for dotted in volatile_mask:
+        _remove_path(masked, dotted.split("."))
+    return masked
+
+
+def _remove_path(node: Any, segments: list[str]) -> None:
+    if not segments:
+        return
+    head, rest = segments[0], segments[1:]
+    if isinstance(node, list):
+        for item in node:
+            _remove_path(item, segments)
+        return
+    if not isinstance(node, dict):
+        return
+    if not rest:
+        node.pop(head, None)
+        return
+    if head in node:
+        _remove_path(node[head], rest)
+
+
+def diff_paths(expected: Any, actual: Any, _prefix: str = "") -> list[str]:
+    """Return dotted paths where ``expected`` and ``actual`` structurally differ."""
+    diffs: list[str] = []
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        for key in sorted(set(expected) | set(actual)):
+            child = f"{_prefix}.{key}" if _prefix else key
+            if key not in expected:
+                diffs.append(f"{child} (added)")
+            elif key not in actual:
+                diffs.append(f"{child} (removed)")
+            else:
+                diffs.extend(diff_paths(expected[key], actual[key], child))
+    elif isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            diffs.append(f"{_prefix} (len {len(expected)}->{len(actual)})")
+        for i, (e, a) in enumerate(zip(expected, actual, strict=False)):
+            diffs.extend(diff_paths(e, a, f"{_prefix}[{i}]"))
+    elif expected != actual:
+        diffs.append(f"{_prefix}: {expected!r} != {actual!r}")
+    return diffs
+
+
+def record_golden(
+    *,
+    output: _JsonDumpable,
+    input_model: _JsonDumpable,
+    volatile_mask: list[str] | None = None,
+) -> dict[str, Any]:
+    """Serialize a compute node's input->output as a golden record."""
+    return {
+        "golden_version": "compute_golden.v1",
+        "input_type": type(input_model).__name__,
+        "output_type": type(output).__name__,
+        "input": input_model.model_dump(mode="json"),
+        "output": output.model_dump(mode="json"),
+        "volatile_mask": list(volatile_mask or []),
+    }
+
+
+def compare_output(golden: dict[str, Any], fresh_output: _JsonDumpable) -> list[str]:
+    """Compare a fresh output against a golden under the golden's volatile mask.
+
+    Returns the list of differing paths — EMPTY means equivalent.
+    """
+    mask = list(golden.get("volatile_mask", []))
+    expected = apply_mask(golden["output"], mask)
+    actual = apply_mask(fresh_output.model_dump(mode="json"), mask)
+    return diff_paths(expected, actual)
+
+
+def outputs_equivalent(
+    a: _JsonDumpable, b: _JsonDumpable, volatile_mask: list[str]
+) -> bool:
+    """True iff two outputs are byte-equal after masking + canonical normalization."""
+    ma = apply_mask(a.model_dump(mode="json"), volatile_mask)
+    mb = apply_mask(b.model_dump(mode="json"), volatile_mask)
+    return _canonical(ma) == _canonical(mb)
+
+
+__all__ = [
+    "apply_mask",
+    "compare_output",
+    "diff_paths",
+    "outputs_equivalent",
+    "record_golden",
+]

--- a/scripts/ci/compute_golden.py
+++ b/scripts/ci/compute_golden.py
@@ -21,7 +21,10 @@ from typing import Any, Protocol
 
 
 class _JsonDumpable(Protocol):
-    def model_dump(self, *, mode: str = ...) -> dict[str, Any]: ...
+    def model_dump(self, *, mode: str = ...) -> dict[str, Any]:
+        # Protocol stub body: never executed (structural typing only).
+        # `pass` (not `...`) avoids CodeQL py/ineffectual-statement (alert #2591).
+        pass
 
 
 def _canonical(payload: Any) -> str:

--- a/tests/unit/canary/__init__.py
+++ b/tests/unit/canary/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/canary/test_adequacy_receipt.py
+++ b/tests/unit/canary/test_adequacy_receipt.py
@@ -185,6 +185,47 @@ def test_receipt_rejects_degenerate_zero_input_pass() -> None:
         )
 
 
+def test_receipt_forge_below_target_claiming_met_is_rejected() -> None:
+    # THE bypass verify-1705 found: a hand-built receipt claiming meets_target=True
+    # at 10% coverage against an 80% target, with no waiver. Must be REJECTED — the
+    # gate cannot trust meets_target unless it is derived from the numbers.
+    with pytest.raises(ValueError, match="meets_target must equal"):
+        ModelAdequacyReceipt(
+            node_id="n",
+            handler_module="m",
+            handler_module_sha256="sha256:x",
+            recorded_at="2026-07-11T00:00:00+00:00",
+            candidate_count=1,
+            selected_count=1,
+            selected_input_hashes=["sha256:a"],
+            branch_coverage_pct=10.0,
+            coverage_target=80.0,
+            meets_target=True,
+            uncovered_waiver=None,
+            volatile_mask=[],
+        )
+
+
+def test_receipt_forge_above_target_claiming_not_met_is_rejected() -> None:
+    # Mirror forge: above target but claiming meets_target=False (would spuriously
+    # demand/allow a waiver on a node that actually passed). Also REJECTED.
+    with pytest.raises(ValueError, match="meets_target must equal"):
+        ModelAdequacyReceipt(
+            node_id="n",
+            handler_module="m",
+            handler_module_sha256="sha256:x",
+            recorded_at="2026-07-11T00:00:00+00:00",
+            candidate_count=1,
+            selected_count=1,
+            selected_input_hashes=["sha256:a"],
+            branch_coverage_pct=90.0,
+            coverage_target=80.0,
+            meets_target=False,
+            uncovered_waiver=ModelUncoveredWaiver(reason="x", uncovered_branch_count=0),
+            volatile_mask=[],
+        )
+
+
 # --- coverage-driven (skipped under --cov) ---
 
 

--- a/tests/unit/canary/test_adequacy_receipt.py
+++ b/tests/unit/canary/test_adequacy_receipt.py
@@ -165,6 +165,26 @@ def test_receipt_rejects_waiver_when_target_met() -> None:
         )
 
 
+def test_receipt_rejects_degenerate_zero_input_pass() -> None:
+    # meets_target=True with zero inputs is a degenerate pass (coverage measured
+    # over nothing) — canon-inventory's seam-review catch.
+    with pytest.raises(ValueError, match="selected_count >= 1"):
+        ModelAdequacyReceipt(
+            node_id="n",
+            handler_module="m",
+            handler_module_sha256="sha256:x",
+            recorded_at="2026-07-11T00:00:00+00:00",
+            candidate_count=0,
+            selected_count=0,
+            selected_input_hashes=[],
+            branch_coverage_pct=0.0,
+            coverage_target=0.0,
+            meets_target=True,
+            uncovered_waiver=None,
+            volatile_mask=[],
+        )
+
+
 # --- coverage-driven (skipped under --cov) ---
 
 

--- a/tests/unit/canary/test_adequacy_receipt.py
+++ b/tests/unit/canary/test_adequacy_receipt.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the coverage-guided adequacy receipt (OMN-14353 #41)."""
+
+from __future__ import annotations
+
+import coverage
+import pytest
+
+from omnibase_core.nodes.node_routing_authority_check_compute import (
+    handler as handler_mod,
+)
+from omnibase_core.nodes.node_routing_authority_check_compute.handler import (
+    ModelResidueEntry,
+    ModelRoutingAuthorityCheckInput,
+    ModelRoutingContractEntry,
+    NodeRoutingAuthorityCheckCompute,
+)
+from scripts.ci.adequacy_receipt import (
+    ModelAdequacyReceipt,
+    ModelUncoveredWaiver,
+    build_receipt,
+    handler_module_sha256,
+    input_hash,
+    scrub,
+    select_covering,
+)
+
+pytestmark = pytest.mark.unit
+
+# coverage.py does not support a second concurrent measurement, so the
+# coverage-driven tests are skipped when the suite itself runs under --cov.
+_COVERAGE_ACTIVE = coverage.Coverage.current() is not None
+_needs_coverage = pytest.mark.skipif(
+    _COVERAGE_ACTIVE,
+    reason="nested coverage measurement unsupported (suite under --cov)",
+)
+
+_GOOD_CONTRACT = (
+    "name: n\nnode_type: compute\nmodel_routing:\n"
+    '  provider: "google"\n  served_model_id: "g"\n'
+    '  endpoint_ref: "gemini_pro"\n  routing_source: "b.yaml"\n'
+)
+_GOOD_BIFROST = (
+    'backends:\n  - backend_id: "gemini_pro"\n    tier: "cloud"\n'
+    '    endpoint_url_env: "U"\n    endpoint_url: null\n'
+)
+_CLI_BIFROST = (
+    'backends:\n  - backend_id: "cli-x"\n    tier: "cli_agents"\n'
+    '    endpoint_url: "cli://x"\n'
+)
+
+
+def _mk(**kw: object) -> ModelRoutingAuthorityCheckInput:
+    base: dict[str, object] = {
+        "demo_path_contracts": (ModelRoutingContractEntry(contract_rel="c.yaml"),),
+        "contract_contents": {"c.yaml": _GOOD_CONTRACT},
+        "bifrost_config_rel": "b.yaml",
+        "bifrost_config_content": _GOOD_BIFROST,
+        "demo_path_sources": ("s.py",),
+        "source_contents": {"s.py": "def h(p):\n    return p\n"},
+        "residue_entries": (),
+        "residue_contents": {},
+    }
+    base.update(kw)
+    return ModelRoutingAuthorityCheckInput(**base)  # type: ignore[arg-type]
+
+
+def _pool() -> list[ModelRoutingAuthorityCheckInput]:
+    return [
+        _mk(),
+        _mk(
+            contract_contents={"c.yaml": "name: b\nnode_type: compute\n"},
+            bifrost_config_content=_CLI_BIFROST,
+            source_contents={"s.py": 'import os\nE = os.getenv("SERVICE_ENDPOINT")\n'},
+        ),
+        _mk(
+            residue_entries=(
+                ModelResidueEntry(
+                    file_rel="l.py", baseline_count=2, debt_ticket="T", description="d"
+                ),
+            ),
+            residue_contents={
+                "l.py": 'import os\nA=os.getenv("SERVICE_ENDPOINT")\nB=os.getenv("PROVIDER_HOST")\n'
+            },
+        ),
+        _mk(contract_contents={"c.yaml": "{{bad yaml"}),
+        _mk(contract_contents={"c.yaml": ""}),
+        _mk(
+            bifrost_config_content='backends:\n  - backend_id: "other"\n    endpoint_url: "https://x"\n'
+        ),
+        _mk(source_contents={"s.py": 'X = "openai"\n'}),
+    ]
+
+
+# --- pure helpers (no coverage) ---
+
+
+def test_scrub_redacts_sensitive_keys_deeply() -> None:
+    payload = {
+        "api_key": "s",
+        "keep": 1,
+        "nested": {"password": "p", "ok": 2},
+        "list": [{"auth_token": "t"}, {"fine": 3}],
+    }
+    out = scrub(payload)
+    assert out["api_key"] == "<scrubbed>"
+    assert out["keep"] == 1
+    assert out["nested"]["password"] == "<scrubbed>"
+    assert out["nested"]["ok"] == 2
+    assert out["list"][0]["auth_token"] == "<scrubbed>"
+    assert out["list"][1]["fine"] == 3
+
+
+def test_input_hash_is_order_independent() -> None:
+    a = _mk()
+    b = _mk()
+    assert input_hash(a) == input_hash(b)
+    assert input_hash(a).startswith("sha256:")
+
+
+def test_handler_module_sha256_matches_file() -> None:
+    import hashlib
+    from pathlib import Path
+
+    expected = (
+        "sha256:" + hashlib.sha256(Path(handler_mod.__file__).read_bytes()).hexdigest()
+    )
+    assert handler_module_sha256(handler_mod.__file__) == expected
+
+
+def test_receipt_requires_waiver_below_target() -> None:
+    with pytest.raises(ValueError, match="requires an explicit uncovered_waiver"):
+        ModelAdequacyReceipt(
+            node_id="n",
+            handler_module="m",
+            handler_module_sha256="sha256:x",
+            recorded_at="2026-07-11T00:00:00+00:00",
+            candidate_count=1,
+            selected_count=1,
+            selected_input_hashes=["sha256:a"],
+            branch_coverage_pct=50.0,
+            coverage_target=80.0,
+            meets_target=False,
+            uncovered_waiver=None,
+            volatile_mask=[],
+        )
+
+
+def test_receipt_rejects_waiver_when_target_met() -> None:
+    with pytest.raises(ValueError, match="uncovered_waiver forbidden"):
+        ModelAdequacyReceipt(
+            node_id="n",
+            handler_module="m",
+            handler_module_sha256="sha256:x",
+            recorded_at="2026-07-11T00:00:00+00:00",
+            candidate_count=1,
+            selected_count=1,
+            selected_input_hashes=["sha256:a"],
+            branch_coverage_pct=90.0,
+            coverage_target=80.0,
+            meets_target=True,
+            uncovered_waiver=ModelUncoveredWaiver(reason="x", uncovered_branch_count=0),
+            volatile_mask=[],
+        )
+
+
+# --- coverage-driven (skipped under --cov) ---
+
+
+@_needs_coverage
+def test_selection_drops_redundant_candidates() -> None:
+    handler = NodeRoutingAuthorityCheckCompute()
+    base = _mk()
+    # base twice + one distinct: the duplicate adds no new arcs, so it is dropped.
+    candidates = [base, base, _mk(contract_contents={"c.yaml": "{{bad"})]
+    selected_idx, _ = select_covering(
+        handler_call=handler.check,
+        candidates=candidates,
+        source_match="node_routing_authority_check_compute",
+    )
+    assert len(selected_idx) < len(candidates)
+
+
+def _receipt(target: float) -> ModelAdequacyReceipt:
+    handler = NodeRoutingAuthorityCheckCompute()
+    return build_receipt(
+        node_id="node_routing_authority_check_compute",
+        handler_module_file=handler_mod.__file__,
+        handler_call=handler.check,
+        candidates=_pool(),
+        source_match="node_routing_authority_check_compute",
+        volatile_mask=[],
+        coverage_target=target,
+    )
+
+
+@_needs_coverage
+def test_build_receipt_below_target_is_fail_closed_with_waiver() -> None:
+    # An unreachable target forces below-target — the receipt MUST carry a waiver
+    # (a node below target can never be silently canonical). This is the
+    # load-bearing safety property, asserted independently of the node's absolute
+    # coverage (the fixture handler's magnitude is not the thing under test).
+    receipt = _receipt(target=100.0)
+    assert 0.0 <= receipt.branch_coverage_pct <= 100.0
+    assert receipt.meets_target is False
+    assert receipt.uncovered_waiver is not None
+    assert receipt.uncovered_waiver.reason
+    assert receipt.selected_count <= receipt.candidate_count
+    assert len(receipt.selected_input_hashes) == receipt.selected_count
+    assert receipt.handler_module_sha256.startswith("sha256:")
+
+
+@_needs_coverage
+def test_build_receipt_at_zero_target_meets_without_waiver() -> None:
+    # target=0 is trivially met — and the fail-closed validator FORBIDS a waiver
+    # when the target is met, so this exercises the other branch of the invariant.
+    receipt = _receipt(target=0.0)
+    assert receipt.meets_target is True
+    assert receipt.uncovered_waiver is None


### PR DESCRIPTION
## OMN-14354 — coverage-guided adequacy receipt + fail-closed uncovered-waiver

Split from OMN-14353/#1425 (compute-golden primitive) so the **load-bearing safety artifact** gets its own dedicated adversarial verification, independent of the primitive.

### What
- `scripts/ci/adequacy_receipt.py`:
  - **coverage-guided greedy selection** — minimal candidate subset maximizing the legacy handler's branch arcs (Fable gap #1).
  - **`ModelAdequacyReceipt`** — branch_coverage_pct + coverage_target + meets_target + volatile_mask + provenance (handler-module sha256, recorded_at, per-input hash) + `uncovered_waiver`.
  - **Fail-closed validator (the thing to verify): below-target coverage REQUIRES an explicit `uncovered_waiver`; a waiver is FORBIDDEN when the target is met.** A node can never be silently canonical on a happy-path golden, and the waiver can't be bypassed.
  - **deny-by-default scrub** over recorded payloads.
- `tests/unit/canary/test_adequacy_receipt.py` — scrub, provenance, both fail-closed branches (unreachable target → waiver present; zero target → waiver forbidden), greedy selection drops redundant candidates. Coverage-driven tests skip under `--cov` (no nested measurement).

### Verification focus
The fail-closed waiver is un-forgeable/un-bypassable: `meets_target=False` without a waiver raises; `meets_target=True` with a waiver raises; scrub redacts sensitive keys; provenance pins the exact handler source (the gate recomputes sha256 to reject a stale receipt).

### Note (honest)
Assertions are **node-coverage-magnitude-independent by design**: the routing-authority handler was refactored to a thin shell on current dev (732 deletions), so the fixture's absolute coverage is not the thing under test — the fail-closed waiver invariant is. The earlier "54.9%" demo figure was measured against the pre-refactor handler.

### Consumed by
`canon-inventory`'s canonical-shape ratchet-gate (seam contract already handed over: coverage % vs target, waiver present+reason, provenance, volatile mask).

### dod_evidence
- `uv run pytest tests/unit/canary/test_adequacy_receipt.py` → 8 passed. ruff + mypy clean; pre-commit exit 0.
- No self-authored OCC companion (independent verifier per no-self-evidence rule).

---

Evidence-Source: OCC#3882
Evidence-Commit: 775e35e2c162c9dd527b590bfd1412f59bf64de1
Evidence-Ticket: OMN-14354

