### PR TITLE
feat(OMN-14358): effect_golden — contract-driven declared-effect readback oracle

### DIFF
--- a/scripts/ci/effect_golden.py
+++ b/scripts/ci/effect_golden.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Effect-golden readback oracle for EFFECT nodes (OMN-14358).
+
+The EFFECT analog of ``compute_golden``. An EFFECT node's "output" is not a return
+value — it is the SIDE EFFECT (a published event, a written file). This harness
+proves the DECLARED side-effects actually happened by READBACK against a REAL
+observable sink, NOT by "didn't throw".
+
+Why not "didn't throw": a ``MagicMock`` event bus makes ``bus.publish(...)``
+succeed silently with no real sink, so a "didn't throw" check passes even when
+nothing was published (the OMN-14294 blind spot). Only a readback against a real
+recording sink distinguishes a real publish from a mock/suppressed one — the T3
+canary (Task #44) proved this discriminates (suppressed effect → readback FAIL
+while "didn't throw" stayed identically True).
+
+Effects are asserted CONJUNCTIVELY: every declared topic must have a captured
+event AND every declared file glob must match a non-empty file. A volatile mask
+excludes minted ``run_id``/``timestamp``/``correlation_id`` from effect-payload
+equivalence.
+
+Self-contained (does not import ``compute_golden``, which lives on a separate PR);
+the mask/diff machinery is consolidated once both land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+
+class RecordingEventSink:
+    """A REAL observable sink — appends every publish so effects can be read back.
+
+    This is the anti-MagicMock: the readback oracle reads ``captured``, so a
+    suppressed or mocked publish is visibly absent instead of silently "succeeding".
+    """
+
+    def __init__(self) -> None:
+        self.captured: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        self.captured.append((topic, payload))
+
+
+class ModelEffectReadback(BaseModel):
+    """Verdict of reading back an EFFECT node's DECLARED side-effects."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    ok: bool
+    published_ok: bool
+    files_ok: bool
+    declared_topics: list[str] = Field(default_factory=list)
+    captured_topics: list[str] = Field(default_factory=list)
+    declared_file_globs: list[str] = Field(default_factory=list)
+    matched_files: list[str] = Field(default_factory=list)
+    missing_effects: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check(self) -> Self:
+        if self.ok != (self.published_ok and self.files_ok):
+            raise ValueError("ok must equal (published_ok and files_ok)")
+        if self.ok and self.missing_effects:
+            raise ValueError("ok=True forbids missing_effects")
+        if not self.ok and not self.missing_effects:
+            raise ValueError("ok=False requires at least one missing_effect")
+        return self
+
+
+class _ContractPublishTopics(BaseModel):
+    """Minimal validated slice of a contract.yaml — just the declared topics."""
+
+    model_config = ConfigDict(extra="ignore")
+    publish_topics: list[str] = Field(default_factory=list)
+
+
+def parse_publish_topics(contract_path: str | Path) -> list[str]:
+    """Contract-driven declared topics: the node's ``contract.yaml`` publish_topics.
+
+    Validates the contract slice via Pydantic (no manual dict access).
+    """
+    model = load_and_validate_yaml_model(Path(contract_path), _ContractPublishTopics)
+    return model.publish_topics
+
+
+def _glob_has_nonempty_match(root: Path, pattern: str) -> bool:
+    return any(p.is_file() and p.read_bytes().strip() for p in root.glob(pattern))
+
+
+def readback_effects(
+    *,
+    sink: RecordingEventSink,
+    declared_topics: list[str],
+    declared_file_globs: list[str],
+    root: Path,
+) -> ModelEffectReadback:
+    """Assert ALL declared effects actually happened — conjunctively, by readback.
+
+    A declared topic passes iff the recording sink captured ≥1 event on it. A
+    declared file glob passes iff it matches ≥1 non-empty file under ``root``.
+    NOT "didn't throw" — absence of an effect is a FAIL, never a silent pass.
+    """
+    captured_topics = sorted({t for t, _ in sink.captured})
+    missing: list[str] = []
+
+    for topic in declared_topics:
+        if topic not in captured_topics:
+            missing.append(f"topic:{topic}")
+
+    matched: list[str] = []
+    for pattern in declared_file_globs:
+        if _glob_has_nonempty_match(root, pattern):
+            matched.append(pattern)
+        else:
+            missing.append(f"file:{pattern}")
+
+    published_ok = all(t in captured_topics for t in declared_topics)
+    files_ok = len(matched) == len(declared_file_globs)
+    return ModelEffectReadback(
+        ok=(published_ok and files_ok),
+        published_ok=published_ok,
+        files_ok=files_ok,
+        declared_topics=sorted(declared_topics),
+        captured_topics=captured_topics,
+        declared_file_globs=sorted(declared_file_globs),
+        matched_files=sorted(matched),
+        missing_effects=sorted(missing),
+    )
+
+
+def _apply_mask(payload: dict[str, Any], volatile_mask: list[str]) -> dict[str, Any]:
+    """Remove top-level volatile keys (run_id/timestamp/correlation_id) before compare."""
+    masked = json.loads(json.dumps(payload))
+    for key in volatile_mask:
+        masked.pop(key, None)
+    return masked
+
+
+def record_effect_golden(
+    *,
+    sink: RecordingEventSink,
+    declared_topics: list[str],
+    declared_file_globs: list[str],
+    volatile_mask: list[str] | None = None,
+) -> dict[str, Any]:
+    """Serialize the observed effects (masked event payloads) as an effect golden."""
+    mask = list(volatile_mask or [])
+    return {
+        "golden_version": "effect_golden.v1",
+        "declared_topics": sorted(declared_topics),
+        "declared_file_globs": sorted(declared_file_globs),
+        "events": [[t, _apply_mask(p, mask)] for t, p in sink.captured],
+        "volatile_mask": mask,
+    }
+
+
+def compare_effect_golden(
+    golden: dict[str, Any], sink: RecordingEventSink
+) -> list[str]:
+    """Diff freshly-observed events against a golden under its volatile mask.
+
+    Returns differing descriptions — EMPTY means the effect payloads are equivalent.
+    """
+    mask = list(golden.get("volatile_mask", []))
+    expected = [[t, _apply_mask(p, mask)] for t, p in _events_of(golden)]
+    actual = [[t, _apply_mask(p, mask)] for t, p in sink.captured]
+    diffs: list[str] = []
+    if len(expected) != len(actual):
+        diffs.append(f"event count {len(expected)} -> {len(actual)}")
+    for i, (e, a) in enumerate(zip(expected, actual, strict=False)):
+        if e != a:
+            diffs.append(f"event[{i}]: {e!r} != {a!r}")
+    return diffs
+
+
+def _events_of(golden: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    return [(row[0], row[1]) for row in golden.get("events", [])]
+
+
+__all__ = [
+    "ModelEffectReadback",
+    "RecordingEventSink",
+    "compare_effect_golden",
+    "parse_publish_topics",
+    "readback_effects",
+    "record_effect_golden",
+]

--- a/tests/unit/canary/__init__.py
+++ b/tests/unit/canary/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/canary/test_effect_golden.py
+++ b/tests/unit/canary/test_effect_golden.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Effect-readback oracle canary (OMN-14358).
+
+Proves the effect-golden readback is NON-VACUOUS on a real EFFECT node
+(``NodeComplianceEvidenceEffect``): a suppressed declared side-effect is CAUGHT
+by readback, while a "didn't throw" check stays blind. This is the EFFECT analog
+of the compute-oracle canary — the MagicMock blind spot (OMN-14294) turned into a
+defeated pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.models.nodes.compliance_evidence.model_evidence_report_state import (
+    ModelEvidenceReportState,
+)
+from omnibase_core.nodes.node_compliance_evidence_effect.handler import (
+    NodeComplianceEvidenceEffect,
+)
+from scripts.ci.effect_golden import (
+    ModelEffectReadback,
+    RecordingEventSink,
+    compare_effect_golden,
+    parse_publish_topics,
+    readback_effects,
+    record_effect_golden,
+)
+
+pytestmark = pytest.mark.unit
+
+TOPIC = "onex.evt.core.compliance-scan-completed.v1"
+# Declared effects (contract): publish TOPIC + write the run-specific report file.
+DECLARED_FILES = ["compliance/runs/*.yaml"]
+VOLATILE = ["run_id", "timestamp", "correlation_id"]
+
+
+def _report(run_id: str | None = "fixed-run") -> ModelEvidenceReportState:
+    return ModelEvidenceReportState(
+        total=3, passed=2, failed=1, results=[], run_id=run_id
+    )
+
+
+def test_contract_declares_the_publish_topic() -> None:
+    contract = (
+        Path(__file__).resolve().parents[3]
+        / "src/omnibase_core/nodes/node_compliance_evidence_effect/contract.yaml"
+    )
+    assert TOPIC in parse_publish_topics(contract)
+
+
+def test_readback_passes_when_all_declared_effects_happen(tmp_path: Path) -> None:
+    sink = RecordingEventSink()
+    node = NodeComplianceEvidenceEffect(tmp_path, sink, TOPIC)
+    node.execute(_report())
+    rb = readback_effects(
+        sink=sink,
+        declared_topics=[TOPIC],
+        declared_file_globs=DECLARED_FILES,
+        root=tmp_path,
+    )
+    assert rb.ok is True
+    assert rb.published_ok and rb.files_ok
+    assert rb.missing_effects == []
+
+
+def test_readback_CATCHES_a_suppressed_effect(tmp_path: Path) -> None:
+    # THE proof: event_bus=None suppresses the publish (handler logs, never emits).
+    # execute() STILL returns a Path (no exception) — 'didn't throw' is blind — but
+    # the declared topic never reaches a real sink, so readback FAILS.
+    sink = RecordingEventSink()  # stays empty: the node was given no bus
+    node = NodeComplianceEvidenceEffect(tmp_path, None, TOPIC)
+    returned = node.execute(_report())  # does NOT throw
+    assert isinstance(returned, Path)  # 'didn't throw' would PASS here
+    rb = readback_effects(
+        sink=sink,
+        declared_topics=[TOPIC],
+        declared_file_globs=DECLARED_FILES,
+        root=tmp_path,
+    )
+    assert rb.ok is False  # readback DISCRIMINATES where 'didn't throw' cannot
+    assert rb.published_ok is False
+    assert rb.files_ok is True  # the file leg still happened
+    assert f"topic:{TOPIC}" in rb.missing_effects
+
+
+def test_readback_catches_a_missing_file(tmp_path: Path) -> None:
+    # Event published but the declared file glob matches nothing -> conjunctive FAIL.
+    sink = RecordingEventSink()
+    sink.publish(TOPIC, {"run_id": "x"})
+    rb = readback_effects(
+        sink=sink,
+        declared_topics=[TOPIC],
+        declared_file_globs=DECLARED_FILES,
+        root=tmp_path,
+    )
+    assert rb.ok is False
+    assert rb.published_ok is True
+    assert rb.files_ok is False
+    assert any(m.startswith("file:") for m in rb.missing_effects)
+
+
+def test_effect_golden_equivalence_masks_volatile_fields(tmp_path: Path) -> None:
+    # Record with one run_id; replay with another. Under the volatile mask the
+    # event payloads are equivalent (run_id excluded).
+    sinkA = RecordingEventSink()
+    NodeComplianceEvidenceEffect(tmp_path / "a", sinkA, TOPIC).execute(_report("run-A"))
+    golden = record_effect_golden(
+        sink=sinkA,
+        declared_topics=[TOPIC],
+        declared_file_globs=DECLARED_FILES,
+        volatile_mask=VOLATILE,
+    )
+    sinkB = RecordingEventSink()
+    NodeComplianceEvidenceEffect(tmp_path / "b", sinkB, TOPIC).execute(_report("run-B"))
+    assert compare_effect_golden(golden, sinkB) == []
+
+
+def test_effect_golden_compare_catches_payload_change() -> None:
+    golden = {
+        "golden_version": "effect_golden.v1",
+        "events": [[TOPIC, {"passed": 2, "failed": 1}]],
+        "volatile_mask": VOLATILE,
+    }
+    sink = RecordingEventSink()
+    sink.publish(TOPIC, {"passed": 99, "failed": 1})  # a real behavior change
+    diffs = compare_effect_golden(golden, sink)
+    assert diffs, "compare must catch a changed effect payload"
+
+
+def test_readback_model_rejects_inconsistent_verdict() -> None:
+    with pytest.raises(ValueError, match="ok must equal"):
+        ModelEffectReadback(
+            ok=True, published_ok=False, files_ok=True, missing_effects=[]
+        )


### PR DESCRIPTION
## OMN-14358 — effect_golden: contract-driven declared-effect readback oracle

The EFFECT analog of `compute_golden` (OMN-14353). An EFFECT node's "output" is its SIDE EFFECT (published event / written file). This harness proves the DECLARED side-effects actually happened by **READBACK against a REAL recording sink**, not by "didn't throw" — closing the MagicMock blind spot (OMN-14294). De-risked at the mechanism level by the T3 canary (Task #44).

### What
`scripts/ci/effect_golden.py`:
- **`RecordingEventSink`** — a real observable sink; the readback reads `captured`, so a mocked/suppressed publish is visibly absent instead of silently "succeeding".
- **`parse_publish_topics`** — contract-driven declared topics from `contract.yaml` (via the canonical `load_and_validate_yaml_model`, no manual YAML).
- **`readback_effects`** — CONJUNCTIVE: every declared topic must have a captured event AND every declared file glob must match a non-empty file. Returns a typed `ModelEffectReadback` + the `missing_effects`. Absence of a declared effect is a FAIL.
- **`record_effect_golden` / `compare_effect_golden`** — effect-payload equivalence under a volatile mask (`run_id`/`timestamp`/`correlation_id`).

### Proof (canary: `node_compliance_evidence_effect`)
- Real bus → readback PASS (event published + file written).
- **Suppressed effect (`event_bus=None`)** → `execute()` still returns a Path (no throw), but **readback FAILS** on the missing topic. Readback DISCRIMINATES where "didn't throw" is blind.
- Missing file leg → conjunctive FAIL. Volatile mask makes two runs with different `run_id` equivalent; a payload change is caught.

### dod_evidence
- `uv run pytest tests/unit/canary/test_effect_golden.py` → 7 passed. ruff + mypy clean; pre-commit exit 0 (incl. the manual-YAML gate — uses the canonical loader).

### Scope / follow-ons
- Widening across omnimarket's ~100 effect nodes is a cheap fan-out once this lands (not here).
- ORCHESTRATOR sequence-recorder = **OMN-14359** (flagged, not built).
- Logic-surface resolution (handler + delegated modules) folds into the synthesis/full-recorder ticket.
- No self-authored OCC companion (independent verifier per no-self-evidence rule).



---

Evidence-Source: OCC#3885
Evidence-Commit: 8b6c7aea0feda9e91d41aae21f54fdf400823655
Evidence-Ticket: OMN-14358

