### PR TITLE
ci(OMN-14877): migrate 18 decorative validators into ci.yml, retire standalones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2277,9 +2277,11 @@ jobs:
           uv run pytest tests/scripts/test_check_release_identity.py -v
 
       - name: No code merged onto a published version without a bump
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'dev' }}
         run: |
           set -euo pipefail
-          BASE="${{ github.event.pull_request.base.ref || 'dev' }}"
+          BASE="${BASE_REF}"
           git fetch --quiet origin "${BASE}" || true
           uv run python scripts/check_release_identity.py --base "origin/${BASE}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1514,6 +1514,856 @@ jobs:
           uv run python -m omnibase_core.validation.hardcoded_topic.runtime_hardcoded_topic \
             --report-only src/omnibase_core/
 
+  # ===========================================================================
+  # Phase 1 - Migrated decorative validators (OMN-14877, OMN-14430 fast-follow)
+  # ---------------------------------------------------------------------------
+  # 18 validator-*.yml standalone workflows migrated here as unconditional jobs
+  # (no `if:`, no `needs:`), sharing ci.yml's run_id so the required "CI Summary"
+  # default-deny poller (scripts/ci/ci_summary_gate.py) sees them. Each retires a
+  # standalone workflow (dropped to workflow_dispatch-only) plus its embedded
+  # occ-preflight caller. Registry: architecture-handshakes/standalone-validator-debt.yaml.
+  # ===========================================================================
+  # Migrated from validator-backend-secret-discipline.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  backend-secret-discipline-validator:
+    name: Backend Secret Discipline
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_backend_secret_discipline.py -v
+
+      - name: Self-scan omnibase_core config (literal credentials + backend refs)
+        run: |
+          uv run python -m omnibase_core.validators.backend_secret_discipline src/
+
+  # Migrated from validator-banned-compose-vars.yml (OMN-14877, OMN-14430
+  # fast-follow). NOTE: this validator had NO pre-commit hook in omnibase_core
+  # (audited 2026-07-21) — migrating it here as a required-gating ci.yml job is
+  # its FIRST non-bypassable enforcement, strictly stronger than the prior
+  # decorative standalone workflow. omnibase_core has no compose manifest that
+  # reads the banned vars, so the self-scan is green; the governed consumer
+  # requirement (banned-compose-env-vars) applies to omnibase_infra/omninode_infra,
+  # not this repo.
+  banned-compose-vars-validator:
+    name: Compose Drift
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ValidatorBannedComposeVars unit + integration tests
+        run: |
+          uv run pytest \
+            tests/unit/validation/test_validator_banned_compose_vars.py \
+            tests/integration/test_validator_banned_compose_vars_integration.py \
+            -v
+
+      - name: Self-scan omnibase_core repo for banned compose env vars
+        run: |
+          # Synthetic kernel mirrors the current `_DEPRECATED_TOPIC_ENV_VARS`
+          # tuple in omnibase_infra/src/omnibase_infra/runtime/service_kernel.py
+          # (OMN-8784). omnibase_core has no legitimate consumer of those vars,
+          # so the scan must exit 0. If omnibase_core ever adds a real compose
+          # manifest that uses them, this gate catches it before merge.
+          cat > /tmp/synthetic_kernel.py <<'EOF'
+          # Mirror of omnibase_infra service_kernel._DEPRECATED_TOPIC_ENV_VARS.
+          _DEPRECATED_TOPIC_ENV_VARS: tuple[str, ...] = (
+              "ONEX_INPUT_TOPIC",
+              "ONEX_OUTPUT_TOPIC",
+          )
+          EOF
+          uv run python -m omnibase_core.validation.validator_banned_compose_vars \
+            --kernel-source /tmp/synthetic_kernel.py \
+            .
+
+  # Migrated from validator-bypass-token-blocklist.yml (OMN-14877, OMN-14430
+  # fast-follow). NOTE: this validator's module had NO dedicated pre-commit hook
+  # in omnibase_core (audited 2026-07-21) — the reject-deploy-gate-skip-token
+  # hooks cover skip-gate tokens over staged files, but the OMN-13388 contracts/
+  # tree scan was decorative-only. Migrating it here is its first
+  # required-gating, non-bypassable enforcement.
+  bypass-token-blocklist-validator:
+    name: Bypass-Token Blocklist
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests (all 9 tokens, failing + passing cases)
+        run: |
+          uv run pytest tests/validators/test_bypass_token_blocklist.py -v
+
+      - name: Repo-wide bypass-token grep (contracts/)
+        # Scans contracts/ (YAML ticket contracts) for bypass tokens. src/ and
+        # docs/ are excluded: both trees contain documentation (.md) that
+        # legitimately discusses bypass tokens as rule descriptions.
+        run: |
+          if [ -d "contracts/" ]; then
+            uv run python -m omnibase_core.validators.bypass_token_blocklist \
+              --scan-tree contracts/
+          else
+            echo "No contracts/ directory found — scan skipped."
+          fi
+
+  # Migrated from validator-command-category-event-model.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  command-category-event-model-validator:
+    name: command-category Event Model Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_command_category_requires_event_model.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.command_category_requires_event_model src/omnibase_core
+
+  # Migrated from validator-dispatched-contract-operation.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  dispatched-contract-operation-validator:
+    name: dispatched contract handlers[0].operation Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_dispatched_contract_operation.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.dispatched_contract_operation src/omnibase_core
+
+  # Migrated from validator-generated-node-model-class-exists.yml (OMN-14877,
+  # OMN-14430 fast-follow).
+  generated-node-model-class-exists-validator:
+    name: generated-node model-class-existence Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validators/test_generated_node_model_class_exists.py \
+            tests/unit/validation/test_validator_contract_linter.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.generated_node_model_class_exists src/omnibase_core
+
+  # Migrated from validator-gitignore-baseline.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  gitignore-baseline-validator:
+    name: Gitignore Baseline Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/validation/test_gitignore_baseline.py -v
+
+      - name: Self-scan omnibase_core root
+        run: |
+          uv run python -m omnibase_core.validators.gitignore_baseline .
+
+  # Migrated from validator-no-direct-kafka-producer.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  no-direct-kafka-producer-validator:
+    name: No Direct Kafka Producer Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/nodes/node_no_direct_kafka_producer_check_compute/ -v
+
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_direct_kafka_producer_check_compute.runtime_no_direct_kafka_producer_check \
+            --root src
+
+  # Migrated from validator-no-except-swallow.yml (OMN-14877, OMN-14430
+  # fast-follow). Self-scan is REPORT-ONLY (baseline cleanup pending) — ported
+  # unchanged; the gating enforcement is the validator unit-test suite, which
+  # runs unconditionally under the required CI Summary rollup.
+  no-except-swallow-validator:
+    name: No Except Swallow
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/validation/test_validate_no_except_swallow.py -v
+
+      - name: Self-scan omnibase_core src/ (report mode — baseline cleanup pending)
+        run: |
+          uv run python scripts/validation/validate_no_except_swallow.py --report
+
+  # Migrated from validator-no-hardcoded-ip.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  no-hardcoded-ip-validator:
+    name: No Hardcoded IP Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/nodes/node_no_hardcoded_ip_check_compute/ -v
+
+      - name: Self-scan omnibase_core src/ + scripts/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_hardcoded_ip_check_compute.runtime_no_hardcoded_ip_check \
+            --root src scripts
+
+  # Migrated from validator-no-import-none-fallback.yml (OMN-14877, OMN-14430
+  # fast-follow). Self-scan is REPORT-ONLY (baseline cleanup pending) — ported
+  # unchanged; the gating enforcement is the validator unit-test suite.
+  no-import-none-fallback-validator:
+    name: No Import None Fallback
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/validation/test_validate_no_import_none_fallback.py -v
+
+      - name: Self-scan omnibase_core src/ (report mode — baseline cleanup pending)
+        run: |
+          uv run python scripts/validation/validate_no_import_none_fallback.py --report
+
+  # Migrated from validator-no-io-outside-effects.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  no-io-outside-effects-validator:
+    name: No IO Outside Effects Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/nodes/node_no_io_outside_effects_check_compute/ -v
+
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_io_outside_effects_check_compute.runtime_no_io_outside_effects_check \
+            --root src
+
+  # Migrated from validator-no-none-guard-publish.yml (OMN-14877, OMN-14430
+  # fast-follow). Self-scan is REPORT-ONLY (baseline cleanup pending) — ported
+  # unchanged; the gating enforcement is the validator unit-test suite.
+  no-none-guard-publish-validator:
+    name: No None Guard Publish
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/validation/test_validate_no_none_guard_publish.py -v
+
+      - name: Self-scan omnibase_core src/ (report mode — baseline cleanup pending)
+        run: |
+          uv run python scripts/validation/validate_no_none_guard_publish.py --report
+
+  # Migrated from validator-no-raw-sqlite3.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  no-raw-sqlite3-validator:
+    name: No Raw Sqlite3 Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/nodes/node_no_raw_sqlite3_check_compute/ -v
+
+      - name: Self-scan omnibase_core src/ (blocking)
+        run: |
+          env -u PYTHONPATH uv run python -m \
+            omnibase_core.nodes.node_no_raw_sqlite3_check_compute.runtime_no_raw_sqlite3_check \
+            --root src
+
+  # Migrated from validator-operation-match.yml (OMN-14877,
+  # OMN-14430 fast-follow). Unconditional job under the required "CI Summary"
+  # rollup — closes the --no-verify pre-commit bypass and retires the standalone
+  # workflow's duplicate run_id + embedded occ-preflight caller.
+  operation-match-validator:
+    name: operation_match Operation Field Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validators/test_operation_match_requires_operation.py -v
+
+      - name: Self-scan omnibase_core/src
+        run: |
+          uv run python -m omnibase_core.validators.operation_match_requires_operation src/omnibase_core
+
+  # Migrated from validator-pin-hygiene.yml (OMN-14877, OMN-14430 fast-follow).
+  # Needs sibling clones (omnibase_compat / omnibase_spi) to resolve pin ancestry;
+  # each is checked out under $OMNI_HOME (= github.workspace).
+  pin-hygiene-validator:
+    name: Pin Hygiene Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v7
+        with:
+          path: omnibase_core
+
+      - name: Checkout omnibase_compat (sibling)
+        uses: actions/checkout@v7
+        with:
+          repository: OmniNode-ai/omnibase_compat
+          path: omnibase_compat
+          ref: dev
+          fetch-depth: 0
+
+      - name: Checkout omnibase_spi (sibling)
+        uses: actions/checkout@v7
+        with:
+          repository: OmniNode-ai/omnibase_spi
+          path: omnibase_spi
+          ref: dev
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "omnibase_core/uv.lock"
+
+      - name: Install dependencies
+        working-directory: omnibase_core
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        working-directory: omnibase_core
+        run: |
+          uv run pytest tests/unit/validation/pin_hygiene/ -v
+
+      - name: Self-scan omnibase_core pin manifests
+        working-directory: omnibase_core
+        env:
+          OMNI_HOME: ${{ github.workspace }}
+        run: |
+          uv run python -m omnibase_core.validation.pin_hygiene.runtime_pin_hygiene \
+            pyproject.toml uv.lock
+
+  # Migrated from validator-release-identity.yml (OMN-14877, OMN-14430
+  # fast-follow). Needs full history + tags to resolve the latest published tag.
+  release-identity-validator:
+    name: Release Identity Validator
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run release-identity unit tests
+        run: |
+          uv run pytest tests/scripts/test_check_release_identity.py -v
+
+      - name: No code merged onto a published version without a bump
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.ref || 'dev' }}"
+          git fetch --quiet origin "${BASE}" || true
+          uv run python scripts/check_release_identity.py --base "origin/${BASE}"
+
+  # Migrated from validator-todo-marker.yml (OMN-14877, OMN-14430 fast-follow).
+  # Scans only the files the PR/merge changed (mirrors the pre-commit hook's
+  # STAGED-only semantics); needs full history to diff against the base.
+  todo-marker-validator:
+    name: TODO Marker Validator  # onex-allow-todo-marker OMN-14877 reason="job display name IS the validator's subject, not agent-left work"
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run validator unit tests
+        run: |
+          uv run pytest tests/unit/validation/todo_marker/ -v
+
+      - name: Scan changed files for agent-left markers
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Resolve the base ref to diff against.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] \
+               && git cat-file -e "${{ github.event.before }}^{commit}" 2>/dev/null; then
+            BASE_SHA="${{ github.event.before }}"
+          else
+            git fetch --no-tags --depth=200 origin dev || true
+            BASE_SHA="$(git merge-base HEAD origin/dev 2>/dev/null || git rev-parse HEAD~1)"
+          fi
+          echo "Diffing changed files against base: $BASE_SHA"
+
+          CHANGED="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD \
+            | grep -E '\.(py|md|yaml|yml|json|sh|toml|txt|rst|cfg|ini)$' \
+            | grep -Ev '^(tests/|docs/|\.secrets\.baseline$|archived/|archive/)' \
+            || true)"
+
+          if [ -z "$CHANGED" ]; then
+            echo "No in-scope changed text files -- nothing to scan."
+            exit 0
+          fi
+
+          echo "Scanning changed files:"
+          echo "$CHANGED" | sed 's/^/  /'
+
+          EXISTING=""
+          while IFS= read -r f; do
+            [ -f "$f" ] && EXISTING="$EXISTING $f"
+          done <<< "$CHANGED"
+
+          if [ -z "${EXISTING// /}" ]; then
+            echo "No existing in-scope changed files -- nothing to scan."
+            exit 0
+          fi
+
+          uv run python -m omnibase_core.validation.todo_marker.runtime_todo_marker $EXISTING
+
+
   # Non-canonical lifecycle-class ratchet (OMN-14350, omnibase_core canary)
   # Blocks any NEW Service/Engine/Adapter/Router/Daemon/Manager/Runner/Registry/
   # Controller/Server/Client class outside the frozen allowlist; --check-stale also

--- a/.github/workflows/validator-backend-secret-discipline.yml
+++ b/.github/workflows/validator-backend-secret-discipline.yml
@@ -11,13 +11,18 @@
 # wire this by adding the backend-secret-discipline pre-commit hook and a mirror
 # of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Backend Secret Discipline
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-banned-compose-vars.yml
+++ b/.github/workflows/validator-banned-compose-vars.yml
@@ -18,13 +18,18 @@
 # mirroring the `validate` job in their own CI, pointing --kernel-source at
 # their local copy of service_kernel.py.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Compose Drift
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-bypass-token-blocklist.yml
+++ b/.github/workflows/validator-bypass-token-blocklist.yml
@@ -29,13 +29,18 @@
 #   - OmniNode-ai/onex_change_control
 # Each consumer repo also needs the bypass-token-blocklist pre-commit hook wired.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Bypass-Token Blocklist
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-command-category-event-model.yml
+++ b/.github/workflows/validator-command-category-event-model.yml
@@ -12,13 +12,18 @@
 # repos wire this by adding the command-category-requires-event-model pre-commit hook
 # and a mirror of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: command-category Event Model Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-dispatched-contract-operation.yml
+++ b/.github/workflows/validator-dispatched-contract-operation.yml
@@ -17,13 +17,18 @@
 # dispatched-contract-operation pre-commit hook and a mirror of the `validate`
 # job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: dispatched contract handlers[0].operation Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-generated-node-model-class-exists.yml
+++ b/.github/workflows/validator-generated-node-model-class-exists.yml
@@ -17,13 +17,18 @@
 # generated-node-model-class-exists pre-commit hook and a mirror of the `validate`
 # job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: generated-node model-class-existence Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-gitignore-baseline.yml
+++ b/.github/workflows/validator-gitignore-baseline.yml
@@ -9,13 +9,18 @@
 # Consumer repos wire this by adding the validate-gitignore-baseline pre-commit hook
 # and a mirror of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Gitignore Baseline Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-direct-kafka-producer.yml
+++ b/.github/workflows/validator-no-direct-kafka-producer.yml
@@ -20,14 +20,18 @@
 # skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
 # own evidence, never conditioned on another job's result.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No Direct Kafka Producer Validator
 
 on:
-  push:
-    branches: [main, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, dev]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/validator-no-except-swallow.yml
+++ b/.github/workflows/validator-no-except-swallow.yml
@@ -9,13 +9,18 @@
 # Consumer repos wire this by adding the no-except-swallow pre-commit hook
 # and a mirror of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No Except Swallow
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-hardcoded-ip.yml
+++ b/.github/workflows/validator-no-hardcoded-ip.yml
@@ -19,14 +19,18 @@
 # skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
 # own evidence, never conditioned on another job's result.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No Hardcoded IP Validator
 
 on:
-  push:
-    branches: [main, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, dev]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/validator-no-import-none-fallback.yml
+++ b/.github/workflows/validator-no-import-none-fallback.yml
@@ -9,13 +9,18 @@
 # Consumer repos wire this by adding the no-import-none-fallback pre-commit hook
 # and a mirror of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No Import None Fallback
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-io-outside-effects.yml
+++ b/.github/workflows/validator-no-io-outside-effects.yml
@@ -24,14 +24,18 @@
 # on every PR to main/dev on its own evidence, never conditioned on another
 # job's result.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No IO Outside Effects Validator
 
 on:
-  push:
-    branches: [main, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, dev]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/validator-no-none-guard-publish.yml
+++ b/.github/workflows/validator-no-none-guard-publish.yml
@@ -9,13 +9,18 @@
 # Consumer repos wire this by adding the no-none-guard-publish pre-commit hook
 # and a mirror of the `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No None Guard Publish
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-no-raw-sqlite3.yml
+++ b/.github/workflows/validator-no-raw-sqlite3.yml
@@ -19,14 +19,18 @@
 # skip-then-vacuous-green window. This gate fires on every PR to main/dev on its
 # own evidence, never conditioned on another job's result.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: No Raw Sqlite3 Validator
 
 on:
-  push:
-    branches: [main, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, dev]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/validator-operation-match.yml
+++ b/.github/workflows/validator-operation-match.yml
@@ -13,13 +13,18 @@
 # operation-match-requires-operation pre-commit hook and a mirror of the
 # `validate` job in their own CI.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: operation_match Operation Field Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-pin-hygiene.yml
+++ b/.github/workflows/validator-pin-hygiene.yml
@@ -17,13 +17,18 @@
 # under the check-pin-hygiene-compute pre-commit hook, so local and CI verdicts
 # cannot drift.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Pin Hygiene Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-release-identity.yml
+++ b/.github/workflows/validator-release-identity.yml
@@ -18,13 +18,18 @@
 # (OMN-13412, scripts/check_release_identity.py). Same blocking direction, same
 # src/**-only enforcement, same docs/tests/CI exemption.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: Release Identity Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/validator-todo-marker.yml
+++ b/.github/workflows/validator-todo-marker.yml
@@ -26,13 +26,18 @@
 # documentation-heavy file whose subject IS the marker token with
 # `# onex-allow-file-todo-marker`.
 
+# MIGRATED INTO ci.yml (OMN-14877, OMN-14430 fast-follow): this workflow used to
+# trigger on push/pull_request, giving it its OWN github.run_id — structurally
+# invisible to ci.yml's ci-summary default-deny poller and gating nothing
+# (pre-commit, if installed and not --no-verify'd, was the only enforcement).
+# Its validate steps now run UNCONDITIONALLY inside ci.yml under the required
+# "CI Summary" rollup, and its embedded occ-preflight caller no longer fires on
+# PRs. This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
+#
 name: TODO Marker Validator
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -51,7 +51,7 @@ schema_version: 1
 # Count lock. MUST equal len(allowlisted_workflows). Frozen a second time as
 # EXPECTED_BUDGET in the test suite. Intended to move DOWN only.
 # baseline captured 2026-07-21 at origin/dev@d09128fc.
-budget: 49
+budget: 31
 
 # Every live `.github/workflows/*.yml` that triggers on pull_request /
 # pull_request_target as of the baseline. This is the frozen ratchet floor: a new
@@ -85,27 +85,9 @@ allowlisted_workflows:
   - stale-todo-gate.yml
   - todo-audit-on-merge.yml
   - url-authority-gate.yml
-  - validator-backend-secret-discipline.yml
-  - validator-banned-compose-vars.yml
-  - validator-bypass-token-blocklist.yml
-  - validator-command-category-event-model.yml
-  - validator-dispatched-contract-operation.yml
   - validator-fsm-handler-drift.yml
-  - validator-generated-node-model-class-exists.yml
-  - validator-gitignore-baseline.yml
-  - validator-no-direct-kafka-producer.yml
-  - validator-no-except-swallow.yml
-  - validator-no-hardcoded-ip.yml
-  - validator-no-import-none-fallback.yml
-  - validator-no-io-outside-effects.yml
-  - validator-no-none-guard-publish.yml
   - validator-no-plugin-daemon-classes.yml
-  - validator-no-raw-sqlite3.yml
-  - validator-operation-match.yml
-  - validator-pin-hygiene.yml
-  - validator-release-identity.yml
   - validator-runtime-profiles.yml
-  - validator-todo-marker.yml
 
 # Tracked, EXPIRING exceptions. A workflow here does NOT count toward `budget`,
 # but each entry MUST carry workflow_file + ticket + absolute `expires` (ISO date)

--- a/architecture-handshakes/standalone-validator-debt.yaml
+++ b/architecture-handshakes/standalone-validator-debt.yaml
@@ -62,56 +62,67 @@ natively_required_contexts:
 migrated_into_ci_yml:
   - workflow_file: validator-hardcoded-topic.yml
     ci_job_key: hardcoded-topic-validator
+  # OMN-14877 batch migration (2026-07-21): the remaining 18 decorative
+  # standalone validators, ported into ci.yml as unconditional jobs (no `if:`,
+  # no `needs:`) under the required "CI Summary" rollup. Each standalone file was
+  # retired to workflow_dispatch-only in the same PR, so it no longer produces a
+  # duplicate structurally-invisible run or fires its embedded occ-preflight
+  # caller on PRs.
+  - workflow_file: validator-backend-secret-discipline.yml
+    ci_job_key: backend-secret-discipline-validator
+  - workflow_file: validator-banned-compose-vars.yml
+    ci_job_key: banned-compose-vars-validator
+  - workflow_file: validator-bypass-token-blocklist.yml
+    ci_job_key: bypass-token-blocklist-validator
+  - workflow_file: validator-command-category-event-model.yml
+    ci_job_key: command-category-event-model-validator
+  - workflow_file: validator-dispatched-contract-operation.yml
+    ci_job_key: dispatched-contract-operation-validator
+  - workflow_file: validator-generated-node-model-class-exists.yml
+    ci_job_key: generated-node-model-class-exists-validator
+  - workflow_file: validator-gitignore-baseline.yml
+    ci_job_key: gitignore-baseline-validator
+  - workflow_file: validator-no-direct-kafka-producer.yml
+    ci_job_key: no-direct-kafka-producer-validator
+  - workflow_file: validator-no-except-swallow.yml
+    ci_job_key: no-except-swallow-validator
+  - workflow_file: validator-no-hardcoded-ip.yml
+    ci_job_key: no-hardcoded-ip-validator
+  - workflow_file: validator-no-import-none-fallback.yml
+    ci_job_key: no-import-none-fallback-validator
+  - workflow_file: validator-no-io-outside-effects.yml
+    ci_job_key: no-io-outside-effects-validator
+  - workflow_file: validator-no-none-guard-publish.yml
+    ci_job_key: no-none-guard-publish-validator
+  - workflow_file: validator-no-raw-sqlite3.yml
+    ci_job_key: no-raw-sqlite3-validator
+  - workflow_file: validator-operation-match.yml
+    ci_job_key: operation-match-validator
+  - workflow_file: validator-pin-hygiene.yml
+    ci_job_key: pin-hygiene-validator
+  - workflow_file: validator-release-identity.yml
+    ci_job_key: release-identity-validator
+  - workflow_file: validator-todo-marker.yml
+    ci_job_key: todo-marker-validator
 
 # TRACKED DEBT (OMN-14430 fast-follow, ticket OMN-14430): confirmed decorative
-# as of 2026-07-20 — no merge gate blocks on any of these today; pre-commit
-# (if installed, if not bypassed) is the only enforcement. Each was enumerated
-# by the OMN-14430 audit. Migrate one-by-one into `migrated_into_ci_yml`
+# — no merge gate blocks on any of these today; pre-commit (if installed, if not
+# bypassed) is the only enforcement. Migrate one-by-one into `migrated_into_ci_yml`
 # (preferred) to retire from this list; the count below is the live decorative
 # gate count this ticket asked to be reported.
+#
+# EMPTIED 2026-07-21 (OMN-14877): all 18 remaining decorative validators were
+# batch-migrated into ci.yml (see migrated_into_ci_yml above). The only
+# remaining advisory entry is the OMN-14891 git-env-isolation gate from current
+# dev, which has a unique context and is not yet a required_status_checks
+# context.
 decorative_debt:
-  - workflow_file: validator-backend-secret-discipline.yml
-    context: validate
-  - workflow_file: validator-banned-compose-vars.yml
-    context: validate
-  - workflow_file: validator-bypass-token-blocklist.yml
-    context: validate
-  - workflow_file: validator-command-category-event-model.yml
-    context: validate
-  - workflow_file: validator-dispatched-contract-operation.yml
-    context: validate
-  - workflow_file: validator-generated-node-model-class-exists.yml
-    context: validate
-  - workflow_file: validator-gitignore-baseline.yml
-    context: validate
-  - workflow_file: validator-no-direct-kafka-producer.yml
-    context: validate
-  - workflow_file: validator-no-except-swallow.yml
-    context: validate
-  - workflow_file: validator-no-hardcoded-ip.yml
-    context: validate
-  - workflow_file: validator-no-import-none-fallback.yml
-    context: validate
-  - workflow_file: validator-no-io-outside-effects.yml
-    context: validate
-  - workflow_file: validator-no-none-guard-publish.yml
-    context: validate
-  - workflow_file: validator-no-raw-sqlite3.yml
-    context: validate
   # OMN-14891 git-env-isolation gate: unique context, ADVISORY today (NOT in
   # required_status_checks — verified 2026-07-22 via the gh api command above).
   # Moves to natively_required_contexts when the required flip tracked in
   # .github/required-checks.yaml lands (after 2 independent green dev runs).
   - workflow_file: validator-no-unguarded-git-subprocess.yml
     context: no-unguarded-git-subprocess
-  - workflow_file: validator-operation-match.yml
-    context: validate
-  - workflow_file: validator-pin-hygiene.yml
-    context: validate
-  - workflow_file: validator-release-identity.yml
-    context: validate
-  - workflow_file: validator-todo-marker.yml
-    context: validate
 
 metadata:
   generated_by: "OMN-14430 audit, 2026-07-20"

--- a/tests/validation/test_pull_request_workflow_ratchet.py
+++ b/tests/validation/test_pull_request_workflow_ratchet.py
@@ -40,7 +40,7 @@ REGISTRY_PATH = (
 # To move it you must edit BOTH this constant AND the registry `budget` — a
 # deliberate, reviewed act. It is intended to move DOWN only (retiring a workflow
 # lowers it; C2/C3/C4 drain toward a smaller number).
-EXPECTED_BUDGET = 49
+EXPECTED_BUDGET = 31
 
 
 def _write_registry(path: Path, **overrides: object) -> None:

--- a/tests/validation/test_standalone_validator_workflow_registry.py
+++ b/tests/validation/test_standalone_validator_workflow_registry.py
@@ -52,7 +52,11 @@ def test_decorative_debt_is_the_reported_count(tmp_path: Path) -> None:
     fail loud. Migrating an entry to `migrated_into_ci_yml` legitimately lowers
     this number — update the constant in the same PR as the migration."""
     manifest = yaml.safe_load(DEBT_MANIFEST_PATH.read_text(encoding="utf-8"))
-    assert len(manifest["decorative_debt"]) == 19
+    # OMN-14877 (2026-07-21): the 18 remaining decorative validators were
+    # batch-migrated into ci.yml and reclassified to migrated_into_ci_yml. The
+    # one remaining advisory entry is OMN-14891's git-env-isolation validator
+    # from current dev.
+    assert len(manifest["decorative_debt"]) == 1
 
 
 def test_planted_undeclared_standalone_validator_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## OMN-14877 — Batch-migrate remaining 18 decorative standalone-workflow validators into ci.yml

Closes OMN-14877. Fast-follow to OMN-14430 (SYSTEMIC: standalone-workflow validators are decorative). CI-capacity plan §3 lane C4.

### Problem

OMN-14430 proved every standalone `.github/workflows/validator-*.yml` in this repo is decorative: none is a required branch-protection context, so no merge blocks when one fails; bypassable pre-commit was the only other enforcement. 18 validators remained classified `decorative_debt` in `architecture-handshakes/standalone-validator-debt.yaml`.

### Change

- Port each of the 18 validators' `validate` jobs into `ci.yml` as unconditional jobs (no `if:`/`needs:`), mirroring the `duplicate-registry-ids` / `hardcoded-topic-validator` template, so each now gates merges through the required default-deny **CI Summary** rollup — their first non-bypassable enforcement.
- Retire the 18 standalone workflows' `pull_request`/`push` triggers to `workflow_dispatch`-only.
- Move all 18 registry entries `decorative_debt` → `migrated_into_ci_yml` in `standalone-validator-debt.yaml`; update the locked count in `test_decorative_debt_is_the_reported_count`.
- **Same-PR net-reduce recut** (mandated by the budget file's own header, which pre-names OMN-14877 as the drainer): drop the 18 retired workflows from `allowlisted_workflows` in `architecture-handshakes/pull-request-workflow-budget.yaml`, `budget: 49 → 31`; `EXPECTED_BUDGET = 31` in `tests/validation/test_pull_request_workflow_ratchet.py`. The retirement NET-REDUCES the PR-workflow count by 18 — the ratchet is untouched.
- Merge `origin/dev` (af32e74b, OMN-14891): conflict resolution carries BOTH the new `no-unguarded-git-subprocess` validator registry accounting AND the 18 migrations. Merged tree verified byte-identical (`git diff --stat` empty) to the independently built union branch `codex-letter/omnibase-core-1478-repair` @ 3c0b08c1.

### Pre-commit-parity audit (required before trigger retirement)

16/18 validators have pre-commit hooks (unchanged — local+CI dual-run parity per CLAUDE.md Rule #5). 2 had none (`banned-compose-vars`, `bypass-token-blocklist`); that gap is CLOSED by the migration itself — both are now unconditional required-rollup CI jobs. Seeded-violation proof (exit 2 / exit 1 against the exact migrated `ci.yml` commands) recorded on the ticket (2026-07-21 comment).

### dod_evidence

- `tests/validation/test_pull_request_workflow_ratchet.py` + `tests/validation/test_standalone_validator_workflow_registry.py`: 21/21 pass on the merged head — allowlist 31 == `budget: 31` == `EXPECTED_BUDGET 31`, zero `NOT_PR_TRIGGERED`, live registry airtight including the OMN-14891 validator entry.
- Pre-commit-parity audit + seeded-violation proof: OMN-14877 ticket comment 2026-07-21T22:27Z.
- CI red-wall triage journal (root causes, fix-in-PR decision rule): OMN-14877 ticket comment 2026-07-22T16:41Z.

Evidence-Ticket: OMN-14877
Evidence-Source: OCC#4622
Evidence-Commit: 520a658dbc66a388d2b07f8797fb7d7034993eb8