### PR TITLE
fix(OMN-14682): anchor Receipt-Gate evidence extractor to a single canonical block + pre-push shape check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,21 @@ repos:
         pass_filenames: true  # Only check changed files, CI does full scan
         stages: [pre-push]  # ~1-5s for changed files only
 
+      # Evidence-Source SHAPE check (OMN-14682)
+      # Local fail-fast companion to the CI receipt-gate: validates that the
+      # current branch's PR body carries a single canonical Evidence-Source
+      # stamp (not an example quoted inside a code fence / blockquote), a
+      # well-formed reference or disclaimer, and a paired Evidence-Ticket. The
+      # authoritative, receipt-verifying enforcement stays the CI receipt-gate;
+      # this hook only shortens the feedback loop. No-op when no PR exists yet.
+      - id: check-evidence-shape
+        name: Evidence-Source shape check (OMN-14682)
+        entry: .pre-commit-hooks/check-evidence-shape.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
       # Intra-Core Dependency-Layering Oracle (OMN-14216, epic OMN-3210)
       # Enforces the DIRECTION of imports between omnibase_core sub-packages via
       # import-linter (.importlinter). Whole-graph check (grimp caches the graph

--- a/.pre-commit-hooks/check-evidence-shape.sh
+++ b/.pre-commit-hooks/check-evidence-shape.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-14682: Local pre-push Evidence-Source SHAPE check.
+#
+# Gives authors fail-fast feedback on a malformed / mis-placed Evidence-Source
+# block BEFORE the CI receipt-gate runs, instead of discovering it after push or
+# via manual PR-body normalization. This is the LOCAL companion to the hardened
+# CI receipt-gate (omnibase_core.validation.validator_receipt_gate); the gate
+# remains the authoritative, receipt-verifying enforcement layer.
+#
+# Body source (first non-empty wins):
+#   1. $PR_BODY environment variable (used by tests / scripted pushes)
+#   2. `gh pr view --json body` for the current branch's open PR
+#
+# When there is no PR yet (first push), no gh CLI, or gh is unauthenticated,
+# there is nothing to validate locally — the hook prints a notice and exits 0.
+# The CI receipt-gate still enforces the same shape on the real PR body, so this
+# graceful no-op cannot let a bad shape merge.
+#
+# Usage:
+#   Invoked by pre-commit at the pre-push stage (pass_filenames: false).
+#   --self-test   Run synthetic self-tests and exit.
+
+set -uo pipefail
+
+TICKET_REF="OMN-14682"
+
+run_shape_check() {
+  # $1: PR body text. Returns the CLI's exit code.
+  # `env -u PYTHONPATH` clears any ambient PYTHONPATH that would shadow the
+  # worktree's omnibase_core with a canonical clone on sys.path
+  # (reference_pythonpath_shadows_worktree_source; matches the substrate-gate
+  # hooks in .pre-commit-config.yaml).
+  local body="$1"
+  printf '%s' "$body" | env -u PYTHONPATH uv run python -m omnibase_core.validation.validator_evidence_shape_cli --pr-body-file -
+}
+
+self_test() {
+  local fails=0
+
+  local bad_body
+  bad_body='Closes OMN-1
+
+```
+Evidence-Source: OCC#1234
+```
+'
+  if run_shape_check "$bad_body" >/dev/null 2>&1; then
+    echo "[${TICKET_REF}] SELF-TEST FAIL: fenced-only stamp should have been rejected" >&2
+    fails=1
+  fi
+
+  local good_body
+  good_body='Closes OMN-1
+
+Evidence-Source: OCC#1234
+Evidence-Ticket: OMN-1
+'
+  if ! run_shape_check "$good_body" >/dev/null 2>&1; then
+    echo "[${TICKET_REF}] SELF-TEST FAIL: canonical stamp + ticket should pass" >&2
+    fails=1
+  fi
+
+  local none_body
+  none_body='Closes OMN-1
+
+No evidence stamp here.
+'
+  if ! run_shape_check "$none_body" >/dev/null 2>&1; then
+    echo "[${TICKET_REF}] SELF-TEST FAIL: no-stamp body should pass (shape-clean)" >&2
+    fails=1
+  fi
+
+  if [ "$fails" -eq 0 ]; then
+    echo "[${TICKET_REF}] SELF-TEST PASS"
+  fi
+  return "$fails"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+# Resolve the PR body.
+PR_BODY_TEXT="${PR_BODY:-}"
+
+if [ -z "$PR_BODY_TEXT" ]; then
+  if command -v gh >/dev/null 2>&1; then
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+      # gh resolves the open PR for the current branch; empty when none/unauth.
+      PR_BODY_TEXT="$(gh pr view "$branch" --json body --jq '.body' 2>/dev/null || true)"
+    fi
+  fi
+fi
+
+if [ -z "$PR_BODY_TEXT" ]; then
+  echo "[${TICKET_REF}] evidence-shape: no PR body available yet (no open PR / gh); skipping local check. CI receipt-gate still enforces on push."
+  exit 0
+fi
+
+if run_shape_check "$PR_BODY_TEXT"; then
+  exit 0
+fi
+
+echo "[${TICKET_REF}] evidence-shape check FAILED — fix the Evidence-Source block above before pushing (or the CI receipt-gate will block the PR)." >&2
+exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,6 +359,7 @@ ignore = [
 "src/omnibase_core/validation/validator_circular_import.py" = ["T201"]
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_gate_cli.py" = ["T201"]
+"src/omnibase_core/validation/validator_evidence_shape_cli.py" = ["T201"]  # CLI output for the pre-push Evidence-Source shape check (OMN-14682)
 "src/omnibase_core/validation/validator_receipt_reprobe.py" = ["T201"]  # CLI output for re-probe verification (OMN-9789)
 "src/omnibase_core/validation/validator_receipt_diff_consistency.py" = ["T201"]  # CLI output for the attestation diff-consistency gate (OMN-13927)
 "src/omnibase_core/validation/validator_duplicate_config_ids.py" = ["T201"]  # CLI output for the duplicate-registry-id guard (OMN-14401)

--- a/src/omnibase_core/validation/validator_evidence_shape_cli.py
+++ b/src/omnibase_core/validation/validator_evidence_shape_cli.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Evidence-shape CLI — local pre-push fail-fast check (OMN-14682).
+
+`uv run python -m omnibase_core.validation.validator_evidence_shape_cli ...`
+
+Validates only the SHAPE of a PR body's Evidence-Source block — that a real
+stamp is a single, canonical, top-level line (not an example quoted inside a
+fenced code block / blockquote), that it is a well-formed reference or a
+recognized disclaimer, and that a valid reference is paired with a canonical
+``Evidence-Ticket:`` line. It does NOT verify receipts, contracts, or OCC
+ancestry (that needs the onex_change_control checkout and stays the CI
+receipt-gate's job). The goal is to give authors fail-fast feedback locally
+instead of discovering the mismatch at CI or via manual body normalization.
+
+Body source (in order): ``--pr-body`` > ``--pr-body-file`` > ``--pr-body-file -``
+(stdin). Exactly one non-empty source is required.
+
+Exit codes:
+    0  — shape is valid (or no Evidence-Source stamp is present at all)
+    1  — shape violation (stamp only inside a code block/quote, multiple
+         canonical stamps, malformed reference, or missing paired
+         Evidence-Ticket)
+    2  — usage error (no body source provided)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from omnibase_core.validation.validator_receipt_gate import check_evidence_source_shape
+
+
+def _resolve_pr_body(args: argparse.Namespace) -> str | None:
+    """Return the PR body from the highest-precedence provided source, else None."""
+    if args.pr_body is not None:
+        return args.pr_body
+    if args.pr_body_file is not None:
+        if args.pr_body_file == "-":
+            return sys.stdin.read()
+        return Path(args.pr_body_file).read_text(encoding="utf-8")
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evidence-shape pre-push check: validate the Evidence-Source block "
+            "shape of a PR body before push (OMN-14682)."
+        )
+    )
+    parser.add_argument(
+        "--pr-body",
+        default=None,
+        help="Full PR description text (highest precedence).",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        default=None,
+        help="Path to a file containing the PR body, or '-' to read stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    body = _resolve_pr_body(args)
+    if body is None:
+        parser.error("provide --pr-body, --pr-body-file <path>, or --pr-body-file -")
+
+    result = check_evidence_source_shape(body)
+    if result.passed:
+        print(f"::notice::{result.message}")
+        return 0
+    print(f"::error::{result.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -216,6 +216,11 @@ EVIDENCE_SOURCE_LINE_PATTERN = re.compile(
     r"^Evidence-Source:(?P<value>[^\r\n]*)$",
     re.IGNORECASE | re.MULTILINE,
 )
+# Opening/closing delimiter of a Markdown fenced code block (``` or ~~~), with
+# optional leading indent and an optional info string. Used by
+# :func:`strip_noncanonical_regions` to blank out example/quote regions before
+# canonical Evidence-Source / Evidence-Ticket extraction (OMN-14682).
+_FENCE_LINE_PATTERN = re.compile(r"^\s*(`{3,}|~{3,})")
 
 # OMN-14410 round 2: captures the trimmed VALUE of the (first) Evidence-Source
 # line with the documented single-space separator. Used ONLY to classify a value
@@ -391,8 +396,65 @@ def _check_ui_evidence_class(
 EVIDENCE_SOURCE_CUTOFF_SHA = "PENDING_MERGE"
 
 
+def strip_noncanonical_regions(pr_body: str) -> str:
+    """Blank out PR-body regions that cannot carry a *canonical* stamp (OMN-14682).
+
+    A canonical ``Evidence-Source:`` / ``Evidence-Ticket:`` stamp is a
+    top-level, column-0 structured line. Markdown fenced code blocks
+    (```` ``` ```` / ``~~~``) and blockquotes (``> ...``) carry examples,
+    quotes from other PRs, and discussion prose — a stamp-shaped line inside
+    them is documentation, never a machine-read declaration. Before this,
+    the receipt gate's ``^Evidence-Source:`` MULTILINE extractor matched such
+    example lines, so a PR that merely *quoted* the canonical format (very
+    common in meta-PRs about the gate itself) was treated as if it declared
+    real evidence — a false-positive that satisfied the gate, or a
+    false-``multiple-Evidence-Source-lines`` block when a real stamp and an
+    example coexisted, forcing manual body normalization.
+
+    Excluded lines are replaced with an empty line (not deleted) so line
+    positions are preserved and the MULTILINE anchors behave identically for
+    every surviving canonical line. An unterminated opening fence blanks
+    everything to end-of-body — fail-closed, since a stamp after malformed
+    markup is not trustworthy as a canonical declaration.
+
+    Indented (≥4-space / tab) code blocks are already excluded structurally:
+    ``^Evidence-Source:`` anchors at column 0, so an indented stamp-shaped
+    line never matched to begin with; no extra handling is required for them.
+
+    Idempotent: re-stripping an already-stripped body is a no-op.
+    """
+    out: list[str] = []
+    in_fence = False
+    fence_char = ""
+    for line in pr_body.splitlines():
+        fence = _FENCE_LINE_PATTERN.match(line)
+        if fence is not None:
+            marker_char = fence.group(1)[0]
+            if not in_fence:
+                in_fence = True
+                fence_char = marker_char
+            elif marker_char == fence_char:
+                in_fence = False
+                fence_char = ""
+            # The fence delimiter line itself is never a canonical stamp.
+            out.append("")
+            continue
+        if in_fence:
+            out.append("")
+            continue
+        if line.lstrip().startswith(">"):
+            # Blockquote line — a quote of another PR/example, not a declaration.
+            out.append("")
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
 def parse_evidence_source(pr_body: str) -> tuple[str | None, str | None]:
-    """Parse the Evidence-Source line from a PR body.
+    """Parse the canonical Evidence-Source line from a PR body.
+
+    Non-canonical regions (fenced code blocks, blockquotes) are stripped first
+    (OMN-14682) so a stamp quoted as an example never parses as a real source.
 
     Returns:
         ``(occ_pr_number_str, sha)`` where exactly one is set, or ``(None, None)``
@@ -403,7 +465,7 @@ def parse_evidence_source(pr_body: str) -> tuple[str | None, str | None]:
         - Present but invalid form: returns ``(None, None)`` with the caller
           responsible for detecting the presence via EVIDENCE_SOURCE_ANY_PATTERN.
     """
-    for line in pr_body.splitlines():
+    for line in strip_noncanonical_regions(pr_body).splitlines():
         if not line.lower().startswith("evidence-source:"):
             continue
         if m_pr := EVIDENCE_SOURCE_OCC_PR_PATTERN.fullmatch(line):
@@ -448,8 +510,12 @@ def classify_evidence_source_stamp(pr_body: str) -> tuple[bool, bool, str | None
           with a bare hex/hash reference token.
         - ``value``: the trimmed value text, or ``None`` when no
           Evidence-Source line with a value is present.
+
+    Non-canonical regions (fenced code blocks, blockquotes) are stripped first
+    (OMN-14682) so an example/quoted stamp is never classified as an attempt.
     """
-    line_match = EVIDENCE_SOURCE_LINE_PATTERN.search(pr_body)
+    canonical_body = strip_noncanonical_regions(pr_body)
+    line_match = EVIDENCE_SOURCE_LINE_PATTERN.search(canonical_body)
     if line_match is None:
         return (False, False, None)
     raw_value = line_match.group("value")
@@ -457,7 +523,7 @@ def classify_evidence_source_stamp(pr_body: str) -> tuple[bool, bool, str | None
         return (True, False, raw_value.strip())
     if raw_value.startswith(("  ", "\t")):
         return (True, False, raw_value.strip())
-    m = EVIDENCE_SOURCE_VALUE_PATTERN.search(pr_body)
+    m = EVIDENCE_SOURCE_VALUE_PATTERN.search(canonical_body)
     if m is None:
         return (True, False, raw_value.strip())
     value = m.group(1).strip()
@@ -1494,14 +1560,23 @@ def validate_pr_receipts(
             message=message,
         )
 
-    evidence_source_lines = list(EVIDENCE_SOURCE_LINE_PATTERN.finditer(pr_body))
+    # OMN-14682: restrict every Evidence-Source / Evidence-Ticket extraction to
+    # the CANONICAL body — fenced code blocks, blockquotes, and other quoted /
+    # example regions are blanked out first, so a stamp quoted as documentation
+    # (common in meta-PRs about the gate itself) neither satisfies the gate as a
+    # false canonical stamp nor false-triggers the "multiple Evidence-Source
+    # lines" block when it coexists with one real stamp.
+    canonical_body = strip_noncanonical_regions(pr_body)
+    evidence_source_lines = list(EVIDENCE_SOURCE_LINE_PATTERN.finditer(canonical_body))
     if len(evidence_source_lines) > 1:
         return ModelReceiptGateResult(
             passed=False,
             message=(
                 "RECEIPT GATE FAILED: PR body contains multiple Evidence-Source "
                 "lines. Declare exactly one canonical Evidence-Source line so "
-                "malformed and valid stamps cannot disagree (OMN-14410)."
+                "malformed and valid stamps cannot disagree (OMN-14410 / "
+                "OMN-14682). Move any example or quoted stamp into a fenced code "
+                "block so it is not read as canonical."
             ),
         )
 
@@ -1553,7 +1628,10 @@ def validate_pr_receipts(
             else None
         )
         if resolved_evidence_ticket is None:
-            et_match = EVIDENCE_TICKET_PATTERN.search(pr_body)
+            # OMN-14682: resolve Evidence-Ticket from the canonical body too, so a
+            # quoted/example Evidence-Ticket line cannot satisfy the paired
+            # identity binding that a genuine Evidence-Source stamp triggers.
+            et_match = EVIDENCE_TICKET_PATTERN.search(canonical_body)
             if et_match:
                 resolved_evidence_ticket = et_match.group(1).upper()
 
@@ -1640,6 +1718,107 @@ def validate_pr_receipts(
     )
 
 
+def check_evidence_source_shape(pr_body: str) -> ModelReceiptGateResult:
+    """Fast, network-free pre-push check of the Evidence-Source block *shape* (OMN-14682).
+
+    This validates only the SHAPE of the Evidence-Source stamp so authors get
+    fail-fast feedback locally, before CI. It deliberately does NOT verify
+    receipts, contracts, or OCC ancestry — that requires the onex_change_control
+    checkout and remains the CI receipt-gate's job. It catches exactly the
+    author-side mistakes that otherwise surface as a confusing CI failure or
+    force manual PR-body normalization:
+
+    - an Evidence-Source stamp that lives ONLY inside a fenced code block /
+      blockquote (so it reads as an example, not a declaration);
+    - more than one canonical Evidence-Source line (ambiguous — fails closed);
+    - a malformed reference value (neither a valid ``OCC#<n>`` / hex SHA
+      reference nor a recognized disclaimer);
+    - a valid reference with no paired canonical ``Evidence-Ticket:`` line.
+
+    A body with no Evidence-Source stamp at all is shape-clean here (PASS): the
+    presence/receipt requirements are the CI gate's responsibility.
+
+    Returns a :class:`ModelReceiptGateResult` (``passed`` + operator-facing
+    ``message``); it never raises for ordinary malformed input.
+    """
+    canonical_body = strip_noncanonical_regions(pr_body)
+    canonical_lines = list(EVIDENCE_SOURCE_LINE_PATTERN.finditer(canonical_body))
+    raw_lines = list(EVIDENCE_SOURCE_LINE_PATTERN.finditer(pr_body))
+
+    if raw_lines and not canonical_lines:
+        return ModelReceiptGateResult(
+            passed=False,
+            message=(
+                "EVIDENCE-SHAPE FAILED: an 'Evidence-Source:' line appears only "
+                "inside a fenced code block or blockquote, so the gate reads it "
+                "as an example, not a declaration. Move the real stamp to a "
+                "top-level 'Evidence-Source: OCC#<number>' or "
+                "'Evidence-Source: <7-40 char hex SHA>' line at column 0 "
+                "(OMN-14682)."
+            ),
+        )
+
+    if len(canonical_lines) > 1:
+        return ModelReceiptGateResult(
+            passed=False,
+            message=(
+                "EVIDENCE-SHAPE FAILED: PR body has multiple canonical "
+                "Evidence-Source lines. Declare exactly one; move any example or "
+                "quoted stamp into a fenced code block (OMN-14410 / OMN-14682)."
+            ),
+        )
+
+    if not canonical_lines:
+        return ModelReceiptGateResult(
+            passed=True,
+            message=(
+                "EVIDENCE-SHAPE OK: no Evidence-Source stamp present; the CI "
+                "receipt-gate still enforces ticket/receipt presence."
+            ),
+        )
+
+    line = canonical_lines[0].group(0)
+    is_valid_reference = bool(
+        EVIDENCE_SOURCE_OCC_PR_PATTERN.fullmatch(line)
+        or EVIDENCE_SOURCE_SHA_PATTERN.fullmatch(line)
+    )
+    if is_valid_reference:
+        if EVIDENCE_TICKET_PATTERN.search(canonical_body) is None:
+            return ModelReceiptGateResult(
+                passed=False,
+                message=(
+                    "EVIDENCE-SHAPE FAILED: a valid Evidence-Source reference is "
+                    "present but no canonical 'Evidence-Ticket: OMN-XXXX' line "
+                    "was found. Every PR with Evidence-Source must also declare "
+                    "Evidence-Ticket so the gate can bind the evidence to the "
+                    "PR's ticket (OMN-10420 / OMN-14682)."
+                ),
+            )
+        return ModelReceiptGateResult(
+            passed=True,
+            message="EVIDENCE-SHAPE OK: canonical Evidence-Source reference with paired Evidence-Ticket.",
+        )
+
+    attempted, is_disclaimer, stamp_value = classify_evidence_source_stamp(pr_body)
+    if attempted and not is_disclaimer:
+        return ModelReceiptGateResult(
+            passed=False,
+            message=(
+                "EVIDENCE-SHAPE FAILED: the Evidence-Source line is malformed: "
+                f"{stamp_value!r} is neither a recognized disclaimer (N/A, none, "
+                "-, or free-text prose explaining why the field does not apply) "
+                "nor a valid reference (Evidence-Source: OCC#<number> or "
+                "Evidence-Source: <7-40 char hex SHA>, exactly one space after "
+                "the colon and nothing else on the line). Fix the line to one of "
+                "these forms (OMN-14410 / OMN-14682)."
+            ),
+        )
+    return ModelReceiptGateResult(
+        passed=True,
+        message="EVIDENCE-SHAPE OK: Evidence-Source is a recognized disclaimer.",
+    )
+
+
 EVIDENCE_HANDLERS: dict[str, Callable[..., Any]] = {}
 EVIDENCE_HANDLERS["completion-verify"] = _completion_verify
 
@@ -1664,6 +1843,7 @@ __all__ = [
     "TICKET_PATTERN",
     "ContractEntryNotFoundError",
     "_CONTRACT_SHA256_REQUIRED_AFTER",
+    "check_evidence_source_shape",
     "check_receipt_contract_binding",
     "classify_evidence_class",
     "classify_evidence_source_stamp",
@@ -1671,5 +1851,6 @@ __all__ = [
     "compute_contract_sha256",
     "parse_evidence_source",
     "parse_pr_opened_at",
+    "strip_noncanonical_regions",
     "validate_pr_receipts",
 ]

--- a/tests/unit/validation/test_receipt_gate_canonical_evidence_block.py
+++ b/tests/unit/validation/test_receipt_gate_canonical_evidence_block.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-14682 — canonical Evidence-Source block + pre-push shape check.
+
+The Receipt Gate's ``^Evidence-Source:`` MULTILINE extractor matched any
+column-0 stamp-shaped line, including one quoted as an EXAMPLE inside a fenced
+code block or blockquote (common in meta-PRs about the gate itself). That
+false-positive either satisfied the gate on prose or, when a real stamp and an
+example coexisted, false-blocked the PR with a "multiple Evidence-Source lines"
+error that forced manual body normalization.
+
+These tests pin BOTH directions so neither re-breaks (whack-a-mole):
+
+* FALSE-POSITIVE (this ticket): a stamp that lives only in a fence/blockquote is
+  NOT read as canonical; a real stamp coexisting with a fenced example is used
+  on its own without a spurious multiple-lines block.
+* FALSE-NEGATIVE (OMN-14410): a genuine disclaimer still skips identity binding;
+  a malformed reference still hard-fails; a valid reference still binds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validation.validator_receipt_gate import (
+    check_evidence_source_shape,
+    classify_evidence_source_stamp,
+    parse_evidence_source,
+    strip_noncanonical_regions,
+    validate_pr_receipts,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _empty_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    contracts = tmp_path / "contracts"
+    receipts = tmp_path / "receipts"
+    contracts.mkdir()
+    receipts.mkdir()
+    return contracts, receipts
+
+
+# ---------------------------------------------------------------------------
+# strip_noncanonical_regions — the core primitive
+# ---------------------------------------------------------------------------
+
+
+class TestStripNoncanonicalRegions:
+    def test_blanks_backtick_fenced_stamp(self) -> None:
+        body = "Intro\n\n```\nEvidence-Source: OCC#1234\n```\n\nOutro"
+        stripped = strip_noncanonical_regions(body)
+        assert "Evidence-Source: OCC#1234" not in stripped
+        assert "Intro" in stripped
+        assert "Outro" in stripped
+
+    def test_blanks_tilde_fenced_stamp(self) -> None:
+        body = "~~~\nEvidence-Source: OCC#1234\n~~~"
+        assert "Evidence-Source" not in strip_noncanonical_regions(body)
+
+    def test_blanks_fence_with_info_string(self) -> None:
+        body = "```text\nEvidence-Source: OCC#1234\n```"
+        assert "Evidence-Source" not in strip_noncanonical_regions(body)
+
+    def test_blanks_blockquote_stamp(self) -> None:
+        body = "> Evidence-Source: OCC#1234"
+        assert "Evidence-Source" not in strip_noncanonical_regions(body)
+
+    def test_preserves_canonical_column0_stamp(self) -> None:
+        body = "Evidence-Source: OCC#1234\nEvidence-Ticket: OMN-1"
+        stripped = strip_noncanonical_regions(body)
+        assert "Evidence-Source: OCC#1234" in stripped
+        assert "Evidence-Ticket: OMN-1" in stripped
+
+    def test_keeps_real_stamp_drops_fenced_example(self) -> None:
+        body = (
+            "Evidence-Source: OCC#500\n"
+            "Evidence-Ticket: OMN-1\n\n"
+            "For example:\n\n"
+            "```\nEvidence-Source: OCC#999\n```\n"
+        )
+        stripped = strip_noncanonical_regions(body)
+        assert "OCC#500" in stripped
+        assert "OCC#999" not in stripped
+
+    def test_unterminated_fence_fails_closed(self) -> None:
+        # An opening fence with no close blanks everything after it.
+        body = "```\nEvidence-Source: OCC#1234\nEvidence-Ticket: OMN-1"
+        stripped = strip_noncanonical_regions(body)
+        assert "Evidence-Source" not in stripped
+        assert "Evidence-Ticket" not in stripped
+
+    def test_idempotent(self) -> None:
+        body = "A\n```\nEvidence-Source: OCC#1\n```\nB"
+        once = strip_noncanonical_regions(body)
+        twice = strip_noncanonical_regions(once)
+        assert once == twice
+
+    def test_no_fence_body_unchanged_by_line_content(self) -> None:
+        body = "Evidence-Source: OCC#1\nEvidence-Ticket: OMN-1"
+        assert strip_noncanonical_regions(body) == body
+
+
+# ---------------------------------------------------------------------------
+# FALSE-POSITIVE direction (OMN-14682): fenced/quoted stamp is not canonical
+# ---------------------------------------------------------------------------
+
+
+class TestFalsePositiveFencedStamp:
+    def test_parse_evidence_source_ignores_fenced_stamp(self) -> None:
+        body = "Closes OMN-1\n\n```\nEvidence-Source: OCC#1234\n```"
+        assert parse_evidence_source(body) == (None, None)
+
+    def test_parse_evidence_source_ignores_blockquoted_stamp(self) -> None:
+        body = "Closes OMN-1\n\n> Evidence-Source: OCC#1234"
+        assert parse_evidence_source(body) == (None, None)
+
+    def test_parse_evidence_source_uses_real_stamp_over_fenced_example(self) -> None:
+        body = (
+            "Closes OMN-1\n\n"
+            "Evidence-Source: OCC#500\n"
+            "Evidence-Ticket: OMN-1\n\n"
+            "```\nEvidence-Source: OCC#999\n```\n"
+        )
+        assert parse_evidence_source(body) == ("500", None)
+
+    def test_classify_ignores_fenced_stamp(self) -> None:
+        body = "```\nEvidence-Source: not-a-ref garbage\n```"
+        attempted, _is_disclaimer, value = classify_evidence_source_stamp(body)
+        assert attempted is False
+        assert value is None
+
+    def test_gate_does_not_report_multiple_lines_for_real_plus_fenced(
+        self, tmp_path: Path
+    ) -> None:
+        # Real stamp + a fenced example must NOT trip the multiple-lines block.
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = (
+            "Closes OMN-1\n\n"
+            "Evidence-Source: OCC#500\n"
+            "Evidence-Ticket: OMN-1\n\n"
+            "Documented format:\n\n"
+            "```\nEvidence-Source: OCC#999\n```\n"
+        )
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="OMN-1: something",
+            branch_name="jonah/omn-1-x",
+        )
+        assert result.passed is False
+        assert "multiple" not in result.message.lower()
+
+    def test_gate_multiple_lines_still_fires_for_two_real_stamps(
+        self, tmp_path: Path
+    ) -> None:
+        # Two genuine column-0 stamps remain ambiguous → fail closed.
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = "Closes OMN-1\n\nEvidence-Source: OCC#500\nEvidence-Source: OCC#600\n"
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+        )
+        assert result.passed is False
+        assert "multiple Evidence-Source" in result.message
+
+    def test_gate_fenced_only_stamp_is_treated_as_no_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        # AC1: prose/fenced-only mention (no structured block) fails the gate
+        # (here: no receipt exists, and the fenced stamp is not counted).
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = "Closes OMN-1\n\n```\nEvidence-Source: OCC#1234\n```\n"
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="OMN-1: something",
+        )
+        assert result.passed is False
+        # It must NOT fail on identity binding (the fenced stamp did not trigger
+        # it) — it fails on the missing contract/receipt for the cited ticket.
+        assert "IDENTITY BINDING" not in result.message
+        assert "no contract" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# FALSE-NEGATIVE direction (OMN-14410) stays fixed
+# ---------------------------------------------------------------------------
+
+
+class TestFalseNegativeDirectionPreserved:
+    def test_disclaimer_still_classifies_as_disclaimer(self) -> None:
+        attempted, is_disclaimer, _ = classify_evidence_source_stamp(
+            "Evidence-Source: N/A"
+        )
+        assert attempted is True
+        assert is_disclaimer is True
+
+    def test_prose_disclaimer_still_skips_binding(self, tmp_path: Path) -> None:
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = (
+            "Closes OMN-1\n\n"
+            "Evidence-Source: does not apply — this PR IS the evidence source\n"
+        )
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="OMN-1: something",
+        )
+        # Skips identity binding; fails later on missing receipts, not on binding.
+        assert result.passed is False
+        assert "IDENTITY BINDING" not in result.message
+
+    def test_malformed_reference_still_hard_fails(self, tmp_path: Path) -> None:
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = "Closes OMN-1\n\nEvidence-Source: OCC#12 34 broken\n"
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="OMN-1: something",
+        )
+        assert result.passed is False
+        assert "malformed" in result.message.lower()
+
+    def test_valid_reference_still_requires_evidence_ticket(
+        self, tmp_path: Path
+    ) -> None:
+        contracts, receipts = _empty_dirs(tmp_path)
+        body = "Closes OMN-1\n\nEvidence-Source: OCC#1234\n"
+        result = validate_pr_receipts(
+            pr_body=body,
+            contracts_dir=contracts,
+            receipts_dir=receipts,
+            pr_title="OMN-1: something",
+        )
+        assert result.passed is False
+        assert "Evidence-Ticket" in result.message
+
+
+# ---------------------------------------------------------------------------
+# check_evidence_source_shape — the network-free pre-push primitive (AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEvidenceSourceShape:
+    def test_fenced_only_stamp_fails(self) -> None:
+        body = "Closes OMN-1\n\n```\nEvidence-Source: OCC#1234\n```"
+        result = check_evidence_source_shape(body)
+        assert result.passed is False
+        assert "only inside a fenced code block" in result.message
+
+    def test_blockquoted_only_stamp_is_shape_clean(self) -> None:
+        # A ``> Evidence-Source:`` line is not matched by the column-0 stamp
+        # pattern at all, so it reads as "no stamp present" (shape-clean). The
+        # real protection is that parse_evidence_source also ignores it, so the
+        # receipt gate still fails closed on the missing genuine evidence.
+        result = check_evidence_source_shape("> Evidence-Source: OCC#1234")
+        assert result.passed is True
+        assert parse_evidence_source("> Evidence-Source: OCC#1234") == (None, None)
+
+    def test_multiple_canonical_stamps_fail(self) -> None:
+        body = "Evidence-Source: OCC#1\nEvidence-Source: OCC#2"
+        result = check_evidence_source_shape(body)
+        assert result.passed is False
+        assert "multiple canonical" in result.message
+
+    def test_valid_reference_with_ticket_passes(self) -> None:
+        body = "Evidence-Source: OCC#1234\nEvidence-Ticket: OMN-1"
+        result = check_evidence_source_shape(body)
+        assert result.passed is True
+
+    def test_valid_reference_without_ticket_fails(self) -> None:
+        result = check_evidence_source_shape("Evidence-Source: OCC#1234")
+        assert result.passed is False
+        assert "Evidence-Ticket" in result.message
+
+    def test_malformed_reference_fails(self) -> None:
+        result = check_evidence_source_shape("Evidence-Source: OCC#12 34 broken")
+        assert result.passed is False
+        assert "malformed" in result.message.lower()
+
+    def test_recognized_disclaimer_passes(self) -> None:
+        result = check_evidence_source_shape("Evidence-Source: N/A")
+        assert result.passed is True
+
+    def test_no_stamp_is_shape_clean(self) -> None:
+        result = check_evidence_source_shape("Closes OMN-1\n\nNo stamp here.")
+        assert result.passed is True
+
+    def test_real_stamp_plus_fenced_example_passes(self) -> None:
+        body = (
+            "Evidence-Source: OCC#500\n"
+            "Evidence-Ticket: OMN-1\n\n"
+            "```\nEvidence-Source: OCC#999\n```\n"
+        )
+        result = check_evidence_source_shape(body)
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# CLI wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceShapeCli:
+    def test_cli_pass_valid_reference(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from omnibase_core.validation.validator_evidence_shape_cli import main
+
+        rc = main(["--pr-body", "Evidence-Source: OCC#1234\nEvidence-Ticket: OMN-1"])
+        assert rc == 0
+
+    def test_cli_fail_fenced_only(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from omnibase_core.validation.validator_evidence_shape_cli import main
+
+        rc = main(["--pr-body", "```\nEvidence-Source: OCC#1234\n```"])
+        assert rc == 1
+
+    def test_cli_reads_body_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from omnibase_core.validation.validator_evidence_shape_cli import main
+
+        body_file = tmp_path / "body.txt"
+        body_file.write_text(
+            "Evidence-Source: OCC#1234\nEvidence-Ticket: OMN-1", encoding="utf-8"
+        )
+        rc = main(["--pr-body-file", str(body_file)])
+        assert rc == 0
+
+    def test_cli_usage_error_without_body(self) -> None:
+        from omnibase_core.validation.validator_evidence_shape_cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main([])
+        assert exc.value.code == 2


### PR DESCRIPTION
## Summary

Closes OMN-14682.

The Receipt Gate's `^Evidence-Source:` MULTILINE extractor matched **any** column-0 stamp-shaped line, including one quoted as an EXAMPLE inside a fenced code block or blockquote (very common in meta-PRs about the gate itself). That false-positive either satisfied the gate on prose, or — when a real stamp and a fenced example coexisted — false-blocked the PR with a *"multiple Evidence-Source lines"* error that forced manual PR-body normalization.

This is the **false-positive sibling** of OMN-14410 (already fixed), which hardened the *false-negative* direction (structured evidence present but not recognized).

## What changed (`src/omnibase_core/validation/validator_receipt_gate.py`)

- **`strip_noncanonical_regions()`** — blanks out fenced code blocks and blockquotes before any Evidence-Source / Evidence-Ticket extraction, so only a top-level, column-0 structured line is read as canonical. Unterminated fences fail **closed**; the function is idempotent. (Indented code is already excluded structurally, since the extractor anchors at column 0.)
- Every Evidence-Source / Evidence-Ticket extraction — `parse_evidence_source`, `classify_evidence_source_stamp`, and the `validate_pr_receipts` multiple-lines + first-line + Evidence-Ticket resolution — now runs against the **canonical body**. A fenced/quoted stamp no longer satisfies the gate as canonical evidence, nor trips the multiple-lines block when it coexists with one real stamp. Two genuine column-0 stamps still fail closed (ambiguity).
- **`check_evidence_source_shape()`** — network-free shape validator, exposed via `validator_evidence_shape_cli` and a **pre-push hook** (`.pre-commit-hooks/check-evidence-shape.sh`, wired `stages: [pre-push]`). Authors get fail-fast feedback locally before CI (rule #5: gate + hook in the same PR). The CI receipt-gate remains the authoritative, receipt-verifying enforcement layer; the hook no-ops when no PR exists yet.

The canonical stamp shape is unchanged: a top-level `Evidence` source line (`OCC#<pr>` or a hex SHA) paired with its ticket line. Format examples are kept out of this body deliberately, so no automated extractor mis-reads a documentation example as this PR's real stamp.

## Acceptance criteria (OMN-14682)

- [x] A PR body whose only source mention is inside a fence/quote FAILS the gate (treated as no evidence).
- [x] A PR body with both a fenced example and a valid structured block resolves on the structured block's value only (no spurious multiple-lines block).
- [x] Local pre-push check catches the same shape violations before CI.
- [x] Regression test proves BOTH directions stay fixed together (this false-positive + OMN-14410's false-negative) — no whack-a-mole.

## dod_evidence

- New regression suite `tests/unit/validation/test_receipt_gate_canonical_evidence_block.py` (33 cases): `strip_noncanonical_regions` (fences/tilde/info-string/blockquote/unterminated/idempotent), false-positive fenced-stamp direction, preserved OMN-14410 false-negative direction, `check_evidence_source_shape`, and the CLI.
- Local gates (worktree, `env -u PYTHONPATH uv run ...`):
  - `ruff format` / `ruff check src/ tests/` — clean.
  - `mypy --strict` on both changed source files — `Success: no issues found in 2 source files`.
  - Full validation suite `tests/unit/validation/` + `tests/unit/scripts/validation/test_validate_pr_receipts.py` — **4843 passed, 5 skipped** (198 in the receipt-gate cluster).
  - Pre-push hook `--self-test` — PASS; fenced-only body rejected (rc=1); valid stamp+ticket accepted (rc=0).
- `pre-commit run --all-files` residual failures (`no-hardcoded-topics`, `no-untracked-todos`, `deterministic-skill-routing`) are **pre-existing whole-repo/cross-repo debt in files this PR does not touch** — none cite the changed files.

## OCC Evidence

Evidence-Ticket: OMN-14682
Evidence-Source: OCC#4419
Evidence-Commit: 22bc6d98d47dc3ad6b70b9ccb71ddade1da868f6

## Follow-up finding (out of scope here)

The `occ-preflight` reusable-workflow shell grep (`^Evidence-Source:`) has the **same over-match** this ticket fixes in the Python validator — it matched a fenced example on the first revision of this body and resolved it to an unrelated OCC PR. That shell surface lives outside omnibase_core; filing/fixing it is a separate ticket. This body now avoids any line-start source stamp so the shell grep has nothing to mis-read.

## Notes

Enforcement-only change: no runtime/dispatch/topic/contract surface touched. New CLI added to the `T201` per-file-ignore allowlist alongside `validator_receipt_gate_cli.py`.
