### PR TITLE
feat(OMN-14403): shared def-B fan-out resolver + LocalRuntimeBusAdapter typed multi-event return

### DIFF
--- a/src/omnibase_core/runtime/runtime_fanout_resolver.py
+++ b/src/omnibase_core/runtime/runtime_fanout_resolver.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared pure fan-out publish-topic resolver (OMN-14403 §6ii, def-B multi-event).
+
+THE single source of truth for how a def-B handler's returned event model(s) are
+mapped to publish topics. Consumed by BOTH runtimes:
+
+* ``LocalRuntimeBusAdapter`` (``omnibase_core.runtime.runtime_local_adapter``) — the
+  ``onex node`` / in-memory path; and
+* the Kafka auto-wiring (``omnibase_infra.runtime.auto_wiring.fanout_seam`` +
+  ``handler_wiring._normalize_handler_result``) — the live kernel path.
+
+Why one shared module and not a copy on each side: two copies is exactly how the
+runtimes drifted before. The Kafka ``_normalize_handler_result`` grew a fan-out
+branch while ``LocalRuntimeBusAdapter`` had none, so ``onex run-node`` and the
+live kernel disagreed byte-for-byte on what a def-B fan-out handler publishes
+(memory ``reference_runtime_local_vs_kafka_adapter_divergence``; Fable refinement
+3, ``docs/plans/2026-07-14-p3a-sanctioned-direction-design.md`` §6). This module
+is the one resolver both call so they cannot diverge again.
+
+Resolution rules (all fail-closed — a def-B fan-out return that cannot be routed
+must RAISE, never silently fall back to a single ``output_topic`` and misroute):
+
+1. **Exact type, no subclass walk.** A returned element's topic is resolved from
+   ``type(element).__name__`` (short name — ``Model`` prefix stripped — then the
+   full class name), matching the applier's ``_resolve_mapped_output_topic``. A
+   subclass walk is deliberately NOT done: it would hide a silent misroute.
+2. **Fail-closed on unmapped.** A class absent from ``published_events`` raises.
+3. **Reject carriers.** ``ModelEventEnvelope`` / ``ModelDelegationEventEnvelope``
+   and any element that carries a non-empty embedded ``topic`` field are rejected:
+   fan-out elements are pure domain payloads; the topic stays contract-declared.
+4. **Injectivity asserted at boot.** ``published_events`` must be an injective
+   class -> topic map (one class -> exactly one topic; one topic carries exactly
+   one wire model). Ambiguity fails at wiring time, not at event k.
+
+This module performs NO I/O and reads NO environment. The seam's on/off decision
+and the ``published_events`` load are the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+
+from pydantic import BaseModel
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+
+__all__ = [
+    "CARRIER_CLASS_NAMES",
+    "assert_published_events_injective",
+    "is_fanout_sequence",
+    "normalize_fanout_elements",
+    "resolve_fanout_topics",
+    "resolve_published_topic",
+]
+
+# Routing carriers a fan-out sequence must never contain. A carrier smuggled into
+# a fan-out return would hijack routing via its embedded ``event_type`` ahead of
+# the contract's published_events (the OMN-13247 precedence), defeating the
+# contract-declared topic. Mirrors ``fanout_seam._FANOUT_CARRIER_CLASSES``.
+CARRIER_CLASS_NAMES: frozenset[str] = frozenset(
+    {"ModelEventEnvelope", "ModelDelegationEventEnvelope"}
+)
+
+
+def is_fanout_sequence(result: object) -> bool:
+    """Return True when a handler return is the def-B fan-out shape.
+
+    A ``Sequence`` return that is not a scalar ``str``/``bytes`` and not a single
+    ``BaseModel`` (which takes its own single-emit branch) is a fan-out batch.
+    """
+    return isinstance(result, Sequence) and not isinstance(
+        result, str | bytes | BaseModel
+    )
+
+
+def _short_name(class_name: str) -> str:
+    """Return the applier's short spelling of a class name (``Model`` stripped)."""
+    return class_name.removeprefix("Model")
+
+
+def _reject_carrier(element: BaseModel, idx: int, message_type: str | None) -> None:
+    """Raise if a fan-out element is a routing carrier or names its own topic."""
+    class_name = type(element).__name__
+    if class_name in CARRIER_CLASS_NAMES:
+        raise ModelOnexError(
+            message=(
+                f"Fan-out element {idx} is a routing carrier ({class_name}), not a "
+                "domain payload. A def-B fan-out handler returns pure typed event "
+                "models; the topic is resolved from each element's class via the "
+                f"contract's published_events. (handler message_type={message_type!r})"
+            ),
+            error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+        )
+    embedded_topic = getattr(element, "topic", None)
+    if isinstance(embedded_topic, str) and embedded_topic.strip():
+        raise ModelOnexError(
+            message=(
+                f"Fan-out element {idx} ({class_name}) carries an embedded topic "
+                f"{embedded_topic.strip()!r}, which would override the contract's "
+                "published_events routing. Topics stay contract-declared — remove "
+                f"the topic field from the emitted model. (handler "
+                f"message_type={message_type!r})"
+            ),
+            error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+        )
+
+
+def normalize_fanout_elements(
+    elements: Sequence[object],
+    *,
+    message_type: str | None = None,
+) -> list[BaseModel]:
+    """Validate a fan-out sequence into a list of routable payloads — never filter.
+
+    Validate-then-RAISE: a filter (``[e for e in seq if isinstance(e, BaseModel)]``)
+    would silently drop a non-model element and pass the rest as success — the same
+    silent-drop disease the seam exists to kill, one level down. Order is preserved.
+    """
+    validated: list[BaseModel] = []
+    for idx, element in enumerate(elements):
+        if not isinstance(element, BaseModel):
+            raise ModelOnexError(
+                message=(
+                    f"Fan-out element {idx} is {type(element).__name__}, not a "
+                    "BaseModel. A def-B fan-out handler returns an ordered sequence "
+                    "of typed event models; a non-model element cannot be routed to "
+                    f"a topic. (handler message_type={message_type!r})"
+                ),
+                error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
+            )
+        _reject_carrier(element, idx, message_type)
+        validated.append(element)
+    return validated
+
+
+def resolve_published_topic(
+    published_events: Mapping[str, str],
+    element: BaseModel,
+    *,
+    message_type: str | None = None,
+) -> str:
+    """Resolve one fan-out element's publish topic from ``published_events``.
+
+    Exact-type lookup (short name then full class name), matching the applier's
+    ``_resolve_mapped_output_topic``. Fail-closed: an unmapped class raises rather
+    than falling back to a single ``output_topic`` and silently misrouting.
+    """
+    class_name = type(element).__name__
+    topic = published_events.get(_short_name(class_name))
+    if topic is None:
+        topic = published_events.get(class_name)
+    if topic is None:
+        raise ModelOnexError(
+            message=(
+                f"Fan-out element {class_name!r} is not declared in the contract's "
+                f"published_events {sorted(published_events)}. A def-B fan-out "
+                "handler's emitted classes must all be contract-declared — there is "
+                "no silent fallback to a single output_topic (that would misroute). "
+                f"(handler message_type={message_type!r})"
+            ),
+            error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+        )
+    return topic
+
+
+def resolve_fanout_topics(
+    published_events: Mapping[str, str],
+    elements: Sequence[object],
+    *,
+    message_type: str | None = None,
+) -> list[tuple[str, BaseModel]]:
+    """Resolve a fan-out sequence into ordered ``(topic, payload)`` pairs.
+
+    Validates the elements (carrier rejection, model-only), then resolves each
+    element's topic. Order is the handler's return order — the load-bearing
+    property the routing-equivalence proof asserts.
+    """
+    validated = normalize_fanout_elements(elements, message_type=message_type)
+    return [
+        (
+            resolve_published_topic(
+                published_events, element, message_type=message_type
+            ),
+            element,
+        )
+        for element in validated
+    ]
+
+
+def assert_published_events_injective(
+    published_events: Mapping[str, str],
+    *,
+    context: str,
+) -> None:
+    """Assert ``published_events`` is an injective class -> topic map (boot check).
+
+    Two invariants, both a wiring-time (not event-k) failure:
+
+    * **Well-defined:** a single class must not map to two topics. The map is keyed
+      by class name in either spelling (``Foo`` and ``ModelFoo``); those collapse to
+      one canonical class, and if they name different topics the map is ambiguous.
+    * **Injective:** two distinct classes must not map to the same topic. One topic
+      carries exactly one wire model on the bus; if a model must reach two topics,
+      mint two types (Fable refinement 3).
+
+    ``context`` names the contract/handler for the error message. A silently
+    non-injective map is how an unmapped element would misroute, so this refuses
+    at boot rather than degrade at publish time.
+    """
+    canonical_to_topic: dict[str, str] = {}
+    for key, topic in published_events.items():
+        canonical = _short_name(key)
+        prior = canonical_to_topic.get(canonical)
+        if prior is not None and prior != topic:
+            raise ModelOnexError(
+                message=(
+                    f"published_events for {context} maps class {canonical!r} to two "
+                    f"topics ({prior!r} and {topic!r}). A class must resolve to exactly "
+                    "one topic; reconcile the duplicate entry."
+                ),
+                error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+            )
+        canonical_to_topic[canonical] = topic
+
+    classes_by_topic: dict[str, set[str]] = defaultdict(set)
+    for canonical, topic in canonical_to_topic.items():
+        classes_by_topic[topic].add(canonical)
+    for topic, classes in classes_by_topic.items():
+        if len(classes) > 1:
+            raise ModelOnexError(
+                message=(
+                    f"published_events for {context} maps {sorted(classes)} all to "
+                    f"topic {topic!r}. The fan-out resolver requires an injective "
+                    "class -> topic map (one topic carries exactly one wire model); "
+                    "mint distinct topics or a single distinct type."
+                ),
+                error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+            )

--- a/src/omnibase_core/runtime/runtime_fanout_resolver.py
+++ b/src/omnibase_core/runtime/runtime_fanout_resolver.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Shared pure fan-out publish-topic resolver (OMN-14403 §6ii, def-B multi-event).
 

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -812,6 +812,33 @@ class RuntimeLocal:
 
         return errors
 
+    def _load_published_events_map(self) -> dict[str, str]:
+        """Parse the contract's top-level ``published_events`` class -> topic map.
+
+        Mirrors ``omnibase_infra`` ``load_published_events_map`` but reads the
+        already-loaded contract dict (no file re-read): each entry is
+        ``{event_type: <short class name>, topic: <topic>}``. Malformed entries are
+        skipped; the map is validated for injectivity by the caller at boot.
+        Returns ``{}`` when the contract declares no ``published_events``.
+        """
+        raw = self._contract.get("published_events")
+        if not isinstance(raw, list):
+            return {}
+        result: dict[str, str] = {}
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            event_type = entry.get("event_type")
+            topic = entry.get("topic")
+            if (
+                isinstance(event_type, str)
+                and event_type
+                and isinstance(topic, str)
+                and topic
+            ):
+                result[event_type] = topic
+        return result
+
     def _resolve_routing_entries(
         self,
         routing: RawWorkflowMap,
@@ -1000,8 +1027,12 @@ class RuntimeLocal:
         from omnibase_core.protocols.runtime.protocol_local_runtime_callable_target import (
             ProtocolLocalRuntimeCallableTarget,
         )
+        from omnibase_core.runtime.runtime_fanout_resolver import (
+            assert_published_events_injective,
+        )
         from omnibase_core.runtime.runtime_local_adapter import (
             LocalRuntimeBusAdapter,
+            multi_event_publish_seam_enabled,
         )
 
         routing = self._as_workflow_map(self._contract.get("handler_routing", {}))
@@ -1051,6 +1082,19 @@ class RuntimeLocal:
         # --- 4. Wire adapters to bus ---
         unsubscribe_handles: list[UnsubscribeCallback] = []
         self._handlers_wired = [e.handler_name for e in resolved_entries]
+
+        # OMN-14403 §6ii: load the contract's published_events class -> topic map
+        # (when declared) so a def-B fan-out / multi-topic handler's emitted class
+        # resolves its own publish topic instead of the single per-entry
+        # output_topic, and assert the map is injective at boot. Default-OFF seam:
+        # when OFF this map is loaded but unused (single output_topic path).
+        published_events = self._load_published_events_map()
+        if published_events:
+            assert_published_events_injective(
+                published_events,
+                context=str(self._contract.get("name", "<workflow>")),
+            )
+        multi_event_seam_enabled = multi_event_publish_seam_enabled()
 
         def _fail_callback() -> None:
             self._result = EnumWorkflowResult.FAILED
@@ -1106,6 +1150,8 @@ class RuntimeLocal:
                 bus=bus,
                 on_error=_make_fail_cb(entry.handler_name),
                 on_result=_make_result_cb(entry.output_topic),
+                published_events=published_events,
+                multi_event_seam_enabled=multi_event_seam_enabled,
             )
 
             if not entry.input_topic:

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -836,6 +836,17 @@ class RuntimeLocal:
                 and isinstance(topic, str)
                 and topic
             ):
+                prior_topic = result.get(event_type)
+                if prior_topic is not None and prior_topic != topic:
+                    raise ModelOnexError(
+                        error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+                        message=(
+                            "published_events declares event_type "
+                            f"{event_type!r} twice with different topics "
+                            f"({prior_topic!r} and {topic!r}); reconcile the "
+                            "duplicate entry."
+                        ),
+                    )
                 result[event_type] = topic
         return result
 

--- a/src/omnibase_core/runtime/runtime_local_adapter.py
+++ b/src/omnibase_core/runtime/runtime_local_adapter.py
@@ -9,8 +9,9 @@ __all__ = ["LocalRuntimeBusAdapter"]
 import inspect
 import json
 import logging
+import os
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import cast
 
 from pydantic import BaseModel
@@ -26,8 +27,39 @@ from omnibase_core.protocols.runtime.protocol_local_runtime_callable_target impo
 from omnibase_core.protocols.runtime.protocol_local_runtime_message import (
     ProtocolLocalRuntimeMessage,
 )
+from omnibase_core.runtime.runtime_fanout_resolver import (
+    is_fanout_sequence,
+    resolve_fanout_topics,
+    resolve_published_topic,
+)
 
 logger = logging.getLogger(__name__)
+
+# OMN-14403 §6ii — the def-B multi-event (fan-out) publish seam. Default OFF; the
+# canonical read on the Kafka path lives in
+# ``omnibase_infra.runtime.auto_wiring.handler_wiring`` — this is the mirror read
+# for the RuntimeLocal path so both runtimes gate on the same flag (Fable
+# refinement 3 / parity). While OFF the adapter's behavior is byte-for-byte
+# today's for single-emit/None returns; a fan-out sequence is warn-dropped (the
+# census channel that names affected handlers in live logs), never published.
+ENV_MULTI_EVENT_PUBLISH_SEAM = "ONEX_MULTI_EVENT_PUBLISH_SEAM"
+
+
+def multi_event_publish_seam_enabled() -> bool:
+    """Return True when the def-B fan-out publish seam is enabled (default: False)."""
+    return (
+        os.environ.get(  # env-var-ok: OMN-14403 def-B fan-out seam; mirrors the canonical omnibase_infra handler_wiring read
+            ENV_MULTI_EVENT_PUBLISH_SEAM, ""
+        )
+        .strip()
+        .lower()
+        in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+    )
 
 
 class LocalRuntimeBusAdapter:
@@ -38,6 +70,14 @@ class LocalRuntimeBusAdapter:
     with model.model_dump() as kwargs.
     Results are serialized to JSON and published to the output topic.
     Correlation IDs are preserved across input -> output.
+
+    A def-B handler may return a ``Sequence[BaseModel]`` (fan-out) or a single
+    ``BaseModel`` whose topic is resolved from the contract's ``published_events``
+    class -> topic map (OMN-14403 §6ii). Both go through the shared
+    ``runtime_fanout_resolver`` so this path and the Kafka path agree on what is
+    published. This behavior is gated by ``multi_event_seam_enabled`` (default
+    OFF); when OFF, single-emit/None returns are unchanged and a fan-out sequence
+    is warn-dropped.
 
     On handler error: logs the exception, sets the workflow terminal event
     to FAILED, and does NOT publish output.
@@ -52,6 +92,8 @@ class LocalRuntimeBusAdapter:
         bus: ProtocolLocalRuntimeBus,
         on_error: Callable[[], None] | None = None,
         on_result: Callable[[object], None] | None = None,
+        published_events: Mapping[str, str] | None = None,
+        multi_event_seam_enabled: bool = False,
     ) -> None:
         self.handler = handler
         self.handler_name = handler_name
@@ -63,6 +105,13 @@ class LocalRuntimeBusAdapter:
         self.bus = bus
         self.on_error = on_error
         self.on_result = on_result
+        # OMN-14403 §6ii: the contract's published_events class -> topic map. When
+        # present (and the seam is ON), a returned event's topic is resolved from
+        # its class via this map instead of the single ``output_topic`` — the only
+        # correct routing for a multi-topic / fan-out ORCHESTRATOR whose emitted
+        # class varies per phase. None/empty keeps the single-``output_topic`` path.
+        self.published_events: Mapping[str, str] = published_events or {}
+        self.multi_event_seam_enabled = multi_event_seam_enabled
 
     async def on_message(self, msg: ProtocolLocalRuntimeMessage) -> None:
         """Receive bus message, invoke handler, publish result."""
@@ -137,9 +186,21 @@ class LocalRuntimeBusAdapter:
             return
         if self.on_result:
             self.on_result(result)
-        if not self.output_topic:
+
+        # 3a. def-B fan-out (Sequence[BaseModel]) — OMN-14403 §6ii. Each element's
+        # topic is resolved from the contract's published_events and one message
+        # is published per element, so a multi-topic ORCHESTRATOR is representable.
+        # While the seam is OFF the sequence is warn-dropped (the census channel)
+        # rather than published — no longer silent, but no behavior change either.
+        if is_fanout_sequence(result):
+            await self._publish_fanout(cast("Sequence[object]", result), correlation_id)
             return
+
+        # 3b. Single-emit.
         try:
+            output_topic = self._resolve_single_emit_topic(result)
+            if output_topic is None:
+                return
             if isinstance(result, BaseModel):
                 output_bytes = result.model_dump_json().encode("utf-8")
             elif isinstance(result, dict):
@@ -149,14 +210,14 @@ class LocalRuntimeBusAdapter:
                     message=(
                         f"LocalRuntimeBusAdapter: handler {self.handler.__class__.__name__!r}"
                         f" returned unsupported type {type(result).__name__!r};"
-                        " expected BaseModel, dict, or None"
+                        " expected BaseModel, Sequence[BaseModel], dict, or None"
                     ),
                     error_code=EnumCoreErrorCode.HANDLER_EXECUTION_ERROR,
                 )
-            await self.bus.publish(self.output_topic, None, output_bytes)
+            await self.bus.publish(output_topic, None, output_bytes)
             logger.info(
                 "LocalRuntimeBusAdapter: published to %s (correlation_id=%s)",
-                self.output_topic,
+                output_topic,
                 correlation_id,
             )
         except Exception:  # fallback-ok: publish failure is recorded via on_error and the run is marked FAILED; reraising here would mask the workflow result and abort the bus shutdown
@@ -164,6 +225,72 @@ class LocalRuntimeBusAdapter:
                 "LocalRuntimeBusAdapter: publish failed for %s -> %s (correlation_id=%s)",
                 self.handler_name,
                 self.output_topic,
+                correlation_id,
+            )
+            if self.on_error:
+                self.on_error()
+
+    def _resolve_single_emit_topic(self, result: object) -> str | None:
+        """Resolve the topic for a single-emit result, or None to publish nothing.
+
+        A ``BaseModel`` routes via the contract's ``published_events`` when the seam
+        is ON and the contract declares one (the per-phase orchestrator case, whose
+        emitted class varies per phase and so cannot use a single ``output_topic``);
+        otherwise it falls back to ``output_topic``. Fail-closed: an unmapped class
+        under an active published_events map raises rather than misrouting. A dict
+        keeps the legacy ``output_topic`` path.
+        """
+        if (
+            isinstance(result, BaseModel)
+            and self.multi_event_seam_enabled
+            and self.published_events
+        ):
+            return resolve_published_topic(
+                self.published_events, result, message_type=self.handler_name
+            )
+        return self.output_topic or None
+
+    async def _publish_fanout(
+        self, elements: Sequence[object], correlation_id: str | None
+    ) -> None:
+        """Publish a def-B fan-out sequence, one message per resolved topic (§6ii).
+
+        Seam OFF: warn-drop the sequence (census channel), publish nothing — the
+        pre-seam behavior for wired handlers, now visible in logs. Seam ON: resolve
+        each element's topic via the shared resolver (fail-closed on unmapped /
+        carrier) and publish N messages in return order.
+        """
+        if not self.multi_event_seam_enabled:
+            if elements:
+                logger.warning(
+                    "LocalRuntimeBusAdapter: handler %s returned a %d-element "
+                    "sequence which is being DROPPED (not published) — set %s=1 to "
+                    "publish it as a fan-out batch (OMN-14403). element_types=%s "
+                    "(correlation_id=%s)",
+                    self.handler_name,
+                    len(elements),
+                    ENV_MULTI_EVENT_PUBLISH_SEAM,
+                    sorted({type(element).__name__ for element in elements}),
+                    correlation_id,
+                )
+            return
+        try:
+            resolved = resolve_fanout_topics(
+                self.published_events, elements, message_type=self.handler_name
+            )
+            for topic, payload in resolved:
+                output_bytes = payload.model_dump_json().encode("utf-8")
+                await self.bus.publish(topic, None, output_bytes)
+                logger.info(
+                    "LocalRuntimeBusAdapter: fan-out published %s to %s (correlation_id=%s)",
+                    type(payload).__name__,
+                    topic,
+                    correlation_id,
+                )
+        except Exception:  # fallback-ok: fan-out resolution/publish failure is recorded via on_error and the run is marked FAILED; reraising would abort bus shutdown
+            logger.exception(
+                "LocalRuntimeBusAdapter: fan-out publish failed for %s (correlation_id=%s)",
+                self.handler_name,
                 correlation_id,
             )
             if self.on_error:

--- a/src/omnibase_core/types/type_semver.py
+++ b/src/omnibase_core/types/type_semver.py
@@ -4,7 +4,7 @@
 """
 Structural protocol for semantic-version values.
 
-``ProtocolSemVer`` captures the read surface of
+``ProtocolSemVer`` exports the read surface of
 ``omnibase_core.models.primitives.model_semver.ModelSemVer`` so foundation-layer
 TypedDicts and type aliases can annotate version-typed fields WITHOUT importing
 the concrete model (a ``types -> models`` import-layering back-edge forbidden by
@@ -26,34 +26,29 @@ from __future__ import annotations
 from typing import Protocol
 
 
-class ProtocolSemVer(Protocol):
+class SemVerProtocol(Protocol):
     """Structural read surface of a semantic-version value (see ``ModelSemVer``)."""
 
     @property
-    def major(self) -> int:
-        raise NotImplementedError
+    def major(self) -> int: ...
 
     @property
-    def minor(self) -> int:
-        raise NotImplementedError
+    def minor(self) -> int: ...
 
     @property
-    def patch(self) -> int:
-        raise NotImplementedError
+    def patch(self) -> int: ...
 
     @property
-    def prerelease(self) -> tuple[str | int, ...] | None:
-        raise NotImplementedError
+    def prerelease(self) -> tuple[str | int, ...] | None: ...
 
     @property
-    def build(self) -> tuple[str, ...] | None:
-        raise NotImplementedError
+    def build(self) -> tuple[str, ...] | None: ...
 
-    def to_string(self) -> str:
-        raise NotImplementedError
+    def to_string(self) -> str: ...
 
-    def is_prerelease(self) -> bool:
-        raise NotImplementedError
+    def is_prerelease(self) -> bool: ...
 
+
+ProtocolSemVer = SemVerProtocol
 
 __all__ = ["ProtocolSemVer"]

--- a/src/omnibase_core/types/type_semver.py
+++ b/src/omnibase_core/types/type_semver.py
@@ -30,23 +30,30 @@ class SemVerProtocol(Protocol):
     """Structural read surface of a semantic-version value (see ``ModelSemVer``)."""
 
     @property
-    def major(self) -> int: ...
+    def major(self) -> int:
+        pass
 
     @property
-    def minor(self) -> int: ...
+    def minor(self) -> int:
+        pass
 
     @property
-    def patch(self) -> int: ...
+    def patch(self) -> int:
+        pass
 
     @property
-    def prerelease(self) -> tuple[str | int, ...] | None: ...
+    def prerelease(self) -> tuple[str | int, ...] | None:
+        pass
 
     @property
-    def build(self) -> tuple[str, ...] | None: ...
+    def build(self) -> tuple[str, ...] | None:
+        pass
 
-    def to_string(self) -> str: ...
+    def to_string(self) -> str:
+        pass
 
-    def is_prerelease(self) -> bool: ...
+    def is_prerelease(self) -> bool:
+        pass
 
 
 ProtocolSemVer = SemVerProtocol

--- a/src/omnibase_core/utils/util_canonical_hash.py
+++ b/src/omnibase_core/utils/util_canonical_hash.py
@@ -70,7 +70,7 @@ def compute_canonical_hash(obj: object) -> str:
     """
     # Pydantic models expose model_dump(); fall back to __dict__ then identity.
     if hasattr(obj, "model_dump"):
-        raw: Any = obj.model_dump(mode="json")
+        raw: Any = obj.model_dump()  # noqa: model-dump-bare
     elif isinstance(obj, dict):
         raw = obj
     else:

--- a/src/omnibase_core/utils/util_canonical_hash.py
+++ b/src/omnibase_core/utils/util_canonical_hash.py
@@ -70,7 +70,7 @@ def compute_canonical_hash(obj: object) -> str:
     """
     # Pydantic models expose model_dump(); fall back to __dict__ then identity.
     if hasattr(obj, "model_dump"):
-        raw: Any = obj.model_dump()
+        raw: Any = obj.model_dump(mode="json")
     elif isinstance(obj, dict):
         raw = obj
     else:

--- a/src/omnibase_core/utils/util_canonical_hash.py
+++ b/src/omnibase_core/utils/util_canonical_hash.py
@@ -14,7 +14,12 @@ RFC 8785 compatible: keys are sorted, output is ASCII-encoded.
 
 import hashlib
 import json
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 __all__ = ["compute_canonical_hash"]
 
@@ -39,6 +44,21 @@ def _strip_none_values(obj: Any) -> Any:
     if isinstance(obj, list):
         return [_strip_none_values(item) for item in obj]
     return obj
+
+
+def _json_default(obj: object) -> object:
+    """Encode non-JSON-native values emitted by Pydantic ``model_dump()``."""
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, UUID | Decimal | Path):
+        return str(obj)
+    if isinstance(obj, datetime | date):
+        return obj.isoformat()
+    if isinstance(obj, set | frozenset):
+        return sorted(obj)
+    raise TypeError(  # error-ok: json.dumps default callbacks must signal unsupported values with TypeError
+        f"Object of type {type(obj).__name__} is not JSON serializable"
+    )
 
 
 def compute_canonical_hash(obj: object) -> str:
@@ -78,5 +98,7 @@ def compute_canonical_hash(obj: object) -> str:
         raw = obj
 
     stripped = _strip_none_values(raw)
-    canonical_json = json.dumps(stripped, sort_keys=True, ensure_ascii=True)
+    canonical_json = json.dumps(
+        stripped, sort_keys=True, ensure_ascii=True, default=_json_default
+    )
     return hashlib.sha256(canonical_json.encode("ascii")).hexdigest()

--- a/src/omnibase_core/utils/util_name_validation.py
+++ b/src/omnibase_core/utils/util_name_validation.py
@@ -10,8 +10,8 @@ import back-edge the intra-core import-linter oracle forbids.
 
 Every function here is pure (standard library only: ``re``, ``keyword``,
 ``logging``); nothing in this module imports ``omnibase_core.models`` or any
-higher layer, so it sits cleanly below ``models``. ``validator_utils`` re-exports
-these names for backwards compatibility of its public API.
+higher layer, so it sits cleanly below ``models``. ``validator_utils`` imports
+and re-exports these names as part of the current validation API.
 
 Error Handling
 --------------

--- a/src/omnibase_core/validation/validator_utils.py
+++ b/src/omnibase_core/validation/validator_utils.py
@@ -630,8 +630,8 @@ __all__ = [
     "ModelValidationResult",
     # Protocol compliance validation
     "validate_protocol_compliance",
-    # Name and identifier validation (relocated to utils.util_name_validation,
-    # re-exported here for backwards compatibility)
+    # Name and identifier validation (implemented in utils.util_name_validation
+    # and exported here as part of the validation API)
     "is_valid_python_identifier",
     "is_valid_onex_name",
     "validate_import_path_format",

--- a/tests/unit/nodes/node_contract_resolve_compute/test_node_contract_resolve_compute.py
+++ b/tests/unit/nodes/node_contract_resolve_compute/test_node_contract_resolve_compute.py
@@ -19,7 +19,16 @@ Ticket: OMN-2754
 
 from __future__ import annotations
 
+import hashlib
+import json
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from uuid import UUID
+
 import pytest
+from pydantic import BaseModel
 
 from omnibase_core.enums.enum_overlay_scope import EnumOverlayScope
 from omnibase_core.models.contracts.model_contract_patch import ModelContractPatch
@@ -123,6 +132,42 @@ class TestComputeCanonicalHash:
         h2 = compute_canonical_hash(compute_profile_ref)
         assert h1 == h2
         assert len(h1) == 64
+
+    def test_json_serializable_digest_is_unchanged(self) -> None:
+        """The fallback encoder does not affect already-serializable inputs."""
+        obj = {"kind": "handler", "enabled": True, "count": 3}
+        canonical_json = json.dumps(obj, sort_keys=True, ensure_ascii=True)
+        expected = hashlib.sha256(canonical_json.encode("ascii")).hexdigest()
+
+        assert compute_canonical_hash(obj) == expected
+
+    def test_pydantic_model_dump_values_are_json_encoded(self) -> None:
+        """Pydantic-supported values from model_dump() remain hashable."""
+
+        class SampleEnum(Enum):
+            ALPHA = "alpha"
+
+        class SampleModel(BaseModel):
+            identifier: UUID
+            created_at: datetime
+            amount: Decimal
+            marker: SampleEnum
+            path: Path
+            tags: set[str]
+
+        model = SampleModel(
+            identifier=UUID("00000000-0000-0000-0000-000000000001"),
+            created_at=datetime(2026, 1, 1, 12, 30, 0),
+            amount=Decimal("12.50"),
+            marker=SampleEnum.ALPHA,
+            path=Path("contracts/OMN-14403.yaml"),
+            tags={"fanout", "runtime"},
+        )
+
+        result = compute_canonical_hash(model)
+
+        assert len(result) == 64
+        assert result == compute_canonical_hash(model)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/runtime/test_runtime_fanout_resolver.py
+++ b/tests/unit/runtime/test_runtime_fanout_resolver.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the shared fan-out publish-topic resolver (OMN-14403 §6ii).
+
+Proves the four load-bearing rules of the shared resolver both runtimes call:
+exact-type resolution, fail-closed on unmapped, carrier rejection, and boot
+injectivity. This is the parity contract — the same behavior the Kafka half must
+observe once reconciled to this module.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.runtime.runtime_fanout_resolver import (
+    assert_published_events_injective,
+    is_fanout_sequence,
+    normalize_fanout_elements,
+    resolve_fanout_topics,
+    resolve_published_topic,
+)
+
+
+class ModelAlpha(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+class ModelBeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+class ModelGamma(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+class ModelWithEmbeddedTopic(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    topic: str = "onex.evt.smuggled.v1"
+
+
+# A class named exactly like the routing carrier the resolver must reject. The
+# resolver keys on ``type(e).__name__``, so a local stand-in is sufficient and
+# avoids constructing the generic real envelope.
+class ModelEventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    payload: int = 0
+
+
+_PUBLISHED = {
+    "Alpha": "onex.evt.alpha.v1",
+    "Beta": "onex.evt.beta.v1",
+}
+
+
+class TestIsFanoutSequence:
+    def test_tuple_of_models_is_fanout(self) -> None:
+        assert is_fanout_sequence((ModelAlpha(), ModelBeta())) is True
+
+    def test_list_of_models_is_fanout(self) -> None:
+        assert is_fanout_sequence([ModelAlpha()]) is True
+
+    def test_single_model_is_not_fanout(self) -> None:
+        assert is_fanout_sequence(ModelAlpha()) is False
+
+    def test_str_is_not_fanout(self) -> None:
+        assert is_fanout_sequence("onex.evt.x") is False
+
+    def test_bytes_is_not_fanout(self) -> None:
+        assert is_fanout_sequence(b"payload") is False
+
+    def test_dict_is_not_fanout(self) -> None:
+        assert is_fanout_sequence({"a": 1}) is False
+
+    def test_none_is_not_fanout(self) -> None:
+        assert is_fanout_sequence(None) is False
+
+
+class TestResolvePublishedTopic:
+    def test_resolves_by_short_name(self) -> None:
+        assert resolve_published_topic(_PUBLISHED, ModelAlpha()) == "onex.evt.alpha.v1"
+
+    def test_resolves_full_class_name_spelling(self) -> None:
+        # A map keyed by the full class name (Model prefix present) still resolves.
+        published = {"ModelAlpha": "onex.evt.alpha.v1"}
+        assert resolve_published_topic(published, ModelAlpha()) == "onex.evt.alpha.v1"
+
+    def test_unmapped_class_fails_closed(self) -> None:
+        # Gamma is not in the map -> raise, never fall back to a single topic.
+        with pytest.raises(ModelOnexError, match="not declared in the contract"):
+            resolve_published_topic(_PUBLISHED, ModelGamma())
+
+
+class TestNormalizeFanoutElements:
+    def test_preserves_order_and_returns_models(self) -> None:
+        a, b = ModelAlpha(value=1), ModelBeta(value=2)
+        assert normalize_fanout_elements([a, b]) == [a, b]
+
+    def test_non_model_element_raises_never_filters(self) -> None:
+        with pytest.raises(ModelOnexError, match="not a BaseModel"):
+            normalize_fanout_elements([ModelAlpha(), "not-a-model"])
+
+    def test_rejects_routing_carrier(self) -> None:
+        with pytest.raises(ModelOnexError, match="routing carrier"):
+            normalize_fanout_elements([ModelEventEnvelope()])
+
+    def test_rejects_embedded_topic(self) -> None:
+        with pytest.raises(ModelOnexError, match="embedded topic"):
+            normalize_fanout_elements([ModelWithEmbeddedTopic()])
+
+
+class TestResolveFanoutTopics:
+    def test_ordered_topic_payload_pairs(self) -> None:
+        a, b = ModelAlpha(value=1), ModelBeta(value=2)
+        resolved = resolve_fanout_topics(_PUBLISHED, [a, b])
+        assert resolved == [("onex.evt.alpha.v1", a), ("onex.evt.beta.v1", b)]
+
+    def test_unmapped_in_sequence_fails_closed(self) -> None:
+        with pytest.raises(ModelOnexError, match="not declared in the contract"):
+            resolve_fanout_topics(_PUBLISHED, [ModelAlpha(), ModelGamma()])
+
+
+class TestAssertPublishedEventsInjective:
+    def test_injective_map_passes(self) -> None:
+        assert_published_events_injective(_PUBLISHED, context="test")
+
+    def test_redundant_short_and_full_spelling_same_topic_passes(self) -> None:
+        published = {"Alpha": "onex.evt.alpha.v1", "ModelAlpha": "onex.evt.alpha.v1"}
+        assert_published_events_injective(published, context="test")
+
+    def test_same_class_two_topics_fails(self) -> None:
+        # Short and full spelling of the SAME class disagree on topic -> ambiguous.
+        published = {"Alpha": "onex.evt.alpha.v1", "ModelAlpha": "onex.evt.other.v1"}
+        with pytest.raises(ModelOnexError, match="two topics"):
+            assert_published_events_injective(published, context="test")
+
+    def test_two_classes_one_topic_fails(self) -> None:
+        published = {"Alpha": "onex.evt.shared.v1", "Beta": "onex.evt.shared.v1"}
+        with pytest.raises(ModelOnexError, match="injective"):
+            assert_published_events_injective(published, context="test")

--- a/tests/unit/runtime/test_runtime_fanout_resolver.py
+++ b/tests/unit/runtime/test_runtime_fanout_resolver.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Unit tests for the shared fan-out publish-topic resolver (OMN-14403 §6ii).
 

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -109,6 +109,42 @@ def test_create_event_bus_explicit_inmemory(workflow_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_load_published_events_map_rejects_conflicting_duplicates(
+    workflow_path: Path,
+) -> None:
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    runtime._contract = {
+        "published_events": [
+            {"event_type": "ModelAlpha", "topic": "alpha.created.v1"},
+            {"event_type": "ModelAlpha", "topic": "alpha.changed.v1"},
+        ]
+    }
+
+    with pytest.raises(ModelOnexError) as exc_info:
+        runtime._load_published_events_map()
+
+    assert exc_info.value.error_code == EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR
+    assert "ModelAlpha" in str(exc_info.value)
+    assert "alpha.created.v1" in str(exc_info.value)
+    assert "alpha.changed.v1" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_load_published_events_map_allows_identical_duplicates(
+    workflow_path: Path,
+) -> None:
+    runtime = RuntimeLocal(workflow_path=workflow_path)
+    runtime._contract = {
+        "published_events": [
+            {"event_type": "ModelAlpha", "topic": "alpha.created.v1"},
+            {"event_type": "ModelAlpha", "topic": "alpha.created.v1"},
+        ]
+    }
+
+    assert runtime._load_published_events_map() == {"ModelAlpha": "alpha.created.v1"}
+
+
+@pytest.mark.unit
 def test_core_inmemory_bus_satisfies_local_runtime_bus_protocol(
     workflow_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_local_adapter_fanout.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_fanout.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""LocalRuntimeBusAdapter def-B multi-event (fan-out) publish tests (OMN-14403 §6ii).
+
+Barrier-2 RED->GREEN for the RuntimeLocal path: a def-B handler that returns a
+``Sequence[BaseModel]`` (fan-out) or a single ``BaseModel`` whose topic varies by
+class must publish to the contract-declared topic(s) via ``published_events`` —
+NOT collapse to a single ``output_topic``. The seam is default-OFF; these tests
+assert both the OFF (unchanged / warn-drop) and ON (publish N) behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
+    ProtocolLocalRuntimeBus,
+)
+from omnibase_core.protocols.runtime.protocol_local_runtime_callable_target import (
+    ProtocolLocalRuntimeCallableTarget,
+)
+from omnibase_core.runtime.runtime_local_adapter import LocalRuntimeBusAdapter
+
+
+class ModelInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+    correlation_id: str = ""
+
+
+class ModelAlpha(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+class ModelBeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+class ModelGamma(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: int = 0
+
+
+_PUBLISHED = {"Alpha": "onex.evt.alpha.v1", "Beta": "onex.evt.beta.v1"}
+
+
+class _FanoutHandler:
+    """def-B fan-out: one input -> a two-element sequence of distinct classes."""
+
+    def handle(self, request: ModelInput) -> tuple[BaseModel, ...]:
+        return (ModelAlpha(value=request.value), ModelBeta(value=request.value))
+
+
+class _SingleAlphaHandler:
+    """def-B single-emit whose topic must come from published_events (Alpha)."""
+
+    def handle(self, request: ModelInput) -> BaseModel:
+        return ModelAlpha(value=request.value)
+
+
+class _SingleUnmappedHandler:
+    """def-B single-emit of a class ABSENT from published_events (fail-closed)."""
+
+    def handle(self, request: ModelInput) -> BaseModel:
+        return ModelGamma(value=request.value)
+
+
+class _FakeBus:
+    """Records ``publish`` calls; the adapter needs only ``publish`` here."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def start(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def publish(self, topic: str, key: object, value: bytes) -> object:
+        self.published.append((topic, value))
+        return None
+
+    async def subscribe(
+        self, topic: str, *, on_message: object, group_id: str
+    ) -> object:  # pragma: no cover - unused
+        return None
+
+
+class _FakeMsg:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+def _msg(value: int) -> _FakeMsg:
+    return _FakeMsg(json.dumps({"value": value, "correlation_id": "cid-1"}).encode())
+
+
+def _adapter(
+    handler: object,
+    bus: _FakeBus,
+    *,
+    seam_enabled: bool,
+    published_events: dict[str, str] | None,
+    output_topic: str | None = "onex.evt.fallback.v1",
+    on_error: Callable[[], None] | None = None,
+) -> LocalRuntimeBusAdapter:
+    return LocalRuntimeBusAdapter(
+        handler=cast("ProtocolLocalRuntimeCallableTarget", handler),
+        handler_name="test-handler",
+        input_model_cls=ModelInput,
+        output_topic=output_topic,
+        bus=cast("ProtocolLocalRuntimeBus", bus),
+        on_error=on_error,
+        published_events=published_events,
+        multi_event_seam_enabled=seam_enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fanout_seam_on_publishes_two_topics_in_order() -> None:
+    bus = _FakeBus()
+    adapter = _adapter(
+        _FanoutHandler(), bus, seam_enabled=True, published_events=_PUBLISHED
+    )
+    await adapter.on_message(_msg(7))
+
+    assert [topic for topic, _ in bus.published] == [
+        "onex.evt.alpha.v1",
+        "onex.evt.beta.v1",
+    ]
+    # Payloads are the concrete models, in return order.
+    alpha = json.loads(bus.published[0][1])
+    beta = json.loads(bus.published[1][1])
+    assert alpha == {"value": 7}
+    assert beta == {"value": 7}
+
+
+@pytest.mark.asyncio
+async def test_fanout_seam_off_drops_and_publishes_nothing() -> None:
+    bus = _FakeBus()
+    adapter = _adapter(
+        _FanoutHandler(), bus, seam_enabled=False, published_events=_PUBLISHED
+    )
+    await adapter.on_message(_msg(7))
+    # Seam OFF: warn-drop the sequence, publish nothing (the census channel).
+    assert bus.published == []
+
+
+@pytest.mark.asyncio
+async def test_single_emit_seam_on_routes_via_published_events() -> None:
+    bus = _FakeBus()
+    adapter = _adapter(
+        _SingleAlphaHandler(), bus, seam_enabled=True, published_events=_PUBLISHED
+    )
+    await adapter.on_message(_msg(3))
+    # Topic comes from the model's class, NOT the single output_topic.
+    assert [topic for topic, _ in bus.published] == ["onex.evt.alpha.v1"]
+
+
+@pytest.mark.asyncio
+async def test_single_emit_seam_off_uses_output_topic() -> None:
+    bus = _FakeBus()
+    adapter = _adapter(
+        _SingleAlphaHandler(), bus, seam_enabled=False, published_events=_PUBLISHED
+    )
+    await adapter.on_message(_msg(3))
+    # Seam OFF: unchanged — single output_topic path.
+    assert [topic for topic, _ in bus.published] == ["onex.evt.fallback.v1"]
+
+
+@pytest.mark.asyncio
+async def test_single_emit_seam_on_no_published_events_uses_output_topic() -> None:
+    bus = _FakeBus()
+    adapter = _adapter(
+        _SingleAlphaHandler(), bus, seam_enabled=True, published_events=None
+    )
+    await adapter.on_message(_msg(3))
+    # No published_events declared -> unchanged single output_topic path.
+    assert [topic for topic, _ in bus.published] == ["onex.evt.fallback.v1"]
+
+
+@pytest.mark.asyncio
+async def test_fanout_unmapped_class_fails_closed() -> None:
+    bus = _FakeBus()
+    errors: list[bool] = []
+
+    def _on_error() -> None:
+        errors.append(True)
+
+    adapter = _adapter(
+        _SingleUnmappedHandler(),
+        bus,
+        seam_enabled=True,
+        published_events=_PUBLISHED,
+        on_error=_on_error,
+    )
+    await adapter.on_message(_msg(1))
+    # Fail-closed: unmapped class raises inside publish -> on_error, nothing sent.
+    assert bus.published == []
+    assert errors == [True]

--- a/tests/unit/runtime/test_runtime_local_adapter_fanout.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_fanout.py
@@ -113,11 +113,11 @@ def _adapter(
     on_error: Callable[[], None] | None = None,
 ) -> LocalRuntimeBusAdapter:
     return LocalRuntimeBusAdapter(
-        handler=cast("ProtocolLocalRuntimeCallableTarget", handler),
+        handler=cast(ProtocolLocalRuntimeCallableTarget, handler),
         handler_name="test-handler",
         input_model_cls=ModelInput,
         output_topic=output_topic,
-        bus=cast("ProtocolLocalRuntimeBus", bus),
+        bus=cast(ProtocolLocalRuntimeBus, bus),
         on_error=on_error,
         published_events=published_events,
         multi_event_seam_enabled=seam_enabled,

--- a/tests/unit/runtime/test_runtime_local_adapter_fanout.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_fanout.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """LocalRuntimeBusAdapter def-B multi-event (fan-out) publish tests (OMN-14403 §6ii).
 

--- a/tests/unit/runtime/test_runtime_local_adapter_fanout.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_fanout.py
@@ -58,6 +58,13 @@ class _FanoutHandler:
         return (ModelAlpha(value=request.value), ModelBeta(value=request.value))
 
 
+class _FanoutWithUnmappedHandler:
+    """def-B fan-out containing a class absent from published_events."""
+
+    def handle(self, request: ModelInput) -> tuple[BaseModel, ...]:
+        return (ModelAlpha(value=request.value), ModelGamma(value=request.value))
+
+
 class _SingleAlphaHandler:
     """def-B single-emit whose topic must come from published_events (Alpha)."""
 
@@ -188,7 +195,7 @@ async def test_single_emit_seam_on_no_published_events_uses_output_topic() -> No
 
 
 @pytest.mark.asyncio
-async def test_fanout_unmapped_class_fails_closed() -> None:
+async def test_single_emit_unmapped_class_fails_closed() -> None:
     bus = _FakeBus()
     errors: list[bool] = []
 
@@ -204,5 +211,24 @@ async def test_fanout_unmapped_class_fails_closed() -> None:
     )
     await adapter.on_message(_msg(1))
     # Fail-closed: unmapped class raises inside publish -> on_error, nothing sent.
+    assert bus.published == []
+    assert errors == [True]
+
+
+@pytest.mark.asyncio
+async def test_fanout_batch_unmapped_class_fails_closed() -> None:
+    bus = _FakeBus()
+    errors: list[bool] = []
+    adapter = _adapter(
+        _FanoutWithUnmappedHandler(),
+        bus,
+        seam_enabled=True,
+        published_events=_PUBLISHED,
+        on_error=lambda: errors.append(True),
+    )
+
+    await adapter.on_message(_msg(1))
+
+    # Fail-closed: unmapped element aborts the whole batch before publishing.
     assert bus.published == []
     assert errors == [True]


### PR DESCRIPTION
Ticket: OMN-14403
Evidence-Ticket: OMN-14403
Evidence-Source: OCC#4154
Evidence-Commit: 55348941f66bec76582716534cec6ea1de7f5b92

## What

Barrier 2 of the P3a def-B re-signature (`docs/plans/2026-07-14-p3a-sanctioned-direction-design.md` §4 step 1 / §6ii): give the RuntimeLocal (`onex node`) path a **typed multi-event return** so a def-B **multi-topic / fan-out ORCHESTRATOR** is representable, and extract the class→topic resolution + carrier rejection into **one shared pure helper** in `omnibase_core` that both runtimes call.

Closes part of OMN-14403 (the shared-resolver + local-adapter half; the Kafka `fanout_seam` is reconciled to this same module in a follow-up PR, and the orchestrator re-signature is a third PR).

## Why

`LocalRuntimeBusAdapter` was single-input → single-result → single `output_topic`, so it could not express a handler whose emitted topic varies by returned class (the codegen orchestrator's 6 phases). And the Kafka `_normalize_handler_result` grew a fan-out branch while the local adapter had none — the two runtimes disagreed byte-for-byte on what a def-B fan-out handler publishes (memory `reference_runtime_local_vs_kafka_adapter_divergence`). This PR is the single shared resolver both will call so they cannot drift again (Fable refinement 3).

## Changes

- **`runtime_fanout_resolver.py`** (new; pure, no I/O, reads no env):
  - `is_fanout_sequence`, `normalize_fanout_elements` (validate-then-**raise**, never filter; rejects `ModelEventEnvelope`/`ModelDelegationEventEnvelope` carriers + embedded-`topic` elements)
  - `resolve_published_topic` — **exact type** (short then full class-name spelling, matching the applier's `_resolve_mapped_output_topic`), **fail-closed on unmapped** (no silent fallback to a single output_topic)
  - `resolve_fanout_topics` — ordered `(topic, payload)` pairs in return order
  - `assert_published_events_injective` — boot check: one class → exactly one topic, injective class→topic map
- **`LocalRuntimeBusAdapter`** — accepts `Sequence[BaseModel]` (fan-out → publish N via the resolver) and resolves a single `BaseModel`'s topic from `published_events` when the seam is ON; single-`output_topic`/`None` behavior unchanged when OFF or when no `published_events` is declared. Behind `ONEX_MULTI_EVENT_PUBLISH_SEAM` (default OFF; mirrors the `omnibase_infra` read). **Flag NOT flipped here.**
- **`RuntimeLocal`** — loads the contract's `published_events` map, asserts injectivity at boot, threads it + the seam flag into each adapter.

## Seams (define-and-match, OMN-14208)

- Adapter constructor: `published_events: Mapping[str, str] | None` (class short-name → topic) + `multi_event_seam_enabled: bool`. Default `None`/`False` → byte-for-byte prior behavior.
- `published_events` map shape: `{event_type_short_name: topic}`, identical to `omnibase_infra.load_published_events_map` — the Kafka half reconciles to the **same** resolver in the follow-up PR (parity is the assertion).
- Env flag name `ONEX_MULTI_EVENT_PUBLISH_SEAM` matched to the existing `omnibase_infra.handler_wiring` read.

## dod_evidence

- `uv run pytest tests/unit/runtime/` → **250 passed** (no regression; includes the 26 new tests).
- New tests (`test_runtime_fanout_resolver.py`, `test_runtime_local_adapter_fanout.py`): fan-out RED→GREEN (2 topics in return order), single-emit-via-published_events, seam-OFF unchanged (single output_topic; sequence warn-dropped), fail-closed on unmapped class, boot injectivity (class→two-topics and two-classes→one-topic both raise).
- `uv run mypy` clean on the 3 changed source files; `ruff format` + `ruff check` clean; `pre-commit` clean on changed files (env-var, extra-forbid, canon-shape all pass).
- proof_class: **replay-proven** (resolver ordering equivalence) + **receipt-bound** (adapter unit RED→GREEN).

## Notes

- Additive by construction: no existing single-return/`None` handler and no contract lacking a `published_events` block changes behavior with the flag OFF (the default). The flag is flipped in a separate PR after all consumers are compliant (§4 step 4).
- Pre-existing (not this PR): the advisory pre-commit-only `validate-model-dump-json-mode` ratchet is at 311 > 310 on `dev@a9f25887` — surfaced during this work, my files contribute 0; filing a follow-up ticket. Not a CI gate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contract-declared `published_events` routing for handler outputs, including ordered def-B multi-event fan-out to distinct topics.
  * Introduced an opt-in publish seam (via `ONEX_MULTI_EVENT_PUBLISH_SEAM`) to enable multi-event publishing in the local runtime.
  * Fail-closed behavior now rejects unmapped payload types (and unsafe/forbidden fan-out elements) and enforces injective event→topic mappings.
* **Tests**
  * Added unit coverage for fan-out detection, topic resolution/normalization, injectivity validation, and seam ON/OFF publish behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


