### PR TITLE
fix(OMN-14925): align pre-push naming hook with CI-canonical baseline-aware validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -531,16 +531,24 @@ repos:
       # CLASS vs FILE Naming Conventions:
       # - validate-naming-conventions: CLASS naming (ModelUser, EnumStatus, ProtocolEventBus)
       # - validate-file-naming-conventions: FILE naming (model_user.py, enum_status.py)
+      #
+      # OMN-14925: invoke the SAME script + baseline semantics as the required CI
+      # "Naming Conventions" context (.github/workflows/ci.yml job `naming-conventions`,
+      # OMN-13574) — `scripts/validate_class_naming.py` with no args. That validator
+      # scopes to src/omnibase_core/ and applies its ALLOWED_EXCEPTIONS grandfather set,
+      # so the local pre-push hook and the required CI gate render the same verdict.
+      # The prior `scripts/validation/validate_naming.py src/` raw full-src scan had NO
+      # baseline and reported 29 pre-existing dev violations, failing every src-touching
+      # push while CI stayed green. Disposition of that orphaned script: OMN-14926.
       - id: validate-naming-conventions
         name: ONEX Naming Convention Validation
-        entry: uv run python scripts/validation/validate_naming.py
-        args: ['src/']
+        entry: uv run python scripts/validate_class_naming.py
         language: system
         pass_filenames: false
         files: ^src/.*\.py$
         exclude: ^(tests/|archive/|archived/|scripts/validation/).*\.py$
-        stages: [pre-push]  # Moved to pre-push: ~14s full codebase scan
-        # Architectural exemptions documented in validate_naming.py ARCHITECTURAL_EXEMPTIONS
+        stages: [pre-push]  # Moved to pre-push: full src/omnibase_core class-naming scan
+        # Grandfathered exceptions live in scripts/validate_class_naming.py ALLOWED_EXCEPTIONS
 
       # NOTE: always_run=true means files: pattern is ignored - script does its own discovery
       - id: validate-file-naming-conventions


### PR DESCRIPTION
## Summary

Re-points the `validate-naming-conventions` pre-push hook to invoke the **exact** validator the required CI "Naming Conventions" context runs, so the local pre-push gate and the required CI gate render one verdict on identical source. Config-only diff (`.pre-commit-config.yaml`), `src/` untouched.

`Evidence-Ticket: OMN-14925`
Parent defect: OMN-14918 · Disposition follow-up: OMN-14926 · Flake surfaced+ticketed while landing: OMN-14927

## Root cause (verified live on dev @ e0cfb208)

The hook ran a **raw full-`src/` scan with no baseline**:

```
uv run python scripts/validation/validate_naming.py src/   ->  29 errors, exit 1
```

The **required** CI context "Naming Conventions" (`.github/workflows/ci.yml` job `naming-conventions`, OMN-13574 failing-rollup into the Quality Gate) runs a **different, baseline-aware** validator:

```
uv run python scripts/validate_class_naming.py             ->  OK: 3195 classes in 3048 files conform, exit 0
```

`validate_class_naming.py` scopes to `src/omnibase_core/` and applies its `ALLOWED_EXCEPTIONS` grandfather set. Same concern (class-prefix naming), same source tree, **opposite verdict**: CI green / local red. The 29 are pre-existing, baselined-away dev violations the local hook never learned about — so every `src/`-touching branch failed its push after the full pre-push suite ran, while CI stayed green.

## Fix

`.pre-commit-config.yaml`: `entry` -> `uv run python scripts/validate_class_naming.py` (dropped the `src/` arg to match CI's no-arg invocation). `files:`/`exclude:`/`stages:` unchanged, so it still only triggers on `src/**.py` pushes. Comment block updated to document the CI-parity and point at OMN-14926 for the orphaned script's disposition.

## Proof (RED/GREEN)

**GREEN — clean dev worktree:**
```
$ pre-commit run validate-naming-conventions --all-files --hook-stage pre-push
ONEX Naming Convention Validation........................................Passed
```

**RED — seeded a NEW mis-named class** (`class SeedBadlyNamedThing` in a `models/model_*.py`), then removed it:
```
ONEX Naming Convention Validation........................................Failed
- exit code: 1
[models (Pydantic data models)]
  src/omnibase_core/models/model_omn14925_seed.py:7: Class 'SeedBadlyNamedThing' should match pattern 'Model*' ...
Summary: 1 violation(s) in 3051 files
```
Seed removed -> Passed again; `git status` clean (only `.pre-commit-config.yaml`).

Acceptance (i) clean-dev passes, (ii) new violation still RED for the right reason, (iii) same validator+baseline as the required CI job, (iv) no CI change — all met.

## Cost evidence

Two doomed pushes on 2026-07-21/22 (one after an ~8h pre-push suite) blocked purely by this divergence; both were otherwise clean against every other hook and the full selector suite. 29 pre-existing baselined violations; divergence proof = CI green / local red on identical source.

## Push provenance (no bypass)

Pushed from omni-201-ts via a dedicated clone (`~/push-lanes/omnibase_core_hookfix`), **no `--no-verify` / no skip tokens**. The smart-test selector maps a repo-root config change to the whole `tests/unit/` tree (not full-suite escalation); the pre-push suite ran it green: `42395 passed, 58 skipped, 3 xpassed`. The naming hook itself correctly logged "(no files to check) Skipped" on this config-only push. A pre-existing, isolation-only flake (`test_validator_startup_contract` oversized-file test — green in isolation x2, fails ~1/42395 under `-n` parallelism, and **cannot** be caused by a config-only diff) is ticketed as OMN-14927 and auto-recovered via `--reruns 2` (deterministic failures still block).

## Notes
- `occ-preflight` will be red until the OCC companion lands — that stays a Codex/OnexBot task; not self-authored here.
- Follow-up OMN-14926 decides retire-vs-ratchet for the now-orphaned `scripts/validation/validate_naming.py` and audits whether its 29 findings are real debt or stale rules (several flag one class against two conflicting prefixes).



Evidence-Ticket: OMN-14925
Evidence-Source: OCC#4597
Evidence-Commit: d082e6aabc593bbe03f12c9c0c0580a30917c785
