### PR TITLE
fix(OMN-14621): restore model-dump-json-mode ratchet (311 -> 310)

### DIFF
--- a/src/omnibase_core/models/core/model_cli_command_registry.py
+++ b/src/omnibase_core/models/core/model_cli_command_registry.py
@@ -302,7 +302,7 @@ def _coerce_reloaded_command_registry(
         return None
 
     if hasattr(registry_obj, "model_dump"):
-        registry_data = registry_obj.model_dump()
+        registry_data = registry_obj.model_dump(mode="json")
     else:
         registry_data = {
             "commands": getattr(registry_obj, "commands", {}),


### PR DESCRIPTION
## Summary

The `validate-model-dump-json-mode` advisory pre-commit ratchet (`.pre-commit-config.yaml`, `--max-violations 310`) is drifting on `dev`: current count at `dev@a9f25887` is 311, one over ceiling. Flagged independently (not introduced by their own diffs) by p3a-build's PR1/PR3 work — see `docs/tracking/ROLLING_WORK_LEDGER.md` 2026-07-14T11:17Z / 12:09Z entries.

**Root cause:** `_coerce_reloaded_command_registry()` in `model_cli_command_registry.py` dumps a stale `ModelCliCommandRegistry` instance (created before an import-cache reload) and immediately re-validates it via `ModelCliCommandRegistry.model_validate(registry_data)` — a validation-boundary crossing that the script's own suppression standard explicitly excludes from a `# noqa: model-dump-bare` waiver ("allowed only for in-memory dict-to-dict usage that does not cross JSON, hashing, persistence, transport, or **validation** boundaries").

git-blame confirms this is the most recently introduced violation among the 311 (added 2026-07-11, PR #1422), consistent with it being the drift that pushed the ratchet from 310 to 311.

**Fix:** add `mode="json"` to the `model_dump()` call. Safe — every field on `ModelCliCommandRegistry` / `ModelCliCommandDefinition` (str/bool/list/dict/`Path`/nested `BaseModel`, no `datetime`/`UUID`/tuple/set) round-trips cleanly through a JSON-mode dump back into `model_validate()`.

## dod_evidence (OMN-14621)

RED/GREEN proof, local, against the actual ratchet script + pre-commit hook:
- **RED** (pre-fix, `dev@a9f25887`): `uv run python scripts/validation/validate-model-dump-json-mode.py --directory src/ --max-violations 310` → `Violation count (311) exceeds maximum allowed (310)`, exit 1.
- **GREEN** (post-fix): same command → `Violation count (310) is within maximum allowed (310)`, exit 0.
- `pre-commit run validate-model-dump-json-mode` — Passed.
- Targeted tests: `tests/unit/models/core/test_model_cli_command_registry.py` — 37/37 passed.
- `uv run mypy` / `uv run ruff format --check` / `uv run ruff check` on the touched file — clean.
- Full local suite (`uv run pytest tests/ -n 8`): 43140 passed, 3 failed, 65 skipped, 12 xfailed, 43 xpassed. All 3 failures proven pre-existing/environmental, unrelated to this 1-line change:
  - `test_execution_resolver_performance.py::test_repeated_resolution_consistency` — timing-variance assertion, passes in isolation (parallel-worker load noise).
  - `test_workflow_validator.py::test_iteration_limit_raises_on_excessive_iterations` — passes in isolation (same load-timing class).
  - `test_harness_dispatch.py::test_infra_not_importable_in_core_environment` — passes with `env -u PYTHONPATH` (ambient local-machine `PYTHONPATH` shadowing the sibling `omnibase_infra` clone; a known local-environment artifact, not a code regression).

Advisory / pre-commit-only gate, not a CI-required check. proof_class: code-only (local RED→GREEN pre-commit proof).

Evidence-Ticket: OMN-14621
Evidence-Source: OCC#4156
Evidence-Commit: a132c85ef6272cf9aa80d2db1d7dac2fc6f22def

Closes OMN-14621.

## Test plan
- [x] `uv run ruff format --check` / `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] Targeted model test suite — 37/37 passed
- [x] `pre-commit run validate-model-dump-json-mode` — Passed
- [x] RED/GREEN local proof above
- [x] Full local suite — 43140 passed, 3 pre-existing/environmental failures (documented, unrelated)
- [ ] `gh pr checks` green on CI (watching)
