### PR TITLE
refactor(OMN-14490): graduate canonical ModelNodeIntrospectionEvent + nested DTOs to omnibase_core (additive)

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -253,6 +253,9 @@ from .enum_import_status import EnumImportStatus
 # Injection scope enum (DI container scoping)
 from .enum_injection_scope import EnumInjectionScope
 
+# Node introspection enums (OMN-14490 — graduated from omnibase_infra)
+from .enum_introspection_reason import EnumIntrospectionReason
+
 # Invariant-related enums (OMN-1192, OMN-1206)
 from .enum_invariant_report_status import EnumInvariantReportStatus
 from .enum_invariant_type import EnumInvariantType
@@ -652,6 +655,7 @@ __all__ = [
     # Validator mode (OMN-9767 — corpus classification Phase 3, parent OMN-9757)
     "EnumValidatorMode",
     # Node domain
+    "EnumIntrospectionReason",
     "EnumNodeArchetype",
     "EnumNodeArchitectureType",
     "EnumNodeKind",

--- a/src/omnibase_core/enums/enum_introspection_reason.py
+++ b/src/omnibase_core/enums/enum_introspection_reason.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""
+Introspection Reason Enumeration.
+
+Defines reason values for node introspection events, categorizing why a node
+emits an introspection event for filtering, alerting, and analytics.
+
+Thread Safety:
+    All enums in this module are immutable and thread-safe.
+    Enum values can be safely shared across threads without synchronization.
+"""
+
+from enum import Enum, unique
+
+
+@unique
+class EnumIntrospectionReason(str, Enum):
+    """
+    Reasons why a node emits an introspection event.
+
+    Used by ModelNodeIntrospectionEvent to categorize introspection
+    events for filtering, alerting, and analytics.
+
+    Values:
+        STARTUP: Node just started and is announcing presence.
+        SHUTDOWN: Node is gracefully shutting down.
+        REQUEST: Explicit request for introspection (e.g., admin query).
+        HEARTBEAT: Periodic health heartbeat.
+        HEALTH_CHANGE: Node health status changed.
+        CAPABILITY_CHANGE: Node capabilities changed at runtime.
+
+    Example:
+        >>> reason = EnumIntrospectionReason.STARTUP
+        >>> reason.is_lifecycle_event()
+        True
+        >>> str(EnumIntrospectionReason.HEARTBEAT)
+        'heartbeat'
+    """
+
+    STARTUP = "startup"
+    """Node just started and is announcing presence."""
+
+    SHUTDOWN = "shutdown"
+    """Node is gracefully shutting down."""
+
+    REQUEST = "request"
+    """Explicit request for introspection (e.g., admin query)."""
+
+    HEARTBEAT = "heartbeat"
+    """Periodic health heartbeat."""
+
+    HEALTH_CHANGE = "health_change"
+    """Node health status changed."""
+
+    CAPABILITY_CHANGE = "capability_change"
+    """Node capabilities changed at runtime."""
+
+    def __str__(self) -> str:
+        """Return the string value for serialization."""
+        return self.value
+
+    def is_lifecycle_event(self) -> bool:
+        """
+        Check if this reason represents a lifecycle event.
+
+        Lifecycle events indicate node startup or shutdown, which are
+        significant for registration and discovery workflows.
+
+        Returns:
+            True if the reason is a lifecycle event, False otherwise
+
+        Example:
+            >>> EnumIntrospectionReason.STARTUP.is_lifecycle_event()
+            True
+            >>> EnumIntrospectionReason.HEARTBEAT.is_lifecycle_event()
+            False
+        """
+        return self in {
+            EnumIntrospectionReason.STARTUP,
+            EnumIntrospectionReason.SHUTDOWN,
+        }
+
+    def is_health_related(self) -> bool:
+        """
+        Check if this reason is health-related.
+
+        Health-related reasons indicate the node is reporting its health
+        status, either periodically or due to a change.
+
+        Returns:
+            True if the reason is health-related, False otherwise
+
+        Example:
+            >>> EnumIntrospectionReason.HEARTBEAT.is_health_related()
+            True
+            >>> EnumIntrospectionReason.REQUEST.is_health_related()
+            False
+        """
+        return self in {
+            EnumIntrospectionReason.HEARTBEAT,
+            EnumIntrospectionReason.HEALTH_CHANGE,
+        }
+
+    def is_change_event(self) -> bool:
+        """
+        Check if this reason indicates a state change.
+
+        Change events indicate something about the node changed that
+        may require re-evaluation by the registration system.
+
+        Returns:
+            True if the reason indicates a change, False otherwise
+
+        Example:
+            >>> EnumIntrospectionReason.CAPABILITY_CHANGE.is_change_event()
+            True
+            >>> EnumIntrospectionReason.HEARTBEAT.is_change_event()
+            False
+        """
+        return self in {
+            EnumIntrospectionReason.HEALTH_CHANGE,
+            EnumIntrospectionReason.CAPABILITY_CHANGE,
+        }
+
+    @classmethod
+    def get_description(cls, reason: "EnumIntrospectionReason") -> str:
+        """
+        Get a human-readable description of the introspection reason.
+
+        Args:
+            reason: The introspection reason to describe
+
+        Returns:
+            A human-readable description of the reason
+
+        Example:
+            >>> EnumIntrospectionReason.get_description(
+            ...     EnumIntrospectionReason.STARTUP
+            ... )
+            'Node just started and is announcing presence'
+        """
+        descriptions = {
+            cls.STARTUP: "Node just started and is announcing presence",
+            cls.SHUTDOWN: "Node is gracefully shutting down",
+            cls.REQUEST: "Explicit request for introspection",
+            cls.HEARTBEAT: "Periodic health heartbeat",
+            cls.HEALTH_CHANGE: "Node health status changed",
+            cls.CAPABILITY_CHANGE: "Node capabilities changed at runtime",
+        }
+        return descriptions.get(reason, "Unknown introspection reason")
+
+
+__all__: list[str] = ["EnumIntrospectionReason"]

--- a/src/omnibase_core/models/registration/__init__.py
+++ b/src/omnibase_core/models/registration/__init__.py
@@ -81,14 +81,47 @@ See Also:
     omnibase_core.nodes.NodeOrchestrator: Aggregates outcomes
 """
 
+from omnibase_core.models.registration.model_discovered_capabilities import (
+    ModelDiscoveredCapabilities,
+)
 from omnibase_core.models.registration.model_dual_registration_outcome import (
     ModelDualRegistrationOutcome,
 )
+from omnibase_core.models.registration.model_event_bus_topic_entry import (
+    ModelEventBusTopicEntry,
+)
+from omnibase_core.models.registration.model_introspection_performance_metrics import (
+    ModelIntrospectionPerformanceMetrics,
+)
+from omnibase_core.models.registration.model_mcp_contract_config import (
+    ModelMCPContractConfig,
+)
+from omnibase_core.models.registration.model_node_capabilities import (
+    ModelNodeCapabilities,
+)
+from omnibase_core.models.registration.model_node_event_bus_config import (
+    ModelNodeEventBusConfig,
+)
+from omnibase_core.models.registration.model_node_introspection_event import (
+    ModelNodeIntrospectionEvent,
+)
+from omnibase_core.models.registration.model_node_metadata import ModelNodeMetadata
 from omnibase_core.models.registration.model_registration_payload import (
     ModelRegistrationPayload,
 )
 
 __all__ = [
+    # Registration workflow payloads
     "ModelRegistrationPayload",
     "ModelDualRegistrationOutcome",
+    # Node introspection wire event + nested DTOs
+    # (OMN-14490 — graduated from omnibase_infra as the single canonical home)
+    "ModelNodeIntrospectionEvent",
+    "ModelDiscoveredCapabilities",
+    "ModelEventBusTopicEntry",
+    "ModelIntrospectionPerformanceMetrics",
+    "ModelMCPContractConfig",
+    "ModelNodeCapabilities",
+    "ModelNodeEventBusConfig",
+    "ModelNodeMetadata",
 ]

--- a/src/omnibase_core/models/registration/model_discovered_capabilities.py
+++ b/src/omnibase_core/models/registration/model_discovered_capabilities.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Model for capabilities discovered via runtime reflection."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.types import JsonType
+
+
+class ModelDiscoveredCapabilities(BaseModel):
+    """Capabilities discovered via runtime reflection.
+
+    This model represents what introspection discovers about a node at runtime,
+    as opposed to ModelNodeCapabilities which represents declared/contract capabilities.
+
+    Attributes:
+        operations: Method names matching operation keywords (execute, handle, process).
+        has_fsm: Whether the node has FSM state management.
+        method_signatures: Mapping of method names to their signature strings.
+        attributes: Additional discovered attributes (flexible JSON storage).
+
+    Example:
+        >>> caps = ModelDiscoveredCapabilities(
+        ...     operations=("execute", "query", "batch_execute"),
+        ...     has_fsm=True,
+        ...     method_signatures={"execute": "(query: str) -> list[dict]"},
+        ... )
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    operations: tuple[str, ...] = Field(
+        default=(),
+        description="Method names matching operation keywords (execute, handle, process)",
+    )
+    has_fsm: bool = Field(
+        default=False,
+        description="Whether the node has FSM state management",
+    )
+    method_signatures: dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of method names to their signature strings",
+    )
+    attributes: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Additional discovered attributes",
+    )
+
+
+__all__ = ["ModelDiscoveredCapabilities"]

--- a/src/omnibase_core/models/registration/model_event_bus_topic_entry.py
+++ b/src/omnibase_core/models/registration/model_event_bus_topic_entry.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Event Bus Topic Entry Model.
+
+The model for a single topic entry in the event bus
+configuration, containing the realm-agnostic topic string and
+optional tooling metadata.
+
+Key Design Decisions:
+    1. Topics stored as realm-agnostic strings (e.g., "onex.evt.intent-classified.v1")  # onex-topic-allow: pending contract auto-wiring
+    2. Metadata fields (event_type, message_category, description) are tooling-only
+    3. Routing uses ONLY the topic string - never metadata fields
+    4. Model is frozen (immutable) with extra="forbid" for safety
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelEventBusTopicEntry(BaseModel):
+    """Single topic entry with optional metadata.
+
+    IMPORTANT: Routing depends ONLY on the `topic` string.
+    Metadata fields (event_type, message_category, description) are
+    tooling-facing only and are never used for routing decisions.
+
+    Attributes:
+        topic: Realm-agnostic topic string (e.g., "onex.evt.intent-classified.v1").  # onex-topic-allow: pending contract auto-wiring
+            This is the ONLY field used for routing.
+        event_type: Optional event model name. Tooling metadata only.
+        message_category: Message category (EVENT, COMMAND, INTENT).
+            Tooling metadata only. Defaults to "EVENT".
+        description: Optional human-readable description. Tooling metadata only.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    topic: str = Field(
+        ...,
+        description="Realm-agnostic topic string (e.g., 'onex.evt.intent-classified.v1'). "  # onex-topic-allow: pending contract auto-wiring
+        "This is the ONLY field used for routing.",
+    )
+    event_type: str | None = Field(
+        default=None,
+        description="Optional event model name. Tooling metadata only - never used for routing.",
+    )
+    message_category: str = Field(
+        default="EVENT",
+        description="Message category (EVENT, COMMAND, INTENT). "
+        "Tooling metadata only - never used for routing.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Optional human-readable description. Tooling metadata only.",
+    )
+
+
+__all__ = ["ModelEventBusTopicEntry"]

--- a/src/omnibase_core/models/registration/model_introspection_performance_metrics.py
+++ b/src/omnibase_core/models/registration/model_introspection_performance_metrics.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Performance metrics model for node introspection operations.
+
+A Pydantic model for capturing performance metrics from
+introspection operations. It mirrors the dataclass IntrospectionPerformanceMetrics
+from MixinNodeIntrospection but provides Pydantic serialization for event payloads.
+
+The model enables:
+- Performance monitoring of introspection operations
+- Detection of slow operations exceeding the <50ms threshold
+- Cache hit/miss tracking for performance optimization
+- Serialization to JSON for event bus transmission
+
+Related:
+    - ModelNodeIntrospectionEvent - Contains this model as an optional field
+    - OMN-926 - Ticket for adding performance metrics to introspection events
+"""
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelIntrospectionPerformanceMetrics(BaseModel):
+    """Performance metrics captured during node introspection.
+
+    This model provides timing information for introspection operations,
+    enabling observability and alerting when operations exceed the
+    <50ms target threshold defined in MixinNodeIntrospection.
+
+    Attributes:
+        get_capabilities_ms: Time taken by get_capabilities() in milliseconds.
+        discover_capabilities_ms: Time taken by _discover_capabilities() in ms.
+        get_endpoints_ms: Time taken by get_endpoints() in milliseconds.
+        get_current_state_ms: Time taken by get_current_state() in milliseconds.
+        total_introspection_ms: Total time for get_introspection_data() in ms.
+        cache_hit: Whether the result was served from cache.
+        method_count: Number of methods discovered during reflection.
+        threshold_exceeded: Whether any operation exceeded performance thresholds.
+        slow_operations: List of operation names that exceeded their thresholds.
+        captured_at: UTC timestamp when metrics were captured.
+
+    Performance Thresholds:
+        The following thresholds are used (defined in MixinNodeIntrospection):
+        - get_capabilities: <50ms
+        - discover_capabilities: <30ms
+        - total_introspection: <50ms
+        - cache_hit: <1ms
+    """
+
+    # Timing metrics in milliseconds
+    get_capabilities_ms: float = Field(
+        default=0.0,
+        description="Time taken by get_capabilities() in milliseconds",
+        ge=0.0,
+    )
+    discover_capabilities_ms: float = Field(
+        default=0.0,
+        description="Time taken by _discover_capabilities() in milliseconds",
+        ge=0.0,
+    )
+    get_endpoints_ms: float = Field(
+        default=0.0,
+        description="Time taken by get_endpoints() in milliseconds",
+        ge=0.0,
+    )
+    get_current_state_ms: float = Field(
+        default=0.0,
+        description="Time taken by get_current_state() in milliseconds",
+        ge=0.0,
+    )
+    total_introspection_ms: float = Field(
+        default=0.0,
+        description="Total time for get_introspection_data() in milliseconds",
+        ge=0.0,
+    )
+
+    # Cache and discovery information
+    cache_hit: bool = Field(
+        default=False,
+        description="Whether the result was served from cache",
+    )
+    method_count: int = Field(
+        default=0,
+        description="Number of methods discovered during reflection",
+        ge=0,
+    )
+
+    # Threshold violation tracking
+    threshold_exceeded: bool = Field(
+        default=False,
+        description="Whether any operation exceeded performance thresholds",
+    )
+    slow_operations: list[str] = Field(
+        default_factory=list,
+        description="List of operation names that exceeded their thresholds",
+    )
+
+    # Capture timestamp
+    captured_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when metrics were captured",
+    )
+
+    # Frozen for immutability - metrics are snapshots
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,  # ORM/pytest-xdist compatibility
+    )
+
+
+__all__ = ["ModelIntrospectionPerformanceMetrics"]

--- a/src/omnibase_core/models/registration/model_mcp_contract_config.py
+++ b/src/omnibase_core/models/registration/model_mcp_contract_config.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""MCP contract configuration model for enabling nodes as MCP tools.
+
+This model defines the `mcp` field that can be added to ONEX contracts to expose
+orchestrator nodes as MCP tools for AI agent integration.
+
+Example contract.yaml:
+    node_type: ORCHESTRATOR_GENERIC
+    mcp:
+      expose: true
+      tool_name: "workflow_execute"
+      description: "Execute a workflow"
+      timeout_seconds: 30
+
+Enforcement Rule:
+    The `mcp.expose` field is ONLY valid for ORCHESTRATOR_GENERIC nodes.
+    Non-orchestrator nodes with `mcp.expose: true` will be ignored during
+    registration - the MCP tags will not be added to the registry.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ModelMCPContractConfig(BaseModel):
+    """MCP configuration for exposing a node as an MCP tool.
+
+    This configuration is embedded in a node's contract.yaml to enable
+    AI agents to discover and invoke the node as an MCP tool.
+
+    Attributes:
+        expose: Whether to expose this node as an MCP tool. When True and
+            the node is an orchestrator, it will be registered with
+            MCP-specific tags for tool discovery.
+        tool_name: Optional stable name for the MCP tool. If not provided,
+            defaults to the node's name. Use this to provide a consistent
+            tool name across node version changes.
+        description: Optional AI-friendly description of what this tool does.
+            If not provided, the node's description from the contract is used.
+        timeout_seconds: Optional execution timeout in seconds. Defaults to 30.
+            This is enforced when AI agents invoke the tool.
+
+    Example:
+        >>> config = ModelMCPContractConfig(
+        ...     expose=True,
+        ...     tool_name="my_workflow",
+        ...     description="Execute my custom workflow",
+        ...     timeout_seconds=60,
+        ... )
+        >>> config.expose
+        True
+    """
+
+    expose: bool = Field(
+        default=False,
+        description="Whether to expose this node as an MCP tool. "
+        "Only valid for ORCHESTRATOR_GENERIC nodes.",
+    )
+    tool_name: str | None = Field(
+        default=None,
+        description="Optional stable name for the MCP tool. "
+        "Defaults to the node's name if not specified.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Optional AI-friendly description of what this tool does. "
+        "If not provided, the node's description from the contract is used.",
+    )
+    timeout_seconds: int = Field(
+        default=30,
+        ge=1,
+        le=300,
+        description="Execution timeout in seconds for tool invocations. "
+        "Minimum: 1, Maximum: 300 (5 minutes).",
+    )
+
+
+__all__ = ["ModelMCPContractConfig"]

--- a/src/omnibase_core/models/registration/model_node_capabilities.py
+++ b/src/omnibase_core/models/registration/model_node_capabilities.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Node Capabilities Model.
+
+ModelNodeCapabilities for strongly-typed node capabilities
+in the ONEX 2-way registration pattern.
+
+Note:
+    This model does NOT use MixinDictLikeAccessors because it requires custom
+    logic to differentiate between known model fields (model_fields) and custom
+    capabilities stored in model_extra. The mixin's simple hasattr/getattr pattern
+    would not correctly handle this distinction.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
+from omnibase_core.models.registration.model_mcp_contract_config import (
+    ModelMCPContractConfig,
+)
+from omnibase_core.types import JsonType
+
+
+class ModelNodeCapabilities(BaseModel):
+    """Strongly-typed node capabilities model.
+
+    Uses explicit capability fields instead of generic dictionaries.
+    Uses extra="allow" to support custom capabilities while
+    providing type safety for known fields.
+
+    Known capability fields are typed explicitly. Additional custom
+    capabilities can be added via the extra="allow" config, and they
+    will be stored as model extra fields accessible via model_extra.
+
+    Attributes:
+        postgres: Whether node has PostgreSQL capability.
+        read: Whether node has read capability.
+        write: Whether node has write capability.
+        database: Whether node has generic database capability.
+        processing: Whether node has processing capability.
+        batch_size: Optional batch size limit.
+        max_batch: Optional maximum batch size.
+        supported_types: List of supported data types.
+        routing: Whether node has routing capability.
+        config: Nested configuration dictionary (JSON-serializable values only).
+        transactions: Whether node supports transactions.
+        feature: Generic feature flag.
+
+    Example:
+        >>> caps = ModelNodeCapabilities(
+        ...     postgres=True,
+        ...     read=True,
+        ...     write=True,
+        ... )
+        >>> caps.postgres
+        True
+
+        >>> # Custom capabilities via extra="allow"
+        >>> caps = ModelNodeCapabilities(
+        ...     custom_capability=True,  # type: ignore[call-arg]
+        ...     another_field="value",  # type: ignore[call-arg]
+        ... )
+        >>> caps.model_extra["custom_capability"]
+        True
+    """
+
+    model_config = ConfigDict(
+        extra="allow",  # Accept additional fields not explicitly defined
+        frozen=False,  # Allow updates (ModelNodeRegistration is mutable)
+        from_attributes=True,
+    )
+
+    # Database capabilities
+    postgres: bool = Field(default=False, description="PostgreSQL capability")
+    read: bool = Field(default=False, description="Read capability")
+    write: bool = Field(default=False, description="Write capability")
+    database: bool = Field(default=False, description="Generic database capability")
+    transactions: bool = Field(default=False, description="Transaction support")
+
+    # Processing capabilities
+    processing: bool = Field(default=False, description="Processing capability")
+    batch_size: int | None = Field(default=None, description="Batch size limit")
+    max_batch: int | None = Field(default=None, description="Maximum batch size")
+    supported_types: list[str] = Field(
+        default_factory=list, description="Supported data types"
+    )
+
+    # Network capabilities
+    routing: bool = Field(default=False, description="Routing capability")
+
+    # Generic feature flag (used in tests)
+    feature: bool = Field(default=False, description="Generic feature flag")
+
+    # Configuration (nested) - uses JsonType for JSON-serializable values.
+    # Supports primitives (str, int, float, bool, None), lists, and nested dicts.
+    config: dict[str, JsonType] = Field(
+        default_factory=dict,
+        description="Nested configuration (JSON-serializable values)",
+    )
+
+    # Contract-declared feature flags with current state
+    feature_flags: ModelFeatureFlags = Field(
+        default_factory=ModelFeatureFlags,
+        description="Contract-declared feature flags with current state",
+    )
+
+    # MCP configuration for exposing node as AI agent tool
+    # Only valid for ORCHESTRATOR nodes - ignored for other node types
+    mcp: ModelMCPContractConfig | None = Field(
+        default=None,
+        description="MCP configuration for exposing node as AI agent tool. "
+        "Only valid for ORCHESTRATOR_GENERIC nodes.",
+    )
+
+    def __getitem__(self, key: str) -> object:
+        """Enable dict-like access to capabilities.
+
+        Args:
+            key: The capability name to retrieve.
+
+        Returns:
+            The capability value (from known field or model_extra).
+
+        Raises:
+            KeyError: If key is not found in known fields or model_extra.
+
+        Example:
+            >>> caps = ModelNodeCapabilities(postgres=True, custom=42)
+            >>> caps["postgres"]
+            True
+            >>> caps["custom"]  # Custom capability from model_extra
+            42
+        """
+        if key in type(self).model_fields:
+            return getattr(self, key)
+        extra = self.model_extra or {}
+        if key in extra:
+            return extra[key]
+        raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        """Enable membership testing for capabilities.
+
+        Returns True if key is a known field OR exists in model_extra.
+
+        Args:
+            key: The capability name to check.
+
+        Returns:
+            True if the key exists as a known field or in model_extra.
+
+        Example:
+            >>> caps = ModelNodeCapabilities(postgres=True, custom=42)
+            >>> "postgres" in caps
+            True
+            >>> "custom" in caps  # Custom capability in model_extra
+            True
+            >>> "unknown" in caps
+            False
+        """
+        if not isinstance(key, str):
+            return False
+
+        # Check known fields first (access via class to avoid deprecation)
+        if key in type(self).model_fields:
+            return True
+
+        # Check model_extra for custom capabilities
+        return bool(self.model_extra and key in self.model_extra)
+
+    def get(self, key: str, default: object = None) -> object:
+        """Safely get a capability value with optional default.
+
+        Args:
+            key: The capability name to retrieve.
+            default: Value to return if key is not found (defaults to None).
+
+        Returns:
+            The capability value if found, otherwise the default value.
+
+        Example:
+            >>> caps = ModelNodeCapabilities(postgres=True)
+            >>> caps.get("postgres")
+            True
+            >>> caps.get("unknown", False)
+            False
+            >>> caps.get("unknown")  # Returns None by default
+        """
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+__all__ = [
+    "ModelNodeCapabilities",
+]

--- a/src/omnibase_core/models/registration/model_node_event_bus_config.py
+++ b/src/omnibase_core/models/registration/model_node_event_bus_config.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Node Event Bus Configuration Model.
+
+The model for a node's resolved event bus configuration,
+containing lists of topics the node subscribes to and publishes to.
+
+Key Design Decisions:
+    1. Topics stored as realm-agnostic strings (e.g., "onex.evt.intent-classified.v1")  # onex-topic-allow: pending contract auto-wiring
+    2. Metadata fields are tooling-only; routing uses ONLY topic strings
+    3. Property methods extract topic strings only for routing lookups
+    4. Model is frozen (immutable) with extra="forbid" for safety
+
+Example:
+    >>> from omnibase_core.models.registration import (
+    ...     ModelEventBusTopicEntry,
+    ...     ModelNodeEventBusConfig,
+    ... )
+    >>> entry = ModelEventBusTopicEntry(
+    ...     topic="onex.evt.intent-classified.v1",  # onex-topic-allow: pending contract auto-wiring
+    ...     event_type="ModelIntentClassified",
+    ... )
+    >>> config = ModelNodeEventBusConfig(subscribe_topics=[entry])
+    >>> config.subscribe_topic_strings
+    ['onex.evt.intent-classified.v1']  # onex-topic-allow: pending contract auto-wiring
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.registration.model_event_bus_topic_entry import (
+    ModelEventBusTopicEntry,
+)
+
+
+class ModelNodeEventBusConfig(BaseModel):
+    """Resolved event bus configuration for registry storage.
+
+    This model holds the resolved, realm-agnostic topic strings
+    that a node subscribes to and publishes to. It is designed for
+    storage in the registry to enable dynamic topic-based routing.
+
+    The property methods (subscribe_topic_strings, publish_topic_strings)
+    extract only the topic strings for routing lookups, ignoring all
+    metadata fields.
+
+    Attributes:
+        subscribe_topics: List of topics the node subscribes to.
+        publish_topics: List of topics the node publishes to.
+
+    Example:
+        >>> config = ModelNodeEventBusConfig(
+        ...     subscribe_topics=[
+        ...         ModelEventBusTopicEntry(topic="onex.evt.input.v1"),  # onex-topic-allow: pending contract auto-wiring
+        ...     ],
+        ...     publish_topics=[
+        ...         ModelEventBusTopicEntry(topic="onex.evt.output.v1"),  # onex-topic-allow: pending contract auto-wiring
+        ...     ],
+        ... )
+        >>> config.subscribe_topic_strings
+        ['onex.evt.input.v1']  # onex-topic-allow: pending contract auto-wiring
+        >>> config.publish_topic_strings
+        ['onex.evt.output.v1']  # onex-topic-allow: pending contract auto-wiring
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    subscribe_topics: list[ModelEventBusTopicEntry] = Field(
+        default_factory=list,
+        description="List of topics the node subscribes to.",
+    )
+    publish_topics: list[ModelEventBusTopicEntry] = Field(
+        default_factory=list,
+        description="List of topics the node publishes to.",
+    )
+
+    @property
+    def subscribe_topic_strings(self) -> list[str]:
+        """Extract topic strings only, for routing lookups.
+
+        Returns:
+            List of realm-agnostic topic strings from subscribe_topics.
+            Metadata fields are ignored.
+        """
+        return [entry.topic for entry in self.subscribe_topics]
+
+    @property
+    def publish_topic_strings(self) -> list[str]:
+        """Extract topic strings only, for routing lookups.
+
+        Returns:
+            List of realm-agnostic topic strings from publish_topics.
+            Metadata fields are ignored.
+        """
+        return [entry.topic for entry in self.publish_topics]
+
+
+__all__ = ["ModelEventBusTopicEntry", "ModelNodeEventBusConfig"]

--- a/src/omnibase_core/models/registration/model_node_introspection_event.py
+++ b/src/omnibase_core/models/registration/model_node_introspection_event.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unified Node Introspection Event Model.
+
+ModelNodeIntrospectionEvent for node introspection broadcasts
+in the ONEX registration and discovery patterns.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums import EnumIntrospectionReason, EnumNodeKind
+from omnibase_core.models.capabilities import ModelContractCapabilities
+from omnibase_core.models.core.model_feature_flags import ModelFeatureFlags
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.registration.model_discovered_capabilities import (
+    ModelDiscoveredCapabilities,
+)
+from omnibase_core.models.registration.model_introspection_performance_metrics import (
+    ModelIntrospectionPerformanceMetrics,
+)
+from omnibase_core.models.registration.model_node_capabilities import (
+    ModelNodeCapabilities,
+)
+from omnibase_core.models.registration.model_node_event_bus_config import (
+    ModelNodeEventBusConfig,
+)
+from omnibase_core.models.registration.model_node_metadata import ModelNodeMetadata
+from omnibase_core.utils.util_validators import (
+    ensure_timezone_aware,
+    validate_endpoint_urls_dict,
+)
+
+
+class ModelNodeIntrospectionEvent(BaseModel):
+    """Unified event model for node introspection broadcasts.
+
+    Nodes publish this event to announce their presence, capabilities,
+    and endpoints to the cluster. Used by the Registry node to maintain
+    a live catalog of available nodes and by introspection for service discovery.
+
+    This model co-locates both declared capabilities (from contract) and
+    discovered capabilities (from reflection) - they are NOT unified as they
+    represent fundamentally different data.
+
+    Attributes:
+        node_id: Unique node identifier.
+        node_type: ONEX node type (EFFECT, COMPUTE, REDUCER, ORCHESTRATOR).
+        node_version: Semantic version of the node.
+        declared_capabilities: Contract-declared capabilities (feature flags).
+        discovered_capabilities: Runtime-discovered capabilities (reflection).
+        contract_capabilities: Contract-derived capabilities (design-time truth).
+            Populated from the node's contract when available, None otherwise.
+        endpoints: Dictionary of exposed endpoints (name -> URL).
+        current_state: Current FSM state if the node has state management.
+        reason: Why this introspection event was emitted.
+        correlation_id: Required correlation ID for tracing and idempotency.
+        timestamp: Event timestamp (must be timezone-aware).
+        node_role: Optional role descriptor (registry, adapter, etc).
+        metadata: Additional node metadata.
+        network_id: Network/cluster identifier.
+        deployment_id: Deployment/release identifier.
+        epoch: Registration epoch for ordering.
+        performance_metrics: Optional metrics from introspection operation.
+        event_bus: Resolved event bus topic configuration for registry-driven routing.
+            If None, node is NOT included in dynamic topic routing lookups.
+
+    Example:
+        >>> from uuid import uuid4
+        >>> from datetime import datetime, timezone
+        >>> from omnibase_core.enums import EnumNodeKind
+        >>> from omnibase_core.models.primitives.model_semver import ModelSemVer
+        >>> event = ModelNodeIntrospectionEvent(
+        ...     node_id=uuid4(),
+        ...     node_type=EnumNodeKind.EFFECT,
+        ...     node_version=ModelSemVer(major=1, minor=2, patch=3),
+        ...     correlation_id=uuid4(),
+        ...     timestamp=datetime.now(timezone.utc),
+        ... )
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+    )
+
+    # Core identity (required, strongly typed)
+    node_id: UUID = Field(..., description="Unique node identifier")
+    node_name: str | None = Field(
+        default=None,
+        description="Human-readable node name from contract metadata or snake_case class name. "
+        "None only as degraded fallback — UUID fallback in e2e is a regression.",
+    )
+    node_type: EnumNodeKind = Field(..., description="ONEX node type")
+    node_version: ModelSemVer = Field(
+        default_factory=lambda: ModelSemVer(major=1, minor=0, patch=0),
+        description="Semantic version of the node",
+    )
+
+    # Co-located capabilities (different purposes, different structures)
+    declared_capabilities: ModelNodeCapabilities = Field(
+        default_factory=ModelNodeCapabilities,
+        description="Node-declared capabilities from contract (feature flags)",
+    )
+    discovered_capabilities: ModelDiscoveredCapabilities = Field(
+        default_factory=ModelDiscoveredCapabilities,
+        description="Capabilities discovered via runtime reflection",
+    )
+    contract_capabilities: ModelContractCapabilities | None = Field(
+        default=None,
+        description="Contract-derived capabilities (design-time truth, deterministic). "
+        "Populated by ContractCapabilityExtractor from the node's contract. "
+        "None when contract is not available or extraction fails.",
+    )
+
+    # Endpoints and state
+    endpoints: dict[str, str] = Field(
+        default_factory=dict,
+        description="Exposed endpoints (name -> URL)",
+    )
+
+    @field_validator("endpoints")
+    @classmethod
+    def validate_endpoint_urls(cls, v: dict[str, str]) -> dict[str, str]:
+        """Validate that all endpoint values are valid URLs.
+
+        Delegates to shared utility for consistent validation across all models.
+        """
+        return validate_endpoint_urls_dict(v)
+
+    current_state: str | None = Field(
+        default=None,
+        description="Current FSM state if node has state management",
+    )
+
+    # Event metadata (strongly typed)
+    reason: EnumIntrospectionReason = Field(
+        default=EnumIntrospectionReason.STARTUP,
+        description="Why this introspection event was emitted",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Request correlation ID for tracing (required for idempotency)",
+    )
+    timestamp: datetime = Field(
+        ...,
+        description="Event timestamp (must be timezone-aware)",
+    )
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp_timezone_aware(cls, v: datetime) -> datetime:
+        """Validate that timestamp is timezone-aware.
+
+        Delegates to the shared core utility for consistent validation.
+        """
+        return ensure_timezone_aware(v, "timestamp")
+
+    # Optional registration fields
+    node_role: str | None = Field(
+        default=None,
+        description="Node role (registry, adapter, etc)",
+    )
+    metadata: ModelNodeMetadata = Field(
+        default_factory=ModelNodeMetadata,
+        description="Additional node metadata",
+    )
+    network_id: str | None = Field(
+        default=None,
+        description="Network/cluster identifier",
+    )
+    deployment_id: str | None = Field(
+        default=None,
+        description="Deployment/release identifier",
+    )
+    epoch: int | None = Field(
+        default=None,
+        ge=0,
+        description="Registration epoch for ordering (monotonically increasing)",
+    )
+
+    # Optional discovery fields
+    performance_metrics: ModelIntrospectionPerformanceMetrics | None = Field(
+        default=None,
+        description="Performance metrics from introspection operation",
+    )
+    event_bus: ModelNodeEventBusConfig | None = Field(
+        default=None,
+        description="Resolved event bus topic configuration. "
+        "Contains environment-qualified topic strings for registry-driven routing. "
+        "If None, node is NOT included in dynamic topic routing lookups.",
+    )
+
+    # Feature flags
+    resolved_feature_flags: ModelFeatureFlags = Field(
+        default_factory=ModelFeatureFlags,
+        description="Feature flag values after applying env/control-plane overrides. "
+        "Contrast with declared_capabilities.feature_flags which holds contract defaults only.",
+    )
+
+
+__all__ = ["ModelNodeIntrospectionEvent"]

--- a/src/omnibase_core/models/registration/model_node_metadata.py
+++ b/src/omnibase_core/models/registration/model_node_metadata.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Node Metadata Model.
+
+ModelNodeMetadata for strongly-typed node metadata
+in the ONEX 2-way registration pattern.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelNodeMetadata(BaseModel):
+    """Strongly-typed node metadata model.
+
+    Replaces dict[str, Any] with explicit metadata fields.
+    Uses extra="allow" to support custom metadata while
+    providing type safety for known fields.
+
+    Known metadata fields are typed explicitly. Additional custom
+    metadata can be added via the extra="allow" config, and they
+    will be stored as model extra fields accessible via model_extra.
+
+    Attributes:
+        version: Software version string.
+        environment: Deployment environment (e.g., production, staging).
+        region: Geographic region identifier.
+        cluster: Cluster identifier.
+        description: Human-readable description (supports Unicode).
+        priority: Priority level for scheduling/routing.
+        key: Generic key field (used in tests).
+        key1: Generic key field (used in tests).
+        meta: Generic meta field (used in tests).
+
+    Example:
+        >>> meta = ModelNodeMetadata(
+        ...     version="1.0.0",
+        ...     environment="production",
+        ...     region="us-west-2",
+        ... )
+        >>> meta.environment
+        'production'
+
+        >>> # Unicode support
+        >>> meta = ModelNodeMetadata(description="Узел обработки")
+        >>> meta.description
+        'Узел обработки'
+    """
+
+    model_config = ConfigDict(
+        extra="allow",  # Accept additional fields not explicitly defined
+        frozen=False,  # Allow updates (ModelNodeRegistration is mutable)
+        from_attributes=True,
+    )
+
+    # Common metadata fields
+    version: str | None = Field(default=None, description="Software version string")
+    environment: str | None = Field(
+        default=None, description="Deployment environment (production, staging, etc.)"
+    )
+    region: str | None = Field(default=None, description="Geographic region identifier")
+    cluster: str | None = Field(default=None, description="Cluster identifier")
+    description: str | None = Field(
+        default=None, description="Human-readable description (supports Unicode)"
+    )
+
+    # Scheduling/routing metadata
+    priority: int | None = Field(
+        default=None, description="Priority level for scheduling/routing"
+    )
+
+    # Generic fields used in tests - using constrained types
+    key: str | None = Field(default=None, description="Generic key field")
+    key1: str | None = Field(default=None, description="Generic key1 field")
+    meta: str | None = Field(default=None, description="Generic meta field")
+
+
+__all__ = ["ModelNodeMetadata"]

--- a/src/omnibase_core/utils/util_validators.py
+++ b/src/omnibase_core/utils/util_validators.py
@@ -58,11 +58,13 @@ Deterministic Ordering
 
 from datetime import datetime
 from typing import TypeVar
+from urllib.parse import urlparse
 
 __all__ = [
     "convert_list_to_tuple",
     "convert_dict_to_frozen_pairs",
     "ensure_timezone_aware",
+    "validate_endpoint_urls_dict",
 ]
 
 # Generic type variable for list/tuple element types
@@ -217,3 +219,44 @@ def ensure_timezone_aware(v: datetime, field_name: str = "timestamp") -> datetim
             f"Got naive or effectively naive datetime: {v}"
         )
     return v
+
+
+def validate_endpoint_urls_dict(endpoints: dict[str, str]) -> dict[str, str]:
+    """Validate that every endpoint value is a well-formed URL.
+
+    Single source of truth for endpoint-URL validation in Pydantic field
+    validators (e.g. ``ModelNodeIntrospectionEvent.endpoints``). A URL is
+    considered valid only when it parses to both a scheme and a netloc.
+
+    Args:
+        endpoints: Mapping of endpoint name to URL string.
+
+    Returns:
+        The validated endpoints mapping (unchanged if valid).
+
+    Raises:
+        ValueError: If any endpoint URL is missing a scheme or netloc. The
+            error message strips any userinfo from the URL to avoid leaking
+            embedded credentials.
+
+    Example:
+        >>> validate_endpoint_urls_dict({"api": "http://localhost:8080"})
+        {'api': 'http://localhost:8080'}
+        >>> validate_endpoint_urls_dict({"api": "localhost:8080"})
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid URL for endpoint 'api': localhost:8080
+    """
+    for name, url in endpoints.items():
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            # Render a credential-safe form: drop any user:pass@ userinfo.
+            safe_netloc = parsed.netloc.rsplit("@", 1)[-1] if parsed.netloc else ""
+            safe_url = (
+                f"{parsed.scheme}://{safe_netloc}{parsed.path}"
+                if (parsed.scheme or safe_netloc)
+                else url.rsplit("@", 1)[-1]
+            )
+            # error-ok: ValueError appropriate for Pydantic field_validator boundary validation
+            raise ValueError(f"Invalid URL for endpoint '{name}': {safe_url}")
+    return endpoints

--- a/tests/unit/models/registration/test_model_node_introspection_event.py
+++ b/tests/unit/models/registration/test_model_node_introspection_event.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Cross-boundary regression tests for the canonical node introspection event.
+
+OMN-14490: ``ModelNodeIntrospectionEvent`` is the single canonical wire model for
+the ``node-introspection.v1`` topic, graduated from ``omnibase_infra`` into
+``omnibase_core`` so the producer (infra) and every consumer (e.g. omnimarket's
+``node_projection_registration``) share ONE definition.
+
+The defect this file guards against: a consumer that re-declares a *slim* local
+copy with ``extra="ignore"`` silently DROPS the rich producer fields
+(``endpoints`` / ``declared_capabilities`` / ``discovered_capabilities`` /
+``contract_capabilities`` / ``current_state``). These tests prove the canonical
+model (a) round-trips those fields losslessly across the JSON wire boundary and
+(b) fails LOUD (``extra="forbid"``) on an unmodeled field instead of dropping it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums import EnumIntrospectionReason, EnumNodeKind
+from omnibase_core.models.capabilities import ModelContractCapabilities
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.registration import (
+    ModelDiscoveredCapabilities,
+    ModelEventBusTopicEntry,
+    ModelNodeCapabilities,
+    ModelNodeEventBusConfig,
+    ModelNodeIntrospectionEvent,
+    ModelNodeMetadata,
+)
+
+# The rich producer fields that a slim ``extra="ignore"`` consumer silently drops.
+_RICH_FIELDS = (
+    "endpoints",
+    "declared_capabilities",
+    "discovered_capabilities",
+    "contract_capabilities",
+    "current_state",
+)
+
+
+def _rich_event() -> ModelNodeIntrospectionEvent:
+    """A fully-populated event mirroring a real producer broadcast.
+
+    Every rich field carries a NON-default value so a silent drop is detectable.
+    """
+    return ModelNodeIntrospectionEvent(
+        node_id=uuid4(),
+        node_name="node_delegation_orchestrator",
+        node_type=EnumNodeKind.ORCHESTRATOR,
+        node_version=ModelSemVer(major=1, minor=2, patch=3),
+        correlation_id=uuid4(),
+        timestamp=datetime.now(UTC),
+        reason=EnumIntrospectionReason.STARTUP,
+        endpoints={
+            "api": "http://localhost:8085",
+            "grpc": "grpc://localhost:9090",
+        },
+        current_state="READY",
+        declared_capabilities=ModelNodeCapabilities(postgres=True, write=True),
+        discovered_capabilities=ModelDiscoveredCapabilities(
+            operations=("execute", "handle"),
+            has_fsm=True,
+        ),
+        contract_capabilities=ModelContractCapabilities(
+            contract_type="ORCHESTRATOR_GENERIC",
+            contract_version=ModelSemVer(major=1, minor=0, patch=0),
+            intent_types=["delegate.request"],
+        ),
+        metadata=ModelNodeMetadata(),
+        event_bus=ModelNodeEventBusConfig(
+            subscribe_topics=[ModelEventBusTopicEntry(topic="onex.evt.in.v1")],
+            publish_topics=[ModelEventBusTopicEntry(topic="onex.evt.out.v1")],
+        ),
+    )
+
+
+def test_rich_fields_survive_the_json_wire_boundary() -> None:
+    """The exact fields the slim consumer dropped must round-trip losslessly."""
+    event = _rich_event()
+
+    wire = event.model_dump(mode="json")
+    restored = ModelNodeIntrospectionEvent.model_validate(wire)
+
+    assert restored == event, "round-trip mutated the event"
+
+    # Each rich field is present in the wire payload AND non-default after restore.
+    for field in _RICH_FIELDS:
+        assert field in wire, f"producer field {field!r} missing from wire payload"
+    assert restored.endpoints == {
+        "api": "http://localhost:8085",
+        "grpc": "grpc://localhost:9090",
+    }
+    assert restored.current_state == "READY"
+    assert restored.declared_capabilities.postgres is True
+    assert restored.declared_capabilities.write is True
+    assert restored.discovered_capabilities.operations == ("execute", "handle")
+    assert restored.discovered_capabilities.has_fsm is True
+    assert restored.contract_capabilities is not None
+    assert restored.event_bus is not None
+    assert restored.event_bus.subscribe_topic_strings == ["onex.evt.in.v1"]
+
+
+def test_extra_forbid_fails_loud_instead_of_silent_drop() -> None:
+    """An unmodeled wire field must RAISE, not be silently ignored.
+
+    ``extra="ignore"`` (the slim consumer's config) is exactly what made
+    OMN-14490 a silent data loss. The canonical model uses ``extra="forbid"``.
+    """
+    wire = _rich_event().model_dump(mode="json")
+    wire["unexpected_producer_field"] = {"added": "by a newer producer"}
+
+    with pytest.raises(ValidationError):
+        ModelNodeIntrospectionEvent.model_validate(wire)
+
+
+def test_naive_timestamp_is_rejected() -> None:
+    """The timezone-aware validator is wired to the canonical core utility."""
+    with pytest.raises(ValidationError):
+        ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=datetime.now(),
+        )
+
+
+def test_malformed_endpoint_url_is_rejected() -> None:
+    """The endpoint-URL validator is wired to the canonical core utility."""
+    with pytest.raises(ValidationError):
+        ModelNodeIntrospectionEvent(
+            node_id=uuid4(),
+            node_type=EnumNodeKind.EFFECT,
+            correlation_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            endpoints={"api": "localhost:8085"},  # missing scheme
+        )


### PR DESCRIPTION
## OMN-14490 — graduate the canonical node-introspection wire event to omnibase_core (ADDITIVE, core-first)

**Refs OMN-14490** (reference pattern for the broader duplicate-model consolidation, Task #38).

### Problem
`node-introspection.v1` (HW≈23881, very hot) had TWO `ModelNodeIntrospectionEvent` definitions:
the rich `omnibase_infra` producer event vs a slim per-repo `extra="ignore"` consumer copy in
omnimarket `node_projection_registration` that **silently dropped** `endpoints` /
`declared_capabilities` / `discovered_capabilities` / `contract_capabilities` / `current_state`.
Silent field-dropping across a live seam is the OMN-14485/14490 class.

### What this PR does (additive only — no infra copies deleted)
Graduates the shared wire event + its full nested closure into **omnibase_core** as the single
canonical home (it references core domain types — `EnumNodeKind`, `ModelContractCapabilities`,
`ModelSemVer`, `ModelFeatureFlags` — so it CANNOT live in compat; that would invert compat→core).

Canonical import paths (final — codemod lane targets these):
- `omnibase_core.models.registration.model_node_introspection_event.ModelNodeIntrospectionEvent`
- `omnibase_core.models.registration` also exports the 7 nested DTOs:
  `ModelNodeCapabilities`, `ModelDiscoveredCapabilities`, `ModelNodeEventBusConfig`,
  `ModelNodeMetadata`, `ModelMCPContractConfig`, `ModelEventBusTopicEntry`,
  `ModelIntrospectionPerformanceMetrics`
- `omnibase_core.enums.EnumIntrospectionReason` (was `omnibase_infra.enums`)

Design decisions:
- Canonical event uses **`extra="forbid"`** (fail LOUD on unmodeled fields) — the operator directive;
  `extra="ignore"` on the slim consumer is exactly what made this silent. Safe now because producer +
  consumer share the ONE model.
- The two shared field validators are wired to **core single-source utilities**: reuse existing
  `omnibase_core.utils.util_validators.ensure_timezone_aware`; add `validate_endpoint_urls_dict`
  to the same module. Zero `omnibase_infra` dependency in the graduated closure.
- `ModelNodeCapabilities` keeps `extra="allow"` by design (custom capabilities via `model_extra`).

### dod_evidence
- New cross-boundary regression test `tests/unit/models/registration/test_model_node_introspection_event.py`
  (4 tests): rich fields survive the JSON wire round-trip; `extra="forbid"` RAISES on an unknown wire
  key (RED against exists-but-wrong = the slim `extra="ignore"` drop); naive-timestamp + malformed-URL
  rejected (validators wired). All 4 GREEN.
- `uv run mypy src/omnibase_core/models/registration/ src/omnibase_core/utils/util_validators.py src/omnibase_core/enums/enum_introspection_reason.py` → **Success: no issues found in 13 source files**.
- `uv run ruff format/check` clean.
- Regression: `tests/unit/models/registration/` + `tests/unit/models/discovery/` → **71 passed, 1 skipped** (additive `__init__`/util/enum edits break nothing).

### Landing order (Codex — core FIRST)
1. **THIS core PR → dev** (additive; core lands green independently, no window where infra is broken).
2. **infra child PR**: repoint the producer + delete infra copies + update ~83 call-sites to the core
   canonical paths (mechanical **codemod lane**, prepared against this worktree, LANDS AFTER core).
3. **omnimarket child PR**: delete the slim consumer copy; consume the canonical core model.

### Follow-ups (NOT in this PR)
- Discovery service-discovery `ModelNodeIntrospectionEvent` rename (`ModelNodeDiscoveryAnnouncement`)
  + twin-kill: incoming as commit 2 on this branch.
- Two same-name-different-module pairs surfaced by graduation (`ModelNodeCapabilities`,
  `ModelNodeMetadata` in `discovery`/`core` vs new `registration`) → tracked under Task #38 consolidation.

**Draft — do not merge.** OCC evidence companion owed from a non-implementer verifier (implementer must
not self-author OCC evidence).
