### PR TITLE
feat(OMN-13973): wire governed impacted-test selector as pre-push hook (WS7 D6a)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1655,6 +1655,29 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+  # Governed impacted-test selector at PRE-PUSH (OMN-13973 / WS7 OMN-14655, D6a).
+  # Runs the fast local IMPACTED SUBSET of the unit suite once per `git push`,
+  # via the SAME selector CI uses (scripts/ci/detect_test_paths.py +
+  # test_selection_adjacency.yaml, ENABLE_SMART_TESTS) -- never a hand-typed -k.
+  # Fail-closed: escalates to the full unit suite when it cannot prove narrowing
+  # is safe (shared module / pyproject deps / scripts/ci/ / >=8 modules / main).
+  # NET-NEGATIVE-SURFACE: retires the "run the whole suite by hand before every
+  # push" default (root CLAUDE.md Rule #4). This is a fast local mirror ADVISORY
+  # of the full CI suite -- NOT byte-parity with an enforced CI context (on CI
+  # the selector is behind ENABLE_SMART_TESTS off-by-default; the enforced gate
+  # is the full suite). FAIL-LOUD: hard-errors if base/selector/adjacency cannot
+  # resolve (plan section 3d.4); never a green skip.
+  - repo: local
+    hooks:
+      - id: prepush-smart-tests
+        name: Governed impacted-test selector (pre-push, OMN-13973)
+        entry: bash scripts/hooks/prepush_smart_tests.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        stages: [pre-push]
+
 # Configuration
 default_install_hook_types: [pre-commit, pre-push, commit-msg]
 default_stages: [pre-commit]

--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Pre-push governed impacted-test selector (OMN-13973 / WS7 OMN-14655, D6a lane).
+#
+# Runs the FAST LOCAL IMPACTED SUBSET of the unit suite once per `git push`,
+# using the SAME governed selector CI uses -- scripts/ci/detect_test_paths.py +
+# scripts/ci/test_selection_adjacency.yaml -- NOT a hand-typed `-k`. The selector
+# is fail-closed: it escalates to the full unit suite whenever it cannot prove
+# narrowing is safe (a shared module, a dependency-bearing pyproject.toml change,
+# a scripts/ci/ change, >=8 changed modules, or the main branch). See root
+# CLAUDE.md Rule #4.
+#
+# This hook is deliberately NOT byte-parity with an enforced CI context. On CI the
+# selector is gated behind ENABLE_SMART_TESTS (off by default during rollout) and
+# the enforced merge gate is the FULL suite. This hook is *net-new, fast local
+# subset enforcement* -- a fast local mirror that is ADVISORY of the full CI
+# suite, run before the push leaves the machine. It retires the "run the whole
+# suite by hand before every push" default (CLAUDE.md Rule #4: "until OMN-13973
+# lands, the full local suite remains the fail-closed default").
+#
+# FAIL-LOUD (CLAUDE.md Rule #8; plan section 3d.4): if the diff base, the
+# selector, or its adjacency config cannot resolve, this hook HARD-ERRORS with a
+# remediation message and a non-zero exit. It never degrades to a green skip -- a
+# gate that cannot run must be indistinguishable from a failing gate.
+#
+# Env overrides (all optional):
+#   PREPUSH_BASE_REF     git ref to diff against            (default: origin/dev)
+#   PREPUSH_ADJACENCY    adjacency yaml path            (default: selector built-in)
+#   PREPUSH_PYTEST_ARGS  extra args appended to the pytest invocation
+#   ENABLE_SMART_TESTS   set false/0/off to force the FULL suite (parity with the
+#                        CI var name); default here is smart selection ON, because
+#                        the whole point of the local hook is the impacted subset.
+#   PREPUSH_FULL_SUITE   set non-empty to force the FULL suite.
+
+set -euo pipefail
+
+log() { printf '[prepush-smart-tests] %s\n' "$1" >&2; }
+die() {
+  log "ERROR: $1"
+  log "REMEDIATION: $2"
+  exit 1
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+  || die "not inside a git worktree" \
+         "run 'git push' from within the omnibase_core repository"
+cd "$REPO_ROOT"
+
+BASE_REF="${PREPUSH_BASE_REF:-origin/dev}"
+
+# Deterministic diff base (plan section 3d.3): fetch the base ref best-effort so
+# an online push gets an up-to-date merge-base, then REQUIRE it to resolve.
+# Offline is tolerated ONLY when the ref already exists locally; an entirely
+# unresolvable base HARD-ERRORS rather than silently diffing against nothing.
+git fetch --quiet origin "${BASE_REF#origin/}" 2>/dev/null || true
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  die "base ref '${BASE_REF}' could not be resolved" \
+      "fetch it ('git fetch origin ${BASE_REF#origin/}') or set PREPUSH_BASE_REF to a resolvable ref"
+fi
+
+BASE_SHA="$(git merge-base "${BASE_REF}" HEAD 2>/dev/null)" \
+  || die "no common ancestor between '${BASE_REF}' and HEAD" \
+         "rebase your branch onto ${BASE_REF} so a merge-base exists"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+
+CHANGED_FILE="$(mktemp)"
+SELECTION_FILE="$(mktemp)"
+SELECTION_ERR="$(mktemp)"
+trap 'rm -f "$CHANGED_FILE" "$SELECTION_FILE" "$SELECTION_ERR"' EXIT
+
+git diff --name-only "${BASE_SHA}" HEAD > "$CHANGED_FILE"
+
+# Feature-flag: default ON (impacted subset). Honor the CI var name and an
+# explicit full-suite override. Neither knob is a silent bypass -- forcing OFF
+# runs MORE tests (the whole suite), never fewer.
+FLAG="on"
+case "${ENABLE_SMART_TESTS:-}" in
+  false | False | FALSE | 0 | off | OFF) FLAG="off" ;;
+esac
+if [ -n "${PREPUSH_FULL_SUITE:-}" ]; then
+  FLAG="off"
+fi
+
+# DRY: invoke the EXACT module CI runs (scripts.ci.detect_test_paths), same flags.
+# Split on the optional adjacency override to avoid empty-array expansion under
+# `set -u` on bash 3.2 (macOS system bash).
+run_selector() {
+  if [ -n "${PREPUSH_ADJACENCY:-}" ]; then
+    uv run python -m scripts.ci.detect_test_paths \
+      --changed-files-from "$CHANGED_FILE" \
+      --ref-name "$BRANCH" \
+      --event-name pull_request \
+      --feature-flag "$FLAG" \
+      --base-ref "$BASE_SHA" \
+      --adjacency "$PREPUSH_ADJACENCY"
+  else
+    uv run python -m scripts.ci.detect_test_paths \
+      --changed-files-from "$CHANGED_FILE" \
+      --ref-name "$BRANCH" \
+      --event-name pull_request \
+      --feature-flag "$FLAG" \
+      --base-ref "$BASE_SHA"
+  fi
+}
+
+if ! run_selector > "$SELECTION_FILE" 2> "$SELECTION_ERR"; then
+  log "selector stderr follows:"
+  cat "$SELECTION_ERR" >&2 || true
+  die "governed test selector failed to resolve a selection" \
+      "verify scripts/ci/detect_test_paths.py + scripts/ci/test_selection_adjacency.yaml resolve under 'uv run' in this worktree"
+fi
+
+# Parse the selection with stdlib json -- fail loud on any parse error.
+read_sel() {
+  python3 - "$SELECTION_FILE" "$1" << 'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+val = data[sys.argv[2]]
+if isinstance(val, list):
+    print("\n".join(val))
+else:
+    print(val)
+PY
+}
+
+IS_FULL="$(read_sel is_full_suite)" \
+  || die "could not parse selector output (is_full_suite)" \
+         "the selector emitted non-JSON; inspect $SELECTION_FILE"
+REASON="$(read_sel full_suite_reason 2> /dev/null || true)"
+
+PATHS=()
+PATHS_STR=""
+while IFS= read -r p; do
+  if [ -n "$p" ]; then
+    PATHS+=("$p")
+    PATHS_STR="${PATHS_STR}${p} "
+  fi
+done < <(read_sel selected_paths)
+
+log "selection: is_full_suite=${IS_FULL} reason=${REASON:-none} paths=[ ${PATHS_STR}] (feature-flag=${FLAG})"
+
+# Assemble the pytest target set. tests/integration is always ignored -- it needs
+# real services and stays a CI-only concern (plan section 2 CI-only).
+RC=0
+if [ "$IS_FULL" = "True" ] || [ "$IS_FULL" = "true" ]; then
+  log "running FULL suite (fail-closed escalation): uv run pytest tests/ --ignore=tests/integration ${PREPUSH_PYTEST_ARGS:-}"
+  # shellcheck disable=SC2086
+  uv run pytest tests/ --ignore=tests/integration --tb=short ${PREPUSH_PYTEST_ARGS:-} || RC=$?
+elif [ "${#PATHS[@]}" -gt 0 ]; then
+  log "running impacted subset: uv run pytest ${PATHS_STR}--ignore=tests/integration ${PREPUSH_PYTEST_ARGS:-}"
+  # shellcheck disable=SC2086
+  uv run pytest "${PATHS[@]}" --ignore=tests/integration --tb=short ${PREPUSH_PYTEST_ARGS:-} || RC=$?
+else
+  log "no impacted unit tests mapped for this push (no source/test change contributed a target); nothing to run."
+fi
+
+if [ "$RC" -ne 0 ]; then
+  log "ERROR: impacted tests failed (pytest exit ${RC})"
+  log "REMEDIATION: fix the failing tests, then re-push. Reproduce with: uv run pytest ${PATHS_STR:-tests/} --ignore=tests/integration"
+  exit "$RC"
+fi
+
+log "impacted tests passed; allowing push."
+exit "$RC"


### PR DESCRIPTION
## OMN-13973 — Governed impacted-test selector wired as a PRE-PUSH hook (WS7 / OMN-14655 D6a)

Wires the governed change-aware test selector (`scripts/ci/detect_test_paths.py` + `scripts/ci/test_selection_adjacency.yaml`, `ENABLE_SMART_TESTS`) as a **pre-push** pre-commit hook on the `omnibase_core` canary. This is the plan's single biggest shift-left win (`docs/plans/2026-07-15-ci-precommit-gate-parity-plan.md` §pre-push / §4 step 5) and, per that plan, a **separate lane** from the already-landed static-parity wiring (D6a) — different failure modes (test flake, selector escalation, runtime cost).

Closes OMN-13973. Refs OMN-14655 (WS7), OMN-14643 (merge-flow throughput epic).

### What changed (2 files)
- **`scripts/hooks/prepush_smart_tests.sh`** (new) — the pre-push wrapper. Computes changed files vs the `origin/dev` merge-base, invokes the **exact CI module** `uv run python -m scripts.ci.detect_test_paths` with the same flags CI uses (DRY — not a hand-typed `-k`), parses the selection, and runs `uv run pytest <selected_paths> --ignore=tests/integration`.
- **`.pre-commit-config.yaml`** — new `repo: local` hook `prepush-smart-tests`, `stages: [pre-push]`, `always_run: true`, `pass_filenames: false`, `verbose: true`.

### Design (why this is NOT byte-parity with a CI gate — DRIFT-2-by-scope)
On CI the selector is gated behind `ENABLE_SMART_TESTS` (off by default during OMN-13973 rollout) and the enforced merge gate is the **full** suite. So this hook is deliberately **net-new, fast local impacted-subset enforcement — an advisory local mirror of the full CI suite**, not a claim of parity with an enforced CI context. It is labeled as such in the hook and config comments.

- **Fail-closed (CLAUDE.md Rule #4):** the selector escalates to the full unit suite whenever it cannot prove narrowing is safe — shared module (`models`/`contracts`/`enums`/`validation`/`runtime`/`event_bus`), a dependency-bearing `pyproject.toml` change, a `scripts/ci/` change, ≥8 changed modules, or the `main` branch.
- **Fail-loud (CLAUDE.md Rule #8; plan §3d.4):** if the diff base, the selector, or its adjacency config cannot resolve, the hook **hard-errors** (exit 1 + remediation). It never degrades to a green skip. Verified live below and by the landed `precommit-fail-loud-meta-gate`, which scans this script (`repo: local` + `language: system`) and passes it.
- **`default_install_hook_types` already includes `pre-push`** (`.pre-commit-config.yaml:1659`) — §3d.5 install-gap does not apply to core; verified the git hook is actually written (below).
- **`tests/integration` stays CI-only** (needs real services) — always `--ignore`d.
- **DRY:** the hook shells out to the same `scripts.ci.detect_test_paths` module and `test_selection_adjacency.yaml` CI runs; no re-implementation of the selection rule.

### Net-negative-surface ledger (plan §5, CLAUDE.md net-negative-surface rule)
This hook **retires the "run the whole unit suite by hand before every push" manual default** that CLAUDE.md Rule #4 mandates as the fail-closed local stopgap ("until OMN-13973 lands, the full local suite remains the fail-closed default"). One new hook replaces a manual, un-enforced, whole-suite pre-push step with a governed, fail-closed, fail-loud impacted subset. No new bespoke validator — it invokes the existing CI entrypoint.

### Installation-proof + measured evidence (fresh clone; a green `pre-commit run` proves nothing about the git-push path)
All proofs run in a fresh clone (`origin` → GitHub, `origin/dev` = `f3115241`), pushing to a local bare remote so the real `.git/hooks/pre-push` path fires.

**1. Installation (git-push path):** `pre-commit install` wrote `pre-commit installed at .git/hooks/pre-push`; an actual `git push` fired the hook:
```
- hook id: prepush-smart-tests
[prepush-smart-tests] selection: is_full_suite=False reason=None paths=[ tests/unit/crypto/ ] (feature-flag=on)
[prepush-smart-tests] running impacted subset: uv run pytest tests/unit/crypto/ --ignore=tests/integration
tests/unit/crypto/test_crypto_blake3_hasher.py ... PASSED  (65 passed in 0.86s)
```

**2. Subset selection:** a single-module change under `src/omnibase_core/crypto/` selected **only** `tests/unit/crypto/` (`is_full_suite=False`). Hook-only wall-clock: **2s** (65 tests, 0.86s pytest).

**3. Fail-closed escalation:** a change to a shared module (`src/omnibase_core/models/__init__.py`) escalated correctly:
```
[prepush-smart-tests] selection: is_full_suite=True reason=shared_module paths=[ tests/ ] (feature-flag=on)
[prepush-smart-tests] running FULL suite (fail-closed escalation): uv run pytest tests/ --ignore=tests/integration ...
collected 42777 items
```

**4. Fail-loud (hard error, not skip):** an unresolvable adjacency config (`PREPUSH_ADJACENCY=/tmp/does-not-exist.yaml`):
```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/omn13973-does-not-exist.yaml'
[prepush-smart-tests] ERROR: governed test selector failed to resolve a selection
[prepush-smart-tests] REMEDIATION: verify scripts/ci/detect_test_paths.py + scripts/ci/test_selection_adjacency.yaml resolve under 'uv run' in this worktree
>>> hook exit code: 1   # push blocked
```
Via the real pre-commit pre-push runner the same condition reports `Governed impacted-test selector (pre-push, OMN-13973)....Failed`.

### dod_evidence
- `dod_evidence`: pre-push hook installation proven on the git-push path (`.git/hooks/pre-push` written + fired); governed subset selection (`tests/unit/crypto/`, 65 passed/0.86s), fail-closed escalation on a shared-module change (`is_full_suite=True`, `reason=shared_module`, full suite = 42777 items), and fail-loud hard-error (exit 1 + remediation) on unresolvable config — all captured above. `validate_precommit_fail_loud.py` + `validate_precommit_pin_parity.py` pass over the new hook. Measured hook wall-clock on the subset path: 2s.
- `proof_class`: receipt-bound (local-readback: real git-push hook fire + pytest execution + hard-error exit code).

### Notes
- Not merging — Codex owns the queue. OCC evidence companion to be authored by a non-implementer (not self-authored per policy).




Evidence-Ticket: OMN-13973
Evidence-Source: OCC#4305
Evidence-Commit: 50041ddc8c3008665af4bd038668689fb6c6559f
Evidence-Head: bf05747e7f4378d743ec523e56bd89afdb9bba39
