### PR TITLE
feat(OMN-14700): RSD-regenerate governed test selector as canonical node_test_selector_compute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ node_no_direct_kafka_producer_check_compute = "omnibase_core.nodes.node_no_direc
 node_no_env_fallbacks_check_compute = "omnibase_core.nodes.node_no_env_fallbacks_check_compute"
 node_no_raw_sqlite3_check_compute = "omnibase_core.nodes.node_no_raw_sqlite3_check_compute"
 node_no_io_outside_effects_check_compute = "omnibase_core.nodes.node_no_io_outside_effects_check_compute"
+node_test_selector_compute = "omnibase_core.nodes.node_test_selector_compute"
 
 [project.optional-dependencies]
 spi = ["omnibase-spi>=0.20.2"]
@@ -404,6 +405,8 @@ ignore = [
 "src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py" = ["T201"]
 "src/omnibase_core/nodes/node_no_env_fallbacks_check_compute/runtime_no_env_fallbacks_check.py" = ["T201"]
 "src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/runtime_no_raw_sqlite3_check.py" = ["T201"]
+# OMN-14700: CLI runner for the test_selector COMPUTE node writes the selection JSON to stdout.
+"src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py" = ["T201"]
 # OMN-14694/OMN-14662: CLI runner for the no-io-outside-effects COMPUTE node prints findings.
 "src/omnibase_core/nodes/node_no_io_outside_effects_check_compute/runtime_no_io_outside_effects_check.py" = ["T201"]
 "src/omnibase_core/validation/validator_transport_import.py" = ["T201"]  # CLI output for pre-commit hook violations (OMN-13283)

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -1,46 +1,34 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Load and validate the static module adjacency map."""
+"""Load and validate the static module adjacency map.
+
+Promotion bridge (OMN-14700): the ``ModelAdjacencyMap`` family now lives in
+``omnibase_core.models.nodes.test_selector.model_adjacency_map`` (the canonical
+model layer) so the ``node_test_selector_compute`` node and this legacy
+``detect_test_paths.py`` oracle validate against ONE model (no fork). The models
+are re-exported here; only ``load_adjacency_map`` (the YAML filesystem read — the
+caller-boundary I/O the node never performs) is defined locally. Deleted by the
+CI + pre-push swap follow-up (OMN-14700 DoD 2/3).
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
+    ModelAdjacencyEntry,
+    ModelAdjacencyMap,
+    ModelThresholds,
+)
 
-class ModelAdjacencyEntry(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-    reverse_deps: list[str] = Field(default_factory=list)
-
-
-class ModelThresholds(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-    modules_changed_for_full_suite: int = Field(..., ge=1)
-
-
-class ModelAdjacencyMap(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    schema_version: int = Field(..., ge=1)
-    shared_modules: list[str]
-    thresholds: ModelThresholds
-    test_infrastructure_paths: list[str]
-    adjacency: dict[str, ModelAdjacencyEntry]
-
-    @model_validator(mode="after")
-    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
-        for shared in self.shared_modules:
-            if shared not in self.adjacency:
-                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
-        for module, entry in self.adjacency.items():
-            for dep in entry.reverse_deps:
-                if dep not in self.adjacency:
-                    raise ValueError(
-                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
-                    )
-        return self
+__all__ = [
+    "ModelAdjacencyEntry",
+    "ModelAdjacencyMap",
+    "ModelThresholds",
+    "load_adjacency_map",
+]
 
 
 def load_adjacency_map(path: Path) -> ModelAdjacencyMap:

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -13,8 +13,8 @@ script.
 
 from __future__ import annotations
 
+from omnibase_core.enums.enum_full_suite_reason import EnumFullSuiteReason
 from omnibase_core.models.nodes.test_selector.model_test_selection import (
-    EnumFullSuiteReason,
     ModelTestSelection,
     ModuleName,
     TestPath,

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -1,52 +1,28 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Pydantic output contract for change-aware test selection."""
+"""Pydantic output contract for change-aware test selection.
+
+Promotion bridge (OMN-14700): the canonical definitions now live in
+``omnibase_core.models.nodes.test_selector.model_test_selection`` so the
+RSD-regenerated ``node_test_selector_compute`` and this legacy
+``detect_test_paths.py`` oracle share ONE model (no fork). This module re-exports
+them so the oracle and its tests keep importing ``scripts.ci.test_selection_models``
+unchanged until the CI + pre-push swap follow-up (OMN-14700 DoD 2/3) deletes the
+script.
+"""
 
 from __future__ import annotations
 
-from enum import StrEnum
-from typing import Annotated, Self
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+    ModuleName,
+    TestPath,
+)
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
-
-
-class EnumFullSuiteReason(StrEnum):
-    SHARED_MODULE = "shared_module"
-    THRESHOLD_MODULES = "threshold_modules"
-    TEST_INFRASTRUCTURE = "test_infrastructure"
-    MAIN_BRANCH = "main_branch"
-    MERGE_GROUP = "merge_group"
-    SCHEDULED = "scheduled"
-    FEATURE_FLAG_OFF = "feature_flag_off"
-
-
-TestPath = Annotated[
-    str,
-    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+__all__ = [
+    "EnumFullSuiteReason",
+    "ModelTestSelection",
+    "ModuleName",
+    "TestPath",
 ]
-ModuleName = Annotated[
-    str,
-    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
-]
-
-
-class ModelTestSelection(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    selected_paths: list[TestPath] = Field(..., min_length=1)
-    split_count: int = Field(..., ge=1, le=40)
-    is_full_suite: bool
-    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
-    matrix: list[int] = Field(...)
-
-    @model_validator(mode="after")
-    def validate_full_suite_reason(self) -> Self:
-        if self.is_full_suite and self.full_suite_reason is None:
-            raise ValueError("full_suite_reason required when is_full_suite=True")
-        if not self.is_full_suite and self.full_suite_reason is not None:
-            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
-        if len(self.matrix) != self.split_count:
-            raise ValueError(
-                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
-            )
-        return self

--- a/src/omnibase_core/enums/enum_full_suite_reason.py
+++ b/src/omnibase_core/enums/enum_full_suite_reason.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Full-suite escalation reason for change-aware test selection (OMN-14700).
+
+Why the governed test selector escalated a change-set to the full suite instead
+of a narrowed shard set. Consumed by
+:class:`~omnibase_core.models.nodes.test_selector.model_test_selection.ModelTestSelection`
+and produced by ``node_test_selector_compute``. Promoted verbatim from
+``scripts/ci/test_selection_models.py`` (same string values) so the node and the
+legacy ``detect_test_paths.py`` oracle share ONE enum (no fork).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["EnumFullSuiteReason"]
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"

--- a/src/omnibase_core/models/nodes/test_selector/__init__.py
+++ b/src/omnibase_core/models/nodes/test_selector/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical I/O models for the test-selector COMPUTE node (OMN-14700).
+
+Promoted verbatim from ``scripts/ci/test_selection_models.py`` and
+``scripts/ci/test_selection_loader.py`` into the canonical ``omnibase_core``
+model layer (root CLAUDE.md rule #7) so the RSD-regenerated
+``node_test_selector_compute`` node and the legacy ``detect_test_paths.py``
+oracle share ONE definition of each shape (no fork). The two ``scripts/ci``
+modules re-export these names until the CI/pre-push swap follow-up
+(OMN-14700 DoD 2/3) deletes the script.
+
+Parent epic: OMN-2362 (Generic Validator Node Architecture / WS8).
+"""
+
+from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
+    ModelAdjacencyEntry,
+    ModelAdjacencyMap,
+    ModelThresholds,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+    ModuleName,
+    TestPath,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection_request import (
+    ModelTestSelectionRequest,
+)
+
+__all__ = [
+    "EnumFullSuiteReason",
+    "ModelAdjacencyEntry",
+    "ModelAdjacencyMap",
+    "ModelTestSelection",
+    "ModelTestSelectionRequest",
+    "ModelThresholds",
+    "ModuleName",
+    "TestPath",
+]

--- a/src/omnibase_core/models/nodes/test_selector/__init__.py
+++ b/src/omnibase_core/models/nodes/test_selector/__init__.py
@@ -14,13 +14,13 @@ modules re-export these names until the CI/pre-push swap follow-up
 Parent epic: OMN-2362 (Generic Validator Node Architecture / WS8).
 """
 
+from omnibase_core.enums.enum_full_suite_reason import EnumFullSuiteReason
 from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
     ModelAdjacencyEntry,
     ModelAdjacencyMap,
     ModelThresholds,
 )
 from omnibase_core.models.nodes.test_selector.model_test_selection import (
-    EnumFullSuiteReason,
     ModelTestSelection,
     ModuleName,
     TestPath,

--- a/src/omnibase_core/models/nodes/test_selector/model_adjacency_map.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_adjacency_map.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Static module adjacency map — canonical model layer.
+
+Canonical home (OMN-14700) for the shapes previously defined in
+``scripts/ci/test_selection_loader.py``. Moved verbatim so both the
+``node_test_selector_compute`` handler (which takes the loaded map as a pure
+input) and the ``detect_test_paths.py`` oracle validate against ONE model.
+
+The YAML file read (``load_adjacency_map``) is filesystem I/O and stays at the
+caller boundary (``scripts/ci/test_selection_loader.py`` for the legacy oracle,
+``runtime_test_selector.py`` for the node entrypoint) — never inside the node.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = [
+    "ModelAdjacencyEntry",
+    "ModelAdjacencyMap",
+    "ModelThresholds",
+]
+
+
+class ModelAdjacencyEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reverse_deps: list[str] = Field(default_factory=list)
+
+
+class ModelThresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    modules_changed_for_full_suite: int = Field(..., ge=1)
+
+
+class ModelAdjacencyMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(..., ge=1)
+    shared_modules: list[str]
+    thresholds: ModelThresholds
+    test_infrastructure_paths: list[str]
+    adjacency: dict[str, ModelAdjacencyEntry]
+
+    @model_validator(mode="after")
+    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        for shared in self.shared_modules:
+            if shared not in self.adjacency:
+                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
+        for module, entry in self.adjacency.items():
+            for dep in entry.reverse_deps:
+                if dep not in self.adjacency:
+                    raise ValueError(
+                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                    )
+        return self

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
@@ -10,27 +10,17 @@ the ``detect_test_paths.py`` oracle emit the identical model.
 
 from __future__ import annotations
 
-from enum import StrEnum
 from typing import Annotated, Self
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
+from omnibase_core.enums.enum_full_suite_reason import EnumFullSuiteReason
+
 __all__ = [
-    "EnumFullSuiteReason",
     "ModelTestSelection",
     "ModuleName",
     "TestPath",
 ]
-
-
-class EnumFullSuiteReason(StrEnum):
-    SHARED_MODULE = "shared_module"
-    THRESHOLD_MODULES = "threshold_modules"
-    TEST_INFRASTRUCTURE = "test_infrastructure"
-    MAIN_BRANCH = "main_branch"
-    MERGE_GROUP = "merge_group"
-    SCHEDULED = "scheduled"
-    FEATURE_FLAG_OFF = "feature_flag_off"
 
 
 TestPath = Annotated[

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pydantic output contract for change-aware test selection.
+
+Canonical home (OMN-14700) for the shapes previously defined in
+``scripts/ci/test_selection_models.py``. Moved verbatim — same field names,
+constraints, and validator — so the ``node_test_selector_compute`` handler and
+the ``detect_test_paths.py`` oracle emit the identical model.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+__all__ = [
+    "EnumFullSuiteReason",
+    "ModelTestSelection",
+    "ModuleName",
+    "TestPath",
+]
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"
+
+
+TestPath = Annotated[
+    str,
+    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
+]
+
+
+class ModelTestSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_paths: list[TestPath] = Field(..., min_length=1)
+    split_count: int = Field(..., ge=1, le=40)
+    is_full_suite: bool
+    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
+    matrix: list[int] = Field(...)
+
+    @model_validator(mode="after")
+    def validate_full_suite_reason(self) -> Self:
+        if self.is_full_suite and self.full_suite_reason is None:
+            raise ValueError("full_suite_reason required when is_full_suite=True")
+        if not self.is_full_suite and self.full_suite_reason is not None:
+            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
+        if len(self.matrix) != self.split_count:
+            raise ValueError(
+                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
+            )
+        return self

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Input contract for the test-selector COMPUTE node (OMN-14700).
+
+The node is pure/deterministic/no-I/O: every fact it needs is carried on this
+request. The three I/O-derived inputs are resolved at the caller/EFFECT
+boundary (``runtime_test_selector.py``), never inside the handler:
+
+* ``changed_files`` — the git-diff file list (a ``git diff`` at the boundary).
+* ``adjacency`` — the parsed ``test_selection_adjacency.yaml`` (a YAML read).
+* ``pyproject_dependency_relevant`` — the content-aware pyproject.toml
+  classification (a base-vs-head ``git show`` + TOML parse).
+* ``test_file_counts`` — recursive ``test_*.py`` counts per candidate selected
+  path (a filesystem walk). The node sums the counts of the paths it selects to
+  compute the volume-aware split count; an absent path counts as ``0``, exactly
+  mirroring the oracle's ``_count_test_files`` skip-if-missing behaviour.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
+    ModelAdjacencyMap,
+)
+
+__all__ = ["ModelTestSelectionRequest"]
+
+
+class ModelTestSelectionRequest(BaseModel):
+    """Typed, side-effect-free request for a change-aware test selection."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ref_name: str
+    adjacency: ModelAdjacencyMap
+    changed_files: list[str] = Field(default_factory=list)
+    event_name: str = "pull_request"
+    feature_flag_enabled: bool = True
+    pyproject_dependency_relevant: bool | None = None
+    test_file_counts: dict[str, int] = Field(default_factory=dict)

--- a/src/omnibase_core/nodes/node_test_selector_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""test_selector COMPUTE node package (OMN-14700).
+
+Exposes :class:`NodeTestSelectorCompute` — the RSD-regenerated canonical form of
+the governed impacted-test selector (``scripts/ci/detect_test_paths.py``). Pure,
+deterministic, def-B ``handle(request) -> response``; emits the existing
+``ModelTestSelection`` shape.
+"""
+
+from omnibase_core.nodes.node_test_selector_compute.handler import (
+    NodeTestSelectorCompute,
+)
+
+__all__ = ["NodeTestSelectorCompute"]

--- a/src/omnibase_core/nodes/node_test_selector_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_test_selector_compute/contract.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# ONEX contract for the test_selector COMPUTE node.
+# RSD-regenerates the governed impacted-test selector (scripts/ci/detect_test_paths.py,
+# OMN-13973) into a canonical def-B NodeCompute. Deterministic change-aware test
+# selection over the changed-file list + parsed adjacency map, reproducing
+# detect_test_paths.py's compute_selection byte-for-byte.
+#
+# See: OMN-14700 (parent epic OMN-2362 — Generic Validator Node Architecture / WS8)
+
+name: node_test_selector_compute
+node_id: node_test_selector_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  Resolves a change-aware test selection: given the changed-file list, the parsed module adjacency map,
+  the pyproject.toml dependency-relevance classification, and per-path test-file counts, it returns the
+  existing ModelTestSelection (selected_paths, split_count, is_full_suite, full_suite_reason, matrix).
+  Reproduces scripts/ci/detect_test_paths.py's compute_selection byte-for-byte — same escalation precedence
+  (feature-flag / main-branch / merge_group / schedule / test-infrastructure / shared-module / module-threshold)
+  and the same volume-aware split-count arithmetic. Pure — no filesystem access, no git, no clock, no
+  global state; all I/O is done at the caller/EFFECT boundary and passed in on the request. #magic___^_^___line
+input_model: omnibase_core.models.nodes.test_selector.model_test_selection_request.ModelTestSelectionRequest
+output_model: omnibase_core.models.nodes.test_selector.model_test_selection.ModelTestSelection
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeTestSelectorCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_test_selector_compute/handler.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/handler.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NodeTestSelectorCompute — change-aware test-selection COMPUTE handler.
+
+RSD-regenerates the governed impacted-test selector
+(``scripts/ci/detect_test_paths.py``, OMN-13973) into a canonical COMPUTE node
+on the def-B ``handle(request) -> response`` shape (root CLAUDE.md rule #7a),
+following the OMN-14659 WS8 convert-clean template
+(``node_no_env_fallbacks_check_compute``).
+
+Architecture: COMPUTE node — pure, deterministic, no I/O. Every fact the
+selection depends on (the changed-file list, the parsed adjacency map, the
+pyproject.toml relevance classification, and the per-path test-file counts)
+arrives on :class:`ModelTestSelectionRequest`; the git-diff, YAML read,
+``git show`` classification, and filesystem walk all happen at the paired
+caller/EFFECT boundary (``runtime_test_selector.py``), never in this handler.
+The handler core imports no event-envelope type — the runtime adapter owns that
+boundary — which is the def-B canonical shape (C-core).
+
+Output shape: the existing typed :class:`ModelTestSelection` /
+:class:`EnumFullSuiteReason` (promoted to the canonical model layer under
+OMN-14700, NOT forked). The pure algorithm lives in :mod:`.selector_core` and
+reproduces the oracle byte-for-byte (proven by the differential test battery).
+
+Ticket: OMN-14700 (parent epic OMN-2362 — Generic Validator Node Architecture / WS8).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    ModelTestSelection,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection_request import (
+    ModelTestSelectionRequest,
+)
+from omnibase_core.nodes.node_test_selector_compute.selector_core import (
+    compute_selection,
+)
+
+__all__ = ["NodeTestSelectorCompute"]
+
+
+class NodeTestSelectorCompute:
+    """COMPUTE handler that resolves a change-aware test selection."""
+
+    def handle(self, request: ModelTestSelectionRequest) -> ModelTestSelection:
+        """Definition-B canonical entry-point.
+
+        Typed request in, typed response out — pure, no I/O, no clock.
+        """
+        return compute_selection(
+            changed_files=request.changed_files,
+            adjacency=request.adjacency,
+            ref_name=request.ref_name,
+            event_name=request.event_name,
+            feature_flag_enabled=request.feature_flag_enabled,
+            pyproject_dependency_relevant=request.pyproject_dependency_relevant,
+            test_file_counts=request.test_file_counts,
+        )

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI runtime for the change-aware test selector — CI + pre-push entrypoint.
+
+This is the stable entrypoint that the CI job and the pre-push hook
+(``scripts/hooks/prepush_smart_tests.sh``) will invoke once the transparent
+script→node swap follow-up lands (OMN-14700 DoD 2/3). It reproduces
+``scripts/ci/detect_test_paths.py``'s stdout byte-for-byte for equivalent args —
+a single ``ModelTestSelection.model_dump_json()`` line.
+
+Boundary discipline (root CLAUDE.md rule #7a + the OMN-14694 no-I/O-outside-EFFECT
+gate): every git-derived fact is resolved by the CALLER and passed in — the
+changed-file list (``--changed-files-from``) and the ``pyproject.toml``
+dependency-relevance classification (``--pyproject-relevant``). This mirrors the
+repo's own CI convention (e.g. ``canonical-inference-gate.yml`` runs ``git show``
+in the workflow step, then feeds a pure classifier), and keeps this COMPUTE node
+package free of ``subprocess``/git. The one pure classifier the caller needs,
+``classify_pyproject_dependency_relevant`` (in-memory TOML diff, no I/O), lives in
+:mod:`.selector_core` for reuse.
+
+The remaining boundary work here is read-only filesystem access the gate permits:
+reading the changed-file list, loading the adjacency YAML, and counting
+``test_*.py`` files. The pure ``NodeTestSelectorCompute`` handler receives only
+typed data. Selection is resolved in two passes: pass 1 determines the selected
+paths (independent of file volume), pass 2 counts ``test_*.py`` under exactly
+those paths and re-runs the node to size the volume-aware split count — mirroring
+the oracle, which computes ``selected`` first and then walks it.
+
+Usage::
+
+    python -m omnibase_core.nodes.node_test_selector_compute.runtime_test_selector \\
+        --changed-files-from changed.txt --ref-name my-branch [--event-name pull_request] \\
+        [--adjacency scripts/ci/test_selection_adjacency.yaml] [--feature-flag on] \\
+        [--pyproject-relevant on|off] [--repo-root .]
+
+Exit code: always 0 on a successful computation (the selection JSON is the product).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
+    ModelAdjacencyMap,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    ModelTestSelection,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection_request import (
+    ModelTestSelectionRequest,
+)
+from omnibase_core.nodes.node_test_selector_compute.handler import (
+    NodeTestSelectorCompute,
+)
+
+__all__ = ["main"]
+
+_DEFAULT_ADJACENCY_REL = "scripts/ci/test_selection_adjacency.yaml"
+
+# --pyproject-relevant token -> the node's pyproject_dependency_relevant value.
+# Absent (None) means "not classified" -> the node fails closed and escalates
+# when pyproject.toml is in the diff.
+_PYPROJECT_RELEVANT: dict[str, bool] = {"on": True, "off": False}
+
+
+def _load_adjacency(path: Path) -> ModelAdjacencyMap:
+    """YAML read boundary — parse the static adjacency map into its typed model."""
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return ModelAdjacencyMap.model_validate(raw)
+
+
+def _count_test_files(rel_path: str, repo_root: Path) -> int:
+    """Recursive ``test_*.py`` count beneath ``repo_root / rel_path`` (0 if absent)."""
+    directory = repo_root / rel_path
+    if not directory.is_dir():
+        return 0
+    return sum(1 for _ in directory.rglob("test_*.py"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="test-selector",
+        description=(
+            "Resolve change-aware test paths via the test_selector COMPUTE node "
+            "(OMN-14700)."
+        ),
+    )
+    parser.add_argument(
+        "--changed-files-from",
+        type=Path,
+        required=True,
+        help="Path to a file with one changed-file path per line.",
+    )
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--event-name", default="pull_request")
+    parser.add_argument(
+        "--adjacency",
+        type=Path,
+        default=None,
+        help=(f"Adjacency map YAML (default: <repo-root>/{_DEFAULT_ADJACENCY_REL})."),
+    )
+    parser.add_argument(
+        "--feature-flag",
+        choices=("on", "off"),
+        default="on",
+        help="When 'off', emit a FEATURE_FLAG_OFF full-suite selection regardless of changed files.",
+    )
+    parser.add_argument(
+        "--pyproject-relevant",
+        choices=("on", "off"),
+        default=None,
+        help=(
+            "Caller-supplied content-aware classification of a pyproject.toml change "
+            "('on' = a dependency-bearing table changed -> escalate; 'off' = "
+            "metadata-only -> do not escalate on pyproject.toml alone). Compute it "
+            "with selector_core.classify_pyproject_dependency_relevant over a base-vs-"
+            "head diff at the git boundary. When pyproject.toml is in the diff and "
+            "this is omitted, the selector fails closed and escalates."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used to read the adjacency map and count test files "
+        "(default: current working directory).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root: Path = args.repo_root
+    adjacency_path: Path = args.adjacency or (repo_root / _DEFAULT_ADJACENCY_REL)
+    adjacency = _load_adjacency(adjacency_path)
+
+    changed = [
+        line.strip()
+        for line in args.changed_files_from.read_text().splitlines()
+        if line.strip()
+    ]
+
+    pyproject_dependency_relevant: bool | None = (
+        _PYPROJECT_RELEVANT[args.pyproject_relevant]
+        if args.pyproject_relevant is not None
+        else None
+    )
+
+    node = NodeTestSelectorCompute()
+    feature_flag_enabled = args.feature_flag == "on"
+
+    def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
+        return ModelTestSelectionRequest(
+            changed_files=changed,
+            ref_name=args.ref_name,
+            adjacency=adjacency,
+            event_name=args.event_name,
+            feature_flag_enabled=feature_flag_enabled,
+            pyproject_dependency_relevant=pyproject_dependency_relevant,
+            test_file_counts=counts,
+        )
+
+    # Pass 1: selection (independent of test-file volume).
+    prelim = node.handle(_request({}))
+
+    # Pass 2: count test_*.py under exactly the selected paths and re-run so the
+    # volume-aware split count matches the oracle. Full-suite selections have a
+    # fixed 40-split shape, so counting is skipped there.
+    if prelim.is_full_suite:
+        selection: ModelTestSelection = prelim
+    else:
+        counts = {
+            path: _count_test_files(path, repo_root) for path in prelim.selected_paths
+        }
+        selection = node.handle(_request(counts))
+
+    sys.stdout.write(selection.model_dump_json())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 import math
 import tomllib
 
+from omnibase_core.enums.enum_full_suite_reason import EnumFullSuiteReason
 from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
     ModelAdjacencyMap,
 )
 from omnibase_core.models.nodes.test_selector.model_test_selection import (
-    EnumFullSuiteReason,
     ModelTestSelection,
 )
 

--- a/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pure change-aware test-selection algorithm (OMN-14700).
+
+Verbatim port of the deterministic logic in ``scripts/ci/detect_test_paths.py``
+into the canonical node layer, with ONE structural change required for purity:
+the volume-aware split count takes a caller-supplied ``test_file_counts`` map
+instead of walking the filesystem. Every escalation branch, its ordering, the
+path-count floor, and the ceil/threshold/cap arithmetic are unchanged, so this
+module reproduces the oracle byte-for-byte (proven by the differential test
+battery in ``tests/unit/nodes/node_test_selector_compute/``).
+
+No I/O, no clock, no global state — safe to run inside a COMPUTE handler.
+``detect_test_paths.py`` remains the frozen reference oracle until the CI +
+pre-push swap follow-up (OMN-14700 DoD 2/3) deletes it.
+"""
+
+from __future__ import annotations
+
+import math
+import tomllib
+
+from omnibase_core.models.nodes.test_selector.model_adjacency_map import (
+    ModelAdjacencyMap,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+__all__ = [
+    "PYPROJECT_PATH",
+    "VOLUME_MAX_SPLITS",
+    "VOLUME_TARGET_FILES_PER_SPLIT",
+    "VOLUME_THRESHOLD_FILES",
+    "classify_pyproject_dependency_relevant",
+    "compute_selection",
+    "path_count_floor",
+    "resolve_test_paths",
+    "split_count_from_total",
+    "volume_split_from_total",
+]
+
+SRC_PREFIX = "src/omnibase_core/"
+TEST_UNIT_PREFIX = "tests/unit/"
+
+FULL_SUITE_BRANCHES = frozenset({"main"})
+
+# pyproject.toml is handled content-aware (not as a bare path-prefix trigger).
+# See classify_pyproject_dependency_relevant / step 2 in compute_selection.
+PYPROJECT_PATH = "pyproject.toml"
+
+# Keys under [project] whose change is metadata-only — it cannot alter dependency
+# resolution, build inputs, or test behavior, so a diff confined to these must NOT
+# escalate to the full suite. Everything else in pyproject.toml (the `dependencies`
+# array, [project.optional-dependencies], [dependency-groups], [build-system],
+# [tool.*] including [tool.pytest.ini_options]/[tool.coverage], requires-python)
+# is treated as escalation-worthy. This is deliberately an allow-list of SAFE keys
+# (not a block-list of dependency tables): an unrecognized/new pyproject key
+# escalates by default, keeping the selector fail-closed.
+_PYPROJECT_SAFE_PROJECT_KEYS = frozenset(
+    {
+        "version",
+        "name",
+        "description",
+        "readme",
+        "authors",
+        "maintainers",
+        "keywords",
+        "classifiers",
+        "urls",
+        "license",
+        "license-files",
+        "entry-points",
+        "scripts",
+        "gui-scripts",
+    }
+)
+
+# Volume-aware split sizing (OMN-11026). Match main's ~40-files-per-split density
+# when smart-selection expands into large test directories; the path-count floor
+# still keeps small PRs cheap.
+VOLUME_TARGET_FILES_PER_SPLIT = 40
+VOLUME_THRESHOLD_FILES = 80
+VOLUME_MAX_SPLITS = 40
+
+
+def resolve_test_paths(
+    changed_files: list[str],
+    config: ModelAdjacencyMap,
+) -> list[str]:
+    """Map changed file paths to deterministic UNIT test directories.
+
+    Behavior:
+      - Source changes under src/omnibase_core/<module>: include
+        tests/unit/<module>/ plus the module's reverse-dep expansion.
+      - Test-only changes under tests/unit/: include the changed unit-test directory.
+      - Test-only changes under tests/integration/: ignored (integration runs always).
+      - Files outside src/ and tests/unit/: no contribution; the caller decides
+        whether to escalate to the full suite.
+    """
+    direct_modules: set[str] = set()
+    selected: set[str] = set()
+
+    for path in changed_files:
+        if path.startswith(SRC_PREFIX):
+            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
+            if module in config.adjacency:
+                direct_modules.add(module)
+        elif path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+
+    expanded: set[str] = set(direct_modules)
+    for module in direct_modules:
+        expanded.update(config.adjacency[module].reverse_deps)
+
+    for module in expanded:
+        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+
+    return sorted(selected)
+
+
+def compute_selection(
+    changed_files: list[str],
+    adjacency: ModelAdjacencyMap,
+    ref_name: str,
+    event_name: str = "pull_request",
+    feature_flag_enabled: bool = True,
+    pyproject_dependency_relevant: bool | None = None,
+    test_file_counts: dict[str, int] | None = None,
+) -> ModelTestSelection:
+    """Resolve the test selection for a change set — pure, deterministic.
+
+    ``pyproject_dependency_relevant`` carries the content-aware classification of a
+    ``pyproject.toml`` change (see ``classify_pyproject_dependency_relevant``):
+    ``True`` = a dependency-bearing table changed (escalate), ``False`` = the change
+    is metadata-only (do not escalate on ``pyproject.toml`` alone), ``None`` = not
+    classified. When ``pyproject.toml`` is in the change set and this is not
+    ``False`` (i.e. ``True`` or ``None``), the selector fails closed and escalates.
+
+    ``test_file_counts`` maps a selected test path to the recursive count of
+    ``test_*.py`` files beneath it (computed by the caller/EFFECT boundary). It is
+    consulted only on the smart-selection path to size the split count; an absent
+    entry counts as ``0`` (mirrors the oracle's skip-if-missing directory).
+    """
+    counts = test_file_counts or {}
+
+    # 0. Feature flag short-circuit: off → legacy 40-split full suite.
+    if not feature_flag_enabled:
+        return _full_suite(EnumFullSuiteReason.FEATURE_FLAG_OFF)
+
+    # 1. Branch / event escalation.
+    if ref_name in FULL_SUITE_BRANCHES:
+        return _full_suite(EnumFullSuiteReason.MAIN_BRANCH)
+    if event_name == "merge_group":
+        return _full_suite(EnumFullSuiteReason.MERGE_GROUP)
+    if event_name == "schedule":
+        return _full_suite(EnumFullSuiteReason.SCHEDULED)
+
+    # 2. Test infrastructure escalation.
+    for changed in changed_files:
+        if changed == PYPROJECT_PATH:
+            # Content-aware: pyproject.toml escalates only when a dependency-bearing
+            # table changed, OR when classification is unavailable (None) — fail
+            # closed. A bare `version` bump / entry-point registration / metadata
+            # edit must NOT force the full suite.
+            if pyproject_dependency_relevant is None or pyproject_dependency_relevant:
+                return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+            continue
+        if any(
+            changed == infra or changed.startswith(infra.rstrip("/") + "/")
+            for infra in adjacency.test_infrastructure_paths
+        ):
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
+    # 3. Shared module escalation.
+    changed_modules = {
+        path[len(SRC_PREFIX) :].split("/", 1)[0]
+        for path in changed_files
+        if path.startswith(SRC_PREFIX)
+    } & set(adjacency.adjacency.keys())
+    if changed_modules & set(adjacency.shared_modules):
+        return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
+
+    # 4. Threshold escalation: too many distinct modules.
+    if len(changed_modules) >= adjacency.thresholds.modules_changed_for_full_suite:
+        return _full_suite(EnumFullSuiteReason.THRESHOLD_MODULES)
+
+    # 5. Smart selection.
+    selected = resolve_test_paths(changed_files, adjacency)
+    if not selected:
+        # Conservative one-shard fallback over the full tests/unit/ tree. NOT a
+        # no-op — it runs the unit suite for changes with no unit-test mapping
+        # (doc-only, integration-only, low-signal metadata).
+        selected = ["tests/unit/"]
+    total = sum(counts.get(path, 0) for path in selected)
+    split_count = split_count_from_total(selected, total)
+
+    return ModelTestSelection(
+        selected_paths=selected,
+        split_count=split_count,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=list(range(1, split_count + 1)),
+    )
+
+
+def _full_suite(reason: EnumFullSuiteReason) -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=40,
+        is_full_suite=True,
+        full_suite_reason=reason,
+        matrix=list(range(1, 41)),
+    )
+
+
+def split_count_from_total(selected_paths: list[str], total_test_files: int) -> int:
+    """Volume-aware split count for a set of selected unit-test paths.
+
+    Combines the path-count floor (keeps small PRs cheap) with test-volume scaling
+    (a large expanded selection needs enough splits to fit the job timeout). The
+    final value is ``max(path_floor, volume_scaled)`` capped at ``VOLUME_MAX_SPLITS``
+    — identical to the oracle's ``_split_count_for``, but the file total is supplied
+    rather than walked.
+    """
+    path_floor = path_count_floor(len(selected_paths))
+    volume_scaled = volume_split_from_total(total_test_files)
+    return min(max(path_floor, volume_scaled), VOLUME_MAX_SPLITS)
+
+
+def path_count_floor(n: int) -> int:
+    """Original path-count heuristic, retained as a lower bound."""
+    if n <= 2:
+        return 1
+    if n <= 5:
+        return 2
+    if n <= 10:
+        return 3
+    if n <= 16:
+        return 4
+    return 5
+
+
+def volume_split_from_total(total_test_files: int) -> int:
+    """Scale splits by the number of selected test files.
+
+    Returns 0 when the count is below ``VOLUME_THRESHOLD_FILES`` — the caller then
+    falls back to the path-count floor. Mirrors the oracle's ``_volume_split_count``
+    (which returns 0 for a synthetic/absent path list), with the total supplied
+    instead of walked.
+    """
+    if total_test_files < VOLUME_THRESHOLD_FILES:
+        return 0
+    return math.ceil(total_test_files / VOLUME_TARGET_FILES_PER_SPLIT)
+
+
+def _pyproject_without_safe_keys(data: dict[str, object]) -> dict[str, object]:
+    """Return the parsed pyproject with metadata-only ``[project]`` keys removed."""
+    reduced = dict(data)
+    project = reduced.get("project")
+    if isinstance(project, dict):
+        reduced["project"] = {
+            key: value
+            for key, value in project.items()
+            if key not in _PYPROJECT_SAFE_PROJECT_KEYS
+        }
+    return reduced
+
+
+def classify_pyproject_dependency_relevant(
+    old_content: str | None,
+    new_content: str | None,
+) -> bool:
+    """Classify whether a ``pyproject.toml`` change should escalate to the full suite.
+
+    Returns ``True`` (escalate) when the change touches any escalation-worthy content
+    OR cannot be proven metadata-only. Returns ``False`` (safe to narrow) only when
+    both revisions parse as TOML and differ solely in metadata-only ``[project]``
+    keys (``version``, ``entry-points``, ``scripts``, ``urls``, ``description``, …).
+
+    Fail-closed by construction: missing base or head content, or a TOML parse
+    failure, all return ``True``. Pure — parses in-memory strings, no file I/O.
+    """
+    if old_content is None or new_content is None:
+        return True
+    try:
+        old_data = tomllib.loads(old_content)
+        new_data = tomllib.loads(new_content)
+    except tomllib.TOMLDecodeError:
+        return True
+    return _pyproject_without_safe_keys(old_data) != _pyproject_without_safe_keys(
+        new_data
+    )

--- a/tests/unit/nodes/node_test_selector_compute/__init__.py
+++ b/tests/unit/nodes/node_test_selector_compute/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Oracle-parity differential battery for node_test_selector_compute (OMN-14700).
+
+``scripts/ci/detect_test_paths.py`` IS the verified oracle. This suite asserts
+that the RSD-regenerated ``NodeTestSelectorCompute`` produces byte-for-byte
+identical ``ModelTestSelection`` output to the oracle across every representative
+change-set — single-module, shared-module, test-infra, scripts/ci, threshold,
+event/branch escalation, feature-flag-off, pyproject classification, reverse-dep
+expansion, empty, and (hermetically) the volume-scaling split path. A node that
+diverges on any case FAILS the RSD correctness gate.
+
+Parity is proven at the compute layer: both sides emit the SAME
+``ModelTestSelection`` class, so ``model_dump_json()`` equality is a true
+byte-for-byte comparison. The node is fed the identical per-path ``test_*.py``
+counts the oracle walks (via the oracle's own ``_count_test_files``), so the
+volume-aware split count is compared on equal footing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import scripts.ci.detect_test_paths as detect
+from omnibase_core.models.nodes.test_selector.model_test_selection import (
+    ModelTestSelection,
+)
+from omnibase_core.models.nodes.test_selector.model_test_selection_request import (
+    ModelTestSelectionRequest,
+)
+from omnibase_core.nodes.node_test_selector_compute.handler import (
+    NodeTestSelectorCompute,
+)
+from scripts.ci.detect_test_paths import _count_test_files, compute_selection
+from scripts.ci.test_selection_loader import load_adjacency_map
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+ADJ_MAP = load_adjacency_map(ADJ)
+
+
+def _node_selection(
+    changed_files: list[str],
+    ref_name: str,
+    repo_root: Path,
+    **kwargs: object,
+) -> ModelTestSelection:
+    """Two-phase node dispatch mirroring the runtime/oracle: select, then count.
+
+    Pass 1 resolves the selected paths (independent of volume); pass 2 counts
+    ``test_*.py`` under exactly those paths with the oracle's own helper and
+    re-runs the pure node to size the split. This is precisely what
+    ``runtime_test_selector.py`` does at the I/O boundary.
+    """
+    node = NodeTestSelectorCompute()
+
+    def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
+        return ModelTestSelectionRequest(
+            changed_files=changed_files,
+            ref_name=ref_name,
+            adjacency=ADJ_MAP,
+            test_file_counts=counts,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    prelim = node.handle(_request({}))
+    if prelim.is_full_suite:
+        return prelim
+    counts = {
+        path: _count_test_files([path], repo_root) for path in prelim.selected_paths
+    }
+    return node.handle(_request(counts))
+
+
+def _assert_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    changed_files: list[str],
+    ref_name: str,
+    *,
+    repo_root: Path = REPO_ROOT,
+    **kwargs: object,
+) -> ModelTestSelection:
+    """Assert node output == oracle output, byte-for-byte, for one change-set."""
+    # Pin the oracle's filesystem root so its internal _count_test_files walk and
+    # the node's injected counts are computed against the identical tree.
+    monkeypatch.setattr(detect, "REPO_ROOT", repo_root)
+    oracle = compute_selection(
+        changed_files=changed_files,
+        adjacency_path=ADJ,
+        ref_name=ref_name,
+        **kwargs,  # type: ignore[arg-type]
+    )
+    node = _node_selection(changed_files, ref_name, repo_root, **kwargs)
+    assert node.model_dump_json() == oracle.model_dump_json(), {
+        "changed_files": changed_files,
+        "ref_name": ref_name,
+        "kwargs": kwargs,
+        "node": node.model_dump(),
+        "oracle": oracle.model_dump(),
+    }
+    return node
+
+
+# =============================================================================
+# Representative change-set battery (task-required cases)
+# =============================================================================
+
+
+def test_parity_single_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["src/omnibase_core/cli/foo.py"], "pr-branch")
+    assert sel.is_full_suite is False
+    assert "tests/unit/cli/" in sel.selected_paths
+
+
+def test_parity_shared_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["src/omnibase_core/models/foo.py"], "pr-branch")
+    assert sel.is_full_suite is True
+    assert sel.full_suite_reason == "shared_module"
+
+
+def test_parity_test_infrastructure_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["tests/conftest.py"], "pr-branch")
+    assert sel.full_suite_reason == "test_infrastructure"
+
+
+def test_parity_scripts_ci_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["scripts/ci/detect_test_paths.py"], "pr-branch")
+    assert sel.full_suite_reason == "test_infrastructure"
+
+
+def test_parity_multi_module_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    changed = [
+        f"src/omnibase_core/{m}/x.py"
+        for m in (
+            "cli",
+            "constants",
+            "decorators",
+            "logging",
+            "merge",
+            "navigation",
+            "package",
+            "rendering",
+        )
+    ]
+    sel = _assert_parity(monkeypatch, changed, "pr-branch")
+    assert sel.full_suite_reason == "threshold_modules"
+
+
+def test_parity_empty_change_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, [], "pr-branch")
+    assert sel.is_full_suite is False
+    assert sel.selected_paths == ["tests/unit/"]
+
+
+def test_parity_main_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["src/omnibase_core/cli/x.py"], "main")
+    assert sel.full_suite_reason == "main_branch"
+
+
+def test_parity_merge_group_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(
+        monkeypatch,
+        ["src/omnibase_core/cli/x.py"],
+        "pr-branch",
+        event_name="merge_group",
+    )
+    assert sel.full_suite_reason == "merge_group"
+
+
+def test_parity_schedule_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(
+        monkeypatch,
+        ["src/omnibase_core/cli/x.py"],
+        "pr-branch",
+        event_name="schedule",
+    )
+    assert sel.full_suite_reason == "scheduled"
+
+
+def test_parity_feature_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(
+        monkeypatch,
+        ["src/omnibase_core/cli/x.py"],
+        "pr-branch",
+        feature_flag_enabled=False,
+    )
+    assert sel.full_suite_reason == "feature_flag_off"
+
+
+def test_parity_test_only_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(monkeypatch, ["tests/unit/nodes/test_foo.py"], "pr-branch")
+    assert sel.selected_paths == ["tests/unit/nodes/"] or sel.split_count >= 1
+
+
+def test_parity_integration_only_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    sel = _assert_parity(
+        monkeypatch, ["tests/integration/nodes/test_foo.py"], "pr-branch"
+    )
+    assert sel.selected_paths == ["tests/unit/"]
+
+
+def test_parity_protocols_reverse_dep_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sel = _assert_parity(
+        monkeypatch, ["src/omnibase_core/protocols/foo.py"], "pr-branch"
+    )
+    assert sel.is_full_suite is False
+
+
+def test_parity_mixins_real_tree_volume_scaling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # mixins -> [models, nodes] expansion against the real repo tree: the dominant
+    # volume-scaling case (the oracle's own regression). Parity here proves the
+    # node's injected-count split math matches the oracle's rglob walk.
+    sel = _assert_parity(
+        monkeypatch, ["src/omnibase_core/mixins/mixin_caching.py"], "pr-branch"
+    )
+    assert sel.is_full_suite is False
+    assert sel.matrix == list(range(1, sel.split_count + 1))
+
+
+# =============================================================================
+# pyproject.toml content-aware classification (compute-layer parity)
+# =============================================================================
+
+
+@pytest.mark.parametrize("relevant", [True, False, None])
+def test_parity_pyproject_classification(
+    monkeypatch: pytest.MonkeyPatch, relevant: bool | None
+) -> None:
+    _assert_parity(
+        monkeypatch,
+        ["pyproject.toml"],
+        "pr-branch",
+        pyproject_dependency_relevant=relevant,
+    )
+
+
+def test_parity_pyproject_metadata_only_with_shared_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A metadata-only pyproject bundled with a shared-module change must still
+    # escalate via SHARED_MODULE — precedence parity, not TEST_INFRASTRUCTURE.
+    sel = _assert_parity(
+        monkeypatch,
+        ["pyproject.toml", "src/omnibase_core/models/foo.py"],
+        "pr-branch",
+        pyproject_dependency_relevant=False,
+    )
+    assert sel.full_suite_reason == "shared_module"
+
+
+# =============================================================================
+# Hermetic volume-scaling parity across the threshold and cap
+# =============================================================================
+
+
+@pytest.mark.parametrize("n_files", [0, 79, 80, 120, 400, 2000])
+def test_parity_volume_split_across_thresholds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, n_files: int
+) -> None:
+    # Build a controlled tree so the volume-scaling branch is exercised
+    # deterministically at the boundary (below/at/above VOLUME_THRESHOLD_FILES and
+    # above the VOLUME_MAX_SPLITS cap). mixins expands to [models, nodes]; only
+    # mixins gets files, so the total equals n_files on both sides.
+    mixins_dir = tmp_path / "tests/unit/mixins"
+    mixins_dir.mkdir(parents=True)
+    for i in range(n_files):
+        (mixins_dir / f"test_v{i}.py").write_text("")
+    _assert_parity(
+        monkeypatch,
+        ["src/omnibase_core/mixins/mixin_caching.py"],
+        "pr-branch",
+        repo_root=tmp_path,
+    )

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI stdout parity: runtime_test_selector vs detect_test_paths (OMN-14700).
+
+The follow-up (OMN-14700 DoD 2/3) will point the CI job and the pre-push hook at
+``runtime_test_selector.main`` in place of ``detect_test_paths.main``. That swap
+is only safe if the two entrypoints emit identical stdout for identical args.
+This suite runs BOTH CLIs over the same change-sets, adjacency map, and repo root
+and asserts the emitted ``ModelTestSelection`` JSON line is byte-for-byte equal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+    main as node_main,
+)
+from scripts.ci.detect_test_paths import main as oracle_main
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+
+# Change-sets that need no git base-ref (no pyproject.toml classification), so the
+# CLIs are pure functions of the working tree + args.
+_CASES: list[tuple[str, list[str], list[str]]] = [
+    ("single_module", ["src/omnibase_core/cli/foo.py"], ["--ref-name", "pr-branch"]),
+    ("shared_module", ["src/omnibase_core/models/foo.py"], ["--ref-name", "pr-branch"]),
+    ("test_infra", ["tests/conftest.py"], ["--ref-name", "pr-branch"]),
+    ("empty", [], ["--ref-name", "pr-branch"]),
+    ("main_branch", ["src/omnibase_core/cli/x.py"], ["--ref-name", "main"]),
+    (
+        "feature_flag_off",
+        ["src/omnibase_core/cli/x.py"],
+        ["--ref-name", "pr-branch", "--feature-flag", "off"],
+    ),
+    (
+        "mixins_volume",
+        ["src/omnibase_core/mixins/mixin_caching.py"],
+        ["--ref-name", "pr-branch"],
+    ),
+    (
+        "merge_group",
+        ["src/omnibase_core/cli/x.py"],
+        ["--ref-name", "pr-branch", "--event-name", "merge_group"],
+    ),
+]
+
+
+def _changed_file(tmp_path: Path, changed: list[str]) -> Path:
+    p = tmp_path / "changed.txt"
+    p.write_text("\n".join(changed) + ("\n" if changed else ""))
+    return p
+
+
+@pytest.mark.parametrize(
+    ("name", "changed", "extra"), _CASES, ids=[c[0] for c in _CASES]
+)
+def test_cli_stdout_parity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    name: str,
+    changed: list[str],
+    extra: list[str],
+) -> None:
+    changed_file = _changed_file(tmp_path, changed)
+    common = [
+        "--changed-files-from",
+        str(changed_file),
+        "--adjacency",
+        str(ADJ),
+        "--repo-root",
+        str(REPO_ROOT),
+        *extra,
+    ]
+
+    oracle_rc = oracle_main(common)
+    oracle_out = capsys.readouterr().out
+
+    node_rc = node_main(common)
+    node_out = capsys.readouterr().out
+
+    assert oracle_rc == 0
+    assert node_rc == 0
+    assert node_out == oracle_out, {
+        "case": name,
+        "node": node_out,
+        "oracle": oracle_out,
+    }
+    # Sanity: the emitted line is valid ModelTestSelection JSON.
+    payload = json.loads(node_out)
+    assert set(payload) == {
+        "selected_paths",
+        "split_count",
+        "is_full_suite",
+        "full_suite_reason",
+        "matrix",
+    }
+
+
+def test_cli_emits_single_trailing_newline(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    changed_file = _changed_file(tmp_path, ["src/omnibase_core/cli/foo.py"])
+    rc = node_main(
+        [
+            "--changed-files-from",
+            str(changed_file),
+            "--adjacency",
+            str(ADJ),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--ref-name",
+            "pr-branch",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.endswith("\n")
+    assert not out.rstrip("\n").endswith("\n")  # exactly one trailing newline


### PR DESCRIPTION
## Summary

RSD-regenerates the governed impacted-test selector (`scripts/ci/detect_test_paths.py`, OMN-13973) into a canonical **def-B `NodeCompute`** per root CLAUDE.md rule #7a. Closes **OMN-14700** (DoD item 1; items 2–3 are the follow-up swap). Parent epic **OMN-2362** (WS8).

### RSD path used: convert-clean canonical-rewrite lane (NOT LLM generate_node)

`onex:generate_node` uses a non-deterministic LLM `BusinessLogicGenerator`, needs live Kafka/PG/Consul, and emits a non-canonical `./generated_nodes/` scaffold — structurally unable to satisfy a **byte-for-byte oracle-parity gate** on a port whose reference implementation already exists. This work therefore used the **convert-clean canonical-rewrite RSD lane** — the same lane that produced the WS8 sibling nodes (`node_no_utcnow_check_compute`, `node_no_env_fallbacks_check_compute`) — preserving the frozen deterministic logic verbatim with the original script as the independent verified oracle. This is the RSD path this epic uses to reduce the patent to practice; the LLM prompt-to-code lane was rejected on correctness grounds.

## What changed

**Canonical node** (`src/omnibase_core/nodes/node_test_selector_compute/`):
- `contract.yaml` — COMPUTE, `handler:NodeTestSelectorCompute`, `purity: pure`.
- `handler.py` — def-B `handle(request: ModelTestSelectionRequest) -> ModelTestSelection`. Stateless, deterministic, no I/O, no `ModelEventEnvelope`. Classified **canonical** by the OMN-14355 ratchet (`--full` OK, 16 nodes).
- `selector_core.py` — verbatim port of `compute_selection` + escalation precedence + volume-split arithmetic; the only structural change for purity is that the volume file-count is an **input** (`test_file_counts`) instead of a filesystem walk. `classify_pyproject_dependency_relevant` (pure, in-memory TOML diff) lives here for callers.
- `runtime_test_selector.py` — the stable entrypoint the follow-up CI/hook will call. Does only gate-permitted read-only FS access; every git-derived fact (changed-file list AND pyproject relevance) is resolved by the caller and passed in — matching the repo's own CI convention (git show in the workflow step + a pure classifier) and the new OMN-14694 no-I/O-outside-EFFECT gate.

**Promoted I/O shapes (reused, not forked — rule #7):** `ModelTestSelection` / `EnumFullSuiteReason` / `ModelAdjacencyMap` moved to `src/omnibase_core/models/nodes/test_selector/`; `ModelTestSelectionRequest` added. `scripts/ci/test_selection_{models,loader}.py` now **re-export** the promoted classes so `detect_test_paths.py` (the frozen oracle) and its tests keep working unchanged until the follow-up deletes the script.

## Verified oracle (mandatory RSD correctness gate)

`detect_test_paths.py` **is** the oracle. The differential battery asserts `node.model_dump_json() == oracle.model_dump_json()` **byte-for-byte** on every representative input:

| case | result |
|---|---|
| single-module | node == oracle |
| shared-module (`SHARED_MODULE`) | node == oracle |
| test-infra (`tests/conftest.py`) | node == oracle |
| scripts/ci (`TEST_INFRASTRUCTURE`) | node == oracle |
| multi-module (`THRESHOLD_MODULES`) | node == oracle |
| empty change-set | node == oracle |
| main branch / merge_group / schedule | node == oracle |
| feature-flag-off | node == oracle |
| pyproject relevance on / off / None | node == oracle |
| protocols reverse-dep expansion | node == oracle |
| mixins real-tree volume scaling | node == oracle |
| hermetic volume split (0/79/80/120/400/2000) | node == oracle |

Plus a CLI stdout parity suite (`runtime_test_selector` vs `detect_test_paths`, byte-for-byte). Live proof on the real tree: both emit `split_count:18` for a `mixins/` change.

## dod_evidence

- `uv run pytest tests/unit/nodes/node_test_selector_compute/` → **33 passed** (differential battery + CLI parity).
- `uv run pytest tests/unit/scripts/ci/` → **216 passed** (oracle unchanged; canonical-shape ratchet OK).
- `uv run pytest tests/unit/nodes tests/unit/test_entry_point_discovery.py tests/test_doctor/test_entry_points.py tests/unit/validation/test_contract_validator.py` → **782 passed**.
- `ruff format` / `ruff check` clean; `mypy src/omnibase_core/nodes/node_test_selector_compute/ .../models/nodes/test_selector/` clean.
- `pre-commit run --files <changed>` → all gates pass (incl. OMN-14694 no-I/O, OMN-14355 canonical-shape, dict-any, extra-forbid).
- Live: `python -m ...runtime_test_selector` output == `python -m scripts.ci.detect_test_paths` output.

## Scope / follow-ups

Node + oracle-parity tests + stable entrypoint only. **Not** in this PR (DoD 2/3, after this + #1451 merge): repoint the CI job + `prepush_smart_tests.sh` onto the node entrypoint (transparent substitution); burn down the `scripts_exceptions.yaml` `disposition: convert` entry; delete `detect_test_paths.py` and the re-export shims.

OCC evidence companion is intentionally **not** self-authored (no-self-authored-evidence rule); an independent emitter authors it.



Evidence-Ticket: OMN-14700
Evidence-Source: OCC#4291
Evidence-Commit: f71a34b97dfd2b44ccee20e3a889cf6851a76d83
Evidence-Head: 637b419f4d53ccd8e936716d9108010e4bc474cc
