### PR TITLE
fix(OMN-14743): stamp event_type on RuntimeLocal fan-out emit (fail-closed) — delegation routing stall

### DIFF
--- a/src/omnibase_core/runtime/runtime_fanout_resolver.py
+++ b/src/omnibase_core/runtime/runtime_fanout_resolver.py
@@ -50,8 +50,10 @@ from omnibase_core.models.errors.model_onex_error import ModelOnexError
 __all__ = [
     "CARRIER_CLASS_NAMES",
     "assert_published_events_injective",
+    "derive_event_type_from_topic",
     "is_fanout_sequence",
     "normalize_fanout_elements",
+    "resolve_fanout_emissions",
     "resolve_fanout_topics",
     "resolve_published_topic",
 ]
@@ -188,6 +190,76 @@ def resolve_fanout_topics(
         )
         for element in validated
     ]
+
+
+def derive_event_type_from_topic(topic: str) -> str | None:
+    """Derive the ``ModelEventEnvelope.event_type`` routing key from an ONEX topic.
+
+    ONEX topics follow ``onex.{kind}.{producer}.{event-name}.v{n}``; the
+    dispatch-engine registers type-scoped handlers under the
+    ``{producer}.{event-name}`` alias. An emitted envelope MUST carry this
+    ``event_type`` or a type-scoped dispatcher (``event_model``-scoped, OMN-12294)
+    silently drops it (``reference_no_dispatcher_can_be_typescoping_drop``).
+
+    This is byte-for-byte the applier's
+    ``service_dispatch_result_applier._derive_event_type_from_topic`` so the
+    RuntimeLocal fan-out emit and the Kafka applier produce the SAME event_type
+    for the same topic — the OMN-14743 regression was the RuntimeLocal fan-out
+    path publishing a raw payload with NO envelope/event_type while the Kafka
+    applier stamped one, so the reducer's type-scoped Kafka dispatcher matched the
+    07-11/13 (applier-stamped) intents and dropped the 07-17 (fan-out, null)
+    intents.
+
+    Returns ``None`` when the topic does not follow the ONEX convention.
+    """
+    parts = topic.split(".")
+    if len(parts) >= 5 and parts[0] == "onex":
+        producer = parts[2]
+        event_name = parts[3]
+        return f"{producer}.{event_name}"
+    return None
+
+
+def resolve_fanout_emissions(
+    published_events: Mapping[str, str],
+    elements: Sequence[object],
+    *,
+    message_type: str | None = None,
+) -> list[tuple[str, str, BaseModel]]:
+    """Resolve a fan-out sequence into ordered ``(topic, event_type, payload)`` triples.
+
+    Extends ``resolve_fanout_topics`` with the emit-boundary ``event_type``
+    derivation and a FAIL-CLOSED guard: a resolved publish topic that yields no
+    derivable ``event_type`` RAISES rather than emitting an envelope the
+    downstream type-scoped dispatcher will silently drop (OMN-14743). This
+    converts the silent type-scoped-drop class into a loud emit-time failure —
+    the same discipline as the OMN-14721 completeness guard, applied at the emit
+    side so a mis-shaped topic can never again produce a null-``event_type``
+    envelope that stalls the chain.
+
+    Order is the handler's return order (the routing-equivalence invariant).
+    """
+    emissions: list[tuple[str, str, BaseModel]] = []
+    for topic, payload in resolve_fanout_topics(
+        published_events, elements, message_type=message_type
+    ):
+        event_type = derive_event_type_from_topic(topic)
+        if event_type is None:
+            raise ModelOnexError(
+                message=(
+                    f"Fan-out element {type(payload).__name__!r} resolved to publish "
+                    f"topic {topic!r}, which does not follow the ONEX "
+                    "onex.{kind}.{producer}.{event-name}.v{n} convention, so no "
+                    "event_type routing key can be derived. An emitted fan-out "
+                    "envelope MUST carry a non-null event_type or the consuming "
+                    "type-scoped dispatcher silently drops it (OMN-14743). Fix the "
+                    "contract's published_events topic to the canonical ONEX shape. "
+                    f"(handler message_type={message_type!r})"
+                ),
+                error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
+            )
+        emissions.append((topic, event_type, payload))
+    return emissions
 
 
 def assert_published_events_injective(

--- a/src/omnibase_core/runtime/runtime_local_adapter.py
+++ b/src/omnibase_core/runtime/runtime_local_adapter.py
@@ -13,11 +13,13 @@ import os
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import cast
+from uuid import UUID, uuid4, uuid5
 
 from pydantic import BaseModel
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
     ProtocolLocalRuntimeBus,
 )
@@ -29,7 +31,7 @@ from omnibase_core.protocols.runtime.protocol_local_runtime_message import (
 )
 from omnibase_core.runtime.runtime_fanout_resolver import (
     is_fanout_sequence,
-    resolve_fanout_topics,
+    resolve_fanout_emissions,
     resolve_published_topic,
 )
 
@@ -121,8 +123,18 @@ class LocalRuntimeBusAdapter:
             decoded: object = (
                 json.loads(msg.value) if isinstance(msg.value, bytes) else {}
             )
-            payload_dict = decoded if isinstance(decoded, dict) else {}
-            correlation_value = payload_dict.get("correlation_id")
+            decoded_dict = decoded if isinstance(decoded, dict) else {}
+            # A fan-out emit is published as a ``ModelEventEnvelope`` carrying the
+            # topic-derived ``event_type`` (OMN-14743) so a cross-process
+            # type-scoped dispatcher matches it. Unwrap to the inner domain
+            # ``payload`` before validating into ``input_model_cls`` — a raw
+            # (non-enveloped) message passes through unchanged. ``envelope_id`` is
+            # the discriminator: a domain payload (e.g. ModelRoutingIntent, which
+            # itself has a ``payload`` field) never carries ``envelope_id``.
+            payload_dict, envelope_correlation = _unwrap_envelope_dict(decoded_dict)
+            correlation_value = envelope_correlation or payload_dict.get(
+                "correlation_id"
+            )
             correlation_id = (
                 correlation_value if isinstance(correlation_value, str) else None
             )
@@ -275,16 +287,27 @@ class LocalRuntimeBusAdapter:
                 )
             return
         try:
-            resolved = resolve_fanout_topics(
+            # Resolve (topic, event_type, payload) triples. ``resolve_fanout_emissions``
+            # is FAIL-CLOSED on a topic that yields no derivable event_type — an
+            # emitted fan-out envelope with a null event_type is silently dropped by
+            # the consuming type-scoped dispatcher (the OMN-14743 stall). Order is
+            # the handler's return order.
+            emissions = resolve_fanout_emissions(
                 self.published_events, elements, message_type=self.handler_name
             )
-            for topic, payload in resolved:
-                output_bytes = payload.model_dump_json().encode("utf-8")
+            correlation_uuid = _coerce_correlation_uuid(correlation_id)
+            for idx, (topic, event_type, payload) in enumerate(emissions):
+                envelope = self._build_output_envelope(
+                    payload, event_type, correlation_uuid, idx
+                )
+                output_bytes = envelope.model_dump_json().encode("utf-8")
                 await self.bus.publish(topic, None, output_bytes)
                 logger.info(
-                    "LocalRuntimeBusAdapter: fan-out published %s to %s (correlation_id=%s)",
+                    "LocalRuntimeBusAdapter: fan-out published %s to %s "
+                    "(event_type=%s correlation_id=%s)",
                     type(payload).__name__,
                     topic,
+                    event_type,
                     correlation_id,
                 )
         except Exception:  # fallback-ok: fan-out resolution/publish failure is recorded via on_error and the run is marked FAILED; reraising would abort bus shutdown
@@ -295,6 +318,69 @@ class LocalRuntimeBusAdapter:
             )
             if self.on_error:
                 self.on_error()
+
+    def _build_output_envelope(
+        self,
+        payload: BaseModel,
+        event_type: str,
+        correlation_uuid: UUID | None,
+        idx: int,
+    ) -> ModelEventEnvelope[BaseModel]:
+        """Wrap a fan-out payload in an event envelope carrying ``event_type``.
+
+        Mirrors the Kafka applier's envelope shape
+        (``service_dispatch_result_applier.apply``): a deterministic
+        ``uuid5(correlation_id, "type:index")`` envelope_id so a redelivery
+        dedupes, and the topic-derived ``event_type`` routing key so a
+        type-scoped dispatcher matches (OMN-14743). When no correlation_id is
+        available the envelope_id falls back to ``uuid4`` (dedup is best-effort,
+        matching the applier).
+        """
+        envelope_id = (
+            uuid5(correlation_uuid, f"{type(payload).__name__}:{idx}")
+            if correlation_uuid is not None
+            else uuid4()
+        )
+        # Construct WITHOUT the ``[BaseModel]`` runtime subscript: subscripting the
+        # generic at runtime coerces the payload to the bare ``BaseModel`` schema and
+        # drops the concrete model's fields on ``model_dump_json`` (payload -> {}).
+        # The applier constructs the same way (annotate the var, not the call).
+        envelope: ModelEventEnvelope[BaseModel] = ModelEventEnvelope(
+            envelope_id=envelope_id,
+            payload=payload,
+            correlation_id=correlation_uuid,
+            event_type=event_type,
+        )
+        return envelope
+
+
+def _coerce_correlation_uuid(correlation_id: str | None) -> UUID | None:
+    """Coerce a wire correlation_id string into a UUID, or None when unparseable."""
+    if not correlation_id:
+        return None
+    try:
+        return UUID(correlation_id)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+def _unwrap_envelope_dict(
+    decoded: Mapping[str, object],
+) -> tuple[dict[str, object], str | None]:
+    """Unwrap a ``ModelEventEnvelope`` wire dict to its inner payload dict.
+
+    Returns ``(payload_dict, correlation_id)``. A fan-out emit publishes a
+    ``ModelEventEnvelope`` (OMN-14743); the inner domain ``payload`` is what the
+    subscribed handler's ``input_model_cls`` validates against. ``envelope_id`` is
+    the discriminator — a raw (non-enveloped) message, or a domain payload that
+    happens to carry its own ``payload`` field (e.g. ModelRoutingIntent), lacks
+    ``envelope_id`` and is returned unchanged.
+    """
+    if "envelope_id" in decoded and isinstance(decoded.get("payload"), dict):
+        inner = cast("dict[str, object]", decoded["payload"])
+        correlation = decoded.get("correlation_id")
+        return inner, correlation if isinstance(correlation, str) else None
+    return dict(decoded), None
 
 
 def _invoke_handle_method(

--- a/tests/unit/runtime/test_runtime_fanout_resolver.py
+++ b/tests/unit/runtime/test_runtime_fanout_resolver.py
@@ -16,8 +16,10 @@ from pydantic import BaseModel, ConfigDict
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.runtime.runtime_fanout_resolver import (
     assert_published_events_injective,
+    derive_event_type_from_topic,
     is_fanout_sequence,
     normalize_fanout_elements,
+    resolve_fanout_emissions,
     resolve_fanout_topics,
     resolve_published_topic,
 )
@@ -142,3 +144,52 @@ class TestAssertPublishedEventsInjective:
         published = {"Alpha": "onex.evt.shared.v1", "Beta": "onex.evt.shared.v1"}
         with pytest.raises(ModelOnexError, match="injective"):
             assert_published_events_injective(published, context="test")
+
+
+# Canonical 5-segment ONEX topics so an event_type is derivable (OMN-14743).
+_PUBLISHED_CANONICAL = {
+    "Alpha": "onex.evt.omni.alpha.v1",
+    "Beta": "onex.cmd.omni.beta.v1",
+}
+
+
+class TestDeriveEventTypeFromTopic:
+    def test_canonical_topic_derives_producer_event_name(self) -> None:
+        assert (
+            derive_event_type_from_topic(
+                "onex.cmd.omnibase-infra.delegation-routing-request.v1"
+            )
+            == "omnibase-infra.delegation-routing-request"
+        )
+
+    def test_evt_topic_derives(self) -> None:
+        assert derive_event_type_from_topic("onex.evt.omni.alpha.v1") == "omni.alpha"
+
+    def test_four_segment_topic_yields_none(self) -> None:
+        # Missing the {event-name} segment -> not derivable.
+        assert derive_event_type_from_topic("onex.evt.alpha.v1") is None
+
+    def test_non_onex_prefix_yields_none(self) -> None:
+        assert derive_event_type_from_topic("kafka.raw.a.b.c") is None
+
+
+class TestResolveFanoutEmissions:
+    def test_returns_topic_event_type_payload_triples_in_order(self) -> None:
+        elements = [ModelAlpha(value=1), ModelBeta(value=2)]
+        emissions = resolve_fanout_emissions(_PUBLISHED_CANONICAL, elements)
+        assert [(t, et, type(p).__name__) for t, et, p in emissions] == [
+            ("onex.evt.omni.alpha.v1", "omni.alpha", "ModelAlpha"),
+            ("onex.cmd.omni.beta.v1", "omni.beta", "ModelBeta"),
+        ]
+
+    def test_fails_closed_when_topic_yields_no_event_type(self) -> None:
+        # A 4-segment topic resolves fine as a topic but yields no event_type ->
+        # emitting it would produce a null-event_type envelope the type-scoped
+        # dispatcher drops, so the emit boundary must raise instead.
+        published = {"Alpha": "onex.evt.alpha.v1"}
+        with pytest.raises(ModelOnexError, match="event_type"):
+            resolve_fanout_emissions(published, [ModelAlpha(value=1)])
+
+    def test_unmapped_class_still_fails_closed(self) -> None:
+        with pytest.raises(ModelOnexError):
+            resolve_fanout_emissions(_PUBLISHED_CANONICAL, [ModelGamma(value=1)])

--- a/tests/unit/runtime/test_runtime_local_adapter_event_type.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_event_type.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""RuntimeLocal fan-out emit stamps event_type on the envelope (OMN-14743).
+
+The delegation stall: the RuntimeLocal fan-out publish path emitted the routing
+intent as a RAW payload with NO envelope and NO ``event_type``, while the Kafka
+applier stamped a topic-derived ``event_type``. The routing reducer's Kafka
+consumer type-scopes its dispatcher on the ``event_type`` alias
+(``omnibase-infra.delegation-routing-request``); an envelope whose ``event_type``
+is null falls back to the payload class name (``ModelRoutingIntent``), matches NO
+registered dispatcher, and is dropped — ``routing-decision.v1`` is never
+published and the workflow stalls at ``RECEIVED``.
+
+These tests pin the fix at the emit boundary: a fan-out emit MUST publish a
+``ModelEventEnvelope`` carrying the exact topic-derived ``event_type`` the 07-11/13
+working intents had, and a topic that yields no derivable ``event_type`` MUST
+fail closed (raise) rather than emit a silently-dropped envelope.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.models.delegation.wire.model_delegation_wire_request import (
+    ModelDelegationRequest,
+)
+from omnibase_core.models.delegation.wire.model_orchestrator_intents import (
+    ModelRoutingIntent,
+)
+from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
+    ProtocolLocalRuntimeBus,
+)
+from omnibase_core.protocols.runtime.protocol_local_runtime_callable_target import (
+    ProtocolLocalRuntimeCallableTarget,
+)
+from omnibase_core.runtime.runtime_local_adapter import LocalRuntimeBusAdapter
+
+# The exact live topic + the event_type the working 07-11/13 intents carried.
+_ROUTING_REQUEST_TOPIC = "onex.cmd.omnibase-infra.delegation-routing-request.v1"
+_EXPECTED_EVENT_TYPE = "omnibase-infra.delegation-routing-request"
+# A non-canonical (4-segment) topic yields no derivable event_type -> fail-closed.
+_NON_ONEX_TOPIC = "onex.evt.routingintent.v1"
+
+_PUBLISHED_ROUTING = {"RoutingIntent": _ROUTING_REQUEST_TOPIC}
+_PUBLISHED_NON_ONEX = {"RoutingIntent": _NON_ONEX_TOPIC}
+
+
+def _delegation_request(correlation_id: str) -> ModelDelegationRequest:
+    return ModelDelegationRequest(
+        prompt="Write tests",
+        task_type="test",
+        correlation_id=UUID(correlation_id),
+        emitted_at=datetime.now(UTC),
+    )
+
+
+class _RoutingIntentFanoutHandler:
+    """def-B fan-out: returns a one-element sequence of ModelRoutingIntent."""
+
+    def __init__(self, correlation_id: str) -> None:
+        self._correlation_id = correlation_id
+
+    def handle(self, request: object) -> tuple[ModelRoutingIntent, ...]:
+        _ = request
+        return (ModelRoutingIntent(payload=_delegation_request(self._correlation_id)),)
+
+
+class _CapturingRoutingHandler:
+    """Consume-side handler whose input model is ModelRoutingIntent (type-scoped)."""
+
+    def __init__(self) -> None:
+        self.received: list[object] = []
+
+    def handle(self, intent: ModelRoutingIntent) -> None:
+        self.received.append(intent)
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def start(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def publish(self, topic: str, key: object, value: bytes) -> object:
+        self.published.append((topic, value))
+        return None
+
+    async def subscribe(
+        self, topic: str, *, on_message: object, group_id: str
+    ) -> object:  # pragma: no cover - unused
+        return None
+
+
+class _FakeMsg:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+def _adapter(
+    handler: object,
+    bus: _FakeBus,
+    *,
+    published_events: dict[str, str],
+    input_model_cls: type | None,
+    on_error: Callable[[], None] | None = None,
+) -> LocalRuntimeBusAdapter:
+    return LocalRuntimeBusAdapter(
+        handler=cast(ProtocolLocalRuntimeCallableTarget, handler),
+        handler_name="test-routing-handler",
+        input_model_cls=input_model_cls,  # type: ignore[arg-type]
+        output_topic="onex.evt.fallback.v1",
+        bus=cast(ProtocolLocalRuntimeBus, bus),
+        on_error=on_error,
+        published_events=published_events,
+        multi_event_seam_enabled=True,
+    )
+
+
+def _input_msg(correlation_id: str) -> _FakeMsg:
+    return _FakeMsg(json.dumps({"correlation_id": correlation_id}).encode())
+
+
+@pytest.mark.asyncio
+async def test_fanout_emit_stamps_topic_derived_event_type() -> None:
+    """The gating fix: the emitted routing-intent envelope carries the event_type
+    alias the reducer's type-scoped dispatcher matches — not a null value.
+
+    RED before the fix: ``_publish_fanout`` published ``payload.model_dump_json()``
+    (a raw ModelRoutingIntent, no ``event_type`` key), so this event_type
+    assertion had no field to read and the reducer dispatcher dropped the message.
+    """
+    cid = str(uuid4())
+    bus = _FakeBus()
+    adapter = _adapter(
+        _RoutingIntentFanoutHandler(cid),
+        bus,
+        published_events=_PUBLISHED_ROUTING,
+        input_model_cls=None,  # operation_match entry: raw dict forwarded
+    )
+
+    await adapter.on_message(_input_msg(cid))
+
+    assert [topic for topic, _ in bus.published] == [_ROUTING_REQUEST_TOPIC]
+    wire = json.loads(bus.published[0][1])
+    # The wire message is a ModelEventEnvelope, not a raw payload.
+    assert wire["event_type"] == _EXPECTED_EVENT_TYPE
+    assert wire["correlation_id"] == cid
+    # The domain payload validates back into ModelRoutingIntent.
+    intent = ModelRoutingIntent.model_validate(wire["payload"])
+    assert intent.intent == "routing_reducer"
+    assert str(intent.payload.correlation_id) == cid
+
+
+@pytest.mark.asyncio
+async def test_fanout_emit_fails_closed_on_non_derivable_event_type() -> None:
+    """Fail-closed: a topic that yields no event_type must raise, not emit a
+    null-event_type envelope the consuming dispatcher would silently drop.
+
+    RED before the fix: the raw-payload emit published happily to any topic with
+    no event_type at all — the exact silent-drop condition. Now the emit boundary
+    converts it into a loud failure (on_error, nothing published).
+    """
+    cid = str(uuid4())
+    bus = _FakeBus()
+    errors: list[bool] = []
+    adapter = _adapter(
+        _RoutingIntentFanoutHandler(cid),
+        bus,
+        published_events=_PUBLISHED_NON_ONEX,
+        input_model_cls=None,
+        on_error=lambda: errors.append(True),
+    )
+
+    await adapter.on_message(_input_msg(cid))
+
+    assert bus.published == []
+    assert errors == [True]
+
+
+@pytest.mark.asyncio
+async def test_enveloped_message_round_trips_through_consume() -> None:
+    """A subscribed adapter unwraps the fan-out envelope to the inner domain model.
+
+    Proves the RuntimeLocal round-trip stays consistent: the emit publishes a
+    ModelEventEnvelope; a consuming adapter whose input model is ModelRoutingIntent
+    receives the inner ModelRoutingIntent (not the envelope), so the local
+    delivery path agrees with the Kafka wire shape.
+    """
+    cid = str(uuid4())
+    emit_bus = _FakeBus()
+    emit_adapter = _adapter(
+        _RoutingIntentFanoutHandler(cid),
+        emit_bus,
+        published_events=_PUBLISHED_ROUTING,
+        input_model_cls=None,
+    )
+    await emit_adapter.on_message(_input_msg(cid))
+    enveloped_bytes = emit_bus.published[0][1]
+
+    capture = _CapturingRoutingHandler()
+    consume_bus = _FakeBus()
+    consume_adapter = _adapter(
+        capture,
+        consume_bus,
+        published_events={},
+        input_model_cls=ModelRoutingIntent,
+    )
+
+    await consume_adapter.on_message(_FakeMsg(enveloped_bytes))
+
+    assert len(capture.received) == 1
+    received = capture.received[0]
+    assert isinstance(received, ModelRoutingIntent)
+    assert str(received.payload.correlation_id) == cid

--- a/tests/unit/runtime/test_runtime_local_adapter_fanout.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_fanout.py
@@ -48,7 +48,10 @@ class ModelGamma(BaseModel):
     value: int = 0
 
 
-_PUBLISHED = {"Alpha": "onex.evt.alpha.v1", "Beta": "onex.evt.beta.v1"}
+# Canonical 5-segment ONEX topics (onex.{kind}.{producer}.{event-name}.v{n}) so
+# the emit boundary can derive a non-null event_type (OMN-14743). A 4-segment
+# topic yields no event_type and is fail-closed (see the dedicated event_type test).
+_PUBLISHED = {"Alpha": "onex.evt.omni.alpha.v1", "Beta": "onex.evt.omni.beta.v1"}
 
 
 class _FanoutHandler:
@@ -140,14 +143,17 @@ async def test_fanout_seam_on_publishes_two_topics_in_order() -> None:
     await adapter.on_message(_msg(7))
 
     assert [topic for topic, _ in bus.published] == [
-        "onex.evt.alpha.v1",
-        "onex.evt.beta.v1",
+        "onex.evt.omni.alpha.v1",
+        "onex.evt.omni.beta.v1",
     ]
-    # Payloads are the concrete models, in return order.
+    # OMN-14743: each emit is a ModelEventEnvelope carrying the topic-derived
+    # event_type; the concrete model is the envelope payload, in return order.
     alpha = json.loads(bus.published[0][1])
     beta = json.loads(bus.published[1][1])
-    assert alpha == {"value": 7}
-    assert beta == {"value": 7}
+    assert alpha["payload"] == {"value": 7}
+    assert alpha["event_type"] == "omni.alpha"
+    assert beta["payload"] == {"value": 7}
+    assert beta["event_type"] == "omni.beta"
 
 
 @pytest.mark.asyncio
@@ -169,7 +175,7 @@ async def test_single_emit_seam_on_routes_via_published_events() -> None:
     )
     await adapter.on_message(_msg(3))
     # Topic comes from the model's class, NOT the single output_topic.
-    assert [topic for topic, _ in bus.published] == ["onex.evt.alpha.v1"]
+    assert [topic for topic, _ in bus.published] == ["onex.evt.omni.alpha.v1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## OMN-14743 — delegation routing-decision never published (release blocker)

### Root cause (confirmed live on .201 stability-test, corr 14716002/14716003)
The delegation vertical stalls at `RECEIVED`: the routing intent is emitted, consumed, and resolved (`model=Qwen`), yet `onex.evt.omnibase-infra.routing-decision.v1` is **never published**. The break is at the **emit boundary**:

- The RuntimeLocal def-B fan-out publish path (`LocalRuntimeBusAdapter._publish_fanout`) published the routing intent as a **raw payload with no envelope and no `event_type`**, while the Kafka applier (`service_dispatch_result_applier`) stamps a topic-derived `event_type`.
- The routing reducer's dispatcher is **type-scoped** on the `event_type` alias `omnibase-infra.delegation-routing-request` (OMN-12294). The dispatch engine keys routing on `event_type` when present and **falls back to the payload class name** (`ModelRoutingIntent`) otherwise. A null `event_type` therefore routes on `ModelRoutingIntent`, matches **no** registered dispatcher, and is dropped (`NO_DISPATCHER`) — `HandlerRoutingIntent` never runs, no decision is published (`reference_no_dispatcher_can_be_typescoping_drop`).
- Working 07-11/13 intents carried `event_type: "omnibase-infra.delegation-routing-request"`; the 07-17 stalled ones carried `event_type: null`. Regression window fits OMN-14403 (shared def-B fan-out resolver + LocalRuntimeBusAdapter typed multi-event return, merged 07-14).

### Fix (general — covers every emitted fan-out event, not just RoutingIntent)
- `runtime_fanout_resolver`: add `derive_event_type_from_topic` (byte-for-byte the applier's `_derive_event_type_from_topic`) and `resolve_fanout_emissions`, which resolves `(topic, event_type, payload)` triples and **fails closed** when a resolved topic yields no derivable `event_type` — converting the silent type-scoped-drop class into a loud emit-time failure (same discipline as the OMN-14721 completeness guard, at the emit side).
- `runtime_local_adapter`: `_publish_fanout` now wraps each payload in a `ModelEventEnvelope` carrying the topic-derived `event_type` (matching the applier's wire shape), and `on_message` unwraps envelopes on the consume side so the RuntimeLocal round-trip stays consistent with the Kafka wire (closes the `reference_runtime_local_vs_kafka_adapter_divergence` for this path).

### dod_evidence (RED → GREEN)
Reverted the two source files to `origin/dev` and re-ran the new tests:
- `test_runtime_fanout_resolver.py::TestResolveFanoutEmissions` / `TestDeriveEventTypeFromTopic` — **ImportError** pre-fix (functions did not exist).
- `test_runtime_local_adapter_event_type.py::test_fanout_emit_stamps_topic_derived_event_type` — pre-fix `KeyError: 'event_type'` (raw payload on the wire, no envelope).
- `test_runtime_local_adapter_event_type.py::test_fanout_emit_fails_closed_on_non_derivable_event_type` — pre-fix the raw emit published silently to a non-canonical topic; post-fix it fails closed (`on_error`, nothing published).
- `test_runtime_local_adapter_fanout.py::test_fanout_seam_on_publishes_two_topics_in_order` — pre-fix `KeyError: 'payload'` (no envelope).

Restored the fix → **37 passed**; full `tests/unit/runtime/` → **293 passed**. `ruff format`/`ruff check`/`mypy`/`pre-commit run` all clean.

### Seam matched (OMN-14208)
Seam = the `event_type` field on the emitted `ModelRoutingIntent` envelope ↔ the reducer's type-scoped dispatcher. A **real cross-boundary regression test** drives the actual seam (real core emit → real `MessageDispatchEngine` type-scoped routing → real `HandlerRoutingIntent`) and ships in the paired omnimarket branch (gated on this fix landing + re-pin): stamped `event_type` → `SUCCESS` + `ModelRoutingDecision`; null `event_type` → `NO_DISPATCHER` (the live drop).

### Verification gap (honest)
The infra applier path stamps `event_type` unconditionally, so the exact runtime/adapter identity on build #2330 that produced the null `event_type` is not fully reproducible from static code alone (the disambiguator flagged this too). This fix makes the fan-out emit boundary carry `event_type` **and fail closed**, so this silent-drop class cannot recur regardless of which runtime emits. Definitive confirmation is a .201 branch-preview readback that `event_type` is non-null on `delegation-routing-request.v1` and `routing-decision.v1` HWM advances for a fresh correlation (post-merge + redeploy).

Closes OMN-14743

Evidence-Ticket: OMN-14743
Evidence-Source: OCC#4351
Evidence-Commit: c72b3c9dcb431d83ea330f0c94a0341324fb91ad
Evidence-Head: ab28e0613d4fef90d8b7c757077ff476387ad84e

