### PR TITLE
refactor(OMN-14961): add core-execution-tier-no-nodes import-linter contract

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -132,6 +132,48 @@ ignore_imports =
     # after which this line + the ratchet are deleted. The set only SHRINKS.
     omnibase_core.protocols.** -> omnibase_core.models.**
 
+[importlinter:contract:core-execution-tier-no-nodes]
+name = Execution-tier packages must not import nodes (direct)
+# OMN-14961 (OMN-3210 family, closure-boundary lock completing the OMN-14216
+# oracle's source coverage for the execution tier). `runtime`, `pipeline`, `cli`,
+# and `validators` were absent from every .importlinter source set despite
+# carrying real cross-subpackage traffic (runtime -> models 50 edges,
+# validators -> models 26, all downward-legal per the 2026-07-22 readback).
+# Their layer position existed only by convention; this block formalizes it.
+#
+# Honest framing: this contract changes no live edges for the four modules
+# below — it is a closure-boundary LOCK, not a closure shrink, matching the
+# ticket's precondition finding (live grimp re-verification, 2026-07-23).
+#
+# `infrastructure` is DELIBERATELY EXCLUDED from source_modules. The live
+# grimp readback found 4 real direct edges, all in one file:
+# src/omnibase_core/infrastructure/infra_bases.py imports ModelServiceCompute/
+# ModelServiceEffect/ModelServiceOrchestrator/ModelServiceReducer from
+# omnibase_core.nodes.node_service_{compute,effect,orchestrator,reducer}. That
+# file has zero production consumers anywhere in the OmniNode org (verified by
+# exhaustive grep across every canonical repo) but IS referenced as a
+# documented "Service Wrappers" pattern from 6 architecture/tutorial docs
+# (docs/architecture/overview.md, docs/architecture/NODE_CLASS_HIERARCHY.md,
+# docs/architecture/ECOSYSTEM_DIRECTORY_STRUCTURE.md,
+# docs/guides/node-building/03_EFFECT_NODE_TUTORIAL.md,
+# docs/guides/node-building/04_EFFECT_NODE_TUTORIAL.md,
+# docs/reference/SERVICE_WRAPPERS.md). Severing the 4 edges means either
+# relocating infra_bases.py into nodes/ or retiring the documented pattern —
+# an architecture call out of scope for a lint-contract ticket, not a
+# mechanical import removal. Per this ticket's own precondition contingency
+# ("otherwise drop that source module from the contract and record why"),
+# `infrastructure` is dropped from source_modules here; fast-follow tracked
+# under OMN-14961's follow-up ticket. Never add an ignore line instead.
+type = forbidden
+allow_indirect_imports = True
+source_modules =
+    omnibase_core.runtime
+    omnibase_core.pipeline
+    omnibase_core.cli
+    omnibase_core.validators
+forbidden_modules =
+    omnibase_core.nodes
+
 [importlinter:contract:core-no-kafka-transport]
 name = Core must not import Kafka transport (aiokafka/confluent_kafka/omnibase_infra) — invariant I2
 # Invariant I2 of the single-runtime / transport-via-DI unification (epic OMN-14717,


### PR DESCRIPTION
## Summary

Adds the new `[importlinter:contract:core-execution-tier-no-nodes]` block per OMN-14961 (OMN-3210 family), locking `runtime`/`pipeline`/`cli`/`validators` against importing `omnibase_core.nodes` (direct edges, `allow_indirect_imports = True`). No other `.importlinter` block touched.

Closes OMN-14961

## Honest framing

This is a **closure-boundary LOCK, not a closure shrink** — zero live edges change for `runtime`/`pipeline`/`cli`/`validators`. No architecture decision, no code moves for those four modules.

## Precondition re-verification (live grimp, 2026-07-23, this session)

Per-source direct-edge count to `omnibase_core.nodes` (submodule-level, not just the `omnibase_core.nodes` package name):

```
omnibase_core.runtime         0
omnibase_core.infrastructure  4   <-- NOT zero, contrary to the 2026-07-22 oracle note
omnibase_core.pipeline        0
omnibase_core.cli             0
omnibase_core.validators      0
```

All 4 `infrastructure` edges are in one file, `src/omnibase_core/infrastructure/infra_bases.py`:
```
omnibase_core.infrastructure.infra_bases -> omnibase_core.nodes.node_service_reducer
omnibase_core.infrastructure.infra_bases -> omnibase_core.nodes.node_service_effect
omnibase_core.infrastructure.infra_bases -> omnibase_core.nodes.node_service_orchestrator
omnibase_core.infrastructure.infra_bases -> omnibase_core.nodes.node_service_compute
```

## Precondition contingency applied: `infrastructure` dropped from `source_modules`

`infra_bases.py` is a pure re-export shim (`ModelServiceCompute`/`Effect`/`Orchestrator`/`Reducer`, each a real class defined under `omnibase_core.nodes.node_service_*` because it subclasses `NodeCompute`/`NodeEffect`/`NodeOrchestrator`/`NodeReducer`). Investigated whether the 4 edges are mechanically severable:

- **Zero production consumers anywhere in the org** — exhaustive `grep -rl infra_bases` across every canonical repo (omnibase_core, omnibase_infra, omnibase_spi, omniclaude, omnimarket, omniintelligence, omnimemory, onex_change_control, omnidash) finds only the module itself and its own dedicated test (`tests/unit/infrastructure/test_infra_bases.py`).
- **But it IS a documented pattern** — referenced from 6 architecture/tutorial docs: `docs/architecture/overview.md`, `docs/architecture/NODE_CLASS_HIERARCHY.md`, `docs/architecture/ECOSYSTEM_DIRECTORY_STRUCTURE.md`, `docs/guides/node-building/03_EFFECT_NODE_TUTORIAL.md`, `docs/guides/node-building/04_EFFECT_NODE_TUTORIAL.md`, `docs/reference/SERVICE_WRAPPERS.md`.

Severing therefore means either relocating `infra_bases.py` into `nodes/` or retiring the documented "Service Wrappers" pattern — an architecture call, not a mechanical `<=5`-edge import removal as scoped by this ticket's precondition contingency: *"if any edge exists: sever in-PR if <=5 and mechanical; otherwise drop that source module from the contract and record why."* `infrastructure` is dropped from `source_modules` for this PR. **No ignore line was added.** Fast-follow ticket to be filed under OMN-3210 to decide relocate-vs-retire for `infra_bases.py`, after which `infrastructure` can be added to this contract.

## Acceptance evidence

**1. `lint-imports` green, zero ignore lines added, all 6 contracts kept:**
```
Foundation primitives must not import higher layers (direct) KEPT
Models must not import behavioral/orchestration layers (direct) KEPT
Services and validation must not import nodes (direct) KEPT
Protocols (seam) must not import domain/behavioral layers (direct) KEPT
Execution-tier packages must not import nodes (direct) KEPT
Core must not import Kafka transport (aiokafka/confluent_kafka/omnibase_infra) — invariant I2 KEPT

Contracts: 6 kept, 0 broken.
```

**2. Seeded-violation RED->GREEN, two seeds** (added, captured RED, reverted — final `git status` shows only `.importlinter` modified):

Seed (a): `from omnibase_core.nodes.node_test_selector_compute import selector_core` appended to `src/omnibase_core/runtime/runtime_dispatch.py`
Seed (b): same import appended to `src/omnibase_core/validators/backend_secret_discipline.py`

RED transcript:
```
Execution-tier packages must not import nodes (direct) BROKEN
...
Broken contracts
----------------

Execution-tier packages must not import nodes (direct)
------------------------------------------------------

omnibase_core.runtime is not allowed to import omnibase_core.nodes:

-   omnibase_core.runtime.runtime_dispatch ->
omnibase_core.nodes.node_test_selector_compute.selector_core (l.475)


omnibase_core.validators is not allowed to import omnibase_core.nodes:

-   omnibase_core.validators.backend_secret_discipline ->
omnibase_core.nodes.node_test_selector_compute.selector_core (l.417)

Contracts: 5 kept, 1 broken.
```

Reverted (`git checkout --`); re-ran `lint-imports` -> 6 kept, 0 broken again.

**3. Pre-commit:** `Contract-Config Compliance (OMN-10688)` and full local hook suite pass on the changed file (`uv run pre-commit run --files .importlinter`).

## Seam declaration

- New `.importlinter` block only; no other contract touched.
- The 4 frozen `types->models` ignores (OMN-14339) and the RSD-owned `protocols->models` wildcard + 65-edge ratchet untouched.
- No `test_selection_adjacency.yaml` change (no edges changed for the four included source modules).
- No `import_ratchet_baseline.py` change (tracks hub-inbound importers of utils/mixins/protocols — unaffected).

## dod_evidence

- proof_class: code-only (PR is draft; CI + merge not yet run)
- Live grimp readback + lint-imports transcripts above are the durable evidence for this PR.

## Test plan

- [x] `uv run lint-imports` green, 6/6 contracts kept, 0 ignore lines in new block
- [x] Seeded-violation RED->GREEN for both `runtime` and `validators` seeds
- [x] `uv run pre-commit run --files .importlinter` passes
- [ ] CI (`gh pr checks`) — pending, draft PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added architectural import checks to prevent execution-tier components from directly depending on node implementations.
  * Documented the approved exception for existing infrastructure-level imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Evidence-Ticket: OMN-14961
Evidence-Source: OCC#4680
Evidence-Commit: 4eced1510cb4d52c6ec662de5cc59b018a3ac000
