### PR TITLE
fix(OMN-14404): batch-report every stale OCC receipt binding, not just the first

### DIFF
--- a/src/omnibase_core/models/validation/model_occ_eligibility_result.py
+++ b/src/omnibase_core/models/validation/model_occ_eligibility_result.py
@@ -25,6 +25,7 @@ class ModelOccEligibilityResult(BaseModel):
     receipt_ids: tuple[str, ...] = Field(default_factory=tuple)
     missing_contracts: tuple[str, ...] = Field(default_factory=tuple)
     missing_or_nonpass_receipts: tuple[str, ...] = Field(default_factory=tuple)
+    stale_receipt_bindings: tuple[str, ...] = Field(default_factory=tuple)
     dependency_prs: tuple[str, ...] = Field(default_factory=tuple)
     detail: str = Field(default="")
 
@@ -38,6 +39,7 @@ class ModelOccEligibilityResult(BaseModel):
             "receipt_ids": sorted(self.receipt_ids),
             "missing_contracts": sorted(self.missing_contracts),
             "missing_or_nonpass_receipts": sorted(self.missing_or_nonpass_receipts),
+            "stale_receipt_bindings": sorted(self.stale_receipt_bindings),
             "dependency_prs": sorted(self.dependency_prs, key=str),
             "detail": self.detail,
         }

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -121,7 +121,33 @@ def validate_occ_merge_eligibility(
     missing_contracts: list[str] = []
     missing_receipts: list[str] = []
     nonpass_receipts: list[str] = []
+    # OMN-14404: stale contract bindings accumulate like every other failure
+    # class in this function. Returning on the first one discards the other N-1
+    # already-resolved receipts and costs the operator a full CI round per stale
+    # receipt, which is what manufactured the #3965 -> #3966 -> #3968 -> #3969
+    # serial OCC repair chain. Keys mirror `missing_or_nonpass_receipts`;
+    # `stale_binding_details` holds the human-readable per-receipt message.
+    stale_bindings: list[str] = []
+    stale_binding_details: list[str] = []
     tickets_with_pr_bound_receipt: set[str] = set()
+
+    def _stale_binding_result() -> ModelOccEligibilityResult:
+        detail = "; ".join(stale_binding_details)
+        if len(stale_bindings) > 1:
+            detail = (
+                f"{len(stale_bindings)} receipts have stale contract bindings "
+                f"(repair all of them in one pass): {detail}"
+            )
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            stale_receipt_bindings=tuple(sorted(stale_bindings)),
+            detail=detail,
+        )
 
     for ticket_id in ticket_ids:
         contract_path = snapshot.contracts_dir / f"{ticket_id}.yaml"
@@ -133,6 +159,13 @@ def validate_occ_merge_eligibility(
             contract_hash = _sha256_file(contract_path)
         except (OSError, yaml.YAMLError) as exc:
             missing_contracts.append(ticket_id)
+            # OMN-14404: a stale binding found in an earlier iteration still
+            # dominates, exactly as it did when the binding check returned
+            # inline. Same guard at every hard-fail return below; it can only
+            # fire on bindings from PRIOR iterations, because the binding check
+            # is the last check in an iteration and `continue`s on failure.
+            if stale_bindings:
+                return _stale_binding_result()
             return ModelOccEligibilityResult(
                 eligible=False,
                 reason=EnumOccEligibilityReason.MISSING_CONTRACT,
@@ -165,6 +198,8 @@ def validate_occ_merge_eligibility(
             if supersession is not None:
                 if supersession.error is not None:
                     nonpass_receipts.append(receipt_key)
+                    if stale_bindings:
+                        return _stale_binding_result()
                     return ModelOccEligibilityResult(
                         eligible=False,
                         reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
@@ -189,6 +224,8 @@ def validate_occ_merge_eligibility(
                     receipt = ModelDodReceipt.model_validate(receipt_raw)
                 except (OSError, yaml.YAMLError, ValidationError) as exc:
                     nonpass_receipts.append(receipt_key)
+                    if stale_bindings:
+                        return _stale_binding_result()
                     return ModelOccEligibilityResult(
                         eligible=False,
                         reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
@@ -201,6 +238,8 @@ def validate_occ_merge_eligibility(
                     )
                 receipt_source = receipt_path
             if receipt.ticket_id != ticket_id:
+                if stale_bindings:
+                    return _stale_binding_result()
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,
@@ -242,6 +281,8 @@ def validate_occ_merge_eligibility(
                 receipt.contract_sha256 is None
                 and receipt.contract_entry_sha256 is None
             ):
+                if stale_bindings:
+                    return _stale_binding_result()
                 return ModelOccEligibilityResult(
                     eligible=False,
                     reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
@@ -265,15 +306,11 @@ def validate_occ_merge_eligibility(
                 is_bound_to_this_pr=is_bound,
             )
             if binding_error is not None:
-                return ModelOccEligibilityResult(
-                    eligible=False,
-                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
-                    ticket_ids=ticket_ids,
-                    occ_commit_sha=snapshot.occ_commit_sha,
-                    contract_hashes=contract_hashes,
-                    receipt_ids=tuple(sorted(receipt_ids)),
-                    detail=f"receipt {receipt_source}: {binding_error}",
+                stale_bindings.append(receipt_key)
+                stale_binding_details.append(
+                    f"receipt {receipt_source}: {binding_error}"
                 )
+                continue
             if is_bound:
                 tickets_with_pr_bound_receipt.add(ticket_id)
             if receipt.status is not EnumReceiptStatus.PASS:
@@ -281,6 +318,12 @@ def validate_occ_merge_eligibility(
                 continue
             receipt_ids.append(receipt_key)
 
+    # OMN-14404: stale bindings are reported FIRST, ahead of MISSING_CONTRACT,
+    # MISSING_RECEIPT/NONPASS_RECEIPT and the terminal unbound-ticket check. This
+    # reproduces the pre-batching precedence exactly: the old in-loop early return
+    # preempted every one of those post-loop checks, in every iteration order.
+    if stale_bindings:
+        return _stale_binding_result()
     if missing_contracts:
         return ModelOccEligibilityResult(
             eligible=False,

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -19,6 +19,7 @@ from omnibase_core.validation.validator_occ_merge_eligibility import (
 
 TICKET = "OMN-10484"
 PR_SHA = "1" * 40
+STALE_HASH = f"sha256:{'0' * 64}"
 
 
 def _contract_text(ticket_id: str = TICKET) -> str:
@@ -88,6 +89,35 @@ def _write_receipt(
         yaml.safe_dump(receipt, sort_keys=True),
         encoding="utf-8",
     )
+
+
+def _write_multi_entry_contract(
+    root: Path,
+    evidence_item_ids: tuple[str, ...],
+    *,
+    ticket_id: str = TICKET,
+) -> str:
+    """Write a contract carrying one dod_evidence entry per id, return its hash."""
+    text = yaml.safe_dump(
+        {
+            "ticket_id": ticket_id,
+            "title": "multi-entry OCC eligibility",
+            "dod_evidence": [
+                {
+                    "id": item_id,
+                    "description": f"probe {item_id}",
+                    "checks": [
+                        {"check_type": "command", "check_value": f"probe {item_id}"}
+                    ],
+                }
+                for item_id in evidence_item_ids
+            ],
+        },
+        sort_keys=True,
+    )
+    (root / "contracts").mkdir(parents=True, exist_ok=True)
+    (root / "contracts" / f"{ticket_id}.yaml").write_text(text, encoding="utf-8")
+    return _contract_hash(text)
 
 
 def _snapshot(
@@ -325,3 +355,150 @@ def test_eligible_output_is_replay_stable(tmp_path: Path) -> None:
     assert first.occ_commit_sha == "b" * 40
     assert first.contract_hashes == {TICKET: contract_hash}
     assert first.receipt_ids == (f"{TICKET}:dod-001:command",)
+
+
+# --- OMN-14404: batch-report every stale receipt binding -----------------------
+#
+# The validator used to return on the FIRST stale binding, discarding the other
+# N-1 receipts it had already resolved. Operators therefore learned about exactly
+# one stale receipt per CI round: repair it, re-run, get the next. That is what
+# manufactured the #3965 -> #3966 -> #3968 -> #3969 serial OCC repair chain on
+# 2026-07-11 (#3965 fixed one receipt; #3966 fixed "the remaining").
+
+
+@pytest.mark.unit
+def test_all_stale_receipt_bindings_are_reported_not_just_the_first(
+    tmp_path: Path,
+) -> None:
+    """N>1 stale bindings must ALL be named in a single result.
+
+    This is the regression that proves the first-fail-only bug is dead: against
+    the pre-fix validator it sees only dod-001.
+    """
+    item_ids = ("dod-001", "dod-002", "dod-003")
+    _write_multi_entry_contract(tmp_path, item_ids)
+    for item_id in item_ids:
+        _write_receipt(tmp_path, evidence_item_id=item_id, contract_sha256=STALE_HASH)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert result.stale_receipt_bindings == tuple(
+        f"{TICKET}:{item_id}:command" for item_id in item_ids
+    )
+    # the operator-facing detail names every stale receipt, not only the first
+    for item_id in item_ids:
+        assert item_id in result.detail
+    assert "3 receipts have stale contract bindings" in result.detail
+
+
+@pytest.mark.unit
+def test_stale_receipt_bindings_batch_across_multiple_tickets(tmp_path: Path) -> None:
+    """Accumulation spans tickets: the loop no longer aborts on the first one."""
+    second_ticket = "OMN-10485"
+    _write_contract(tmp_path)
+    _write_contract(tmp_path, ticket_id=second_ticket)
+    _write_receipt(tmp_path, contract_sha256=STALE_HASH)
+    _write_receipt(tmp_path, ticket_id=second_ticket, contract_sha256=STALE_HASH)
+    snapshot = ModelOccEligibilityInput(
+        repo="omnibase_core",
+        pr_number=123,
+        pr_title=f"feat({TICKET}): harden OCC eligibility",
+        pr_body=f"Closes: {TICKET}\nCloses: {second_ticket}",
+        pr_branch=f"jonah/{TICKET.lower()}-occ-eligibility",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(
+            f"feat({TICKET}): add eligibility",
+            f"feat({second_ticket}): add eligibility",
+        ),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert result.stale_receipt_bindings == (
+        f"{TICKET}:dod-001:command",
+        f"{second_ticket}:dod-001:command",
+    )
+
+
+@pytest.mark.unit
+def test_single_stale_receipt_binding_reporting_is_unchanged(tmp_path: Path) -> None:
+    """The N=1 case keeps its pre-batching reason and detail wording."""
+    _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=STALE_HASH)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert result.stale_receipt_bindings == (f"{TICKET}:dod-001:command",)
+    assert result.detail.startswith("receipt ")
+    assert "receipts have stale contract bindings" not in result.detail
+
+
+@pytest.mark.unit
+def test_stale_bindings_take_precedence_over_missing_and_nonpass_receipts(
+    tmp_path: Path,
+) -> None:
+    """Precedence is unchanged: a stale binding dominates missing/non-PASS.
+
+    Pre-fix, the stale binding returned from inside the loop, so it preempted the
+    post-loop MISSING_RECEIPT / NONPASS_RECEIPT report in every iteration order.
+    Batch-reporting preserves that: the stale set is checked first.
+    """
+    contract_hash = _write_multi_entry_contract(
+        tmp_path, ("dod-001", "dod-002", "dod-003")
+    )
+    _write_receipt(tmp_path, evidence_item_id="dod-001", contract_sha256=STALE_HASH)
+    # dod-002 gets no receipt at all -> MISSING_RECEIPT class
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="dod-003",
+        status=EnumReceiptStatus.FAIL,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert result.stale_receipt_bindings == (f"{TICKET}:dod-001:command",)
+    # the missing/non-PASS set is not surfaced while a stale binding outranks it,
+    # matching the pre-fix early-return payload
+    assert result.missing_or_nonpass_receipts == ()
+
+
+@pytest.mark.unit
+def test_zero_stale_bindings_stays_eligible_with_empty_stale_set(
+    tmp_path: Path,
+) -> None:
+    contract_hash = _write_multi_entry_contract(tmp_path, ("dod-001", "dod-002"))
+    _write_receipt(tmp_path, evidence_item_id="dod-001", contract_sha256=contract_hash)
+    _write_receipt(tmp_path, evidence_item_id="dod-002", contract_sha256=contract_hash)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+    assert result.stale_receipt_bindings == ()
+
+
+@pytest.mark.unit
+def test_batched_stale_binding_output_is_replay_stable(tmp_path: Path) -> None:
+    item_ids = ("dod-001", "dod-002", "dod-003")
+    _write_multi_entry_contract(tmp_path, item_ids)
+    for item_id in item_ids:
+        _write_receipt(tmp_path, evidence_item_id=item_id, contract_sha256=STALE_HASH)
+    snapshot = _snapshot(tmp_path)
+
+    first = validate_occ_merge_eligibility(snapshot)
+    second = validate_occ_merge_eligibility(snapshot)
+
+    assert first.to_json() == second.to_json()
+    assert "stale_receipt_bindings" in first.to_json()


### PR DESCRIPTION
## OMN-14404 — batch-report every stale OCC receipt binding, not just the first

Closes: OMN-14404

### The bug

`validate_occ_merge_eligibility()` early-returned on the **first** stale receipt binding, discarding the other N-1 receipts it had already fully resolved — including their supersession chains, which the loop resolves *before* the binding check. The repair set was computed and then thrown away.

Consequence: the OCC preflight gate reported exactly **one** stale receipt per CI round. Repair it, re-run, get the next. That is what manufactured the serial OCC repair chain on 2026-07-11 to land one product PR:

| OCC PR | what it did |
|---|---|
| #3965 | superseded **one** stale receipt (singular, in its own title) |
| #3966 | superseded "**the remaining**" stale receipts |
| #3968 | superseded the next stale family |
| #3969 | superseded the next stale family |

#3965 fixing one receipt while #3966 fixed "the remaining" is this defect caught red-handed.

### The fix

Accumulate, then batch-report — the idiom **already present in this same function** for `missing_receipts` / `nonpass_receipts`. The early `return` becomes `append` + `continue`; the batch report runs after the loop.

- `ModelOccEligibilityResult` gains **one additive field**, `stale_receipt_bindings` — a sorted, deterministic `tuple[str, ...]` of receipt keys, mirroring the shape and naming of `missing_or_nonpass_receipts`, and surfaced in `as_dict()`/`to_json()`. **No existing field was changed or removed; the model's `ConfigDict` is untouched.**
- `reason` remains `EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH`, so no caller breaks.
- `detail` for the N=1 case is byte-identical to the pre-fix wording; N>1 gains a `"<N> receipts have stale contract bindings (repair all of them in one pass): ..."` prefix and names every stale receipt.

### Precedence decision (required by the ticket)

**A stale binding dominates every other failure class — it is reported first, ahead of `MISSING_CONTRACT`, `MISSING_RECEIPT`/`NONPASS_RECEIPT`, and the terminal unbound-ticket `PR_TICKET_MISMATCH`.**

This is **exactly today's behavior, deliberately preserved**, not a new choice. The pre-fix early return fired from *inside* the loop, so it preempted every post-loop check in **every iteration order** — verified in both directions (stale-then-missing and missing-then-stale both yielded `CONTRACT_HASH_MISMATCH` pre-fix). Placing the stale batch-report ahead of the `missing_contracts` check reproduces that precedence.

One consequence needed handling: because the loop now `continue`s past a stale binding, it can reach in-loop hard-fail returns that were previously unreachable (unreadable contract, supersession error, invalid receipt YAML, receipt `ticket_id` mismatch, missing-both-hashes). Left alone, those would silently discard the accumulated stale set and re-create the serial repair chain through a side door — the missing-both-hashes path in particular, since it shares the `CONTRACT_HASH_MISMATCH` reason. Each therefore carries an `if stale_bindings: return _stale_binding_result()` guard. The guard can only fire on bindings from *prior* iterations, because the binding check is the last check in an iteration and `continue`s on failure.

`eligible` and the CLI exit code are unchanged on every path. The hosted gate branches only on `eligible` (`.github/workflows/occ-preflight.yml:507-508`); `reason` is print-only (`:510`).

### Tests

Six new tests in `tests/unit/validation/test_occ_merge_eligibility.py`:

- `test_all_stale_receipt_bindings_are_reported_not_just_the_first` — **the regression.** N=3 stale bindings must all be named. Verified **red before the fix**: the pre-fix validator returned `stale_receipt_bindings == ()` and its `detail` named only `dod-001`; post-fix it names `dod-001`, `dod-002`, `dod-003`.
- `test_stale_receipt_bindings_batch_across_multiple_tickets` — accumulation spans tickets, not just entries.
- `test_single_stale_receipt_binding_reporting_is_unchanged` — N=1 reason + detail wording preserved.
- `test_stale_bindings_take_precedence_over_missing_and_nonpass_receipts` — the mixed case, pinning the documented precedence.
- `test_zero_stale_bindings_stays_eligible_with_empty_stale_set` — no false positives.
- `test_batched_stale_binding_output_is_replay_stable` — deterministic `to_json()`.

### Verification

- `tests/unit/validation/` (full directory): **4701 passed, 5 skipped, 0 failed**
- `uv run ruff format src/ tests/` + `uv run ruff check --fix src/ tests/` — clean
- `uv run mypy` on both changed modules — `Success: no issues found in 2 source files`
- pre-commit ran on the staged files at commit time and passed; no `--no-verify`, no skip token

### Scope

Phase A of `docs/plans/2026-07-11-occ-receipt-binding-root-cause-plan.md`, and Phase A only. Per-entry binding, `check_receipt_hardening.py`, the OCC version pin and `contract_entry_sha256` are **not** touched — those are OMN-14369 / OMN-14405 / OMN-14406 and land separately. Batch-reporting is orthogonal and ships alone.

### OCC companion

The OCC evidence companion is **OCC#3984** (`evidence(OMN-14404): OCC Evidence-Source autobind for omnibase_core#1431`), merged 2026-07-12T01:22:41Z. It was produced by the independent OCC autogen path, **not** self-authored by this PR's implementer — self-attestation would defeat the gate. It carries `contracts/OMN-14404.yaml` plus a receipt bound to this PR (`dod-OmniNode-ai-omnibase_core-pr-1431`), which is why `occ-preflight / eligibility` resolves an Evidence-Source SHA and passes.

Evidence-Source: OCC#3984
Evidence-Ticket: OMN-14404
