### PR TITLE
fix(OMN-14891): systemic git-environment isolation for the test suite

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -578,3 +578,16 @@ gates:
       flip happens only after 2 independent green runs on dev, tracked as a follow-up. mode stays ADVISORY
       until that flip lands (same PR as the flip, per schema-v3 rule: mode changes and branch-protection
       changes land together)."
+
+  - name: "no-unguarded-git-subprocess"
+    mode: ADVISORY
+    producer_kind: local
+    workflow: validator-no-unguarded-git-subprocess.yml
+    job_path: ["no-unguarded-git-subprocess"]
+    skip_semantics: never
+    rationale: "OMN-14891: blocks reintroduction of git shell-outs in tests/ that inherit GIT_DIR / GIT_WORK_TREE
+      / GIT_INDEX_FILE / GIT_COMMON_DIR from a git hook (those OVERRIDE cwd= and -C, so a tmp_path fixture
+      under the pre-push hook mutates the REAL invoking worktree -- observed twice, incl. 6707 phantom
+      staged deletions on the shared canonical clone). Runs unconditionally on every PR but is NOT YET
+      in required_status_checks; per the schema-v3 ordering rule the branch-protection flip and the mode
+      change to REQUIRED land together in a follow-up, after 2 independent green runs on dev."

--- a/.github/workflows/validator-no-unguarded-git-subprocess.yml
+++ b/.github/workflows/validator-no-unguarded-git-subprocess.yml
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# No Unguarded Git Subprocess — test git-environment isolation gate [OMN-14891]
+#
+# Canonical CI gate for `omnibase_core.validators.no_unguarded_git_subprocess`.
+# Required status check context (once flipped): "no-unguarded-git-subprocess".
+#
+# The job id/name is deliberately unique ("no-unguarded-git-subprocess"), NOT the
+# shared "validate" used by some of core's other validator workflows. GitHub
+# surfaces the check-run context as the bare job name, so a shared name collides
+# across unrelated workflows and cannot be made a required status check without
+# forcing all of them. This mirrors validator-no-plugin-daemon-classes.yml
+# (OMN-13309 / OMN-13284).
+#
+# THE DEFECT THIS GATES
+# ---------------------
+# Git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR into the
+# environment of every hook it runs, and those variables OVERRIDE both `cwd=` and
+# `git -C`. So when pytest runs as a subprocess of the repo's own pre-push hook, a
+# fixture doing `subprocess.run(["git", "init"], cwd=tmp_path)` re-initialises the
+# REAL invoking worktree instead of tmp_path.
+#
+# Observed twice, log-proven:
+#   * 2026-07-20 (OMN-14891) — the shared canonical clone's .git/config gained
+#     `core.bare = true` plus a bogus `[user] t / t@t.t` block; 6707 lines of
+#     phantom staged deletions entered the real index; an amend committed that
+#     index as a 6668-file / 1.4M-line deletion.
+#   * 2026-07-21 (OMN-14863) — recurred; fixture commits wrote f.txt / file.txt
+#     into the real index.
+# `$OMNI_HOME/<repo>/.git/config` is shared by every worktree of that repo, so one
+# session's test run corrupts every concurrent session in a sibling worktree.
+#
+# Rationale (Operating Rule #5, "enforcement not detection"): OMN-14744 fixed one
+# file in omnibase_infra by hand and the class recurred in a different repo across
+# five different files. The systemic remedy is the session-level os.environ scrub
+# in tests/conftest.py; this workflow is what stops the shape being reintroduced.
+# A pre-commit-only check is advisory — it does not block a PR that bypassed local
+# hooks.
+#
+# Related: OMN-14892 (index corruption under the same full-suite run),
+#          OMN-14744 (the per-file precedent that did not hold).
+#
+# This workflow runs:
+#   1. unit pytest for the validator (incl. its live self-scan of tests/)
+#   2. pytest for the git-environment isolation regression (the RED-proven pair)
+#   3. a standalone self-scan of the tests/ tree; must exit 0
+
+name: No Unguarded Git Subprocess
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: no-unguarded-git-subprocess-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  occ-preflight:
+    uses: ./.github/workflows/occ-preflight.yml
+    permissions:
+      contents: read
+      pull-requests: read
+    with:
+      contracts-dir: contracts
+      receipts-dir: drift/dod_receipts
+
+  no-unguarded-git-subprocess:
+    needs: occ-preflight
+    name: no-unguarded-git-subprocess
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # The regression test shells out to git, so CI needs an identity for the
+      # decoy repos it creates in tmp_path.
+      - name: Configure git identity for fixture repos
+        run: |
+          git config --global user.email "ci@omninode.ai"
+          git config --global user.name "OmniNode CI"
+
+      - name: Run no-unguarded-git-subprocess unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validators/test_no_unguarded_git_subprocess.py \
+            -v
+
+      - name: Run git-environment isolation regression
+        run: |
+          uv run pytest \
+            tests/unit/test_git_env_isolation.py \
+            -v
+
+      - name: Self-scan omnibase_core tests/
+        run: uv run python -m omnibase_core.validators.no_unguarded_git_subprocess tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -411,6 +411,23 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # OMN-14891: no test may shell out to git while able to inherit GIT_DIR /
+      # GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR from a git hook. Those
+      # variables OVERRIDE `cwd=` and `git -C`, so a tmp_path fixture running under
+      # the pre-push hook mutates the REAL invoking worktree — twice observed
+      # (core.bare=true + a bogus [user] block + 6707 phantom staged deletions on
+      # the shared canonical clone). The session scrub in tests/conftest.py is the
+      # remedy; this blocks reintroduction. Whole-tree arg so a partially-staged
+      # commit cannot hide a violation elsewhere.
+      - id: no-unguarded-git-subprocess
+        name: Block unguarded git subprocess calls in tests (OMN-14891)
+        entry: uv run python -m omnibase_core.validators.no_unguarded_git_subprocess tests
+        language: system
+        types: [python]
+        files: ^tests/.*\.py$
+        pass_filenames: false
+        stages: [pre-commit]
+
       # OMN-14350: non-canonical lifecycle-word class ratchet (omnibase_core canary).
       # Flags CamelCase classes carrying Service/Engine/Adapter/Router/Daemon/Manager/
       # Runner/Registry/Controller/Server/Client and blocks any NEW one outside the

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -483,15 +483,15 @@
   description: >
     Reject forbidden I/O surfaces inside .py modules that sit in a NON-EFFECT node package: database-driver
     imports (sqlite3, aiosqlite, psycopg, psycopg2, asyncpg, sqlalchemy), network/HTTP clients (httpx,
-    requests, aiohttp, urllib3, socket, urllib.request), subprocess execution, git invocation, Linear API
-    access, filesystem writes (open write-mode, os/shutil mutators, pathlib.Path write methods), and direct
-    event-bus / infra-adapter instantiation. Unlike the universal OMN-14659 arch lints, this rule is
-    archetype-keyed: the pure COMPUTE node (node_no_io_outside_effects_check_compute) keys off each node's
-    declared archetype (contract.yaml node_type / descriptor.node_archetype) and only scans the modules
-    co-located with a non-EFFECT contract — EFFECT is the only I/O-permitted archetype. The paired EFFECT
-    node (node_source_file_gather_effect) owns the filesystem walk for full-tree (no-filenames) invocation;
-    the same COMPUTE node backs this pre-commit hook and the CI gate. Only EFFECT nodes may perform I/O.
-    Suppress a proven-legitimate exception with: # io-ok: <reason>
+    requests, aiohttp, urllib3, socket, urllib.request), subprocess execution, git invocation, Linear
+    API access, filesystem writes (open write-mode, os/shutil mutators, pathlib.Path write methods), and
+    direct event-bus / infra-adapter instantiation. Unlike the universal OMN-14659 arch lints, this rule
+    is archetype-keyed: the pure COMPUTE node (node_no_io_outside_effects_check_compute) keys off each
+    node's declared archetype (contract.yaml node_type / descriptor.node_archetype) and only scans the
+    modules co-located with a non-EFFECT contract — EFFECT is the only I/O-permitted archetype. The paired
+    EFFECT node (node_source_file_gather_effect) owns the filesystem walk for full-tree (no-filenames)
+    invocation; the same COMPUTE node backs this pre-commit hook and the CI gate. Only EFFECT nodes may
+    perform I/O. Suppress a proven-legitimate exception with: # io-ok: <reason>
   language: python
   entry: python -m omnibase_core.nodes.node_no_io_outside_effects_check_compute.runtime_no_io_outside_effects_check
   types_or: [python, yaml]
@@ -707,5 +707,23 @@
   language: python
   entry: python -m omnibase_core.validators.projection_exposure_drift
   files: (^|/)(contract\.yaml|migrations/.*\.sql)$
+  pass_filenames: false
+  stages: [pre-commit]
+
+- id: no-unguarded-git-subprocess
+  name: Block unguarded git subprocess calls in tests (OMN-14891)
+  description: >
+    OMN-14891: reject a subprocess call in tests/ whose argv starts with "git" unless it passes an env=
+    that provably drops GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_COMMON_DIR, GIT_OBJECT_DIRECTORY,
+    and GIT_ALTERNATE_OBJECT_DIRECTORIES. Git exports those into every hook environment and they OVERRIDE
+    both `cwd=` and `git -C`, so a tmp_path fixture running under a pre-push hook mutates the REAL invoking
+    worktree instead. `git config --global`/`--system` in tests/ is rejected outright. Consumers should
+    also install the session-level os.environ scrub in their top-level tests/conftest.py (see omnibase_core.validators.no_unguarded_git_subprocess.strip_git_location_env),
+    which is the primary remedy; this hook prevents reintroduction. Precedent: OMN-14744 (per-file fix
+    that did not hold).
+  language: system
+  entry: python -m omnibase_core.validators.no_unguarded_git_subprocess tests
+  types: [python]
+  files: ^tests/.*\.py$
   pass_filenames: false
   stages: [pre-commit]

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -112,7 +112,22 @@ allowlisted_workflows:
 # + justification + `retires` (the surface/manual step it removes, per the
 # net-negative rule). A past-expiry waiver fails the gate. Empty at baseline —
 # the sanctioned default is retire-one, not waive.
-waivers: []
+waivers:
+  - workflow_file: validator-no-unguarded-git-subprocess.yml
+    ticket: OMN-14891
+    expires: "2026-08-19"
+    justification: >-
+      Load-bearing git-environment-isolation gate blocking a twice-observed (2026-07-20 OMN-14891, 2026-07-21
+      OMN-14863) repo-corruption class: git hook-exported GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE override
+      cwd=/-C in test subprocesses and mutate the REAL shared canonical clone. The gate needs its own
+      unique check context ("no-unguarded-git-subprocess") ahead of the branch-protection required flip
+      tracked in .github/required-checks.yaml (ADVISORY until 2 independent green dev runs). Waived rather
+      than budget-bumped so the count lock stays flat; the slot regularizes when the OMN-14877 decorative-validator
+      drain frees allowlist slots (this file then takes a freed slot or migrates into ci.yml and the waiver
+      is removed).
+    retires: >-
+      The recurring manual post-incident .git/config + index forensics-and-repair step for hook-context
+      test corruption, and the per-file hand-fix pattern of OMN-14744 that demonstrably did not hold.
 
 metadata:
   generated_by: "C7 / OMN-14907, 2026-07-21"

--- a/architecture-handshakes/standalone-validator-debt.yaml
+++ b/architecture-handshakes/standalone-validator-debt.yaml
@@ -98,6 +98,12 @@ decorative_debt:
     context: validate
   - workflow_file: validator-no-raw-sqlite3.yml
     context: validate
+  # OMN-14891 git-env-isolation gate: unique context, ADVISORY today (NOT in
+  # required_status_checks — verified 2026-07-22 via the gh api command above).
+  # Moves to natively_required_contexts when the required flip tracked in
+  # .github/required-checks.yaml lands (after 2 independent green dev runs).
+  - workflow_file: validator-no-unguarded-git-subprocess.yml
+    context: no-unguarded-git-subprocess
   - workflow_file: validator-operation-match.yml
     context: validate
   - workflow_file: validator-pin-hygiene.yml

--- a/scripts/validation/validate-file-locations.py
+++ b/scripts/validation/validate-file-locations.py
@@ -131,6 +131,15 @@ class FileLocationValidator:
         # commit. Exempting runtime/ unblocks the fleet; whether the seam should
         # instead relocate to mixins/ is an OMN-12549 call tracked as a follow-up.
         "mixin_node_dispatch.py": ["runtime"],
+        # Single canonical ProtocolSemVer, co-located with the SemVer type it
+        # describes (OMN-14624, #1471). Same situation as mixin_node_dispatch.py
+        # above: it landed in types/ without an exemption, so the whole-tree
+        # file-location scan is RED on dev and blocks EVERY core src/ commit
+        # (this exemption is not this PR's subject — see OMN-14891 PR body).
+        # Exempting types/ unblocks the fleet; whether ProtocolSemVer should
+        # instead relocate to protocol/ is an OMN-14624 call tracked as a
+        # follow-up.
+        "type_semver.py": ["types"],
         # Navigation subsystem data types (OMN-2540, OMN-2546)
         "model_action_set.py": ["navigation"],
         "model_backward_chaining.py": ["navigation"],

--- a/src/omnibase_core/models/validation/model_git_subprocess_finding.py
+++ b/src/omnibase_core/models/validation/model_git_subprocess_finding.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelGitSubprocessFinding — finding from the unguarded-git-subprocess guard (OMN-14891)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ModelGitSubprocessFinding:
+    """An unguarded ``git`` subprocess invocation found in a test file."""
+
+    path: Path
+    line: int
+    column: int
+    call: str
+    reason: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column + 1}: {self.call}(...) shells out to "
+            f"git without a scrubbed env ({self.reason})"
+        )

--- a/src/omnibase_core/validators/no_unguarded_git_subprocess.py
+++ b/src/omnibase_core/validators/no_unguarded_git_subprocess.py
@@ -1,0 +1,505 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Block unguarded ``git`` subprocess invocations in test files (OMN-14891).
+
+THE DEFECT
+----------
+A test fixture that shells out to git inside a ``tmp_path`` directory::
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "x"], cwd=repo, check=True)
+
+is safe *in isolation*. It is NOT safe when pytest runs as a subprocess of the
+repo's own pre-push hook: git exports ``GIT_DIR`` / ``GIT_WORK_TREE`` /
+``GIT_INDEX_FILE`` / ``GIT_COMMON_DIR`` into every hook's environment, and those
+variables **override both ``-C`` and ``cwd``**. The child git command therefore
+silently targets the REAL invoking worktree.
+
+Observed damage (twice, log-proven): the shared canonical clone's ``.git/config``
+was rewritten (``core.bare = true`` from a fixture ``git init``, plus a bogus
+``[user]`` block), 6707 lines of phantom staged deletions were written into the
+real index, and an amend then committed that index as a 6668-file deletion.
+``$OMNI_HOME/<repo>/.git/config`` is shared by every worktree of that repo, so
+one session's test run corrupts every concurrent session.
+
+WHY THIS GATE EXISTS
+--------------------
+OMN-14744 fixed exactly one file in omnibase_infra. The class then recurred in a
+different repo across five different files. Per-file patching does not hold, so
+the remedy is systemic: a session-level ``os.environ`` scrub in the top-level
+``tests/conftest.py`` (the primary remedy) **plus** this gate, which keeps a new
+unguarded call from being introduced (CLAUDE.md Rule #5 — a detection surface
+that is not wired as a gate gets ignored).
+
+THE RULE
+--------
+Inside test files, a ``subprocess`` call whose argv begins with the literal
+``"git"`` must pass an explicit ``env=``, and that ``env=`` expression must be
+provably free of the inherited git location variables. Three acceptance tiers:
+
+1. **canonical helper** — the env expression references a helper whose name is in
+   :data:`CANONICAL_SCRUB_NAMES` (e.g. ``scrub_git_location_env``).
+2. **full replacement** — the env expression is a dict/``dict(...)`` literal that
+   never reads ``os.environ``. A replacement environment cannot inherit
+   ``GIT_DIR``, so it is safe by construction.
+3. **verified local scrub** — the env expression references a helper function that
+   removes every variable in :data:`GIT_LOCATION_ENV_VARS`, or the call is
+   lexically enclosed by a function that performs that removal inline (the shape
+   the existing per-file fixes use: build ``env``, pop the vars, pass ``env=env``).
+
+Anything else fails CLOSED, including a bare ``env=os.environ.copy()``.
+
+Additionally, ``git config --global`` / ``--system`` is rejected outright in test
+files: an ``os.environ`` scrub fixes *location*, but it does not stop a fixture
+from deliberately writing the real user's ``~/.gitconfig``.
+
+Usage::
+
+    python -m omnibase_core.validators.no_unguarded_git_subprocess tests/
+
+When pre-commit supplies staged filenames, each is scanned. When no paths are
+supplied, ``tests/`` is scanned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from pathlib import Path
+
+from omnibase_core.models.validation.model_git_subprocess_finding import (
+    ModelGitSubprocessFinding,
+)
+
+DEFAULT_SCAN_ROOT = Path("tests")
+
+# The git environment variables that OVERRIDE `-C` and `cwd`. These are the
+# variables that produced the OMN-14891 / OMN-14892 corruption; a scrub that
+# misses any one of them is not a scrub. `GIT_CEILING_DIRECTORIES` is scrubbed by
+# the conftest fixture too, but it can only make discovery fail (never redirect
+# it at the real repo), so it is not required of a module-local helper here.
+GIT_LOCATION_ENV_VARS: tuple[str, ...] = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+# Additionally scrubbed by the session fixture; see tests/conftest.py.
+GIT_DISCOVERY_ENV_VARS: tuple[str, ...] = ("GIT_CEILING_DIRECTORIES",)
+
+# Names that, when referenced inside an `env=` expression, mark the environment
+# as canonically scrubbed.
+CANONICAL_SCRUB_NAMES: frozenset[str] = frozenset(
+    ("scrub_git_location_env", "scrubbed_git_env")
+)
+
+# subprocess entrypoints that execute an argv.
+SUBPROCESS_CALLABLES: frozenset[str] = frozenset(
+    ("run", "call", "check_call", "check_output", "Popen")
+)
+
+_ENVIRON_NAMES: frozenset[str] = frozenset(("environ", "os.environ"))
+
+# `tests/fixtures/` holds inert data corpora consumed BY tests (including files
+# that are deliberately syntactically invalid, e.g.
+# tests/fixtures/validation/exports/syntax_error.py). Nothing there is executed
+# as test code, so it is excluded from the scan rather than reported.
+EXCLUDED_DIR_NAMES: frozenset[str] = frozenset(("fixtures", "__pycache__"))
+
+
+# ---------------------------------------------------------------------------
+# the remedy (kept in the same module as the guard so the two cannot drift)
+# ---------------------------------------------------------------------------
+
+
+def scrub_git_location_env(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a copy of ``environ`` with inherited git overrides removed.
+
+    Defaults to :data:`os.environ`. Removes every location override
+    (:data:`GIT_LOCATION_ENV_VARS`), the discovery limiter
+    (:data:`GIT_DISCOVERY_ENV_VARS`), and any ``GIT_CONFIG*`` override a hook or
+    wrapper injected. Everything else (``PATH``, ``HOME``, ``GIT_AUTHOR_*``,
+    ``GIT_COMMITTER_*``) is preserved, so commits still resolve an identity.
+    """
+    scrubbed = dict(os.environ if environ is None else environ)
+    strip_git_location_env(scrubbed)
+    return scrubbed
+
+
+def strip_git_location_env(environ: MutableMapping[str, str]) -> tuple[str, ...]:
+    """Remove inherited git overrides from ``environ`` IN PLACE.
+
+    Returns the names actually removed, so a caller (the session fixture in
+    ``tests/conftest.py``) can report what it neutralised.
+    """
+    removed: list[str] = []
+    for key in tuple(environ):
+        if key.startswith("GIT_CONFIG"):
+            del environ[key]
+            removed.append(key)
+    for key in (*GIT_LOCATION_ENV_VARS, *GIT_DISCOVERY_ENV_VARS):
+        if environ.pop(key, None) is not None:
+            removed.append(key)
+    return tuple(removed)
+
+
+def validate_paths(paths: Sequence[Path]) -> list[ModelGitSubprocessFinding]:
+    """Validate Python files under the provided paths."""
+    findings: list[ModelGitSubprocessFinding] = []
+    for path in _iter_python_files(paths):
+        findings.extend(validate_file(path))
+    return findings
+
+
+def validate_file(path: Path) -> list[ModelGitSubprocessFinding]:
+    """Validate one Python file for unguarded git subprocess calls."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return [
+            ModelGitSubprocessFinding(
+                path=path,
+                line=1,
+                column=0,
+                call="<parse-error>",
+                reason=f"could not decode as UTF-8: {exc}",
+            )
+        ]
+    return validate_source(path, source)
+
+
+def validate_source(path: Path, source: str) -> list[ModelGitSubprocessFinding]:
+    """Validate in-memory ``source`` attributed to ``path``."""
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [
+            ModelGitSubprocessFinding(
+                path=path,
+                line=exc.lineno or 1,
+                column=exc.offset or 0,
+                call="<syntax-error>",
+                reason=exc.msg or "syntax error",
+            )
+        ]
+
+    scrubbing_helpers = _scrubbing_helper_names(tree)
+    enclosed_by_scrub = _calls_enclosed_by_scrub(tree)
+    findings: list[ModelGitSubprocessFinding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _subprocess_call_name(node)
+        if call_name is None:
+            continue
+        argv = _argv_elements(node)
+        if argv is None or not _argv_is_git(argv):
+            continue
+
+        reason = _guard_reason(
+            node,
+            argv,
+            scrubbing_helpers,
+            enclosed_by_scrub=id(node) in enclosed_by_scrub,
+        )
+        if reason is None:
+            continue
+        findings.append(
+            ModelGitSubprocessFinding(
+                path=path,
+                line=node.lineno,
+                column=node.col_offset,
+                call=call_name,
+                reason=reason,
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# call classification
+# ---------------------------------------------------------------------------
+
+
+def _subprocess_call_name(node: ast.Call) -> str | None:
+    """Return the dotted name if ``node`` invokes a subprocess entrypoint."""
+    name = _qualified_expr_name(node.func)
+    if name is None:
+        return None
+    tail = name.rsplit(".", maxsplit=1)[-1]
+    if tail not in SUBPROCESS_CALLABLES:
+        return None
+    # `subprocess.run(...)` / `sp.run(...)` / bare `run(...)` all qualify; a
+    # `self.run(...)` / `client.check_output(...)` method call does not execute
+    # an argv, but it also cannot have a literal `["git", ...]` first arg in
+    # practice, so argv classification below filters those out anyway.
+    return name
+
+
+def _argv_elements(node: ast.Call) -> list[ast.expr] | None:
+    """Return the literal argv sequence elements, if the first arg is one."""
+    if not node.args:
+        return None
+    first = node.args[0]
+    if isinstance(first, (ast.List, ast.Tuple)):
+        return list(first.elts)
+    return None
+
+
+def _argv_is_git(argv: Sequence[ast.expr]) -> bool:
+    """True when the argv's program (element 0) is the literal string ``git``."""
+    if not argv:
+        return False
+    head = argv[0]
+    return isinstance(head, ast.Constant) and head.value == "git"
+
+
+# ---------------------------------------------------------------------------
+# guard evaluation
+# ---------------------------------------------------------------------------
+
+
+def _guard_reason(
+    node: ast.Call,
+    argv: Sequence[ast.expr],
+    scrubbing_helpers: frozenset[str],
+    *,
+    enclosed_by_scrub: bool,
+) -> str | None:
+    """Return a failure reason, or None when the call is adequately guarded."""
+    global_config = _global_config_reason(argv)
+    if global_config is not None:
+        return global_config
+
+    env_kwarg = next(
+        (kw.value for kw in node.keywords if kw.arg == "env"),
+        None,
+    )
+    if env_kwarg is None:
+        return (
+            "no env= keyword, so GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE inherited "
+            "from a git hook override cwd and -C and retarget the real worktree"
+        )
+    if enclosed_by_scrub or _env_is_scrubbed(env_kwarg, scrubbing_helpers):
+        return None
+    return (
+        "env= is derived from the ambient environment without removing "
+        f"{', '.join(GIT_LOCATION_ENV_VARS)}"
+    )
+
+
+def _global_config_reason(argv: Sequence[ast.expr]) -> str | None:
+    """Reject `git config --global/--system`, which escapes any env scrub."""
+    literals = [
+        element.value
+        for element in argv
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    ]
+    if "config" not in literals:
+        return None
+    for scope in ("--global", "--system"):
+        if scope in literals:
+            return (
+                f"`git config {scope}` writes the real user's git configuration; "
+                "an env scrub cannot contain it"
+            )
+    return None
+
+
+def _env_is_scrubbed(env: ast.expr, scrubbing_helpers: frozenset[str]) -> bool:
+    """True when the ``env=`` expression provably drops the git location vars."""
+    referenced = _referenced_names(env)
+
+    # Tier 1: the canonical shared scrub helper.
+    if referenced & CANONICAL_SCRUB_NAMES:
+        return True
+    # Tier 3: a verified module-local scrub helper.
+    if referenced & scrubbing_helpers:
+        return True
+    # Tier 2: a full replacement environment that never reads os.environ.
+    return _is_replacement_env(env) and not (referenced & _ENVIRON_NAMES)
+
+
+def _is_replacement_env(env: ast.expr) -> bool:
+    """True for dict literals / ``dict(...)`` / ``{**a, **b}`` constructions."""
+    if isinstance(env, ast.Dict):
+        return True
+    if isinstance(env, ast.Call):
+        return _qualified_expr_name(env.func) == "dict"
+    return False
+
+
+def _scrubbing_helper_names(tree: ast.Module) -> frozenset[str]:
+    """Names of functions that remove every git location var."""
+    return frozenset(fn.name for fn in _scrubbing_functions(tree))
+
+
+def _calls_enclosed_by_scrub(tree: ast.Module) -> frozenset[int]:
+    """``id()`` of every Call lexically inside a function that scrubs inline.
+
+    This is the shape the pre-existing per-file fixes use: a ``_git(...)`` helper
+    copies ``os.environ``, pops the location vars, and passes ``env=env`` to the
+    subprocess call in the same function body. The ``env=`` expression is then a
+    bare local name that carries no static evidence on its own.
+    """
+    enclosed: set[int] = set()
+    for fn in _scrubbing_functions(tree):
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call):
+                enclosed.add(id(node))
+    return frozenset(enclosed)
+
+
+def _scrubbing_functions(
+    tree: ast.Module,
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and _drops_all(node)
+    ]
+
+
+def _drops_all(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when ``func`` removes every variable in GIT_LOCATION_ENV_VARS."""
+    dropped: set[str] = set()
+    for node in ast.walk(func):
+        # `env.pop("GIT_DIR", None)` / `env.pop("GIT_DIR")`
+        if isinstance(node, ast.Call):
+            name = _qualified_expr_name(node.func)
+            if name is not None and name.rsplit(".", maxsplit=1)[-1] == "pop":
+                dropped.update(_string_constants(node.args))
+            continue
+        # `del env["GIT_DIR"]`
+        if isinstance(node, ast.Delete):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    dropped.update(_string_constants([target.slice]))
+        # `for key in ("GIT_DIR", ...): env.pop(key, None)` — the loop iterable
+        # supplies the names; the pop above contributes the `key` variable, so
+        # harvest the literals from the iterable directly.
+        if isinstance(node, ast.For):
+            dropped.update(_iterable_string_constants(node.iter))
+    return set(GIT_LOCATION_ENV_VARS).issubset(dropped)
+
+
+def _string_constants(nodes: Sequence[ast.expr]) -> set[str]:
+    return {
+        node.value
+        for node in nodes
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+def _iterable_string_constants(node: ast.expr) -> set[str]:
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return _string_constants(list(node.elts))
+    if isinstance(node, ast.Call):
+        # `tuple(("GIT_DIR", ...))` / `frozenset([...])`
+        collected: set[str] = set()
+        for arg in node.args:
+            collected |= _iterable_string_constants(arg)
+        return collected
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _referenced_names(node: ast.expr) -> frozenset[str]:
+    """All simple and dotted names appearing anywhere inside ``node``."""
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            names.add(child.id)
+        elif isinstance(child, ast.Attribute):
+            qualified = _qualified_expr_name(child)
+            if qualified is not None:
+                names.add(qualified)
+                names.add(qualified.rsplit(".", maxsplit=1)[-1])
+    return frozenset(names)
+
+
+def _qualified_expr_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _qualified_expr_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Subscript):
+        return _qualified_expr_name(node.value)
+    if isinstance(node, ast.Call):
+        return _qualified_expr_name(node.func)
+    return None
+
+
+def _iter_python_files(paths: Sequence[Path]) -> Iterator[Path]:
+    scan_paths = tuple(paths) or (DEFAULT_SCAN_ROOT,)
+    for path in scan_paths:
+        if path.is_file() and path.suffix == ".py":
+            if not _is_excluded(path):
+                yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob("*.py")
+                if not _is_excluded(candidate)
+            )
+
+
+def _is_excluded(path: Path) -> bool:
+    return bool(EXCLUDED_DIR_NAMES.intersection(path.parts))
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Block git subprocess invocations in tests that inherit GIT_DIR, "
+            "GIT_WORK_TREE, GIT_INDEX_FILE, or GIT_COMMON_DIR from a git hook."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_SCAN_ROOT],
+        help="Python file or directory paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    findings = validate_paths(args.paths)
+    if not findings:
+        return 0
+
+    sys.stderr.write("Unguarded git subprocess guard failed (OMN-14891):\n")
+    for finding in findings:
+        sys.stderr.write(f"  {finding.format()}\n")
+    sys.stderr.write(
+        "\nGit exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR into "
+        "every hook environment, and those OVERRIDE both `cwd=` and `git -C`. A test "
+        "fixture that shells out to git under a pre-push hook therefore mutates the "
+        "REAL invoking worktree, not tmp_path.\n"
+        "Fix: pass env=scrub_git_location_env(os.environ) (see tests/conftest.py), or "
+        "pass a full replacement env dict that never reads os.environ.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())  # error-ok: CLI entry point requires SystemExit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,13 +51,96 @@ Mitigation:
 import asyncio
 import gc
 import logging
+import os
 from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pytest
 
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    GIT_DISCOVERY_ENV_VARS,
+    GIT_LOCATION_ENV_VARS,
+    strip_git_location_env,
+)
+
 # Configure logging to reduce memory overhead
 logging.basicConfig(level=logging.WARNING)
+
+
+# ===========================================================================
+# OMN-14891: git environment isolation (session-wide, autouse)
+# ===========================================================================
+#
+# Git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR into the
+# environment of every hook it runs. Those variables OVERRIDE both `cwd=` and
+# `git -C`. So when pytest runs as a subprocess of this repo's own pre-push hook,
+# a fixture doing `subprocess.run(["git", "init"], cwd=tmp_path)` does not touch
+# tmp_path at all — it re-initialises the REAL invoking worktree.
+#
+# That is not hypothetical. It happened twice:
+#   * 2026-07-20 (OMN-14891): the shared canonical clone's .git/config gained
+#     `core.bare = true` plus a bogus `[user] t / t@t.t` block, 6707 lines of
+#     phantom staged deletions landed in the real index, and an amend committed
+#     that index as a 6668-file / 1.4M-line deletion.
+#   * 2026-07-21 (OMN-14863): recurred — fixture commits wrote f.txt / file.txt
+#     into the real index.
+#
+# `$OMNI_HOME/<repo>/.git/config` is shared by every worktree of that repo, so
+# one session's test run corrupts every concurrent session in a sibling worktree.
+#
+# OMN-14744 fixed one file in omnibase_infra; the class recurred in a different
+# repo across five different files. Per-file patching does not hold, so the scrub
+# is applied ONCE here for the whole session.
+#
+# WHY BOTH pytest_configure AND an autouse fixture:
+#   * `_scrub_git_environment()` is called from `pytest_configure` below, which
+#     runs BEFORE collection — so module-import-time and module-scoped-fixture
+#     git calls are covered too. A session fixture alone starts too late for
+#     those.
+#   * The autouse session fixture re-asserts the scrub so the guarantee is
+#     visible as a fixture (and holds under `-p no:cacheprovider`, plugin
+#     reordering, and any code that re-populates os.environ during startup).
+# Under xdist (`-n4`) both run in every worker process, so every worker is
+# covered independently.
+#
+# DECISION — GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM are scrubbed, NOT pinned:
+#   Inherited `GIT_CONFIG*` overrides are DELETED (a hook or wrapper could point
+#   them anywhere), but they are deliberately NOT pinned to /dev/null. Pinning
+#   would strip commit identity session-wide and break every fixture that commits
+#   without explicit `-c user.email` overrides — a blast radius that cannot be
+#   validated here, because this repo's full suite is itself pathological
+#   (OMN-14892 / OMN-14753). The residual risk pinning would have covered — a
+#   fixture writing the real user's ~/.gitconfig — is instead closed statically
+#   and with zero runtime blast radius by the companion gate, which rejects
+#   `git config --global` / `--system` anywhere under tests/. Once location is
+#   correct, a plain `git config user.email` cannot escape the tmp repo.
+_GIT_ENV_VARS_SCRUBBED: tuple[str, ...] = (
+    *GIT_LOCATION_ENV_VARS,
+    *GIT_DISCOVERY_ENV_VARS,
+)
+
+
+def _scrub_git_environment() -> tuple[str, ...]:
+    """Remove inherited git location/config overrides from os.environ."""
+    return strip_git_location_env(os.environ)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def git_environment_isolation() -> Generator[None, None, None]:
+    """Guarantee no inherited git override survives into any test (OMN-14891).
+
+    Intentionally does NOT restore the variables on teardown: restoring them
+    would re-arm the corruption for anything running after the last test in the
+    worker, and no test may legitimately depend on inheriting a git hook's
+    GIT_DIR.
+    """
+    _scrub_git_environment()
+    for name in _GIT_ENV_VARS_SCRUBBED:
+        assert name not in os.environ, (
+            f"{name} survived the OMN-14891 git-environment scrub; git subprocesses "
+            "in fixtures would target the real invoking worktree instead of tmp_path"
+        )
+    return
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -203,6 +286,11 @@ def pytest_configure(config: pytest.Config) -> None:
     Args:
         config: pytest configuration object
     """
+    # OMN-14891: scrub inherited git overrides BEFORE collection, so that
+    # import-time and module-scoped-fixture git calls are covered too. The
+    # autouse `git_environment_isolation` session fixture re-asserts this.
+    _scrub_git_environment()
+
     # Register custom markers
     config.addinivalue_line(
         "markers",

--- a/tests/integration/test_validation_integration.py
+++ b/tests/integration/test_validation_integration.py
@@ -12,6 +12,7 @@ Tests the integration of all validation scripts including:
 - CI/CD integration scenarios
 """
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -19,8 +20,33 @@ from pathlib import Path
 
 import pytest
 
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
 # Get the path to validation scripts
 VALIDATION_SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts" / "validation"
+
+
+def _git(
+    repo: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[bytes]:
+    """Run git against ``repo`` with inherited hook overrides removed (OMN-14891).
+
+    Every git call in this module MUST go through here. Git exports GIT_DIR /
+    GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR into hook environments and
+    those OVERRIDE ``cwd=``, so a bare ``subprocess.run(["git", ...], cwd=repo)``
+    here mutates the real invoking worktree when pytest runs under the pre-push
+    hook. The session-level scrub in ``tests/conftest.py`` is the primary remedy;
+    this keeps the call correct even outside a pytest session.
+    """
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        env=scrub_git_location_env(os.environ),
+    )
 
 
 @pytest.fixture
@@ -54,21 +80,13 @@ testpaths = ["tests"]
 @pytest.fixture
 def git_repo(temp_repo):
     """Initialize the temp repository as a git repository."""
-    subprocess.run(["git", "init"], cwd=temp_repo, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"],
-        cwd=temp_repo,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=temp_repo,
-        check=True,
-    )
+    _git(temp_repo, "init")
+    _git(temp_repo, "config", "user.email", "test@example.com")
+    _git(temp_repo, "config", "user.name", "Test User")
 
     # Add all files
-    subprocess.run(["git", "add", "."], cwd=temp_repo, check=True)
-    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=temp_repo, check=True)
+    _git(temp_repo, "add", ".")
+    _git(temp_repo, "commit", "-m", "Initial commit")
 
     return temp_repo
 
@@ -376,7 +394,7 @@ class ModelLegacy(BaseModel):
         problematic_file.write_text(problematic_content)
 
         # Stage the file
-        subprocess.run(["git", "add", str(problematic_file)], cwd=git_repo, check=True)
+        _git(git_repo, "add", str(problematic_file))
 
         # Simulate pre-commit validation on staged file
         compat_script = VALIDATION_SCRIPTS_DIR / "validate-no-backward-compatibility.py"
@@ -432,7 +450,7 @@ class ModelProblem(BaseModel):
 
         # Stage files
         for file_path in files_to_validate:
-            subprocess.run(["git", "add", file_path], cwd=git_repo, check=True)
+            _git(git_repo, "add", file_path)
 
         # Test validation with file list (pre-commit style)
         compat_script = VALIDATION_SCRIPTS_DIR / "validate-no-backward-compatibility.py"
@@ -452,7 +470,7 @@ class ModelProblem(BaseModel):
         # Create and stage non-Python files
         readme_file = git_repo / "NEW_README.md"
         readme_file.write_text("# Updated README")
-        subprocess.run(["git", "add", str(readme_file)], cwd=git_repo, check=True)
+        _git(git_repo, "add", str(readme_file))
 
         # Test validation with non-Python files
         compat_script = VALIDATION_SCRIPTS_DIR / "validate-no-backward-compatibility.py"
@@ -786,11 +804,7 @@ outputs:
         )
 
         # 2. Stage files
-        subprocess.run(
-            ["git", "add", str(new_model), str(new_contract)],
-            cwd=git_repo,
-            check=True,
-        )
+        _git(git_repo, "add", str(new_model), str(new_contract))
 
         # 3. Run pre-commit validation
         validation_passed = True
@@ -835,11 +849,8 @@ outputs:
         assert validation_passed
 
         # 5. Commit should succeed
-        result = subprocess.run(
-            ["git", "commit", "-m", "Add new feature model and contract"],
-            cwd=git_repo,
-            capture_output=True,
-            check=False,
+        result = _git(
+            git_repo, "commit", "-m", "Add new feature model and contract", check=False
         )
         assert result.returncode == 0
 
@@ -864,12 +875,8 @@ class ModelUser(BaseModel):
         )
 
         # Commit initial version
-        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Add initial user model"],
-            cwd=git_repo,
-            check=True,
-        )
+        _git(git_repo, "add", ".")
+        _git(git_repo, "commit", "-m", "Add initial user model")
 
         # Refactor model (add new field)
         refactored_model = '''

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -12,11 +12,16 @@ identity gate (OMN-13412) and the recurrence guard for the OMN-13402/OMN-13405
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 from packaging.version import Version
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
 
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_release_identity.py"
 
@@ -123,7 +128,16 @@ def test_live_invocation_smoke():
     """
     repo = _SCRIPT.resolve().parents[1]
     smoke_tag = "v0.45.999999"
-    subprocess.run(["git", "tag", "-f", smoke_tag, "HEAD"], cwd=repo, check=True)
+    # OMN-14891: this test deliberately targets the real repo, but it must do so
+    # via cwd= rather than whatever GIT_DIR a git hook exported — otherwise the
+    # tag lands in an unrelated worktree's gitdir and the finally: below deletes
+    # a tag it never created.
+    subprocess.run(
+        ["git", "tag", "-f", smoke_tag, "HEAD"],
+        cwd=repo,
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
     try:
         result = subprocess.run(
             ["python", str(_SCRIPT)],
@@ -135,4 +149,9 @@ def test_live_invocation_smoke():
         assert result.returncode == 0, result.stderr
         assert "ahead of latest published" in result.stdout
     finally:
-        subprocess.run(["git", "tag", "-d", smoke_tag], cwd=repo, check=False)
+        subprocess.run(
+            ["git", "tag", "-d", smoke_tag],
+            cwd=repo,
+            check=False,
+            env=scrub_git_location_env(os.environ),
+        )

--- a/tests/unit/scripts/ci/test_detect_test_paths_cli.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_cli.py
@@ -5,9 +5,14 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
@@ -108,6 +113,9 @@ def _init_repo_with_base_pyproject(repo: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
+        # OMN-14891: without this, an inherited GIT_DIR from a git hook makes
+        # rev-parse report the REAL worktree's HEAD instead of this tmp repo's.
+        env=scrub_git_location_env(os.environ),
     ).stdout.strip()
 
 

--- a/tests/unit/test_git_env_isolation.py
+++ b/tests/unit/test_git_env_isolation.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression proof for the OMN-14891 git-environment hijack.
+
+Git exports ``GIT_DIR`` / ``GIT_WORK_TREE`` / ``GIT_INDEX_FILE`` /
+``GIT_COMMON_DIR`` into every hook environment, and those variables OVERRIDE both
+``cwd=`` and ``git -C``. A test fixture doing ``subprocess.run(["git", "init"],
+cwd=tmp_path)`` therefore mutates the REAL invoking worktree when pytest runs
+under this repo's pre-push hook.
+
+WHY THIS FILE IS NOT VACUOUS
+----------------------------
+A test that merely asserts "``GIT_DIR`` is not in ``os.environ``" is worthless:
+it passes for free whenever pytest happens to be launched from a normal shell,
+which is exactly the condition under which the bug is invisible. So the proof
+here is a DISCRIMINATOR PAIR over the same helper and the same child script:
+
+* :func:`test_inherited_git_dir_hijacks_unguarded_git_calls` is the NEGATIVE
+  CONTROL. It runs the child WITHOUT the scrub and asserts the decoy repo IS
+  corrupted. If this assertion ever stops holding, the harness has stopped
+  reproducing the defect and the sibling test below has become vacuous — so the
+  suite goes red rather than silently green.
+* :func:`test_scrub_prevents_inherited_git_dir_hijack` runs the identical child
+  WITH the scrub and asserts the decoy is untouched while the intended tmp repo
+  is written.
+
+Neither test can pass by accident: the pair only goes green when the fake
+``GIT_DIR`` is demonstrably load-bearing AND the scrub demonstrably defeats it.
+
+Every git invocation below is itself guarded via ``scrub_git_location_env`` — a
+test for this hazard must not be an instance of it.
+
+Tickets: OMN-14891 (this defect), OMN-14744 (the per-file fix that did not hold),
+OMN-14892 (index corruption under the same full-suite run).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    GIT_DISCOVERY_ENV_VARS,
+    GIT_LOCATION_ENV_VARS,
+    scrub_git_location_env,
+    strip_git_location_env,
+)
+
+pytestmark = pytest.mark.unit
+
+# A value that cannot plausibly occur in any real git config.
+SENTINEL_EMAIL = "hijack@omn14891.invalid"
+SENTINEL_NAME = "omn14891-hijack-probe"
+
+# The child program. `SCRUB` is substituted with either the real scrub call or a
+# no-op, so the hijacked and guarded runs execute byte-identical git operations
+# and differ only in whether the environment was cleaned.
+_CHILD_PROGRAM = """\
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, {src!r})
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    strip_git_location_env,
+)
+
+work = {work!r}
+
+{scrub}
+
+# Deliberately UNGUARDED, exactly as the polluting fixtures were written: no
+# env= keyword, so this inherits whatever git overrides are in the environment.
+subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+subprocess.run(
+    ["git", "config", "user.email", {email!r}], cwd=work, check=True
+)
+subprocess.run(["git", "config", "user.name", {name!r}], cwd=work, check=True)
+"""
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run git against ``repo`` with a scrubbed environment."""
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env=scrub_git_location_env(os.environ),
+    )
+
+
+def _make_decoy_repo(tmp_path: Path) -> Path:
+    """A throwaway stand-in for the real invoking worktree. Never the real repo."""
+    decoy = tmp_path / "decoy_worktree"
+    decoy.mkdir()
+    _git(decoy, "init", "-q")
+    return decoy
+
+
+def _run_child(
+    work: Path, decoy: Path, *, scrub: bool
+) -> subprocess.CompletedProcess[str]:
+    """Run the fixture-style git operations in a child that inherits GIT_DIR."""
+    work.mkdir(parents=True, exist_ok=True)
+    src = str(Path(__file__).resolve().parents[2] / "src")
+    program = _CHILD_PROGRAM.format(
+        src=src,
+        work=str(work),
+        email=SENTINEL_EMAIL,
+        name=SENTINEL_NAME,
+        scrub=(
+            "strip_git_location_env(os.environ)"
+            if scrub
+            else "# scrub deliberately omitted (negative control)"
+        ),
+    )
+    script = work.parent / f"child_{'guarded' if scrub else 'hijacked'}.py"
+    script.write_text(program, encoding="utf-8")
+
+    # Start from a clean environment, then inject the FAKE overrides a git hook
+    # would export. The fake GIT_DIR points at the decoy, never the real repo.
+    child_env = scrub_git_location_env(os.environ)
+    child_env["GIT_DIR"] = str(decoy / ".git")
+    child_env["GIT_WORK_TREE"] = str(decoy)
+    child_env["GIT_INDEX_FILE"] = str(decoy / ".git" / "index")
+
+    return subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+
+
+def _decoy_config(decoy: Path) -> str:
+    return (decoy / ".git" / "config").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# negative control: the fake GIT_DIR must genuinely be load-bearing
+# ---------------------------------------------------------------------------
+
+
+def test_inherited_git_dir_hijacks_unguarded_git_calls(tmp_path: Path) -> None:
+    """WITHOUT the scrub, an inherited GIT_DIR redirects git at the decoy repo.
+
+    This is the reproduction. It asserts the DAMAGE happens, which is what makes
+    the guarded sibling test below a real proof instead of a tautology.
+    """
+    decoy = _make_decoy_repo(tmp_path)
+    assert SENTINEL_EMAIL not in _decoy_config(decoy)
+
+    result = _run_child(tmp_path / "unguarded_work", decoy, scrub=False)
+    assert result.returncode == 0, result.stderr
+
+    hijacked = _decoy_config(decoy)
+    assert SENTINEL_EMAIL in hijacked, (
+        "the fake GIT_DIR did not redirect the child's git calls, so this test "
+        "cannot prove anything about the scrub — the harness is broken"
+    )
+    assert SENTINEL_NAME in hijacked
+
+
+# ---------------------------------------------------------------------------
+# the fix
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_prevents_inherited_git_dir_hijack(tmp_path: Path) -> None:
+    """WITH the scrub, the identical operations leave the decoy untouched."""
+    decoy = _make_decoy_repo(tmp_path)
+    work = tmp_path / "guarded_work"
+
+    result = _run_child(work, decoy, scrub=True)
+    assert result.returncode == 0, result.stderr
+
+    guarded = _decoy_config(decoy)
+    assert SENTINEL_EMAIL not in guarded, (
+        f"OMN-14891 regression: git wrote into the directory named by GIT_DIR "
+        f"({decoy / '.git'}) despite cwd={work}"
+    )
+    assert SENTINEL_NAME not in guarded
+    assert "bare = true" not in guarded, (
+        "OMN-14891 regression: `git init` re-initialised the GIT_DIR target as "
+        "bare — the exact mutation observed on the shared canonical clone"
+    )
+
+    # The operations must still have DONE something; a scrub that broke git
+    # would pass the assertions above for the wrong reason.
+    assert SENTINEL_EMAIL in (work / ".git" / "config").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# the session fixture itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("variable", [*GIT_LOCATION_ENV_VARS, *GIT_DISCOVERY_ENV_VARS])
+def test_session_fixture_scrubs_git_variable(variable: str) -> None:
+    """The autouse session fixture in tests/conftest.py removed each override."""
+    assert variable not in os.environ
+
+
+def test_no_git_config_override_survives() -> None:
+    assert [key for key in os.environ if key.startswith("GIT_CONFIG")] == []
+
+
+def test_strip_reports_and_removes(tmp_path: Path) -> None:
+    environ = {
+        "GIT_DIR": "/x/.git",
+        "GIT_WORK_TREE": "/x",
+        "GIT_CONFIG_GLOBAL": "/x/gitconfig",
+        "PATH": "/usr/bin",
+        "GIT_AUTHOR_NAME": "kept",
+    }
+    removed = strip_git_location_env(environ)
+
+    assert set(removed) == {"GIT_DIR", "GIT_WORK_TREE", "GIT_CONFIG_GLOBAL"}
+    # Identity and PATH must survive, or every committing fixture breaks.
+    assert environ == {"PATH": "/usr/bin", "GIT_AUTHOR_NAME": "kept"}

--- a/tests/unit/validators/test_no_unguarded_git_subprocess.py
+++ b/tests/unit/validators/test_no_unguarded_git_subprocess.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the unguarded-git-subprocess guard (OMN-14891).
+
+The guard must FAIL CLOSED on any git shell-out in tests/ that can inherit
+GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_COMMON_DIR from a git hook, while
+staying silent on legitimately-scrubbed calls and on the many non-call
+occurrences of the string ``"git"`` that already exist in this suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    GIT_LOCATION_ENV_VARS,
+    main,
+    validate_paths,
+    validate_source,
+)
+
+pytestmark = pytest.mark.unit
+
+FAKE = Path("tests/unit/fake_test_module.py")
+
+
+# ---------------------------------------------------------------------------
+# must FIRE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'subprocess.run(["git", "init"], cwd=repo, check=True)',
+        'subprocess.run(["git", "-C", str(repo), "add", "."], check=True)',
+        'subprocess.check_call(["git", "commit", "-m", "x"], cwd=repo)',
+        'subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo)',
+        'subprocess.Popen(["git", "status"], cwd=repo)',
+        'subprocess.call(["git", "status"], cwd=repo)',
+        'subprocess.run(("git", "init"), cwd=repo)',
+    ],
+)
+def test_unguarded_git_call_is_flagged(source: str) -> None:
+    assert len(validate_source(FAKE, source)) == 1
+
+
+def test_env_copied_from_os_environ_is_not_a_scrub() -> None:
+    """`env=os.environ.copy()` inherits every override — the exact defect."""
+    findings = validate_source(
+        FAKE, 'subprocess.run(["git", "init"], cwd=repo, env=os.environ.copy())'
+    )
+    assert len(findings) == 1
+    assert "without removing" in findings[0].reason
+
+
+def test_partial_scrub_is_not_a_scrub() -> None:
+    """A helper that misses even one location variable must still fail."""
+    source = """
+import os
+import subprocess
+
+
+def _git(repo, *args):
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE"):
+        env.pop(key, None)
+    return subprocess.run(["git", *args], cwd=repo, env=env)
+"""
+    assert len(validate_source(FAKE, source)) == 1
+
+
+def test_git_config_global_is_rejected_even_when_scrubbed() -> None:
+    """An env scrub fixes location; it cannot stop a deliberate global write."""
+    source = (
+        'subprocess.run(["git", "config", "--global", "user.email", "x@y.z"], '
+        "env=scrub_git_location_env(os.environ))"
+    )
+    findings = validate_source(FAKE, source)
+    assert len(findings) == 1
+    assert "--global" in findings[0].reason
+
+
+def test_git_config_system_is_rejected() -> None:
+    source = (
+        'subprocess.run(["git", "config", "--system", "x", "y"], '
+        "env=scrub_git_location_env(os.environ))"
+    )
+    assert len(validate_source(FAKE, source)) == 1
+
+
+# ---------------------------------------------------------------------------
+# must NOT fire
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_helper_is_accepted() -> None:
+    source = (
+        'subprocess.run(["git", "init"], cwd=repo, '
+        "env=scrub_git_location_env(os.environ))"
+    )
+    assert validate_source(FAKE, source) == []
+
+
+def test_full_replacement_env_is_accepted() -> None:
+    """A replacement environment cannot inherit GIT_DIR by construction."""
+    source = 'subprocess.run(["git", "init"], cwd=repo, env={"PATH": "/usr/bin"})'
+    assert validate_source(FAKE, source) == []
+
+
+def test_replacement_env_reading_os_environ_is_rejected() -> None:
+    """`{**os.environ}` looks like a literal but still inherits everything."""
+    source = 'subprocess.run(["git", "init"], cwd=repo, env={**os.environ})'
+    assert len(validate_source(FAKE, source)) == 1
+
+
+def test_inline_scrub_in_enclosing_function_is_accepted() -> None:
+    """The shape the pre-existing per-file fixes use."""
+    keys = ",\n        ".join(f'"{name}"' for name in GIT_LOCATION_ENV_VARS)
+    source = f"""
+import os
+import subprocess
+
+
+def _git(repo, *args):
+    env = os.environ.copy()
+    for key in (
+        {keys},
+    ):
+        env.pop(key, None)
+    return subprocess.run(["git", *args], cwd=repo, env=env)
+"""
+    assert validate_source(FAKE, source) == []
+
+
+def test_scrubbing_helper_referenced_by_name_is_accepted() -> None:
+    keys = ",\n        ".join(f'"{name}"' for name in GIT_LOCATION_ENV_VARS)
+    source = f"""
+import os
+import subprocess
+
+
+def _base_env():
+    env = dict(os.environ)
+    for key in (
+        {keys},
+    ):
+        env.pop(key, None)
+    return env
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=repo, env={{**_base_env()}})
+"""
+    assert validate_source(FAKE, source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # `git` as a dict key, not a program.
+        'config = {"permissions": {"git": {"commit": False}}}',
+        # `git` as a plain value.
+        'fields["mutation_verb"] = "git"',
+        'assert "git" not in load_runtime_ops_verb_allowlist()',
+        # `git` as an exception argument, not an argv.
+        'raise subprocess.TimeoutExpired("git", 60)',
+        # source code *about* a git call, held in a string literal.
+        'src = \'subprocess.run([\\"git\\", \\"status\\"])\'',
+        # a non-git program.
+        'subprocess.run(["python", str(script)], cwd=repo)',
+        # git appears as an argument, not the program.
+        'subprocess.run(["sudo", "git", "status"], cwd=repo)',
+    ],
+)
+def test_non_call_occurrences_do_not_fire(source: str) -> None:
+    assert validate_source(FAKE, source) == []
+
+
+def test_dynamic_argv_is_not_flagged() -> None:
+    """A non-literal argv carries no static evidence; it is out of scope."""
+    assert validate_source(FAKE, "subprocess.run(argv, cwd=repo)") == []
+
+
+# ---------------------------------------------------------------------------
+# self-scan + CLI
+# ---------------------------------------------------------------------------
+
+
+def test_repo_tests_tree_is_clean() -> None:
+    """The live regression: tests/ must contain no unguarded git call.
+
+    This is what turns the guard from detection into enforcement — it fails the
+    moment anyone reintroduces the OMN-14891 shape anywhere under tests/.
+    """
+    tests_root = Path(__file__).resolve().parents[2]
+    findings = validate_paths([tests_root])
+    assert findings == [], "\n".join(finding.format() for finding in findings)
+
+
+def test_guard_itself_is_not_flagged() -> None:
+    """The scrub helper and this suite must not trip their own gate."""
+    here = Path(__file__).resolve()
+    assert validate_paths([here]) == []
+
+
+def test_main_returns_nonzero_on_violation(tmp_path: Path) -> None:
+    offender = tmp_path / "test_offender.py"
+    offender.write_text(
+        'import subprocess\nsubprocess.run(["git", "init"], cwd="/tmp")\n',
+        encoding="utf-8",
+    )
+    assert main([str(offender)]) == 1
+
+
+def test_main_returns_zero_when_clean(tmp_path: Path) -> None:
+    clean = tmp_path / "test_clean.py"
+    clean.write_text("x = 1\n", encoding="utf-8")
+    assert main([str(clean)]) == 0

--- a/tests/validation/test_pull_request_workflow_ratchet.py
+++ b/tests/validation/test_pull_request_workflow_ratchet.py
@@ -13,7 +13,7 @@ not watch reject something is decorative).
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -23,6 +23,7 @@ from omnibase_core.models.validation.model_workflow_ratchet_gap import (
     WORKFLOW_RATCHET_GAP_CODES,
 )
 from omnibase_core.validation.validator_pull_request_workflow_ratchet import (
+    _validate_waivers,
     live_pull_request_workflows,
     triggers_on_pull_request,
     verify_pull_request_workflow_ratchet,
@@ -306,8 +307,21 @@ def test_gap_codes_are_closed_set() -> None:
 
 
 def test_live_pull_request_workflows_matches_registry() -> None:
-    """Sanity: the helper's live enumeration equals the registry allowlist on the
-    real repo (no waivers at baseline)."""
+    """Sanity: the helper's live enumeration equals the registry allowlist plus
+    the ACTIVE waived files on the real repo.
+
+    Waiver semantics are the validator's own ``_validate_waivers`` (one canonical
+    semantic — imported, not replicated): a waiver counts as ACTIVE only when it
+    is a mapping carrying all required fields (workflow_file/ticket/expires/
+    justification/retires), its ``expires`` parses as an ISO date, and
+    ``expires >= today`` (the validator flags ``expires < today`` as
+    WAIVER_EXPIRED). Any waiver that contributes a gap — expired, incomplete, or
+    malformed — drops out of the active set here, so this test goes RED the day a
+    waiver lapses instead of silently extending the exemption (fail-closed)."""
     live = set(live_pull_request_workflows(REPO_ROOT / ".github" / "workflows"))
     registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
-    assert live == set(registry["allowlisted_workflows"])
+    waived, waiver_gaps = _validate_waivers(
+        registry.get("waivers", []) or [], datetime.now(UTC).date()
+    )
+    active_waived = waived - {gap.workflow_file for gap in waiver_gaps}
+    assert live == set(registry["allowlisted_workflows"]) | active_waived

--- a/tests/validation/test_standalone_validator_workflow_registry.py
+++ b/tests/validation/test_standalone_validator_workflow_registry.py
@@ -52,7 +52,7 @@ def test_decorative_debt_is_the_reported_count(tmp_path: Path) -> None:
     fail loud. Migrating an entry to `migrated_into_ci_yml` legitimately lowers
     this number — update the constant in the same PR as the migration."""
     manifest = yaml.safe_load(DEBT_MANIFEST_PATH.read_text(encoding="utf-8"))
-    assert len(manifest["decorative_debt"]) == 18
+    assert len(manifest["decorative_debt"]) == 19
 
 
 def test_planted_undeclared_standalone_validator_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## OMN-14891 — systemic git-environment isolation for the test suite

Evidence-Ticket: OMN-14891

Closes OMN-14891.

### What this changes
- **Session-level git-env scrub in `tests/conftest.py`**: a session-scoped fixture unsets `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` / `GIT_COMMON_DIR` for the whole test session. Those variables **override** `cwd=` and `git -C`, so a `tmp_path` test that shells out to git while inheriting them from a pre-push hook mutates the **real invoking worktree** — observed twice (`core.bare=true` + a bogus `[user]` block + ~6707 phantom staged deletions on the shared canonical clone).
- **`no-unguarded-git-subprocess` guard** (`src/omnibase_core/validators/no_unguarded_git_subprocess.py` + `model_git_subprocess_finding.py`), wired as a pre-commit hook and registered **ADVISORY** in `.github/required-checks.yaml` (plus `.github/workflows/validator-no-unguarded-git-subprocess.yml`). It blocks reintroduction of an unguarded git subprocess in `tests/`.
- **RED-proven discriminator regression pair**: `tests/unit/test_git_env_isolation.py` and `tests/unit/validators/test_no_unguarded_git_subprocess.py` fail against the pre-fix state and pass after.

### Key finding (why session-level scrub, not more per-file patches)
Of the 5 known polluters, 4 were already hand-patched (OMN-14744) and correct — yet **two entirely un-listed files were still polluting**: `tests/integration/test_validation_integration.py` (12 sites) and `tests/scripts/test_check_release_identity.py` (2 sites). That is direct evidence **per-file patching does not hold**; the correct fix is the session-level scrub plus a gate that blocks regression.

### Owed follow-ups (not in this PR)
1. Flip the `no-unguarded-git-subprocess` gate **advisory → required** after 2 consecutive green runs.
2. **Fan the hook to `omnibase_infra`** per the OMN-14744 recurrence.

### Notes
- **occ-preflight** is expected to stay red pending a **Codex-authored OCC companion** — deliberately not self-authored.
- **Naming-blocker history**: the branch was rebased onto `dev@d55b7050` (OMN-14925 / #1480), which aligns the local pre-push naming hook to the CI-canonical baseline-aware validator (`validate_class_naming.py`). Before that fix, the branch's pre-push was blocked by the old raw `validate_naming.py src/` full-scan failing on 29 pre-existing baselined violations (none from this branch — its own two src files are clean). Post-rebase the naming hook passes.
- **Recovery note**: after the local push attempt (~8h) was externally terminated, this branch was pushed from the fleet box `omninode-pc` with pre-push + pre-commit hooks installed (readback-verified) and the full omnibase_core unit suite run there. The run was **consolidated after a duplicate-launch collision** (a second concurrent push of the same branch was stopped so a single clean run produced the result).

---

## Re-drive provenance (session fable-gwexec-0722)

This branch's first pre-push run ended in an **honest RED** (30 failed / 43,206 passed, 10h14m serial) and was **fully triaged** before this landing — no bypass at any point:
- **3 failures were the branch's own** (2 ratchet + 1 debt-registry), fixed by 2 yaml registrations (waiver entry in `pull-request-workflow-budget.yaml` + `decorative_debt` entry in `standalone-validator-debt.yaml`) plus 2 sanctioned test evolutions (waiver-aware ratchet assertion mirroring the validator's own expiry semantics + the debt-registry count bump its own docstring mandates). An adversarial expired-waiver check confirmed the evolved assertion stays fail-closed.
- **27 failures were pre-existing dev-latent test pollution** (sys.modules-purge ordering), reproduced test-ID-identical on the pure dev base with this branch absent — tracked as **OMN-14944** (pollution) + **OMN-14945** (pytest.ini precedence that dropped xdist/reruns and unmasked them). NOT this branch's defect.
- This landing re-ran with the hook's own supported `PREPUSH_PYTEST_ARGS="-n 12 --reruns 2"` knob (CI-equivalent xdist profile): **43,236 passed / 0 failed** in 47m, governed selector hook Passed, PUSH_EXIT=0.

proof: box terminal summary 2026-07-22T20:56Z, ground-truth `git ls-remote` SHA fbb4f7a8.

Evidence-Source: OCC#4608
Evidence-Commit: 0f660d209381b7b933664dd34514742ddf894890
