### PR TITLE
feat(OMN-14665): triage 5 docstring-IP findings + self-wire ip/kafka/sqlite arch gates into core CI + pre-commit

### DIFF
--- a/.github/workflows/validator-no-direct-kafka-producer.yml
+++ b/.github/workflows/validator-no-direct-kafka-producer.yml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# No-direct-Kafka-producer arch gate [OMN-14659 / self-wired OMN-14665]
+#
+# Required status check context: "No Direct Kafka Producer Validator / validate"
+#
+# Rejects direct Kafka producer client usage (AIOKafkaProducer, KafkaProducer,
+# confluent_kafka, aiokafka via import, bare-name usage, or attribute access)
+# outside the shared publisher layer. The AST scan runs as a pure COMPUTE node
+# (node_no_direct_kafka_producer_check_compute) over explicit (path, source)
+# pairs; the paired EFFECT node (node_source_file_gather_effect) owns the
+# filesystem walk for the full-tree run. The SAME COMPUTE node backs the
+# check-no-direct-kafka-producer pre-commit hook, so local and CI verdicts
+# cannot drift (enforcement, not detection — CLAUDE.md Rule #5). Suppress a
+# false-positive symbol-name substring match with `# onex-allow-kafka-producer`.
+#
+# STANDALONE workflow with NO `needs:` (OMN-14666 / OMN-14668 lesson): a
+# cross-job dependency can SKIP the gate on an unrelated failure, opening a
+# skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
+# own evidence, never conditioned on another job's result.
+
+name: No Direct Kafka Producer Validator
+
+on:
+  push:
+    branches: [main, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+  UV_HTTP_TIMEOUT: "600"
+
+concurrency:
+  group: validator-no-direct-kafka-producer-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNI_RUNNER_SELECTOR_V1 — trusted events default to self-hosted omnibase-ci;
+    # pull_request defaults to ubuntu-latest (hosted, so fleet saturation can
+    # never cancel this gate and falsely skip it).
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests (COMPUTE + CLI runtime)
+        run: |
+          uv run pytest tests/unit/nodes/node_no_direct_kafka_producer_check_compute/ -v
+
+      # Blocking self-scan: this repo's src/ is clean against the rule (the 8
+      # pre-existing findings were all substring-match false positives on symbol
+      # names — ProtocolKafkaProducer* health-check types and this check's own
+      # Node/Model/Visitor class names — triaged with per-line
+      # # onex-allow-kafka-producer markers under OMN-14665). The same COMPUTE
+      # node backs the check-no-direct-kafka-producer pre-commit hook, so
+      # verdicts cannot drift.
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check \
+            --root src

--- a/.github/workflows/validator-no-hardcoded-ip.yml
+++ b/.github/workflows/validator-no-hardcoded-ip.yml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# No-hardcoded-internal-IP arch gate [OMN-14659 / self-wired OMN-14665]
+#
+# Required status check context: "No Hardcoded IP Validator / validate"
+#
+# Rejects hardcoded internal IP literals (192.168.x.x, 10.x.x.x, 172.16-31.x.x,
+# optionally http(s)-prefixed and port-suffixed) in Python/YAML source. The
+# per-line scan runs as a pure COMPUTE node (node_no_hardcoded_ip_check_compute)
+# over explicit (path, source) pairs; the paired EFFECT node
+# (node_source_file_gather_effect) owns the filesystem walk for the full-tree
+# run. The SAME COMPUTE node backs the check-no-hardcoded-ip pre-commit hook, so
+# local and CI verdicts cannot drift (enforcement, not detection — CLAUDE.md
+# Rule #5). Suppress a justified line with `# onex-allow-internal-ip`.
+#
+# STANDALONE workflow with NO `needs:` (OMN-14666 / OMN-14668 lesson): a
+# cross-job dependency can SKIP the gate on an unrelated failure, opening a
+# skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
+# own evidence, never conditioned on another job's result.
+
+name: No Hardcoded IP Validator
+
+on:
+  push:
+    branches: [main, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+  UV_HTTP_TIMEOUT: "600"
+
+concurrency:
+  group: validator-no-hardcoded-ip-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNI_RUNNER_SELECTOR_V1 — trusted events default to self-hosted omnibase-ci;
+    # pull_request defaults to ubuntu-latest (hosted, so fleet saturation can
+    # never cancel this gate and falsely skip it).
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests (COMPUTE + CLI runtime)
+        run: |
+          uv run pytest tests/unit/nodes/node_no_hardcoded_ip_check_compute/ -v
+
+      # Blocking self-scan: this repo's src/ is clean against the rule (the 5
+      # docstring-IP findings in model_handler_packaging.py were triaged to
+      # per-line # onex-allow-internal-ip markers under OMN-14665). The same
+      # COMPUTE node backs the check-no-hardcoded-ip pre-commit hook, so verdicts
+      # cannot drift.
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check \
+            --root src

--- a/.github/workflows/validator-no-raw-sqlite3.yml
+++ b/.github/workflows/validator-no-raw-sqlite3.yml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# No-raw-sqlite3 arch gate [OMN-14659 / self-wired OMN-14665]
+#
+# Required status check context: "No Raw Sqlite3 Validator / validate"
+#
+# Rejects raw sqlite3.connect() calls outside *_adapter.py definitions. Database
+# access must go through an injected adapter. The AST scan runs as a pure COMPUTE
+# node (node_no_raw_sqlite3_check_compute) over explicit (path, source) pairs;
+# the paired EFFECT node (node_source_file_gather_effect) owns the filesystem
+# walk for the full-tree run. The SAME COMPUTE node backs the check-no-raw-sqlite3
+# pre-commit hook, so local and CI verdicts cannot drift (enforcement, not
+# detection — CLAUDE.md Rule #5). Suppress a legitimate adapter-bootstrap call
+# site with `# di-ok`.
+#
+# STANDALONE workflow with NO `needs:` (OMN-14666 / OMN-14668 lesson): a
+# cross-job dependency can SKIP the gate on an unrelated failure, opening a
+# skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
+# own evidence, never conditioned on another job's result.
+
+name: No Raw Sqlite3 Validator
+
+on:
+  push:
+    branches: [main, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+  UV_HTTP_TIMEOUT: "600"
+
+concurrency:
+  group: validator-no-raw-sqlite3-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNI_RUNNER_SELECTOR_V1 — trusted events default to self-hosted omnibase-ci;
+    # pull_request defaults to ubuntu-latest (hosted, so fleet saturation can
+    # never cancel this gate and falsely skip it).
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests (COMPUTE + CLI runtime)
+        run: |
+          uv run pytest tests/unit/nodes/node_no_raw_sqlite3_check_compute/ -v
+
+      # Blocking self-scan: this repo's src/ is clean against the rule (the 1
+      # pre-existing finding — the zero-infra local-harness projection store,
+      # which IS an in-process adapter bootstrap owning its own connection by
+      # design, OMN-13420 — was triaged with the sanctioned # di-ok marker under
+      # OMN-14665). The same COMPUTE node backs the check-no-raw-sqlite3
+      # pre-commit hook, so verdicts cannot drift.
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check \
+            --root src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1300,19 +1300,58 @@ repos:
 
       # No localhost/hardcoded-endpoint fallback defaults (OMN-14659). Scoped to
       # src/ only, matching the check-no-utcnow precedent above — this repo's src/
-      # tree is currently clean against this check (verified 2026-07-16). The
-      # sibling no-hardcoded-ip / no-direct-kafka-producer / no-raw-sqlite3 nodes
-      # generated in the same ticket are intentionally NOT self-wired here: a
-      # full-tree run against src/ turns up pre-existing findings (docstring IP
-      # examples, ProtocolKafkaProducer* symbol names, a legitimate sqlite3
-      # harness) that would need triage/suppression before this repo's own gate
-      # could go green. They remain available as remote hooks
-      # (.pre-commit-hooks.yaml) and standalone CI entrypoints for other repos.
+      # tree is currently clean against this check (verified 2026-07-16).
       - id: check-no-env-fallbacks
         name: No Localhost/Hardcoded-Endpoint Fallbacks (OMN-14659)
         entry: env -u PYTHONPATH uv run python -m omnibase_core.nodes.node_no_env_fallbacks_check_compute.runtime_no_env_fallbacks_check
         language: system
         files: ^src/.*\.(py|sh|bash)$
+        pass_filenames: true
+        stages: [pre-commit]
+
+      # No hardcoded internal IP literals (OMN-14659, self-wired OMN-14665).
+      # The 5 pre-existing findings — illustrative RFC1918/RFC5737 example IPs in
+      # the model_handler_packaging.py docstrings (which DOCUMENT that IP-literal
+      # hosts are valid in artifact-reference URLs) — were triaged to per-line
+      # `# onex-allow-internal-ip` markers (not a blanket allowlist). src/ is now
+      # green (verified 2026-07-17). Scoped to src/ .py/.yaml, matching the
+      # remote hook's types_or. Suppress a justified line with:
+      # # onex-allow-internal-ip
+      - id: check-no-hardcoded-ip
+        name: No Hardcoded Internal IP Addresses (OMN-14659)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check
+        language: system
+        files: ^src/.*\.(py|ya?ml)$
+        pass_filenames: true
+        stages: [pre-commit]
+
+      # No direct Kafka producer usage outside the shared publisher layer
+      # (OMN-14659, self-wired OMN-14665). The 8 pre-existing findings were all
+      # false positives from the oracle's SUBSTRING match on symbol names
+      # (ProtocolKafkaProducer* health-check types, and this check's own
+      # Node/Model/Visitor class names) — triaged with the additive per-line
+      # `# onex-allow-kafka-producer` marker shipped in the same PR. src/ is now
+      # green (verified 2026-07-17).
+      - id: check-no-direct-kafka-producer
+        name: No Direct Kafka Producer Usage (OMN-14659)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check
+        language: system
+        files: ^src/.*\.py$
+        pass_filenames: true
+        stages: [pre-commit]
+
+      # No raw sqlite3.connect() outside *_adapter.py (OMN-14659, self-wired
+      # OMN-14665). The 1 pre-existing finding — the local-harness projection
+      # store (harness_projection_store_sqlite.py), which IS a zero-infra
+      # in-process adapter bootstrap that owns its own connection by design
+      # (OMN-13420) — was triaged with the sanctioned `# di-ok` marker. src/ is
+      # now green (verified 2026-07-17). Suppress a legitimate adapter-bootstrap
+      # call site with: # di-ok
+      - id: check-no-raw-sqlite3
+        name: No Raw sqlite3.connect() Outside Adapters (OMN-14659)
+        entry: env -u PYTHONPATH uv run python -m omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check
+        language: system
+        files: ^src/.*\.py$
         pass_filenames: true
         stages: [pre-commit]
 

--- a/src/omnibase_core/mixins/mixin_health_check.py
+++ b/src/omnibase_core/mixins/mixin_health_check.py
@@ -41,7 +41,7 @@ from omnibase_core.logging.logging_structured import (
 )
 from omnibase_core.models.health.model_health_status import ModelHealthStatus
 from omnibase_core.protocols.http import ProtocolHttpClient
-from omnibase_core.protocols.protocol_health_check_clients import (
+from omnibase_core.protocols.protocol_health_check_clients import (  # onex-allow-kafka-producer: ProtocolKafkaProducer* are health-check protocol type names, not direct producer clients
     ProtocolConnectionPool,
     ProtocolConnectionPoolWithConnection,
     ProtocolKafkaProducerAio,

--- a/src/omnibase_core/models/handlers/model_handler_packaging.py
+++ b/src/omnibase_core/models/handlers/model_handler_packaging.py
@@ -32,8 +32,8 @@ File Scheme Notes:
 
 IP Address Literals:
     IP addresses are ALLOWED in the netloc (host) portion of URLs:
-    - https://192.168.1.100:8080/path    - IPv4 address with port
-    - oci://10.0.0.5:5000/org/handler    - IPv4 in OCI reference
+    - https://192.168.1.100:8080/path    - IPv4 address with port  # onex-allow-internal-ip
+    - oci://10.0.0.5:5000/org/handler    - IPv4 in OCI reference  # onex-allow-internal-ip
     - registry://[2001:db8::1]:8443/path - IPv6 address (bracketed)
 
     Validation only checks URL structure, not IP format or reachability.
@@ -119,7 +119,7 @@ def _validate_artifact_reference(reference: str) -> tuple[bool, str]:
     - path is present when required by scheme
 
     IP Address Literal Handling:
-        IP address literals (e.g., 192.168.1.1, [::1]) are ALLOWED in the netloc
+        IP address literals (e.g., 192.168.1.1, [::1]) are ALLOWED in the netloc  # onex-allow-internal-ip
         (host) portion of URLs. This validation only checks that a netloc exists
         when required by the scheme; it does not validate the format or
         reachability of the host. IP addresses are valid hosts for artifact
@@ -129,8 +129,8 @@ def _validate_artifact_reference(reference: str) -> tuple[bool, str]:
         - Internal infrastructure with IP-based addressing
 
         Examples of valid URLs with IP addresses:
-        - https://192.168.1.100:8080/artifacts/handler.whl
-        - oci://10.0.0.5:5000/myorg/handler:v1.0.0
+        - https://192.168.1.100:8080/artifacts/handler.whl  # onex-allow-internal-ip
+        - oci://10.0.0.5:5000/myorg/handler:v1.0.0  # onex-allow-internal-ip
         - registry://[2001:db8::1]:8443/handlers/validator
 
         Domain name validation (format, TLD, etc.) is intentionally NOT performed

--- a/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/__init__.py
+++ b/src/omnibase_core/models/nodes/no_direct_kafka_producer_check/__init__.py
@@ -12,7 +12,7 @@ per-node fork. Import ``ModelValidationReport`` /
 is the shared (path, source) DTO — also not forked here.
 """
 
-from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (  # onex-allow-kafka-producer: this check's own input-model name contains the "KafkaProducer" substring; not a producer client
     ModelNoDirectKafkaProducerCheckInput,
 )
 

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/__init__.py
@@ -9,7 +9,7 @@ Exposes :class:`NodeNoDirectKafkaProducerCheckCompute` — AST-scans explicit
 outside the shared publisher layer, and returns a ``ModelValidationReport``.
 """
 
-from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (  # onex-allow-kafka-producer: this check's own node-class name contains the "KafkaProducer" substring; not a producer client
     NodeNoDirectKafkaProducerCheckCompute,
 )
 

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/handler.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/handler.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import ast
 from typing import Final, Literal
 
-from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (  # onex-allow-kafka-producer: this check's own input-model name contains the "KafkaProducer" substring; not a producer client
     ModelNoDirectKafkaProducerCheckInput,
 )
 from omnibase_core.models.validation.model_validation_finding import (
@@ -46,7 +46,7 @@ from omnibase_core.models.validation.model_validation_report import (
     ModelValidationReport,
     ModelValidationRequestRef,
 )
-from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.visitor_kafka_producer import (
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.visitor_kafka_producer import (  # onex-allow-kafka-producer: this check's own visitor-class name contains the "KafkaProducer" substring; not a producer client
     VALIDATOR_ID,
     DirectKafkaProducerVisitor,
     is_allowed_publisher_path,
@@ -104,6 +104,6 @@ class NodeNoDirectKafkaProducerCheckCompute:
                 )
             ]
 
-        visitor = DirectKafkaProducerVisitor(path)
+        visitor = DirectKafkaProducerVisitor(path, source.splitlines())
         visitor.visit(tree)
         return visitor.findings

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/runtime_no_direct_kafka_producer_check.py
@@ -37,7 +37,7 @@ import sys
 from pathlib import Path
 from typing import Final
 
-from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (
+from omnibase_core.models.nodes.no_direct_kafka_producer_check.model_no_direct_kafka_producer_check_input import (  # onex-allow-kafka-producer: this check's own input-model name contains the "KafkaProducer" substring; not a producer client
     ModelNoDirectKafkaProducerCheckInput,
 )
 from omnibase_core.models.nodes.no_utcnow_check.model_source_file import (
@@ -49,7 +49,7 @@ from omnibase_core.models.nodes.source_file_gather.model_source_file_gather_inpu
 from omnibase_core.models.validation.model_validation_report import (
     ModelValidationReport,
 )
-from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (
+from omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.handler import (  # onex-allow-kafka-producer: this check's own node-class name contains the "KafkaProducer" substring; not a producer client
     NodeNoDirectKafkaProducerCheckCompute,
 )
 from omnibase_core.nodes.node_source_file_gather_effect.handler import (
@@ -147,9 +147,9 @@ def main(argv: list[str] | None = None) -> int:
         files, read_errors = _gather_from_root(parsed.root)
 
     if read_errors:
-        print(
+        print(  # print-ok: CLI output
             f"ERROR: Failed to read {len(read_errors)} Python file(s):"
-        )  # print-ok: CLI output
+        )
         for read_error in read_errors:
             print(f"  {read_error}")  # print-ok: CLI output
         return 1

--- a/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/visitor_kafka_producer.py
+++ b/src/omnibase_core/nodes/node_no_direct_kafka_producer_check_compute/visitor_kafka_producer.py
@@ -14,6 +14,20 @@ Detects ``AIOKafkaProducer`` / ``KafkaProducer`` / ``confluent_kafka`` /
 attribute access (``kafka.KafkaProducer``) — except on files that are part of
 the shared publisher layer (matched by filename or parent-directory
 substring, exactly like the oracle).
+
+Line-level suppression (OMN-14665): a finding is dropped when its reported
+line carries the ``# onex-allow-kafka-producer`` marker. Findings are always
+reported at the AST node's ``lineno`` — for a multi-line ``from ... import (``
+that is the ``from`` line, which is exactly where the marker sits. This is the
+additive, opt-in
+per-line exemption the other WS8 arch gates already ship (``# di-ok`` for
+raw-sqlite3, ``# onex-allow-internal-ip`` for hardcoded-ip, ``# fallback-ok``
+for env-fallbacks). It is needed because the oracle's import check is a
+*substring* match on the symbol name, so a legitimate symbol that merely
+*contains* a forbidden token — e.g. the ``ProtocolKafkaProducerAio`` health-check
+protocol type, or this very node's own ``NodeNoDirectKafkaProducerCheckCompute``
+class — is a false positive that has no other escape hatch. A corpus line
+without the marker is unaffected, so oracle message/flag parity is preserved.
 """
 
 from __future__ import annotations
@@ -44,6 +58,9 @@ _FORBIDDEN_SYMBOLS: Final[tuple[str, ...]] = (
     "confluent_kafka",
     "aiokafka",
 )
+
+# Per-line suppression marker (OMN-14665) — see module docstring.
+_SUPPRESS_MARKER: Final[str] = "# onex-allow-kafka-producer"
 
 # Modules that are allowed to use these symbols — the shared publisher layer
 # (oracle ALLOWED_PATHS).
@@ -76,8 +93,9 @@ def is_allowed_publisher_path(path: str) -> bool:
 class DirectKafkaProducerVisitor(ast.NodeVisitor):
     """Walk an AST looking for direct Kafka producer client usage."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, source_lines: list[str] | None = None) -> None:
         self._path = path
+        self._source_lines = source_lines or []
         self.findings: list[ModelValidationFinding] = []
 
     def _check_name(self, name: str, lineno: int, context: str) -> None:
@@ -89,7 +107,24 @@ class DirectKafkaProducerVisitor(ast.NodeVisitor):
                 )
                 return
 
+    def _is_suppressed(self, lineno: int) -> bool:
+        """True if the finding's reported line carries the
+        ``# onex-allow-kafka-producer`` marker.
+
+        Every finding is reported at its AST node's ``lineno``; for a multi-line
+        ``from ... import (`` that is the ``from`` line, which is exactly where
+        the marker is placed. Only that line is consulted — deliberately NOT the
+        line above — so a marker can never leak onto an unrelated violation on
+        the following line.
+        """
+        return (
+            0 < lineno <= len(self._source_lines)
+            and _SUPPRESS_MARKER in self._source_lines[lineno - 1]
+        )
+
     def _add_finding(self, lineno: int, message: str) -> None:
+        if self._is_suppressed(lineno):
+            return
         self.findings.append(
             ModelValidationFinding(
                 validator_id=VALIDATOR_ID,

--- a/src/omnibase_core/runtime/harness/harness_projection_store_sqlite.py
+++ b/src/omnibase_core/runtime/harness/harness_projection_store_sqlite.py
@@ -32,7 +32,9 @@ class SqliteProjectionStore:
         self._path = path
         # check_same_thread=False so the single-process asyncio harness can reuse
         # the connection across the event-loop callback boundary.
-        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self._conn = sqlite3.connect(
+            path, check_same_thread=False
+        )  # di-ok: this IS the local-harness projection-store adapter bootstrap (zero-infra, in-process); it owns its own connection by design (OMN-13420)
         self._conn.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {self._TABLE} (

--- a/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_node_no_direct_kafka_producer_check_compute.py
+++ b/tests/unit/nodes/node_no_direct_kafka_producer_check_compute/test_node_no_direct_kafka_producer_check_compute.py
@@ -153,6 +153,54 @@ def test_non_publisher_layer_path_is_not_excluded() -> None:
 
 
 # =============================================================================
+# Per-line suppression marker (OMN-14665) — additive, opt-in exemption for a
+# symbol that merely *contains* a forbidden substring (e.g. the check's own
+# node/model class names, or a ProtocolKafkaProducer* health-check type).
+# =============================================================================
+
+
+def test_suppression_marker_on_finding_line_exempts_it() -> None:
+    report = _report(
+        "a.py",
+        "from x import ProtocolKafkaProducerAio  # onex-allow-kafka-producer: type name only\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_suppression_marker_on_from_line_covers_multiline_import() -> None:
+    # A multi-line ``from ... import (`` reports the finding at the ``from``
+    # line (node.lineno), so the marker on that line must suppress it.
+    report = _report(
+        "a.py",
+        "from x import (  # onex-allow-kafka-producer: type name only\n"
+        "    ProtocolKafkaProducerAio,\n"
+        ")\n",
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_suppression_marker_does_not_exempt_a_real_violation_elsewhere() -> None:
+    # The marker only exempts its own line — a genuine producer import on an
+    # unmarked line still flags.
+    report = _report(
+        "a.py",
+        "from x import ProtocolKafkaProducerAio  # onex-allow-kafka-producer: type name only\n"
+        "from aiokafka import AIOKafkaProducer\n",
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) >= 1
+    assert all(
+        "aiokafka" in f.message or "AIOKafkaProducer" in f.message
+        for f in report.findings
+    )
+
+
+# =============================================================================
 # SyntaxError handling
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Closes **OMN-14665**. Triages the three pre-existing finding classes that #1447 (OMN-14659) explicitly left un-self-wired, then wires all three WS8 arch ValidatorNode gates (`arch-no-hardcoded-ip`, `arch-no-direct-kafka-producer`, `arch-no-raw-sqlite3`) into omnibase_core's own `.pre-commit-config.yaml` + CI so core lints itself (CLAUDE.md Rule #5 — enforcement in-repo).

## Triage — per-line sanctioned annotations, never a blanket allowlist

- **arch-no-hardcoded-ip (5 findings)** — `models/handlers/model_handler_packaging.py` lines 35/36/122/132/133 are illustrative RFC1918/RFC5737 example IPs in docstrings that **document** that IP-literal hosts are valid in artifact-reference URL netlocs. Pure documentation, not config. Annotated each with `# onex-allow-internal-ip`. (The file's existing `# onex-allow-file-internal-ip` only covers the OMN-13294 private-ip gate; the ported OMN-14659 gate honors only the per-line marker.)
- **arch-no-direct-kafka-producer (8 findings)** — all false positives from the oracle's **substring** match on symbol names: `ProtocolKafkaProducer*` health-check protocol types and this check's own `Node`/`Model`/`Visitor` class names — none is a producer client. Added an **additive, opt-in** per-line `# onex-allow-kafka-producer` marker to the visitor (mirrors the raw-sqlite3 `# di-ok` mechanism; corpus lines carry no marker, so oracle flag/message parity is preserved) and annotated the 8 lines. New unit tests cover the marker (line-exact; deliberately does not leak onto the following line).
- **arch-no-raw-sqlite3 (1 finding)** — `runtime/harness/harness_projection_store_sqlite.py` is the zero-infra local-harness projection store, an in-process adapter bootstrap that owns its own connection by design (OMN-13420). Annotated with the sanctioned `# di-ok` marker.

## Wiring

- **`.pre-commit-config.yaml`**: added `check-no-hardcoded-ip` / `check-no-direct-kafka-producer` / `check-no-raw-sqlite3` hooks (scoped to `src/`, matching the `check-no-env-fallbacks` precedent); replaced the now-stale "intentionally NOT self-wired" comment.
- **`.github/workflows/`**: three STANDALONE, no-`needs:` validator workflows (OMN-14666/14668 skip-then-vacuous-green lesson) running each node's unit tests + a blocking `src/` self-scan, mirroring `validator-no-io-outside-effects.yml`. The **same** COMPUTE node backs the pre-commit hook and the CI self-scan, so local/CI verdicts cannot drift.
- Fixed a pre-existing `# print-ok` marker placement (opening line) in `runtime_no_direct_kafka_producer_check.py` that surfaced once the file was touched.

**Not** added to `required_status_checks` — that is a branch-protection mutation, out of scope for this (non-gated dev) lane. Operator/Codex can promote to required later.

## dod_evidence

- All three gates self-scan `src/` **green** (exit 0): hardcoded-ip, kafka-producer, raw-sqlite3.
- **58** validator-node unit tests pass, incl. 3 new `# onex-allow-kafka-producer` suppression tests.
- **105** `model_handler_packaging` + `mixin_health_check` unit tests pass.
- `ruff format` + `ruff check` clean; `mypy` clean on changed src; `pre-commit run --files <changed>` — all three new hooks report **Passed**, full run 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Evidence-Ticket: OMN-14665
Evidence-Source: OCC#4315
Evidence-Commit: fdd79e6a59dc2a5186d39d561f1c2ffdf390219d
Evidence-Head: 501ff50621e3df817c34ea7b5192d9068bd78628

