### PR TITLE
ci(OMN-14668): pin precommit parity gate to hosted runner (ubuntu-latest)

### DIFF
--- a/.github/workflows/precommit-parity-gate.yml
+++ b/.github/workflows/precommit-parity-gate.yml
@@ -26,12 +26,13 @@
 #   * has NO `needs:` of any kind and NO `paths:` filter, so it fires on EVERY
 #     PR to main/dev and passes/fails on its own byte-match evidence, never
 #     conditioned on another job's result.
-#   * runs on GitHub-hosted PR runners (short, dependency-free
-#     `uv run --no-project --with pyyaml`), so self-hosted fleet saturation can
-#     never cancel it and falsely skip the gate. omnibase_core's `ci-summary`
-#     poller only inspects jobs within the ci.yml run, so this standalone job is
-#     its own independent check context and cannot be false-greened by the
-#     summary aggregator.
+#   * runs UNCONDITIONALLY on a GitHub-hosted runner (ubuntu-latest) for EVERY
+#     event — not just fork PRs (OMN-14668). The job is short and dependency-free
+#     (`uv run --no-project --with pyyaml`), so self-hosted fleet saturation or an
+#     absent self-hosted runner can never leave it queued/cancelled and falsely
+#     skip the gate. omnibase_core's `ci-summary` poller only inspects jobs within
+#     the ci.yml run, so this standalone job is its own independent check context
+#     and cannot be false-greened by the summary aggregator.
 #
 # Enforcement, not detection (CLAUDE.md Rule #5): wired as the CI counterpart of
 # the precommit-fail-loud-meta-gate + precommit-pin-parity pre-commit hooks
@@ -53,15 +54,16 @@ permissions:
 jobs:
   precommit-parity-gate:
     name: Precommit Parity Gate
-    # OMNI_RUNNER_SELECTOR_V1 — trusted events default to self-hosted omnibase-ci;
-    # pull_request defaults to ubuntu-latest (hosted, so fleet saturation can
-    # never cancel this gate and falsely skip it).
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
+    # OMN-14668: canonical OMNI_RUNNER_SELECTOR_V1 form for the byte-match parity
+    # gate is HOSTED-PINNED — `runs-on: ubuntu-latest`, unconditionally, for every
+    # event. It deliberately opts OUT of the trusted-self-hosted vs public-fork
+    # branch that heavier build jobs use, because this gate is short and
+    # dependency-free and must never depend on self-hosted fleet availability
+    # (a saturated/absent fleet = queued-or-cancelled = false-green window). This
+    # matches the already-hosted omnibase_spi / omnibase_compat parity gates; the
+    # prior form routed only fork PRs to hosted and left trusted push/merge_group
+    # on self-hosted.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## OMN-14668 — kill the self-hosted false-green window in the byte-match parity gate (CANARY)

The 6 merged WS7 byte-match precommit parity gates are the false-green killers, but only 2 of 6 (omnibase_spi, omnibase_compat) run unconditionally on GitHub-hosted runners. The other 4 (omnibase_core, omnibase_infra, omnimarket, onex_change_control) reference the self-hosted `omnibase-ci` fleet in their runner selector, opening a false-green window: a saturated or absent self-hosted runner leaves this *required* check queued/cancelled instead of executing — a silent skip in the very gate meant to kill false-greens.

This PR is the **canary** (omnibase_core first). Same change fans out to the other 3 self-hosted gates once proven.

### runs-on: before → after

**Before** (OMNI_RUNNER_SELECTOR_V1 "core form" — any PR → hosted, but push/merge_group → self-hosted):
```yaml
runs-on: >-
  ${{
    github.event_name != 'pull_request'
    && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
    || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
  }}
```

**After** (canonical hosted-pinned form — matches omnibase_spi / omnibase_compat):
```yaml
runs-on: ubuntu-latest
```

### Why hosted is viable
The gate is short and dependency-free: `uv run --no-project --with pyyaml python3 scripts/validation/validate_precommit_{fail_loud,pin_parity}.py`. Both scripts parse local files only (`.pre-commit-config.yaml`, `.github/workflows/ci.yml`) — no sibling checkout, no private-repo access, no network. Nothing requires the self-hosted fleet.

### Self-test still fires (not broken while relocating)
No change to `on:` triggers (still fires on every PR to main/dev, no `paths:` filter), no change to `needs:` (still none), no change to the two validate steps. Only `runs-on` changed. The `Precommit Parity Gate` check still executes CI-side on the PR SHA — see `gh pr checks` on this PR, which must show it running on and passing on a hosted runner.

### OMNI_RUNNER_SELECTOR_V1 convergence
Three divergent forms exist across the 6 parity gates:
- **Form A** (core, pre-this-PR): PR → hosted, else self-hosted
- **Form B** (infra, omnimarket, occ): only *fork* PR → hosted, internal PR → self-hosted
- **Form C** (spi, compat): unconditional `ubuntu-latest`

This PR converges core to **Form C**, the canonical hosted-pinned form for this gate class. Fan-out PRs converge infra/omnimarket/occ to the same.

### dod_evidence
CI-config-only change (`.github/workflows/precommit-parity-gate.yml`). Proof = this PR's own `Precommit Parity Gate` check executing on a GitHub-hosted runner and passing on the PR SHA (verified via `gh run view --json` runner labels). Non-deployable (no runtime contract/source touched).

Closes OMN-14668 (canary leg).



Evidence-Ticket: OMN-14668
Evidence-Source: OCC#4304
Evidence-Commit: e0455192bbac0a09b7adc35d315c14c3da6b50fb
Evidence-Head: a2df441b3421c31fcc3984453e306ea326a539e5
