### PR TITLE
refactor(OMN-14634): fix check-no-fallbacks debt in compliance handlers

### DIFF
--- a/src/omnibase_core/nodes/node_compliance_evidence_effect/event_bus_no_op.py
+++ b/src/omnibase_core/nodes/node_compliance_evidence_effect/event_bus_no_op.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""No-op completion event bus stub for NodeComplianceEvidenceEffect.
+
+Replaces the previous ``event_bus: Any = None`` + None-guard pattern in
+``handler.py`` (silent DI bypass, flagged by ``check_no_fallbacks.py``).
+Callers that genuinely have no bus to inject now get an explicit, typed
+stub instead of an implicit ``None`` — the publish call always executes,
+it just has nowhere durable to land.
+
+Ticket: OMN-14634
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["NoOpCompletionEventBus"]
+
+
+class NoOpCompletionEventBus:
+    """Stateless no-op stub used when no real event bus is injected.
+
+    Stateless and side-effect-free, so a single module-level instance in
+    ``handler.py`` is safe to share across callers.
+    """
+
+    # ONEX_EXCLUDE: dict_str_any — payload is a pre-serialized completion
+    # event dict; matches the duck-typed publish(topic, payload) surface
+    # every real event-bus implementation in this codebase already exposes.
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        logger.info("No event bus configured — completion event logged only: %s", topic)

--- a/src/omnibase_core/nodes/node_compliance_evidence_effect/handler.py
+++ b/src/omnibase_core/nodes/node_compliance_evidence_effect/handler.py
@@ -33,10 +33,15 @@ from omnibase_core.models.nodes.compliance_evidence.model_compliance_evidence_ou
 from omnibase_core.models.nodes.compliance_evidence.model_evidence_report_state import (
     ModelEvidenceReportState,
 )
+from omnibase_core.nodes.node_compliance_evidence_effect.event_bus_no_op import (
+    NoOpCompletionEventBus,
+)
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["NodeComplianceEvidenceEffect"]
+__all__ = ["NodeComplianceEvidenceEffect", "NoOpCompletionEventBus"]
+
+_NO_OP_EVENT_BUS = NoOpCompletionEventBus()
 
 
 class NodeComplianceEvidenceEffect:
@@ -44,15 +49,17 @@ class NodeComplianceEvidenceEffect:
 
     Args:
         state_root: Root directory for state artifacts (typically ``.onex_state``).
-        event_bus: Optional event bus for emitting completion events. When ``None``
-            the completion event is logged but not published (local-dev fallback).
+        event_bus: Event bus for emitting completion events. Defaults to a
+            no-op stub (:class:`NoOpCompletionEventBus`) when the caller has
+            no real bus to inject — the publish call always fires, it simply
+            has nowhere durable to land.
         completion_topic: Topic string from the contract's publish_topics.
     """
 
     def __init__(
         self,
         state_root: Path,
-        event_bus: Any = None,  # fallback-ok: pre-existing debt predating OMN-14629, tracked in OMN-14634
+        event_bus: Any = _NO_OP_EVENT_BUS,
         completion_topic: str = "",
     ) -> None:
         self._state_root = Path(state_root)
@@ -157,13 +164,5 @@ class NodeComplianceEvidenceEffect:
             "passed": report_data["passed"],
             "failed": report_data["failed"],
         }
-        if (
-            self._event_bus is not None
-        ):  # fallback-ok: pre-existing debt predating OMN-14629, tracked in OMN-14634
-            self._event_bus.publish(self._completion_topic, event_payload)
-            logger.info("Completion event emitted: %s", self._completion_topic)
-        else:
-            logger.info(
-                "No event bus configured — completion event logged only: %s",
-                self._completion_topic,
-            )
+        self._event_bus.publish(self._completion_topic, event_payload)
+        logger.info("Completion event emitted: %s", self._completion_topic)

--- a/src/omnibase_core/nodes/node_compliance_scan_compute/handler.py
+++ b/src/omnibase_core/nodes/node_compliance_scan_compute/handler.py
@@ -179,18 +179,21 @@ class NodeComplianceScanCompute:
                     )
                 )
 
-        node_id = ""
+        node_id = contract_path.parent.name
         if contract_data is not None:
-            node_id = str(
-                contract_data.get(
-                    "node_id"
-                )  # fallback-ok: pre-existing debt predating OMN-14629, tracked in OMN-14634
-                or contract_data.get("handler_id")
-                or contract_data.get("name")
-                or contract_path.parent.name
-            )
-        else:
-            node_id = contract_path.parent.name
+            # Explicit precedence: node_id > handler_id > name > directory
+            # name. Falls through on a falsy value (missing key or empty
+            # string) at each step, matching the prior 'or'-chain semantics
+            # but with each fallback step now traceable individually.
+            candidate_node_id = contract_data.get("node_id")
+            candidate_handler_id = contract_data.get("handler_id")
+            candidate_name = contract_data.get("name")
+            if candidate_node_id:
+                node_id = str(candidate_node_id)
+            elif candidate_handler_id:
+                node_id = str(candidate_handler_id)
+            elif candidate_name:
+                node_id = str(candidate_name)
 
         all_passed = all(c.passed for c in checks)
 
@@ -415,9 +418,17 @@ class NodeComplianceScanCompute:
         self, data: dict[str, Any], checks: list[ModelCheckResult]
     ) -> None:
         """Check 4: node_kind matches handler output constraints."""
-        node_kind = (
-            data.get("node_kind") or data.get("node_type") or ""
-        )  # fallback-ok: pre-existing debt predating OMN-14629, tracked in OMN-14634
+        # Explicit precedence: node_kind > node_type > unset. Falls through
+        # on a falsy value (missing key or empty string) at each step,
+        # matching the prior 'or'-chain semantics but individually traceable.
+        candidate_node_kind = data.get("node_kind")
+        candidate_node_type = data.get("node_type")
+        if candidate_node_kind:
+            node_kind: Any = candidate_node_kind
+        elif candidate_node_type:
+            node_kind = candidate_node_type
+        else:
+            node_kind = ""
         node_kind_str = str(node_kind).upper()
 
         if not node_kind_str:
@@ -610,9 +621,17 @@ class NodeComplianceScanCompute:
                     item.get("infisical_path") or item.get("infisical")
                 )
                 if not has_env and not has_infisical:
-                    key = (
-                        item.get("key") or item.get("name") or str(item)
-                    )  # fallback-ok: pre-existing debt predating OMN-14629, tracked in OMN-14634
+                    # Explicit precedence: key > name > str(item). Falls
+                    # through on a falsy value at each step, matching the
+                    # prior 'or'-chain semantics but individually traceable.
+                    candidate_key = item.get("key")
+                    candidate_name = item.get("name")
+                    if candidate_key:
+                        key = candidate_key
+                    elif candidate_name:
+                        key = candidate_name
+                    else:
+                        key = str(item)
                     missing.append(key)
             elif isinstance(item, str):
                 # String-only config requirement: presence check passes

--- a/tests/unit/canary/test_effect_golden.py
+++ b/tests/unit/canary/test_effect_golden.py
@@ -68,11 +68,13 @@ def test_readback_passes_when_all_declared_effects_happen(tmp_path: Path) -> Non
 
 
 def test_readback_CATCHES_a_suppressed_effect(tmp_path: Path) -> None:
-    # THE proof: event_bus=None suppresses the publish (handler logs, never emits).
-    # execute() STILL returns a Path (no exception) — 'didn't throw' is blind — but
-    # the declared topic never reaches a real sink, so readback FAILS.
-    sink = RecordingEventSink()  # stays empty: the node was given no bus
-    node = NodeComplianceEvidenceEffect(tmp_path, None, TOPIC)
+    # THE proof: the default no-op event bus stub (OMN-14634 — no more bare
+    # event_bus=None DI bypass) suppresses the publish (handler logs, never
+    # emits) when no real bus is injected. execute() STILL returns a Path (no
+    # exception) — 'didn't throw' is blind — but the declared topic never
+    # reaches a real sink, so readback FAILS.
+    sink = RecordingEventSink()  # stays empty: the node was given no real bus
+    node = NodeComplianceEvidenceEffect(tmp_path, completion_topic=TOPIC)
     returned = node.execute(_report())  # does NOT throw
     assert isinstance(returned, Path)  # 'didn't throw' would PASS here
     rb = readback_effects(

--- a/tests/unit/nodes/node_compliance_scan_compute/test_compliance_scan_compute.py
+++ b/tests/unit/nodes/node_compliance_scan_compute/test_compliance_scan_compute.py
@@ -237,3 +237,135 @@ class TestSourceOnlyFlag:
         results = scanner.scan(str(tmp_path), source_only=True)
         assert len(results) == 1
         assert results[0].node_id == "node_real"
+
+
+class TestOrChainFallbackPrecedence:
+    """Behavioral proof for OMN-14634: the 3 or-chains that were rewritten as
+    explicit if/elif precedence must keep IDENTICAL cascade behavior — same
+    winner at every fallback depth, including when a higher-precedence field
+    is present alongside a lower-precedence one (a bug here would silently
+    pick the WRONG field, not crash — the RED case is "exists but wrong",
+    not "absent").
+    """
+
+    def test_node_id_falls_back_to_handler_id_when_node_id_absent(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_x"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text("handler_id: my_handler\n")
+
+        results = scanner.scan(str(tmp_path))
+        assert results[0].node_id == "my_handler"
+
+    def test_node_id_prefers_node_id_over_handler_id(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_y"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text(
+            "node_id: canonical_id\nhandler_id: my_handler\n"
+        )
+
+        results = scanner.scan(str(tmp_path))
+        assert results[0].node_id == "canonical_id"
+
+    def test_node_id_falls_back_to_name_when_node_id_and_handler_id_absent(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_z"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text("name: friendly_name\n")
+
+        results = scanner.scan(str(tmp_path))
+        assert results[0].node_id == "friendly_name"
+
+    def test_node_id_falls_back_to_directory_name_when_all_fields_absent(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_dirname_fallback"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text("description: no identifying fields\n")
+
+        results = scanner.scan(str(tmp_path))
+        assert results[0].node_id == "node_dirname_fallback"
+
+    def test_node_kind_check_falls_back_to_node_type(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_k"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text("node_id: node_k\nnode_type: EFFECT\n")
+
+        results = scanner.scan(str(tmp_path))
+        check4 = next(c for c in results[0].checks if c.check_id == 4)
+        assert check4.passed is True
+        assert "EFFECT" in check4.message
+
+    def test_node_kind_prefers_node_kind_over_node_type(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_k2"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text(
+            "node_id: node_k2\nnode_kind: COMPUTE\nnode_type: EFFECT\n"
+        )
+
+        results = scanner.scan(str(tmp_path))
+        check4 = next(c for c in results[0].checks if c.check_id == 4)
+        assert check4.passed is True
+        assert "COMPUTE" in check4.message
+        assert "EFFECT" not in check4.message
+
+    def test_config_readiness_missing_mapping_falls_back_to_name(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_cfg"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text(
+            "node_id: node_cfg\n"
+            "node_kind: COMPUTE\n"
+            "config_requirements:\n"
+            "  - name: MY_SETTING\n"
+        )
+
+        results = scanner.scan(str(tmp_path))
+        check7 = next(c for c in results[0].checks if c.check_id == 7)
+        assert check7.passed is False
+        assert "MY_SETTING" in check7.message
+
+    def test_config_readiness_prefers_key_over_name(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_cfg2"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text(
+            "node_id: node_cfg2\n"
+            "node_kind: COMPUTE\n"
+            "config_requirements:\n"
+            "  - key: MY_KEY\n"
+            "    name: MY_SETTING\n"
+        )
+
+        results = scanner.scan(str(tmp_path))
+        check7 = next(c for c in results[0].checks if c.check_id == 7)
+        assert check7.passed is False
+        assert "MY_KEY" in check7.message
+        assert "MY_SETTING" not in check7.message
+
+    def test_config_readiness_falls_back_to_str_item_when_no_key_or_name(
+        self, scanner: NodeComplianceScanCompute, tmp_path: Path
+    ) -> None:
+        node_dir = tmp_path / "nodes" / "node_cfg3"
+        node_dir.mkdir(parents=True)
+        (node_dir / "contract.yaml").write_text(
+            "node_id: node_cfg3\n"
+            "node_kind: COMPUTE\n"
+            "config_requirements:\n"
+            "  - description: unnamed requirement\n"
+        )
+
+        results = scanner.scan(str(tmp_path))
+        check7 = next(c for c in results[0].checks if c.check_id == 7)
+        assert check7.passed is False
+        assert "unnamed requirement" in check7.message

--- a/tests/unit/nodes/test_compliance_evidence_effect/test_compliance_evidence_effect.py
+++ b/tests/unit/nodes/test_compliance_evidence_effect/test_compliance_evidence_effect.py
@@ -27,6 +27,7 @@ from omnibase_core.models.nodes.compliance_evidence.model_evidence_report_state 
 )
 from omnibase_core.nodes.node_compliance_evidence_effect.handler import (
     NodeComplianceEvidenceEffect,
+    NoOpCompletionEventBus,
 )
 
 pytestmark = pytest.mark.unit
@@ -104,3 +105,63 @@ def test_evidence_writes_report_to_disk(
     failing_node = next(r for r in loaded["results"] if r["node_id"] == "node_epsilon")
     assert failing_node["passed"] is False
     assert failing_node["checks"][0]["name"] == "handler_resolution"
+
+
+class _RecordingBus:
+    """Real observable stub — records every publish call (anti-MagicMock)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def publish(self, topic: str, payload: dict[str, object]) -> None:
+        self.calls.append((topic, payload))
+
+
+def test_default_event_bus_is_no_op_stub_not_none(tmp_path: Path) -> None:
+    """OMN-14634: the injectable_none_default violation is fixed — the
+    default is a typed no-op stub instance, never a bare ``None``."""
+    handler = NodeComplianceEvidenceEffect(state_root=tmp_path)
+    assert handler._event_bus is not None
+    assert isinstance(handler._event_bus, NoOpCompletionEventBus)
+
+
+def test_injected_bus_publish_is_called_unconditionally(
+    tmp_path: Path, sample_report: ModelEvidenceReportState
+) -> None:
+    """OMN-14634: the none_guard_publish_skip violation is fixed — publish()
+    is invoked directly with no ``is not None`` guard around the call site.
+    A real (non-None) bus must observe exactly one publish call."""
+    bus = _RecordingBus()
+    handler = NodeComplianceEvidenceEffect(
+        state_root=tmp_path,
+        event_bus=bus,
+        completion_topic="onex.evt.core.compliance-scan-completed.v1",
+    )
+    handler.execute(sample_report)
+
+    assert len(bus.calls) == 1
+    topic, payload = bus.calls[0]
+    assert topic == "onex.evt.core.compliance-scan-completed.v1"
+    assert payload["total"] == 5
+    assert payload["passed"] == 4
+    assert payload["failed"] == 1
+
+
+def test_explicit_none_event_bus_no_longer_silently_tolerated(
+    tmp_path: Path, sample_report: ModelEvidenceReportState
+) -> None:
+    """OMN-14634 RED/GREEN discriminator for none_guard_publish_skip: with
+    the ``is not None`` guard removed, explicitly passing ``event_bus=None``
+    (misuse — omit the arg to get the no-op stub default) now fails loudly
+    with AttributeError instead of being silently swallowed. Under the
+    pre-fix guarded implementation this call did NOT raise (the guard
+    caught it and logged-only) — this test is RED against that code and
+    GREEN against the fixed handler, proving the guard is actually gone
+    and not just cosmetically rewritten."""
+    handler = NodeComplianceEvidenceEffect(
+        state_root=tmp_path,
+        event_bus=None,  # type: ignore[arg-type]
+        completion_topic="onex.evt.core.compliance-scan-completed.v1",
+    )
+    with pytest.raises(AttributeError):
+        handler.execute(sample_report)


### PR DESCRIPTION
## Summary

Fixes the 5 pre-existing `check-no-fallbacks` violations tracked in OMN-14634. These were confirmed byte-identical on `origin/dev` (predate this work) and were suppressed with `# fallback-ok` markers in the OMN-14629 rank2 PR (core#1443, still open) as explicitly out of scope there. This PR is the real fix, built on a fresh worktree off `origin/dev`, independent of #1443's diff — a merge conflict between the two on `_emit_completion`/`_check_*` bodies is expected and left for normal rebase resolution at merge time.

- `node_compliance_evidence_effect/handler.py`: replaced `event_bus: Any = None` + `if self._event_bus is not None:` publish-skip guard with an injected `NoOpCompletionEventBus` stub (new file `event_bus_no_op.py`, split out to satisfy the repo's single-class-per-file + `Protocol*`-must-live-in-`protocol/` gates). The publish call now always fires; a caller with no real bus gets an explicit no-op stub instead of an implicit `None`.
- `node_compliance_scan_compute/handler.py`: replaced 3x 3-way `or`-chain contract-field resolution (`node_id` precedence, `node_kind`/`node_type` precedence, config-requirement `key`/`name` precedence) with explicit `if`/`elif` precedence logic per the hook's own guidance ("Use explicit fallback logic ... instead of 'x or y or z'"). Fallback-cascade behavior (including falsy-value fallthrough) is preserved exactly.

## Behavioral proof (non-vacuous)

- `TestOrChainFallbackPrecedence` (new, 8 tests): proves the exact winner at every fallback depth for all 3 rewritten or-chains, including the case where a higher-precedence field coexists with a lower-precedence one (the RED case for this class of bug is "exists but wrong," not "absent" — a naive rewrite could silently invert precedence without any test noticing).
- `test_explicit_none_event_bus_no_longer_silently_tolerated` (new): a real RED/GREEN discriminator. Verified RED against the pre-fix guarded implementation (temporarily reverted `handler.py` to the `origin/dev` version and ran this test in isolation — it does **not** raise, confirming the guard silently swallows) and GREEN against the fix (raises `AttributeError`, proving the guard is structurally gone, not cosmetically rewritten).
- The pre-existing OMN-14358 effect-golden canary `test_readback_CATCHES_a_suppressed_effect` is updated to exercise the new no-op-stub default (omitting `event_bus` instead of passing `None` explicitly) and continues to pass with identical assertions — the readback-discriminates-suppression narrative is preserved end to end.
- Full local verification: `check_no_fallbacks.py` reports 0 violations on both files (was 5); `ruff format`/`ruff check` clean; `mypy` clean (0 errors, 5 files); full `pre-commit run --files <changed>` green (all ~90 hooks, including `ONEX No Fallback Patterns Validation`, `ONEX Single Class Per File`, `ONEX dict[str, Any] Anti-Pattern Detection`, `No event-bus none-guard-before-publish (OMN-10818)`); `tests/unit/nodes/` + `tests/unit/canary/` full directories green (496 passed, 0 failed).

Closes OMN-14634.

OCC companion owed — Codex/autogen owns it.

## Test plan
- [x] `python3 scripts/validation/check_no_fallbacks.py` on both changed handler files → 0 violations
- [x] `uv run ruff format` / `uv run ruff check` clean on changed files
- [x] `uv run mypy` clean on changed source dirs
- [x] `uv run pre-commit run --files <changed>` — full hook suite green
- [x] `uv run pytest tests/unit/nodes/test_compliance_evidence_effect/ tests/unit/nodes/node_compliance_scan_compute/ tests/unit/canary/test_effect_golden.py -v` — 31 passed
- [x] `uv run pytest tests/unit/nodes/ tests/unit/canary/ -q` (broader regression) — 496 passed
- [x] RED/GREEN discriminator manually verified against pre-fix `handler.py` (temporarily reverted, confirmed test fails RED as expected, restored fix)

Evidence-Source: OCC#4220
Evidence-Ticket: OMN-14634
Evidence-Commit: 75fe5011138c766556d13553084f330cbf948b38
Evidence-Head: ad2748fed17bcc541ccb086ef783c5316322df5b

