### PR TITLE
feat(OMN-14720): in-memory transport + parametrized conformance suite (net-new, stacked on #1463)

### DIFF
--- a/src/omnibase_core/runtime/transport/__init__.py
+++ b/src/omnibase_core/runtime/transport/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Concrete transports for the unified runtime dispatch loop.
+
+Net-new foundation (epic OMN-14717). Exposes the in-memory transport that models
+Kafka's per-partition offset semantics. The parametrized conformance suite lives in
+:mod:`omnibase_core.runtime.transport.runtime_transport_conformance` and is imported
+directly by tests (never from this ``__init__``) so the production import graph stays
+free of any test-framework dependency.
+"""
+
+from omnibase_core.runtime.transport.runtime_in_memory_broker import InMemoryBroker
+from omnibase_core.runtime.transport.runtime_in_memory_transport import (
+    InMemoryTransport,
+)
+
+__all__ = ["InMemoryBroker", "InMemoryTransport"]

--- a/src/omnibase_core/runtime/transport/runtime_in_memory_broker.py
+++ b/src/omnibase_core/runtime/transport/runtime_in_memory_broker.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Shared in-memory broker backing the in-memory transport.
+
+Net-new foundation for the single-runtime / transport-via-DI unification (epic
+OMN-14717, ticket OMN-14720; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` sections
+(c)/(d.4)). Nothing in production wires it yet — reversible, zero behavior change.
+
+The broker is the append-only log + per-``(topic, group, partition)`` committed
+cursor that every in-memory producer/consumer sharing it sees. Records are
+append-only (never removed); a consumer group's *durability* is the committed
+offset; a consumer instance's *fetch position* is instance-local (owned by
+``InMemoryTransport``) so a restart resumes from the committed offset. This is what
+makes the in-memory transport model Kafka's monotonic per-partition offset (plan
+HOLE 2), not SQS per-message ack.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.model_transport_message import ModelTransportMessage
+
+__all__ = ["InMemoryBroker"]
+
+
+class InMemoryBroker:
+    """Append-only log + per-group committed cursor shared by in-memory transports.
+
+    ``num_partitions`` controls partition fan-out. Partition assignment is
+    deterministic: keyed messages hash to a stable partition; unkeyed messages
+    round-robin per topic in send order. The stored value is a canonical
+    :class:`ModelTransportMessage` whose opaque ``ack_token`` is the
+    ``(topic, partition, offset)`` coordinate (group-independent — the runtime never
+    interprets it).
+    """
+
+    def __init__(self, num_partitions: int = 1) -> None:
+        if num_partitions < 1:
+            raise ModelOnexError(
+                f"num_partitions must be a positive integer, got {num_partitions}",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        self.num_partitions = num_partitions
+        # topic -> partition index -> append-ordered messages (offset == list index).
+        self._logs: dict[str, list[list[ModelTransportMessage]]] = {}
+        # (topic, group, partition) -> highest committed offset (-1 == none committed).
+        self._committed: dict[tuple[str, str, int], int] = {}
+        # topic -> monotonic counter for round-robin assignment of unkeyed messages.
+        self._round_robin: dict[str, int] = {}
+
+    def _select_partition(self, topic: str, key: bytes | None) -> int:
+        if self.num_partitions == 1:
+            return 0
+        if key is None:
+            counter = self._round_robin.get(topic, 0)
+            self._round_robin[topic] = counter + 1
+            return counter % self.num_partitions
+        digest = hashlib.sha256(key).digest()
+        return int.from_bytes(digest[:8], "big") % self.num_partitions
+
+    def append(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: Mapping[str, bytes],
+    ) -> ModelTransportMessage:
+        """Append one message, assigning partition + offset deterministically."""
+        partition = self._select_partition(topic, key)
+        partitions = self._logs.setdefault(
+            topic, [[] for _ in range(self.num_partitions)]
+        )
+        log = partitions[partition]
+        offset = len(log)
+        message = ModelTransportMessage(
+            topic=topic,
+            partition=partition,
+            offset=offset,
+            key=key,
+            value=value,
+            headers=dict(headers),
+            ack_token=(topic, partition, offset),
+        )
+        log.append(message)
+        return message
+
+    def records(self, topic: str, partition: int) -> Sequence[ModelTransportMessage]:
+        partitions = self._logs.get(topic)
+        if partitions is None:
+            return ()
+        return partitions[partition]
+
+    def record_at(
+        self, topic: str, partition: int, offset: int
+    ) -> ModelTransportMessage | None:
+        log = self.records(topic, partition)
+        if 0 <= offset < len(log):
+            return log[offset]
+        return None
+
+    def committed_offset(self, topic: str, group: str, partition: int) -> int:
+        return self._committed.get((topic, group, partition), -1)
+
+    def commit_offset(
+        self, topic: str, group: str, partition: int, offset: int
+    ) -> None:
+        """Advance the committed high-water mark to ``offset`` (commits all <= it).
+
+        The high-water mark is monotonic: committing an offset at or below the
+        current mark is a no-op. Committing offset ``k`` records that every offset
+        ``<= k`` on this partition is durable — a later consumer instance on the same
+        group will not be redelivered any of them.
+        """
+        key = (topic, group, partition)
+        if offset > self._committed.get(key, -1):
+            self._committed[key] = offset

--- a/src/omnibase_core/runtime/transport/runtime_in_memory_transport.py
+++ b/src/omnibase_core/runtime/transport/runtime_in_memory_transport.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""In-memory transport modelling Kafka's per-partition offset semantics.
+
+Net-new foundation for the single-runtime / transport-via-DI unification (epic
+OMN-14717, ticket OMN-14720; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` sections
+(c)/(d.4)). A real, usable transport for tests and local runs — NOT test-only
+scaffolding — that nothing in production wires yet, so it is fully reversible with
+zero production behavior change.
+
+Why Kafka semantics and not SQS (plan HOLE 2)
+---------------------------------------------
+A naive in-memory transport keyed by an individual ``delivery_id`` where
+``commit(one)`` discards exactly that one message models SQS / per-message ack.
+Under that model the plan's HOLE-1 out-of-order-commit bug is *invisible* in-memory
+and only bites the real broker. This transport instead models Kafka's monotonic
+per-``(topic, group, partition)`` committed-offset **cursor**:
+
+* ``commit(msg)`` advances the committed high-water mark to ``msg.offset`` — thereby
+  committing every earlier offset on that partition too. You cannot commit ``m3``
+  while ``m2`` is uncommitted without also committing ``m2``. This is exactly what
+  makes the HOLE-1 bug (committing a later offset defeats redelivery of an earlier
+  failed one) observable in-memory.
+* ``nack(msg)`` does NOT advance the cursor; it re-exposes ``msg`` and every later
+  same-partition offset (mirrors a Kafka ``seek``).
+* A restart (a NEW consumer instance on the same group) resumes from the committed
+  offset, so every uncommitted offset is redelivered.
+* Optional opt-in chaos/duplicate mode redelivers a committed offset once more so an
+  idempotence-requiring golden chain must prove handler idempotence — stricter than a
+  naive Kafka happy path.
+
+Bracketed (NOT modelled here; only the configured broker escalation covers them):
+partition rebalance/assignment, cross-broker replication/durability, consumer-group
+coordination, idempotent-producer/txn dedup, wall-clock latency, real network
+partitions.
+
+Structural conformance
+----------------------
+``InMemoryTransport`` structurally satisfies both ``ProtocolTransportConsumer`` and
+``ProtocolTransportProducer`` (proven in the unit tests, which assign it to those
+protocol types and ``isinstance``-check it). It deliberately does NOT import those
+protocols: ``commit`` / ``nack`` accept ``object`` (a supertype of the protocol's
+``ProtocolTransportMessage`` parameter, so the impl stays contravariantly
+compatible) and narrow to the concrete ``ModelTransportMessage`` this transport
+itself yields from ``poll``. The parametrized conformance suite
+(:mod:`omnibase_core.runtime.transport.runtime_transport_conformance`) asserts the
+observable Kafka semantics against ANY transport, which is what licenses
+"in-memory golden chain ⇒ Kafka golden chain".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.model_transport_message import ModelTransportMessage
+from omnibase_core.runtime.transport.runtime_in_memory_broker import InMemoryBroker
+
+__all__ = ["InMemoryTransport"]
+
+
+class InMemoryTransport:
+    """A single in-memory transport that is both consumer and producer.
+
+    Consumer identity (``group`` + assigned ``topics``) is construction-time config
+    supplied by the composition root — there is no runtime ``subscribe`` call,
+    mirroring the pull-based protocol. Fetch position is *instance-local*: a new
+    instance on the same ``group`` (a "restart") initialises each partition's
+    position from the broker's committed offset, so uncommitted offsets redeliver.
+    """
+
+    def __init__(
+        self,
+        *,
+        broker: InMemoryBroker,
+        group: str = "onex.transport.inmemory",
+        topics: Sequence[str] = (),
+        chaos_duplicate: bool = False,
+    ) -> None:
+        self._broker = broker
+        self._group = group
+        self._topics: tuple[str, ...] = tuple(topics)
+        self._chaos_duplicate = chaos_duplicate
+        self._started = False
+        # (topic, partition) -> next offset this instance will fetch.
+        self._positions: dict[tuple[str, int], int] = {}
+        # Committed offsets awaiting one extra chaos redelivery, in commit order.
+        self._chaos_pending: list[ModelTransportMessage] = []
+        # (topic, partition, offset) already chaos-redelivered (at most once each).
+        self._chaos_seen: set[tuple[str, int, int]] = set()
+
+    # -- consumer protocol -------------------------------------------------
+
+    async def start(self) -> None:
+        self._started = True
+
+    async def close(self) -> None:
+        self._started = False
+
+    def _require_started(self) -> None:
+        if not self._started:
+            raise ModelOnexError(
+                "InMemoryTransport consumer used before start()",
+                error_code=EnumCoreErrorCode.INVALID_STATE,
+            )
+
+    def _position(self, topic: str, partition: int) -> int:
+        """Instance-local fetch position, lazily seeded from the committed offset."""
+        cursor = (topic, partition)
+        if cursor not in self._positions:
+            self._positions[cursor] = (
+                self._broker.committed_offset(topic, self._group, partition) + 1
+            )
+        return self._positions[cursor]
+
+    async def poll(
+        self, *, max_messages: int, timeout_ms: int
+    ) -> Sequence[ModelTransportMessage]:
+        """Return up to ``max_messages`` messages at/after the fetch position.
+
+        Polled messages are marked in-flight (the fetch position advances past
+        them) but are NOT removed from the log — a ``nack`` or a restart re-exposes
+        any that stay uncommitted. ``timeout_ms`` is ignored: the in-memory log
+        never blocks, it returns whatever is currently available (possibly empty).
+        Chaos-mode duplicates of already-committed offsets are drained first.
+        """
+        self._require_started()
+        if max_messages < 1:
+            raise ModelOnexError(
+                f"max_messages must be a positive integer, got {max_messages}",
+                error_code=EnumCoreErrorCode.INVALID_INPUT,
+            )
+
+        batch: list[ModelTransportMessage] = []
+
+        # Chaos redeliveries of committed offsets come first (opt-in).
+        while self._chaos_pending and len(batch) < max_messages:
+            batch.append(self._chaos_pending.pop(0))
+
+        # Fresh delivery from each assigned (topic, partition) in a deterministic
+        # order. Ascending offset within a partition is guaranteed by the log.
+        for topic in sorted(self._topics):
+            for partition in range(self._broker.num_partitions):
+                if len(batch) >= max_messages:
+                    break
+                log = self._broker.records(topic, partition)
+                position = self._position(topic, partition)
+                while position < len(log) and len(batch) < max_messages:
+                    batch.append(log[position])
+                    position += 1
+                self._positions[(topic, partition)] = position
+        return batch
+
+    async def commit(self, message: object) -> None:
+        """Advance the partition high-water mark to ``message`` (commits all <= it).
+
+        ``message`` is typed ``object`` (a supertype of the protocol's
+        ``ProtocolTransportMessage``) so this module stays independent of the
+        protocol type; at runtime it is always a :class:`ModelTransportMessage` this
+        transport yielded from ``poll``, so it is narrowed here.
+        """
+        self._require_started()
+        msg = cast(ModelTransportMessage, message)
+        self._broker.commit_offset(msg.topic, self._group, msg.partition, msg.offset)
+        if self._chaos_duplicate:
+            token = (msg.topic, msg.partition, msg.offset)
+            if token not in self._chaos_seen:
+                self._chaos_seen.add(token)
+                record = self._broker.record_at(msg.topic, msg.partition, msg.offset)
+                if record is not None:
+                    self._chaos_pending.append(record)
+
+    async def nack(self, message: object) -> None:
+        """Re-expose ``message`` and later same-partition offsets (mirrors seek).
+
+        ``message`` is typed ``object`` for the same protocol-independence reason as
+        :meth:`commit`; it is narrowed to the concrete transport message here.
+        """
+        self._require_started()
+        msg = cast(ModelTransportMessage, message)
+        cursor = (msg.topic, msg.partition)
+        current = self._position(msg.topic, msg.partition)
+        self._positions[cursor] = min(current, msg.offset)
+
+    # -- producer protocol -------------------------------------------------
+
+    async def send(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: Mapping[str, bytes],
+    ) -> None:
+        """Append one event to the shared log, awaiting the (synchronous) ack."""
+        self._broker.append(topic, key, value, headers)

--- a/src/omnibase_core/runtime/transport/runtime_transport_conformance.py
+++ b/src/omnibase_core/runtime/transport/runtime_transport_conformance.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Parametrized transport conformance suite (the substitutability oracle).
+
+Net-new foundation for the single-runtime / transport-via-DI unification (epic
+OMN-14717, ticket OMN-14720; see
+``docs/plans/2026-07-17-single-runtime-transport-di-unification-plan.md`` section
+(d.4)). This is the mechanism that licenses "in-memory golden chain ⇒ Kafka golden
+chain": one suite of behavioural assertions runs against ANY transport
+implementation and asserts identical observable Kafka semantics.
+
+How to use it
+-------------
+The suite is a mixin of undecorated ``async def test_*`` methods that consume two
+fixtures BY NAME — ``transport_producer`` (a ``ProtocolTransportProducer``) and
+``transport_consumer_factory`` (``(*, group, topics) -> ProtocolTransportConsumer``).
+A concrete subclass supplies both fixtures; each test then gets a *fresh*
+environment (fresh in-memory broker / fresh Kafka topic) so offsets and committed
+cursors do not bleed across tests.
+
+The suite is deliberately kept free of pytest and of the ``protocols`` import hub:
+the fixtures are typed ``Any`` here (the harness is transport-agnostic; the concrete
+protocol binding is asserted in the subclass). Core parametrises it against
+``InMemoryTransport`` (this repo, S2); infra (S3) subclasses the SAME suite with a
+Kafka-backed environment, which is what proves the two transports substitutable::
+
+    class TestKafkaTransportConformance(TransportConformanceSuite):
+        pytestmark = pytest.mark.asyncio  # pytest.ini runs asyncio in STRICT mode
+
+        @pytest.fixture
+        def transport_producer(self) -> KafkaTransport: ...
+
+        @pytest.fixture
+        def transport_consumer_factory(self) -> Callable[..., KafkaTransport]: ...
+
+The assertions encode the corrected Kafka semantics (plan HOLE 2), NOT SQS
+per-message ack:
+
+* ``poll`` returns messages in per-partition offset order;
+* **commit at offset k commits ALL offsets <= k on that partition** (the corrected
+  assertion — replaces Design B's wrong "advances past exactly one message");
+* ``nack`` redelivers from the offset (the message + later same-partition offsets);
+* uncommitted offsets are redelivered on restart (new consumer, same group);
+* ``send`` is per-topic ordered and headers/keys/partition/offset round-trip.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+__all__ = ["CONFORMANCE_TOPIC", "TransportConformanceSuite"]
+
+# A single topic is enough: every assertion is about per-partition offset behaviour,
+# and messages with the same key land on the same partition on any transport. This is
+# a SYNTHETIC test topic that never routes in production — deliberately NOT an
+# ``onex.(cmd|evt|dlq).*`` name so it stays out of the canonical topic registry.
+CONFORMANCE_TOPIC = "transport.conformance.v1"  # env-var-ok: fixed synthetic test topic, never env-configured
+
+
+async def _drain(
+    consumer: Any, *, max_polls: int = 10, max_messages: int = 64
+) -> list[Any]:
+    """Poll until an empty batch (or ``max_polls``), collecting every message."""
+    collected: list[Any] = []
+    for _ in range(max_polls):
+        batch = await consumer.poll(max_messages=max_messages, timeout_ms=50)
+        if not batch:
+            break
+        collected.extend(batch)
+    return collected
+
+
+class TransportConformanceSuite:
+    """Shared behavioural conformance for any transport implementation.
+
+    Subclasses MUST provide ``transport_producer`` and ``transport_consumer_factory``
+    pytest fixtures. This base class is intentionally NOT named ``Test*`` so pytest
+    does not collect it directly (``python_classes = ["Test*"]``); only the concrete
+    subclass is collected, inheriting these methods.
+    """
+
+    async def test_poll_returns_messages_in_per_partition_offset_order(
+        self, transport_producer: Any, transport_consumer_factory: Any
+    ) -> None:
+        # Same key => one partition => a clean per-partition ordering check.
+        for i in range(4):
+            await transport_producer.send(
+                CONFORMANCE_TOPIC, key=b"order", value=str(i).encode(), headers={}
+            )
+        consumer = transport_consumer_factory(
+            group="g-order", topics=[CONFORMANCE_TOPIC]
+        )
+        await consumer.start()
+        messages = await _drain(consumer)
+        await consumer.close()
+
+        assert messages, "expected the produced messages to be polled"
+        by_partition: dict[int, list[int]] = defaultdict(list)
+        for message in messages:
+            by_partition[message.partition].append(message.offset)
+        for partition, offsets in by_partition.items():
+            assert offsets == sorted(offsets), (
+                f"partition {partition} offsets out of order: {offsets}"
+            )
+            # Contiguous within the partition (no gaps in delivery order).
+            assert offsets == list(range(offsets[0], offsets[0] + len(offsets)))
+        # Same key => single partition => strict send order preserved end-to-end.
+        assert [m.value for m in messages] == [b"0", b"1", b"2", b"3"]
+
+    async def test_commit_at_k_commits_all_leq_k_on_partition(
+        self, transport_producer: Any, transport_consumer_factory: Any
+    ) -> None:
+        # THE corrected assertion (plan HOLE 2): committing offset k commits every
+        # offset <= k on that partition, NOT just the one message.
+        for i in range(3):
+            await transport_producer.send(
+                CONFORMANCE_TOPIC, key=b"commit", value=str(i).encode(), headers={}
+            )
+        first = transport_consumer_factory(group="g-commit", topics=[CONFORMANCE_TOPIC])
+        await first.start()
+        batch = await _drain(first)
+        assert len(batch) == 3
+        partition = batch[0].partition
+        assert all(m.partition == partition for m in batch), "same key => 1 partition"
+        base = min(m.offset for m in batch)
+        middle = next(m for m in batch if m.offset == base + 1)
+
+        # Commit ONLY the middle offset — never explicitly commit the first.
+        await first.commit(middle)
+        await first.close()
+
+        # Restart: a new consumer on the same group resumes from the committed HWM.
+        second = transport_consumer_factory(
+            group="g-commit", topics=[CONFORMANCE_TOPIC]
+        )
+        await second.start()
+        redelivered = await _drain(second)
+        await second.close()
+
+        redelivered_offsets = {m.offset for m in redelivered}
+        # base and base+1 are BOTH committed by the single commit at base+1.
+        assert base not in redelivered_offsets, (
+            "commit at k must commit the earlier offset k-1 too (all <= k)"
+        )
+        assert (base + 1) not in redelivered_offsets
+        # base+2 was never committed => still redelivered.
+        assert redelivered_offsets == {base + 2}
+
+    async def test_nack_redelivers_from_offset_including_later(
+        self, transport_producer: Any, transport_consumer_factory: Any
+    ) -> None:
+        for i in range(3):
+            await transport_producer.send(
+                CONFORMANCE_TOPIC, key=b"nack", value=str(i).encode(), headers={}
+            )
+        consumer = transport_consumer_factory(
+            group="g-nack", topics=[CONFORMANCE_TOPIC]
+        )
+        await consumer.start()
+        batch = await _drain(consumer)
+        assert len(batch) == 3
+        base = min(m.offset for m in batch)
+        target = next(m for m in batch if m.offset == base + 1)
+
+        await consumer.nack(target)
+        redelivered = await _drain(consumer)
+        await consumer.close()
+
+        offsets = sorted(m.offset for m in redelivered)
+        # nack re-exposes the message AND every later same-partition offset.
+        assert offsets == [base + 1, base + 2]
+
+    async def test_uncommitted_offsets_redeliver_on_restart(
+        self, transport_producer: Any, transport_consumer_factory: Any
+    ) -> None:
+        for i in range(3):
+            await transport_producer.send(
+                CONFORMANCE_TOPIC, key=b"restart", value=str(i).encode(), headers={}
+            )
+        first = transport_consumer_factory(
+            group="g-restart", topics=[CONFORMANCE_TOPIC]
+        )
+        await first.start()
+        batch = await _drain(first)
+        assert len(batch) == 3
+        base = min(m.offset for m in batch)
+        earliest = next(m for m in batch if m.offset == base)
+
+        # Commit only the earliest, then "crash" without committing the rest.
+        await first.commit(earliest)
+        await first.close()
+
+        second = transport_consumer_factory(
+            group="g-restart", topics=[CONFORMANCE_TOPIC]
+        )
+        await second.start()
+        redelivered = await _drain(second)
+        await second.close()
+
+        offsets = sorted(m.offset for m in redelivered)
+        assert offsets == [base + 1, base + 2]
+
+    async def test_send_is_per_topic_ordered_and_roundtrips(
+        self, transport_producer: Any, transport_consumer_factory: Any
+    ) -> None:
+        payloads = [
+            (b"key-a", b"v0", {"h": b"0"}),
+            (b"key-a", b"v1", {"h": b"1"}),
+            (b"key-a", b"v2", {"h": b"2"}),
+        ]
+        for key, value, headers in payloads:
+            await transport_producer.send(
+                CONFORMANCE_TOPIC, key=key, value=value, headers=headers
+            )
+        consumer = transport_consumer_factory(
+            group="g-roundtrip", topics=[CONFORMANCE_TOPIC]
+        )
+        await consumer.start()
+        messages = await _drain(consumer)
+        await consumer.close()
+
+        assert len(messages) == 3
+        # Same key => single partition => strict send order preserved.
+        assert [m.value for m in messages] == [b"v0", b"v1", b"v2"]
+        assert [m.key for m in messages] == [b"key-a", b"key-a", b"key-a"]
+        assert [dict(m.headers) for m in messages] == [
+            {"h": b"0"},
+            {"h": b"1"},
+            {"h": b"2"},
+        ]
+        # partition/offset round-trip: contiguous ascending offsets on one partition.
+        base = messages[0].offset
+        assert [m.offset for m in messages] == [base, base + 1, base + 2]
+        assert all(m.topic == CONFORMANCE_TOPIC for m in messages)
+        assert len({m.partition for m in messages}) == 1

--- a/tests/unit/runtime/transport/__init__.py
+++ b/tests/unit/runtime/transport/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the net-new in-memory transport + conformance suite (OMN-14720)."""

--- a/tests/unit/runtime/transport/test_in_memory_transport.py
+++ b/tests/unit/runtime/transport/test_in_memory_transport.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Focused unit tests for ``InMemoryTransport`` cursor edge cases (OMN-14720).
+
+These exercise the Kafka-faithful per-``(topic, group, partition)`` monotonic
+committed-offset cursor directly, including the plan's HOLE-1 out-of-order-commit
+bug being *observable* in-memory, nack-then-repoll, restart redelivery, chaos
+duplication, and per-partition isolation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.protocols.runtime.protocol_transport_consumer import (
+    ProtocolTransportConsumer,
+)
+from omnibase_core.protocols.runtime.protocol_transport_producer import (
+    ProtocolTransportProducer,
+)
+from omnibase_core.runtime.transport.runtime_in_memory_broker import InMemoryBroker
+from omnibase_core.runtime.transport.runtime_in_memory_transport import (
+    InMemoryTransport,
+)
+
+TOPIC = "transport.inmemory-edge.v1"
+
+
+def _consumer(
+    broker: InMemoryBroker,
+    *,
+    group: str = "g",
+    topics: Sequence[str] = (TOPIC,),
+    chaos_duplicate: bool = False,
+) -> InMemoryTransport:
+    return InMemoryTransport(
+        broker=broker, group=group, topics=topics, chaos_duplicate=chaos_duplicate
+    )
+
+
+async def _send_n(broker: InMemoryBroker, n: int, *, key: bytes | None = b"k") -> None:
+    producer = InMemoryTransport(broker=broker, group="producer")
+    for i in range(n):
+        await producer.send(TOPIC, key=key, value=str(i).encode(), headers={})
+
+
+# --------------------------------------------------------------------------- #
+# Structural protocol satisfaction
+# --------------------------------------------------------------------------- #
+
+
+def test_in_memory_transport_satisfies_both_protocols() -> None:
+    broker = InMemoryBroker()
+    # mypy: the concrete class is assignable to each structural protocol.
+    consumer: ProtocolTransportConsumer = InMemoryTransport(broker=broker)
+    producer: ProtocolTransportProducer = InMemoryTransport(broker=broker)
+    assert isinstance(consumer, ProtocolTransportConsumer)
+    assert isinstance(producer, ProtocolTransportProducer)
+
+
+# --------------------------------------------------------------------------- #
+# HOLE 1 — out-of-order commit is observable in-memory
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_commit_defeats_earlier_redelivery_hole1() -> None:
+    """Committing a LATER offset silently commits an earlier uncommitted one.
+
+    This is the plan's HOLE-1 bug made visible in-memory: a buggy dispatch loop that
+    processes offset 0 OK, fails offset 1 (should redeliver), but keeps going and
+    commits offset 2 — the commit at offset 2 advances the HWM past offset 1, so the
+    failed message is NOT redelivered on restart (silent loss). A correct runtime
+    must stop the per-partition prefix at offset 1 and never commit offset 2.
+    """
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)  # single partition: offsets 0, 1, 2
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in batch] == [0, 1, 2]
+    # Buggy loop: skip committing the "failed" offset 1, commit offset 2 anyway.
+    await consumer.commit(batch[2])
+    await consumer.close()
+
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    # Offset 1 (the failed message) is silently gone — HOLE-1 is visible here.
+    assert redelivered == []
+
+
+@pytest.mark.asyncio
+async def test_contiguous_prefix_commit_preserves_redelivery() -> None:
+    """The correct pattern: commit only the contiguous prefix, redeliver the rest.
+
+    Commit offset 0 (the contiguous successfully-terminalized prefix) and stop; on
+    restart, offsets 1 and 2 are redelivered — the redelivery HOLE 1 destroys is
+    preserved when the runtime does not commit past a failure.
+    """
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.commit(batch[0])  # only the contiguous prefix
+    await consumer.close()
+
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    assert [m.offset for m in redelivered] == [1, 2]
+
+
+# --------------------------------------------------------------------------- #
+# commit-at-k commits all <= k (durable-cursor semantics)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_commit_at_k_commits_all_leq_k() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 4)  # offsets 0..3 on one partition
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in batch] == [0, 1, 2, 3]
+    # Commit offset 2 without ever committing 0 or 1.
+    await consumer.commit(batch[2])
+    await consumer.close()
+    # Broker HWM proves all <= 2 committed.
+    assert broker.committed_offset(TOPIC, "g", 0) == 2
+
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    # Only offset 3 (> k) survives; 0, 1, 2 are all committed.
+    assert [m.offset for m in redelivered] == [3]
+
+
+@pytest.mark.asyncio
+async def test_commit_high_water_mark_is_monotonic() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.commit(batch[2])  # commit offset 2
+    await consumer.commit(batch[0])  # a lower commit must NOT move the HWM back
+    await consumer.close()
+    assert broker.committed_offset(TOPIC, "g", 0) == 2
+
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    assert redelivered == []
+
+
+# --------------------------------------------------------------------------- #
+# nack — re-expose from the offset
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_nack_then_repoll_redelivers_from_cursor() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in batch] == [0, 1, 2]
+
+    # nack the middle message: re-exposes it AND every later same-partition offset.
+    await consumer.nack(batch[1])
+    repoll = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    assert [m.offset for m in repoll] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_nack_earliest_redelivers_whole_partition() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.nack(batch[0])
+    repoll = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    assert [m.offset for m in repoll] == [0, 1, 2]
+
+
+# --------------------------------------------------------------------------- #
+# in-flight / restart semantics
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_poll_marks_in_flight_but_does_not_remove() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    first = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in first] == [0, 1, 2]
+    # Same instance, no commit/nack: in-flight messages are NOT re-delivered.
+    second = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert second == []
+    await consumer.close()
+
+    # Records were never removed: a restart (new instance, same group) redelivers all.
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    assert [m.offset for m in redelivered] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_fresh_group_reads_from_beginning() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 2)
+    consumer = _consumer(broker, group="brand-new")
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    assert [m.offset for m in batch] == [0, 1]
+
+
+# --------------------------------------------------------------------------- #
+# chaos / duplicate mode
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_chaos_mode_redelivers_committed_offset_exactly_once() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 1)
+
+    consumer = _consumer(broker, chaos_duplicate=True)
+    await consumer.start()
+    first = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in first] == [0]
+
+    await consumer.commit(first[0])  # commit schedules ONE chaos redelivery
+    duplicate = await consumer.poll(max_messages=10, timeout_ms=0)
+    assert [m.offset for m in duplicate] == [0]
+    assert duplicate[0].value == first[0].value  # same committed message, redelivered
+
+    await consumer.commit(duplicate[0])  # committing the duplicate does not re-arm it
+    third = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    assert third == []  # delivered at most once more
+
+
+@pytest.mark.asyncio
+async def test_non_chaos_consumer_does_not_duplicate() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 1)
+
+    consumer = _consumer(broker, chaos_duplicate=False)
+    await consumer.start()
+    first = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.commit(first[0])
+    again = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    assert again == []
+
+
+# --------------------------------------------------------------------------- #
+# partitioning
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_per_partition_isolation_under_commit() -> None:
+    """Committing one partition must not affect another partition's redelivery."""
+    broker = InMemoryBroker(num_partitions=2)
+    producer = InMemoryTransport(broker=broker, group="producer")
+    # Unkeyed => deterministic round-robin: sends land p0, p1, p0, p1.
+    for i in range(4):
+        await producer.send(TOPIC, key=None, value=str(i).encode(), headers={})
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    p0 = [m for m in batch if m.partition == 0]
+    p1 = [m for m in batch if m.partition == 1]
+    assert [m.offset for m in p0] == [0, 1]
+    assert [m.offset for m in p1] == [0, 1]
+
+    # Commit the whole of partition 0 only.
+    await consumer.commit(max(p0, key=lambda m: m.offset))
+    await consumer.close()
+
+    restart = _consumer(broker)
+    await restart.start()
+    redelivered = await restart.poll(max_messages=10, timeout_ms=0)
+    await restart.close()
+    # Partition 0 fully committed; partition 1 fully redelivered.
+    assert {m.partition for m in redelivered} == {1}
+    assert sorted(m.offset for m in redelivered) == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_keyed_partition_assignment_is_stable() -> None:
+    broker = InMemoryBroker(num_partitions=3)
+    producer = InMemoryTransport(broker=broker, group="producer")
+    for _ in range(5):
+        await producer.send(TOPIC, key=b"stable-key", value=b"x", headers={})
+
+    consumer = _consumer(broker)
+    await consumer.start()
+    batch = await consumer.poll(max_messages=10, timeout_ms=0)
+    await consumer.close()
+    # Same key => all on one partition, contiguous offsets.
+    assert len({m.partition for m in batch}) == 1
+    assert [m.offset for m in batch] == [0, 1, 2, 3, 4]
+
+
+# --------------------------------------------------------------------------- #
+# fail-fast guards
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_poll_before_start_raises() -> None:
+    broker = InMemoryBroker()
+    consumer = _consumer(broker)
+    with pytest.raises(ModelOnexError):
+        await consumer.poll(max_messages=1, timeout_ms=0)
+
+
+@pytest.mark.asyncio
+async def test_poll_zero_max_messages_raises() -> None:
+    broker = InMemoryBroker()
+    consumer = _consumer(broker)
+    await consumer.start()
+    with pytest.raises(ModelOnexError):
+        await consumer.poll(max_messages=0, timeout_ms=0)
+    await consumer.close()
+
+
+def test_zero_partitions_rejected() -> None:
+    with pytest.raises(ModelOnexError):
+        InMemoryBroker(num_partitions=0)
+
+
+@pytest.mark.asyncio
+async def test_poll_respects_max_messages_bound() -> None:
+    broker = InMemoryBroker()
+    await _send_n(broker, 3)
+    consumer = _consumer(broker)
+    await consumer.start()
+    first = await consumer.poll(max_messages=2, timeout_ms=0)
+    assert [m.offset for m in first] == [0, 1]
+    second = await consumer.poll(max_messages=2, timeout_ms=0)
+    await consumer.close()
+    assert [m.offset for m in second] == [2]

--- a/tests/unit/runtime/transport/test_transport_conformance_inmemory.py
+++ b/tests/unit/runtime/transport/test_transport_conformance_inmemory.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Run the shared transport conformance suite against ``InMemoryTransport``.
+
+This is the in-memory side of the substitutability oracle (ticket OMN-14720, epic
+OMN-14717). The identical suite is subclassed with a Kafka-backed environment in
+omnibase_infra (S3), which is what licenses "in-memory golden chain ⇒ Kafka golden
+chain". The base suite lives in
+``omnibase_core.runtime.transport.runtime_transport_conformance`` and is deliberately
+importable (pytest-free, protocols-hub-free) so infra can subclass it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import pytest
+
+from omnibase_core.runtime.transport.runtime_in_memory_broker import InMemoryBroker
+from omnibase_core.runtime.transport.runtime_in_memory_transport import (
+    InMemoryTransport,
+)
+from omnibase_core.runtime.transport.runtime_transport_conformance import (
+    TransportConformanceSuite,
+)
+
+
+class TestInMemoryTransportConformance(TransportConformanceSuite):
+    """Parametrize the shared conformance suite over the in-memory transport."""
+
+    # pytest.ini runs asyncio in STRICT mode, so every async test needs the marker.
+    # Setting it at class level applies it to the inherited async test methods, which
+    # keeps the shared suite itself free of any pytest import.
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.fixture
+    def _broker(self) -> InMemoryBroker:
+        return InMemoryBroker()
+
+    @pytest.fixture
+    def transport_producer(self, _broker: InMemoryBroker) -> InMemoryTransport:
+        return InMemoryTransport(broker=_broker, group="conformance-producer")
+
+    @pytest.fixture
+    def transport_consumer_factory(
+        self, _broker: InMemoryBroker
+    ) -> Callable[..., InMemoryTransport]:
+        def factory(*, group: str, topics: Sequence[str]) -> InMemoryTransport:
+            return InMemoryTransport(broker=_broker, group=group, topics=topics)
+
+        return factory


### PR DESCRIPTION
## OMN-14720 — S2: in-memory transport + parametrized conformance suite (net-new, unused)

S2 of the single-runtime / transport-via-DI unification (epic **OMN-14717**). **Stacked on #1463 (S1, OMN-14719); land after S1 — Codex handles merge order.** Because S1 is unmerged, this PR's diff (against `dev`) currently shows the S1 files too; only the `runtime/transport/**` + `tests/unit/runtime/transport/**` files below are S2's.

Net-new, fully unwired — **zero production behavior change, fully reversible**. Nothing imports these yet; the runtime (S4) and the Kafka face (S3) consume them later.

### What's added
- **`InMemoryBroker` + `InMemoryTransport`** (`src/omnibase_core/runtime/transport/`): a real, usable transport (tests + local, not scaffolding) that models **Kafka** semantics, not SQS — a monotonic per-`(topic, group, partition)` **committed-offset cursor**:
  - `commit(msg)` advances the HWM to `msg.offset`, thereby committing **every earlier offset on that partition too** (plan **HOLE 2**). This is what makes the plan's HOLE-1 out-of-order-commit bug *observable in-memory*.
  - `nack(msg)` re-exposes `msg` + all later same-partition offsets (mirrors Kafka `seek`).
  - Restart (new consumer instance, same group) redelivers all uncommitted offsets.
  - Opt-in **chaos/duplicate** mode redelivers a committed offset once more (idempotence must be proven).
  - Producer `send()` is per-topic ordered; partition/offset assigned deterministically.
- **`TransportConformanceSuite`**: one parametrized suite asserting the **corrected** Kafka semantics against ANY transport — poll per-partition offset order; **commit at offset k commits ALL offsets ≤ k on that partition** (the corrected assertion, replacing Design B's "advances past exactly one message"); nack redelivers from the offset; uncommitted-on-restart redelivers; send per-topic ordered + headers/keys/partition/offset round-trip. Importable, **pytest-free and protocols-hub-free**, so infra (S3) subclasses it with the Kafka face. Run here against `InMemoryTransport`.
- **Focused unit tests** for the cursor edge cases (HOLE-1 out-of-order commit, contiguous-prefix commit, monotonic HWM, nack-then-repoll, restart redelivery, chaos exactly-once, in-flight-not-removed, per-partition isolation, deterministic partitioning, fail-fast guards).

### Design notes
- Implemented against S1's **structural `ProtocolTransportMessage` / concrete `ModelTransportMessage` split** — no protocol imports the concrete model (protocols→models ratchet stays 65/65); **core never imports kafka** (import-linter I2 contract green).
- `InMemoryTransport` structurally satisfies `ProtocolTransportConsumer` + `ProtocolTransportProducer` (proven in tests by static assignment + `isinstance`) **without importing the `protocols` hub**: `commit`/`nack` accept `object` (a supertype of the protocol's `ProtocolTransportMessage` param, so it stays contravariantly compatible) and narrow to the concrete `ModelTransportMessage` the transport itself yields. This keeps the frozen **OMN-14340** protocols-hub import ratchet untouched (protocols hub unchanged at 63).

### dod_evidence (OMN-14720)
- `env -u PYTHONPATH uv run pytest tests/unit/runtime/transport/` → **22 passed** (17 unit + 5 conformance). The **commit-at-k-commits-all-≤-k** assertion is present + passing in BOTH `TransportConformanceSuite.test_commit_at_k_commits_all_leq_k_on_partition` and unit `test_commit_at_k_commits_all_leq_k`.
- `ruff format` + `ruff check`: clean. `mypy` (strict): **0 errors** in 7 files.
- `lint-imports` (import-linter): **5 contracts kept, 0 broken** (incl. `core-no-kafka-transport` I2).
- `check_import_ratchet.py`: **OK** — protocols→models=65 (frozen max), protocols hub=63 (unchanged), mixins=17.
- `pre-commit run --files <all transport files>`: **111 hooks passed/skipped, 0 failed** (incl. single-class-per-file, no-hardcoded-topics, env-var, canonical-handler-shape, no-kafka-in-core).

### Files (S2)
- `src/omnibase_core/runtime/transport/__init__.py`
- `src/omnibase_core/runtime/transport/runtime_in_memory_broker.py`
- `src/omnibase_core/runtime/transport/runtime_in_memory_transport.py`
- `src/omnibase_core/runtime/transport/runtime_transport_conformance.py`
- `tests/unit/runtime/transport/{__init__.py,test_in_memory_transport.py,test_transport_conformance_inmemory.py}`

Closes OMN-14720 (after S1/#1463 lands).

Evidence-Ticket: OMN-14720
Evidence-Source: OCC#4343
Evidence-Commit: f70e3f580fbceff1b61a0f8f35ce353f124d04d6
Evidence-Head: 4568d2b4743abf59ce1fa26e67cb6b079ba7f64d
