### PR TITLE
feat(OMN-14624): single canonical ProtocolSemVer + break types->protocols eager back-edge

### DIFF
--- a/src/omnibase_core/protocols/base/protocol_sem_ver.py
+++ b/src/omnibase_core/protocols/base/protocol_sem_ver.py
@@ -2,35 +2,16 @@
 # SPDX-License-Identifier: MIT
 
 """
-Semantic Version Protocol.
+Semantic Version Protocol (canonical re-export).
 
-Provides a structured approach to versioning with major, minor, and patch
-components. Used throughout Core for protocol versioning, dependency
-management, and compatibility checking.
+The single canonical ``ProtocolSemVer`` structural protocol lives in
+``omnibase_core.types.type_semver`` (the richer superset surface). This module
+re-exports it so the historical ``omnibase_core.protocols.base`` import path
+keeps resolving to the same object.
 """
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
-
-
-@runtime_checkable
-class ProtocolSemVer(Protocol):
-    """
-    Protocol for semantic version objects following SemVer specification.
-
-    Provides a structured approach to versioning with major, minor, and patch
-    components. Used throughout Core for protocol versioning, dependency
-    management, and compatibility checking.
-    """
-
-    major: int
-    minor: int
-    patch: int
-
-    def __str__(self) -> str:
-        """Return version string in 'major.minor.patch' format."""
-        ...
-
+from omnibase_core.types.type_semver import ProtocolSemVer
 
 __all__ = ["ProtocolSemVer"]

--- a/src/omnibase_core/types/__init__.py
+++ b/src/omnibase_core/types/__init__.py
@@ -26,8 +26,13 @@ error_codes → types.__init__ → constraints → (circular back to error_codes
 Solution: Use TYPE_CHECKING and __getattr__ for lazy loading, similar to ModelBaseCollection.
 """
 
-# Constraint imports are direct at module level for IDE support and import performance.
-# The __getattr__ fallback at the bottom provides lazy-loading as a backup mechanism.
+# type_constraints and type_core are NOT imported eagerly here (OMN-14624).
+# Both import UP into ``omnibase_core.protocols``; importing them at package-init
+# time closes a ``protocols -> types -> protocols`` cycle whenever ``protocols`` is
+# imported before ``types`` (an order-dependent ImportError). Their public names are
+# served lazily via ``__getattr__`` at the bottom of this module; direct submodule
+# imports (``from omnibase_core.types.type_constraints import ...``) remain the fast
+# path for hot consumers and are unaffected.
 # Core types for breaking circular dependencies
 # Converter functions
 from .converter_error_details import convert_error_details_to_typed_dict
@@ -42,46 +47,10 @@ from .type_compute_pipeline import (
     StepResultMapping,
     TransformInputT,
 )
-from .type_constraints import (
-    BasicValueType,
-    CollectionItemType,
-    ComplexContextValueType,
-    Configurable,
-    ConfigurableType,
-    ContextValueType,
-    ErrorType,
-    Executable,
-    ExecutableType,
-    Identifiable,
-    IdentifiableType,
-    MetadataType,
-    ModelType,
-    Nameable,
-    NameableType,
-    NumericType,
-    PrimitiveValueType,
-    ProtocolMetadataProvider,
-    ProtocolValidatable,
-    Serializable,
-    SerializableType,
-    SimpleValueType,
-    SuccessType,
-    ValidatableType,
-    is_complex_context_value,
-    is_configurable,
-    is_context_value,
-    is_executable,
-    is_identifiable,
-    is_metadata_provider,
-    is_nameable,
-    is_primitive_value,
-    is_serializable,
-    is_validatable,
-    validate_context_value,
-    validate_primitive_value,
-)
-from .type_core import ProtocolSchemaValue, TypedDictBasicErrorContext
 
+# NOTE(OMN-14624): type_constraints + type_core public names are lazy-loaded via
+# __getattr__ below (both import upward into omnibase_core.protocols). Do NOT add
+# eager ``from .type_constraints import ...`` / ``from .type_core import ...`` here.
 # Effect result type aliases (centralized to avoid primitive soup unions)
 from .type_effect_result import DbParamType, EffectResultType
 
@@ -707,11 +676,27 @@ __all__ = [
 # =============================================================================
 def __getattr__(name: str) -> object:
     """
-    Lazy import for constraints module to avoid circular imports.
+    Lazy import for the ``type_constraints`` and ``type_core`` submodules.
 
-    All constraint imports are lazy-loaded to prevent circular dependency:
+    Both submodules import UP into ``omnibase_core.protocols``. Eager import at
+    package-init time therefore closes a ``protocols -> types -> protocols`` cycle
+    whenever ``protocols`` is imported before ``types`` (OMN-14624). Their public
+    names are resolved lazily here so ``types/__init__`` never imports ``protocols``
+    at module-init time:
     error_codes -> types.__init__ -> constraints -> models -> error_codes
     """
+    # Public names re-exported from ``type_core`` (imports omnibase_core.protocols).
+    type_core_exports = {
+        "ProtocolSchemaValue",
+        "TypedDictBasicErrorContext",
+    }
+    if name in type_core_exports:
+        from omnibase_core.types import type_core
+
+        attr = getattr(type_core, name)
+        globals()[name] = attr
+        return attr
+
     # List of all constraint exports that should be lazy-loaded
     constraint_exports = {
         "BasicValueType",

--- a/src/omnibase_core/types/type_semver.py
+++ b/src/omnibase_core/types/type_semver.py
@@ -4,17 +4,27 @@
 """
 Structural protocol for semantic-version values.
 
-``ProtocolSemVer`` exports the read surface of
+``ProtocolSemVer`` is the SINGLE canonical structural protocol for semantic-version
+values across ``omnibase_core`` (OMN-14624). It exports the read surface of
 ``omnibase_core.models.primitives.model_semver.ModelSemVer`` so foundation-layer
 TypedDicts and type aliases can annotate version-typed fields WITHOUT importing
 the concrete model (a ``types -> models`` import-layering back-edge forbidden by
 the ``core-foundation-no-upward`` contract in ``.importlinter``; OMN-3210 /
 OMN-14337).
 
+``omnibase_core.protocols.base.protocol_sem_ver`` re-exports this object so the
+historical protocol-layer import path resolves to the *same* canonical protocol.
+
 ``ModelSemVer`` (a frozen Pydantic model, 345+ importers, imports ``ModelOnexError``)
 cannot be relocated down into ``types/`` without an exception-type behavior change
 and repo-wide churn, so a structural protocol is used instead. ``ModelSemVer``
 satisfies this protocol structurally — no runtime coupling, no behavior change.
+
+The protocol is ``@runtime_checkable`` so ``isinstance(value, ProtocolSemVer)``
+duck-typing checks work (preserving the behavior the former protocol-layer
+duplicate offered). This module MUST stay a pure typing-only leaf — it imports
+only ``typing`` — so ``types/`` remains importable before ``protocols`` in any
+order.
 
 Construction of ``ModelSemVer`` instances still happens against the concrete
 model imported directly by producing code; this protocol only types the *value*
@@ -23,39 +33,33 @@ carried through foundation shapes.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
-class SemVerProtocol(Protocol):
+@runtime_checkable
+class ProtocolSemVer(Protocol):
     """Structural read surface of a semantic-version value (see ``ModelSemVer``)."""
 
     @property
-    def major(self) -> int:
-        pass
+    def major(self) -> int: ...
 
     @property
-    def minor(self) -> int:
-        pass
+    def minor(self) -> int: ...
 
     @property
-    def patch(self) -> int:
-        pass
+    def patch(self) -> int: ...
 
     @property
-    def prerelease(self) -> tuple[str | int, ...] | None:
-        pass
+    def prerelease(self) -> tuple[str | int, ...] | None: ...
 
     @property
-    def build(self) -> tuple[str, ...] | None:
-        pass
+    def build(self) -> tuple[str, ...] | None: ...
 
-    def to_string(self) -> str:
-        pass
+    def to_string(self) -> str: ...
 
-    def is_prerelease(self) -> bool:
-        pass
+    def is_prerelease(self) -> bool: ...
 
+    def __str__(self) -> str: ...
 
-ProtocolSemVer = SemVerProtocol
 
 __all__ = ["ProtocolSemVer"]

--- a/tests/unit/test_protocol_sem_ver_canonical.py
+++ b/tests/unit/test_protocol_sem_ver_canonical.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Regression tests for OMN-14624: single canonical ``ProtocolSemVer`` object and
+no order-dependent circular import.
+
+Background
+----------
+Two ``ProtocolSemVer`` definitions used to exist in ``omnibase_core``:
+
+* ``types/type_semver.py`` — the richer structural surface (major/minor/patch,
+  prerelease, build, ``to_string()``, ``is_prerelease()``).
+* ``protocols/base/protocol_sem_ver.py`` — a narrower duplicate
+  (major/minor/patch + ``__str__``).
+
+OMN-14624 collapses these to ONE canonical object living in
+``types.type_semver`` and makes ``protocols.base.protocol_sem_ver`` a one-line
+re-export. That re-export creates a ``protocols -> types`` edge. Because
+``types/__init__.py`` used to *eagerly* import ``type_constraints`` and
+``type_core`` (both of which import UP into ``omnibase_core.protocols``), the
+re-export closed a ``protocols -> types -> protocols`` loop that raised an
+order-dependent ``ImportError`` whenever ``protocols`` was imported before
+``types`` (``cannot import name 'ProtocolConfigurable' from partially
+initialized module 'omnibase_core.protocols'``).
+
+The fix routes ``type_constraints`` / ``type_core`` through the lazy
+``__getattr__`` loader in ``types/__init__.py`` so the package no longer imports
+protocols at module-init time.
+
+These tests are the independent oracle. The both-order subprocess tests FAIL on
+the re-export-only (unfixed) state and PASS once the eager back-edge is removed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# Each script imports ProtocolSemVer via all three public paths and asserts they
+# are one and the same object (criterion D identity). A fresh interpreter is used
+# so module import ORDER is exactly what the script dictates — the whole point of
+# the regression. All lines are top-level (zero indent) so the script is valid.
+_IDENTITY_ASSERTIONS = (
+    "from omnibase_core.protocols.base import ProtocolSemVer as p_base\n"
+    "from omnibase_core.protocols import ProtocolSemVer as p_pkg\n"
+    "from omnibase_core.types.type_semver import ProtocolSemVer as t_canon\n"
+    "assert p_base is t_canon, 'protocols.base.ProtocolSemVer is not canonical'\n"
+    "assert p_pkg is t_canon, 'protocols.ProtocolSemVer is not canonical'\n"
+    "print('IMPORT_ORDER_OK')\n"
+)
+
+_PROTOCOLS_FIRST = "import omnibase_core.protocols\nimport omnibase_core.types\n"
+_TYPES_FIRST = "import omnibase_core.types\nimport omnibase_core.protocols\n"
+
+
+def _run_fresh_interpreter(body: str) -> subprocess.CompletedProcess[str]:
+    """Run ``body`` in a fresh interpreter (no pytest/conftest pollution).
+
+    Uses ``sys.executable`` and inherits the environment so the child resolves
+    the same ``omnibase_core`` source tree as the parent test process.
+    """
+    script = body + _IDENTITY_ASSERTIONS
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+def test_protocols_first_import_order() -> None:
+    """Importing ``protocols`` BEFORE ``types`` must not deadlock the cycle."""
+    result = _run_fresh_interpreter(_PROTOCOLS_FIRST)
+    assert result.returncode == 0, (
+        "protocols-first import failed (circular import regression):\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "IMPORT_ORDER_OK" in result.stdout
+
+
+@pytest.mark.unit
+def test_types_first_import_order() -> None:
+    """Importing ``types`` BEFORE ``protocols`` must also import cleanly."""
+    result = _run_fresh_interpreter(_TYPES_FIRST)
+    assert result.returncode == 0, (
+        "types-first import failed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "IMPORT_ORDER_OK" in result.stdout
+
+
+@pytest.mark.unit
+def test_single_canonical_protocol_identity() -> None:
+    """All three public import paths resolve to one canonical object (criterion D)."""
+    from omnibase_core.protocols import ProtocolSemVer as ProtocolSemVerFromPkg
+    from omnibase_core.protocols.base import ProtocolSemVer as ProtocolSemVerFromBase
+    from omnibase_core.protocols.base.protocol_sem_ver import (
+        ProtocolSemVer as ProtocolSemVerFromModule,
+    )
+    from omnibase_core.types.type_semver import (
+        ProtocolSemVer as ProtocolSemVerCanonical,
+    )
+
+    assert ProtocolSemVerFromBase is ProtocolSemVerCanonical
+    assert ProtocolSemVerFromPkg is ProtocolSemVerCanonical
+    assert ProtocolSemVerFromModule is ProtocolSemVerCanonical
+
+
+@pytest.mark.unit
+def test_canonical_protocol_is_runtime_checkable() -> None:
+    """The canonical protocol is ``@runtime_checkable`` and enforces the full surface.
+
+    ``ModelSemVer`` (the only concrete implementation) satisfies it; a bare object
+    and a narrow-only duck (major/minor/patch but no ``to_string``/``is_prerelease``)
+    do NOT — proving the isinstance check tests the real richer surface rather than
+    passing vacuously.
+    """
+    from omnibase_core.models.primitives.model_semver import ModelSemVer
+    from omnibase_core.types.type_semver import ProtocolSemVer
+
+    version = ModelSemVer(major=1, minor=2, patch=3, prerelease=("alpha", 1))
+    assert isinstance(version, ProtocolSemVer)
+
+    # EXISTS-but-WRONG: object missing the method surface must NOT match.
+    class _NarrowOnly:
+        major = 1
+        minor = 2
+        patch = 3
+
+    assert not isinstance(_NarrowOnly(), ProtocolSemVer)
+    assert not isinstance(object(), ProtocolSemVer)


### PR DESCRIPTION
## Summary

Closes OMN-14624.

`omnibase_core` had **two** `ProtocolSemVer` definitions:

- `types/type_semver.py::ProtocolSemVer` — richer structural surface (`major`, `minor`, `patch`, `prerelease`, `build`, `to_string()`, `is_prerelease()`).
- `protocols/base/protocol_sem_ver.py::ProtocolSemVer` — narrower duplicate (`major`, `minor`, `patch`, `__str__`).

This PR collapses them to **one canonical object** living in `types/type_semver.py` and makes `protocols/base/protocol_sem_ver.py` a one-line re-export — while removing the order-dependent circular import the dedupe would otherwise introduce.

### Changes
- **`types/type_semver.py`** (canonical home): kept the richer superset surface; added `@runtime_checkable` and `__str__` so the six `protocols.base` callers keep the exact surface they use. Stays a pure typing-only leaf (imports only `typing`).
- **`protocols/base/protocol_sem_ver.py`**: now `from omnibase_core.types.type_semver import ProtocolSemVer`. `protocols/base/__init__` still exports it. Identity holds: `omnibase_core.protocols.base.ProtocolSemVer is omnibase_core.types.type_semver.ProtocolSemVer`.
- **`types/__init__.py`**: no longer eagerly imports `type_constraints` / `type_core` (both import UP into `omnibase_core.protocols`). Their public names are served lazily through the existing `__getattr__` loader (extended to cover the `type_core` names). Direct submodule imports (`from omnibase_core.types.type_constraints import ...`) remain the fast path and are unaffected.
- New subprocess-based both-order regression test.

### The cycle and why the back-edge fix is load-bearing
Adding the `protocols.base -> types` re-export closes a `protocols -> types -> protocols` loop, because `types/__init__.py` used to **eagerly** import `type_constraints` (`from omnibase_core.protocols import ProtocolConfigurable`) and `type_core` (`from omnibase_core.protocols import ProtocolSchemaValue`) at package-init time. When `protocols` is imported before `types`, `protocols` is only partially initialized when `type_constraints` reaches back into it -> `ImportError`. Routing those two submodules through the lazy `__getattr__` loader means `types/__init__` never imports `protocols` at module-init time, so the loop cannot form in any import order.

## dod_evidence

### RED - re-export applied WITHOUT the back-edge fix (proves the cycle is real)
Fresh interpreter, `import omnibase_core.protocols` before `import omnibase_core.types`:

```
CIRCULAR_IMPORT_ERROR: ImportError: cannot import name 'ProtocolConfigurable' from
partially initialized module 'omnibase_core.protocols' (most likely due to a circular import)
  File ".../protocols/__init__.py", line 54, in <module>
    from omnibase_core.protocols.base import (  # Protocols; Type Variables
  File ".../protocols/base/__init__.py", line 56, in <module>
    from omnibase_core.protocols.base.protocol_sem_ver import ProtocolSemVer
  File ".../protocols/base/protocol_sem_ver.py", line 15, in <module>
    from omnibase_core.types.type_semver import ProtocolSemVer
  File ".../types/__init__.py", line 45, in <module>
    from .type_constraints import (
  File ".../types/type_constraints.py", line 29, in <module>
    from omnibase_core.protocols import ProtocolConfigurable as Configurable
ImportError: cannot import name 'ProtocolConfigurable' from partially initialized module 'omnibase_core.protocols'
```

The new regression test also fails on this state for the right reason:
`test_protocols_first_import_order` -> same `ImportError`; `test_canonical_protocol_is_runtime_checkable` -> `TypeError: Instance and class checks can only be used with @runtime_checkable protocols` (canonical not yet `@runtime_checkable`).

### GREEN - full fix (both import orders + identity + runtime_checkable)
```
protocols-first: rc=0  identity_ok
types-first    : rc=0  identity_ok
isinstance(ModelSemVer(...), ProtocolSemVer) = True
isinstance(object(), ProtocolSemVer)         = False   # richer surface enforced, not vacuous
runtime_checkable = True

tests/unit/test_protocol_sem_ver_canonical.py .... 4 passed
```

### Gates (run locally in the worktree, `env -u PYTHONPATH`)
- `ruff format` + `ruff check`: clean
- `mypy src/omnibase_core/` (strict): **Success - no issues found in 4163 source files** (protocol widening is type-safe)
- `lint-imports` (import-linter): **5 kept, 0 broken** - `core-foundation-no-upward` and `core-protocols-no-upward` both KEPT (`protocols -> types` is a legal forward edge; no new `types -> models` edge)
- `pre-commit run` on changed files: all applicable hooks pass
- Tests: 4 (new regression) + 478 (types / `test_no_circular_imports` / `test_init_exports`) + 498 (semver / node-metadata-block / service-registration / all `protocols/` suites) all pass; full-tree runtime import smoke (protocols-first) clean

## Scope / notes
- **Contained to `omnibase_core`; no version bump** (internal protocol-layer dedupe + import-structure fix; no external SDK surface change).
- **OCC companion required:** this PR touches runtime-contract-adjacent core source, so a `onex_change_control` evidence companion (Evidence-Source + Ticket, dev-target) is required for the Receipt-Gate before merge, per the OCC receipt-gate flow.
- Out of scope: `omnibase_spi.protocols.types.protocol_base_types.ProtocolSemVer` is a third, fully independent duplicate (narrow, self-contained, does not import core) - tracked separately.

Do not merge / do not arm auto-merge (omnibase_core has auto-merge disabled; merges are Codex-owned).

Evidence-Ticket: OMN-14624
Evidence-Source: OCC#4442
Evidence-Commit: 0c2f7e5738bbed0eacbb3cdf7e08eae6db730e27
