### PR TITLE
fix(OMN-14712): scan multiple roots in no-hardcoded-ip check — close scripts/ scan-scope gap

### DIFF
--- a/.github/workflows/validator-no-hardcoded-ip.yml
+++ b/.github/workflows/validator-no-hardcoded-ip.yml
@@ -77,13 +77,26 @@ jobs:
         run: |
           uv run pytest tests/unit/nodes/node_no_hardcoded_ip_check_compute/ -v
 
-      # Blocking self-scan: this repo's src/ is clean against the rule (the 5
-      # docstring-IP findings in model_handler_packaging.py were triaged to
-      # per-line # onex-allow-internal-ip markers under OMN-14665). The same
-      # COMPUTE node backs the check-no-hardcoded-ip pre-commit hook, so verdicts
-      # cannot drift.
-      - name: Self-scan omnibase_core src/ (blocking)
+      # Blocking self-scan: this repo's src/ and scripts/ are clean against the
+      # rule (the 5 docstring-IP findings in model_handler_packaging.py were
+      # triaged to per-line # onex-allow-internal-ip markers under OMN-14665).
+      #
+      # Scope (OMN-14712): the ported oracle
+      # (omniclaude/scripts/validation/validate_no_hardcoded_ip.py) scans three
+      # top-level roots — src/, tests/, scripts/. The OMN-14659 port narrowed to
+      # src/ only, which was a scan-scope false-negative: a non-allowlisted
+      # hardcoded IP under tests/ or scripts/ passed CI. The runtime now accepts
+      # multiple --root values, so we close the scripts/ hole here. tests/ is
+      # deliberately NOT scanned yet: it carries ~155 legitimate IP *fixtures*
+      # (the detector's own acceptance corpus + rate-limit / session-context /
+      # service-discovery model tests) that need per-line # onex-allow-internal-ip
+      # triage first — tracked as a follow-up so this required gate stays green.
+      # Add `tests` to --root below once that triage lands.
+      #
+      # The same COMPUTE node backs the check-no-hardcoded-ip pre-commit hook, so
+      # verdicts cannot drift.
+      - name: Self-scan omnibase_core src/ + scripts/ (blocking)
         run: |
           env -u PYTHONPATH uv run python -m \
             omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check \
-            --root src
+            --root src scripts

--- a/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/runtime_no_hardcoded_ip_check.py
+++ b/src/omnibase_core/nodes/node_no_hardcoded_ip_check_compute/runtime_no_hardcoded_ip_check.py
@@ -13,22 +13,32 @@ Two modes:
 
 * **pre-commit** (explicit filenames): the staged files pre-commit hands us
   are read directly here — no directory walk needed.
-* **full-tree** (no filenames — CI / manual ``python -m ...``): walks
+* **full-tree** (no filenames — CI / manual ``python -m ...``): walks each
   ``--root`` (default ``src``) via the paired ``node_source_file_gather_effect``
   EFFECT node for ``*.py``/``*.yaml``/``*.yml`` files, reproducing the oracle
   CI gate's file-type scope
   (``omniclaude/scripts/validation/validate_no_hardcoded_ip.py``).
 
-  The oracle additionally scans ``tests/`` and ``scripts/`` as separate top-level
-  roots (this repo's ``ModelSourceFileGatherInput`` walks a single ``root``);
-  pass ``--root`` explicitly for a non-``src`` scan when porting this
-  entrypoint into another repo's CI.
+  ``--root`` accepts **multiple** top-level roots (``nargs="+"``) — the oracle
+  scanned three (``src``/``tests``/``scripts``); scanning only ``src`` was a
+  scan-scope false-negative in which a non-allowlisted hardcoded IP under
+  ``tests/`` or ``scripts/`` passed CI (OMN-14712). Each root is gathered
+  independently (``ModelSourceFileGatherInput`` walks a single ``root``) and the
+  eligible files are unioned before the pure COMPUTE dispatch. A non-existent
+  root (e.g. ``scripts`` in a repo without one) gathers zero files rather than
+  erroring, so the same invocation ports cleanly across repos.
+
+  The omnibase_core CI self-scan currently passes ``--root src scripts`` (both
+  clean). ``tests`` is not yet in the CI scope: it carries ~155 legitimate IP
+  *fixtures* (this validator's own acceptance corpus among them) that need
+  per-line ``# onex-allow-internal-ip`` triage before the required gate can scan
+  it green — tracked as a follow-up to OMN-14712.
 
 Usage::
 
     python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check file1.py file2.yaml
     python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check
-    python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check --root src
+    python -m omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check --root src tests scripts
 
 Exit codes: 0 — ``overall_status == "PASS"``; 1 — FAIL findings present.
 
@@ -63,7 +73,7 @@ from omnibase_core.nodes.node_source_file_gather_effect.handler import (
 
 __all__ = ["main"]
 
-_DEFAULT_ROOT: Final[str] = "src"
+_DEFAULT_ROOTS: Final[tuple[str, ...]] = ("src",)
 _SCANNED_SUFFIXES: Final[tuple[str, ...]] = (".py", ".yaml", ".yml")
 
 
@@ -90,25 +100,35 @@ def _gather_from_filenames(
     return files, read_errors
 
 
-def _gather_from_root(root: str) -> tuple[list[ModelSourceFile], list[str]]:
+def _gather_from_roots(roots: list[str]) -> tuple[list[ModelSourceFile], list[str]]:
     """Full-tree walk mode (CI / manual), reusing ``node_source_file_gather_effect``.
 
     This is the EFFECT boundary — the only filesystem walk in this module —
-    delegated to the paired canonical node rather than re-implemented here.
+    delegated to the paired canonical node rather than re-implemented here. Each
+    root is gathered independently (the EFFECT node walks a single ``root``) and
+    the eligible files are unioned so the CI self-scan can cover ``src``,
+    ``tests``, and ``scripts`` in one invocation (OMN-14712). A non-existent
+    root gathers zero files rather than erroring, so a repo without a
+    ``scripts/`` dir still passes the same command line.
     """
-    output = NodeSourceFileGatherEffect().handle(
-        ModelSourceFileGatherInput(
-            root=root, include_patterns=["**/*.py", "**/*.yaml", "**/*.yml"]
+    files: list[ModelSourceFile] = []
+    read_errors: list[str] = []
+    effect = NodeSourceFileGatherEffect()
+    for root in roots:
+        output = effect.handle(
+            ModelSourceFileGatherInput(
+                root=root, include_patterns=["**/*.py", "**/*.yaml", "**/*.yml"]
+            )
         )
-    )
-    read_errors = [
-        f"{skipped.path}: {skipped.reason}"
-        for skipped in output.skipped
-        if skipped.reason.startswith(("read error:", "error checking file size:"))
-    ]
-    return [
-        ModelSourceFile(path=f.path, source=f.source) for f in output.files
-    ], read_errors
+        read_errors.extend(
+            f"{skipped.path}: {skipped.reason}"
+            for skipped in output.skipped
+            if skipped.reason.startswith(("read error:", "error checking file size:"))
+        )
+        files.extend(
+            ModelSourceFile(path=f.path, source=f.source) for f in output.files
+        )
+    return files, read_errors
 
 
 def _run(files: list[ModelSourceFile]) -> ModelValidationReport:
@@ -141,10 +161,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--root",
-        default=_DEFAULT_ROOT,
+        nargs="+",
+        default=list(_DEFAULT_ROOTS),
+        metavar="ROOT",
         help=(
-            "Root directory for a full-tree walk when no filenames are given "
-            f"(default: {_DEFAULT_ROOT})"
+            "One or more root directories for a full-tree walk when no "
+            "filenames are given. Each root is walked independently and the "
+            "eligible files are unioned. Non-existent roots gather zero files "
+            f"(default: {' '.join(_DEFAULT_ROOTS)})"
         ),
     )
     parsed = parser.parse_args(argv)
@@ -152,7 +176,7 @@ def main(argv: list[str] | None = None) -> int:
     if parsed.filenames:
         files, read_errors = _gather_from_filenames([Path(f) for f in parsed.filenames])
     else:
-        files, read_errors = _gather_from_root(parsed.root)
+        files, read_errors = _gather_from_roots(parsed.root)
 
     if read_errors:
         print(

--- a/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_runtime_no_hardcoded_ip_check.py
+++ b/tests/unit/nodes/node_no_hardcoded_ip_check_compute/test_runtime_no_hardcoded_ip_check.py
@@ -99,3 +99,63 @@ def test_main_full_tree_mode_empty_root_passes(
 
     assert exit_code == 0
     assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out
+
+
+def test_main_multi_root_detects_violation_outside_src(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """RED-proof for OMN-14712: a hardcoded IP under a non-``src`` root (e.g.
+    ``tests``) must be caught when that root is passed. Scanning ``src`` only
+    was the scan-scope false-negative this fix closes."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "clean.py").write_text('BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n')
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_bad.py").write_text('BROKER = "192.168.86.201"\n')
+
+    # src-only: the tests/ violation is invisible (proves the prior blind spot).
+    assert main(["--root", str(src)]) == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out
+
+    # src + tests: the same violation is now caught.
+    exit_code = main(["--root", str(src), str(tests)])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "ERROR: 1 hardcoded internal IP(s) found:" in out
+    assert "test_bad.py" in out
+    assert "192.168.86.201" in out
+
+
+def test_main_multi_root_all_clean_passes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text('BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n')
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_a.py").write_text('public_dns = "8.8.8.8"\n')
+
+    exit_code = main(["--root", str(src), str(tests)])
+
+    assert exit_code == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out
+
+
+def test_main_multi_root_tolerates_missing_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A non-existent root (e.g. ``scripts`` in a repo without one) gathers zero
+    files rather than erroring, so the same ``--root src tests scripts`` command
+    line ports across repos."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text('BROKER = os.environ["KAFKA_BOOTSTRAP_SERVERS"]\n')
+    missing = tmp_path / "scripts"  # never created
+
+    exit_code = main(["--root", str(src), str(missing)])
+
+    assert exit_code == 0
+    assert "OK: No hardcoded internal IPs found" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

`node_no_hardcoded_ip_check_compute`'s CLI runtime (`runtime_no_hardcoded_ip_check.py`, shipped under OMN-14659) took a single `--root` (default `src`), and the **required** `validator-no-hardcoded-ip.yml` full-tree self-scan invoked it with `--root src` only. The ported oracle (`omniclaude/scripts/validation/validate_no_hardcoded_ip.py`) scans **three** top-level roots — `src/` + `tests/` + `scripts/`. Net effect: a non-allowlisted hardcoded internal IP under `tests/` or `scripts/` passed CI — a scan-scope false-negative in an arch gate.

Closes OMN-14712.

## Changes

- **`runtime_no_hardcoded_ip_check.py`** — `--root` now accepts multiple roots (`nargs="+"`, default `["src"]`). Each root is gathered independently via the paired `node_source_file_gather_effect` EFFECT node and the eligible files are unioned before the pure COMPUTE dispatch. A non-existent root (e.g. `scripts` in a repo without one) gathers zero files rather than erroring, so the same command line ports cleanly across repos.
- **`.github/workflows/validator-no-hardcoded-ip.yml`** — self-scan now passes `--root src scripts`. Both roots verified clean (exit 0).
- **`test_runtime_no_hardcoded_ip_check.py`** — three new RED-proof tests: a violation under a non-`src` root is detected (and invisible when only `src` is scanned — proving the prior blind spot), multi-root over clean dirs passes, and a missing root is tolerated.

## Why `tests/` is not in the CI scan (yet)

A full-tree scan of `omnibase_core/tests/` surfaces **~155** hardcoded internal-IP findings — almost all **legitimate test fixtures**: this validator's own acceptance corpus (which must contain IP literals to test the detector) plus rate-limit / session-context / service-discovery / permission model tests that use example RFC1918 IPs as input data. Flipping the required gate to scan `tests/` today would wedge every core PR. That triage (per-line `# onex-allow-internal-ip` per CLAUDE.md Rule #6) is tracked as follow-up **OMN-14715**; the runtime already supports it via `--root src tests scripts` once the fixtures are annotated. `src/` and `scripts/` are clean today, so this PR closes the `scripts/` hole immediately while keeping the gate green.

## dod_evidence (OMN-14712)

Local gates (worktree `OMN-14712/omnibase_core`, off `origin/dev` @ 74da2365):

```
uv run pytest tests/unit/nodes/node_no_hardcoded_ip_check_compute/ -v   → 19 passed
uv run mypy .../runtime_no_hardcoded_ip_check.py                        → Success: no issues found
uv run ruff check <changed files>                                       → All checks passed
uv run ruff format --check <changed files>                              → 2 files already formatted
pre-commit run --files <changed files>                                  → all hooks Passed (incl. "No Hardcoded Internal IP Addresses")
self-scan --root src scripts                                            → OK: No hardcoded internal IPs found (exit 0)
self-scan --root scripts                                                → OK (exit 0)   |   --root tests → 155 findings (tracked: OMN-14715)
```

`gh pr checks` green required before merge (Codex owns the queue — this PR is not self-merged).

Evidence-Ticket: OMN-14712
Evidence-Source: OCC#4337
Evidence-Commit: cab105b2b4dbea4cdb1cd272957de447ace52882
Evidence-Head: c595066581612a1fc67bf9981ff7422166ba300a
