### PR TITLE
feat(OMN-14719): net-new transport protocol + ModelTransportMessage in core (unused foundation)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -36,6 +36,12 @@
 [importlinter]
 root_packages =
     omnibase_core
+# Required so the `core-no-kafka-transport` forbidden contract (invariant I2,
+# OMN-14719) can name external packages (aiokafka / confluent_kafka / omnibase_infra):
+# import-linter mandates this at the top level when any contract forbids external
+# modules. It adds external packages that core actually imports as leaf nodes; it does
+# not affect the intra-core forbidden/ratchet contracts (they name only omnibase_core.*).
+include_external_packages = True
 
 [importlinter:contract:core-foundation-no-upward]
 name = Foundation primitives must not import higher layers (direct)
@@ -125,3 +131,39 @@ ignore_imports =
     # regenerates these modules canonically (dissolving the protocols<->models cycle),
     # after which this line + the ratchet are deleted. The set only SHRINKS.
     omnibase_core.protocols.** -> omnibase_core.models.**
+
+[importlinter:contract:core-no-kafka-transport]
+name = Core must not import Kafka transport (aiokafka/confluent_kafka/omnibase_infra) — invariant I2
+# Invariant I2 of the single-runtime / transport-via-DI unification (epic OMN-14717,
+# ticket OMN-14719, plan 2026-07-17-single-runtime-transport-di-unification-plan.md).
+#
+# The target architecture puts the ONE runtime in omnibase_core and the concrete
+# Kafka transport in omnibase_infra, injected inward via the ProtocolTransport*
+# abstractions. Dependency inversion therefore REQUIRES that core never import Kafka
+# (aiokafka / confluent_kafka) nor reach "up" into omnibase_infra — that is what keeps
+# the compat <- core <- spi <- infra layering true. This contract is the mechanical
+# guard for that invariant.
+#
+# It is currently VACUOUS (grimp confirms core imports neither aiokafka,
+# confluent_kafka, nor omnibase_infra statically) — that is expected: it is the fence
+# that keeps the target true as the runtime moves into core, not a fix for a present
+# violation.
+#
+# `include_external_packages` is required so grimp records imports of the external
+# aiokafka / confluent_kafka / omnibase_infra packages. grimp attributes an external
+# import to its TOP-LEVEL package, so `omnibase_infra` (not the .event_bus.event_bus_kafka
+# submodule the plan names) is the checkable granularity — and forbidding all of
+# omnibase_infra is the stronger, layering-correct fence.
+#
+# Plan-declared deferred exception (I2): src/omnibase_core/cli/cli_run_node.py loads
+# confluent_kafka via importlib.import_module("confluent_kafka") (a DYNAMIC import).
+# grimp's static graph does not see dynamic importlib calls, so this contract stays
+# green without an ignore entry; cli_run_node.py is re-expressed over
+# ProtocolTransportProducer in a follow-up (plan step S11).
+type = forbidden
+source_modules =
+    omnibase_core
+forbidden_modules =
+    aiokafka
+    confluent_kafka
+    omnibase_infra

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -42,6 +42,9 @@ from omnibase_core.models.runtime.model_runtime_skill_response import (
 from omnibase_core.models.runtime.model_runtime_target_selector import (
     ModelRuntimeTargetSelector,
 )
+from omnibase_core.models.runtime.model_transport_message import (
+    ModelTransportMessage,
+)
 from omnibase_core.models.runtime.payloads import (
     ModelCancelExecutionPayload,
     ModelDelayUntilPayload,
@@ -67,6 +70,7 @@ __all__ = [
     "ModelRuntimeAddress",
     "ModelRuntimeAddressRegistry",
     "ModelRuntimeTargetSelector",
+    "ModelTransportMessage",
     # Aliveness probe contract (Wave 3)
     "ModelRuntimeAlivenessProbeCommand",
     "ModelRuntimeAlivenessProbeReceipt",

--- a/src/omnibase_core/models/runtime/model_transport_message.py
+++ b/src/omnibase_core/models/runtime/model_transport_message.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical transport-message model for the unified runtime dispatch loop.
+
+Net-new, currently UNUSED foundation for the single-runtime / transport-via-DI
+unification (epic OMN-14717, ticket OMN-14719; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` section
+(c)). Nothing consumes this yet — it is reversible foundation with zero production
+behavior change.
+
+``ModelTransportMessage`` is the transport-agnostic wire message that the pull-based
+``ProtocolTransportConsumer`` yields and that the runtime commits / nacks. It carries
+per-partition identity (``partition`` + ``offset``) because the runtime's
+per-partition contiguous-prefix commit (plan HOLE 1) and the in-memory transport's
+monotonic per-``(topic, group, partition)`` offset cursor (plan HOLE 2) both need to
+group a poll batch by partition and order by offset. The commit/redeliver *actuation*
+coordinate stays opaque in ``ack_token`` — the runtime never interprets it, which is
+what makes the Kafka and in-memory transports substitutable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelTransportMessage(BaseModel):
+    """One message pulled from a transport, independent of the concrete broker.
+
+    Frozen value object. ``partition`` and ``offset`` are REQUIRED: they are the
+    per-partition identity and the monotonic cursor coordinate the runtime and the
+    in-memory transport both depend on. ``ack_token`` is opaque — the runtime hands
+    it straight back to ``commit()`` / ``nack()`` and never inspects it.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    topic: str = Field(..., description="Source topic the message was polled from.")
+    partition: int = Field(
+        ...,
+        description="Partition the message belongs to (per-partition identity).",
+    )
+    offset: int = Field(
+        ...,
+        description="Monotonic per-partition offset coordinate of the message.",
+    )
+    key: bytes | None = Field(
+        ...,
+        description="Raw partition / routing key, or None when the message is unkeyed.",
+    )
+    value: bytes = Field(..., description="Raw message payload bytes.")
+    headers: Mapping[str, bytes] = Field(
+        ...,
+        description="Raw transport headers (header name -> raw bytes).",
+    )
+    ack_token: object = Field(
+        ...,
+        description=(
+            "Opaque cursor the transport uses to commit / redeliver this message. "
+            "The runtime NEVER interprets it — it hands it back to commit() / nack(). "
+            "For Kafka it wraps the TopicPartition+offset; for the in-memory transport "
+            "the queue coordinate."
+        ),
+    )
+
+
+__all__ = ["ModelTransportMessage"]

--- a/src/omnibase_core/protocols/runtime/__init__.py
+++ b/src/omnibase_core/protocols/runtime/__init__.py
@@ -71,6 +71,15 @@ from omnibase_core.protocols.runtime.protocol_message_handler import (
 from omnibase_core.protocols.runtime.protocol_runtime_skill_client import (
     ProtocolRuntimeSkillClient,
 )
+from omnibase_core.protocols.runtime.protocol_transport_consumer import (
+    ProtocolTransportConsumer,
+)
+from omnibase_core.protocols.runtime.protocol_transport_message import (
+    ProtocolTransportMessage,
+)
+from omnibase_core.protocols.runtime.protocol_transport_producer import (
+    ProtocolTransportProducer,
+)
 
 __all__ = [
     "ProtocolHandlerRegistry",
@@ -83,5 +92,8 @@ __all__ = [
     "ProtocolLocalRuntimePayloadModel",
     "ProtocolMessageHandler",
     "ProtocolRuntimeSkillClient",
+    "ProtocolTransportConsumer",
+    "ProtocolTransportMessage",
+    "ProtocolTransportProducer",
     "UnsubscribeCallback",
 ]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
@@ -41,11 +41,9 @@ class ProtocolTransportConsumer(Protocol):
 
     async def start(self) -> None:
         """Establish the underlying consumer / connection."""
-        raise NotImplementedError  # stub-ok: protocol method body
 
     async def close(self) -> None:
         """Tear down the underlying consumer / connection."""
-        raise NotImplementedError  # stub-ok: protocol method body
 
     async def poll(
         self, *, max_messages: int, timeout_ms: int
@@ -55,15 +53,12 @@ class ProtocolTransportConsumer(Protocol):
         ``max_messages`` bounds the in-flight batch (backpressure). Messages from a
         single partition are returned in ascending ``offset`` order.
         """
-        raise NotImplementedError  # stub-ok: protocol method body
 
     async def commit(self, message: ProtocolTransportMessage) -> None:
         """Advance the partition high-water mark to ``message`` (commits all <= it)."""
-        raise NotImplementedError  # stub-ok: protocol method body
 
     async def nack(self, message: ProtocolTransportMessage) -> None:
         """Hold: make ``message`` and later same-partition offsets redeliverable."""
-        raise NotImplementedError  # stub-ok: protocol method body
 
 
 __all__ = ["ProtocolTransportConsumer"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pull-based transport consumer protocol.
+
+Net-new, currently UNUSED (ticket OMN-14719, epic OMN-14717; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` section
+(c)). The unified runtime depends only on this abstraction; concrete transports
+(Kafka in infra, in-memory in core) implement it and point inward via DI, so core
+never imports Kafka.
+
+Design notes (authoritative in plan section (c)/(d)):
+
+* Deliberately **pull-based** (``poll``), NOT push (``subscribe(on_message=...)``).
+  Pull is the load-bearing inversion: it lets the runtime own commit timing.
+* Assigned topics + consumer group are construction-time config supplied by the
+  composition root, not a runtime-called method — this removes the "who commits"
+  ambiguity of the push callback surface.
+* ``commit`` advances the per-partition high-water mark: committing a message's
+  offset implicitly commits every earlier offset on that partition.
+* ``nack`` does NOT advance the cursor — it makes that message and all later
+  same-partition offsets redeliverable (Kafka: ``seek``).
+* There is **no** ``dlq()`` method. DLQ is runtime policy expressed with the two
+  primitives the protocols already have (``producer.send(dlq_topic, ...)`` then
+  ``consumer.commit(original)``), so DLQ is defined once, in the runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from omnibase_core.protocols.runtime.protocol_transport_message import (
+    ProtocolTransportMessage,
+)
+
+
+@runtime_checkable
+class ProtocolTransportConsumer(Protocol):
+    """Runtime-owned, pull-based consumer over a single transport."""
+
+    async def start(self) -> None:
+        """Establish the underlying consumer / connection."""
+        ...
+
+    async def close(self) -> None:
+        """Tear down the underlying consumer / connection."""
+        ...
+
+    async def poll(
+        self, *, max_messages: int, timeout_ms: int
+    ) -> Sequence[ProtocolTransportMessage]:
+        """Pull up to ``max_messages`` messages, waiting at most ``timeout_ms``.
+
+        ``max_messages`` bounds the in-flight batch (backpressure). Messages from a
+        single partition are returned in ascending ``offset`` order.
+        """
+        ...
+
+    async def commit(self, message: ProtocolTransportMessage) -> None:
+        """Advance the partition high-water mark to ``message`` (commits all <= it)."""
+        ...
+
+    async def nack(self, message: ProtocolTransportMessage) -> None:
+        """Hold: make ``message`` and later same-partition offsets redeliverable."""
+        ...
+
+
+__all__ = ["ProtocolTransportConsumer"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_consumer.py
@@ -41,11 +41,11 @@ class ProtocolTransportConsumer(Protocol):
 
     async def start(self) -> None:
         """Establish the underlying consumer / connection."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
     async def close(self) -> None:
         """Tear down the underlying consumer / connection."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
     async def poll(
         self, *, max_messages: int, timeout_ms: int
@@ -55,15 +55,15 @@ class ProtocolTransportConsumer(Protocol):
         ``max_messages`` bounds the in-flight batch (backpressure). Messages from a
         single partition are returned in ascending ``offset`` order.
         """
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
     async def commit(self, message: ProtocolTransportMessage) -> None:
         """Advance the partition high-water mark to ``message`` (commits all <= it)."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
     async def nack(self, message: ProtocolTransportMessage) -> None:
         """Hold: make ``message`` and later same-partition offsets redeliverable."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
 
 __all__ = ["ProtocolTransportConsumer"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_message.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_message.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Structural protocol for a message pulled from a transport.
+
+Net-new, currently UNUSED (ticket OMN-14719, epic OMN-14717).
+
+The transport protocols speak in terms of this structural shape rather than
+importing the concrete ``ModelTransportMessage`` from ``omnibase_core.models``. This
+mirrors the existing ``ProtocolLocalRuntimeMessage`` convention in this directory and
+keeps the ``protocols`` layer free of a ``protocols -> models`` import edge — that
+edge family is frozen at its ceiling by the OMN-14340 growth ratchet
+(``scripts/ci/check_import_ratchet.py``), so a new one would hard-fail CI. Dependency
+inversion resolves it: the concrete
+``omnibase_core.models.runtime.model_transport_message.ModelTransportMessage``
+structurally satisfies this protocol without the protocol importing it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolTransportMessage(Protocol):
+    """Read-only shape of a message pulled from a transport.
+
+    The runtime groups a poll batch by ``partition`` and orders by ``offset`` to
+    commit a contiguous per-partition prefix; it treats ``ack_token`` as opaque.
+    """
+
+    @property
+    def topic(self) -> str:
+        """Source topic the message was polled from."""
+        ...
+
+    @property
+    def partition(self) -> int:
+        """Partition the message belongs to (per-partition identity)."""
+        ...
+
+    @property
+    def offset(self) -> int:
+        """Monotonic per-partition offset coordinate of the message."""
+        ...
+
+    @property
+    def key(self) -> bytes | None:
+        """Raw partition / routing key, or None when the message is unkeyed."""
+        ...
+
+    @property
+    def value(self) -> bytes:
+        """Raw message payload bytes."""
+        ...
+
+    @property
+    def headers(self) -> Mapping[str, bytes]:
+        """Raw transport headers (header name -> raw bytes)."""
+        ...
+
+    @property
+    def ack_token(self) -> object:
+        """Opaque commit / redeliver cursor the runtime hands back unmodified."""
+        ...
+
+
+__all__ = ["ProtocolTransportMessage"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_message.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_message.py
@@ -30,40 +30,26 @@ class ProtocolTransportMessage(Protocol):
     commit a contiguous per-partition prefix; it treats ``ack_token`` as opaque.
     """
 
-    @property
-    def topic(self) -> str:
-        """Source topic the message was polled from."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    topic: str
+    """Source topic the message was polled from."""
 
-    @property
-    def partition(self) -> int:
-        """Partition the message belongs to (per-partition identity)."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    partition: int
+    """Partition the message belongs to (per-partition identity)."""
 
-    @property
-    def offset(self) -> int:
-        """Monotonic per-partition offset coordinate of the message."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    offset: int
+    """Monotonic per-partition offset coordinate of the message."""
 
-    @property
-    def key(self) -> bytes | None:
-        """Raw partition / routing key, or None when the message is unkeyed."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    key: bytes | None
+    """Raw partition / routing key, or None when the message is unkeyed."""
 
-    @property
-    def value(self) -> bytes:
-        """Raw message payload bytes."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    value: bytes
+    """Raw message payload bytes."""
 
-    @property
-    def headers(self) -> Mapping[str, bytes]:
-        """Raw transport headers (header name -> raw bytes)."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    headers: Mapping[str, bytes]
+    """Raw transport headers (header name -> raw bytes)."""
 
-    @property
-    def ack_token(self) -> object:
-        """Opaque commit / redeliver cursor the runtime hands back unmodified."""
-        raise NotImplementedError  # stub-ok: protocol property body
+    ack_token: object
+    """Opaque commit / redeliver cursor the runtime hands back unmodified."""
 
 
 __all__ = ["ProtocolTransportMessage"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_message.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_message.py
@@ -33,37 +33,37 @@ class ProtocolTransportMessage(Protocol):
     @property
     def topic(self) -> str:
         """Source topic the message was polled from."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def partition(self) -> int:
         """Partition the message belongs to (per-partition identity)."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def offset(self) -> int:
         """Monotonic per-partition offset coordinate of the message."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def key(self) -> bytes | None:
         """Raw partition / routing key, or None when the message is unkeyed."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def value(self) -> bytes:
         """Raw message payload bytes."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def headers(self) -> Mapping[str, bytes]:
         """Raw transport headers (header name -> raw bytes)."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
     @property
     def ack_token(self) -> object:
         """Opaque commit / redeliver cursor the runtime hands back unmodified."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol property body
 
 
 __all__ = ["ProtocolTransportMessage"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
@@ -31,7 +31,7 @@ class ProtocolTransportProducer(Protocol):
         headers: Mapping[str, bytes],
     ) -> None:
         """Publish one event to ``topic`` and await the broker acknowledgement."""
-        ...
+        raise NotImplementedError  # stub-ok: protocol method body
 
 
 __all__ = ["ProtocolTransportProducer"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Transport producer protocol.
+
+Net-new, currently UNUSED (ticket OMN-14719, epic OMN-14717; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` section
+(c)). The unified runtime depends only on this abstraction; concrete transports
+implement it and point inward via DI, so core never imports Kafka.
+
+``send`` awaits the broker acknowledgement for a single event. DLQ is not a producer
+concern — the runtime expresses DLQ as ``send(dlq_topic, ...)`` followed by
+``consumer.commit(original)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolTransportProducer(Protocol):
+    """Runtime-owned producer over a single transport."""
+
+    async def send(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: Mapping[str, bytes],
+    ) -> None:
+        """Publish one event to ``topic`` and await the broker acknowledgement."""
+        ...
+
+
+__all__ = ["ProtocolTransportProducer"]

--- a/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
+++ b/src/omnibase_core/protocols/runtime/protocol_transport_producer.py
@@ -31,7 +31,6 @@ class ProtocolTransportProducer(Protocol):
         headers: Mapping[str, bytes],
     ) -> None:
         """Publish one event to ``topic`` and await the broker acknowledgement."""
-        raise NotImplementedError  # stub-ok: protocol method body
 
 
 __all__ = ["ProtocolTransportProducer"]

--- a/tests/unit/models/runtime/test_model_transport_message.py
+++ b/tests/unit/models/runtime/test_model_transport_message.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``ModelTransportMessage`` (OMN-14719, epic OMN-14717).
+
+Net-new, currently unused foundation. These tests lock the plan section (c)
+contract: ``partition`` / ``offset`` REQUIRED, frozen, ``extra="forbid"``, opaque
+``ack_token`` round-trips by identity.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.runtime import ModelTransportMessage
+from omnibase_core.models.runtime.model_transport_message import (
+    ModelTransportMessage as ModelTransportMessageDirect,
+)
+
+
+def _message(**overrides: object) -> ModelTransportMessage:
+    kwargs: dict[str, object] = {
+        "topic": "onex.cmd.example.v1",
+        "partition": 0,
+        "offset": 0,
+        "key": None,
+        "value": b"payload",
+        "headers": {},
+        "ack_token": object(),
+    }
+    kwargs.update(overrides)
+    return ModelTransportMessage(**kwargs)  # type: ignore[arg-type]
+
+
+def test_reexport_is_same_class() -> None:
+    assert ModelTransportMessage is ModelTransportMessageDirect
+
+
+def test_construct_full_message_round_trips_fields() -> None:
+    token = object()
+    msg = ModelTransportMessage(
+        topic="onex.cmd.example.v1",
+        partition=3,
+        offset=42,
+        key=b"route-key",
+        value=b"payload-bytes",
+        headers={"content-type": b"application/json"},
+        ack_token=token,
+    )
+
+    assert msg.topic == "onex.cmd.example.v1"
+    assert msg.partition == 3
+    assert msg.offset == 42
+    assert msg.key == b"route-key"
+    assert msg.value == b"payload-bytes"
+    assert msg.headers == {"content-type": b"application/json"}
+    # ack_token is opaque and preserved by identity — the runtime hands it back as-is.
+    assert msg.ack_token is token
+
+
+def test_partition_is_required() -> None:
+    with pytest.raises(ValidationError, match="partition"):
+        ModelTransportMessage(
+            topic="t",
+            offset=0,
+            key=None,
+            value=b"",
+            headers={},
+            ack_token=object(),
+        )  # type: ignore[call-arg]
+
+
+def test_offset_is_required() -> None:
+    with pytest.raises(ValidationError, match="offset"):
+        ModelTransportMessage(
+            topic="t",
+            partition=0,
+            key=None,
+            value=b"",
+            headers={},
+            ack_token=object(),
+        )  # type: ignore[call-arg]
+
+
+def test_key_none_is_accepted() -> None:
+    assert _message(key=None).key is None
+
+
+def test_key_bytes_is_accepted() -> None:
+    assert _message(key=b"k").key == b"k"
+
+
+def test_model_is_frozen() -> None:
+    msg = _message()
+    with pytest.raises(ValidationError):
+        msg.offset = 99  # type: ignore[misc]
+
+
+def test_extra_fields_are_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        _message(unexpected="nope")
+
+
+def test_extra_forbid_is_configured() -> None:
+    assert ModelTransportMessage.model_config.get("extra") == "forbid"
+    assert ModelTransportMessage.model_config.get("frozen") is True

--- a/tests/unit/models/runtime/test_model_transport_message.py
+++ b/tests/unit/models/runtime/test_model_transport_message.py
@@ -18,6 +18,8 @@ from omnibase_core.models.runtime.model_transport_message import (
     ModelTransportMessage as ModelTransportMessageDirect,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _message(**overrides: object) -> ModelTransportMessage:
     kwargs: dict[str, object] = {
@@ -30,7 +32,7 @@ def _message(**overrides: object) -> ModelTransportMessage:
         "ack_token": object(),
     }
     kwargs.update(overrides)
-    return ModelTransportMessage(**kwargs)  # type: ignore[arg-type]
+    return ModelTransportMessage(**kwargs)  # type: ignore[arg-type]  # NOTE(OMN-14719)
 
 
 def test_reexport_is_same_class() -> None:
@@ -68,7 +70,7 @@ def test_partition_is_required() -> None:
             value=b"",
             headers={},
             ack_token=object(),
-        )  # type: ignore[call-arg]
+        )  # type: ignore[call-arg]  # NOTE(OMN-14719)
 
 
 def test_offset_is_required() -> None:
@@ -80,7 +82,7 @@ def test_offset_is_required() -> None:
             value=b"",
             headers={},
             ack_token=object(),
-        )  # type: ignore[call-arg]
+        )  # type: ignore[call-arg]  # NOTE(OMN-14719)
 
 
 def test_key_none_is_accepted() -> None:
@@ -94,7 +96,7 @@ def test_key_bytes_is_accepted() -> None:
 def test_model_is_frozen() -> None:
     msg = _message()
     with pytest.raises(ValidationError):
-        msg.offset = 99  # type: ignore[misc]
+        msg.offset = 99  # type: ignore[misc]  # NOTE(OMN-14719)
 
 
 def test_extra_fields_are_forbidden() -> None:

--- a/tests/unit/protocols/runtime/__init__.py
+++ b/tests/unit/protocols/runtime/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/protocols/runtime/test_protocol_transport.py
+++ b/tests/unit/protocols/runtime/test_protocol_transport.py
@@ -23,6 +23,8 @@ from omnibase_core.protocols.runtime import (
     ProtocolTransportProducer,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _message(partition: int = 0, offset: int = 0) -> ModelTransportMessage:
     return ModelTransportMessage(

--- a/tests/unit/protocols/runtime/test_protocol_transport.py
+++ b/tests/unit/protocols/runtime/test_protocol_transport.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the net-new transport protocols (OMN-14719, epic OMN-14717).
+
+Currently unused foundation. These tests prove the protocols are importable, typed,
+``@runtime_checkable``, and that the concrete ``ModelTransportMessage`` structurally
+satisfies ``ProtocolTransportMessage`` (dependency inversion — the protocol layer
+never imports the concrete model, keeping the OMN-14340 protocols->models ratchet
+green).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+from omnibase_core.models.runtime import ModelTransportMessage
+from omnibase_core.protocols.runtime import (
+    ProtocolTransportConsumer,
+    ProtocolTransportMessage,
+    ProtocolTransportProducer,
+)
+
+
+def _message(partition: int = 0, offset: int = 0) -> ModelTransportMessage:
+    return ModelTransportMessage(
+        topic="onex.cmd.example.v1",
+        partition=partition,
+        offset=offset,
+        key=None,
+        value=b"payload",
+        headers={},
+        ack_token=(partition, offset),
+    )
+
+
+class _FakeConsumer:
+    """Minimal structural implementation used to prove the protocol is satisfiable."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.closed = False
+        self.committed: list[ProtocolTransportMessage] = []
+        self.nacked: list[ProtocolTransportMessage] = []
+        self._queue: list[ModelTransportMessage] = [
+            _message(offset=0),
+            _message(offset=1),
+        ]
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def poll(
+        self, *, max_messages: int, timeout_ms: int
+    ) -> Sequence[ProtocolTransportMessage]:
+        batch = self._queue[:max_messages]
+        self._queue = self._queue[max_messages:]
+        return batch
+
+    async def commit(self, message: ProtocolTransportMessage) -> None:
+        self.committed.append(message)
+
+    async def nack(self, message: ProtocolTransportMessage) -> None:
+        self.nacked.append(message)
+
+
+class _FakeProducer:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, bytes | None, bytes, Mapping[str, bytes]]] = []
+
+    async def send(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: Mapping[str, bytes],
+    ) -> None:
+        self.sent.append((topic, key, value, headers))
+
+
+def _accepts_message(message: ProtocolTransportMessage) -> int:
+    # Static: the runtime reads partition/offset/ack_token off the structural shape.
+    return message.partition + message.offset
+
+
+def _accepts_consumer(consumer: ProtocolTransportConsumer) -> ProtocolTransportConsumer:
+    return consumer
+
+
+def _accepts_producer(producer: ProtocolTransportProducer) -> ProtocolTransportProducer:
+    return producer
+
+
+def test_concrete_model_satisfies_message_protocol_statically() -> None:
+    msg = _message(partition=2, offset=5)
+    # Assigning the concrete model to the structural protocol type is the mypy check.
+    as_protocol: ProtocolTransportMessage = msg
+    assert _accepts_message(as_protocol) == 7
+
+
+def test_concrete_model_is_runtime_checkable_message() -> None:
+    assert isinstance(_message(), ProtocolTransportMessage)
+
+
+def test_fake_consumer_satisfies_consumer_protocol() -> None:
+    consumer = _FakeConsumer()
+    assert isinstance(consumer, ProtocolTransportConsumer)
+    assert _accepts_consumer(consumer) is consumer
+
+
+def test_fake_producer_satisfies_producer_protocol() -> None:
+    producer = _FakeProducer()
+    assert isinstance(producer, ProtocolTransportProducer)
+    assert _accepts_producer(producer) is producer
+
+
+@pytest.mark.asyncio
+async def test_fake_consumer_poll_commit_nack_flow() -> None:
+    consumer: ProtocolTransportConsumer = _FakeConsumer()
+    await consumer.start()
+    batch = await consumer.poll(max_messages=1, timeout_ms=10)
+    assert len(batch) == 1
+    await consumer.commit(batch[0])
+    remaining = await consumer.poll(max_messages=10, timeout_ms=10)
+    assert len(remaining) == 1
+    await consumer.nack(remaining[0])
+    await consumer.close()
+
+
+@pytest.mark.asyncio
+async def test_fake_producer_send_awaits() -> None:
+    producer: ProtocolTransportProducer = _FakeProducer()
+    await producer.send("onex.dlq.example.v1", None, b"body", {"h": b"v"})
+    assert isinstance(producer, _FakeProducer)
+    assert producer.sent == [("onex.dlq.example.v1", None, b"body", {"h": b"v"})]


### PR DESCRIPTION
## OMN-14719 — S1: transport protocol + `ModelTransportMessage` in core (net-new, unused)

Epic **OMN-14717** · plan `docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md` §(c) + §(b) invariant **I2**.

**Net-new, currently UNUSED foundation. Zero production behavior change. Fully reversible (`git revert` this single commit).** Nothing imports these surfaces yet — this is only the transport abstraction the unified runtime (S4) and the concrete transports (S2 in-memory / S3 Kafka) will later depend on.

### What this adds
- `src/omnibase_core/models/runtime/model_transport_message.py` — **`ModelTransportMessage`** (`frozen=True, extra="forbid", from_attributes=True`). Fields per plan §c: `topic`, `partition:int` (REQUIRED), `offset:int` (REQUIRED), `key: bytes | None`, `value: bytes`, `headers: Mapping[str, bytes]`, `ack_token: object` (opaque — the runtime never interprets it).
- `src/omnibase_core/protocols/runtime/protocol_transport_message.py` — **`ProtocolTransportMessage`** (structural, `@runtime_checkable`).
- `src/omnibase_core/protocols/runtime/protocol_transport_consumer.py` — **`ProtocolTransportConsumer`**: pull-based `poll(max_messages, timeout_ms) -> Sequence[...]`, `start`/`close`, `commit` (advance per-partition HWM), `nack` (hold / seek). **No `subscribe(on_message=...)` push surface, no `dlq()`** (DLQ is runtime policy = `producer.send` + `consumer.commit`).
- `src/omnibase_core/protocols/runtime/protocol_transport_producer.py` — **`ProtocolTransportProducer`**: `send(topic, key, value, headers)` awaiting broker ack.
- `.importlinter` — new forbidden contract **`core-no-kafka-transport`** (invariant I2): `omnibase_core` may not import `aiokafka` / `confluent_kafka` / `omnibase_infra`. Currently **vacuous** (core imports none today) — it is the fence that keeps dependency inversion true as the runtime moves into core.
- Unit tests: model validation (partition/offset required, frozen, extra forbidden, opaque ack_token round-trip) + protocol conformance (structural satisfaction, `@runtime_checkable`, poll/commit/nack + send flow).

### Boundary seams defined (per operating rule)
- `ModelTransportMessage` field set/types/nesting **frozen** as above; `partition`+`offset` REQUIRED (HOLE 1/2 need per-partition identity + monotonic cursor); `ack_token` opaque.
- `ProtocolTransportConsumer.poll` is keyword-only `max_messages:int, timeout_ms:int`; `commit`/`nack` take one message; `ProtocolTransportProducer.send` is positional `topic, key, value, headers`.
- Consumer/producer speak the **structural** `ProtocolTransportMessage`, which `ModelTransportMessage` satisfies field-by-field. S2/S3/S4 must match these exactly.

### Deliberate design note (protocols do NOT import the concrete model)
The transport protocols reference the **structural** `ProtocolTransportMessage`, not the concrete `ModelTransportMessage`. This mirrors the existing `ProtocolLocalRuntimeMessage` convention in this directory and is required to keep the **OMN-14340 `protocols -> models` growth ratchet** green: that edge family is frozen at exactly 65/65 (`scripts/ci/check_import_ratchet.py`), so a new `protocols -> models` import would hard-fail CI. Dependency inversion resolves it — the concrete model lives in `models/runtime/` per the plan and structurally satisfies the protocol without the protocol importing it.

### I2 deferred exception (plan-declared)
`src/omnibase_core/cli/cli_run_node.py` loads `confluent_kafka` via `importlib.import_module("confluent_kafka")` — a **dynamic** import. grimp's static graph does not see it, so the I2 contract stays green without an ignore entry; `cli_run_node.py` is re-expressed over `ProtocolTransportProducer` in a follow-up (plan S11). The plan named `omnibase_infra.event_bus.event_bus_kafka` as the forbidden edge; grimp attributes external imports to the top-level package, so the contract forbids all of `omnibase_infra` (stronger + the checkable granularity).

### dod_evidence
Verified locally in the worktree (`env -u PYTHONPATH` to defeat the ambient-PYTHONPATH shadow of the canonical clone):
- `uv run pytest tests/unit/models/runtime/test_model_transport_message.py tests/unit/protocols/runtime/test_protocol_transport.py` → **15 passed**.
- `uv run mypy` on the 4 new source files + 2 test files → **Success: no issues found in 6 source files**.
- `uv run ruff format` + `uv run ruff check` → clean.
- `uv run lint-imports` → **5 contracts kept, 0 broken** (incl. new `core-no-kafka-transport` / invariant I2 KEPT).
- `uv run python scripts/ci/check_import_ratchet.py` → **OK, protocols->models=65** (frozen max 65 — unchanged).
- `uv run pre-commit run --files <changed>` → **95 hooks Passed, 0 Failed, exit 0**.

Do not merge — Codex owns merges. No `--auto`, no `--no-verify`.

Evidence-Ticket: OMN-14719
Evidence-Source: OCC#4340
Evidence-Commit: c671d2c20057d4fc28eb116ca6eeff9b99b796a1
Evidence-Head: 83bdb02718d76d84b19560f68302aee53bfd9db5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a transport-agnostic runtime message model with immutable, strict validation and an opaque acknowledgement token.
  * Added runtime consumer and producer protocol interfaces (poll/commit/nack, lifecycle start/close, and async send).
  * Exposed the new message and protocol interfaces via the public API.
* **Bug Fixes**
  * Strengthened import-boundary enforcement to prevent direct Kafka transport/infrastructure dependencies from core.
* **Tests**
  * Added unit tests covering model validation/immutability, export behavior, protocol typing/runtime compatibility, and consumer/producer workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->