### PR TITLE
feat(OMN-14368): parameterize canon-shape classifier for cross-repo scan

### DIFF
--- a/scripts/ci/canonical_handler_shape.py
+++ b/scripts/ci/canonical_handler_shape.py
@@ -64,6 +64,15 @@ Run the check (CI + pre-commit)::
 
     uv run python scripts/ci/canonical_handler_shape.py            # diff-scoped
     uv run python scripts/ci/canonical_handler_shape.py --full     # whole repo
+
+Fan-out to another package (OMN-14368): ``--package``/``--src-root`` (or the
+``ONEX_CANON_SHAPE_PACKAGE`` env var) repoint the scan at a sibling repo's node
+tree without touching omnibase_core's own committed baseline. Both default to
+omnibase_core, so core behavior is byte-for-byte unchanged when unset::
+
+    uv run python scripts/ci/canonical_handler_shape.py --update \\
+        --package omnimarket --src-root ../omnimarket/src \\
+        --baseline ../omnimarket/scripts/ci/canonical_handler_shape_baseline.py
 """
 
 from __future__ import annotations
@@ -71,6 +80,7 @@ from __future__ import annotations
 import argparse
 import ast
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from typing import Literal
@@ -500,6 +510,54 @@ def write_baseline(non_canonical: list[str], path: Path = BASELINE_PATH) -> None
 
 
 # --------------------------------------------------------------------------- #
+# Package scoping (OMN-14368 mechanical-wave fan-out)
+# --------------------------------------------------------------------------- #
+#
+# The classifier and its baseline were hardcoded to omnibase_core (OMN-14355's
+# canary scope was intentionally core-only). The mechanical-wave rewrite needs
+# to observe a canonical-shape flip in omnimarket/omnibase_infra too, so the
+# scan target is parameterized. ``_resolve_scope`` is a pure function (no
+# global mutation) so it is directly unit-testable; only ``main()`` applies
+# the result to the module globals that ``classify_node`` et al. read.
+
+
+def _resolve_scope(
+    package: str,
+    src_root: Path | None,
+    nodes_glob: str | None,
+    baseline: Path | None,
+    receipts_dir: Path | None,
+) -> tuple[Path, str, Path, Path]:
+    """Compute ``(src_root, nodes_glob, baseline_path, receipts_dir)`` for a scope.
+
+    Every argument defaults to the omnibase_core value already in effect on the
+    module (``SRC_ROOT``/``BASELINE_PATH``/``RECEIPTS_DIR``), so calling this
+    with ``package="omnibase_core"`` and all other args ``None`` reproduces
+    today's constants exactly. A non-default ``package`` with no explicit
+    ``--baseline``/``--receipts-dir`` gets a package-suffixed path beside this
+    script rather than silently clobbering omnibase_core's own committed
+    baseline/receipts.
+    """
+    resolved_src_root = src_root if src_root is not None else SRC_ROOT
+    resolved_glob = nodes_glob or f"{package}/**/nodes/**/contract.yaml"
+    if baseline is not None:
+        resolved_baseline = baseline
+    elif package == "omnibase_core":
+        resolved_baseline = BASELINE_PATH
+    else:
+        resolved_baseline = Path(__file__).with_name(
+            f"canonical_handler_shape_baseline_{package}.py"
+        )
+    if receipts_dir is not None:
+        resolved_receipts = receipts_dir
+    elif package == "omnibase_core":
+        resolved_receipts = RECEIPTS_DIR
+    else:
+        resolved_receipts = Path(__file__).with_name(f"adequacy_receipts_{package}")
+    return resolved_src_root, resolved_glob, resolved_baseline, resolved_receipts
+
+
+# --------------------------------------------------------------------------- #
 # Adequacy + equivalence gated flip verification (RECOMPUTE, do not trust)
 # --------------------------------------------------------------------------- #
 #
@@ -797,12 +855,13 @@ def _touched_node_ids(changed_files: list[str]) -> set[str]:
 def _escalation_reason(changed_files: list[str]) -> str | None:
     """Return a full-scan escalation reason, or None to stay diff-scoped."""
     shared = _load_shared_modules()
+    prefix = f"src/{PACKAGE}/"
     for rel in changed_files:
         if rel in GATE_SELF_PATHS or rel.startswith("scripts/ci/adequacy_receipts/"):
             return f"gate/baseline/receipt changed ({rel})"
-        if not rel.startswith("src/omnibase_core/") or not rel.endswith(".py"):
+        if not rel.startswith(prefix) or not rel.endswith(".py"):
             continue
-        module_path = rel[len("src/omnibase_core/") : -len(".py")]
+        module_path = rel[len(prefix) : -len(".py")]
         if any(
             module_path == m or module_path.startswith(m)
             for m in GATE_RESOLUTION_MODULES
@@ -878,7 +937,43 @@ def main(argv: list[str] | None = None) -> int:
         help="Diff base for --scope changed when no files are passed (CI path).",
     )
     parser.add_argument(
-        "--baseline", type=Path, default=BASELINE_PATH, help="Baseline module path."
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Baseline module path. Defaults to omnibase_core's committed "
+        "baseline, or canonical_handler_shape_baseline_<package>.py beside "
+        "this script when --package overrides the target (OMN-14368).",
+    )
+    parser.add_argument(
+        "--package",
+        default=os.environ.get("ONEX_CANON_SHAPE_PACKAGE", "omnibase_core"),
+        help="Target package to classify (OMN-14368 fan-out). Defaults to "
+        "omnibase_core so core CI/pre-commit behavior is unchanged; pass e.g. "
+        "'omnimarket' with --src-root to scan a sibling repo.",
+    )
+    parser.add_argument(
+        "--src-root",
+        type=Path,
+        default=(
+            Path(os.environ["ONEX_CANON_SHAPE_SRC_ROOT"])
+            if "ONEX_CANON_SHAPE_SRC_ROOT" in os.environ
+            else None
+        ),
+        help="Source root containing --package's node tree (defaults to this "
+        "repo's own src/). Pass a sibling repo's src/ dir, e.g. "
+        "../omnimarket/src, to scan a different package.",
+    )
+    parser.add_argument(
+        "--nodes-glob",
+        default=None,
+        help="Override the contract.yaml glob (default: "
+        "'<package>/**/nodes/**/contract.yaml', relative to --src-root).",
+    )
+    parser.add_argument(
+        "--receipts-dir",
+        type=Path,
+        default=None,
+        help="Override the adequacy-receipts directory for --package.",
     )
     parser.add_argument(
         "--json",
@@ -892,6 +987,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    # Apply the resolved scope to the module globals every other function in
+    # this file reads (classify_node, _escalation_reason, verify_*, ...).
+    # Pure computation happens in _resolve_scope; only main() mutates state,
+    # once per process, so unit tests calling these functions directly never
+    # observe a scope left over from a prior test.
+    global PACKAGE, SRC_ROOT, NODES_GLOB, BASELINE_PATH, RECEIPTS_DIR
+    PACKAGE = args.package
+    SRC_ROOT, NODES_GLOB, BASELINE_PATH, RECEIPTS_DIR = _resolve_scope(
+        args.package, args.src_root, args.nodes_glob, args.baseline, args.receipts_dir
+    )
+
     if args.json:
         import json
 
@@ -901,15 +1007,16 @@ def main(argv: list[str] | None = None) -> int:
     if args.update:
         findings = classify_all()
         non_canonical = current_non_canonical(findings)
-        write_baseline(non_canonical, args.baseline)
+        write_baseline(non_canonical, BASELINE_PATH)
         print(
-            f"Regenerated {args.baseline.name} (full scan) — {len(findings)} nodes, "
+            f"Regenerated {BASELINE_PATH.name} (full scan, package={PACKAGE}) — "
+            f"{len(findings)} nodes, "
             f"canonical={len(findings) - len(non_canonical)}, "
             f"non_canonical={len(non_canonical)}"
         )
         return 0
 
-    baseline = load_baseline(args.baseline)
+    baseline = load_baseline(BASELINE_PATH)
 
     full = args.full or args.scope == "full"
     scope_label = "full"

--- a/tests/unit/scripts/ci/test_canonical_handler_shape.py
+++ b/tests/unit/scripts/ci/test_canonical_handler_shape.py
@@ -12,6 +12,8 @@ flip is not proof of equivalence; the OMN-14208-at-scale trap).
 from __future__ import annotations
 
 import ast
+import subprocess
+import sys
 
 import pytest
 
@@ -21,6 +23,7 @@ from scripts.ci.canonical_handler_shape import (
     _contract_bindings,
     _escalation_reason,
     _handle_is_adaptable,
+    _resolve_scope,
     _touched_node_ids,
     classify_all,
     current_non_canonical,
@@ -245,6 +248,73 @@ def test_escalation_on_gate_and_resolution_and_shared_modules() -> None:
 def test_no_escalation_for_plain_node_change() -> None:
     assert _escalation_reason(["src/omnibase_core/nodes/node_x/handler.py"]) is None
     assert _escalation_reason(["docs/foo.md"]) is None
+
+
+# --------------------------------------------------------------------------- #
+# Package scoping (OMN-14368 mechanical-wave fan-out)
+# --------------------------------------------------------------------------- #
+#
+# _resolve_scope is pure (no global mutation) so these tests never touch
+# mod.SRC_ROOT/BASELINE_PATH/RECEIPTS_DIR/PACKAGE — the live regression guards
+# above (test_live_classification_matches_committed_baseline et al.) keep
+# reading the untouched omnibase_core defaults for the whole test session.
+
+
+def test_resolve_scope_default_package_reproduces_current_constants() -> None:
+    src_root, nodes_glob, baseline, receipts_dir = _resolve_scope(
+        "omnibase_core", None, None, None, None
+    )
+    assert src_root == mod.SRC_ROOT
+    assert nodes_glob == "omnibase_core/**/nodes/**/contract.yaml" == mod.NODES_GLOB
+    assert baseline == mod.BASELINE_PATH
+    assert receipts_dir == mod.RECEIPTS_DIR
+
+
+def test_resolve_scope_foreign_package_scopes_independently(tmp_path) -> None:
+    foreign_src = tmp_path / "omnimarket" / "src"
+    src_root, nodes_glob, baseline, receipts_dir = _resolve_scope(
+        "omnimarket", foreign_src, None, None, None
+    )
+    assert src_root == foreign_src
+    assert nodes_glob == "omnimarket/**/nodes/**/contract.yaml"
+    # Never falls back to omnibase_core's own committed baseline/receipts —
+    # a forgotten --baseline on a foreign package must not silently clobber it.
+    assert baseline.name == "canonical_handler_shape_baseline_omnimarket.py"
+    assert baseline != mod.BASELINE_PATH
+    assert receipts_dir.name == "adequacy_receipts_omnimarket"
+    assert receipts_dir != mod.RECEIPTS_DIR
+
+
+def test_resolve_scope_explicit_overrides_win(tmp_path) -> None:
+    explicit_baseline = tmp_path / "custom_baseline.py"
+    explicit_receipts = tmp_path / "custom_receipts"
+    src_root, nodes_glob, baseline, receipts_dir = _resolve_scope(
+        "omnimarket",
+        tmp_path,
+        "custom/**/glob.yaml",
+        explicit_baseline,
+        explicit_receipts,
+    )
+    assert src_root == tmp_path
+    assert nodes_glob == "custom/**/glob.yaml"
+    assert baseline == explicit_baseline
+    assert receipts_dir == explicit_receipts
+
+
+def test_cli_full_scan_default_package_unchanged() -> None:
+    """``--full`` with no --package still checks omnibase_core's own committed
+    baseline end to end. Runs in a subprocess (not in-process main()) so the
+    scope mutation main() applies to module globals can never leak into other
+    tests in this session."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "scripts.ci.canonical_handler_shape", "--full"],
+        cwd=mod.REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "ratchet OK" in proc.stdout
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Gap 1 of OMN-14368 (RSD mechanical-wave enablement). `scripts/ci/canonical_handler_shape.py` (OMN-14355 / #1428) was hardcoded `PACKAGE="omnibase_core"`, so the canonical-shape growth ratchet could never observe a flip for any node outside omnibase_core — even a correctly codemodded + equivalence-proven omnimarket/omnibase_infra node has no per-repo baseline to shrink.

- Adds `--package`/`--src-root`/`--nodes-glob`/`--receipts-dir` CLI args (+ `ONEX_CANON_SHAPE_PACKAGE`/`ONEX_CANON_SHAPE_SRC_ROOT` env overrides). All default to today's omnibase_core-only values.
- Scope computation is a new pure `_resolve_scope()` function — no global mutation, directly unit-testable. Only `main()` applies the resolved scope to the module globals (`SRC_ROOT`, `NODES_GLOB`, `BASELINE_PATH`, `RECEIPTS_DIR`, `PACKAGE`) that `classify_node`/`_escalation_reason`/`verify_*` already read as globals, once per process — so a `--package` override on the CLI can never leak into another pytest test in the same session.
- A non-default `--package` never silently falls back to omnibase_core's own committed baseline/receipts path — it gets a package-suffixed default (`canonical_handler_shape_baseline_<package>.py`) unless `--baseline`/`--receipts-dir` is passed explicitly.
- `_escalation_reason`'s previously-hardcoded `"src/omnibase_core/"` diff-scope prefix is now derived from the (module-global) `PACKAGE` — identical string for the default case, but now correct if `--package` diff-scoping is ever exercised for another repo.

**Classification logic and the 3-part adequacy+equivalence flip proof are untouched.**

## Proof core behavior is unchanged

```
$ env -u PYTHONPATH uv run python scripts/ci/canonical_handler_shape.py --full
Canonical handler-shape ratchet WARNING (OMN-14355, full) — non-blocking: 6 baselined non-canonical node(s)...
Canonical handler-shape ratchet OK (full) — checked 8 node(s); new=0 unproven_flips=0 warn=6.
```

Same 8 nodes, same 6-node baseline, exit 0 — identical to pre-change behavior. Also covered by a new subprocess-isolated regression test (`test_cli_full_scan_default_package_unchanged`) so this can't silently regress.

## Test plan

- [x] `uv run pytest tests/unit/scripts/ci/test_canonical_handler_shape.py -v` — 37 passed (33 original + 4 new: `_resolve_scope` default/foreign-package/explicit-override + CLI subprocess regression).
- [x] `uv run ruff format` / `ruff check --fix` — clean.
- [x] `uv run mypy scripts/ci/canonical_handler_shape.py` — 2 pre-existing `explicit-any` findings on `ConfigDict(...)` lines, confirmed present on unmodified origin/dev via `git stash` (not introduced by this diff).
- [x] `pre-commit run --files <changed>` — clean except `ONEX Backward Compatibility Anti-Pattern Detection`, confirmed pre-existing repo-wide (fires against `util_name_validation.py`/`validator_utils.py`, neither touched by this PR; reproduced identically on unmodified origin/dev via `git stash`).
- [x] Live re-point against omnimarket (`--package omnimarket --src-root <omnimarket>/src`) used to generate that repo's baseline — see the companion omnimarket PR.

Evidence-Ticket: OMN-14368
Evidence-Source: OCC#3904
Evidence-Commit: d820c0b1405a85321f99a2a3205668b091fad832

