### PR TITLE
feat(OMN-14600): add ModelDelegationCompleted/ModelDelegationFailed terminal subclasses

### DIFF
--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -17,6 +17,8 @@ from omnibase_core.models.delegation.wire.model_budget import (
     ModelBudgetLimits,
 )
 from omnibase_core.models.delegation.wire.model_delegation_result import (
+    ModelDelegationCompleted,
+    ModelDelegationFailed,
     ModelDelegationResult,
 )
 from omnibase_core.models.delegation.wire.model_delegation_wire_envelope import (
@@ -71,8 +73,10 @@ __all__: list[str] = [
     "ModelComplianceLoopResult",
     "ModelDelegationBackendConfig",
     "ModelDelegationCircuitBreakerConfig",
+    "ModelDelegationCompleted",
     "ModelDelegationConfig",
     "ModelDelegationEventEnvelope",
+    "ModelDelegationFailed",
     "ModelDelegationFailoverConfig",
     "ModelDelegationFallbackPolicy",
     "ModelDelegationRequest",

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -157,4 +157,31 @@ class ModelDelegationResult(BaseModel):
         return self
 
 
-__all__: list[str] = ["ModelDelegationResult"]
+class ModelDelegationCompleted(ModelDelegationResult):
+    """Delegation terminal, COMPLETED outcome (OMN-14600).
+
+    Thin subclass — adds NO new fields and no new validation. Class identity
+    alone is what class-name -> topic routing (``_outbox_topic_for`` /
+    ``DispatchResultApplier._resolve_mapped_output_topic``) uses to
+    disambiguate the completed-vs-failed terminal, replacing the earlier
+    bespoke ``ModelDelegationEventEnvelope{topic, payload}`` carrier (which
+    the routing layer could never resolve, since one wrapped class covered
+    both outcomes on one topic-per-class map). ``model_dump()`` is
+    byte-identical to a plain ``ModelDelegationResult`` — no wire consumer
+    that reads the flat payload shape needs to change.
+    """
+
+
+class ModelDelegationFailed(ModelDelegationResult):
+    """Delegation terminal, FAILED outcome (OMN-14600).
+
+    Thin subclass — see :class:`ModelDelegationCompleted` docstring; the same
+    rationale applies to the failed-outcome topic.
+    """
+
+
+__all__: list[str] = [
+    "ModelDelegationCompleted",
+    "ModelDelegationFailed",
+    "ModelDelegationResult",
+]


### PR DESCRIPTION
Evidence-Source: OCC#4134
Evidence-Ticket: OMN-14600

## Summary

Root-cause fix for OMN-14600, core-repo half. Executes OMN-14403 §4.4/§15 A1
(canonical two-class split) per operator decision.

Adds `ModelDelegationCompleted(ModelDelegationResult)` and
`ModelDelegationFailed(ModelDelegationResult)` in
`src/omnibase_core/models/delegation/wire/model_delegation_result.py` — thin
subclasses, zero new fields, `model_dump()` byte-identical to the base class.
Class identity alone is what class-name -> topic routing
(`_outbox_topic_for` in omnibase_infra / `DispatchResultApplier._resolve_mapped_output_topic`)
uses to disambiguate the COMPLETED vs FAILED terminal.

**Root cause this replaces:** the delegation orchestrator (omnimarket) emitted
its terminal as a bespoke `ModelDelegationEventEnvelope{topic, payload}`
carrier whose class name never matched any entry in the contract's
`published_events` map (one wrapped class covering two outcomes on one
topic-per-class map). The in-row state_io outbox (omnibase_infra) could
never resolve a topic for it, raised `ModelOnexError`/`BoundaryPublishError`,
and stranded every delegation completion at `COMPLETED/in_flight=true`
forever — live-verified on .201 stability-test.

This is a 3-repo fix (omnibase_core -> omnimarket -> omnibase_infra, in that
dependency order). This PR is core-first per the layering rule (compat ->
core -> spi -> infra); the omnimarket and omnibase_infra PRs will re-pin to
this PR's merged squash commit once it lands and follow separately.

## Proof (live-readback, .201 stability-test, all 3 repos staged, image `ac5a9b1a0b9b`)

- New delegation (cid `86b5dcd7`) reached `COMPLETED`/`in_flight=false` —
  the exact state that was previously impossible.
- Terminal event published to the correct topic; projection landed.
- BOTH pre-fix stranded rows (the legacy `ModelDelegationEventEnvelope` rows
  stuck since before this fix) healed via the omnibase_infra legacy-row
  sweep — proving backward compatibility with in-flight rows from before
  this change.
- Consumer offsets advanced +3/+3 as expected.
- Independent adversarial verify: GO-WITH-FIXES (one non-blocking finding,
  addressed in the companion omnibase_infra PR).

## Local verification

- `uv run pytest tests/ -k delegation -m "not slow"` → 215 passed, 4 skipped
  (unchanged pass/skip count vs pre-change baseline — no regression).
- `uv run ruff format --check src/` / `uv run ruff check src/` → clean.
- Verified `ModelDelegationCompleted(**fields).model_dump()` /
  `ModelDelegationFailed(**fields).model_dump()` are keyed identically to a
  plain `ModelDelegationResult(**fields).model_dump()`.

Closes OMN-14600 (core half; the ticket also gates the omnimarket and
omnibase_infra companion PRs).

dod_evidence: live-readback proof on .201 stability-test (image ac5a9b1a0b9b,
cid 86b5dcd7, COMPLETED/in_flight=false, 2 stranded rows healed, offsets
+3/+3); independent adversarial verify GO-WITH-FIXES.

## Test plan

- [x] Unit tests green locally (215 passed, 4 skipped)
- [x] Lint/format clean
- [x] Live-readback proof on .201 stability-test (see above)
- [ ] CI green on this PR (pending)
Evidence-Commit: df80fa62ee39f576cd7a195a2a994d4bae944292
