### PR TITLE
test(OMN-14456): pin _receipt_bound_to_pr dual-bind as a regression contract

### DIFF
--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -254,6 +254,55 @@ def test_receipt_without_pr_or_commit_binding_is_ineligible(tmp_path: Path) -> N
 
 
 @pytest.mark.unit
+def test_receipt_bound_by_commit_sha_only_is_eligible(tmp_path: Path) -> None:
+    """OMN-14456: commit_sha binding alone must be honored.
+
+    Regression contract for the chicken-and-egg mint path: a receipt produced
+    before the PR existed carries no pr_number, but its commit_sha matches one
+    of the PR's current commits. `_receipt_bound_to_pr` must accept this even
+    though pr_number is a foreign value — this is the *first-run* binding.
+    Tightening the predicate to require both bindings would flip this red.
+    """
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,  # foreign PR number: this binding must not matter here
+        commit_sha=PR_SHA,  # matches snapshot.pr_commit_shas
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+
+
+@pytest.mark.unit
+def test_receipt_bound_by_pr_number_only_is_eligible(tmp_path: Path) -> None:
+    """OMN-14456: pr_number binding alone must be honored.
+
+    Regression contract for rebase survival: a rebase rewrites every commit
+    SHA on the branch, so a receipt's original commit_sha binding is
+    destroyed, but pr_number is untouched by a rebase. `_receipt_bound_to_pr`
+    must accept a receipt whose pr_number matches the PR even though none of
+    its commit_sha matches the PR's (rebased) commit set. Tightening the
+    predicate to require both bindings would flip this red.
+    """
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=123,  # matches snapshot.pr_number
+        commit_sha="c" * 40,  # foreign SHA: simulates a post-rebase mismatch
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+
+
+@pytest.mark.unit
 def test_at_least_one_ticket_receipt_must_bind_to_pr(tmp_path: Path) -> None:
     contract = {
         "ticket_id": TICKET,


### PR DESCRIPTION
## Summary

OMN-14456 ("strict=false means any PR whose branch predates a gate can merge without ever running it") names a "likely fix": `_receipt_bound_to_pr` must accept EITHER `pr_number` match OR `commit_sha` match, so a rebase-stranded PR can re-bind via a fresh `pr_number` once the PR exists.

**That predicate already shipped** — `_receipt_bound_to_pr` (`src/omnibase_core/validation/validator_occ_merge_eligibility.py:82-89`) has implemented exactly this OR-check since commit `a68e9e0d` ("fix(OMN-13888): OCC per-entry receipt hashing + append-only + supersession + dual-accept", PR #1382, merged 2026-07-03) — 9 days before OMN-14456 was filed. It is not just in source: `onex_change_control`'s `uv.lock` pins `omnibase-core==0.46.7` (PyPI, released 2026-07-09), and the installed `.venv` copy is byte-identical to source. The caller (`omnibase_core/.github/workflows/occ-preflight.yml:160-194,489-490`) also already passes every one of the PR's live commit SHAs via repeated `--pr-commit-sha`, not just HEAD.

So there is **no code change to make here**. What was missing: no existing test isolated `commit_sha`-only-match (pr_number foreign — the first-run mint path, before a PR number exists) or `pr_number`-only-match (commit_sha foreign — the rebase-survival path, since a rebase rewrites every commit SHA but leaves `pr_number` untouched) as independently sufficient. Every existing eligible-path test bound both simultaneously, so the OR-guarantee was implemented but never pinned as a regression contract — nothing would catch a future accidental tightening to AND.

This PR adds exactly those two isolation cases.

## Changes

- `tests/unit/validation/test_occ_merge_eligibility.py`: add `test_receipt_bound_by_commit_sha_only_is_eligible` and `test_receipt_bound_by_pr_number_only_is_eligible`, alongside the existing `test_receipt_without_pr_or_commit_binding_is_ineligible` reject case.

## dod_evidence (OMN-14456)

- GREEN (current code, 21/21 tests pass): `uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -v` → all pass, including the 2 new isolation tests and the existing neither-bound reject test.
- RED proof (non-vacuous): temporarily tightened `_receipt_bound_to_pr` to `receipt.pr_number == snapshot.pr_number and receipt.commit_sha.lower() in shas` (AND instead of OR) and reran the same file — exactly `test_receipt_bound_by_commit_sha_only_is_eligible` and `test_receipt_bound_by_pr_number_only_is_eligible` flip to FAILED (`assert False is True` / reason `PR_TICKET_MISMATCH`), while all other 19 tests — including the reject-both case — stay green. Reverted the tightened predicate immediately after (confirmed `git diff` on the source file is clean post-revert; no source change ships in this PR).
- Pre-existing, unrelated finding: local `validate-no-backward-compatibility` pre-commit hook fails repo-wide on 2 files this PR never touches (`src/omnibase_core/utils/util_name_validation.py:14`, `src/omnibase_core/validation/validator_utils.py:634`) — confirmed byte-identical to `origin/dev` via `git diff --stat`. Already tracked as OMN-14370 (explicitly a pre-commit-only hook, not a CI merge gate). Not fixed here — out of scope for this ticket.

Evidence-Ticket: OMN-14456 (comment posted on the ticket documenting the already-shipped predicate + the emitter (OMN-14452) as the real remaining rebase-fragility owner; not auto-closing — ticket flips Done via the normal process, not this merge).

Evidence-Source: OCC#4122
Evidence-Ticket: OMN-14456
Evidence-Commit: cde218b10e4e4a848ba99658eb7a73b9881d1578
