### PR TITLE
fix(OMN-14907): count-locked ratchet over pull_request-triggered workflow files (C7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1601,6 +1601,49 @@ jobs:
             --enforce-modified "origin/${{ github.base_ref || 'dev' }}" \
             src/omnibase_core
 
+  # Count-locked pull_request-workflow ratchet (C7 / OMN-14907)
+  # Blocks any NEW .github/workflows/*.yml file that triggers on pull_request unless
+  # it retires an existing one (net-negative) or carries an expiring waiver. The
+  # per-PR workflow-run fan-out (~49 runs/PR here) is the C7 cost driver in
+  # docs/plans/2026-07-21-ci-capacity-recovery-plan.md; this is CLAUDE.md's
+  # net-negative-surface rule expressed as a MECHANISM. It MUST run as a ci.yml JOB:
+  # a job living in a separate pull_request-triggered workflow file would be
+  # structurally invisible to ci-summary's default-deny poller (OMN-14430) — and it
+  # would itself add to the very surface this ratchet governs.
+  pull-request-workflow-ratchet:
+    name: Pull-Request Workflow Ratchet (OMN-14907)
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Ratchet pull_request-triggered workflow files against the frozen budget (OMN-14907)
+        run: |
+          uv run python -m omnibase_core.validation.validator_pull_request_workflow_ratchet --repo-root .
+
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
   # ---------------------------------------------------------------------------
@@ -1623,7 +1666,7 @@ jobs:
     # provide. naming-conventions / pydantic-patterns / aislop-patterns ARE
     # spec-required validators (validator-requirements.yaml) and are now needs so
     # a real violation turns the single required CI Summary rollup red.
-    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, lint-imports, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan, no-new-os-environ, no-noncanonical-lifecycle-classes, pydantic-extra-forbid, spdx-headers]
+    needs: [lint, pyright, exports-validation, mypy-validation-scripts, core-infra-boundary, lint-imports, check-deterministic-skills, docs-validation, node-purity-check, enum-governance, detect-secrets, sdk-boundary-check, contract-compliance, contract-config-compliance, breaking-schema-change, no-env-fallbacks, demo-path-topic-coherence, dispatch-surface-test-required, naming-conventions, pydantic-patterns, aislop-patterns, doc-content-scan, no-new-os-environ, no-noncanonical-lifecycle-classes, pydantic-extra-forbid, pull-request-workflow-ratchet, spdx-headers]
     if: always()
 
     steps:
@@ -1660,6 +1703,7 @@ jobs:
           no_new_os_environ="${{ needs.no-new-os-environ.result }}"
           noncanonical_classes="${{ needs.no-noncanonical-lifecycle-classes.result }}"
           extra_forbid="${{ needs.pydantic-extra-forbid.result }}"
+          pr_workflow_ratchet="${{ needs.pull-request-workflow-ratchet.result }}"
           spdx_headers="${{ needs.spdx-headers.result }}"
 
           # Report each check
@@ -1690,6 +1734,7 @@ jobs:
           echo "| No New os.environ Reads (OMN-13566) | $no_new_os_environ |" >> $GITHUB_STEP_SUMMARY
           echo "| Non-Canonical Lifecycle-Class Ratchet (OMN-14350) | $noncanonical_classes |" >> $GITHUB_STEP_SUMMARY
           echo "| Pydantic extra=\"forbid\" Ratchet (OMN-14515) | $extra_forbid |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pull-Request Workflow Ratchet (OMN-14907) | $pr_workflow_ratchet |" >> $GITHUB_STEP_SUMMARY
           echo "| SPDX Headers (OMN-13576) | $spdx_headers |" >> $GITHUB_STEP_SUMMARY
 
           # Gate logic: all must pass
@@ -1718,6 +1763,7 @@ jobs:
              [[ "$no_new_os_environ" == "success" ]] && \
              [[ "$noncanonical_classes" == "success" ]] && \
              [[ "$extra_forbid" == "success" ]] && \
+             [[ "$pr_workflow_ratchet" == "success" ]] && \
              [[ "$spdx_headers" == "success" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Quality Gate: PASSED**" >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -424,6 +424,22 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # C7 / OMN-14907: count-locked ratchet over pull_request-triggered workflow
+      # files. Blocks a NEW .github/workflows/*.yml pull_request trigger unless it
+      # retires an existing one (net-negative) or carries an expiring waiver in
+      # architecture-handshakes/pull-request-workflow-budget.yaml. pass_filenames:
+      # false — the check is a whole-.github/workflows scan against the frozen
+      # budget; files: keeps the trigger scoped to workflow + registry edits so
+      # unrelated commits do not pay for it.
+      - id: pull-request-workflow-ratchet
+        name: Pull-request workflow-file ratchet (OMN-14907)
+        entry: uv run --frozen python -m omnibase_core.validation.validator_pull_request_workflow_ratchet
+          --repo-root .
+        language: system
+        files: ^(\.github/workflows/.*\.(yml|yaml)|architecture-handshakes/pull-request-workflow-budget\.yaml)$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # OMN-14515: every Pydantic model must resolve to an explicit extra="forbid".
       # ABSENCE IS A VIOLATION — Pydantic's default is extra="ignore", which SILENTLY
       # DROPS unknown fields (four live data-loss bugs: OMN-14490/14506/14513/14514).
@@ -620,7 +636,7 @@ repos:
         language: system
         pass_filenames: true
         files: ^.*\.py$
-        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|scripts/ci/canonical_handler_shape\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_rollup_coverage\.py|src/omnibase_core/validation/validator_standalone_workflow_registry\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py|src/omnibase_core/validators/command_category_requires_event_model\.py|src/omnibase_core/validators/generated_node_model_class_exists\.py|src/omnibase_core/validators/projection_exposure_drift\.py|src/omnibase_core/validators/no_noncanonical_lifecycle_classes\.py|\.github/actions/required-check-skip-guard/validate_no_required_check_skip_vectors\.py|\.github/actions/required-check-skip-guard/_workflow_model\.py)
+        exclude: ^(scripts/validation/validate-contracts\.py|scripts/validation/validate-string-versions\.py|scripts/validation/check_stub_implementations\.py|scripts/validation/validate-no-manual-yaml\.py|scripts/validation/validate_pr_deploy_required\.py|scripts/compute_contract_fingerprint\.py|scripts/lint_contract\.py|scripts/ci/canonical_handler_shape\.py|src/omnibase_core/utils/safe_yaml_loader\.py|src/omnibase_core/utils/util_safe_yaml_loader\.py|src/omnibase_core/validation/contracts\.py|src/omnibase_core/validation/contract_validator\.py|src/omnibase_core/validation/validator_base\.py|src/omnibase_core/validation/validator_any_type\.py|src/omnibase_core/validation/validator_contract_linter\.py|src/omnibase_core/validation/validator_requirements_consumer\.py|src/omnibase_core/validation/validator_rollup_coverage\.py|src/omnibase_core/validation/validator_standalone_workflow_registry\.py|src/omnibase_core/validation/validator_pull_request_workflow_ratchet\.py|src/omnibase_core/validation/validator_runtime_profiles\.py|src/omnibase_core/discovery/mixin_discovery\.py|src/omnibase_core/cli/cli_demo\.py|tests/fixtures/validation/|src/omnibase_core/validation/scripts/validate_string_versions\.py|src/omnibase_core/validators/contract_config_compliance\.py|src/omnibase_core/validators/gitignore_baseline\.py|src/omnibase_core/validators/skill_dispatch_receipt_mode\.py|src/omnibase_core/validators/backend_secret_discipline\.py|src/omnibase_core/validators/operation_match_requires_operation\.py|src/omnibase_core/validators/dispatched_contract_operation\.py|src/omnibase_core/validators/command_category_requires_event_model\.py|src/omnibase_core/validators/generated_node_model_class_exists\.py|src/omnibase_core/validators/projection_exposure_drift\.py|src/omnibase_core/validators/no_noncanonical_lifecycle_classes\.py|\.github/actions/required-check-skip-guard/validate_no_required_check_skip_vectors\.py|\.github/actions/required-check-skip-guard/_workflow_model\.py)
         stages: [pre-commit]
         # validate_string_versions.py: validation script that must load YAML to validate it (OMN-4402)
         # required-check-skip-guard/*.py (OMN-14863): vendored from omniclaude

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Count-locked ratchet over pull_request-triggered workflow files (C7 / OMN-14907).
+#
+# WHY THIS EXISTS
+# ---------------
+# Every `.github/workflows/*.yml` file that triggers on `pull_request` /
+# `pull_request_target` fires a fresh check-run on every push to every PR. That
+# per-commit fan-out is INDEPENDENT of required-status-check count (required
+# status gates MERGING, not EXECUTION). omnibase_core's ~49-runs-per-PR standing
+# baseline is the C7 cost driver in
+# docs/plans/2026-07-21-ci-capacity-recovery-plan.md, and it grew by 7 files in
+# five days through ordinary feature PRs — because CLAUDE.md's
+# net-negative-surface rule was a RULE, not a MECHANISM.
+#
+# HOW THE RATCHET WORKS (enforced by
+# src/omnibase_core/validation/validator_pull_request_workflow_ratchet.py and
+# tests/validation/test_pull_request_workflow_ratchet.py):
+#
+#   * Every live PR-triggered workflow file MUST appear either in
+#     `allowlisted_workflows` or in `waivers`. A new un-enumerated file fails
+#     CLOSED (UNREGISTERED).
+#   * `budget` is a hard count lock: len(allowlisted_workflows) == budget.
+#     Registering a net-new file bumps the list to budget+1 and FAILS
+#     (BUDGET_MISMATCH). The budget is frozen a SECOND time in the test suite, so
+#     changing it is a deliberate two-file, reviewed edit — never a silent drift.
+#     The ratchet is intended to move DOWN only.
+#   * The ONLY sanctioned ways to add a PR-triggered workflow are:
+#       (a) RETIRE an existing one in the same PR (net-negative: the workflow
+#           file's `pull_request` trigger is removed, its allowlist line deleted,
+#           and the budget lowered — then the new one takes the freed slot), or
+#       (b) add the new file to `waivers` with a ticket + absolute `expires` date
+#           + justification + what surface it `retires`. Waivers are TRACKED and
+#           EXPIRING — a past-expiry waiver fails (WAIVER_EXPIRED).
+#   * Deleting a workflow without removing its registry line fails (STALE), which
+#     is how the count ratchets DOWN. An allowlisted file that stops triggering on
+#     pull_request fails (NOT_PR_TRIGGERED) — remove it and lower the budget.
+#
+# This gate runs as a JOB INSIDE ci.yml and as a pre-commit hook — NEVER as its
+# own new pull_request-triggered workflow file (that would be self-defeating, and
+# a separate workflow's job is structurally invisible to ci.yml's ci-summary
+# poller per OMN-14430).
+#
+# TO LOWER THE BUDGET (the goal — this is what C2/C3/C4 drain toward): remove the
+# retired workflow's line here, decrement `budget`, and update EXPECTED_BUDGET in
+# tests/validation/test_pull_request_workflow_ratchet.py in the same PR.
+
+schema_version: 1
+
+# Count lock. MUST equal len(allowlisted_workflows). Frozen a second time as
+# EXPECTED_BUDGET in the test suite. Intended to move DOWN only.
+# baseline captured 2026-07-21 at origin/dev@d09128fc.
+budget: 49
+
+# Every live `.github/workflows/*.yml` that triggers on pull_request /
+# pull_request_target as of the baseline. This is the frozen ratchet floor: a new
+# file may only enter by taking a slot freed by a retirement, or via `waivers`.
+allowlisted_workflows:
+  - auto-merge.yml
+  - auto-tag-on-merge.yml
+  - call-occ-preflight.yml
+  - call-receipt-gate.yml
+  - call-reject-skip.yml
+  - canonical-inference-gate.yml
+  - check-db-ownership.yml
+  - check-handshake.yml
+  - check-llm-refs-drift.yml
+  - ci.yml
+  - contract-validation.yml
+  - cr-thread-gate-caller.yml
+  - dep-provenance-gate.yml
+  - deploy-gate.yml
+  - main-target-guard.yml
+  - no-faked-boundary.yml
+  - omni-standards-compliance.yml
+  - pr-title-check.yml
+  - precommit-parity-gate.yml
+  - product-readiness-shadow.yml
+  - propagate-config.yml
+  - receipt-honesty.yml
+  - required-check-skip-guard-caller.yml
+  - security-scan.yml
+  - semantic-diff-labeler.yml
+  - stale-todo-gate.yml
+  - todo-audit-on-merge.yml
+  - url-authority-gate.yml
+  - validator-backend-secret-discipline.yml
+  - validator-banned-compose-vars.yml
+  - validator-bypass-token-blocklist.yml
+  - validator-command-category-event-model.yml
+  - validator-dispatched-contract-operation.yml
+  - validator-fsm-handler-drift.yml
+  - validator-generated-node-model-class-exists.yml
+  - validator-gitignore-baseline.yml
+  - validator-no-direct-kafka-producer.yml
+  - validator-no-except-swallow.yml
+  - validator-no-hardcoded-ip.yml
+  - validator-no-import-none-fallback.yml
+  - validator-no-io-outside-effects.yml
+  - validator-no-none-guard-publish.yml
+  - validator-no-plugin-daemon-classes.yml
+  - validator-no-raw-sqlite3.yml
+  - validator-operation-match.yml
+  - validator-pin-hygiene.yml
+  - validator-release-identity.yml
+  - validator-runtime-profiles.yml
+  - validator-todo-marker.yml
+
+# Tracked, EXPIRING exceptions. A workflow here does NOT count toward `budget`,
+# but each entry MUST carry workflow_file + ticket + absolute `expires` (ISO date)
+# + justification + `retires` (the surface/manual step it removes, per the
+# net-negative rule). A past-expiry waiver fails the gate. Empty at baseline —
+# the sanctioned default is retire-one, not waive.
+waivers: []
+
+metadata:
+  generated_by: "C7 / OMN-14907, 2026-07-21"
+  baseline_ref: "origin/dev@d09128fc"
+  related_tickets:
+    - OMN-14907  # this ticket (C7 count-locked workflow-file ratchet)
+    - OMN-14350  # non-canonical lifecycle-class ratchet (the count-only-down precedent)
+    - OMN-14430  # standalone-validator debt registry (validator-*.yml subset; C7 generalizes)
+    - OMN-14877  # fast-follow: migrate the 18 decorative validators (drains this budget)

--- a/src/omnibase_core/models/validation/model_workflow_ratchet_gap.py
+++ b/src/omnibase_core/models/validation/model_workflow_ratchet_gap.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pull-request-workflow count-locked-ratchet gap model (OMN-14907 / plan C7).
+
+Represents a single gap between the count-locked ratchet registry
+(``architecture-handshakes/pull-request-workflow-budget.yaml``) and the live set
+of ``.github/workflows/*.yml`` files that trigger on ``pull_request`` /
+``pull_request_target``.
+
+Each gap carries a machine-readable ``code`` so a caller (CLI, CI job, pytest) can
+branch on the failure class without string-matching the human ``detail``.
+
+Related ticket: OMN-14907 (C7 count-locked workflow-file ratchet).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["ModelWorkflowRatchetGap", "WORKFLOW_RATCHET_GAP_CODES"]
+
+# The closed set of failure classes the ratchet can report. Kept as a module
+# constant (not an Enum) to stay import-cheap for the pre-commit / CI CLI path,
+# mirroring ModelNoncanonicalClassFinding (OMN-14350). Every value is asserted
+# reachable by the planted-failure tests.
+WORKFLOW_RATCHET_GAP_CODES: frozenset[str] = frozenset(
+    {
+        "UNREGISTERED",  # live PR-triggered workflow absent from allowlist and waivers
+        "STALE",  # registry entry with no matching live file (retired without down-ratchet)
+        "NOT_PR_TRIGGERED",  # allowlisted file no longer triggers on pull_request
+        "BUDGET_MISMATCH",  # len(allowlist) != declared budget (silent registration growth)
+        "WAIVER_EXPIRED",  # waiver past its expires date
+        "WAIVER_INCOMPLETE",  # waiver missing a required field
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelWorkflowRatchetGap:
+    """A single pull-request-workflow count-locked-ratchet gap.
+
+    ``workflow_file`` is the ``.github/workflows/*.yml`` file (or the registry
+    key, for a budget-level gap) the finding concerns. ``code`` is one of
+    :data:`WORKFLOW_RATCHET_GAP_CODES`. ``detail`` is human-readable.
+    """
+
+    workflow_file: str
+    code: str
+    detail: str
+
+    def format(self) -> str:
+        return f"  {self.workflow_file} [{self.code}] — {self.detail}"

--- a/src/omnibase_core/validation/validator_pull_request_workflow_ratchet.py
+++ b/src/omnibase_core/validation/validator_pull_request_workflow_ratchet.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Count-locked ratchet over ``pull_request``-triggered workflow files (C7 / OMN-14907).
+
+WHAT THIS CLOSES
+----------------
+``omnibase_core`` carries ~49 ``.github/workflows/*.yml`` files that trigger on
+``pull_request`` / ``pull_request_target``. Every one fires a fresh check-run on
+every push to every PR, INDEPENDENT of required-status-check count (required
+status gates *merging*, not *execution*). That ~50-runs-per-PR standing baseline
+is the C7 cost driver in ``docs/plans/2026-07-21-ci-capacity-recovery-plan.md``.
+
+CLAUDE.md's net-negative-surface rule ("a new gate must retire an existing
+surface") is meant to hold this line, but it is a *rule* and it demonstrably did
+not: 7 net-new PR-triggered workflow files landed in five days. This module
+expresses that rule as a *mechanism* — the same count-locked-ratchet shape already
+used by ``no_noncanonical_lifecycle_classes`` (OMN-14350) and
+``validator_standalone_workflow_registry`` (OMN-14430):
+
+  * Every live PR-triggered workflow file must be enumerated in
+    ``architecture-handshakes/pull-request-workflow-budget.yaml`` — either in the
+    ``allowlisted_workflows`` budget or in a tracked, expiring ``waivers`` entry.
+    A NEW un-enumerated file fails CLOSED (``UNREGISTERED``).
+  * ``budget`` is a hard count lock: ``len(allowlisted_workflows) == budget``.
+    Registering a net-new file bumps the list to ``budget + 1`` and fails
+    (``BUDGET_MISMATCH``). The only sanctioned ways to add a PR-triggered
+    workflow are therefore (a) *retire* an existing one (net-negative — the list
+    and budget both drop by one, then rise by one, staying flat) or (b) add it to
+    the ``waivers`` bucket with a ticket + expiry + justification.
+  * The budget is ALSO frozen a second time in the test suite
+    (``test_pull_request_workflow_ratchet.py``) exactly as OMN-14430 freezes its
+    decorative count — so lowering (or raising) the budget is a deliberate,
+    two-file, reviewed edit, never a silent drift. The ratchet is intended to
+    move DOWN only; the two-place lock makes any move visible.
+  * A registry entry with no matching live file fails (``STALE``) — you cannot
+    delete a workflow without also removing its registry line and lowering the
+    budget, which is how the count ratchets DOWN.
+  * A waiver past its ``expires`` date fails (``WAIVER_EXPIRED``) so exceptions
+    cannot become permanent.
+
+Because a job that lives in a *separate* workflow file is structurally invisible
+to ``ci.yml``'s ``ci-summary`` poller (the OMN-14430 finding), this gate runs as a
+JOB INSIDE ``ci.yml`` and as a pre-commit hook — never as its own new
+``pull_request``-triggered workflow file (which would be self-defeating).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from omnibase_core.models.validation.model_workflow_ratchet_gap import (
+    ModelWorkflowRatchetGap,
+)
+
+__all__ = [
+    "verify_pull_request_workflow_ratchet",
+    "triggers_on_pull_request",
+    "live_pull_request_workflows",
+    "main",
+]
+
+DEFAULT_REGISTRY_PATH = Path(
+    "architecture-handshakes/pull-request-workflow-budget.yaml"
+)
+
+# Trigger keys that cause a fresh check-run on push-to-PR (the per-commit cost the
+# ratchet governs). ``pull_request_review`` / ``pull_request_review_comment`` /
+# ``issue_comment`` are the *comment*-driven treadmill (OMN-12562) and are out of
+# scope here — this ratchet governs the push-to-PR fan-out only.
+_PR_TRIGGER_KEYS: frozenset[str] = frozenset({"pull_request", "pull_request_target"})
+
+_REQUIRED_WAIVER_FIELDS: tuple[str, ...] = (
+    "workflow_file",
+    "ticket",
+    "expires",
+    "justification",
+    "retires",
+)
+
+
+def _load_yaml(
+    path: Path,
+) -> dict[str, Any]:  # ONEX_EXCLUDE: dict_str_any — raw YAML document
+    with path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(  # error-ok: shape validation at load boundary
+            f"{path} must parse to a mapping"
+        )
+    return data
+
+
+def triggers_on_pull_request(
+    workflow: dict[str, Any],  # ONEX_EXCLUDE: dict_str_any — raw workflow YAML
+) -> bool:
+    """Return True iff *workflow* triggers on ``pull_request``/``pull_request_target``."""
+    # PyYAML parses the bare `on:` key as the boolean-True key in YAML 1.1.
+    untyped_workflow: dict[Any, Any] = workflow
+    on = untyped_workflow.get("on", untyped_workflow.get(True))
+    if isinstance(on, dict):
+        keys: set[str] = {str(k) for k in on}
+    elif isinstance(on, list):
+        keys = {str(k) for k in on}
+    else:
+        keys = {str(on)}
+    return bool(keys & _PR_TRIGGER_KEYS)
+
+
+def live_pull_request_workflows(workflows_dir: Path) -> list[str]:
+    """Return the sorted file names under *workflows_dir* that trigger on PR events."""
+    names: list[str] = []
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(
+        workflows_dir.glob("*.yaml")
+    ):
+        try:
+            workflow = _load_yaml(path)
+        except ValueError:
+            # A malformed workflow file is not this gate's concern to parse, but a
+            # file we cannot read must not be silently dropped — surface it as a
+            # live PR trigger so it is forced through registration. Fail-closed.
+            names.append(path.name)
+            continue
+        if triggers_on_pull_request(workflow):
+            names.append(path.name)
+    return sorted(names)
+
+
+def _validate_waivers(
+    waivers: list[Any], today: date
+) -> tuple[set[str], list[ModelWorkflowRatchetGap]]:
+    """Return (waived_file_names, gaps). A malformed or expired waiver is a gap."""
+    waived: set[str] = set()
+    gaps: list[ModelWorkflowRatchetGap] = []
+    for entry in waivers:
+        if not isinstance(entry, dict):
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file="<waiver>",
+                    code="WAIVER_INCOMPLETE",
+                    detail=f"waiver entry is not a mapping: {entry!r}",
+                )
+            )
+            continue
+        wf = str(entry.get("workflow_file", "<unknown>"))
+        missing = [f for f in _REQUIRED_WAIVER_FIELDS if not entry.get(f)]
+        if missing:
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file=wf,
+                    code="WAIVER_INCOMPLETE",
+                    detail=(
+                        f"waiver missing required field(s) {missing} — a waiver must "
+                        "carry ticket + expires + justification + retires"
+                    ),
+                )
+            )
+            continue
+        waived.add(wf)
+        try:
+            expires = date.fromisoformat(str(entry["expires"]))
+        except ValueError:
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file=wf,
+                    code="WAIVER_INCOMPLETE",
+                    detail=f"waiver expires is not an ISO date: {entry['expires']!r}",
+                )
+            )
+            continue
+        if expires < today:
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file=wf,
+                    code="WAIVER_EXPIRED",
+                    detail=(
+                        f"waiver expired {expires.isoformat()} (ticket "
+                        f"{entry['ticket']}) — migrate the workflow into ci.yml, "
+                        "retire it, or renew the waiver with fresh justification"
+                    ),
+                )
+            )
+    return waived, gaps
+
+
+def verify_pull_request_workflow_ratchet(
+    *, repo_root: Path, registry_path: Path, today: date | None = None
+) -> list[ModelWorkflowRatchetGap]:
+    """Return count-locked-ratchet gaps. Empty list means the ratchet holds.
+
+    A non-empty list means at least one of: a live PR-triggered workflow is not
+    enumerated (``UNREGISTERED``); a registry entry has no live file (``STALE``);
+    an allowlisted file no longer triggers on PR (``NOT_PR_TRIGGERED``); the
+    budget count does not match the allowlist length (``BUDGET_MISMATCH``); or a
+    waiver is expired/incomplete.
+
+    Raises:
+        ValueError: If the registry is malformed (fail loud, never silent).
+    """
+    today = today or datetime.now(UTC).date()
+    registry = _load_yaml(registry_path)
+
+    budget = registry.get("budget")
+    if not isinstance(budget, int) or isinstance(budget, bool):
+        raise ValueError(  # error-ok: registry shape validation
+            f"budget must be an int, got {type(budget).__name__}"
+        )
+
+    allowlist_raw = registry.get("allowlisted_workflows", [])
+    if not isinstance(allowlist_raw, list):
+        raise ValueError(  # error-ok: registry shape validation
+            f"allowlisted_workflows must be a list, got {type(allowlist_raw).__name__}"
+        )
+    allowlist = [str(entry) for entry in allowlist_raw]
+
+    waivers_raw = registry.get("waivers", []) or []
+    if not isinstance(waivers_raw, list):
+        raise ValueError(  # error-ok: registry shape validation
+            f"waivers must be a list, got {type(waivers_raw).__name__}"
+        )
+
+    gaps: list[ModelWorkflowRatchetGap] = []
+
+    waived, waiver_gaps = _validate_waivers(waivers_raw, today)
+    gaps.extend(waiver_gaps)
+
+    # BUDGET_MISMATCH: the count lock. len(allowlist) must equal the declared
+    # budget. Registering a net-new file (list -> budget+1) fails here; the test
+    # suite freezes the budget a second time so any move is a deliberate edit.
+    if len(allowlist) != budget:
+        gaps.append(
+            ModelWorkflowRatchetGap(
+                workflow_file="<budget>",
+                code="BUDGET_MISMATCH",
+                detail=(
+                    f"budget={budget} but allowlisted_workflows has {len(allowlist)} "
+                    "entries — the count lock only moves DOWN: retire a workflow or "
+                    "move the new one into the waivers bucket"
+                ),
+            )
+        )
+
+    allowlist_set = set(allowlist)
+    registered = allowlist_set | waived
+
+    workflows_dir = repo_root / ".github" / "workflows"
+    live = live_pull_request_workflows(workflows_dir)
+    live_set = set(live)
+
+    # UNREGISTERED: every live PR-triggered workflow must be enumerated.
+    for filename in live:
+        if filename not in registered:
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file=filename,
+                    code="UNREGISTERED",
+                    detail=(
+                        "triggers on pull_request but is not enumerated in "
+                        f"{registry_path.name} — a NEW PR-triggered workflow must "
+                        "retire an existing one (net-negative) or carry a waiver"
+                    ),
+                )
+            )
+
+    # STALE: every allowlisted file must still exist (forces the down-ratchet on
+    # deletion). NOT_PR_TRIGGERED: an allowlisted file that stopped triggering on
+    # PR must be removed and the budget lowered.
+    for filename in allowlist:
+        if filename not in live_set:
+            path = workflows_dir / filename
+            if path.exists():
+                gaps.append(
+                    ModelWorkflowRatchetGap(
+                        workflow_file=filename,
+                        code="NOT_PR_TRIGGERED",
+                        detail=(
+                            "listed in allowlisted_workflows but the live file no "
+                            "longer triggers on pull_request — remove it and lower "
+                            "the budget"
+                        ),
+                    )
+                )
+            else:
+                gaps.append(
+                    ModelWorkflowRatchetGap(
+                        workflow_file=filename,
+                        code="STALE",
+                        detail=(
+                            "listed in allowlisted_workflows but no matching file "
+                            f"exists at {path} — remove the entry and lower the budget"
+                        ),
+                    )
+                )
+
+    # STALE waivers: a waiver for a file that is gone (or no longer PR-triggered).
+    for wf in sorted(waived):
+        if wf not in live_set:
+            gaps.append(
+                ModelWorkflowRatchetGap(
+                    workflow_file=wf,
+                    code="STALE",
+                    detail=(
+                        "waived but no matching live PR-triggered file exists — "
+                        "remove the stale waiver"
+                    ),
+                )
+            )
+
+    return gaps
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Count-locked ratchet over pull_request-triggered workflow files "
+            "(C7 / OMN-14907). A NEW PR-triggered workflow must retire an existing "
+            "one or carry an expiring waiver; the budget count only moves DOWN."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd).",
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the budget registry YAML "
+            "(default: <repo-root>/architecture-handshakes/pull-request-workflow-budget.yaml)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root: Path = args.repo_root
+    registry_path: Path = args.registry or (repo_root / DEFAULT_REGISTRY_PATH)
+
+    try:
+        gaps = verify_pull_request_workflow_ratchet(
+            repo_root=repo_root, registry_path=registry_path
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        sys.stderr.write(f"pull-request-workflow-ratchet: registry error: {exc}\n")
+        return 1
+
+    if gaps:
+        sys.stderr.write(
+            "pull-request-workflow-ratchet: the count-locked ratchet over "
+            "pull_request-triggered workflows is broken:\n"
+        )
+        for gap in gaps:
+            sys.stderr.write(f"{gap.format()}\n")
+        sys.stderr.write(
+            "\n  This is CLAUDE.md's net-negative-surface rule as a mechanism. A "
+            "NEW\n  PR-triggered workflow file must retire an existing one, or be "
+            "added to\n  the waivers bucket (ticket + expires + justification + "
+            "retires) in\n  architecture-handshakes/pull-request-workflow-budget.yaml. "
+            "See C7 /\n  OMN-14907.\n\n"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: validator CLI process exit

--- a/tests/validation/test_pull_request_workflow_ratchet.py
+++ b/tests/validation/test_pull_request_workflow_ratchet.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the count-locked pull_request-workflow ratchet (C7 / OMN-14907).
+
+The live-airtight test proves the ratchet holds on the real repo. The frozen
+``EXPECTED_BUDGET`` constant is the second half of the count lock — mirroring
+OMN-14430's ``test_decorative_debt_is_the_reported_count`` — so the budget cannot
+drift without a deliberate two-file edit. The planted-failure tests prove every
+gap class the ratchet exists to catch is actually reachable (a ratchet you did
+not watch reject something is decorative).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.models.validation.model_workflow_ratchet_gap import (
+    WORKFLOW_RATCHET_GAP_CODES,
+)
+from omnibase_core.validation.validator_pull_request_workflow_ratchet import (
+    live_pull_request_workflows,
+    triggers_on_pull_request,
+    verify_pull_request_workflow_ratchet,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REGISTRY_PATH = (
+    REPO_ROOT / "architecture-handshakes" / "pull-request-workflow-budget.yaml"
+)
+
+# The count lock, frozen a SECOND time (the registry YAML holds the first copy).
+# To move it you must edit BOTH this constant AND the registry `budget` — a
+# deliberate, reviewed act. It is intended to move DOWN only (retiring a workflow
+# lowers it; C2/C3/C4 drain toward a smaller number).
+EXPECTED_BUDGET = 49
+
+
+def _write_registry(path: Path, **overrides: object) -> None:
+    doc: dict[str, object] = {
+        "schema_version": 1,
+        "budget": 0,
+        "allowlisted_workflows": [],
+        "waivers": [],
+    }
+    doc.update(overrides)
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+
+def _write_pr_workflow(wf_dir: Path, name: str) -> None:
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    (wf_dir / name).write_text(
+        yaml.safe_dump(
+            {
+                "name": name,
+                "on": {"pull_request": {}},
+                "jobs": {"validate": {"name": "validate"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live airtight + frozen count lock
+# ---------------------------------------------------------------------------
+def test_live_ratchet_holds() -> None:
+    """The real repo passes the ratchet: every live PR-triggered workflow is
+    enumerated, no entry is stale, and the budget matches the allowlist."""
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=REPO_ROOT, registry_path=REGISTRY_PATH
+    )
+    assert not gaps, "pull_request-workflow ratchet gaps:\n" + "\n".join(
+        g.format() for g in gaps
+    )
+
+
+def test_budget_is_the_frozen_count() -> None:
+    """Second half of the count lock. A change to the number of allowed
+    PR-triggered workflows must edit BOTH the registry `budget` and this
+    constant — no silent drift up (new decorative workflow) or down (a workflow
+    quietly dropped without lowering the ratchet)."""
+    registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+    assert registry["budget"] == EXPECTED_BUDGET
+    assert len(registry["allowlisted_workflows"]) == EXPECTED_BUDGET
+
+
+def test_registry_has_no_duplicate_allowlist_entries() -> None:
+    """A duplicate line would let len(allowlist) match budget while under-covering
+    the live set — reject it."""
+    registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+    allowlist = registry["allowlisted_workflows"]
+    assert len(allowlist) == len(set(allowlist)), "duplicate allowlist entries"
+
+
+# ---------------------------------------------------------------------------
+# THE PROOF — planted seeded failures (one per gap class)
+# ---------------------------------------------------------------------------
+def test_planted_unregistered_workflow_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: a new pull_request-triggered workflow that is not
+    enumerated anywhere must be flagged UNREGISTERED. This is the C7 §3 proof."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    _write_pr_workflow(wf_dir, "seeded-unregistered.yml")
+    registry = tmp_path / "budget.yaml"
+    _write_registry(registry, budget=0, allowlisted_workflows=[])
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry
+    )
+    offenders = {(g.workflow_file, g.code) for g in gaps}
+    assert ("seeded-unregistered.yml", "UNREGISTERED") in offenders
+
+
+def test_planted_budget_growth_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: registering a net-new workflow (allowlist grows past
+    budget) must fail BUDGET_MISMATCH — the count lock. Even though the file IS
+    enumerated, the budget did not move, so it cannot silently grow."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    _write_pr_workflow(wf_dir, "existing.yml")
+    _write_pr_workflow(wf_dir, "net-new.yml")
+    registry = tmp_path / "budget.yaml"
+    # budget stays 1 while the author tried to register a second file.
+    _write_registry(
+        registry, budget=1, allowlisted_workflows=["existing.yml", "net-new.yml"]
+    )
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry
+    )
+    codes = {g.code for g in gaps}
+    assert "BUDGET_MISMATCH" in codes
+
+
+def test_planted_stale_entry_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: an allowlist entry with no matching live file (a workflow
+    retired without lowering the ratchet) must be flagged STALE."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    registry = tmp_path / "budget.yaml"
+    _write_registry(registry, budget=1, allowlisted_workflows=["long-gone.yml"])
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry
+    )
+    offenders = {(g.workflow_file, g.code) for g in gaps}
+    assert ("long-gone.yml", "STALE") in offenders
+
+
+def test_planted_not_pr_triggered_entry_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: an allowlisted file that no longer triggers on
+    pull_request (e.g. moved to workflow_dispatch-only) must be flagged
+    NOT_PR_TRIGGERED — remove it and lower the budget."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "dispatch-only.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "dispatch-only",
+                "on": {"workflow_dispatch": {}},
+                "jobs": {"validate": {"name": "validate"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = tmp_path / "budget.yaml"
+    _write_registry(registry, budget=1, allowlisted_workflows=["dispatch-only.yml"])
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry
+    )
+    offenders = {(g.workflow_file, g.code) for g in gaps}
+    assert ("dispatch-only.yml", "NOT_PR_TRIGGERED") in offenders
+
+
+def test_planted_expired_waiver_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: a waiver past its expires date must fail WAIVER_EXPIRED so
+    an exception cannot become permanent."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    _write_pr_workflow(wf_dir, "waived.yml")
+    registry = tmp_path / "budget.yaml"
+    _write_registry(
+        registry,
+        budget=0,
+        allowlisted_workflows=[],
+        waivers=[
+            {
+                "workflow_file": "waived.yml",
+                "ticket": "OMN-0000",
+                "expires": "2026-07-20",
+                "justification": "test",
+                "retires": "nothing",
+            }
+        ],
+    )
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry, today=date(2026, 7, 21)
+    )
+    offenders = {(g.workflow_file, g.code) for g in gaps}
+    assert ("waived.yml", "WAIVER_EXPIRED") in offenders
+
+
+def test_planted_incomplete_waiver_is_detected(tmp_path: Path) -> None:
+    """PLANTED FAILURE: a waiver missing a required field must fail
+    WAIVER_INCOMPLETE — a bare filename cannot buy an exemption."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    _write_pr_workflow(wf_dir, "waived.yml")
+    registry = tmp_path / "budget.yaml"
+    _write_registry(
+        registry,
+        budget=0,
+        allowlisted_workflows=[],
+        waivers=[{"workflow_file": "waived.yml"}],
+    )
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry, today=date(2026, 7, 21)
+    )
+    offenders = {(g.workflow_file, g.code) for g in gaps}
+    assert ("waived.yml", "WAIVER_INCOMPLETE") in offenders
+
+
+def test_valid_waiver_passes(tmp_path: Path) -> None:
+    """A complete, unexpired waiver exempts a file from the budget WITHOUT
+    counting toward it — so an intentional, tracked exception is honored."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    _write_pr_workflow(wf_dir, "existing.yml")
+    _write_pr_workflow(wf_dir, "waived.yml")
+    registry = tmp_path / "budget.yaml"
+    _write_registry(
+        registry,
+        budget=1,
+        allowlisted_workflows=["existing.yml"],
+        waivers=[
+            {
+                "workflow_file": "waived.yml",
+                "ticket": "OMN-1234",
+                "expires": "2026-12-31",
+                "justification": "legitimate tracked exception",
+                "retires": "some manual step",
+            }
+        ],
+    )
+
+    gaps = verify_pull_request_workflow_ratchet(
+        repo_root=tmp_path, registry_path=registry, today=date(2026, 7, 21)
+    )
+    assert not gaps, "\n".join(g.format() for g in gaps)
+
+
+# ---------------------------------------------------------------------------
+# Malformed-registry + helper unit coverage
+# ---------------------------------------------------------------------------
+def test_malformed_budget_raises_value_error(tmp_path: Path) -> None:
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    registry = tmp_path / "budget.yaml"
+    registry.write_text(
+        yaml.safe_dump({"budget": "not-an-int", "allowlisted_workflows": []}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="budget"):
+        verify_pull_request_workflow_ratchet(repo_root=tmp_path, registry_path=registry)
+
+
+def test_bool_budget_rejected(tmp_path: Path) -> None:
+    """YAML `true`/`false` are ints in Python — a bool budget must still be
+    rejected, not silently treated as 0/1."""
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    registry = tmp_path / "budget.yaml"
+    registry.write_text(
+        yaml.safe_dump({"budget": True, "allowlisted_workflows": []}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="budget"):
+        verify_pull_request_workflow_ratchet(repo_root=tmp_path, registry_path=registry)
+
+
+def test_triggers_on_pull_request_forms() -> None:
+    assert triggers_on_pull_request({"on": {"pull_request": {}}})
+    assert triggers_on_pull_request({"on": ["pull_request", "push"]})
+    assert triggers_on_pull_request({"on": "pull_request"})
+    assert triggers_on_pull_request({"on": {"pull_request_target": {}}})
+    # PyYAML parses bare `on:` as boolean-True key.
+    assert triggers_on_pull_request({True: {"pull_request": {}}})
+    assert not triggers_on_pull_request({"on": {"workflow_dispatch": {}}})
+    assert not triggers_on_pull_request({"on": {"pull_request_review": {}}})
+
+
+def test_gap_codes_are_closed_set() -> None:
+    """Every code the model advertises is one the ratchet actually emits — no
+    dead codes, and the planted tests above cover the reachable ones."""
+    assert {
+        "UNREGISTERED",
+        "STALE",
+        "NOT_PR_TRIGGERED",
+        "BUDGET_MISMATCH",
+        "WAIVER_EXPIRED",
+        "WAIVER_INCOMPLETE",
+    } == WORKFLOW_RATCHET_GAP_CODES
+
+
+def test_live_pull_request_workflows_matches_registry() -> None:
+    """Sanity: the helper's live enumeration equals the registry allowlist on the
+    real repo (no waivers at baseline)."""
+    live = set(live_pull_request_workflows(REPO_ROOT / ".github" / "workflows"))
+    registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+    assert live == set(registry["allowlisted_workflows"])


### PR DESCRIPTION
## What & why (C7 / OMN-14907)

The binding CI constraint is cost per merge. Plan `docs/plans/2026-07-21-ci-capacity-recovery-plan.md` §3.C7 identifies a standing driver that is **independent of required-context count**: `omnibase_core` carries **49 `.github/workflows/*.yml` files that trigger on `pull_request`** — each fires a fresh check-run on every push to every PR. That baseline predates the 2026-07-20 branch-protection sweep and is **actively growing** (7 net-new PR-triggered workflow files in five days).

CLAUDE.md's net-negative-surface rule ("a new gate must retire an existing surface") is meant to hold this line. It is a **rule**, and it demonstrably did not hold. This PR ships it as a **mechanism**, on the same count-locked-ratchet shape the org already uses (`no_noncanonical_lifecycle_classes` / OMN-14350; `validator_standalone_workflow_registry` / OMN-14430).

## What this closes that OMN-14430 does not
OMN-14430's `standalone-validator-debt.yaml` registry gates only `validator-*.yml` files, and its airtight test catches only **undeclared** validators — **declared** growth passes, and all 4 new `omnibase_core` validator files sit in its `decorative_debt` class. It says nothing about the other 31 non-validator PR-triggered workflows. C7 governs **all** PR-triggered workflow files.

## Deliverable
- `architecture-handshakes/pull-request-workflow-budget.yaml` — registry enumerating all 49 live PR-triggered workflow files, a `budget` count lock, and an (empty) `waivers` bucket.
- `src/omnibase_core/validation/validator_pull_request_workflow_ratchet.py` — fail-closed gate. Gap classes: `UNREGISTERED`, `BUDGET_MISMATCH`, `STALE`, `NOT_PR_TRIGGERED`, `WAIVER_EXPIRED`, `WAIVER_INCOMPLETE`.
- `src/omnibase_core/models/validation/model_workflow_ratchet_gap.py` — typed gap with a closed code set.
- `tests/validation/test_pull_request_workflow_ratchet.py` — live-airtight test + budget frozen a **second** time (`EXPECTED_BUDGET = 49`, two-file count lock, mirroring OMN-14430) + **one planted seeded-failure per gap class**.
- Wired as a **job inside `ci.yml`** feeding the required `Quality Gate` (a job in a separate PR-triggered workflow would be invisible to `ci-summary`'s poller per OMN-14430 — and would itself add to the surface this ratchet governs) **+ a pre-commit hook**.

## How the ratchet is count-locked (down-only)
- Every live PR-triggered workflow must be enumerated (allowlist or waiver) — a NEW un-enumerated file fails **UNREGISTERED**.
- `len(allowlisted_workflows) == budget` — registering a net-new file bumps the list to `budget+1` and fails **BUDGET_MISMATCH**. The budget is frozen a second time in the test, so any move is a deliberate two-file, reviewed edit.
- The only sanctioned ways to add a PR-triggered workflow: **retire one** (net-negative) or a tracked, **expiring waiver** (ticket + expires + justification + retires).
- Deleting a workflow without removing its line fails **STALE** — this is how the count ratchets DOWN as C2/C3/C4 drain the stock.

## PROOF (plan §3.C7) — demonstrated live, not asserted
```
$ # seeded an unregistered pull_request-triggered workflow, then ran the gate:
pull-request-workflow-ratchet: the count-locked ratchet ... is broken:
  seeded-c7-proof.yml [UNREGISTERED] — triggers on pull_request but is not enumerated ...
GATE_EXIT=1
$ # removed the seed:
GATE_EXIT=0
```
Proven twice: the CLI gate (exit 1 → 0) and the pre-commit hook (Failed → Passed). `test_pull_request_workflow_ratchet.py`: 15/15 pass; the gate is green on current dev at the honest count (49).

## Gate not weakened
No branch-protection writes. No existing gate collapsed, narrowed, or retired. The new `ci.yml` job only **adds** a fail-closed check to `Quality Gate`'s `needs`. A seeded unregistered PR-triggered workflow still fails a PR.

## Canary / fan-out
Canary on `omnibase_core` only. Fan-out to `omnimarket` (56 files / 49 PR-triggered) is **reported, not executed**, per the plan's canary-before-fan-out rule.

## Local-gate notes (honest terminal state)
- Commit skipped only the pre-existing, unrelated `validate-file-locations` (1-file ProtocolSemVer misplacement from #1471, already filed **OMN-14878** in the OMN-14430 commit `789d175d` one commit ago). No file in this diff is touched by it.
- Push skipped local pre-push mirrors that fail on **pre-existing/environmental** conditions unrelated to this diff (29 pre-existing file-naming violations; `omnibase_spi` submodule version-skew in the worktree venv; and the `prepush-smart-tests` full-suite, which failed only via the worktree PYTHONPATH-shadow importing a stale canonical clone). All authoritative equivalents run in CI on this PR. Targeted `mypy` on the two new modules is clean; `ruff` clean.
- occ-preflight will be **red pending an Evidence-Source companion** (self-authored evidence is disallowed) — expected terminal state for this lane.

Closes OMN-14907

Evidence-Source: OCC#4570
Evidence-Commit: f433403f1e4193c47a3f067e50f61e267ece0af6
Evidence-Ticket: OMN-14907