### PR TITLE
docs(OMN-14436): the comment claimed the DoD executor was replaced — nothing replaced it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2174,7 +2174,23 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.3"
-      - name: Validate all ticket contracts (OMN-8808 — replaces dead run_contract_compliance_check.py ref)
+      # OMN-14436: this step does NOT execute DoD check_values, and the comment that
+      # used to sit here claimed otherwise ("OMN-8808 — replaces dead
+      # run_contract_compliance_check.py ref"). NOTHING REPLACED IT.
+      #
+      # validate-yaml only parses the contract YAML. A green result here means exactly
+      # "the contract files are well-formed" — it says nothing about whether the PR's
+      # evidence is true. The real executor (run_contract_compliance_check.py) was
+      # deleted platform-wide in 2026-04 on a misdiagnosis: it was reported "missing"
+      # only because onex_change_control's DEFAULT branch lagged the branch that had
+      # it. The DoD gate has been dead here ever since, behind this green check.
+      #
+      # The executor is revived and proven in onex_change_control (OMN-14436) and wired
+      # into omnibase_infra as the canary (OMN-14454), where it executes check_values
+      # against the PRODUCT tree and is demonstrated to BLOCK. Fan-out to this repo is a
+      # deliberate, watched decision — NOT a default — because a gate nobody watched
+      # come up is a gate nobody has. Until then this step keeps its real, narrow name.
+      - name: Parse ticket contract YAML (does NOT execute DoD checks — see OMN-14436)
         run: cd "$OCC_DIR" && uv run validate-yaml "$GITHUB_WORKSPACE"/contracts/OMN-*.yaml
 
   ci-summary:


### PR DESCRIPTION
Closes OMN-14436

Evidence-Source: b0e03ef25d84ac83db30e88ff5c728528a7d7a24
Evidence-Commit: b0e03ef25d84ac83db30e88ff5c728528a7d7a24
Evidence-Head: 0a36d8fbf59366c81f7b7a4ba44a854e75941685
Evidence-Ticket: OMN-14436

Closes OMN-14436

## The lie
`ci.yml` had a step *named*:

```
Validate all ticket contracts (OMN-8808 — replaces dead run_contract_compliance_check.py ref)
```

**It replaced nothing.** The step runs `uv run validate-yaml`, which only **parses** the contract YAML. A green result means exactly *"the contract files are well-formed"* — and says **nothing** about whether the PR's evidence is true. **No `check_value` has executed in this repo since the executor was removed.**

## How it happened
The executor was deleted platform-wide in 2026-04 on a **misdiagnosis**: it was reported "missing" only because `onex_change_control`'s **default branch** lagged the branch that actually had it. The correct fix was a one-line ref pin. Instead the executor was removed — and **this comment was written to explain the removal.**

So the last thing standing where a verification used to be was **a sentence asserting that the verification still existed.**

That is precisely the failure class this epic is about: **a declaration accepted in place of a verification.** Fixing everything around it while leaving the comment in place would have been a small, perfect instance of the disease.

## What this does
Renames the step to its **real, narrow name** and documents the true state:

```yaml
- name: Parse ticket contract YAML (does NOT execute DoD checks — see OMN-14436)
```

## Where the real gate is
The executor is **revived and proven** in `onex_change_control` (OMN-14436) and wired into `omnibase_infra` as the canary (OMN-14454), where it executes `check_value`s against the **product tree** and was **demonstrated to BLOCK**:

| job | result |
|---|---|
| `Contract Compliance Check` | **FAILURE** — the gate can block |
| `CI Summary` | **FAILURE** — still merge-blocking |
| `Detect Changes` | **SUCCESS** — ran *under* the block |
| `Tests (Split 1/1)` | **EXECUTED** — the test matrix ran under a BLOCK |

## NO fan-out to this repo yet
Deliberate. Fan-out is a **watched decision, not a default** — each repo has its own required-check topology, its own `needs:` graph, and needs its own live BLOCK proof. Even the canary had two hidden bugs that surfaced only under a real run.

**A gate nobody watched come up is a gate nobody has.**

Behavior change: **none.** Comment/step-name only.
