### PR TITLE
fix(OMN-14711): arch-no-raw-sqlite3 detects sqlite3 submodule imports (false-negative fix)

### DIFF
--- a/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/visitor_raw_sqlite3.py
+++ b/src/omnibase_core/nodes/node_no_raw_sqlite3_check_compute/visitor_raw_sqlite3.py
@@ -88,6 +88,17 @@ class RawSqlite3Visitor(ast.NodeVisitor):
         for alias in node.names:
             if alias.name == _FORBIDDEN_MODULE:
                 self._sqlite3_aliases.add(alias.asname or alias.name)
+            elif alias.asname is None and alias.name.startswith(
+                f"{_FORBIDDEN_MODULE}."
+            ):
+                # ``import sqlite3.dbapi2`` (no asname) binds the root
+                # ``sqlite3`` name — importing a submodule also imports the
+                # parent package, so ``sqlite3.connect(...)`` is live. The
+                # alias.name is the dotted path, so an ``== sqlite3`` check
+                # alone would miss this. ``import sqlite3.dbapi2 as foo`` binds
+                # ``foo`` (the submodule, not the root), so the ``asname is
+                # None`` guard prevents a false positive there.
+                self._sqlite3_aliases.add(_FORBIDDEN_MODULE)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:

--- a/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_node_no_raw_sqlite3_check_compute.py
+++ b/tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_node_no_raw_sqlite3_check_compute.py
@@ -74,6 +74,47 @@ def test_must_flag_from_sqlite3_import_connect_as_alias() -> None:
 
 
 # =============================================================================
+# submodule import (OMN-14711) — ``import sqlite3.dbapi2`` (no asname) binds the
+# root ``sqlite3`` name, so ``sqlite3.connect(...)`` is live and MUST be flagged.
+# RED-proves the false-negative fix: without it, alias.name == "sqlite3.dbapi2"
+# never matched ``== "sqlite3"`` and the call evaded the gate.
+# =============================================================================
+
+
+def test_must_flag_sqlite3_connect_via_submodule_import() -> None:
+    report = _report(
+        "a.py", 'import sqlite3.dbapi2\nconn = sqlite3.connect("db.sqlite")\n'
+    )
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.severity == "FAIL"
+    assert finding.validator_id == "arch-no-raw-sqlite3"
+    assert finding.location == "a.py:2"
+
+
+def test_must_pass_submodule_import_with_asname_binds_submodule_not_root() -> None:
+    """``import sqlite3.dbapi2 as foo`` binds ``foo`` to the submodule, not the
+    root ``sqlite3`` name, so a bare ``foo.connect()`` is not a
+    ``sqlite3.connect`` call — no false positive (the ``asname is None`` guard)."""
+    report = _report("a.py", "import sqlite3.dbapi2 as foo\nconn = foo.connect()\n")
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+def test_di_ok_suppresses_submodule_import_violation() -> None:
+    """``# di-ok`` suppression is unchanged for the submodule-import path."""
+    report = _report(
+        "a.py", "import sqlite3.dbapi2\nconn = sqlite3.connect(path)  # di-ok\n"
+    )
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+# =============================================================================
 # must_pass corpus — every case MUST produce zero findings
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Closes OMN-14711.

`RawSqlite3Visitor.visit_Import` in `visitor_raw_sqlite3.py` only recorded the `sqlite3` alias when `alias.name == "sqlite3"` exactly. A submodule import binds the root `sqlite3` name in the namespace but sets `alias.name` to the dotted path — verified via ast: `import sqlite3.dbapi2` -> `alias.name = "sqlite3.dbapi2"`, `alias.asname = None`. Importing a submodule also imports the parent package, so a subsequent `sqlite3.connect(...)` is fully live yet evaded the `arch-no-raw-sqlite3` gate (false negative).

## Fix

Treat an import whose `alias.name` starts with `"sqlite3."` and carries no `asname` as binding the root `sqlite3` alias. The `asname is None` guard prevents a false positive on `import sqlite3.dbapi2 as foo`, which binds `foo` (the submodule), not the root `sqlite3` name. Only widens detection; `# di-ok` suppression and the `_adapter.py` filename exclusion are unchanged.

## Tests (RED-proven)

- `test_must_flag_sqlite3_connect_via_submodule_import` — `import sqlite3.dbapi2\nconn = sqlite3.connect(...)` MUST FAIL. **RED-proven**: with the fix stashed this test fails (`PASS` instead of `FAIL`); with the fix it passes.
- `test_must_pass_submodule_import_with_asname_binds_submodule_not_root` — `import sqlite3.dbapi2 as foo\nconn = foo.connect()` MUST PASS (no false positive).
- `test_di_ok_suppresses_submodule_import_violation` — `# di-ok` suppression still works on the submodule-import path.

## dod_evidence

- RED proof: `pytest -k submodule` with fix stashed → `test_must_flag_sqlite3_connect_via_submodule_import` FAILED (`assert 'PASS' == 'FAIL'`); with fix → all pass.
- Full file: `uv run pytest tests/unit/nodes/node_no_raw_sqlite3_check_compute/test_node_no_raw_sqlite3_check_compute.py` → 16 passed (run with `env -u PYTHONPATH` so the worktree src is used, not the canonical clone).
- `uv run mypy src/.../visitor_raw_sqlite3.py` → Success, no issues.
- `uv run ruff check` / `ruff format` → clean.
- `pre-commit run --files <both files>` → exit 0 (all gates Passed).

proof_class: code-only (validator unit-level RED/GREEN behavior verified locally).

Evidence-Ticket: OMN-14711
Evidence-Source: OCC#4337
Evidence-Commit: cab105b2b4dbea4cdb1cd272957de447ace52882
Evidence-Head: c595066581612a1fc67bf9981ff7422166ba300a
