### PR TITLE
feat(OMN-14659): WS8 fan-out — 4 canonical arch-* ValidatorNode COMPUTE nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1294,6 +1294,24 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # No localhost/hardcoded-endpoint fallback defaults (OMN-14659). Scoped to
+      # src/ only, matching the check-no-utcnow precedent above — this repo's src/
+      # tree is currently clean against this check (verified 2026-07-16). The
+      # sibling no-hardcoded-ip / no-direct-kafka-producer / no-raw-sqlite3 nodes
+      # generated in the same ticket are intentionally NOT self-wired here: a
+      # full-tree run against src/ turns up pre-existing findings (docstring IP
+      # examples, ProtocolKafkaProducer* symbol names, a legitimate sqlite3
+      # harness) that would need triage/suppression before this repo's own gate
+      # could go green. They remain available as remote hooks
+      # (.pre-commit-hooks.yaml) and standalone CI entrypoints for other repos.
+      - id: check-no-env-fallbacks
+        name: No Localhost/Hardcoded-Endpoint Fallbacks (OMN-14659)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check
+        language: system
+        files: ^src/.*\.(py|sh|bash)$
+        pass_filenames: true
+        stages: [pre-commit]
+
       # Canonical Inference Gate (OMN-13219).
       # Fails on non-canonical model-inference surfaces: shelled model CLIs
       # (codex/claude/gemini/opencode via subprocess/exec/shutil.which) and

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -411,6 +411,79 @@
   pass_filenames: true
   stages: [pre-commit]
 
+- id: check-no-hardcoded-ip
+  name: No Hardcoded Internal IP Addresses (OMN-14659)
+  description: >
+    Reject hardcoded internal IP address literals (192.168.x.x, 10.x.x.x, 172.16-31.x.x,
+    optionally http(s)-prefixed and port-suffixed) in Python and YAML source. Ported from the
+    CI gate at omniclaude/scripts/validation/validate_no_hardcoded_ip.py into the
+    node_no_utcnow_check_compute two-node COMPUTE/EFFECT pattern (OMN-14656/OMN-14659): the
+    line scan itself runs as a pure COMPUTE node (node_no_hardcoded_ip_check_compute) over
+    explicit (path, source) pairs, and the paired EFFECT node (node_source_file_gather_effect)
+    owns the filesystem walk for full-tree (no-filenames) invocation. Same node backs the
+    pre-commit hook and any CI entrypoint. All endpoints must be configured via environment
+    variables. Suppress a justified exception with: # onex-allow-internal-ip
+  language: python
+  entry: python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check
+  types_or: [python, yaml]
+  pass_filenames: true
+  stages: [pre-commit]
+
+- id: check-no-direct-kafka-producer
+  name: No Direct Kafka Producer Usage (OMN-14659)
+  description: >
+    Reject direct Kafka producer client usage (AIOKafkaProducer, KafkaProducer,
+    confluent_kafka, aiokafka via import, bare-name usage, or attribute access) outside the
+    shared publisher layer. Ported from the CI gate at
+    omniclaude/scripts/validation/validate_no_direct_kafka_producer.py into the
+    node_no_utcnow_check_compute two-node COMPUTE/EFFECT pattern (OMN-14656/OMN-14659): the
+    AST scan itself runs as a pure COMPUTE node (node_no_direct_kafka_producer_check_compute)
+    over explicit (path, source) pairs, and the paired EFFECT node
+    (node_source_file_gather_effect) owns the filesystem walk for full-tree (no-filenames)
+    invocation. Same node backs the pre-commit hook and any CI entrypoint. Route through the
+    shared publisher abstraction (e.g. emit_via_daemon()) instead.
+  language: python
+  entry: python -m omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check
+  types: [python]
+  pass_filenames: true
+  stages: [pre-commit]
+
+- id: check-no-env-fallbacks
+  name: No Localhost/Hardcoded-Endpoint Fallbacks (OMN-14659)
+  description: >
+    Reject localhost/hardcoded-endpoint fallback defaults (os.environ.get / os.getenv
+    defaults, Pydantic Field defaults, bootstrap_servers literals, shell ${VAR:-...}
+    expansions) in Python and shell source. Ported from the canonical unified CI gate at
+    omniclaude/scripts/validate_no_env_fallbacks.py into the node_no_utcnow_check_compute
+    two-node COMPUTE/EFFECT pattern (OMN-14656/OMN-14659): the line scan itself runs as a pure
+    COMPUTE node (node_no_env_fallbacks_check_compute) over explicit (path, source) pairs, and
+    the paired EFFECT node (node_source_file_gather_effect) owns the filesystem walk for
+    full-tree (no-filenames) invocation. Same node backs the pre-commit hook and any CI
+    entrypoint. Replace with os.environ["VAR"] (fail-fast, no default) or raise explicitly.
+    Suppress a justified exception with: # fallback-ok: <reason>
+  language: python
+  entry: python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check
+  types_or: [python, shell]
+  pass_filenames: true
+  stages: [pre-commit]
+
+- id: check-no-raw-sqlite3
+  name: No Raw sqlite3.connect() Outside Adapters (OMN-14659)
+  description: >
+    Reject raw sqlite3.connect() calls outside *_adapter.py definitions. Ported from the CI
+    gate at omniclaude/scripts/validation/validate_no_raw_sqlite3.py into the
+    node_no_utcnow_check_compute two-node COMPUTE/EFFECT pattern (OMN-14656/OMN-14659): the
+    AST scan itself runs as a pure COMPUTE node (node_no_raw_sqlite3_check_compute) over
+    explicit (path, source) pairs, and the paired EFFECT node (node_source_file_gather_effect)
+    owns the filesystem walk for full-tree (no-filenames) invocation. Same node backs the
+    pre-commit hook and any CI entrypoint. Database access must go through an injected
+    adapter. Suppress a legitimate adapter-bootstrap call site with: # di-ok
+  language: python
+  entry: python -m omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check
+  types: [python]
+  pass_filenames: true
+  stages: [pre-commit]
+
 - id: check-enum-governance
   name: ONEX Enum Governance Validation (OMN-13287)
   description: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,10 @@ node_contract_resolve_compute = "omnibase_core.nodes.node_contract_resolve_compu
 node_contract_verify_replay_compute = "omnibase_core.nodes.node_contract_verify_replay_compute"
 node_source_file_gather_effect = "omnibase_core.nodes.node_source_file_gather_effect"
 node_no_utcnow_check_compute = "omnibase_core.nodes.node_no_utcnow_check_compute"
+node_no_hardcoded_ip_check_compute = "omnibase_core.nodes.node_no_hardcoded_ip_check_compute"
+node_no_direct_kafka_producer_check_compute = "omnibase_core.nodes.node_no_direct_kafka_producer_check_compute"
+node_no_env_fallbacks_check_compute = "omnibase_core.nodes.node_no_env_fallbacks_check_compute"
+node_no_raw_sqlite3_check_compute = "omnibase_core.nodes.node_no_raw_sqlite3_check_compute"
 
 [project.optional-dependencies]
 spi = ["omnibase-spi>=0.20.2"]
@@ -392,6 +396,11 @@ ignore = [
 "src/omnibase_core/validation/doc_content_scan/runtime_doc_content_scan.py" = ["T201"]
 # OMN-14656: CLI runner for the no-utcnow-check COMPUTE node prints findings.
 "src/omnibase_core/nodes/node_no_utcnow_check_compute/runtime_no_utcnow_check.py" = ["T201"]
+# OMN-14659: CLI runners for the WS8 convert_now COMPUTE nodes print findings.
+"src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/runtime_no_hardcoded_ip_check.py" = ["T201"]
+"src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py" = ["T201"]
+"src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/runtime_no_env_fallbacks_check.py" = ["T201"]
+"src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/runtime_no_raw_sqlite3_check.py" = ["T201"]
 "src/omnibase_core/validation/validator_transport_import.py" = ["T201"]  # CLI output for pre-commit hook violations (OMN-13283)
 "src/omnibase_core/validation/validator_node_purity.py" = ["T201"]  # CLI output for pre-commit hook violations (OMN-13283)
 "src/omnibase_core/validation/antipattern_checker.py" = ["T201"]  # CLI output for pre-commit hook violations (OMN-11923)

--- a/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/__init__.py
+++ b/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_direct_kafka_producer_check COMPUTE node models (OMN-14659).
+
+The report/finding shapes are NOT node-local — this node returns the
+canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), not a
+per-node fork. Import ``ModelValidationReport`` /
+``ModelValidationFindingEmbed`` from there. The per-file input shape
+(:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`)
+is the shared (path, source) DTO — also not forked here.
+"""
+
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+    ModelNoDirectKafkaProducerCheckInput,
+)
+
+__all__ = [
+    "ModelNoDirectKafkaProducerCheckInput",
+]

--- a/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/model_no_direct_kafka_producer_check_input.py
+++ b/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/model_no_direct_kafka_producer_check_input.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for the no_direct_kafka_producer_check COMPUTE node."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+
+__all__ = ["ModelNoDirectKafkaProducerCheckInput"]
+
+
+class ModelNoDirectKafkaProducerCheckInput(BaseModel):
+    """Request to AST-scan a set of (path, source) pairs for direct Kafka producer usage."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    files: list[ModelSourceFile] = Field(default_factory=list)

--- a/src/omnibase_core/models/nodes/no_env_fallbacks_check/__init__.py
+++ b/src/omnibase_core/models/nodes/no_env_fallbacks_check/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_env_fallbacks_check COMPUTE node models (OMN-14659).
+
+The report/finding shapes are NOT node-local — this node returns the
+canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), not a
+per-node fork. Import ``ModelValidationReport`` /
+``ModelValidationFindingEmbed`` from there. The per-file input shape
+(:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`)
+is the shared (path, source) DTO — also not forked here.
+"""
+
+from omnibase_core.models.nodes.no_env_fallbacks_check.model_no_env_fallbacks_check_input import (
+    ModelNoEnvFallbacksCheckInput,
+)
+
+__all__ = [
+    "ModelNoEnvFallbacksCheckInput",
+]

--- a/src/omnibase_core/models/nodes/no_env_fallbacks_check/model_no_env_fallbacks_check_input.py
+++ b/src/omnibase_core/models/nodes/no_env_fallbacks_check/model_no_env_fallbacks_check_input.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for the no_env_fallbacks_check COMPUTE node."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+
+__all__ = ["ModelNoEnvFallbacksCheckInput"]
+
+
+class ModelNoEnvFallbacksCheckInput(BaseModel):
+    """Request to scan a set of (path, source) pairs for localhost/hardcoded-endpoint fallbacks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    files: list[ModelSourceFile] = Field(default_factory=list)

--- a/src/omnibase_core/models/nodes/no_hardcoded_ip_check/__init__.py
+++ b/src/omnibase_core/models/nodes/no_hardcoded_ip_check/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_hardcoded_ip_check COMPUTE node models (OMN-14659).
+
+The report/finding shapes are NOT node-local — this node returns the
+canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), not a
+per-node fork. Import ``ModelValidationReport`` /
+``ModelValidationFindingEmbed`` from there. The per-file input shape
+(:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`)
+is the shared (path, source) DTO — also not forked here.
+"""
+
+from omnibase_core.models.nodes.no_hardcoded_ip_check.model_no_hardcoded_ip_check_input import (
+    ModelNoHardcodedIpCheckInput,
+)
+
+__all__ = [
+    "ModelNoHardcodedIpCheckInput",
+]

--- a/src/omnibase_core/models/nodes/no_hardcoded_ip_check/model_no_hardcoded_ip_check_input.py
+++ b/src/omnibase_core/models/nodes/no_hardcoded_ip_check/model_no_hardcoded_ip_check_input.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for the no_hardcoded_ip_check COMPUTE node."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+
+__all__ = ["ModelNoHardcodedIpCheckInput"]
+
+
+class ModelNoHardcodedIpCheckInput(BaseModel):
+    """Request to scan a set of (path, source) pairs for hardcoded internal IPs."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    files: list[ModelSourceFile] = Field(default_factory=list)

--- a/src/omnibase_core/models/nodes/no_raw_sqlite3_check/__init__.py
+++ b/src/omnibase_core/models/nodes/no_raw_sqlite3_check/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_raw_sqlite3_check COMPUTE node models (OMN-14659).
+
+The report/finding shapes are NOT node-local — this node returns the
+canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), not a
+per-node fork. Import ``ModelValidationReport`` /
+``ModelValidationFindingEmbed`` from there. The per-file input shape
+(:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`)
+is the shared (path, source) DTO — also not forked here.
+"""
+
+from omnibase_core.models.nodes.no_raw_sqlite3_check.model_no_raw_sqlite3_check_input import (
+    ModelNoRawSqlite3CheckInput,
+)
+
+__all__ = [
+    "ModelNoRawSqlite3CheckInput",
+]

--- a/src/omnibase_core/models/nodes/no_raw_sqlite3_check/model_no_raw_sqlite3_check_input.py
+++ b/src/omnibase_core/models/nodes/no_raw_sqlite3_check/model_no_raw_sqlite3_check_input.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Input model for the no_raw_sqlite3_check COMPUTE node."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+
+__all__ = ["ModelNoRawSqlite3CheckInput"]
+
+
+class ModelNoRawSqlite3CheckInput(BaseModel):
+    """Request to AST-scan a set of (path, source) pairs for raw sqlite3.connect() calls."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    files: list[ModelSourceFile] = Field(default_factory=list)

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_direct_kafka_producer_check COMPUTE node package (OMN-14659).
+
+Exposes :class:`NodeNoDirectKafkaProducerCheckCompute` — AST-scans explicit
+(path, source) pairs for direct Kafka producer client usage
+(``AIOKafkaProducer``, ``KafkaProducer``, ``confluent_kafka``, ``aiokafka``)
+outside the shared publisher layer, and returns a ``ModelValidationReport``.
+"""
+
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (
+    NodeNoDirectKafkaProducerCheckCompute,
+)
+
+__all__ = ["NodeNoDirectKafkaProducerCheckCompute"]

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/contract.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the no_direct_kafka_producer_check COMPUTE node.
+# AST-scans explicit (path, source) pairs for direct Kafka producer client usage
+# (AIOKafkaProducer, KafkaProducer, confluent_kafka, aiokafka) outside the shared
+# publisher layer, reproducing the CI gate at
+# omniclaude/scripts/validation/validate_no_direct_kafka_producer.py byte-for-byte.
+#
+# See: OMN-14659 — WS8 fan-out (convert-clean generic omniclaude arch validators)
+
+name: node_no_direct_kafka_producer_check_compute
+node_id: node_no_direct_kafka_producer_check_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  AST-scans a set of explicit (path, source) pairs for direct Kafka producer client usage
+  (AIOKafkaProducer, KafkaProducer, confluent_kafka, aiokafka via import, bare-name usage, or
+  attribute access), skipping files whose path is part of the shared publisher layer, and
+  returns an OMN-2362 ValidationReport with a per-violation finding reproducing the
+  arch-no-direct-kafka-producer CI gate's message text byte-for-byte. Pure — no filesystem
+  access, no clock, no global state. #magic___^_^___line
+input_model: omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input.ModelNoDirectKafkaProducerCheckInput
+output_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeNoDirectKafkaProducerCheckCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/handler.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/handler.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeNoDirectKafkaProducerCheckCompute — direct-Kafka-producer validation COMPUTE handler.
+
+Ports the AST-based CI gate at
+``omniclaude/scripts/validation/validate_no_direct_kafka_producer.py`` into a
+canonical COMPUTE node on the def-B ``handle(request) -> response`` shape
+(OMN-14355), following the ``node_no_utcnow_check_compute`` template
+(OMN-14656).
+
+Architecture: COMPUTE node — pure, deterministic, no I/O. Content arrives via
+explicit ``(path, source)`` pairs on the request (see
+:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`,
+reused rather than forked); the filesystem walk + read happens at the paired
+EFFECT boundary (``node_source_file_gather_effect``), never inside this
+handler.
+
+Output shape: the canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), NOT a
+per-node fork — ``overall_status`` is computed by
+``ModelValidationReport.from_findings()`` using the shared
+ERROR > FAIL > WARN > PASS precedence engine. This node emits ``FAIL``
+(direct Kafka producer usage) and ``ERROR`` (unparseable file) findings.
+
+Files whose path matches the shared publisher layer (see
+:mod:`.visitor_kafka_producer`) are skipped entirely — the oracle's own
+per-file exclusion, ported unchanged.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Final, Literal
+
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+    ModelNoDirectKafkaProducerCheckInput,
+)
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationFindingEmbed,
+    ModelValidationReport,
+    ModelValidationRequestRef,
+)
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.visitor_kafka_producer import (
+    VALIDATOR_ID,
+    DirectKafkaProducerVisitor,
+    is_allowed_publisher_path,
+)
+
+__all__ = ["NodeNoDirectKafkaProducerCheckCompute"]
+
+# This node has no notion of a "strict"/"advisory" caller profile (it always
+# reports FAIL/ERROR findings at face value) — "default" is the precedence
+# profile that leaves findings unmodified before aggregation.
+_PROFILE: Final[Literal["strict", "default", "advisory"]] = "default"
+
+
+class NodeNoDirectKafkaProducerCheckCompute:
+    """COMPUTE handler that AST-scans (path, source) pairs for direct Kafka producer usage."""
+
+    def handle(
+        self, request: ModelNoDirectKafkaProducerCheckInput
+    ) -> ModelValidationReport:
+        """Definition-B canonical entry-point (OMN-14355).
+
+        Typed request in, typed response out — pure, no I/O, no clock.
+        """
+        findings: list[ModelValidationFinding] = []
+        for file in request.files:
+            findings.extend(self._check_file(file.path, file.source))
+
+        embedded_findings = tuple(
+            ModelValidationFindingEmbed(**finding.model_dump()) for finding in findings
+        )
+
+        return ModelValidationReport.from_findings(
+            findings=embedded_findings,
+            request=ModelValidationRequestRef(profile=_PROFILE),
+            validators_run=(VALIDATOR_ID,),
+        )
+
+    def _check_file(self, path: str, source: str) -> list[ModelValidationFinding]:
+        """Port of ``check_file`` + the ``is_allowed_path`` skip
+        (validate_no_direct_kafka_producer.py:102-132)."""
+        if is_allowed_publisher_path(path):
+            return []
+
+        try:
+            tree = ast.parse(source, filename=path)
+        except SyntaxError as exc:
+            return [
+                ModelValidationFinding(
+                    validator_id=VALIDATOR_ID,
+                    severity="ERROR",
+                    location=path,
+                    message=f"{path}: SyntaxError: {exc}",
+                    remediation=None,
+                )
+            ]
+
+        visitor = DirectKafkaProducerVisitor(path)
+        visitor.visit(tree)
+        return visitor.findings

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI runtime for the no-direct-kafka-producer check — pre-commit hook + CI entrypoint.
+
+Both invocation surfaces are backed by the SAME canonical COMPUTE node
+(``NodeNoDirectKafkaProducerCheckCompute``) — DRY per the OMN-13305 pattern,
+following the ``node_no_utcnow_check_compute`` template (OMN-14656): a single
+module owns the pure handler plus a synchronous CLI ``main()`` that performs
+all filesystem I/O at the CLI boundary, never inside the handler.
+
+Two modes:
+
+* **pre-commit** (explicit filenames): the staged files pre-commit hands us
+  are read directly here — no directory walk needed.
+* **full-tree** (no filenames — CI / manual ``python -m ...``): walks
+  ``--root`` (default ``src``) via the paired ``node_source_file_gather_effect``
+  EFFECT node, reproducing the oracle CI gate's whole-tree scan
+  (``omniclaude/scripts/validation/validate_no_direct_kafka_producer.py``
+  ``src_root.rglob("*.py")``).
+
+Usage::
+
+    python -m omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check file1.py file2.py
+    python -m omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check
+    python -m omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check --root src
+
+Exit codes: 0 — ``overall_status == "PASS"``; 1 — FAIL/ERROR findings present.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Final
+
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+    ModelNoDirectKafkaProducerCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.models.nodes.source_file_gather.model_source_file_gather_input import (
+    ModelSourceFileGatherInput,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationReport,
+)
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (
+    NodeNoDirectKafkaProducerCheckCompute,
+)
+from omnibase_core.nodes.node_source_file_gather_effect.handler import (
+    NodeSourceFileGatherEffect,
+)
+
+__all__ = ["main"]
+
+_DEFAULT_ROOT: Final[str] = "src"
+
+
+def _gather_from_filenames(
+    paths: list[Path],
+) -> tuple[list[ModelSourceFile], list[str]]:
+    """CLI I/O boundary for pre-commit's explicit staged-file mode.
+
+    Non-``.py`` and missing paths are intentionally skipped. Read errors on
+    existing Python files are returned as fatal diagnostics so the runtime
+    does not report PASS with unscanned source.
+    """
+    files: list[ModelSourceFile] = []
+    read_errors: list[str] = []
+    for path in paths:
+        if path.suffix != ".py" or not path.is_file():
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            read_errors.append(f"{path}: read error: {exc}")
+            continue
+        files.append(ModelSourceFile(path=str(path), source=source))
+    return files, read_errors
+
+
+def _gather_from_root(root: str) -> tuple[list[ModelSourceFile], list[str]]:
+    """Full-tree walk mode (CI / manual), reusing ``node_source_file_gather_effect``.
+
+    This is the EFFECT boundary — the only filesystem walk in this module —
+    delegated to the paired canonical node rather than re-implemented here.
+    """
+    output = NodeSourceFileGatherEffect().handle(
+        ModelSourceFileGatherInput(root=root, include_patterns=["**/*.py"])
+    )
+    read_errors = [
+        f"{skipped.path}: {skipped.reason}"
+        for skipped in output.skipped
+        if skipped.reason.startswith(("read error:", "error checking file size:"))
+    ]
+    return [
+        ModelSourceFile(path=f.path, source=f.source) for f in output.files
+    ], read_errors
+
+
+def _run(files: list[ModelSourceFile]) -> ModelValidationReport:
+    """Dispatch gathered (path, source) pairs to the canonical COMPUTE node."""
+    return NodeNoDirectKafkaProducerCheckCompute().handle(
+        ModelNoDirectKafkaProducerCheckInput(files=files)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: pre-commit staged-file mode, or a full-tree walk with no args.
+
+    Returns:
+        0 on PASS, 1 on FAIL/ERROR.
+    """
+    parser = argparse.ArgumentParser(
+        prog="check-no-direct-kafka-producer",
+        description=(
+            "Detect direct Kafka producer client usage via the "
+            "no-direct-kafka-producer-check COMPUTE node (OMN-14659)."
+        ),
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help=(
+            "Files to check (pre-commit passes staged filenames here). "
+            "When omitted, walks --root recursively (CI / manual mode)."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default=_DEFAULT_ROOT,
+        help=(
+            "Root directory for a full-tree walk when no filenames are given "
+            f"(default: {_DEFAULT_ROOT})"
+        ),
+    )
+    parsed = parser.parse_args(argv)
+
+    if parsed.filenames:
+        files, read_errors = _gather_from_filenames([Path(f) for f in parsed.filenames])
+    else:
+        files, read_errors = _gather_from_root(parsed.root)
+
+    if read_errors:
+        print(
+            f"ERROR: Failed to read {len(read_errors)} Python file(s):"
+        )  # print-ok: CLI output
+        for read_error in read_errors:
+            print(f"  {read_error}")  # print-ok: CLI output
+        return 1
+
+    report = _run(files)
+
+    if report.overall_status == "PASS":
+        print(  # print-ok: CLI output
+            "OK: No direct Kafka producer usage found outside the shared publisher layer"
+        )
+        return 0
+
+    print(  # print-ok: CLI output
+        f"FAIL: Found {report.metrics.total} direct Kafka producer violation(s):"
+    )
+    for finding in report.findings:
+        print(f"  {finding.message}")  # print-ok: CLI output
+    print(  # print-ok: CLI output
+        "\nDirect Kafka producer usage (AIOKafkaProducer, KafkaProducer, confluent_kafka)"
+        " must only occur in the shared publisher layer."
+        "\nUse emit_via_daemon() or the shared publisher abstraction instead."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/visitor_kafka_producer.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/visitor_kafka_producer.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""AST visitor that detects direct Kafka producer client usage.
+
+Split out of ``handler.py`` (single-class-per-file, OMN-14656 convention) so
+the COMPUTE handler module contains exactly one class
+(``NodeNoDirectKafkaProducerCheckCompute``).
+
+Port of ``DirectKafkaVisitor`` + ``is_allowed_path``
+(``omniclaude/scripts/validation/validate_no_direct_kafka_producer.py:32-99``).
+Detects ``AIOKafkaProducer`` / ``KafkaProducer`` / ``confluent_kafka`` /
+``aiokafka`` via ``import``, ``from ... import``, bare-name usage, and
+attribute access (``kafka.KafkaProducer``) — except on files that are part of
+the shared publisher layer (matched by filename or parent-directory
+substring, exactly like the oracle).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import PurePosixPath
+from typing import Final
+
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+
+__all__ = ["VALIDATOR_ID", "DirectKafkaProducerVisitor", "is_allowed_publisher_path"]
+
+_SEVERITY_FAIL: Final = "FAIL"
+
+VALIDATOR_ID: Final[str] = "arch-no-direct-kafka-producer"
+_REMEDIATION: Final[str] = (
+    "route through the shared publisher layer "
+    "(emit_via_daemon() or the shared publisher abstraction) "
+    "instead of instantiating a Kafka producer client directly"
+)
+
+# Forbidden direct Kafka producer symbols (oracle FORBIDDEN_SYMBOLS).
+_FORBIDDEN_SYMBOLS: Final[tuple[str, ...]] = (
+    "AIOKafkaProducer",
+    "KafkaProducer",
+    "confluent_kafka",
+    "aiokafka",
+)
+
+# Modules that are allowed to use these symbols — the shared publisher layer
+# (oracle ALLOWED_PATHS).
+_ALLOWED_PATHS: Final[tuple[str, ...]] = (
+    "publisher",
+    "kafka_publisher_base",
+    "kafka_producer_utils",
+    "action_event_publisher",
+    "embedded_publisher",
+    "emit_client",
+)
+
+
+def is_allowed_publisher_path(path: str) -> bool:
+    """Return True if ``path`` is part of the shared publisher layer.
+
+    Checks only the filename and immediate parent directory name — not the
+    full path — matching the oracle's ``is_allowed_path`` exactly (so pytest
+    temporary directories don't cause false positives).
+    """
+    posix = PurePosixPath(path.replace("\\", "/"))
+    name_lower = posix.name.lower()
+    parent_lower = posix.parent.name.lower()
+    for allowed in _ALLOWED_PATHS:
+        if allowed in name_lower or allowed in parent_lower:
+            return True
+    return False
+
+
+class DirectKafkaProducerVisitor(ast.NodeVisitor):
+    """Walk an AST looking for direct Kafka producer client usage."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self.findings: list[ModelValidationFinding] = []
+
+    def _check_name(self, name: str, lineno: int, context: str) -> None:
+        for sym in _FORBIDDEN_SYMBOLS:
+            if sym in name:
+                self._add_finding(
+                    lineno,
+                    f"{context} uses direct Kafka producer symbol '{sym}'",
+                )
+                return
+
+    def _add_finding(self, lineno: int, message: str) -> None:
+        self.findings.append(
+            ModelValidationFinding(
+                validator_id=VALIDATOR_ID,
+                severity=_SEVERITY_FAIL,
+                location=f"{self._path}:{lineno}",
+                message=f"{self._path}:{lineno}: {message}",
+                remediation=_REMEDIATION,
+            )
+        )
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._check_name(alias.name, node.lineno, f"import '{alias.name}'")
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        self._check_name(module, node.lineno, f"from '{module}' import")
+        for alias in node.names:
+            self._check_name(alias.name, node.lineno, f"imported name '{alias.name}'")
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        for sym in _FORBIDDEN_SYMBOLS:
+            if node.id == sym:
+                self._add_finding(
+                    node.lineno, f"direct usage of Kafka producer symbol '{sym}'"
+                )
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # Catch attribute access like `kafka.KafkaProducer` where the module
+        # is imported as a bare name (e.g., `import kafka; kafka.KafkaProducer(...)`)
+        if node.attr in _FORBIDDEN_SYMBOLS:
+            self._add_finding(
+                node.lineno,
+                f"direct usage of Kafka producer symbol '{node.attr}' via attribute access",
+            )
+        self.generic_visit(node)

--- a/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_env_fallbacks_check COMPUTE node package (OMN-14659).
+
+Exposes :class:`NodeNoEnvFallbacksCheckCompute` — line-scans explicit (path,
+source) pairs for localhost/hardcoded-endpoint fallback defaults in Python
+and shell source, and returns a ``ModelValidationReport``.
+"""
+
+from omnibase_core.nodes.node_no_env_fallbacks_check_compute.handler import (
+    NodeNoEnvFallbacksCheckCompute,
+)
+
+__all__ = ["NodeNoEnvFallbacksCheckCompute"]

--- a/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/contract.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the no_env_fallbacks_check COMPUTE node.
+# Line-scans explicit (path, source) pairs for localhost/hardcoded-endpoint fallback
+# defaults (os.environ.get/os.getenv defaults, Pydantic Field defaults, bootstrap_servers
+# literals, shell ${VAR:-...} expansions), reproducing the CI gate at
+# omniclaude/scripts/validate_no_env_fallbacks.py byte-for-byte per finding.
+#
+# See: OMN-14659 — WS8 fan-out (convert-clean generic omniclaude arch validators)
+
+name: node_no_env_fallbacks_check_compute
+node_id: node_no_env_fallbacks_check_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  Line-scans a set of explicit (path, source) pairs for localhost/hardcoded-endpoint
+  fallback defaults across Python (os.environ.get/os.getenv defaults, default= / : str =
+  literals, bootstrap_servers= literals) and shell (${VAR:-localhost} / ${VAR:-192.168...})
+  source, and returns an OMN-2362 ValidationReport with a per-violation finding reproducing
+  the arch-no-env-fallbacks CI gate's flagged-line text byte-for-byte. A line carrying a
+  # fallback-ok / # cloud-bus-ok / # OMN-7227-exempt marker, or a pure-comment / docstring
+  line, is exempt. Pure — no filesystem access, no clock, no global state. #magic___^_^___line
+input_model: omnibase_core.models.nodes.no_env_fallbacks_check.model_no_env_fallbacks_check_input.ModelNoEnvFallbacksCheckInput
+output_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeNoEnvFallbacksCheckCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/handler.py
+++ b/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/handler.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeNoEnvFallbacksCheckCompute — localhost/hardcoded-endpoint-fallback validation COMPUTE handler.
+
+Ports the canonical unified CI gate at
+``omniclaude/scripts/validate_no_env_fallbacks.py`` into a canonical COMPUTE
+node on the def-B ``handle(request) -> response`` shape (OMN-14355),
+following the ``node_no_utcnow_check_compute`` template (OMN-14656).
+
+Architecture: COMPUTE node — pure, deterministic, no I/O. Content arrives via
+explicit ``(path, source)`` pairs on the request (see
+:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`,
+reused rather than forked); the filesystem walk + read happens at the paired
+EFFECT boundary (``node_source_file_gather_effect``), never inside this
+handler.
+
+Output shape: the canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), NOT a
+per-node fork. This node only ever emits ``FAIL`` findings (a fallback
+default was found), so with the ``"default"`` profile the precedence engine
+gives ``overall_status == "FAIL"`` whenever any finding is present and
+``"PASS"`` otherwise.
+
+Per-finding message text reproduces the CI gate's flagged-line text
+byte-for-byte; see :mod:`.matcher_env_fallbacks` for the port.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from omnibase_core.models.nodes.no_env_fallbacks_check.model_no_env_fallbacks_check_input import (
+    ModelNoEnvFallbacksCheckInput,
+)
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationFindingEmbed,
+    ModelValidationReport,
+    ModelValidationRequestRef,
+)
+from omnibase_core.nodes.node_no_env_fallbacks_check_compute.matcher_env_fallbacks import (
+    VALIDATOR_ID,
+    find_env_fallback_violations,
+)
+
+__all__ = ["NodeNoEnvFallbacksCheckCompute"]
+
+# This node has no notion of a "strict"/"advisory" caller profile (it always
+# reports FAIL findings at face value) — "default" is the precedence profile
+# that leaves findings unmodified before aggregation.
+_PROFILE: Final[Literal["strict", "default", "advisory"]] = "default"
+
+
+class NodeNoEnvFallbacksCheckCompute:
+    """COMPUTE handler that line-scans (path, source) pairs for endpoint fallback defaults."""
+
+    def handle(self, request: ModelNoEnvFallbacksCheckInput) -> ModelValidationReport:
+        """Definition-B canonical entry-point (OMN-14355).
+
+        Typed request in, typed response out — pure, no I/O, no clock.
+        """
+        findings: list[ModelValidationFinding] = []
+        for file in request.files:
+            findings.extend(self._check_file(file.path, file.source))
+
+        embedded_findings = tuple(
+            ModelValidationFindingEmbed(**finding.model_dump()) for finding in findings
+        )
+
+        return ModelValidationReport.from_findings(
+            findings=embedded_findings,
+            request=ModelValidationRequestRef(profile=_PROFILE),
+            validators_run=(VALIDATOR_ID,),
+        )
+
+    def _check_file(self, path: str, source: str) -> list[ModelValidationFinding]:
+        """Port of the per-file dispatch + scan (validate_no_env_fallbacks.py:202-243)."""
+        return find_env_fallback_violations(path, source)

--- a/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/matcher_env_fallbacks.py
+++ b/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/matcher_env_fallbacks.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Line-based matcher that detects localhost/hardcoded-endpoint fallback defaults.
+
+Split out of ``handler.py`` (single-class-per-file convention established by
+``node_no_utcnow_check_compute``, OMN-14656) — this module has no classes at
+all since the port is a per-line regex match with lightweight docstring
+tracking, not an AST walk.
+
+Port of the Python-file and shell-file scanners
+(``omniclaude/scripts/validate_no_env_fallbacks.py:41-186``). Six pattern
+types: ``os.environ.get``/``os.getenv`` with a localhost/private-IP default,
+Pydantic/keyword ``default=``/``: str =`` localhost or private-IP literals,
+``bootstrap_servers=`` localhost/private-IP literals, and ``${VAR:-...}``
+shell-parameter-expansion fallbacks — each exempt on a line carrying one of
+``EXEMPT_MARKERS`` or on a pure-comment / docstring line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import Final
+
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+
+__all__ = [
+    "VALIDATOR_ID",
+    "should_skip_path",
+    "find_env_fallback_violations",
+]
+
+VALIDATOR_ID: Final[str] = "arch-no-env-fallbacks"
+_REMEDIATION: Final[str] = (
+    'replace with os.environ["VAR"] (fail-fast, no default) or raise explicitly; '
+    "annotate a justified exception with # fallback-ok: <reason>"
+)
+
+# ---------------------------------------------------------------------------
+# Pattern building blocks (oracle _LOCALHOST_VARIANTS / _PRIV_IP)
+# ---------------------------------------------------------------------------
+_LOCALHOST_VARIANTS = (
+    r"(?:localhost|127\.0\.0\.1"
+    r"|http://localhost|https://localhost"
+    r"|bolt://localhost|redis://localhost"
+    r"|postgresql://localhost|amqp://localhost"
+    r"|http://127\.0\.0\.1|redis://127\.0\.0\.1|postgresql://127\.0\.0\.1)"
+)
+_PRIV_IP = r"192\.168\.\d{1,3}\.\d{1,3}"
+
+# ---------------------------------------------------------------------------
+# Python patterns (oracle PYTHON_FALLBACK_PATTERNS)
+# ---------------------------------------------------------------------------
+_PYTHON_FALLBACK_PATTERNS: Final[list[re.Pattern[str]]] = [
+    re.compile(
+        rf"""os\.environ\.get\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""
+    ),
+    re.compile(
+        rf"""os\.getenv\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""
+    ),
+    re.compile(rf"""default\s*=\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""),
+    re.compile(rf""":\s*str\s*=\s*["'][^"']*{_LOCALHOST_VARIANTS}[^"']*["']"""),
+    re.compile(
+        rf"""os\.(?:environ\.get|getenv)\(\s*["'][^"']*["']\s*,\s*["'][^"']*{_PRIV_IP}[^"']*["']"""
+    ),
+    re.compile(rf"""(?:default\s*=|:\s*str\s*=)\s*["'][^"']*{_PRIV_IP}[^"']*["']"""),
+    re.compile(
+        rf"""bootstrap_servers\s*=\s*["'](?:{_LOCALHOST_VARIANTS}|{_PRIV_IP})[^"']*["']"""
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Shell patterns (oracle SHELL_FALLBACK_PATTERNS)
+# ---------------------------------------------------------------------------
+_SHELL_FALLBACK_PATTERNS: Final[list[re.Pattern[str]]] = [
+    re.compile(
+        rf"""\$\{{[A-Za-z_][A-Za-z0-9_]*:-[^}}]*{_LOCALHOST_VARIANTS}[^}}]*\}}"""
+    ),
+    re.compile(rf"""\$\{{[A-Za-z_][A-Za-z0-9_]*:-[^}}]*{_PRIV_IP}[^}}]*\}}"""),
+]
+
+# ---------------------------------------------------------------------------
+# Skip / exempt configuration (oracle SKIP_DIRS / EXEMPT_MARKERS)
+# ---------------------------------------------------------------------------
+_SKIP_DIRS: Final[frozenset[str]] = frozenset(
+    {"tests", "node_tests", "__tests__", "test", "__pycache__", ".git", ".venv", "venv"}
+)
+
+_EXEMPT_MARKERS: Final[tuple[str, ...]] = (
+    "# fallback-ok",
+    "# cloud-bus-ok",
+    "# OMN-7227-exempt",
+)
+
+_COMMENT_RE: Final[re.Pattern[str]] = re.compile(r"^\s*#")
+_TRIPLE_QUOTE_DELIMS: Final[tuple[str, str]] = ('"""', "'''")
+
+
+def should_skip_path(path: str) -> bool:
+    """Return True if any path component is a skip directory (oracle ``_should_skip``,
+    dir-membership half only — the SKIP_FILES self-exclusion does not apply generically)."""
+    parts = PurePosixPath(path.replace("\\", "/")).parts
+    return any(part in _SKIP_DIRS for part in parts)
+
+
+def _is_pure_comment(line: str) -> bool:
+    return bool(_COMMENT_RE.match(line))
+
+
+def _has_exempt_marker(line: str) -> bool:
+    return any(marker in line for marker in _EXEMPT_MARKERS)
+
+
+def _has_executable_suffix_after_closing_delim(line: str, delim: str) -> bool:
+    close_index = line.find(delim, len(delim))
+    if close_index == -1:
+        return False
+    suffix = line[close_index + len(delim) :].strip()
+    return bool(suffix and not suffix.startswith("#"))
+
+
+def _scan_python_lines(path: str, source: str) -> list[ModelValidationFinding]:
+    """Port of ``scan_python_file`` (validate_no_env_fallbacks.py:121-166)."""
+    findings: list[ModelValidationFinding] = []
+    in_docstring = False
+    docstring_delim: str | None = None
+
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        stripped = line.strip()
+        skip_line = False
+
+        for delim in _TRIPLE_QUOTE_DELIMS:
+            count = stripped.count(delim)
+            if in_docstring and docstring_delim == delim:
+                if count >= 1:
+                    in_docstring = False
+                    docstring_delim = None
+                    skip_line = True
+                break
+            if not in_docstring and stripped.startswith(delim):
+                if count == 1:
+                    in_docstring = True
+                    docstring_delim = delim
+                elif not _has_executable_suffix_after_closing_delim(stripped, delim):
+                    skip_line = True
+                break
+
+        if in_docstring or skip_line:
+            continue
+        if _is_pure_comment(line):
+            continue
+        if _has_exempt_marker(line):
+            continue
+
+        for pattern in _PYTHON_FALLBACK_PATTERNS:
+            if pattern.search(line):
+                findings.append(_make_finding(path, lineno, line.rstrip()))
+                break
+
+    return findings
+
+
+def _scan_shell_lines(path: str, source: str) -> list[ModelValidationFinding]:
+    """Port of ``scan_shell_file`` (validate_no_env_fallbacks.py:169-185)."""
+    findings: list[ModelValidationFinding] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if _is_pure_comment(line):
+            continue
+        if _has_exempt_marker(line):
+            continue
+        for pattern in _SHELL_FALLBACK_PATTERNS:
+            if pattern.search(line):
+                findings.append(_make_finding(path, lineno, line.rstrip()))
+                break
+    return findings
+
+
+def _make_finding(path: str, lineno: int, line_text: str) -> ModelValidationFinding:
+    return ModelValidationFinding(
+        validator_id=VALIDATOR_ID,
+        severity="FAIL",
+        location=f"{path}:{lineno}",
+        message=f"{path}:{lineno}: {line_text.strip()}",
+        remediation=_REMEDIATION,
+    )
+
+
+def find_env_fallback_violations(
+    path: str, source: str
+) -> list[ModelValidationFinding]:
+    """Dispatch a (path, source) pair to the Python or shell scanner by suffix.
+
+    Any other suffix is not scanned (oracle only handles ``.py``/``.sh``/``.bash``).
+    """
+    if should_skip_path(path):
+        return []
+
+    suffix = PurePosixPath(path.replace("\\", "/")).suffix
+    if suffix == ".py":
+        return _scan_python_lines(path, source)
+    if suffix in (".sh", ".bash"):
+        return _scan_shell_lines(path, source)
+    return []

--- a/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/runtime_no_env_fallbacks_check.py
+++ b/src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/runtime_no_env_fallbacks_check.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI runtime for the no-env-fallbacks check — pre-commit hook + CI entrypoint.
+
+Both invocation surfaces are backed by the SAME canonical COMPUTE node
+(``NodeNoEnvFallbacksCheckCompute``) — DRY per the OMN-13305 pattern,
+following the ``node_no_utcnow_check_compute`` template (OMN-14656): a single
+module owns the pure handler plus a synchronous CLI ``main()`` that performs
+all filesystem I/O at the CLI boundary, never inside the handler.
+
+Two modes:
+
+* **pre-commit** (explicit filenames): the staged files pre-commit hands us
+  are read directly here — no directory walk needed.
+* **full-tree** (no filenames — CI / manual ``python -m ...``): walks
+  ``--root`` (default ``src``) via the paired ``node_source_file_gather_effect``
+  EFFECT node for ``*.py``/``*.sh``/``*.bash`` files, reproducing the oracle
+  CI gate's file-type scope
+  (``omniclaude/scripts/validate_no_env_fallbacks.py``).
+
+  The oracle additionally scans ``scripts/`` as a separate top-level root
+  (this repo's ``ModelSourceFileGatherInput`` walks a single ``root``); pass
+  ``--root`` explicitly for a non-``src`` scan when porting this entrypoint
+  into another repo's CI.
+
+Usage::
+
+    python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check file1.py file2.sh
+    python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check
+    python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check --root src
+
+Exit codes: 0 — ``overall_status == "PASS"``; 1 — FAIL findings present.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Final
+
+from omnibase_core.models.nodes.no_env_fallbacks_check.model_no_env_fallbacks_check_input import (
+    ModelNoEnvFallbacksCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.models.nodes.source_file_gather.model_source_file_gather_input import (
+    ModelSourceFileGatherInput,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationReport,
+)
+from omnibase_core.nodes.node_no_env_fallbacks_check_compute.handler import (
+    NodeNoEnvFallbacksCheckCompute,
+)
+from omnibase_core.nodes.node_source_file_gather_effect.handler import (
+    NodeSourceFileGatherEffect,
+)
+
+__all__ = ["main"]
+
+_DEFAULT_ROOT: Final[str] = "src"
+_SCANNED_SUFFIXES: Final[tuple[str, ...]] = (".py", ".sh", ".bash")
+
+
+def _gather_from_filenames(
+    paths: list[Path],
+) -> tuple[list[ModelSourceFile], list[str]]:
+    """CLI I/O boundary for pre-commit's explicit staged-file mode.
+
+    Non-Python/shell and missing paths are intentionally skipped. Read
+    errors on existing eligible files are returned as fatal diagnostics so
+    the runtime does not report PASS with unscanned source.
+    """
+    files: list[ModelSourceFile] = []
+    read_errors: list[str] = []
+    for path in paths:
+        if path.suffix not in _SCANNED_SUFFIXES or not path.is_file():
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            read_errors.append(f"{path}: read error: {exc}")
+            continue
+        files.append(ModelSourceFile(path=str(path), source=source))
+    return files, read_errors
+
+
+def _gather_from_root(root: str) -> tuple[list[ModelSourceFile], list[str]]:
+    """Full-tree walk mode (CI / manual), reusing ``node_source_file_gather_effect``.
+
+    This is the EFFECT boundary — the only filesystem walk in this module —
+    delegated to the paired canonical node rather than re-implemented here.
+    """
+    output = NodeSourceFileGatherEffect().handle(
+        ModelSourceFileGatherInput(
+            root=root, include_patterns=["**/*.py", "**/*.sh", "**/*.bash"]
+        )
+    )
+    read_errors = [
+        f"{skipped.path}: {skipped.reason}"
+        for skipped in output.skipped
+        if skipped.reason.startswith(("read error:", "error checking file size:"))
+    ]
+    return [
+        ModelSourceFile(path=f.path, source=f.source) for f in output.files
+    ], read_errors
+
+
+def _run(files: list[ModelSourceFile]) -> ModelValidationReport:
+    """Dispatch gathered (path, source) pairs to the canonical COMPUTE node."""
+    return NodeNoEnvFallbacksCheckCompute().handle(
+        ModelNoEnvFallbacksCheckInput(files=files)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: pre-commit staged-file mode, or a full-tree walk with no args.
+
+    Returns:
+        0 on PASS, 1 on FAIL.
+    """
+    parser = argparse.ArgumentParser(
+        prog="check-no-env-fallbacks",
+        description=(
+            "Detect localhost/hardcoded-endpoint fallback defaults via the "
+            "no-env-fallbacks-check COMPUTE node (OMN-14659)."
+        ),
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help=(
+            "Files to check (pre-commit passes staged filenames here). "
+            "When omitted, walks --root recursively (CI / manual mode)."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default=_DEFAULT_ROOT,
+        help=(
+            "Root directory for a full-tree walk when no filenames are given "
+            f"(default: {_DEFAULT_ROOT})"
+        ),
+    )
+    parsed = parser.parse_args(argv)
+
+    if parsed.filenames:
+        files, read_errors = _gather_from_filenames([Path(f) for f in parsed.filenames])
+    else:
+        files, read_errors = _gather_from_root(parsed.root)
+
+    if read_errors:
+        print(
+            f"ERROR: Failed to read {len(read_errors)} file(s):"
+        )  # print-ok: CLI output
+        for read_error in read_errors:
+            print(f"  {read_error}")  # print-ok: CLI output
+        return 1
+
+    report = _run(files)
+
+    if report.overall_status == "PASS":
+        print(  # print-ok: CLI output
+            "PASS: No localhost/hardcoded-endpoint fallbacks found."
+        )
+        return 0
+
+    print(  # print-ok: CLI output
+        f"FAIL: {report.metrics.total} localhost/hardcoded-endpoint fallback(s) found:"
+    )
+    for finding in report.findings:
+        print(f"  {finding.message}")  # print-ok: CLI output
+    print(  # print-ok: CLI output
+        '\nFix: Replace with os.environ["VAR"] (fail-fast, no default) or raise explicitly.'
+        "\nAnnotate justified exceptions with  # fallback-ok: <reason>  on the same line."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_hardcoded_ip_check COMPUTE node package (OMN-14659).
+
+Exposes :class:`NodeNoHardcodedIpCheckCompute` — scans explicit (path,
+source) pairs for hardcoded internal IP addresses (RFC1918 ranges
+192.168.x.x, 10.x.x.x, 172.16-31.x.x) and returns a
+``ModelValidationReport``.
+"""
+
+from omnibase_core.nodes.node_no_hardcoded_ip_check_compute.handler import (
+    NodeNoHardcodedIpCheckCompute,
+)
+
+__all__ = ["NodeNoHardcodedIpCheckCompute"]

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/contract.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the no_hardcoded_ip_check COMPUTE node.
+# Line-scans explicit (path, source) pairs for hardcoded internal IP addresses (RFC1918
+# ranges 192.168.x.x, 10.x.x.x, 172.16-31.x.x), reproducing the CI gate at
+# omniclaude/scripts/validation/validate_no_hardcoded_ip.py byte-for-byte per finding.
+#
+# See: OMN-14659 — WS8 fan-out (convert-clean generic omniclaude arch validators)
+
+name: node_no_hardcoded_ip_check_compute
+node_id: node_no_hardcoded_ip_check_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  Line-scans a set of explicit (path, source) pairs for hardcoded internal IP address
+  literals (192.168.x.x, 10.x.x.x, 172.16-31.x.x, optionally http(s)-prefixed and
+  port-suffixed), and returns an OMN-2362 ValidationReport with a per-violation finding
+  reproducing the arch-no-hardcoded-ip CI gate's flagged-line text byte-for-byte. A line
+  carrying the # onex-allow-internal-ip suppression marker is exempt. Pure — no filesystem
+  access, no clock, no global state. #magic___^_^___line
+input_model: omnibase_core.models.nodes.no_hardcoded_ip_check.model_no_hardcoded_ip_check_input.ModelNoHardcodedIpCheckInput
+output_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeNoHardcodedIpCheckCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/handler.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/handler.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeNoHardcodedIpCheckCompute — hardcoded-internal-IP validation COMPUTE handler.
+
+Ports the line-scan CI gate at
+``omniclaude/scripts/validation/validate_no_hardcoded_ip.py`` into a canonical
+COMPUTE node on the def-B ``handle(request) -> response`` shape (OMN-14355),
+following the ``node_no_utcnow_check_compute`` template (OMN-14656).
+
+Architecture: COMPUTE node — pure, deterministic, no I/O. Content arrives via
+explicit ``(path, source)`` pairs on the request (see
+:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`,
+reused rather than forked);
+the filesystem walk + read happens at the paired EFFECT boundary
+(``node_source_file_gather_effect``), never inside this handler.
+
+Output shape: the canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), NOT a
+per-node fork. This node only ever emits ``FAIL`` findings (a hardcoded
+internal IP was found), so with the ``"default"`` profile the precedence
+engine gives ``overall_status == "FAIL"`` whenever any finding is present and
+``"PASS"`` otherwise.
+
+Per-finding message text reproduces the CI gate's flagged-line text
+byte-for-byte; see :mod:`.matcher_hardcoded_ip` for the port.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from omnibase_core.models.nodes.no_hardcoded_ip_check.model_no_hardcoded_ip_check_input import (
+    ModelNoHardcodedIpCheckInput,
+)
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationFindingEmbed,
+    ModelValidationReport,
+    ModelValidationRequestRef,
+)
+from omnibase_core.nodes.node_no_hardcoded_ip_check_compute.matcher_hardcoded_ip import (
+    VALIDATOR_ID,
+    find_hardcoded_ip_violations,
+)
+
+__all__ = ["NodeNoHardcodedIpCheckCompute"]
+
+# This node has no notion of a "strict"/"advisory" caller profile (it always
+# reports FAIL findings at face value) — "default" is the precedence profile
+# that leaves findings unmodified before aggregation.
+_PROFILE: Final[Literal["strict", "default", "advisory"]] = "default"
+
+
+class NodeNoHardcodedIpCheckCompute:
+    """COMPUTE handler that line-scans (path, source) pairs for hardcoded internal IPs."""
+
+    def handle(self, request: ModelNoHardcodedIpCheckInput) -> ModelValidationReport:
+        """Definition-B canonical entry-point (OMN-14355).
+
+        Typed request in, typed response out — pure, no I/O, no clock.
+        """
+        findings: list[ModelValidationFinding] = []
+        for file in request.files:
+            findings.extend(self._check_file(file.path, file.source))
+
+        embedded_findings = tuple(
+            ModelValidationFindingEmbed(**finding.model_dump()) for finding in findings
+        )
+
+        return ModelValidationReport.from_findings(
+            findings=embedded_findings,
+            request=ModelValidationRequestRef(profile=_PROFILE),
+            validators_run=(VALIDATOR_ID,),
+        )
+
+    def _check_file(self, path: str, source: str) -> list[ModelValidationFinding]:
+        """Port of the per-file scan loop (validate_no_hardcoded_ip.py:49-57)."""
+        return find_hardcoded_ip_violations(path, source)

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/matcher_hardcoded_ip.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/matcher_hardcoded_ip.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Line-based matcher that detects hardcoded internal IP addresses.
+
+Split out of ``handler.py`` (single-class-per-file convention established by
+``node_no_utcnow_check_compute``, OMN-14656) — this module has no classes at
+all since the port is a per-line regex match, not an AST walk.
+
+Port of the module-level regex + scan loop in
+``omniclaude/scripts/validation/validate_no_hardcoded_ip.py``. Detects RFC1918
+internal IP literals (``192.168.x.x``, ``10.x.x.x``, ``172.16-31.x.x``),
+optionally prefixed with ``http(s)://`` and suffixed with ``:port``, on any
+line that does not carry the ``# onex-allow-internal-ip`` suppression marker.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+
+__all__ = ["VALIDATOR_ID", "find_hardcoded_ip_violations"]
+
+VALIDATOR_ID: Final[str] = "arch-no-hardcoded-ip"
+_REMEDIATION: Final[str] = (
+    "configure the endpoint via an environment variable instead of a "
+    "hardcoded internal IP; suppress with # onex-allow-internal-ip if justified"
+)
+
+# Suppression marker: lines containing this comment are exempt.
+_SUPPRESS_MARKER: Final[str] = "onex-allow-internal-ip"
+
+_IP_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"""(?:https?://)?"""
+    r"""(?:192\.168\.\d{1,3}\.\d{1,3}"""
+    r"""|10\.\d{1,3}\.\d{1,3}\.\d{1,3}"""
+    r"""|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})"""
+    r"""(?::\d+)?""",
+)
+
+
+def find_hardcoded_ip_violations(
+    path: str, source: str
+) -> list[ModelValidationFinding]:
+    """Port of the per-file scan loop (validate_no_hardcoded_ip.py:49-57)."""
+    findings: list[ModelValidationFinding] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if _IP_PATTERN.search(line) and _SUPPRESS_MARKER not in line:
+            findings.append(
+                ModelValidationFinding(
+                    validator_id=VALIDATOR_ID,
+                    severity="FAIL",
+                    location=f"{path}:{lineno}",
+                    message=f"{path}:{lineno}: {line.strip()}",
+                    remediation=_REMEDIATION,
+                )
+            )
+    return findings

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/runtime_no_hardcoded_ip_check.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/runtime_no_hardcoded_ip_check.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI runtime for the no-hardcoded-ip check — pre-commit hook + CI entrypoint.
+
+Both invocation surfaces are backed by the SAME canonical COMPUTE node
+(``NodeNoHardcodedIpCheckCompute``) — DRY per the OMN-13305 pattern, following
+the ``node_no_utcnow_check_compute`` template (OMN-14656): a single module
+owns the pure handler plus a synchronous CLI ``main()`` that performs all
+filesystem I/O at the CLI boundary, never inside the handler.
+
+Two modes:
+
+* **pre-commit** (explicit filenames): the staged files pre-commit hands us
+  are read directly here — no directory walk needed.
+* **full-tree** (no filenames — CI / manual ``python -m ...``): walks
+  ``--root`` (default ``src``) via the paired ``node_source_file_gather_effect``
+  EFFECT node for ``*.py``/``*.yaml``/``*.yml`` files, reproducing the oracle
+  CI gate's file-type scope
+  (``omniclaude/scripts/validation/validate_no_hardcoded_ip.py``).
+
+  The oracle additionally scans ``tests/`` and ``scripts/`` as separate top-level
+  roots (this repo's ``ModelSourceFileGatherInput`` walks a single ``root``);
+  pass ``--root`` explicitly for a non-``src`` scan when porting this
+  entrypoint into another repo's CI.
+
+Usage::
+
+    python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check file1.py file2.yaml
+    python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check
+    python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check --root src
+
+Exit codes: 0 — ``overall_status == "PASS"``; 1 — FAIL findings present.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Final
+
+from omnibase_core.models.nodes.no_hardcoded_ip_check.model_no_hardcoded_ip_check_input import (
+    ModelNoHardcodedIpCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.models.nodes.source_file_gather.model_source_file_gather_input import (
+    ModelSourceFileGatherInput,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationReport,
+)
+from omnibase_core.nodes.node_no_hardcoded_ip_check_compute.handler import (
+    NodeNoHardcodedIpCheckCompute,
+)
+from omnibase_core.nodes.node_source_file_gather_effect.handler import (
+    NodeSourceFileGatherEffect,
+)
+
+__all__ = ["main"]
+
+_DEFAULT_ROOT: Final[str] = "src"
+_SCANNED_SUFFIXES: Final[tuple[str, ...]] = (".py", ".yaml", ".yml")
+
+
+def _gather_from_filenames(
+    paths: list[Path],
+) -> tuple[list[ModelSourceFile], list[str]]:
+    """CLI I/O boundary for pre-commit's explicit staged-file mode.
+
+    Non-Python/YAML and missing paths are intentionally skipped. Read errors
+    on existing eligible files are returned as fatal diagnostics so the
+    runtime does not report PASS with unscanned source.
+    """
+    files: list[ModelSourceFile] = []
+    read_errors: list[str] = []
+    for path in paths:
+        if path.suffix not in _SCANNED_SUFFIXES or not path.is_file():
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            read_errors.append(f"{path}: read error: {exc}")
+            continue
+        files.append(ModelSourceFile(path=str(path), source=source))
+    return files, read_errors
+
+
+def _gather_from_root(root: str) -> tuple[list[ModelSourceFile], list[str]]:
+    """Full-tree walk mode (CI / manual), reusing ``node_source_file_gather_effect``.
+
+    This is the EFFECT boundary — the only filesystem walk in this module —
+    delegated to the paired canonical node rather than re-implemented here.
+    """
+    output = NodeSourceFileGatherEffect().handle(
+        ModelSourceFileGatherInput(
+            root=root, include_patterns=["**/*.py", "**/*.yaml", "**/*.yml"]
+        )
+    )
+    read_errors = [
+        f"{skipped.path}: {skipped.reason}"
+        for skipped in output.skipped
+        if skipped.reason.startswith(("read error:", "error checking file size:"))
+    ]
+    return [
+        ModelSourceFile(path=f.path, source=f.source) for f in output.files
+    ], read_errors
+
+
+def _run(files: list[ModelSourceFile]) -> ModelValidationReport:
+    """Dispatch gathered (path, source) pairs to the canonical COMPUTE node."""
+    return NodeNoHardcodedIpCheckCompute().handle(
+        ModelNoHardcodedIpCheckInput(files=files)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: pre-commit staged-file mode, or a full-tree walk with no args.
+
+    Returns:
+        0 on PASS, 1 on FAIL.
+    """
+    parser = argparse.ArgumentParser(
+        prog="check-no-hardcoded-ip",
+        description=(
+            "Detect hardcoded internal IP addresses via the "
+            "no-hardcoded-ip-check COMPUTE node (OMN-14659)."
+        ),
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help=(
+            "Files to check (pre-commit passes staged filenames here). "
+            "When omitted, walks --root recursively (CI / manual mode)."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default=_DEFAULT_ROOT,
+        help=(
+            "Root directory for a full-tree walk when no filenames are given "
+            f"(default: {_DEFAULT_ROOT})"
+        ),
+    )
+    parsed = parser.parse_args(argv)
+
+    if parsed.filenames:
+        files, read_errors = _gather_from_filenames([Path(f) for f in parsed.filenames])
+    else:
+        files, read_errors = _gather_from_root(parsed.root)
+
+    if read_errors:
+        print(
+            f"ERROR: Failed to read {len(read_errors)} file(s):"
+        )  # print-ok: CLI output
+        for read_error in read_errors:
+            print(f"  {read_error}")  # print-ok: CLI output
+        return 1
+
+    report = _run(files)
+
+    if report.overall_status == "PASS":
+        print("OK: No hardcoded internal IPs found")  # print-ok: CLI output
+        return 0
+
+    print(
+        f"ERROR: {report.metrics.total} hardcoded internal IP(s) found:"
+    )  # print-ok: CLI output
+    for finding in report.findings:
+        print(f"  {finding.message}")  # print-ok: CLI output
+    print(  # print-ok: CLI output
+        "\nAll endpoints must be configured via environment variables."
+        "\nSuppress a justified exception with: # onex-allow-internal-ip"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""no_raw_sqlite3_check COMPUTE node package (OMN-14659).
+
+Exposes :class:`NodeNoRawSqlite3CheckCompute` — AST-scans explicit (path,
+source) pairs for raw ``sqlite3.connect()`` calls outside adapter
+definitions, and returns a ``ModelValidationReport``.
+"""
+
+from omnibase_core.nodes.node_no_raw_sqlite3_check_compute.handler import (
+    NodeNoRawSqlite3CheckCompute,
+)
+
+__all__ = ["NodeNoRawSqlite3CheckCompute"]

--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/contract.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the no_raw_sqlite3_check COMPUTE node.
+# AST-scans explicit (path, source) pairs for raw sqlite3.connect() calls outside
+# adapter definitions, reproducing the CI gate at
+# omniclaude/scripts/validation/validate_no_raw_sqlite3.py byte-for-byte per finding.
+#
+# See: OMN-14659 — WS8 fan-out (convert-clean generic omniclaude arch validators)
+
+name: node_no_raw_sqlite3_check_compute
+node_id: node_no_raw_sqlite3_check_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  AST-scans a set of explicit (path, source) pairs for raw sqlite3.connect() calls
+  (via `import sqlite3; sqlite3.connect(...)` or `from sqlite3 import connect [as alias]`),
+  skipping files whose name ends in _adapter.py (the authorised call site) and call sites
+  carrying a # di-ok annotation, and returns an OMN-2362 ValidationReport with a
+  per-violation finding reproducing the arch-no-raw-sqlite3 CI gate's message text
+  byte-for-byte. Pure — no filesystem access, no clock, no global state. #magic___^_^___line
+input_model: omnibase_core.models.nodes.no_raw_sqlite3_check.model_no_raw_sqlite3_check_input.ModelNoRawSqlite3CheckInput
+output_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeNoRawSqlite3CheckCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/handler.py
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/handler.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeNoRawSqlite3CheckCompute — raw-sqlite3.connect() validation COMPUTE handler.
+
+Ports the AST-based CI gate at
+``omniclaude/scripts/validation/validate_no_raw_sqlite3.py`` into a canonical
+COMPUTE node on the def-B ``handle(request) -> response`` shape (OMN-14355),
+following the ``node_no_utcnow_check_compute`` template (OMN-14656).
+
+Architecture: COMPUTE node — pure, deterministic, no I/O. Content arrives via
+explicit ``(path, source)`` pairs on the request (see
+:class:`~omnibase_core.models.nodes.no_utcnow_check.model_source_file.ModelSourceFile`,
+reused rather than forked); the filesystem walk + read happens at the paired
+EFFECT boundary (``node_source_file_gather_effect``), never inside this
+handler.
+
+Output shape: the canonical OMN-2362 generic validator report
+(:mod:`omnibase_core.models.validation.model_validation_report`), NOT a
+per-node fork — ``overall_status`` is computed by
+``ModelValidationReport.from_findings()`` using the shared
+ERROR > FAIL > WARN > PASS precedence engine. This node emits ``FAIL`` (raw
+sqlite3.connect() call) and ``ERROR`` (unparseable file) findings.
+
+Files whose name ends in ``_adapter.py`` are skipped entirely — the
+authorised call site for a direct connection (see
+:mod:`.visitor_raw_sqlite3`, ported unchanged).
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Final, Literal
+
+from omnibase_core.models.nodes.no_raw_sqlite3_check.model_no_raw_sqlite3_check_input import (
+    ModelNoRawSqlite3CheckInput,
+)
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationFindingEmbed,
+    ModelValidationReport,
+    ModelValidationRequestRef,
+)
+from omnibase_core.nodes.node_no_raw_sqlite3_check_compute.visitor_raw_sqlite3 import (
+    VALIDATOR_ID,
+    RawSqlite3Visitor,
+    is_excluded_adapter_filename,
+)
+
+__all__ = ["NodeNoRawSqlite3CheckCompute"]
+
+# This node has no notion of a "strict"/"advisory" caller profile (it always
+# reports FAIL/ERROR findings at face value) — "default" is the precedence
+# profile that leaves findings unmodified before aggregation.
+_PROFILE: Final[Literal["strict", "default", "advisory"]] = "default"
+
+
+class NodeNoRawSqlite3CheckCompute:
+    """COMPUTE handler that AST-scans (path, source) pairs for raw sqlite3.connect() calls."""
+
+    def handle(self, request: ModelNoRawSqlite3CheckInput) -> ModelValidationReport:
+        """Definition-B canonical entry-point (OMN-14355).
+
+        Typed request in, typed response out — pure, no I/O, no clock.
+        """
+        findings: list[ModelValidationFinding] = []
+        for file in request.files:
+            findings.extend(self._check_file(file.path, file.source))
+
+        embedded_findings = tuple(
+            ModelValidationFindingEmbed(**finding.model_dump()) for finding in findings
+        )
+
+        return ModelValidationReport.from_findings(
+            findings=embedded_findings,
+            request=ModelValidationRequestRef(profile=_PROFILE),
+            validators_run=(VALIDATOR_ID,),
+        )
+
+    def _check_file(self, path: str, source: str) -> list[ModelValidationFinding]:
+        """Port of ``check_file`` + the ``_is_checked_file`` adapter-filename skip
+        (validate_no_raw_sqlite3.py:121-149)."""
+        if is_excluded_adapter_filename(path):
+            return []
+
+        try:
+            tree = ast.parse(source, filename=path)
+        except SyntaxError as exc:
+            return [
+                ModelValidationFinding(
+                    validator_id=VALIDATOR_ID,
+                    severity="ERROR",
+                    location=path,
+                    message=f"{path}: SyntaxError: {exc}",
+                    remediation=None,
+                )
+            ]
+
+        source_lines = source.splitlines()
+        visitor = RawSqlite3Visitor(path, source_lines)
+        visitor.visit(tree)
+        return visitor.findings

--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/runtime_no_raw_sqlite3_check.py
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/runtime_no_raw_sqlite3_check.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI runtime for the no-raw-sqlite3 check — pre-commit hook + CI entrypoint.
+
+Both invocation surfaces are backed by the SAME canonical COMPUTE node
+(``NodeNoRawSqlite3CheckCompute``) — DRY per the OMN-13305 pattern, following
+the ``node_no_utcnow_check_compute`` template (OMN-14656): a single module
+owns the pure handler plus a synchronous CLI ``main()`` that performs all
+filesystem I/O at the CLI boundary, never inside the handler.
+
+Two modes:
+
+* **pre-commit** (explicit filenames): the staged files pre-commit hands us
+  are read directly here — no directory walk needed.
+* **full-tree** (no filenames — CI / manual ``python -m ...``): walks
+  ``--root`` (default ``src``) via the paired ``node_source_file_gather_effect``
+  EFFECT node, reproducing the oracle CI gate's tree scan
+  (``omniclaude/scripts/validation/validate_no_raw_sqlite3.py``
+  ``root.rglob("*.py")``). The oracle additionally restricts the walk to
+  ``src/omniclaude`` and ``plugins/onex`` and excludes ``tests/`` — those are
+  omniclaude-specific root-scoping choices, generalized here to a plain
+  ``--root`` (default ``src``) since this node ships as a cross-repo remote
+  pre-commit hook.
+
+Usage::
+
+    python -m omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check file1.py file2.py
+    python -m omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check
+    python -m omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check --root src
+
+Exit codes: 0 — ``overall_status == "PASS"``; 1 — FAIL/ERROR findings present.
+
+Ticket: OMN-14659 (WS8 — convert-clean generic omniclaude arch validators).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Final
+
+from omnibase_core.models.nodes.no_raw_sqlite3_check.model_no_raw_sqlite3_check_input import (
+    ModelNoRawSqlite3CheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.models.nodes.source_file_gather.model_source_file_gather_input import (
+    ModelSourceFileGatherInput,
+)
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationReport,
+)
+from omnibase_core.nodes.node_no_raw_sqlite3_check_compute.handler import (
+    NodeNoRawSqlite3CheckCompute,
+)
+from omnibase_core.nodes.node_source_file_gather_effect.handler import (
+    NodeSourceFileGatherEffect,
+)
+
+__all__ = ["main"]
+
+_DEFAULT_ROOT: Final[str] = "src"
+
+
+def _gather_from_filenames(
+    paths: list[Path],
+) -> tuple[list[ModelSourceFile], list[str]]:
+    """CLI I/O boundary for pre-commit's explicit staged-file mode.
+
+    Non-``.py`` and missing paths are intentionally skipped. Read errors on
+    existing Python files are returned as fatal diagnostics so the runtime
+    does not report PASS with unscanned source.
+    """
+    files: list[ModelSourceFile] = []
+    read_errors: list[str] = []
+    for path in paths:
+        if path.suffix != ".py" or not path.is_file():
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            read_errors.append(f"{path}: read error: {exc}")
+            continue
+        files.append(ModelSourceFile(path=str(path), source=source))
+    return files, read_errors
+
+
+def _gather_from_root(root: str) -> tuple[list[ModelSourceFile], list[str]]:
+    """Full-tree walk mode (CI / manual), reusing ``node_source_file_gather_effect``.
+
+    This is the EFFECT boundary — the only filesystem walk in this module —
+    delegated to the paired canonical node rather than re-implemented here.
+    """
+    output = NodeSourceFileGatherEffect().handle(
+        ModelSourceFileGatherInput(root=root, include_patterns=["**/*.py"])
+    )
+    read_errors = [
+        f"{skipped.path}: {skipped.reason}"
+        for skipped in output.skipped
+        if skipped.reason.startswith(("read error:", "error checking file size:"))
+    ]
+    return [
+        ModelSourceFile(path=f.path, source=f.source) for f in output.files
+    ], read_errors
+
+
+def _run(files: list[ModelSourceFile]) -> ModelValidationReport:
+    """Dispatch gathered (path, source) pairs to the canonical COMPUTE node."""
+    return NodeNoRawSqlite3CheckCompute().handle(
+        ModelNoRawSqlite3CheckInput(files=files)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: pre-commit staged-file mode, or a full-tree walk with no args.
+
+    Returns:
+        0 on PASS, 1 on FAIL/ERROR.
+    """
+    parser = argparse.ArgumentParser(
+        prog="check-no-raw-sqlite3",
+        description=(
+            "Detect raw sqlite3.connect() calls outside adapter definitions via "
+            "the no-raw-sqlite3-check COMPUTE node (OMN-14659)."
+        ),
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help=(
+            "Files to check (pre-commit passes staged filenames here). "
+            "When omitted, walks --root recursively (CI / manual mode)."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default=_DEFAULT_ROOT,
+        help=(
+            "Root directory for a full-tree walk when no filenames are given "
+            f"(default: {_DEFAULT_ROOT})"
+        ),
+    )
+    parsed = parser.parse_args(argv)
+
+    if parsed.filenames:
+        files, read_errors = _gather_from_filenames([Path(f) for f in parsed.filenames])
+    else:
+        files, read_errors = _gather_from_root(parsed.root)
+
+    if read_errors:
+        print(
+            f"ERROR: Failed to read {len(read_errors)} Python file(s):"
+        )  # print-ok: CLI output
+        for read_error in read_errors:
+            print(f"  {read_error}")  # print-ok: CLI output
+        return 1
+
+    report = _run(files)
+
+    if report.overall_status == "PASS":
+        print(  # print-ok: CLI output
+            "OK: No raw sqlite3.connect() calls found outside adapter definitions"
+        )
+        return 0
+
+    print(  # print-ok: CLI output
+        f"FAIL: Found {report.metrics.total} raw sqlite3.connect() call(s) "
+        "outside adapter definitions:"
+    )
+    for finding in report.findings:
+        print(f"  {finding.message}")  # print-ok: CLI output
+    print(  # print-ok: CLI output
+        "\nOnly *_adapter.py files may call sqlite3.connect() directly."
+        "\nOther code must receive a database adapter via DI injection."
+        "\nAdd '# di-ok' to suppress for legitimate adapter bootstrap."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/visitor_raw_sqlite3.py
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/visitor_raw_sqlite3.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""AST visitor that detects raw ``sqlite3.connect()`` calls.
+
+Split out of ``handler.py`` (single-class-per-file, OMN-14656 convention) so
+the COMPUTE handler module contains exactly one class
+(``NodeNoRawSqlite3CheckCompute``).
+
+Port of ``RawSqlite3Visitor`` + ``_call_has_annotation``
+(``omniclaude/scripts/validation/validate_no_raw_sqlite3.py:52-118``).
+Detects ``sqlite3.connect(...)`` (via ``import sqlite3``) and
+``from sqlite3 import connect [as alias]; connect(...)`` / ``alias(...)``,
+except where the call site carries a ``# di-ok`` annotation on its opening
+line, closing line, or the line immediately preceding it.
+
+File-level exclusion: files whose name ends in ``_adapter.py`` are the
+authorised call site for a direct connection and are skipped entirely
+(oracle ``EXCLUDED_FILENAME_PATTERNS``) — the caller-scoped ``CHECKED_DIRS``
+/ ``tests/`` root-scoping in the oracle is a full-tree-walk concern, not
+reproduced here (see the paired ``runtime_no_raw_sqlite3_check.py`` CLI's
+``--root`` default for the generic equivalent).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import PurePosixPath
+from typing import Final
+
+from omnibase_core.models.validation.model_validation_finding import (
+    ModelValidationFinding,
+)
+
+__all__ = ["VALIDATOR_ID", "RawSqlite3Visitor", "is_excluded_adapter_filename"]
+
+_SEVERITY_FAIL: Final = "FAIL"
+
+VALIDATOR_ID: Final[str] = "arch-no-raw-sqlite3"
+_REMEDIATION: Final[str] = "Add '# di-ok' to suppress for legitimate adapter bootstrap."
+
+_FORBIDDEN_CALL: Final[str] = "connect"
+_FORBIDDEN_MODULE: Final[str] = "sqlite3"
+_EXCLUDED_FILENAME_SUFFIX: Final[str] = "_adapter.py"
+_DI_OK_MARKER: Final[str] = "# di-ok"
+
+
+def is_excluded_adapter_filename(path: str) -> bool:
+    """Return True if ``path``'s filename ends in ``_adapter.py`` (oracle
+    ``EXCLUDED_FILENAME_PATTERNS``) — the authorised direct-connection call site."""
+    return PurePosixPath(path.replace("\\", "/")).name.endswith(
+        _EXCLUDED_FILENAME_SUFFIX
+    )
+
+
+def _call_has_annotation(source_lines: list[str], node: ast.Call) -> bool:
+    """Check if the call site has a ``# di-ok`` annotation.
+
+    Checks the call's opening line, closing line (``end_lineno``), and the
+    line immediately preceding the call — this handles ruff-reformatted
+    multi-line calls where the trailing ``)`` lands on a different line from
+    the function name.
+    """
+    candidates = {node.lineno}
+    if hasattr(node, "end_lineno") and node.end_lineno:
+        candidates.add(node.end_lineno)
+    candidates.add(node.lineno - 1)
+    for lineno in candidates:
+        if (
+            0 < lineno <= len(source_lines)
+            and _DI_OK_MARKER in source_lines[lineno - 1]
+        ):
+            return True
+    return False
+
+
+class RawSqlite3Visitor(ast.NodeVisitor):
+    """Walk an AST looking for raw ``sqlite3.connect()`` calls."""
+
+    def __init__(self, path: str, source_lines: list[str]) -> None:
+        self._path = path
+        self._source_lines = source_lines
+        self.findings: list[ModelValidationFinding] = []
+        self._sqlite3_aliases: set[str] = set()
+        self._sqlite3_connect_aliases: set[str] = set()
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name == _FORBIDDEN_MODULE:
+                self._sqlite3_aliases.add(alias.asname or alias.name)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module == _FORBIDDEN_MODULE:
+            for alias in node.names:
+                if alias.name == _FORBIDDEN_CALL:
+                    self._sqlite3_connect_aliases.add(alias.asname or alias.name)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        matched = False
+
+        # sqlite3.connect(...)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == _FORBIDDEN_CALL
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in self._sqlite3_aliases
+        ):
+            matched = True
+
+        # from sqlite3 import connect [as alias]; connect(...) / alias(...)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self._sqlite3_connect_aliases
+        ):
+            matched = True
+
+        if matched and not _call_has_annotation(self._source_lines, node):
+            self.findings.append(
+                ModelValidationFinding(
+                    validator_id=VALIDATOR_ID,
+                    severity=_SEVERITY_FAIL,
+                    location=f"{self._path}:{node.lineno}",
+                    message=(
+                        f"{self._path}:{node.lineno}: raw sqlite3.connect() call — "
+                        "database access must go through an injected adapter, not a "
+                        "direct connection. Add '# di-ok' to suppress for legitimate "
+                        "adapter bootstrap."
+                    ),
+                    remediation=_REMEDIATION,
+                )
+            )
+
+        self.generic_visit(node)

--- a/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
+++ b/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_node_no_direct_kafka_producer_check_compute.py
+++ b/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_node_no_direct_kafka_producer_check_compute.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Perturbation-corpus tests for node_no_direct_kafka_producer_check_compute (OMN-14659).
+
+Every ``must_flag`` / ``must_pass`` case from the OMN-14659 WS8 spec is
+exercised here, plus SyntaxError handling, allowlist-path exclusion (with a
+real, non-commented-out AST hit, beyond the corpus given), and report
+aggregation. Message fidelity is asserted against
+``omniclaude/scripts/validation/validate_no_direct_kafka_producer.py`` — this
+is the load-bearing perturbation-oracle contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+    ModelNoDirectKafkaProducerCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (
+    NodeNoDirectKafkaProducerCheckCompute,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _report(path: str, source: str):
+    handler = NodeNoDirectKafkaProducerCheckCompute()
+    return handler.handle(
+        ModelNoDirectKafkaProducerCheckInput(
+            files=[ModelSourceFile(path=path, source=source)]
+        )
+    )
+
+
+# =============================================================================
+# must_flag corpus — every case MUST produce at least one FAIL finding
+# =============================================================================
+
+
+def test_must_flag_aiokafka_producer_import() -> None:
+    report = _report("a.py", "from aiokafka import AIOKafkaProducer\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) >= 1
+    assert all(f.severity == "FAIL" for f in report.findings)
+    assert all(
+        f.validator_id == "arch-no-direct-kafka-producer" for f in report.findings
+    )
+
+
+def test_must_flag_confluent_kafka_import() -> None:
+    report = _report("a.py", "import confluent_kafka\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        "a.py:1: import 'confluent_kafka' uses direct Kafka producer symbol 'confluent_kafka'"
+    )
+
+
+def test_must_flag_kafka_producer_bare_name() -> None:
+    report = _report("a.py", "producer = KafkaProducer(bootstrap_servers=host)\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        "a.py:1: direct usage of Kafka producer symbol 'KafkaProducer'"
+    )
+
+
+def test_must_flag_kafka_producer_attribute_access() -> None:
+    report = _report("a.py", "client = kafka.KafkaProducer()\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        "a.py:1: direct usage of Kafka producer symbol 'KafkaProducer' via attribute access"
+    )
+
+
+# =============================================================================
+# must_pass corpus — every case MUST produce zero findings
+# =============================================================================
+
+
+def test_must_pass_shared_publisher_import() -> None:
+    report = _report("a.py", "from omniclaude.publisher import Publisher\n")
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_emit_via_daemon_await() -> None:
+    report = _report("a.py", "await emit_via_daemon(event)\n")
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_kafka_producer_utils_import() -> None:
+    report = _report(
+        "a.py",
+        "from omniclaude.lib.kafka_producer_utils import emit_via_daemon\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_allowed_path_documentation_comment() -> None:
+    """This corpus entry is a full-line Python comment — no AST nodes at all,
+    so it passes trivially regardless of the path allowlist mechanism."""
+    report = _report(
+        "a.py",
+        "# file src/omniclaude/lib/kafka_producer_utils.py (allowed publisher-layer path): "
+        "producer = AIOKafkaProducer(bootstrap_servers=host)\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# Path allowlist — real (non-commented) hit on a publisher-layer path,
+# beyond the given corpus, proving is_allowed_publisher_path actually fires.
+# =============================================================================
+
+
+def test_publisher_layer_path_is_excluded_even_with_real_violation() -> None:
+    report = _report(
+        "src/omniclaude/lib/kafka_producer_utils.py",
+        "from aiokafka import AIOKafkaProducer\n"
+        "producer = AIOKafkaProducer(bootstrap_servers=host)\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_non_publisher_layer_path_is_not_excluded() -> None:
+    report = _report(
+        "src/omniclaude/handlers/handler_ingest.py",
+        "from aiokafka import AIOKafkaProducer\n",
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) >= 1
+
+
+# =============================================================================
+# SyntaxError handling
+# =============================================================================
+
+
+def test_syntax_error_yields_single_error_finding() -> None:
+    report = _report("broken.py", "def f(:\n    pass\n")
+
+    assert report.overall_status == "ERROR"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.message.startswith("broken.py: SyntaxError:")
+    assert finding.remediation is None
+
+
+# =============================================================================
+# Aggregation across multiple files
+# =============================================================================
+
+
+def test_aggregate_metrics_and_provenance() -> None:
+    handler = NodeNoDirectKafkaProducerCheckCompute()
+    report = handler.handle(
+        ModelNoDirectKafkaProducerCheckInput(
+            files=[
+                ModelSourceFile(path="a.py", source="import confluent_kafka\n"),
+                ModelSourceFile(
+                    path="b.py", source="from omniclaude.publisher import Publisher\n"
+                ),
+            ]
+        )
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.metrics.total == 1
+    assert report.metrics.fail_count == 1
+    assert report.provenance.validators_run == ("arch-no-direct-kafka-producer",)
+
+
+def test_empty_input_passes_trivially() -> None:
+    handler = NodeNoDirectKafkaProducerCheckCompute()
+    report = handler.handle(ModelNoDirectKafkaProducerCheckInput(files=[]))
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+    assert report.metrics.total == 0

--- a/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_runtime_no_direct_kafka_producer_check.py
+++ b/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_runtime_no_direct_kafka_producer_check.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the no-direct-kafka-producer-check CLI runtime (OMN-14659, OMN-13305 pattern).
+
+Covers both invocation modes: pre-commit's explicit-filenames mode (I/O read
+directly at the CLI boundary) and the full-tree walk mode (delegated to
+``node_source_file_gather_effect``) — both dispatch to the SAME canonical
+``NodeNoDirectKafkaProducerCheckCompute`` handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check import (
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_filenames_mode_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.py"
+    clean.write_text("from omniclaude.publisher import Publisher\n")
+
+    exit_code = main([str(clean)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert (
+        "OK: No direct Kafka producer usage found outside the shared publisher layer"
+        in out
+    )
+
+
+def test_main_filenames_mode_fail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text("import confluent_kafka\n")
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL: Found 1 direct Kafka producer violation(s):" in out
+    assert "confluent_kafka" in out
+
+
+def test_main_filenames_mode_skips_non_python_and_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    not_python = tmp_path / "notes.md"
+    not_python.write_text("KafkaProducer mentioned in prose\n")
+    missing = tmp_path / "missing.py"
+
+    exit_code = main([str(not_python), str(missing)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert (
+        "OK: No direct Kafka producer usage found outside the shared publisher layer"
+        in out
+    )
+
+
+def test_main_full_tree_mode_walks_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bad.py").write_text("producer = KafkaProducer(bootstrap_servers=host)\n")
+    (src / "clean.py").write_text("from omniclaude.publisher import Publisher\n")
+
+    exit_code = main(["--root", str(src)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL: Found 1 direct Kafka producer violation(s):" in out
+    assert "bad.py" in out
+
+
+def test_main_full_tree_mode_empty_root_passes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+
+    exit_code = main(["--root", str(empty_root)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert (
+        "OK: No direct Kafka producer usage found outside the shared publisher layer"
+        in out
+    )
+
+
+def test_main_syntax_error_exits_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    broken = tmp_path / "broken.py"
+    broken.write_text("def f(:\n    pass\n")
+
+    exit_code = main([str(broken)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL: Found 1 direct Kafka producer violation(s):" in out

--- a/tests/unit/nodes/node_no_env_fallbacks_check_compute/__init__.py
+++ b/tests/unit/nodes/node_no_env_fallbacks_check_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_no_env_fallbacks_check_compute/test_node_no_env_fallbacks_check_compute.py
+++ b/tests/unit/nodes/node_no_env_fallbacks_check_compute/test_node_no_env_fallbacks_check_compute.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Perturbation-corpus tests for node_no_env_fallbacks_check_compute (OMN-14659).
+
+Every ``must_flag`` / ``must_pass`` case from the OMN-14659 WS8 spec is
+exercised here, plus shell-file dispatch, the skip-directory exclusion, and
+report aggregation. Message fidelity is asserted byte-for-byte against
+``omniclaude/scripts/validate_no_env_fallbacks.py`` — this is the
+load-bearing perturbation-oracle contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.nodes.no_env_fallbacks_check.model_no_env_fallbacks_check_input import (
+    ModelNoEnvFallbacksCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.nodes.node_no_env_fallbacks_check_compute.handler import (
+    NodeNoEnvFallbacksCheckCompute,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _report(path: str, source: str):
+    handler = NodeNoEnvFallbacksCheckCompute()
+    return handler.handle(
+        ModelNoEnvFallbacksCheckInput(files=[ModelSourceFile(path=path, source=source)])
+    )
+
+
+# =============================================================================
+# must_flag corpus — every case MUST produce exactly one FAIL finding
+# =============================================================================
+
+
+def test_must_flag_environ_get_localhost_default() -> None:
+    report = _report("a.py", 'host = os.environ.get("PG_HOST", "localhost")\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "FAIL"
+    assert finding.validator_id == "arch-no-env-fallbacks"
+    assert finding.location == "a.py:1"
+    assert finding.message == 'a.py:1: host = os.environ.get("PG_HOST", "localhost")'
+
+
+def test_must_flag_getenv_http_localhost_default() -> None:
+    report = _report("a.py", 'url = os.getenv("API_URL", "http://localhost:8080")\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        'a.py:1: url = os.getenv("API_URL", "http://localhost:8080")'
+    )
+
+
+def test_must_flag_priv_ip_str_annotation_default() -> None:
+    report = _report("a.py", 'broker: str = "192.168.86.201"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == 'a.py:1: broker: str = "192.168.86.201"'
+
+
+def test_must_flag_field_default_localhost() -> None:
+    report = _report("a.py", 'endpoint = Field(default="redis://localhost:6379")\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        'a.py:1: endpoint = Field(default="redis://localhost:6379")'
+    )
+
+
+# =============================================================================
+# must_pass corpus — every case MUST produce zero findings
+# =============================================================================
+
+
+def test_must_pass_no_default_fail_fast() -> None:
+    report = _report("a.py", 'host = os.environ["PG_HOST"]\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_exempt_marker() -> None:
+    report = _report(
+        "a.py",
+        'host = os.environ.get("PG_HOST", "localhost")  # fallback-ok: unit test only\n',
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_non_localhost_default() -> None:
+    report = _report("a.py", 'name = os.environ.get("APP_NAME", "myapp")\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_pure_comment_line() -> None:
+    report = _report(
+        "a.py",
+        "# comment: defaults to localhost when unset (pure comment line, skipped)\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# Shell-file dispatch
+# =============================================================================
+
+
+def test_shell_flags_localhost_parameter_expansion() -> None:
+    report = _report("deploy.sh", 'HOST="${PG_HOST:-localhost}"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == 'deploy.sh:1: HOST="${PG_HOST:-localhost}"'
+
+
+def test_shell_exempt_marker_passes() -> None:
+    report = _report(
+        "deploy.sh", 'HOST="${PG_HOST:-localhost}"  # fallback-ok: local dev script\n'
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# Unscanned suffix / skip-directory exclusion
+# =============================================================================
+
+
+def test_unscanned_suffix_is_ignored() -> None:
+    report = _report("notes.md", 'host = os.environ.get("PG_HOST", "localhost")\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_tests_directory_is_skipped() -> None:
+    report = _report(
+        "tests/fixtures/bad.py", 'host = os.environ.get("PG_HOST", "localhost")\n'
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# Aggregation across multiple files
+# =============================================================================
+
+
+def test_aggregate_metrics_and_provenance() -> None:
+    handler = NodeNoEnvFallbacksCheckCompute()
+    report = handler.handle(
+        ModelNoEnvFallbacksCheckInput(
+            files=[
+                ModelSourceFile(
+                    path="a.py",
+                    source='host = os.environ.get("PG_HOST", "localhost")\n',
+                ),
+                ModelSourceFile(path="b.py", source='host = os.environ["PG_HOST"]\n'),
+            ]
+        )
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.metrics.total == 1
+    assert report.metrics.fail_count == 1
+    assert report.provenance.validators_run == ("arch-no-env-fallbacks",)
+
+
+def test_empty_input_passes_trivially() -> None:
+    handler = NodeNoEnvFallbacksCheckCompute()
+    report = handler.handle(ModelNoEnvFallbacksCheckInput(files=[]))
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+    assert report.metrics.total == 0

--- a/tests/unit/nodes/node_no_env_fallbacks_check_compute/test_runtime_no_env_fallbacks_check.py
+++ b/tests/unit/nodes/node_no_env_fallbacks_check_compute/test_runtime_no_env_fallbacks_check.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the no-env-fallbacks-check CLI runtime (OMN-14659, OMN-13305 pattern).
+
+Covers both invocation modes: pre-commit's explicit-filenames mode (I/O read
+directly at the CLI boundary) and the full-tree walk mode (delegated to
+``node_source_file_gather_effect``) — both dispatch to the SAME canonical
+``NodeNoEnvFallbacksCheckCompute`` handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check import (
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_filenames_mode_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.py"
+    clean.write_text('host = os.environ["PG_HOST"]\n')
+
+    exit_code = main([str(clean)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "PASS: No localhost/hardcoded-endpoint fallbacks found." in out
+
+
+def test_main_filenames_mode_fail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text('host = os.environ.get("PG_HOST", "localhost")\n')
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL: 1 localhost/hardcoded-endpoint fallback(s) found:" in out
+    assert "localhost" in out
+
+
+def test_main_filenames_mode_scans_shell_too(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.sh"
+    bad.write_text('HOST="${PG_HOST:-localhost}"\n')
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    assert (
+        "FAIL: 1 localhost/hardcoded-endpoint fallback(s) found:"
+        in capsys.readouterr().out
+    )
+
+
+def test_main_filenames_mode_skips_non_scanned_and_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    not_scanned = tmp_path / "notes.md"
+    not_scanned.write_text('host = os.environ.get("PG_HOST", "localhost")\n')
+    missing = tmp_path / "missing.py"
+
+    exit_code = main([str(not_scanned), str(missing)])
+
+    assert exit_code == 0
+    assert (
+        "PASS: No localhost/hardcoded-endpoint fallbacks found."
+        in capsys.readouterr().out
+    )
+
+
+def test_main_full_tree_mode_walks_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bad.py").write_text('host = os.environ.get("PG_HOST", "localhost")\n')
+    (src / "clean.py").write_text('host = os.environ["PG_HOST"]\n')
+
+    exit_code = main(["--root", str(src)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "FAIL: 1 localhost/hardcoded-endpoint fallback(s) found:" in out
+    assert "bad.py" in out
+
+
+def test_main_full_tree_mode_empty_root_passes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+
+    exit_code = main(["--root", str(empty_root)])
+
+    assert exit_code == 0
+    assert (
+        "PASS: No localhost/hardcoded-endpoint fallbacks found."
+        in capsys.readouterr().out
+    )

--- a/tests/unit/nodes/node_no_hardcoded_ip_check_compute/__init__.py
+++ b/tests/unit/nodes/node_no_hardcoded_ip_check_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_node_no_hardcoded_ip_check_compute.py
+++ b/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_node_no_hardcoded_ip_check_compute.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Perturbation-corpus tests for node_no_hardcoded_ip_check_compute (OMN-14659).
+
+Every ``must_flag`` / ``must_pass`` case from the OMN-14659 WS8 spec is
+exercised here. Message fidelity is asserted byte-for-byte against
+``omniclaude/scripts/validation/validate_no_hardcoded_ip.py`` — this is the
+load-bearing perturbation-oracle contract.
+
+Report/finding shapes are the canonical OMN-2362 generic validator types
+(:mod:`omnibase_core.models.validation.model_validation_report`), not a
+per-node fork — see ``node_no_utcnow_check_compute`` (OMN-14656) for the
+established precedent this node mirrors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.nodes.no_hardcoded_ip_check.model_no_hardcoded_ip_check_input import (
+    ModelNoHardcodedIpCheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.nodes.node_no_hardcoded_ip_check_compute.handler import (
+    NodeNoHardcodedIpCheckCompute,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _report(path: str, source: str):
+    handler = NodeNoHardcodedIpCheckCompute()
+    return handler.handle(
+        ModelNoHardcodedIpCheckInput(files=[ModelSourceFile(path=path, source=source)])
+    )
+
+
+# =============================================================================
+# must_flag corpus — every case MUST produce exactly one FAIL finding
+# =============================================================================
+
+
+def test_must_flag_192_168_literal() -> None:
+    report = _report("a.py", 'BROKER = "192.168.86.201"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "FAIL"
+    assert finding.validator_id == "arch-no-hardcoded-ip"
+    assert finding.location == "a.py:1"
+    assert finding.message == 'a.py:1: BROKER = "192.168.86.201"'
+
+
+def test_must_flag_10_x_with_scheme_and_port() -> None:
+    report = _report("a.py", 'url = "http://10.0.0.5:8080"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == 'a.py:1: url = "http://10.0.0.5:8080"'
+
+
+def test_must_flag_172_16_range() -> None:
+    report = _report("a.py", 'host = "172.16.0.1"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == 'a.py:1: host = "172.16.0.1"'
+
+
+def test_must_flag_https_with_port_and_path() -> None:
+    report = _report("a.py", 'endpoint = "https://192.168.1.1:443/foo"\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == (
+        'a.py:1: endpoint = "https://192.168.1.1:443/foo"'
+    )
+
+
+# =============================================================================
+# must_pass corpus — every case MUST produce zero findings
+# =============================================================================
+
+
+def test_must_pass_env_var_lookup() -> None:
+    report = _report("a.py", 'BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_suppression_marker() -> None:
+    report = _report("a.py", 'ip = "192.168.86.201"  # onex-allow-internal-ip\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_public_dns_ip() -> None:
+    report = _report("a.py", 'public_dns = "8.8.8.8"\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_loopback() -> None:
+    report = _report("a.py", 'loopback = "127.0.0.1"\n')
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# Aggregation across multiple files
+# =============================================================================
+
+
+def test_aggregate_metrics_and_provenance() -> None:
+    handler = NodeNoHardcodedIpCheckCompute()
+    report = handler.handle(
+        ModelNoHardcodedIpCheckInput(
+            files=[
+                ModelSourceFile(path="a.py", source='BROKER = "192.168.86.201"\n'),
+                ModelSourceFile(
+                    path="b.py",
+                    source='BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n',
+                ),
+            ]
+        )
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.metrics.total == 1
+    assert report.metrics.fail_count == 1
+    assert report.metrics.pass_count == 0
+    assert report.provenance.validators_run == ("arch-no-hardcoded-ip",)
+
+
+def test_empty_input_passes_trivially() -> None:
+    handler = NodeNoHardcodedIpCheckCompute()
+    report = handler.handle(ModelNoHardcodedIpCheckInput(files=[]))
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+    assert report.metrics.total == 0

--- a/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_runtime_no_hardcoded_ip_check.py
+++ b/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_runtime_no_hardcoded_ip_check.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the no-hardcoded-ip-check CLI runtime (OMN-14659, OMN-13305 pattern).
+
+Covers both invocation modes: pre-commit's explicit-filenames mode (I/O read
+directly at the CLI boundary) and the full-tree walk mode (delegated to
+``node_source_file_gather_effect``) — both dispatch to the SAME canonical
+``NodeNoHardcodedIpCheckCompute`` handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check import (
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_filenames_mode_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.py"
+    clean.write_text('BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n')
+
+    exit_code = main([str(clean)])
+
+    assert exit_code == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out
+
+
+def test_main_filenames_mode_fail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text('BROKER = "192.168.86.201"\n')
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "ERROR: 1 hardcoded internal IP(s) found:" in out
+    assert "192.168.86.201" in out
+
+
+def test_main_filenames_mode_scans_yaml_too(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text('broker: "10.0.0.5"\n')
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    assert "ERROR: 1 hardcoded internal IP(s) found:" in capsys.readouterr().out
+
+
+def test_main_filenames_mode_skips_non_scanned_and_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    not_scanned = tmp_path / "notes.md"
+    not_scanned.write_text("192.168.86.201 mentioned in prose\n")
+    missing = tmp_path / "missing.py"
+
+    exit_code = main([str(not_scanned), str(missing)])
+
+    assert exit_code == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out
+
+
+def test_main_full_tree_mode_walks_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bad.py").write_text('BROKER = "192.168.86.201"\n')
+    (src / "clean.py").write_text('public_dns = "8.8.8.8"\n')
+
+    exit_code = main(["--root", str(src)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "ERROR: 1 hardcoded internal IP(s) found:" in out
+    assert "bad.py" in out
+
+
+def test_main_full_tree_mode_empty_root_passes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+
+    exit_code = main(["--root", str(empty_root)])
+
+    assert exit_code == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out

--- a/tests/unit/nodes/node_no_raw_sqlite3_check_compute/__init__.py
+++ b/tests/unit/nodes/node_no_raw_sqlite3_check_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_node_no_raw_sqlite3_check_compute.py
+++ b/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_node_no_raw_sqlite3_check_compute.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Perturbation-corpus tests for node_no_raw_sqlite3_check_compute (OMN-14659).
+
+Every ``must_flag`` / ``must_pass`` case from the OMN-14659 WS8 spec is
+exercised here, plus SyntaxError handling, the ``_adapter.py`` filename
+exclusion (with a real, non-commented-out violation, beyond the corpus
+given), ``# di-ok`` annotation on an actual import+call pair, and report
+aggregation. Message fidelity is asserted against
+``omniclaude/scripts/validation/validate_no_raw_sqlite3.py`` — this is the
+load-bearing perturbation-oracle contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.models.nodes.no_raw_sqlite3_check.model_no_raw_sqlite3_check_input import (
+    ModelNoRawSqlite3CheckInput,
+)
+from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
+    ModelSourceFile,
+)
+from omnibase_core.nodes.node_no_raw_sqlite3_check_compute.handler import (
+    NodeNoRawSqlite3CheckCompute,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _report(path: str, source: str):
+    handler = NodeNoRawSqlite3CheckCompute()
+    return handler.handle(
+        ModelNoRawSqlite3CheckInput(files=[ModelSourceFile(path=path, source=source)])
+    )
+
+
+# =============================================================================
+# must_flag corpus — every case MUST produce exactly one FAIL finding
+# =============================================================================
+
+
+def test_must_flag_sqlite3_connect_via_module_import() -> None:
+    report = _report("a.py", 'import sqlite3\nconn = sqlite3.connect("db.sqlite")\n')
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "FAIL"
+    assert finding.validator_id == "arch-no-raw-sqlite3"
+    assert finding.location == "a.py:2"
+    assert finding.message == (
+        "a.py:2: raw sqlite3.connect() call — database access must go through an "
+        "injected adapter, not a direct connection. Add '# di-ok' to suppress for "
+        "legitimate adapter bootstrap."
+    )
+
+
+def test_must_flag_from_sqlite3_import_connect() -> None:
+    report = _report("a.py", "from sqlite3 import connect\nconn = connect(path)\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].location == "a.py:2"
+
+
+def test_must_flag_from_sqlite3_import_connect_as_alias() -> None:
+    report = _report("a.py", "from sqlite3 import connect as c\nconn = c(path)\n")
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].location == "a.py:2"
+
+
+# =============================================================================
+# must_pass corpus — every case MUST produce zero findings
+# =============================================================================
+
+
+def test_must_pass_di_ok_annotation_without_import_in_same_file() -> None:
+    """No `import sqlite3` in this single-line file, so the module alias set is
+    empty and the Attribute-call branch never matches — passes regardless of
+    the `# di-ok` annotation, matching the oracle's own per-file import
+    tracking exactly."""
+    report = _report("a.py", "conn = sqlite3.connect(path)  # di-ok\n")
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_adapter_path_documentation_comment() -> None:
+    """This corpus entry is a full-line Python comment — no AST nodes at all,
+    so it passes trivially regardless of the _adapter.py exclusion mechanism."""
+    report = _report(
+        "a.py",
+        "# file src/omniclaude/db/session_adapter.py (*_adapter.py excluded): "
+        "conn = sqlite3.connect(path)\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_injected_adapter_call() -> None:
+    report = _report("a.py", "db = injected_adapter.connect()\n")
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_must_pass_import_only_no_call() -> None:
+    report = _report(
+        "a.py", "import sqlite3  # import only, no connect() call in this module\n"
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# _adapter.py filename exclusion — real (non-commented) hit on an adapter
+# path, beyond the given corpus, proving is_excluded_adapter_filename fires.
+# =============================================================================
+
+
+def test_adapter_suffixed_file_is_excluded_even_with_real_violation() -> None:
+    report = _report(
+        "src/omniclaude/db/session_adapter.py",
+        'import sqlite3\nconn = sqlite3.connect("db.sqlite")\n',
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_non_adapter_file_is_not_excluded() -> None:
+    report = _report(
+        "src/omniclaude/db/session_store.py",
+        'import sqlite3\nconn = sqlite3.connect("db.sqlite")\n',
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+
+
+# =============================================================================
+# # di-ok annotation on a real import+call pair
+# =============================================================================
+
+
+def test_di_ok_annotation_suppresses_real_violation() -> None:
+    report = _report(
+        "a.py",
+        "import sqlite3\nconn = sqlite3.connect(path)  # di-ok\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
+# SyntaxError handling
+# =============================================================================
+
+
+def test_syntax_error_yields_single_error_finding() -> None:
+    report = _report("broken.py", "def f(:\n    pass\n")
+
+    assert report.overall_status == "ERROR"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.message.startswith("broken.py: SyntaxError:")
+    assert finding.remediation is None
+
+
+# =============================================================================
+# Aggregation across multiple files
+# =============================================================================
+
+
+def test_aggregate_metrics_and_provenance() -> None:
+    handler = NodeNoRawSqlite3CheckCompute()
+    report = handler.handle(
+        ModelNoRawSqlite3CheckInput(
+            files=[
+                ModelSourceFile(
+                    path="a.py",
+                    source='import sqlite3\nconn = sqlite3.connect("db.sqlite")\n',
+                ),
+                ModelSourceFile(
+                    path="b.py", source="db = injected_adapter.connect()\n"
+                ),
+            ]
+        )
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.metrics.total == 1
+    assert report.metrics.fail_count == 1
+    assert report.provenance.validators_run == ("arch-no-raw-sqlite3",)
+
+
+def test_empty_input_passes_trivially() -> None:
+    handler = NodeNoRawSqlite3CheckCompute()
+    report = handler.handle(ModelNoRawSqlite3CheckInput(files=[]))
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+    assert report.metrics.total == 0

--- a/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_runtime_no_raw_sqlite3_check.py
+++ b/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_runtime_no_raw_sqlite3_check.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the no-raw-sqlite3-check CLI runtime (OMN-14659, OMN-13305 pattern).
+
+Covers both invocation modes: pre-commit's explicit-filenames mode (I/O read
+directly at the CLI boundary) and the full-tree walk mode (delegated to
+``node_source_file_gather_effect``) — both dispatch to the SAME canonical
+``NodeNoRawSqlite3CheckCompute`` handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check import (
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_filenames_mode_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clean = tmp_path / "clean.py"
+    clean.write_text("db = injected_adapter.connect()\n")
+
+    exit_code = main([str(clean)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "OK: No raw sqlite3.connect() calls found outside adapter definitions" in out
+
+
+def test_main_filenames_mode_fail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text('import sqlite3\nconn = sqlite3.connect("db.sqlite")\n')
+
+    exit_code = main([str(bad)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert (
+        "FAIL: Found 1 raw sqlite3.connect() call(s) outside adapter definitions:"
+        in out
+    )
+    assert "raw sqlite3.connect() call" in out
+
+
+def test_main_filenames_mode_skips_non_python_and_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    not_python = tmp_path / "notes.md"
+    not_python.write_text("sqlite3.connect() mentioned in prose\n")
+    missing = tmp_path / "missing.py"
+
+    exit_code = main([str(not_python), str(missing)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "OK: No raw sqlite3.connect() calls found outside adapter definitions" in out
+
+
+def test_main_filenames_mode_adapter_suffix_excluded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    adapter = tmp_path / "session_adapter.py"
+    adapter.write_text('import sqlite3\nconn = sqlite3.connect("db.sqlite")\n')
+
+    exit_code = main([str(adapter)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "OK: No raw sqlite3.connect() calls found outside adapter definitions" in out
+
+
+def test_main_full_tree_mode_walks_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bad.py").write_text('import sqlite3\nconn = sqlite3.connect("db.sqlite")\n')
+    (src / "clean.py").write_text("db = injected_adapter.connect()\n")
+
+    exit_code = main(["--root", str(src)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert (
+        "FAIL: Found 1 raw sqlite3.connect() call(s) outside adapter definitions:"
+        in out
+    )
+    assert "bad.py" in out
+
+
+def test_main_full_tree_mode_empty_root_passes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+
+    exit_code = main(["--root", str(empty_root)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "OK: No raw sqlite3.connect() calls found outside adapter definitions" in out
+
+
+def test_main_syntax_error_exits_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    broken = tmp_path / "broken.py"
+    broken.write_text("def f(:\n    pass\n")
+
+    exit_code = main([str(broken)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert (
+        "FAIL: Found 1 raw sqlite3.connect() call(s) outside adapter definitions:"
+        in out
+    )


### PR DESCRIPTION
## Summary

WS8 fan-out under merge-flow umbrella OMN-14643, building on the N=1 validator-node pattern proven in OMN-14656 (omnibase_core#1446: sync file-gather EFFECT + `no-utcnow` ValidatorNode COMPUTE).

Converts 4 clean, generic, single-file pure-AST/line-scan omniclaude `arch-*` CI validators into canonical `ValidatorNode` COMPUTE nodes so the same node backs both the CI gate and the pre-commit hook (retires the freestanding-script surface / rule-7a debt):

| Node | Ports | Suppress annotation |
|---|---|---|
| `node_no_hardcoded_ip_check_compute` | `omniclaude/scripts/validation/validate_no_hardcoded_ip.py` | `# onex-allow-internal-ip` |
| `node_no_direct_kafka_producer_check_compute` | `omniclaude/scripts/validation/validate_no_direct_kafka_producer.py` | (publisher-layer path allowlist) |
| `node_no_env_fallbacks_check_compute` | `omniclaude/scripts/validate_no_env_fallbacks.py` | `# fallback-ok: <reason>` |
| `node_no_raw_sqlite3_check_compute` | `omniclaude/scripts/validation/validate_no_raw_sqlite3.py` | `# di-ok` |

Each node reuses, does NOT re-generate: the shared `node_source_file_gather_effect` (sync EFFECT gather, sole filesystem I/O boundary), `node_no_utcnow_check_compute` as the exact structural template, canonical `omnibase_core.models.validation.ModelValidationReport` / `ModelValidationFinding` (no forked models), and the DRY CLI runtime pattern (`runtime_*_check.py`, OMN-13305) backing both pre-commit and CI.

Deferred (logged, not silently dropped, per ticket scope): cross-file/registry rules (`check_arch_invariants`, `golden_chain_integrity`, `registry_consistency`) and omniclaude-domain-specific rules (`no-linear-outside-effects`, `no-db-in-orchestrator`, `cost-ledger-*`) — separate follow-up tickets.

## Independent adversarial verification (verifier ≠ implementer)

Cross-checked every generated node against the **original omniclaude CI scripts** as ground-truth oracle. Fed IDENTICAL `(path, source)` to the generated COMPUTE node AND the original oracle's own visitor/matcher for each rule; 22/22 checks pass.

| Rule | must_flag→FAIL | msg byte-match vs original CI script | must_pass→PASS | semantic parity |
|------|----|----|----|----|
| `arch-no-hardcoded-ip` | pass | pass (incl. `10.x`, `172.16`, out-of-range `172.32` rejected) | pass | `# onex-allow-internal-ip` suppress; YAML scan proven live |
| `arch-no-direct-kafka-producer` | pass (3 findings, exact) | pass (import/from/bare-name/attr all match) | pass | `is_allowed_path` publisher-layer skip parity |
| `arch-no-env-fallbacks` | pass | pass (flagged-line content) | pass | docstring-not-flagged; `# fallback-ok`; shell `${VAR:-...}` |
| `arch-no-raw-sqlite3` | pass | pass (em-dash U+2014 preserved) | pass | `# di-ok` suppress; `_adapter.py` exclusion |

CLI end-to-end confirmed: must_flag → exit 1 with byte-matching per-line message + oracle `ci_message` header; must_pass → exit 0.

### Gates (all green)
- ruff format `--check` (36 files clean), ruff check (clean), mypy (0 issues / 24 files)
- Trap gates: `validate-no-duplicate-models`, `single-class-per-file` (all 4 node dirs), `check_no_fallbacks` (crucially, `matcher_env_fallbacks.py` with its localhost/IP regex literals is NOT self-flagged), `manual-yaml` — all green
- 75/75 tests pass
- Models reuse canonical `ModelSourceFile`/`ModelValidationReport` (no fork); contracts `node_type: compute` + `node_archetype: compute`; def-B `handle(request)->response` handlers (no `ModelEventEnvelope`); 4 entry-points registered + discoverable; multi-type hook suffix filters (`py/yaml`, `py/sh/bash`) match `types_or` registration — no silent-skip

## Deviations (honest, independently confirmed)

1. Only `check-no-env-fallbacks` is self-wired into this repo's own `.pre-commit-config.yaml`. Verified rationale: env-fallbacks full-tree over `src/` is PASS (green gate), while hardcoded-ip reds on 5 pre-existing docstring IP examples in `model_handler_packaging.py`. Deferring the other three avoids landing a pre-broken gate. All 4 are wired as remote pre-commit hooks + CLI/CI entrypoints, satisfying the DoD ("remote pre-commit hook + CI entrypoint").
2. `--root` full-tree default single-rooted at `src` vs oracles' multi-root — cosmetic for the `pass_filenames` pre-commit path (covers all dirs regardless).

Not a blocker, follow-up: this repo's own CI won't enforce ip/kafka/sqlite locally until the pre-existing findings above are triaged — coverage gap for THIS repo only; consuming repos get enforcement via the remote hooks.

Closes OMN-14659


Evidence-Ticket: OMN-14659
Evidence-Source: OCC#4265
Evidence-Commit: 1fcf7335fd637b4ea603b2599733692e6109a006
Evidence-Head: 6afdc8de61e682aa92ef95baeca40f5235a1f9cd


