### PR TITLE
test(OMN-685): cover load_all on directory with only non-YAML files

### DIFF
--- a/tests/unit/runtime/test_file_registry.py
+++ b/tests/unit/runtime/test_file_registry.py
@@ -384,6 +384,30 @@ class TestFileRegistryDirectoryLoading:
         assert len(contracts) == 1
         assert isinstance(contracts[0], ModelRuntimeHostContract)
 
+    def test_load_all_only_non_yaml_files(
+        self,
+        tmp_path: Path,
+        file_registry: FileRegistry,
+    ) -> None:
+        """Test that load_all() returns [] for a directory with ONLY non-YAML files.
+
+        Distinct from test_load_all_empty_directory (no files at all) and
+        test_load_all_ignores_non_yaml_files (mixed YAML + non-YAML): here the
+        directory is populated exclusively with non-YAML files and no .yaml/.yml
+        file exists. load_all() must return an empty list, not error.
+        """
+        # Arrange - populate the directory with ONLY non-YAML files
+        (tmp_path / "readme.txt").write_text("This is not a YAML file")
+        (tmp_path / "config.json").write_text('{"key": "value"}')
+        (tmp_path / "script.py").write_text("print('hello')")
+        (tmp_path / "data.csv").write_text("col1,col2\n1,2\n")
+
+        # Act
+        contracts = file_registry.load_all(tmp_path)
+
+        # Assert - no YAML files means no registrations, and no error
+        assert contracts == []
+
     def test_load_all_handles_yml_extension(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Closes OMN-685.

Adds a single missing edge-case unit test to `tests/unit/runtime/test_file_registry.py`: `RuntimeFileRegistry.load_all` on a directory that contains **only** non-YAML files (no `.yaml`/`.yml` at all).

This case is genuinely absent. The sibling tests cover adjacent-but-distinct scenarios:
- `test_load_all_empty_directory` — directory with no files at all
- `test_load_all_ignores_non_yaml_files` — mixed directory (YAML + non-YAML)

The new `test_load_all_only_non_yaml_files` populates a directory exclusively with `.txt`/`.json`/`.py`/`.csv` files and asserts `load_all()` returns `[]` and does not raise. This matches the implementation in `src/omnibase_core/runtime/runtime_file_registry.py`, which globs only `*.yaml`/`*.yml`.

## Scope

Test-only, single-test addition. No product-source, contract, or runtime change. Not a prod/branch-protection/OCC-flip/settings surface.

## dod_evidence

- New test passes: `uv run pytest tests/unit/runtime/test_file_registry.py -k "only_non_yaml or non_yaml" -v` → 2 passed
- `uv run ruff format` / `uv run ruff check` → clean
- `uv run mypy tests/unit/runtime/test_file_registry.py` → Success: no issues found
- `pre-commit run --files tests/unit/runtime/test_file_registry.py` → exit 0 (all passed)

Evidence-Ticket: OMN-685
Evidence-Source: OCC#4326
Evidence-Commit: e69c88894809654f2f7008f6faa56dc76dc7cc93
Evidence-Head: d0ec1fd40ab94ec2e9a387f6110d9fddcf4188a9
