### PR TITLE
fix(OMN-14944): restore sys.modules on omnibase_core purge; RegistryNode.model_rebuild()

### DIFF
--- a/src/omnibase_core/navigation/model_contract_graph.py
+++ b/src/omnibase_core/navigation/model_contract_graph.py
@@ -344,6 +344,20 @@ class RegistryTransitionDecl(BaseModel):
     label: str = Field(default="")
 
 
+# RegistryNode declares `declared_transitions: tuple[RegistryTransitionDecl, ...]`
+# as a forward reference (this module uses `from __future__ import annotations`).
+# Pydantic resolves that forward reference lazily via
+# `sys.modules[cls.__module__].__dict__` the first time RegistryNode is
+# constructed or validated. If this module has ever been evicted from and
+# re-added to `sys.modules` (e.g. a test that purges `omnibase_core.*` entries
+# from `sys.modules` -- see OMN-14944), that lazy lookup can go stale and the
+# first construction after re-import raises
+# `PydanticUserError: RegistryNode is not fully defined`. Rebuilding explicitly
+# here, once RegistryTransitionDecl exists in this module's namespace, removes
+# the dependency on sys.modules staying pristine at first-use time.
+RegistryNode.model_rebuild()
+
+
 class RegistrySnapshot(BaseModel):
     """A point-in-time snapshot of the node registry.
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+conftest.py for tests/unit.
+
+Provides :func:`isolated_sys_modules`, a context manager used by tests that
+need to force a fresh import of ``omnibase_core`` (or a submodule) by
+evicting matching entries from ``sys.modules``.
+
+Restoring the evicted entries on exit is mandatory. Several tests
+historically did ``del sys.modules[mod]`` in a bare loop with no restore,
+which permanently evicted the matched ``omnibase_core.*`` entries from the
+interpreter's module cache for the rest of that pytest worker process. Any
+later test in the same process that performed a local/deferred import of an
+evicted module forced a fresh re-execution of that module (and everything
+it transitively imports), minting NEW class objects (enums, exceptions,
+Pydantic models) distinct from the ones already bound at collection time
+elsewhere in the process. That produced identity-based failures
+(``EnumExecutionMode.CONDITIONAL not in {...}`` even though both sides
+print identically) and Pydantic forward-ref resolution breaks
+(``RegistryNode is not fully defined``) in tests that have nothing to do
+with the actual purge. See OMN-14944.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def isolated_sys_modules(predicate: Callable[[str], bool]) -> Iterator[None]:
+    """Temporarily evict ``sys.modules`` entries whose key matches ``predicate``.
+
+    All evicted entries are restored (the exact same module objects put
+    back) when the context exits -- including when the block raises -- so
+    no test can permanently leak a module-cache eviction into later tests
+    running in the same process. Entries newly imported *during* the block
+    are left in place on exit (that is ordinary caching behavior, not a
+    leak); only entries that existed before the block and were evicted by
+    it are restored.
+    """
+    removed = {key: mod for key, mod in sys.modules.items() if predicate(key)}
+    for key in removed:
+        del sys.modules[key]
+    try:
+        yield
+    finally:
+        sys.modules.update(removed)

--- a/tests/unit/test_init_exports.py
+++ b/tests/unit/test_init_exports.py
@@ -17,6 +17,8 @@ import time
 
 import pytest
 
+from tests.unit.conftest import isolated_sys_modules
+
 
 @pytest.mark.unit
 class TestInitExports:
@@ -68,19 +70,14 @@ class TestInitImportPerformance:
 
     def test_init_import_time_acceptable(self):
         """Test that importing omnibase_core is fast (lazy loading works)."""
-        # Clear cached imports
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if key.startswith("omnibase_core") and key != "omnibase_core.__init__"
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: key.startswith("omnibase_core")
+            and key != "omnibase_core.__init__"
+        ):
+            # Time the import
+            start = time.perf_counter()
 
-        # Time the import
-        start = time.perf_counter()
-
-        import_time_ms = (time.perf_counter() - start) * 1000
+            import_time_ms = (time.perf_counter() - start) * 1000
 
         # Import should be fast (< 100ms for lazy loading)
         # This is a reasonable threshold for lazy loading
@@ -90,36 +87,30 @@ class TestInitImportPerformance:
 
     def test_init_lazy_loading_delays_validation_imports(self):
         """Test that validation modules are not imported until accessed."""
-        # Clear cached validation imports
-        modules_to_remove = [
-            key for key in list(sys.modules.keys()) if "omnibase_core.validation" in key
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(lambda key: "omnibase_core.validation" in key):
+            # Import main module
+            import omnibase_core
 
-        # Import main module
-        import omnibase_core
+            # Validation modules should NOT be imported yet
+            validation_modules = [
+                key
+                for key in sys.modules
+                if "omnibase_core.validation" in key and key != "omnibase_core"
+            ]
+            assert len(validation_modules) == 0, (
+                f"Validation modules imported too early: {validation_modules}"
+            )
 
-        # Validation modules should NOT be imported yet
-        validation_modules = [
-            key
-            for key in sys.modules
-            if "omnibase_core.validation" in key and key != "omnibase_core"
-        ]
-        assert len(validation_modules) == 0, (
-            f"Validation modules imported too early: {validation_modules}"
-        )
+            # Now access a validation function - should trigger lazy import
+            _ = omnibase_core.validate_architecture
 
-        # Now access a validation function - should trigger lazy import
-        _ = omnibase_core.validate_architecture
-
-        # Now validation modules SHOULD be imported
-        validation_modules = [
-            key for key in sys.modules if "omnibase_core.validation" in key
-        ]
-        assert len(validation_modules) > 0, (
-            "Lazy loading did not import validation modules"
-        )
+            # Now validation modules SHOULD be imported
+            validation_modules = [
+                key for key in sys.modules if "omnibase_core.validation" in key
+            ]
+            assert len(validation_modules) > 0, (
+                "Lazy loading did not import validation modules"
+            )
 
 
 @pytest.mark.unit
@@ -128,20 +119,14 @@ class TestInitCircularImports:
 
     def test_init_no_circular_imports(self):
         """Test that importing omnibase_core does not cause circular imports."""
-        # Clear all omnibase_core imports
-        modules_to_remove = [
-            key for key in list(sys.modules.keys()) if key.startswith("omnibase_core")
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+            # Should import without circular import errors
+            try:
+                import omnibase_core
 
-        # Should import without circular import errors
-        try:
-            import omnibase_core
-
-            assert omnibase_core is not None
-        except ImportError as e:
-            pytest.fail(f"Circular import detected: {e}")
+                assert omnibase_core is not None
+            except ImportError as e:
+                pytest.fail(f"Circular import detected: {e}")
 
     def test_init_getattr_handles_missing_attributes(self):
         """Test that __getattr__ raises proper error for missing attributes."""
@@ -236,40 +221,26 @@ class TestInitLazyLoadingBehavior:
 
     def test_init_lazy_load_error_classes(self):
         """Test that error classes are lazily loaded through __getattr__."""
-        # Clear cached imports
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if key.startswith("omnibase_core.errors")
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(lambda key: key.startswith("omnibase_core.errors")):
+            # Access error classes through lazy loading
+            from omnibase_core import EnumCoreErrorCode, ModelOnexError
 
-        # Access error classes through lazy loading
-        from omnibase_core import EnumCoreErrorCode, ModelOnexError
-
-        assert EnumCoreErrorCode is not None
-        assert ModelOnexError is not None
+            assert EnumCoreErrorCode is not None
+            assert ModelOnexError is not None
 
     def test_init_lazy_load_validation_functions(self):
         """Test that validation functions are lazily loaded through __getattr__."""
-        # Clear cached validation imports
-        modules_to_remove = [
-            key for key in list(sys.modules.keys()) if "omnibase_core.validation" in key
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(lambda key: "omnibase_core.validation" in key):
+            # Access validation functions through lazy loading
+            from omnibase_core import (
+                ModelValidationResult,
+                validate_all,
+                validate_architecture,
+            )
 
-        # Access validation functions through lazy loading
-        from omnibase_core import (
-            ModelValidationResult,
-            validate_all,
-            validate_architecture,
-        )
-
-        assert ModelValidationResult is not None
-        assert validate_all is not None
-        assert validate_architecture is not None
+            assert ModelValidationResult is not None
+            assert validate_all is not None
+            assert validate_architecture is not None
 
     def test_init_multiple_lazy_loads_return_same_object(self):
         """Test that multiple lazy loads return the same object instance."""

--- a/tests/unit/test_init_fast.py
+++ b/tests/unit/test_init_fast.py
@@ -9,6 +9,8 @@ Tests lazy loading of validation tools to prevent import-time penalties.
 
 import pytest
 
+from tests.unit.conftest import isolated_sys_modules
+
 
 @pytest.mark.unit
 class TestLazyValidationLoading:
@@ -46,23 +48,18 @@ class TestLazyValidationLoading:
         import sys
 
         # Remove validation modules if already imported
-        modules_to_remove = [
-            key
-            for key in sys.modules
-            if "omnibase_core.validation" in key and key != "omnibase_core"
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: "omnibase_core.validation" in key and key != "omnibase_core"
+        ):
+            # Import just the main module
 
-        # Import just the main module
-
-        # Validation modules should NOT be imported yet
-        validation_modules = [
-            key for key in sys.modules if "omnibase_core.validation" in key
-        ]
-        assert len(validation_modules) == 0, (
-            "Validation modules imported at module level (not lazy)"
-        )
+            # Validation modules should NOT be imported yet
+            validation_modules = [
+                key for key in sys.modules if "omnibase_core.validation" in key
+            ]
+            assert len(validation_modules) == 0, (
+                "Validation modules imported at module level (not lazy)"
+            )
 
     def test_get_validation_suite_returns_correct_types(self):
         """Test that get_validation_suite returns ModelValidationResult, ServiceValidationSuite, and validate_all."""
@@ -137,29 +134,24 @@ class TestLazyValidationLoading:
         import time
 
         # Clear any cached validation imports
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if "omnibase_core.validation" in key and key != "omnibase_core"
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: "omnibase_core.validation" in key and key != "omnibase_core"
+        ):
+            # Import main module - should be fast
+            start = time.perf_counter()
+            from omnibase_core.__init___fast import get_validation_tools
 
-        # Import main module - should be fast
-        start = time.perf_counter()
-        from omnibase_core.__init___fast import get_validation_tools
+            import_time = (time.perf_counter() - start) * 1000
 
-        import_time = (time.perf_counter() - start) * 1000
+            # Accessing the function should not trigger imports
+            start_access = time.perf_counter()
+            tools_func = get_validation_tools
+            access_time = (time.perf_counter() - start_access) * 1000
 
-        # Accessing the function should not trigger imports
-        start_access = time.perf_counter()
-        tools_func = get_validation_tools
-        access_time = (time.perf_counter() - start_access) * 1000
-
-        # Verify no validation modules loaded yet
-        validation_modules = [
-            key for key in sys.modules if "omnibase_core.validation." in key
-        ]
+            # Verify no validation modules loaded yet
+            validation_modules = [
+                key for key in sys.modules if "omnibase_core.validation." in key
+            ]
 
         # Should be minimal (not testing specific times, just that no cascade occurred)
         assert len(validation_modules) == 0, (

--- a/tests/unit/test_no_circular_imports.py
+++ b/tests/unit/test_no_circular_imports.py
@@ -22,6 +22,8 @@ from importlib import import_module
 
 import pytest
 
+from tests.unit.conftest import isolated_sys_modules
+
 
 def test_import_core_types():
     """Test that core types can be imported without issues."""
@@ -79,49 +81,46 @@ def test_no_circular_dependency_chain():
     This test verifies the chain can now be imported in any order.
     """
     # Clear any previously imported modules to test fresh imports
-    modules_to_test = [
+    modules_to_test = {
         "omnibase_core.errors.error_codes",
         "omnibase_core.models.common.model_schema_value",
         "omnibase_core.models.common.model_error_context",
         "omnibase_core.models.common.model_numeric_value",
         "omnibase_core.types.type_core",
-    ]
+    }
 
     # Remove from sys.modules if present (for clean test)
-    for mod_name in modules_to_test:
-        if mod_name in sys.modules:
-            del sys.modules[mod_name]
+    with isolated_sys_modules(lambda key: key in modules_to_test):
+        # Now try to import in the order that would trigger circular dependency
+        try:
+            # Step 1: Import error_codes (would try to import ModelSchemaValue)
+            error_codes_mod = import_module("omnibase_core.errors.error_codes")
+            assert error_codes_mod is not None
 
-    # Now try to import in the order that would trigger circular dependency
-    try:
-        # Step 1: Import error_codes (would try to import ModelSchemaValue)
-        error_codes_mod = import_module("omnibase_core.errors.error_codes")
-        assert error_codes_mod is not None
+            # Step 2: Import ModelSchemaValue (would try to import OnexError)
+            schema_value_mod = import_module(
+                "omnibase_core.models.common.model_schema_value"
+            )
+            assert schema_value_mod is not None
 
-        # Step 2: Import ModelSchemaValue (would try to import OnexError)
-        schema_value_mod = import_module(
-            "omnibase_core.models.common.model_schema_value"
-        )
-        assert schema_value_mod is not None
+            # Step 3: Import ModelErrorContext (would try to import OnexError)
+            error_context_mod = import_module(
+                "omnibase_core.models.common.model_error_context"
+            )
+            assert error_context_mod is not None
 
-        # Step 3: Import ModelErrorContext (would try to import OnexError)
-        error_context_mod = import_module(
-            "omnibase_core.models.common.model_error_context"
-        )
-        assert error_context_mod is not None
+            # Step 4: Import ModelNumericValue (would try to import OnexError)
+            numeric_value_mod = import_module(
+                "omnibase_core.models.common.model_numeric_value"
+            )
+            assert numeric_value_mod is not None
 
-        # Step 4: Import ModelNumericValue (would try to import OnexError)
-        numeric_value_mod = import_module(
-            "omnibase_core.models.common.model_numeric_value"
-        )
-        assert numeric_value_mod is not None
+            # If we got here, no circular imports!
+            print("✓ No circular dependencies detected")
 
-        # If we got here, no circular imports!
-        print("✓ No circular dependencies detected")
-
-    except ImportError as e:
-        # Circular import would raise ImportError
-        raise AssertionError(f"Circular import detected: {e}") from e
+        except ImportError as e:
+            # Circular import would raise ImportError
+            raise AssertionError(f"Circular import detected: {e}") from e
 
 
 def test_simple_error_context_functionality():
@@ -207,28 +206,25 @@ def test_import_chain_sequential() -> None:
     exist at module import time.
     """
     # Start with a clean slate - remove all omnibase_core modules
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        # Import in the correct order - each step should succeed
+        steps = [
+            ("types.type_core", "omnibase_core.types.type_core"),
+            ("errors.error_codes", "omnibase_core.errors.error_codes"),
+            (
+                "models.common.model_schema_value",
+                "omnibase_core.models.common.model_schema_value",
+            ),
+            ("types.type_constraints", "omnibase_core.types.type_constraints"),
+            ("models", "omnibase_core.models"),
+        ]
 
-    # Import in the correct order - each step should succeed
-    steps = [
-        ("types.type_core", "omnibase_core.types.type_core"),
-        ("errors.error_codes", "omnibase_core.errors.error_codes"),
-        (
-            "models.common.model_schema_value",
-            "omnibase_core.models.common.model_schema_value",
-        ),
-        ("types.type_constraints", "omnibase_core.types.type_constraints"),
-        ("models", "omnibase_core.models"),
-    ]
-
-    for step_name, module_name in steps:
-        try:
-            importlib.import_module(module_name)
-        except ImportError as e:
-            msg = f"Failed to import {step_name} ({module_name}): {e}"
-            raise AssertionError(msg) from e
+        for step_name, module_name in steps:
+            try:
+                importlib.import_module(module_name)
+            except ImportError as e:
+                msg = f"Failed to import {step_name} ({module_name}): {e}"
+                raise AssertionError(msg) from e
 
 
 def test_type_checking_imports_not_runtime() -> None:
@@ -305,36 +301,33 @@ def test_validation_functions_lazy_import() -> None:
     error_codes_preloaded = "omnibase_core.errors.error_codes" in sys.modules
 
     # Clear module cache
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
-
-    # Import types.constraints
-    from omnibase_core.types.type_constraints import (
-        validate_context_value,
-        validate_primitive_value,
-    )
-
-    # Test successful validation (should not trigger import)
-    assert validate_primitive_value("test")
-    assert validate_context_value("test")
-
-    # Test failed validation (should raise TypeError, not ModelOnexError)
-    try:
-        validate_primitive_value(object())  # Invalid type
-    except TypeError as e:
-        # Expected - validation should fail with TypeError
-        assert "Expected primitive value" in str(e)
-    else:
-        pytest.fail("validate_primitive_value should have raised TypeError")
-
-    # Verify error_codes is NOT imported (lazy import maintained)
-    # Skip this assertion if error_codes was already in sys.modules from
-    # another test in the same pytest-xdist worker process.
-    if not error_codes_preloaded:
-        assert "omnibase_core.errors.error_codes" not in sys.modules, (
-            "error_codes should NOT be imported (lazy import pattern maintained)"
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        # Import types.constraints
+        from omnibase_core.types.type_constraints import (
+            validate_context_value,
+            validate_primitive_value,
         )
+
+        # Test successful validation (should not trigger import)
+        assert validate_primitive_value("test")
+        assert validate_context_value("test")
+
+        # Test failed validation (should raise TypeError, not ModelOnexError)
+        try:
+            validate_primitive_value(object())  # Invalid type
+        except TypeError as e:
+            # Expected - validation should fail with TypeError
+            assert "Expected primitive value" in str(e)
+        else:
+            pytest.fail("validate_primitive_value should have raised TypeError")
+
+        # Verify error_codes is NOT imported (lazy import maintained)
+        # Skip this assertion if error_codes was already in sys.modules from
+        # another test in the same pytest-xdist worker process.
+        if not error_codes_preloaded:
+            assert "omnibase_core.errors.error_codes" not in sys.modules, (
+                "error_codes should NOT be imported (lazy import pattern maintained)"
+            )
 
 
 def test_import_order_documentation() -> None:
@@ -372,32 +365,31 @@ def test_error_codes_safe_imports() -> None:
     by importing from models or types.constraints at runtime.
     """
     # Clear module cache
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        # Import error_codes
 
-    # Import error_codes
+        # Check what omnibase_core modules were imported
+        imported_modules = [
+            key for key in sys.modules if key.startswith("omnibase_core")
+        ]
 
-    # Check what omnibase_core modules were imported
-    imported_modules = [key for key in sys.modules if key.startswith("omnibase_core")]
+        # error_codes should only import from safe modules
+        # It should NOT import from models.* or types.constraints
+        forbidden_imports = [
+            "omnibase_core.models.common.model_schema_value",
+            "omnibase_core.models.common.model_error_context",
+            "omnibase_core.types.type_constraints",
+            "omnibase_core.models.base",
+        ]
 
-    # error_codes should only import from safe modules
-    # It should NOT import from models.* or types.constraints
-    forbidden_imports = [
-        "omnibase_core.models.common.model_schema_value",
-        "omnibase_core.models.common.model_error_context",
-        "omnibase_core.types.type_constraints",
-        "omnibase_core.models.base",
-    ]
+        for forbidden in forbidden_imports:
+            if forbidden in imported_modules:
+                msg = f"error_codes has runtime import of {forbidden} - this will cause circular import!"
+                raise AssertionError(msg)
 
-    for forbidden in forbidden_imports:
-        if forbidden in imported_modules:
-            msg = f"error_codes has runtime import of {forbidden} - this will cause circular import!"
-            raise AssertionError(msg)
-
-    # Note: Previously checked for required imports like enum_onex_status,
-    # but these were removed as unused during tech debt cleanup.
-    # The important check is that forbidden imports are not present.
+        # Note: Previously checked for required imports like enum_onex_status,
+        # but these were removed as unused during tech debt cleanup.
+        # The important check is that forbidden imports are not present.
 
 
 def test_contracts_no_circular_imports() -> None:
@@ -415,29 +407,26 @@ def test_contracts_no_circular_imports() -> None:
     of module-level imports.
     """
     # Clear module cache
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        # Try to import the contract models in the order that would trigger circular import
+        try:
+            # Import model_contract_compute first
+            # Import contracts __init__ (aggregates all contract models)
+            import omnibase_core.models.contracts
+            import omnibase_core.models.contracts.model_contract_compute
 
-    # Try to import the contract models in the order that would trigger circular import
-    try:
-        # Import model_contract_compute first
-        # Import contracts __init__ (aggregates all contract models)
-        import omnibase_core.models.contracts
-        import omnibase_core.models.contracts.model_contract_compute
+            # Import model_validation_rules
+            import omnibase_core.models.contracts.model_validation_rules
 
-        # Import model_validation_rules
-        import omnibase_core.models.contracts.model_validation_rules
+            # Import model_validation_rules_converter
+            import omnibase_core.models.utils.model_validation_rules_converter  # noqa: F401
 
-        # Import model_validation_rules_converter
-        import omnibase_core.models.utils.model_validation_rules_converter  # noqa: F401
+            # If we got here, no circular imports!
+            print("✓ No circular dependencies in contracts modules")
 
-        # If we got here, no circular imports!
-        print("✓ No circular dependencies in contracts modules")
-
-    except ImportError as e:
-        # Circular import would raise ImportError
-        raise AssertionError(f"Circular import detected in contracts: {e}") from e
+        except ImportError as e:
+            # Circular import would raise ImportError
+            raise AssertionError(f"Circular import detected in contracts: {e}") from e
 
 
 def test_contract_compute_uses_lazy_import() -> None:
@@ -448,26 +437,25 @@ def test_contract_compute_uses_lazy_import() -> None:
     field validator function, not at module level.
     """
     # Clear module cache
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        # Import model_contract_compute
 
-    # Import model_contract_compute
+        # Check what modules were imported
+        imported_modules = [
+            key for key in sys.modules if key.startswith("omnibase_core")
+        ]
 
-    # Check what modules were imported
-    imported_modules = [key for key in sys.modules if key.startswith("omnibase_core")]
-
-    # model_validation_rules_converter should NOT be imported at module load time
-    # (it should only be imported when the field validator is actually called)
-    if (
-        "omnibase_core.models.utils.model_validation_rules_converter"
-        in imported_modules
-    ):
-        msg = (
-            "model_contract_compute has runtime import of model_validation_rules_converter "
-            "at module level - this creates circular import! Use lazy import in field validator instead."
-        )
-        raise AssertionError(msg)
+        # model_validation_rules_converter should NOT be imported at module load time
+        # (it should only be imported when the field validator is actually called)
+        if (
+            "omnibase_core.models.utils.model_validation_rules_converter"
+            in imported_modules
+        ):
+            msg = (
+                "model_contract_compute has runtime import of model_validation_rules_converter "
+                "at module level - this creates circular import! Use lazy import in field validator instead."
+            )
+            raise AssertionError(msg)
 
 
 @pytest.mark.unit
@@ -498,39 +486,36 @@ def test_fsm_package_no_circular_imports() -> None:
     its module directly rather than through fsm/__init__.py.
     """
     # Clear module cache to test fresh imports
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        try:
+            # Import through the fsm package init - this was the failing entry point
+            # Verify mixin can be imported
+            from omnibase_core.mixins.mixin_fsm_execution import (  # noqa: F401
+                MixinFSMExecution,
+            )
+            from omnibase_core.models.fsm import (  # noqa: F401
+                ModelFsmState,
+                ModelFSMStateSnapshot,
+                ModelFSMTransitionResult,
+            )
 
-    try:
-        # Import through the fsm package init - this was the failing entry point
-        # Verify mixin can be imported
-        from omnibase_core.mixins.mixin_fsm_execution import (  # noqa: F401
-            MixinFSMExecution,
-        )
-        from omnibase_core.models.fsm import (  # noqa: F401
-            ModelFsmState,
-            ModelFSMStateSnapshot,
-            ModelFSMTransitionResult,
-        )
+            # Also verify the direct module import works
+            from omnibase_core.models.fsm.model_fsm_state import (  # noqa: F401
+                ModelFsmState as DirectState,
+            )
 
-        # Also verify the direct module import works
-        from omnibase_core.models.fsm.model_fsm_state import (  # noqa: F401
-            ModelFsmState as DirectState,
-        )
+            # Verify util_fsm_executor can be imported and used
+            from omnibase_core.utils.util_fsm_executor import (  # noqa: F401
+                FSMState,
+                execute_transition,
+                get_initial_state,
+                validate_fsm_contract,
+            )
 
-        # Verify util_fsm_executor can be imported and used
-        from omnibase_core.utils.util_fsm_executor import (  # noqa: F401
-            FSMState,
-            execute_transition,
-            get_initial_state,
-            validate_fsm_contract,
-        )
-
-    except ImportError as e:
-        raise AssertionError(
-            f"Circular import detected in FSM package (OMN-2048 regression): {e}"
-        ) from e
+        except ImportError as e:
+            raise AssertionError(
+                f"Circular import detected in FSM package (OMN-2048 regression): {e}"
+            ) from e
 
 
 @pytest.mark.unit
@@ -549,32 +534,29 @@ def test_invariant_package_no_circular_imports() -> None:
     package init no longer eagerly imports util_invariant_yaml_parser.
     """
     # Clear module cache to test fresh imports
-    modules_to_remove = [key for key in sys.modules if key.startswith("omnibase_core")]
-    for module in modules_to_remove:
-        del sys.modules[module]
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        try:
+            # Import the module that was the cycle entry point
+            # Import the package init (would have triggered the cycle)
+            import omnibase_core.models.invariant as invariant_pkg
+            from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
+                load_invariant_set_from_file as _load_file,
+            )
+            from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
+                load_invariant_sets_from_directory as _load_dir,
+            )
+            from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
+                parse_invariant_set_from_yaml as _parse,
+            )
 
-    try:
-        # Import the module that was the cycle entry point
-        # Import the package init (would have triggered the cycle)
-        import omnibase_core.models.invariant as invariant_pkg
-        from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
-            load_invariant_set_from_file as _load_file,
-        )
-        from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
-            load_invariant_sets_from_directory as _load_dir,
-        )
-        from omnibase_core.utils.util_invariant_yaml_parser import (  # noqa: F401
-            parse_invariant_set_from_yaml as _parse,
-        )
+            # Verify the lazy-loaded functions are accessible via the package
+            assert hasattr(invariant_pkg, "load_invariant_set_from_file")
+            assert callable(invariant_pkg.load_invariant_set_from_file)
 
-        # Verify the lazy-loaded functions are accessible via the package
-        assert hasattr(invariant_pkg, "load_invariant_set_from_file")
-        assert callable(invariant_pkg.load_invariant_set_from_file)
-
-    except ImportError as e:
-        raise AssertionError(
-            f"Circular import detected in invariant package: {e}"
-        ) from e
+        except ImportError as e:
+            raise AssertionError(
+                f"Circular import detected in invariant package: {e}"
+            ) from e
 
 
 @pytest.mark.unit

--- a/tests/unit/test_omn_14944_sys_modules_purge_regression.py
+++ b/tests/unit/test_omn_14944_sys_modules_purge_regression.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Regression tests for OMN-14944.
+
+``del sys.modules[...]`` loops with no restore (used by several tests to
+force a fresh import of ``omnibase_core.*``) permanently evicted matched
+entries from the interpreter's module cache for the rest of that pytest
+worker process. Two independent downstream failure modes were confirmed:
+
+- B2 (enum identity split): a later local/deferred re-import of an evicted
+  module mints a NEW class object distinct from one already bound at
+  collection time elsewhere in the process (identity-based ``in`` /
+  ``==`` checks then fail even though both sides print identically).
+- B1 (Pydantic forward-ref break): ``RegistryNode`` in
+  ``model_contract_graph.py`` uses ``from __future__ import annotations``
+  and resolves its ``RegistryTransitionDecl`` forward reference lazily via
+  ``sys.modules[cls.__module__].__dict__``; once that module entry is
+  evicted, construction raises
+  ``PydanticUserError: RegistryNode is not fully defined``.
+
+These tests pin both minimal repros from the OMN-14944 diagnosis as
+permanent regressions.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.unit.conftest import isolated_sys_modules
+
+
+def test_init_purge_no_circular_imports_does_not_pollute_reserved_enum_validator() -> (
+    None
+):
+    """B2 regression: the exact minimal-repro pair from the OMN-14944 diagnosis.
+
+    Running ``test_init_no_circular_imports`` (an unconditional
+    ``omnibase_core.*`` purge) ahead of
+    ``TestCanonicalImportPaths`` in the same pytest process previously left
+    ``EnumExecutionMode`` (imported at collection time by the reserved-enum
+    validator test module) permanently desynced from the class object a
+    later local re-import inside the test bodies would mint -- failing
+    ``EnumExecutionMode.CONDITIONAL in RESERVED_EXECUTION_MODES`` by
+    identity. Restoring the purged ``sys.modules`` entries (OMN-14944 fix,
+    ``isolated_sys_modules`` in ``tests/unit/conftest.py``) makes this pair
+    pass in a single process. Invoked as a subprocess (not in-process) so
+    this test's own collection/imports cannot mask the ordering effect
+    under test.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        check=False,
+        args=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "tests/unit/test_init_exports.py::TestInitCircularImports::test_init_no_circular_imports",
+            "tests/unit/validation/test_validator_reserved_enum.py::TestCanonicalImportPaths",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        "sys.modules-purge pollution regressed (OMN-14944 B2):\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_registry_node_construction_survives_omnibase_core_purge() -> None:
+    """B1 regression: RegistryNode construction after an omnibase_core purge.
+
+    Direct-script proof from the OMN-14944 diagnosis, adapted to restore
+    ``sys.modules`` afterward via ``isolated_sys_modules`` so this
+    regression test does not itself become a ninth contaminator.
+    """
+    from omnibase_core.navigation.model_contract_graph import RegistryNode
+
+    with isolated_sys_modules(lambda key: key.startswith("omnibase_core")):
+        node = RegistryNode(node_id="n1", schema_version="1.0.0")
+
+    assert node.node_id == "n1"
+    assert node.schema_version == "1.0.0"


### PR DESCRIPTION
## Summary

Fixes OMN-14944: an interpreter-wide test-isolation leak in omnibase_core's unit test suite. Several tests forced a fresh `omnibase_core` import by evicting matching `sys.modules` entries with a bare `del sys.modules[key]` loop and **no restore**, permanently evicting those entries from the module cache for the rest of that pytest worker process.

Two independently confirmed downstream failure modes:

- **B2 (enum identity split):** a later test's local/deferred re-import of an evicted module (e.g. `tests/unit/validation/test_validator_reserved_enum.py`) forces a fresh re-execution of that module and its transitive imports, minting a **new** class object (`EnumExecutionMode`, `ModelOnexError`, ...) distinct from the one already bound at collection time elsewhere in the process. Identity-based `in`/`==` checks then fail even though both sides print identically.
- **B1 (Pydantic forward-ref break):** `RegistryNode` in `src/omnibase_core/navigation/model_contract_graph.py` forward-references `RegistryTransitionDecl` under `from __future__ import annotations` with no explicit `model_rebuild()`. Pydantic resolves that lazily via `sys.modules[cls.__module__].__dict__` at first construction; once the module has been evicted, that lookup can go stale and construction raises `PydanticUserError: RegistryNode is not fully defined`.

## Fix

1. `tests/unit/conftest.py` (new) adds `isolated_sys_modules(predicate)`, a context manager that evicts matching `sys.modules` entries and restores the exact same objects on exit (including on exception). All purge call sites in `tests/unit/test_init_exports.py`, `tests/unit/test_init_fast.py`, and `tests/unit/test_no_circular_imports.py` now route through it instead of a bare `del` loop. No test semantics changed -- only the leak is closed.
2. `src/omnibase_core/navigation/model_contract_graph.py`: added an explicit `RegistryNode.model_rebuild()` call once `RegistryTransitionDecl` is defined, so first construction no longer depends on `sys.modules[__module__]` staying pristine.
3. `tests/unit/test_omn_14944_sys_modules_purge_regression.py` (new) pins both minimal repros as permanent regressions -- independently verified RED against the pre-fix code (via `git stash`) and GREEN after.

## dod_evidence

Ticket: OMN-14944 (pre-existing, root cause + fix plan already diagnosed and cited independently in ticket comments/relations this session; this PR implements that fix plan).

**Minimal repro** (`tests/unit/test_init_exports.py::TestInitCircularImports::test_init_no_circular_imports` + `tests/unit/validation/test_validator_reserved_enum.py::TestCanonicalImportPaths`), on .200 clean env:
- Before: `2 failed, 2 passed in 1.57s`
- After: `4 passed in 0.65s`

**Direct-script RegistryNode proof** (purge `omnibase_core.*`, then construct `RegistryNode`):
- Before: `PydanticUserError: RegistryNode is not fully defined`
- After: constructs successfully

**Regression tests RED/GREEN control** (via `git stash` of the fix, same new test file): both new regression tests fail against the pre-fix code with the exact errors above, and pass after `git stash pop`.

**Full suite** on clean .200 (`uv run pytest tests/ --ignore=tests/integration -n 12 --reruns 2 --tb=short`, CI-equivalent parallel profile):
- **43322 passed, 53 skipped, 3 xpassed, 0 failed, 0 errors, 0 reruns triggered, in 1836.90s (0:30:36)**
- Supersedes the previously-reported 16-failure full-suite baseline cited in OMN-14944/OMN-14967 -- zero failures remain.

Local gates: `ruff format` (1 file reformatted, applied), `ruff check` (all checks passed), `mypy` on the touched src file (no issues), `pre-commit run --files <touched>` (all hooks passed).

Evidence-Ticket: OMN-14944
Evidence-Source: OCC#4650
Evidence-Commit: 12a9dd84000468f17f531e03f3a0b3098a1e4584

Closes OMN-14944

