### PR TITLE
feat(OMN-14771): add optional topic field to ModelHandlerRoutingEntry (S8 PR2 seam)

### DIFF
--- a/src/omnibase_core/models/contracts/subcontracts/model_handler_routing_entry.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_handler_routing_entry.py
@@ -65,3 +65,17 @@ class ModelHandlerRoutingEntry(BaseModel):
             "subscribed topic."
         ),
     )
+    # dispatch-surface-test-ok: additive optional field; inert in omnibase_core (no entry.topic consumer here — routing_map_builder that reads it lives in a sibling repo and is covered by that repo's real-dispatch tests when RuntimeDispatch lands). Model round-trip is unit-tested. (OMN-14771)
+    topic: str | None = Field(
+        default=None,
+        description=(
+            "Optional per-entry subscribe topic that owns this route (OMN-14771). "
+            "When present, RuntimeDispatch route resolution "
+            "(routing_map_builder._resolve_owning_entry) uses this to map a single "
+            "entry to its owning topic instead of failing closed on topic-agnostic "
+            "multiplexed orchestrator entries. Additive and backward-compatible: "
+            "existing entries omit it and default to None, leaving the legacy "
+            "payload_type_match path (which resolves the topic from the contract's "
+            "subscribe_topics list) unaffected."
+        ),
+    )

--- a/src/omnibase_core/models/contracts/subcontracts/model_handler_routing_entry.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_handler_routing_entry.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-Handler Routing Entry Model — canonical 5-field live shape (OMN-12547 S-1c).
+Handler Routing Entry Model — canonical live routing shape (OMN-12547 S-1c).
 
 Replaces the dead routing_key/handler_key shape with the live infra shape
 (OMN-7654). Each entry identifies a handler class reference plus optional
@@ -27,7 +27,7 @@ from omnibase_core.models.dispatch.model_handler_ref import ModelHandlerRef
 
 
 class ModelHandlerRoutingEntry(BaseModel):
-    """Single handler routing entry in the canonical 5-field live shape (OMN-12547)."""
+    """Single handler routing entry in the canonical live routing shape (OMN-12547)."""
 
     model_config = ConfigDict(
         frozen=True,

--- a/src/omnibase_core/validators/extra_forbid_waivers.yaml
+++ b/src/omnibase_core/validators/extra_forbid_waivers.yaml
@@ -25,4 +25,17 @@
 #
 #   model_config = ConfigDict(extra="forbid")
 #
-waivers: []
+waivers:
+  - fqn: omnibase_core.models.contracts.subcontracts.model_handler_routing_entry:ModelHandlerRoutingEntry
+    ticket: OMN-14771
+    pr: https://github.com/OmniNode-ai/omnibase_core/pull/1468
+    expires_at: 2026-09-30
+    reason: >-
+      S8 PR2 adds an additive optional `topic` field to this routing entry (the
+      PR2<->PR3 RuntimeDispatch seam). The model deliberately keeps extra="ignore"
+      to tolerate legacy handler_routing YAML fields (routing_key, handler_key,
+      priority, output_events, callable, lazy_import) still carried by live
+      contracts; the model docstring defers the extra="forbid" flip to a
+      dedicated migration PR once all consumers carry the live shape. Flipping
+      forbid here would break legacy contract loading and is out of scope for this
+      additive change. Time-boxed to the coordinated migration.

--- a/tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py
@@ -14,10 +14,14 @@ Covers the additive ``topic`` field that RuntimeDispatch route resolution
 
 from __future__ import annotations
 
+import pytest
+
 from omnibase_core.models.contracts.subcontracts.model_handler_routing_entry import (
     ModelHandlerRoutingEntry,
 )
 from omnibase_core.models.dispatch.model_handler_ref import ModelHandlerRef
+
+pytestmark = pytest.mark.unit
 
 
 def _handler_ref() -> ModelHandlerRef:

--- a/tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for ModelHandlerRoutingEntry (OMN-14771 S8 PR2).
+
+Covers the additive ``topic`` field that RuntimeDispatch route resolution
+(routing_map_builder._resolve_owning_entry) reads as ``entry.topic``:
+
+- an entry declaring ``topic`` round-trips through model_dump/model_validate,
+- an entry omitting ``topic`` defaults to None (backward compatibility),
+- the field name/type match the PR2<->PR3 seam exactly ("topic": str | None).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.contracts.subcontracts.model_handler_routing_entry import (
+    ModelHandlerRoutingEntry,
+)
+from omnibase_core.models.dispatch.model_handler_ref import ModelHandlerRef
+
+
+def _handler_ref() -> ModelHandlerRef:
+    return ModelHandlerRef(
+        name="HandlerDelegationRequest",
+        module="omnimarket.nodes.node_delegation_orchestrator.handlers",
+    )
+
+
+def _event_model_ref() -> ModelHandlerRef:
+    return ModelHandlerRef(
+        name="ModelDelegationRequest",
+        module="omnimarket.models",
+    )
+
+
+class TestHandlerRoutingEntryTopic:
+    """The additive ``topic`` field (OMN-14771 PR2 half of the PR2<->PR3 seam)."""
+
+    def test_topic_defaults_to_none_when_omitted(self) -> None:
+        """Existing entries that omit ``topic`` default to None (backward-compatible)."""
+        entry = ModelHandlerRoutingEntry(
+            handler=_handler_ref(),
+            event_model=_event_model_ref(),
+        )
+        assert entry.topic is None
+
+    def test_topic_round_trips_through_dump_and_validate(self) -> None:
+        """An entry declaring ``topic`` round-trips losslessly."""
+        topic = "omnimarket.delegation-orchestrator.routing-decision"
+        entry = ModelHandlerRoutingEntry(
+            handler=_handler_ref(),
+            event_model=_event_model_ref(),
+            topic=topic,
+        )
+        assert entry.topic == topic
+
+        dumped = entry.model_dump()
+        assert dumped["topic"] == topic
+
+        rehydrated = ModelHandlerRoutingEntry.model_validate(dumped)
+        assert rehydrated.topic == topic
+        assert rehydrated == entry
+
+    def test_topic_field_is_optional_str(self) -> None:
+        """Field name/type match the PR2<->PR3 seam: name 'topic', type str | None."""
+        field = ModelHandlerRoutingEntry.model_fields["topic"]
+        # Optional (has default None).
+        assert field.default is None
+        # str | None annotation.
+        assert field.annotation == (str | None)


### PR DESCRIPTION
## OMN-14771 — S8 PR2: add optional `topic` field to `ModelHandlerRoutingEntry`

Epic **OMN-14717** (release-scope delegation product). This is **PR2** of the standalone-safe S8 wave 1 — the **core half of the PR2↔PR3 field-by-field seam**.

### What
Adds one additive, backward-compatible field to `ModelHandlerRoutingEntry`:

```python
topic: str | None = Field(default=None, ...)
```

`routing_map_builder._resolve_owning_entry` reads this as `entry.topic` (currently fails closed on topic-agnostic multiplexed orchestrator entries because the field does not exist). PR3 supplies the matching `topic: <subscribe topic>` on the omnimarket contract entries. Field name/type match the seam **exactly** (`topic`, `str | None`).

### Why standalone-safe
- Default `None` → every existing entry is unchanged.
- The legacy `payload_type_match` per-topic delivery path resolves the topic from the contract's `subscribe_topics` list and does **not** read `entry.topic`; it is untouched.
- `ConfigDict(extra="ignore")` already tolerates the PR3 contract key before this field lands, so **PR2/PR3 are order-independent** for safety.

### Files changed
- `src/omnibase_core/models/contracts/subcontracts/model_handler_routing_entry.py` — add `topic` field.
- `tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py` — new unit tests: default-None, dump/validate round-trip, field name/type assertion.

### dod_evidence
- `uv run ruff format` + `ruff check --fix`: clean (2 files unchanged / all checks passed).
- `uv run mypy src/.../model_handler_routing_entry.py`: `Success: no issues found`.
- `env -u PYTHONPATH uv run pytest tests/unit/models/contracts/subcontracts/test_model_handler_routing_entry.py -v`: **3 passed**.
- Regression: `tests/unit/models/contracts/test_model_contract_base_extensions.py`: **35 passed**.
- `pre-commit run --files <both>`: all hooks pass on the changed files. (One unrelated cross-repo hook, `validate-deterministic-skill-routing`, flags a pre-existing issue in a *sibling* `../omniclaude` skill markdown — it fails identically on any unmodified omnibase_core file and does not exist in isolated CI; not caused by this change.)

Closes OMN-14771.

### Gate accommodations (documented)
- **Dispatch-Surface Test Required (OMN-12960):** suppressed via `# dispatch-surface-test-ok:` on the field. The field is additive and inert in omnibase_core — nothing here reads `entry.topic` (the `routing_map_builder._resolve_owning_entry` consumer lives in a sibling repo and is covered by that repo's real-dispatch tests when RuntimeDispatch lands). A real-dispatch test in this repo would be vacuous. Model round-trip is unit-tested.
- **Pydantic extra="forbid" Ratchet (OMN-14515):** expiring, ticket+PR-keyed waiver added to `extra_forbid_waivers.yaml` (OMN-14771, this PR, `expires_at: 2026-09-30`). This model intentionally keeps `extra="ignore"` to tolerate legacy `handler_routing` YAML fields still carried by live contracts; the model docstring explicitly defers the `extra="forbid"` flip to a dedicated migration PR "once all consumers carry the live shape." Flipping `forbid` in this additive PR would break legacy contract loading and is out of scope.
- **occ-preflight / eligibility cascade** (Canonical Inference Gate, receipt-honesty, etc.): pending the OCC evidence companion, handled by the merge-sweep OCC flow.






Evidence-Ticket: OMN-14771
Evidence-Source: OCC#4407
Evidence-Commit: 0af3bea2eb6df87e7750cfa3f53f98c628cc6f22
