### PR TITLE
fix(OMN-14713): reject invalid octets and require IP boundaries in arch-no-hardcoded-ip matcher

### DIFF
--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/matcher_hardcoded_ip.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/matcher_hardcoded_ip.py
@@ -12,6 +12,16 @@ Port of the module-level regex + scan loop in
 internal IP literals (``192.168.x.x``, ``10.x.x.x``, ``172.16-31.x.x``),
 optionally prefixed with ``http(s)://`` and suffixed with ``:port``, on any
 line that does not carry the ``# onex-allow-internal-ip`` suppression marker.
+
+OMN-14713 hardened the octet grammar against two false-positive classes the
+ported ``\\d{1,3}`` regex admitted: invalid octets (e.g. ``10.256.999.1`` and
+``10.999.0.0`` matched despite octets exceeding 255) and RFC1918 literals
+embedded in longer tokens (a digit- or letter-prefixed token such as
+``210.0.0.x`` or ``x10.0.0.x`` matched its inner ``10.*`` substring). Each
+octet is now bounded to ``0-255`` and the literal is anchored on
+non-word/non-dot boundaries. This strictly *narrows* matches, so the
+fail-closed gate keeps every real violation (all ``must_flag`` corpus cases
+still fire).
 """
 
 from __future__ import annotations
@@ -34,12 +44,25 @@ _REMEDIATION: Final[str] = (
 # Suppression marker: lines containing this comment are exempt.
 _SUPPRESS_MARKER: Final[str] = "onex-allow-internal-ip"
 
+# A single octet constrained to 0-255 (rejects invalid octets like 256/999 that
+# a bare ``\d{1,3}`` would otherwise admit).
+_OCTET: Final[str] = r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])"
+
 _IP_PATTERN: Final[re.Pattern[str]] = re.compile(
+    # Left boundary: the RFC1918 literal must not be preceded by a word char or
+    # dot, so an embedded substring (a digit- or letter-prefixed token whose
+    # tail happens to be a valid 10.* literal) is not flagged. The optional
+    # scheme sits inside the boundary so an http(s):// prefixed literal still
+    # matches.
+    r"""(?<![\w.])"""
     r"""(?:https?://)?"""
-    r"""(?:192\.168\.\d{1,3}\.\d{1,3}"""
-    r"""|10\.\d{1,3}\.\d{1,3}\.\d{1,3}"""
-    r"""|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})"""
-    r"""(?::\d+)?""",
+    rf"""(?:192\.168\.{_OCTET}\.{_OCTET}"""
+    rf"""|10\.{_OCTET}\.{_OCTET}\.{_OCTET}"""
+    rf"""|172\.(?:1[6-9]|2[0-9]|3[01])\.{_OCTET}\.{_OCTET})"""
+    r"""(?::\d+)?"""
+    # Right boundary: reject trailing word chars/dots so a valid IP prefix of a
+    # longer numeric token is not flagged.
+    r"""(?![\w.])""",
 )
 
 

--- a/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_node_no_hardcoded_ip_check_compute.py
+++ b/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_node_no_hardcoded_ip_check_compute.py
@@ -115,6 +115,70 @@ def test_must_pass_loopback() -> None:
 
 
 # =============================================================================
+# OMN-14713 false-positive corpus — invalid octets and embedded literals
+# must NOT flag (the matcher only narrows; the fail-closed gate is preserved).
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param('bad = "10.256.999.1"\n', id="octet-256-and-999"),
+        pytest.param('bad = "10.999.0.0"\n', id="octet-999"),
+        pytest.param('bad = "192.168.256.1"\n', id="192-168-third-octet-256"),
+        pytest.param('bad = "172.16.300.1"\n', id="172-16-octet-300"),
+    ],
+)
+def test_must_pass_invalid_octet_over_255(source: str) -> None:
+    """Octets > 255 are not valid IPs and must not be flagged (OMN-14713)."""
+    report = _report("a.py", source)
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param('x = "210.0.0.55"\n', id="digit-prefixed-inner-10.0.0.55"),
+        pytest.param('x = "x10.0.0.1"\n', id="word-prefixed-inner-10.0.0.1"),
+        pytest.param('x = "10.0.0.55.5"\n', id="dot-suffixed-trailing-octet"),
+        pytest.param('x = "192.168.1.1234"\n', id="digit-suffixed-last-octet"),
+    ],
+)
+def test_must_pass_rfc1918_literal_embedded_in_longer_token(source: str) -> None:
+    """RFC1918 literals embedded in a longer token must not flag (OMN-14713)."""
+    report = _report("a.py", source)
+
+    assert report.overall_status == "PASS"
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_message"),
+    [
+        pytest.param(
+            'host = "10.255.255.255"\n',
+            'a.py:1: host = "10.255.255.255"',
+            id="max-valid-octet-255",
+        ),
+        pytest.param(
+            'host = "172.16.0.255"\n',
+            'a.py:1: host = "172.16.0.255"',
+            id="172-16-boundary-octet-255",
+        ),
+    ],
+)
+def test_must_flag_valid_boundary_octet_255(source: str, expected_message: str) -> None:
+    """The 0-255 tightening must still flag genuine 255-octet IPs (OMN-14713)."""
+    report = _report("a.py", source)
+
+    assert report.overall_status == "FAIL"
+    assert len(report.findings) == 1
+    assert report.findings[0].message == expected_message
+
+
+# =============================================================================
 # Aggregation across multiple files
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes two false-positive classes in the `arch-no-hardcoded-ip` matcher (`_IP_PATTERN` in `node_no_hardcoded_ip_check_compute/matcher_hardcoded_ip.py`, shipped under OMN-14659). The ported regex used a bare `\d{1,3}` per octet with no left/right token boundary.

**Verified against the live (pre-fix) regex — both classes reproduced:**
1. **Invalid octets (>255) matched.** `10.256.999.1` and `10.999.0.0` were flagged despite not being valid IPs.
2. **Embedded literals matched.** `210.0.0.55` matched the inner `10.0.0.55`; a letter-prefixed token matched its inner `10.*` substring — a valid IP substring inside a longer numeric/word token was flagged.

## Change

- Each octet is now bounded to `0-255` via `(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])`.
- The RFC1918 literal is anchored on non-word/non-dot boundaries (`(?<![\w.])` … `(?![\w.])`). The optional `http(s)://` scheme sits inside the boundary so scheme-prefixed literals still match.

This **strictly narrows** matches, so the fail-closed gate keeps every real violation — all existing `must_flag` corpus cases still fire.

## Tests (RED-proven)

Added to the perturbation corpus in `test_node_no_hardcoded_ip_check_compute.py`:
- `test_must_pass_invalid_octet_over_255` — invalid octets (256/999/300) no longer flag.
- `test_must_pass_rfc1918_literal_embedded_in_longer_token` — digit/letter-prefixed and digit/dot-suffixed embedded literals no longer flag.
- `test_must_flag_valid_boundary_octet_255` — the 0-255 tightening still flags genuine 255-octet IPs (`10.255.255.255`, `172.16.0.255`).

All 8 new negative/boundary cases FAILED against the pre-fix regex and PASS against the fix; the original 12 `must_flag`/`must_pass` corpus cases remain green (26 tests in the node package pass).

## Scope / non-overlap

- No overlap with OMN-14069 (Tailscale/CGNAT range *addition* — a false-negative, different file set).
- No overlap with sibling OMN-14712 (scan-scope false-negative — tests/scripts unscanned).

## dod_evidence

- `uv run pytest tests/unit/nodes/node_no_hardcoded_ip_check_compute/` → 26 passed.
- `uv run ruff format`/`ruff check`/`mypy` on changed files → clean.
- `pre-commit run --files <matcher> <test>` → all hooks Passed (incl. "No Hardcoded Internal IP Addresses (OMN-14659)").
- Self-scan of the matcher source file → 0 violations (docstring/comments carry no matchable literal IPs).

Closes OMN-14713

Evidence-Ticket: OMN-14713
Evidence-Source: OCC#4337
Evidence-Commit: cab105b2b4dbea4cdb1cd272957de447ace52882
Evidence-Head: c595066581612a1fc67bf9981ff7422166ba300a
