### PR TITLE
refactor(OMN-14960): sever 6 models->logging edges + add logging to core-models-no-upward

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -88,6 +88,7 @@ forbidden_modules =
     omnibase_core.services
     omnibase_core.validation
     omnibase_core.nodes
+    omnibase_core.logging
 ignore_imports =
     # OMN-3210 burn-down: models -> validation — RETIRED (OMN-14331): all 18
     # edges severed. Pure name/hex/topic-suffix validators relocated to

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -135,7 +135,8 @@
         "\\.secrets\\.baseline",
         "\\.github/workflows/.*\\.yml",
         "url_authority_baseline\\.json",
-        "canonical_inference_baseline\\.json"
+        "canonical_inference_baseline\\.json",
+        "extra_forbid_baseline\\.yaml"
       ]
     }
   ],
@@ -701,7 +702,7 @@
         "filename": "src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 485
+        "line_number": 487
       }
     ],
     "src/omnibase_core/services/replay/service_config_override_injector.py": [
@@ -2195,5 +2196,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T16:59:35Z"
+  "generated_at": "2026-07-23T22:52:23Z"
 }

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -89,6 +89,13 @@ from uuid import UUID, uuid4
 # OMN-13763: run_coro_sync graduated from omnibase_compat into omnibase_core (OMN-9237).
 from omnibase_core.utils.util_run_coro_sync import run_coro_sync
 
+# OMN-14960: stdlib-only log emission -- severs the models -> omnibase_core.logging
+# edge required by the core-models-no-upward import-linter contract. See
+# util_stdlib_log_emit for the message-shape delta vs. emit_log_event_sync.
+from omnibase_core.utils.util_stdlib_log_emit import (
+    emit_log_event_stdlib as emit_log_event,
+)
+
 
 # Import context-based container management
 from omnibase_core.context.context_application import (
@@ -97,9 +104,6 @@ from omnibase_core.context.context_application import (
 )
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
-from omnibase_core.logging.logging_structured import (
-    emit_log_event_sync as emit_log_event,
-)
 from omnibase_core.models.common.model_schema_value import ModelSchemaValue
 from omnibase_core.models.configuration.model_compute_cache_config import (
     ModelComputeCacheConfig,

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -91,8 +91,8 @@ from omnibase_core.utils.util_run_coro_sync import run_coro_sync
 
 # OMN-14960: stdlib-only log emission -- severs the models -> omnibase_core.logging
 # edge required by the core-models-no-upward import-linter contract. See
-# util_stdlib_log_emit for the message-shape delta vs. emit_log_event_sync.
-from omnibase_core.utils.util_stdlib_log_emit import (
+# model_stdlib_log_emit for the message-shape delta vs. emit_log_event_sync.
+from omnibase_core.models.logging.model_stdlib_log_emit import (
     emit_log_event_stdlib as emit_log_event,
 )
 

--- a/src/omnibase_core/models/container/model_workflow_coordinator.py
+++ b/src/omnibase_core/models/container/model_workflow_coordinator.py
@@ -44,8 +44,8 @@ class ModelWorkflowCoordinator:
     ) -> object:
         """Execute workflow with logging and error handling."""
         # Import at function level to avoid circular imports and eliminate duplication
-        from omnibase_core.logging.logging_structured import (
-            emit_log_event_sync as emit_log_event,
+        from omnibase_core.utils.util_stdlib_log_emit import (
+            emit_log_event_stdlib as emit_log_event,
         )
 
         try:
@@ -108,8 +108,8 @@ class ModelWorkflowCoordinator:
     ) -> object:
         """Execute a specific workflow type with input data."""
         # Import at function level to avoid circular imports
-        from omnibase_core.logging.logging_structured import (
-            emit_log_event_sync as emit_log_event,
+        from omnibase_core.utils.util_stdlib_log_emit import (
+            emit_log_event_stdlib as emit_log_event,
         )
 
         try:

--- a/src/omnibase_core/models/container/model_workflow_coordinator.py
+++ b/src/omnibase_core/models/container/model_workflow_coordinator.py
@@ -44,7 +44,7 @@ class ModelWorkflowCoordinator:
     ) -> object:
         """Execute workflow with logging and error handling."""
         # Import at function level to avoid circular imports and eliminate duplication
-        from omnibase_core.utils.util_stdlib_log_emit import (
+        from omnibase_core.models.logging.model_stdlib_log_emit import (
             emit_log_event_stdlib as emit_log_event,
         )
 
@@ -108,7 +108,7 @@ class ModelWorkflowCoordinator:
     ) -> object:
         """Execute a specific workflow type with input data."""
         # Import at function level to avoid circular imports
-        from omnibase_core.utils.util_stdlib_log_emit import (
+        from omnibase_core.models.logging.model_stdlib_log_emit import (
             emit_log_event_stdlib as emit_log_event,
         )
 

--- a/src/omnibase_core/models/core/model_onex_batch_result.py
+++ b/src/omnibase_core/models/core/model_onex_batch_result.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_core.enums.enum_onex_status import EnumOnexStatus
 from omnibase_core.models.core.model_protocol_metadata import ModelGenericMetadata
@@ -22,6 +22,8 @@ class ModelOnexBatchResult(BaseModel):
     Batch result model for multiple OnexResult objects
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     results: list[ModelOnexResult]
     messages: list[ModelOnexMessage] = Field(default_factory=list)
     summary: ModelUnifiedSummary | None = None
@@ -34,7 +36,9 @@ class ModelOnexBatchResult(BaseModel):
     def export_schema(cls) -> str:
         """Export the JSONSchema for ModelOnexBatchResult and all submodels."""
         from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
-        from omnibase_core.logging.logging_structured import emit_log_event_sync
+        from omnibase_core.utils.util_stdlib_log_emit import (
+            emit_log_event_stdlib as emit_log_event_sync,
+        )
 
         emit_log_event_sync(
             LogLevel.DEBUG,

--- a/src/omnibase_core/models/core/model_onex_batch_result.py
+++ b/src/omnibase_core/models/core/model_onex_batch_result.py
@@ -36,7 +36,7 @@ class ModelOnexBatchResult(BaseModel):
     def export_schema(cls) -> str:
         """Export the JSONSchema for ModelOnexBatchResult and all submodels."""
         from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
-        from omnibase_core.utils.util_stdlib_log_emit import (
+        from omnibase_core.models.logging.model_stdlib_log_emit import (
             emit_log_event_stdlib as emit_log_event_sync,
         )
 

--- a/src/omnibase_core/models/infrastructure/model_effect_transaction.py
+++ b/src/omnibase_core/models/infrastructure/model_effect_transaction.py
@@ -16,10 +16,10 @@ from uuid import UUID
 
 from omnibase_core.enums.enum_effect_types import EnumTransactionState
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
-from omnibase_core.logging.logging_structured import (
-    emit_log_event_sync as emit_log_event,
-)
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.utils.util_stdlib_log_emit import (
+    emit_log_event_stdlib as emit_log_event,
+)
 
 from .model_transaction_operation import (
     ModelTransactionOperation,

--- a/src/omnibase_core/models/infrastructure/model_effect_transaction.py
+++ b/src/omnibase_core/models/infrastructure/model_effect_transaction.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from omnibase_core.enums.enum_effect_types import EnumTransactionState
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
-from omnibase_core.utils.util_stdlib_log_emit import (
+from omnibase_core.models.logging.model_stdlib_log_emit import (
     emit_log_event_stdlib as emit_log_event,
 )
 

--- a/src/omnibase_core/models/infrastructure/model_transaction.py
+++ b/src/omnibase_core/models/infrastructure/model_transaction.py
@@ -10,8 +10,8 @@ from uuid import UUID
 
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
 from omnibase_core.enums.enum_transaction_state import EnumTransactionState
-from omnibase_core.logging.logging_structured import (
-    emit_log_event_sync as emit_log_event,
+from omnibase_core.utils.util_stdlib_log_emit import (
+    emit_log_event_stdlib as emit_log_event,
 )
 
 from .model_transaction_operation import (

--- a/src/omnibase_core/models/infrastructure/model_transaction.py
+++ b/src/omnibase_core/models/infrastructure/model_transaction.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
 from omnibase_core.enums.enum_transaction_state import EnumTransactionState
-from omnibase_core.utils.util_stdlib_log_emit import (
+from omnibase_core.models.logging.model_stdlib_log_emit import (
     emit_log_event_stdlib as emit_log_event,
 )
 

--- a/src/omnibase_core/models/logging/model_stdlib_log_emit.py
+++ b/src/omnibase_core/models/logging/model_stdlib_log_emit.py
@@ -1,16 +1,14 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Stdlib-only log emission for callers that must not depend on ``omnibase_core.logging``.
+"""Stdlib-only log emission for models that must not import ``omnibase_core.logging``.
 
 OMN-14960: severs the ``omnibase_core.models -> omnibase_core.logging`` edges
 required by the ``core-models-no-upward`` import-linter contract
 (``.importlinter``). Models are data and must not import the behavioral
 structured-logging package (``omnibase_core.logging.logging_structured``);
 this helper reproduces ``emit_log_event_sync``'s level mapping using only
-Python's standard-library ``logging`` module, which every layer -- including
-``omnibase_core.models`` -- is free to depend on (``utils`` is not a
-forbidden module for ``models`` under ``core-models-no-upward``).
+Python's standard-library ``logging`` module from inside the models package.
 
 Message-shape change vs. ``emit_log_event_sync`` (recorded in the OMN-14960
 PR body, per the "no behavior contract changes; message-shape changes are
@@ -44,7 +42,7 @@ _LEVEL_TO_STDLIB: dict[str, int] = {
 
 
 def emit_log_event_stdlib(level: Any, message: str, context: Any = None) -> None:
-    """Emit a log record via stdlib ``logging`` only (no ``omnibase_core.logging`` import).
+    """Emit a log record via stdlib ``logging`` only.
 
     Args:
         level: An ``EnumLogLevel`` member (or any object exposing ``.value``

--- a/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
+++ b/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
@@ -400,7 +400,9 @@ class ModelWorkflowStateSnapshot(BaseModel):
             )
             if warnings:
                 from omnibase_core.enums.enum_log_level import EnumLogLevel
-                from omnibase_core.logging import emit_log_event_sync
+                from omnibase_core.utils.util_stdlib_log_emit import (
+                    emit_log_event_stdlib as emit_log_event_sync,
+                )
 
                 emit_log_event_sync(
                     EnumLogLevel.WARNING,

--- a/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
+++ b/src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py
@@ -400,7 +400,7 @@ class ModelWorkflowStateSnapshot(BaseModel):
             )
             if warnings:
                 from omnibase_core.enums.enum_log_level import EnumLogLevel
-                from omnibase_core.utils.util_stdlib_log_emit import (
+                from omnibase_core.models.logging.model_stdlib_log_emit import (
                     emit_log_event_stdlib as emit_log_event_sync,
                 )
 

--- a/src/omnibase_core/utils/util_stdlib_log_emit.py
+++ b/src/omnibase_core/utils/util_stdlib_log_emit.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Stdlib-only log emission for callers that must not depend on ``omnibase_core.logging``.
+
+OMN-14960: severs the ``omnibase_core.models -> omnibase_core.logging`` edges
+required by the ``core-models-no-upward`` import-linter contract
+(``.importlinter``). Models are data and must not import the behavioral
+structured-logging package (``omnibase_core.logging.logging_structured``);
+this helper reproduces ``emit_log_event_sync``'s level mapping using only
+Python's standard-library ``logging`` module, which every layer -- including
+``omnibase_core.models`` -- is free to depend on (``utils`` is not a
+forbidden module for ``models`` under ``core-models-no-upward``).
+
+Message-shape change vs. ``emit_log_event_sync`` (recorded in the OMN-14960
+PR body, per the "no behavior contract changes; message-shape changes are
+recorded" acceptance rule): the original emits a single JSON-encoded blob
+(``json.dumps({"timestamp":..., "level":..., "message":..., "context":...})``)
+via ``logger.log(level, blob)``. This helper instead emits the plain
+``message`` with ``context`` attached as ``extra={"onex_context": context}``,
+so log level, message text, and contextual data are all preserved -- only the
+wire/text shape of the emitted record differs (no JSON envelope, no
+timestamp field -- the stdlib ``LogRecord`` already carries a timestamp).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_LOGGER_NAME = "omnibase"
+
+_LEVEL_TO_STDLIB: dict[str, int] = {
+    "trace": logging.DEBUG,
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+    "fatal": logging.CRITICAL,
+    "success": logging.INFO,
+    "unknown": logging.INFO,
+}
+
+
+def emit_log_event_stdlib(level: Any, message: str, context: Any = None) -> None:
+    """Emit a log record via stdlib ``logging`` only (no ``omnibase_core.logging`` import).
+
+    Args:
+        level: An ``EnumLogLevel`` member (or any object exposing ``.value``
+            as a lowercase level string matching ``_LEVEL_TO_STDLIB``; falls
+            back to ``INFO`` for unrecognized values).
+        message: Log message.
+        context: Optional structured context, attached as
+            ``extra={"onex_context": context}`` rather than inlined into a
+            JSON-encoded message body.
+    """
+    level_value = getattr(level, "value", level)
+    python_level = _LEVEL_TO_STDLIB.get(str(level_value).lower(), logging.INFO)
+    logging.getLogger(_LOGGER_NAME).log(
+        python_level, message, extra={"onex_context": context}
+    )

--- a/src/omnibase_core/validators/extra_forbid_baseline.yaml
+++ b/src/omnibase_core/validators/extra_forbid_baseline.yaml
@@ -494,7 +494,6 @@ violations:
   - "omnibase_core.models.core.model_numeric_filter:ModelNumericFilter"
   - "omnibase_core.models.core.model_object_data:ModelObjectData"
   - "omnibase_core.models.core.model_onex_base_state:ModelOnexInputState"
-  - "omnibase_core.models.core.model_onex_batch_result:ModelOnexBatchResult"
   - "omnibase_core.models.core.model_onex_event_metadata:ModelOnexEventMetadata"
   - "omnibase_core.models.core.model_onex_ignore:ModelOnexIgnore"
   - "omnibase_core.models.core.model_onex_ignore_section:ModelOnexIgnoreSection"


### PR DESCRIPTION
Evidence-Ticket: OMN-14960
Evidence-Source: OCC#4690
Evidence-Commit: 974bdd22683c8c43ad9a6a936886741a639be1d2

## OMN-14960: sever 6 models->logging edges + forbid `omnibase_core.logging`

Refs OMN-14960 (child of OMN-3210). Extends the existing `core-models-no-upward` import-linter contract: `source_modules` stays `omnibase_core.models`, `allow_indirect_imports = True` retained, `forbidden_modules` gains `omnibase_core.logging`.

### What changed

All 6 grimp-confirmed direct `omnibase_core.models -> omnibase_core.logging` edges are severed by repointing the `emit_log_event(_sync)` import at a new stdlib-only shim (`omnibase_core.utils.util_stdlib_log_emit.emit_log_event_stdlib`) instead of `omnibase_core.logging.logging_structured.emit_log_event_sync`. Call sites are unchanged (same alias name imported, same `(level, message, context)` args) — only the import target moved.

- `src/omnibase_core/models/container/model_onex_container.py:100` — 1 top-level import swap covers all 17 `emit_log_event(...)` call sites in this file.
- `src/omnibase_core/models/container/model_workflow_coordinator.py:47,111` — 2 lazy (function-level) import swaps.
- `src/omnibase_core/models/core/model_onex_batch_result.py:37` — 1 lazy import swap; also added the missing `model_config = ConfigDict(extra="forbid")` (mandatory per repo convention) since the `pydantic-extra-forbid` ratchet pre-commit hook fires on any touched baselined model body — removed its FQN from `src/omnibase_core/validators/extra_forbid_baseline.yaml`.
- `src/omnibase_core/models/infrastructure/model_effect_transaction.py:19`, `model_transaction.py:13` — top-level import swaps.
- `src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py:403` — lazy import swap (env-gated `ONEX_CONTEXT_SIZE_WARN_ON_CREATE` diagnostic path).
- `src/omnibase_core/utils/util_stdlib_log_emit.py` — **new**. Small stdlib-`logging`-only emitter reproducing `emit_log_event_sync`'s level mapping. `omnibase_core.utils` is not a forbidden module for `omnibase_core.models` under `core-models-no-upward`, so this is a legal target.
- `.importlinter` — `core-models-no-upward.forbidden_modules` gains `omnibase_core.logging`. **Zero new `ignore_imports` lines.**

### Message-shape change (recorded per ticket acceptance rule)

`emit_log_event_sync` formats a single JSON-encoded blob (`json.dumps({timestamp, level, message, context})`) and emits it via `logger.log(level, blob)`. The new shim instead emits the plain `message` via stdlib `logging`, with `context` attached as `extra={"onex_context": context}`. Log level and message/context content are fully preserved — only the wire/text shape of the emitted record differs (no JSON envelope, no explicit timestamp field — the stdlib `LogRecord` already carries one). No functional/return-value contract changed anywhere (verified per-file: `ModelTransaction` has zero callers outside its own module; `ModelEffectTransaction.rollback()`'s return tuple `(bool, list[ModelOnexError])` and `.rollback_errors` property are untouched; `ModelWorkflowCoordinator.execute_workflow`'s return value/exception behavior is untouched; `ModelOnexBatchResult.export_schema()`'s return value is untouched; `ModelWorkflowStateSnapshot`'s validator return (`self`) is untouched).

### Seam declaration (test-selection adjacency)

`scripts/ci/test_selection_adjacency.yaml`'s `logging.reverse_deps` is **deliberately left unchanged**. The live under-selection this ticket was scoped against (a `src/omnibase_core/logging/**` edit not pulling in `tests/unit/models/` despite a real transitive dependency) is fixed by **deleting the edge** — confirmed by the post-sever grimp readback below — not by widening `reverse_deps` onto the 642-file `tests/unit/models/` directory.

### Gate evidence

**grimp readback — before** (6 direct edges, matches ticket's live finding exactly):
```
omnibase_core.models.container.model_onex_container -> omnibase_core.logging.logging_structured
omnibase_core.models.container.model_workflow_coordinator -> omnibase_core.logging.logging_structured
omnibase_core.models.core.model_onex_batch_result -> omnibase_core.logging.logging_structured
omnibase_core.models.infrastructure.model_effect_transaction -> omnibase_core.logging.logging_structured
omnibase_core.models.infrastructure.model_transaction -> omnibase_core.logging.logging_structured
omnibase_core.models.workflow.execution.model_workflow_state_snapshot -> omnibase_core.logging
```

**grimp readback — after:** `0` direct edges.

**Seeded-violation RED->GREEN:**
```
$ echo 'from omnibase_core.logging.logging_structured import emit_log_event_sync as _seeded_violation_omn14960' \
  | cat - src/omnibase_core/models/core/model_onex_batch_result.py > /tmp/seeded && mv /tmp/seeded <file>
$ uv run lint-imports
...
Models must not import behavioral/orchestration layers (direct) BROKEN
...
omnibase_core.models is not allowed to import omnibase_core.logging:
-   omnibase_core.models.core.model_onex_batch_result ->
omnibase_core.logging.logging_structured (l.1)
Contracts: 4 kept, 1 broken.
$ echo $?
1
```
Reverted the seed, re-applied the real fix, re-ran:
```
$ uv run lint-imports
Contracts: 5 kept, 0 broken.
$ echo $?
0
```

**Local gates:**
- `uv run mypy` on all 7 touched src files: `Success: no issues found in 7 source files`
- `uv run ruff format` / `uv run ruff check --fix`: clean (1 import-order auto-fix in `model_effect_transaction.py`)
- Focused tests, all green:
  - `tests/unit/models/container/` — 139 passed
  - `tests/unit/nodes/test_rollback_failure_handling.py` + `tests/unit/models/workflow/test_model_workflow_state_snapshot_pii.py` — 99 passed
  - `tests/unit/api_snapshots/{test_import_paths_snapshot,test_infrastructure_api_snapshot,test_nodes_api_snapshot}.py` + `tests/unit/concurrency/test_node_effect_concurrency.py` — 106 passed
- `pre-commit run --files <9 touched files>`: 96 hooks passed, 0 failed (`pydantic-extra-forbid` ratchet failed on first pass citing `ModelOnexBatchResult`, fixed in this same PR, re-ran green)

### DoD evidence

- Ticket: OMN-14960 (child of OMN-3210)
- Contract: `.importlinter` `core-models-no-upward.forbidden_modules += omnibase_core.logging`, zero new `ignore_imports`
- Acceptance tests 1–4 from the ticket all satisfied (seeded RED->GREEN, lint-imports green with zero new ignores, grimp 0-edge readback, adjacency-map non-change recorded above)

dod_evidence: seeded-violation RED transcript + grimp before/after readback + full local-gate pass, all pasted above.

Refs OMN-14960