### PR TITLE
feat(OMN-14402): add excluded_backend_refs to ModelRoutingIntent

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -35,6 +35,24 @@ class ModelRoutingIntent(BaseModel):
             "None means normal tier selection from the lowest eligible tier."
         ),
     )
+    # OMN-14402: same-tier backend fallback. A local-backend transport/inference
+    # failure used to escalate the WHOLE tier straight to the next (possibly
+    # cloud) tier, even when a sibling backend in the SAME tier also declares the
+    # task type (e.g. routing_tiers.yaml's local tier carries both
+    # local-heavy-reasoning and local-reasoner for "research"). Backend refs
+    # already attempted and failed within the target tier are listed here so the
+    # routing reducer's selection can skip them and land on an untried sibling
+    # instead of deterministically re-resolving the one that just failed.
+    excluded_backend_refs: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Backend refs (routing_tiers.yaml backend_id) already attempted and "
+            "failed within the tier this intent routes to. The routing reducer "
+            "skips these when selecting a model, so a same-tier retry after a "
+            "transport/inference failure lands on a different backend instead "
+            "of deterministically re-selecting the one that just failed."
+        ),
+    )
 
 
 class ModelInferenceIntent(BaseModel):

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -405,6 +405,34 @@ class TestModelRoutingIntent:
         intent = ModelRoutingIntent(payload=req, min_tier_name="cheap_cloud")
         assert intent.min_tier_name == "cheap_cloud"
 
+    def test_excluded_backend_refs_defaults_empty(self) -> None:
+        corr_id = uuid.uuid4()
+        req = ModelDelegationRequest(
+            prompt="test",
+            task_type="test",
+            correlation_id=corr_id,
+            emitted_at=datetime.now(tz=UTC),
+        )
+        intent = ModelRoutingIntent(payload=req)
+        assert intent.excluded_backend_refs == ()
+
+    def test_excluded_backend_refs_round_trips(self) -> None:
+        """OMN-14402: same-tier backend fallback threads already-failed backend
+        refs so the routing reducer can skip them and select a sibling."""
+        corr_id = uuid.uuid4()
+        req = ModelDelegationRequest(
+            prompt="test",
+            task_type="test",
+            correlation_id=corr_id,
+            emitted_at=datetime.now(tz=UTC),
+        )
+        intent = ModelRoutingIntent(
+            payload=req,
+            min_tier_name="local",
+            excluded_backend_refs=("local-heavy-reasoning",),
+        )
+        assert intent.excluded_backend_refs == ("local-heavy-reasoning",)
+
     def test_rejects_invalid_intent_literal(self) -> None:
         corr_id = uuid.uuid4()
         req = ModelDelegationRequest(


### PR DESCRIPTION
Evidence-Ticket: OMN-14402
Evidence-Source: OCC#3994
Evidence-Commit: e1dc544696a0c45695988b8f50487dca1cbeaf34
Evidence-Head: af567d7cc9a45edfc0fd3a44860e7b2a4f97a4b7
Independent verifier: onex_change_control#3994 (runner: codex / verifier: codex-runtime-verifier), merged 2026-07-12T02:59:44Z.

## Summary

Small, additive wire-DTO field needed by the paired omnimarket fix for
**OMN-14402** (local-first gap: a single local-backend failure escalates the
WHOLE `local` tier to cloud without trying a healthy sibling backend in the
same tier).

- `ModelRoutingIntent.excluded_backend_refs: tuple[str, ...]` (default `()`)
  lets the delegation orchestrator tell the routing reducer "skip these
  backend_refs" on a same-tier retry after a transport/inference failure.
  `routing_tiers.yaml`'s `local` tier can carry multiple backends declaring
  the same `task_type` (e.g. `local-heavy-reasoning` and `local-reasoner`
  both serve `research`); `delta()`/`_select_model_for_task` is
  deterministic, so re-emitting the same `ModelRoutingIntent(min_tier_name=
  tier)` always re-selects the identical (already-failed) backend without
  this field.

## Why this crosses into core

`ModelRoutingIntent` is the wire boundary between the delegation
orchestrator and the routing reducer (Kafka in prod;
`HandlerRoutingIntent.handle` deserializes it). Both producer and consumer
live in `omnimarket`, but the DTO itself is core-owned (`extra="forbid"`),
so the new field has to land here first. This mirrors the OMN-14280
`tenant_id` field precedent on the same model family.

## Compatibility

Purely additive: `default_factory=tuple`, so every existing
`ModelRoutingIntent(...)` call site is unaffected and no other field
changed. The omnimarket-side producer/consumer changes are gated with a
`model_fields` check (same pattern OMN-14280 used) so they degrade
gracefully against an out-of-sync core pin during rollout.

## Testing

- `uv run pytest tests/unit/models/delegation/wire/test_delegation_wire_models.py -v` — 94 passed (2 new cases added: default-empty, round-trip).
- `uv run ruff format --check` / `uv run ruff check` — clean on touched files.
- `uv run mypy src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py` — 0 errors.

## Merge-order dependency

OMN-14402 (dod_evidence, ticket) also has an in-flight omnimarket PR that
implements the actual same-tier fallback logic and depends on this field.
That PR currently points its `omnibase-core` git-rev override at this
branch's HEAD commit for development/CI; once this PR merges and core
releases, the omnimarket PR's pin should be bumped to the released version
(tracked in that PR's body).

proof_class: code-only (unit-tested; no live/runtime proof — this is a pure
wire-schema addition with no runtime behavior of its own).

Closes OMN-14402 (companion change; the omnimarket PR is the primary
implementation and cites the same ticket).