### PR TITLE
feat(OMN-14709): flip Product Readiness shadow reason-graph to ENFORCING (non-required)

### DIFF
--- a/.github/workflows/product-readiness-shadow.yml
+++ b/.github/workflows/product-readiness-shadow.yml
@@ -22,13 +22,20 @@
 #   2. This workflow NEVER references or triggers `call-occ-preflight.yml` and so
 #      mints NO OCC request. The authoritative OCC path is untouched and still
 #      runs from its own workflow exactly as before.
-#   3. REPORT-ONLY / NON-REQUIRED. The dev branch-protection required contexts
-#      (CI Summary, verify / verify, contract-validation, deploy-gate, etc.) are
-#      untouched — this workflow adds `product-readiness / evaluate` and
-#      `product-readiness-shadow / reason-graph` as NON-required shadow contexts
-#      and cannot wedge a merge. Making any of these required (or removing
-#      `occ-preflight` from any authoritative product jobs) is a separate
-#      operator-gated WS4 step; do NOT do it here.
+#   3. NON-REQUIRED (unchanged by WS4 step 1). The dev branch-protection required
+#      contexts (CI Summary, verify / verify, contract-validation, deploy-gate,
+#      etc.) are untouched — this workflow's `product-readiness / evaluate` and
+#      `product-readiness-shadow / reason-graph` contexts stay NON-required and
+#      cannot wedge a merge. As of OMN-14709 (WS4 step 1) the reason-graph job is
+#      ENFORCING: it exits NON-ZERO (RED conclusion) when the elected ROOT is a
+#      genuine PRODUCT defect (PRODUCT_FAILED — lint/typecheck/tests/coverage
+#      red), while non-product roots (RUNNER_INFRA / EVIDENCE_MISSING /
+#      GITHUB_API_OUTAGE / POLICY_HELD / DEPLOY_TRIGGER_FAILED) and a green head
+#      stay exit 0. Because the context remains NON-required, a red shadow REPORTS
+#      product-red parity but still cannot block merges. `product-readiness /
+#      evaluate` remains report_only (always green). Adding EITHER context to
+#      required_status_checks (or removing `occ-preflight` from any authoritative
+#      product jobs) is a separate operator-gated step; do NOT do it here.
 #
 # During the shadow window, the `product-readiness / evaluate` verdict is
 # compared against the OLD authoritative `CI Summary` outcome across live PR
@@ -169,12 +176,25 @@ jobs:
           }))
           PY
           )"
-          graph="$(python scripts/ci/product_reason_graph.py graph --facts-json "$facts" --summary 2> summary.md)"
+          # ENFORCING (OMN-14709, WS4 step 1): the reason-graph now exits non-zero
+          # when the elected ROOT is a genuine PRODUCT defect (PRODUCT_FAILED).
+          # Capture that exit code without aborting the step so the graph JSON and
+          # the job-summary annotation are always emitted, then propagate it as the
+          # job conclusion at the end. Non-product roots and a green head keep the
+          # script at exit 0. This workflow stays NON-required in branch protection,
+          # so a red conclusion REPORTS but cannot block a merge (red-side parity).
+          set +e
+          graph="$(python scripts/ci/product_reason_graph.py graph --facts-json "$facts" --summary --enforce 2> summary.md)"
+          graph_rc=$?
+          set -e
           echo "$graph"
           cat summary.md >> "$GITHUB_STEP_SUMMARY"
           root_kind="$(printf '%s' "$graph" | python -c 'import json,sys; r=json.load(sys.stdin)["root"]; print(r["kind"] if r else "READY")')"
           if [ "$root_kind" = "READY" ]; then
-            echo "::notice title=CI Reason Graph::READY — product dimension is green (report-only)"
+            echo "::notice title=CI Reason Graph::READY — product dimension is green"
+          elif [ "$graph_rc" -ne 0 ]; then
+            echo "::error title=CI Reason Graph::ROOT ${root_kind} — genuine product defect (enforcing; NON-required shadow, reports but does not block)"
           else
-            echo "::warning title=CI Reason Graph::ROOT ${root_kind} (report-only shadow; not merge-blocking)"
+            echo "::warning title=CI Reason Graph::ROOT ${root_kind} (non-product root; non-fatal)"
           fi
+          exit "$graph_rc"

--- a/scripts/ci/product_reason_graph.py
+++ b/scripts/ci/product_reason_graph.py
@@ -358,6 +358,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Also print a Markdown summary block to stderr.",
     )
+    p.add_argument(
+        "--enforce",
+        action="store_true",
+        help=(
+            "Exit non-zero when the elected ROOT is a genuine PRODUCT defect "
+            "(PRODUCT_FAILED: lint/typecheck/tests/coverage/change-detection red). "
+            "Non-product roots (GITHUB_API_OUTAGE, RUNNER_INFRA, POLICY_HELD, "
+            "EVIDENCE_MISSING, DEPLOY_TRIGGER_FAILED) and a READY/green head stay "
+            "exit 0 — they are not product defects and must not block a merge. "
+            "Without this flag the surface stays fully report-only (always exit 0)."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -374,7 +386,17 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(graph, sort_keys=True))
         if args.summary:
             print(_render_summary(graph), file=sys.stderr)
-        # Report-only: this surface never fails the check.
+        # Enforcement (OMN-14709, WS4 step 1): a genuine PRODUCT defect — the
+        # elected ROOT is PRODUCT_FAILED (lint/typecheck/tests/coverage/change-
+        # detection red) — exits non-zero so the (still NON-required) shadow check
+        # reports RED. Non-product roots stay non-fatal: infra/API/policy/evidence
+        # faults invalidate the *observability* of the product dimension rather
+        # than proving a product defect, so they must not gate a merge. A READY /
+        # green head has no root and exits 0. Without --enforce the surface stays
+        # fully report-only (always exit 0), preserving the WS1 classifier CLI.
+        root = graph["root"]
+        if args.enforce and root is not None and root["kind"] == PRODUCT_FAILED:
+            return 1
         return 0
 
     parser.error(f"unknown command: {args.command}")  # NoReturn — exits

--- a/tests/ci/test_product_reason_graph_omn14705.py
+++ b/tests/ci/test_product_reason_graph_omn14705.py
@@ -248,22 +248,121 @@ def test_synchronize_new_head_supersedes_receipt() -> None:
 
 
 # --------------------------------------------------------------------------
-# CLI surface — report-only, always exit 0.
+# CLI surface — default (no --enforce) stays fully report-only, always exit 0.
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_cli_graph_is_report_only_exit_zero_on_red() -> None:
-    facts = {"head_sha": _HEAD, "subchecks": {"tests": "failure"}}
-    proc = subprocess.run(
-        [sys.executable, str(_SCRIPT), "graph", "--facts-json", json.dumps(facts)],
+def _run_graph(facts: dict, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "graph",
+            "--facts-json",
+            json.dumps(facts),
+            *extra,
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
+
+
+@pytest.mark.unit
+def test_cli_graph_default_is_report_only_exit_zero_on_red() -> None:
+    # Without --enforce the surface is unchanged: a product-red head still exits 0.
+    facts = {"head_sha": _HEAD, "subchecks": {"tests": "failure"}}
+    proc = _run_graph(facts)
     assert proc.returncode == 0
     payload = json.loads(proc.stdout)
     assert payload["root"]["kind"] == PRODUCT_FAILED
+
+
+# --------------------------------------------------------------------------
+# ENFORCING (OMN-14709, WS4 step 1) — the load-bearing exit-code proof.
+#
+#   * a PRODUCT_FAILED root  -> exit NON-ZERO (genuine product defect; shadow RED)
+#   * a green head           -> exit 0
+#   * a non-product root      -> exit 0 (RUNNER_INFRA / EVIDENCE_MISSING / API /
+#                                        POLICY / DEPLOY are not product defects)
+# The JSON graph is still emitted on stdout in every case (enforcement rides on
+# the exit code, not on suppressing output).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "failing_check", ["change_detection", "lint", "typecheck", "tests", "coverage"]
+)
+def test_cli_enforce_exits_nonzero_on_product_failed_root(failing_check: str) -> None:
+    subchecks = _green_subchecks()
+    subchecks[failing_check] = "failure"
+    facts = {"head_sha": _HEAD, "subchecks": subchecks}
+    proc = _run_graph(facts, "--enforce")
+    assert proc.returncode != 0, proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["root"]["kind"] == PRODUCT_FAILED
+
+
+@pytest.mark.unit
+def test_cli_enforce_exits_zero_on_green_head() -> None:
+    facts = {"head_sha": _HEAD, "subchecks": _green_subchecks()}
+    proc = _run_graph(facts, "--enforce")
+    assert proc.returncode == 0, proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["root"] is None
+    assert payload["ready"] is True
+
+
+@pytest.mark.unit
+def test_cli_enforce_stays_zero_on_runner_infra_root() -> None:
+    # An unconfirmable product subcheck (skipped, no OCC-red explanation) roots as
+    # RUNNER_INFRA — an infra fault, not a product defect. Enforcement must NOT
+    # fail the check on it (it would block merges on flaky infra).
+    subchecks = dict.fromkeys(
+        ("change_detection", "lint", "typecheck", "tests", "coverage"), "skipped"
+    )
+    facts = {"head_sha": _HEAD, "subchecks": subchecks}
+    proc = _run_graph(facts, "--enforce")
+    assert proc.returncode == 0, proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["root"]["kind"] == RUNNER_INFRA
+
+
+@pytest.mark.unit
+def test_cli_enforce_stays_zero_on_evidence_missing_root() -> None:
+    # OCC eligibility red while product checks are skipped -> EVIDENCE_MISSING, a
+    # non-product root. Enforcement stays exit 0: absent evidence is not a product
+    # defect and the shadow must not block a merge on it.
+    subchecks = dict.fromkeys(
+        ("change_detection", "lint", "typecheck", "tests", "coverage"), "skipped"
+    )
+    facts = {"head_sha": _HEAD, "subchecks": subchecks, "occ_eligibility": "failure"}
+    proc = _run_graph(facts, "--enforce")
+    assert proc.returncode == 0, proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["root"]["kind"] == EVIDENCE_MISSING
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("facts", "expected_root"),
+    [
+        ({"gh_api": "5xx"}, GITHUB_API_OUTAGE),
+        ({"policy": "prod-hold"}, POLICY_HELD),
+        ({"deploy_trigger": "failure"}, DEPLOY_TRIGGER_FAILED),
+    ],
+)
+def test_cli_enforce_stays_zero_on_other_non_product_roots(
+    facts: dict, expected_root: str
+) -> None:
+    # API outage / policy hold / deploy-trigger failure are all non-product roots;
+    # enforcement leaves them exit 0 (green product dimension underneath).
+    merged = {"head_sha": _HEAD, "subchecks": _green_subchecks(), **facts}
+    proc = _run_graph(merged, "--enforce")
+    assert proc.returncode == 0, proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["root"]["kind"] == expected_root
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## OMN-14709 · WS4 step 1 — flip Product Readiness shadow to ENFORCING (non-required)

Closes OMN-14709.

### What
The `product-readiness-shadow` reason-graph job previously **always exited 0** (report-only), so its check conclusion was meaninglessly green even when the product dimension was red. This flips it to **ENFORCING while keeping the workflow NON-required**.

- `scripts/ci/product_reason_graph.py` gains an `--enforce` flag. With it, the `graph` command exits **non-zero iff the elected ROOT is `PRODUCT_FAILED`** (a genuine product defect: lint/typecheck/tests/coverage/change-detection red).
- **Non-product roots stay non-fatal (exit 0):** `GITHUB_API_OUTAGE`, `RUNNER_INFRA`, `POLICY_HELD`, `EVIDENCE_MISSING`, `DEPLOY_TRIGGER_FAILED`. These invalidate the *observability* of the product dimension rather than proving a product defect, so they must not gate a merge.
- A **READY / green** head has no root and exits 0.
- Without `--enforce` the surface stays fully report-only (always exit 0), preserving the existing WS1 classifier CLI.
- `.github/workflows/product-readiness-shadow.yml` reason-graph job now passes `--enforce`, captures the exit code without aborting (so the graph JSON + summary annotation are always emitted), and propagates it as the job conclusion.

### Shadow stays NON-required
No `required_status_checks` / branch-protection change in this PR. The `product-readiness-shadow / reason-graph` and `product-readiness / evaluate` contexts remain **NON-required**, so a red shadow **reports product-red parity but cannot block a merge**. That red-side parity is exactly the signal WS4 wants. `product-readiness / evaluate` remains `report_only` (always green).

### dod_evidence — exit-code fixture proof
Extended `tests/ci/test_product_reason_graph_omn14705.py` (27 tests pass) with the load-bearing exit-code assertions, driven through the real CLI (`subprocess`):

| facts input | `--enforce` exit |
| --- | --- |
| PRODUCT_FAILED root (change_detection/lint/typecheck/tests/coverage red) | **non-zero** (1) |
| green head | 0 |
| RUNNER_INFRA root (all subchecks skipped) | 0 |
| EVIDENCE_MISSING root (skipped + occ red) | 0 |
| GITHUB_API_OUTAGE / POLICY_HELD / DEPLOY_TRIGGER_FAILED root | 0 |
| default, no `--enforce`, red head | 0 (report-only preserved) |

Direct CLI demonstration:
```
PRODUCT_FAILED (tests red) + --enforce -> exit=1
GREEN + --enforce                      -> exit=0
RUNNER_INFRA (all skipped) + --enforce -> exit=0
EVIDENCE_MISSING (skipped+occ red)+enf -> exit=0
```

### Local gates
`uv run pytest tests/ci/test_product_reason_graph_omn14705.py` → 27 passed. `ruff format`/`ruff check` clean, `mypy --explicit-package-bases scripts/ci/product_reason_graph.py` clean, `actionlint` clean on the workflow. `pre-commit run --files <changed>`: all hooks green for the changed files; the only red is the `always_run` cross-repo `validate-deterministic-skill-routing` hook flagging a pre-existing `omniclaude/.../contract_sweep/SKILL.md` violation outside this diff (not triggered in GitHub CI — no sibling checkout).


Evidence-Ticket: OMN-14709
Evidence-Source: OCC#4329
Evidence-Commit: b294461459eabaab4703e37ea39a9afded51a931
Evidence-Head: 2d1c94eec2d1f6dbd4e276bc419367eefbeaa845
