### PR TITLE
fix(OMN-14985): close 2 residual sys.modules contaminators PR #1484 missed

### DIFF
--- a/tests/unit/models/contracts/test_model_fast_imports.py
+++ b/tests/unit/models/contracts/test_model_fast_imports.py
@@ -11,6 +11,8 @@ import sys
 
 import pytest
 
+from tests.unit.conftest import isolated_sys_modules
+
 
 @pytest.mark.unit
 class TestModelFastContractFactory:
@@ -465,28 +467,22 @@ class TestZeroImportTimeLoading:
     def test_no_imports_at_module_level(self):
         """Test that no contract imports occur at module import time."""
 
-        # Remove any cached contract modules
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if "model_contract_" in key and "model_fast_imports" not in key
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: "model_contract_" in key and "model_fast_imports" not in key
+        ):
+            # Import the fast imports module
 
-        # Import the fast imports module
+            # Verify no contract modules were imported
+            contract_modules = [
+                key
+                for key in sys.modules
+                if "model_contract_" in key and "model_fast_imports" not in key
+            ]
 
-        # Verify no contract modules were imported
-        contract_modules = [
-            key
-            for key in sys.modules
-            if "model_contract_" in key and "model_fast_imports" not in key
-        ]
-
-        # Should be empty (no imports at module level)
-        assert len(contract_modules) == 0, (
-            f"Contract modules imported at module level: {contract_modules}"
-        )
+            # Should be empty (no imports at module level)
+            assert len(contract_modules) == 0, (
+                f"Contract modules imported at module level: {contract_modules}"
+            )
 
     def test_imports_occur_only_on_demand(self):
         """Test that imports only occur when contracts are actually requested."""

--- a/tests/unit/models/contracts/test_model_lazy_imports.py
+++ b/tests/unit/models/contracts/test_model_lazy_imports.py
@@ -11,6 +11,8 @@ import sys
 
 import pytest
 
+from tests.unit.conftest import isolated_sys_modules
+
 
 @pytest.mark.unit
 class TestModelLazyContractLoader:
@@ -370,28 +372,22 @@ class TestLazyLoadingBehavior:
     def test_no_imports_at_module_level(self):
         """Test that no contract imports occur at module import time."""
 
-        # Remove any cached contract modules
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if "model_contract_" in key and "model_lazy_imports" not in key
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: "model_contract_" in key and "model_lazy_imports" not in key
+        ):
+            # Import the lazy imports module
 
-        # Import the lazy imports module
+            # Verify no contract modules were imported
+            contract_modules = [
+                key
+                for key in sys.modules
+                if "model_contract_" in key and "model_lazy_imports" not in key
+            ]
 
-        # Verify no contract modules were imported
-        contract_modules = [
-            key
-            for key in sys.modules
-            if "model_contract_" in key and "model_lazy_imports" not in key
-        ]
-
-        # Should be empty (no imports at module level)
-        assert len(contract_modules) == 0, (
-            f"Contract modules imported at module level: {contract_modules}"
-        )
+            # Should be empty (no imports at module level)
+            assert len(contract_modules) == 0, (
+                f"Contract modules imported at module level: {contract_modules}"
+            )
 
     def test_imports_occur_only_on_demand(self):
         """Test that imports only occur when contracts are actually requested."""
@@ -449,30 +445,24 @@ class TestPerformanceOptimization:
         """Test that lazy loading defers import penalty until first access."""
         import time
 
-        # Clear cached modules
-        modules_to_remove = [
-            key
-            for key in list(sys.modules.keys())
-            if "model_contract_" in key and "model_lazy_imports" not in key
-        ]
-        for mod in modules_to_remove:
-            del sys.modules[mod]
+        with isolated_sys_modules(
+            lambda key: "model_contract_" in key and "model_lazy_imports" not in key
+        ):
+            # Import lazy imports module - should be fast
+            start = time.perf_counter()
 
-        # Import lazy imports module - should be fast
-        start = time.perf_counter()
+            import_time = (time.perf_counter() - start) * 1000
 
-        import_time = (time.perf_counter() - start) * 1000
+            # Verify no contract modules loaded yet
+            contract_modules = [
+                key
+                for key in sys.modules
+                if "model_contract_" in key and "model_lazy_imports" not in key
+            ]
 
-        # Verify no contract modules loaded yet
-        contract_modules = [
-            key
-            for key in sys.modules
-            if "model_contract_" in key and "model_lazy_imports" not in key
-        ]
-
-        assert len(contract_modules) == 0, (
-            f"Import cascade detected: {contract_modules}"
-        )
+            assert len(contract_modules) == 0, (
+                f"Import cascade detected: {contract_modules}"
+            )
 
     def test_functools_cache_reduces_repeated_loading(self):
         """Test that functools.cache reduces repeated loading overhead."""

--- a/tests/unit/test_omn_14944_sys_modules_purge_regression.py
+++ b/tests/unit/test_omn_14944_sys_modules_purge_regression.py
@@ -22,10 +22,20 @@ worker process. Two independent downstream failure modes were confirmed:
 
 These tests pin both minimal repros from the OMN-14944 diagnosis as
 permanent regressions.
+
+OMN-14985 residual: OMN-14944 named five contaminator sites but the merged
+fix (omnibase_core#1484) only converted three of them
+(``test_init_exports.py``, ``test_init_fast.py``,
+``test_no_circular_imports.py``) to ``isolated_sys_modules``. Two more
+(``tests/unit/models/contracts/test_model_fast_imports.py`` and
+``test_model_lazy_imports.py``, two sites) were converted here.
+``test_no_unrestored_del_sys_modules_in_tests`` below is a static guard
+against this whole class recurring anywhere in ``tests/``.
 """
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -89,3 +99,112 @@ def test_registry_node_construction_survives_omnibase_core_purge() -> None:
 
     assert node.node_id == "n1"
     assert node.schema_version == "1.0.0"
+
+
+def _is_sys_modules_subscript(expr: ast.expr) -> bool:
+    """True if ``expr`` is the AST for ``sys.modules[...]``."""
+    return (
+        isinstance(expr, ast.Subscript)
+        and isinstance(expr.value, ast.Attribute)
+        and expr.value.attr == "modules"
+        and isinstance(expr.value.value, ast.Name)
+        and expr.value.value.id == "sys"
+    )
+
+
+def _enclosing_function(
+    parents: dict[ast.AST, ast.AST], node: ast.AST
+) -> ast.AST | None:
+    current: ast.AST | None = node
+    while current is not None:
+        parent = parents.get(current)
+        if isinstance(parent, ast.FunctionDef | ast.AsyncFunctionDef):
+            return parent
+        current = parent
+    return None
+
+
+def _function_restores_sys_modules(func: ast.AST) -> bool:
+    """True if ``func`` either uses ``isolated_sys_modules`` as a context
+    manager, or manually restores an evicted ``sys.modules`` entry
+    (``sys.modules[key] = ...`` or ``sys.modules.update(...)``) somewhere
+    in its body.
+    """
+    for node in ast.walk(func):
+        if isinstance(node, ast.With):
+            for item in node.items:
+                call = item.context_expr
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "isolated_sys_modules"
+                ):
+                    return True
+        if isinstance(node, ast.Assign) and any(
+            _is_sys_modules_subscript(target) for target in node.targets
+        ):
+            return True
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "modules"
+            and isinstance(node.func.value.value, ast.Name)
+            and node.func.value.value.id == "sys"
+        ):
+            return True
+    return False
+
+
+def test_no_unrestored_del_sys_modules_in_tests() -> None:
+    """Guard (OMN-14985): no test file may evict a ``sys.modules`` entry
+    without restoring it.
+
+    A bare ``del sys.modules[key]`` loop with no restore is exactly the
+    OMN-14944 contaminator class -- it permanently evicts matched entries
+    for the rest of that pytest worker process, corrupting unrelated later
+    tests via class-identity splits or Pydantic forward-ref breaks. This
+    statically scans every ``tests/**/*.py`` file (excluding ``conftest.py``,
+    which implements the restore primitive itself) and fails if any
+    ``del sys.modules[...]`` is not covered, within its enclosing function,
+    by either an ``isolated_sys_modules`` context manager or an explicit
+    manual restore assignment.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    tests_root = repo_root / "tests"
+    conftest_paths = {p.resolve() for p in tests_root.rglob("conftest.py")}
+    violations: list[str] = []
+
+    for path in sorted(tests_root.rglob("*.py")):
+        resolved = path.resolve()
+        if resolved in conftest_paths:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "del sys.modules[" not in source:
+            continue
+
+        tree = ast.parse(source, filename=str(path))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Delete):
+                continue
+            if not any(_is_sys_modules_subscript(t) for t in node.targets):
+                continue
+
+            func = _enclosing_function(parents, node)
+            if func is not None and _function_restores_sys_modules(func):
+                continue
+
+            violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+
+    assert not violations, (
+        "Unrestored `del sys.modules[...]` found (OMN-14944 contaminator "
+        "class -- see OMN-14985). Wrap the deletion in "
+        "`with isolated_sys_modules(predicate):` "
+        "(tests/unit/conftest.py) or add an explicit restore:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
Evidence-Ticket: OMN-14985
Evidence-Source: OCC#4654
Evidence-Commit: c14f19a33d0fb7c7d7c75632891f0a8dcd8115bb

## Summary

OMN-14944 (PR #1484, merged 2026-07-23T22:18:02Z at 4d88af48) added `tests/unit/conftest.py::isolated_sys_modules` (restores sys.modules in a `finally`) and converted three of the originally-named contaminator files. OMN-14944's own description named five contaminator sites; PR #1484 only touched three. This PR closes the remaining two:

- `tests/unit/models/contracts/test_model_fast_imports.py:475` -> converted to `isolated_sys_modules`
- `tests/unit/models/contracts/test_model_lazy_imports.py:380,459` (two sites in this file) -> converted to `isolated_sys_modules`

Both previously did a bare `del sys.modules[mod]` with no restore. Currently harmless for the known 27 OMN-14944 victims only because `RegistryNode.model_rebuild()` is now unconditional and their purge predicate (`"model_contract_" in key`) never intersects the enum modules driving the B2 failure mechanism -- a latent leak, not a proven-safe pattern.

Also adds a static AST guard test, `test_no_unrestored_del_sys_modules_in_tests` (extends `tests/unit/test_omn_14944_sys_modules_purge_regression.py`), asserting no test file in `tests/` performs a bare `del sys.modules[...]` without either an `isolated_sys_modules` context manager or an explicit manual restore assignment in the same function -- so this whole contaminator class cannot recur silently anywhere in the repo (verified against the one pre-existing safe pattern, `tests/unit/utils/test_safe_yaml_loader_imports.py`, which already uses a manual try/finally restore).

## Evidence

- Targeted single-process run (the 3 changed test files, 74 tests): **74 passed, 0 failed** (`uv run pytest -p no:xdist tests/unit/models/contracts/test_model_fast_imports.py tests/unit/models/contracts/test_model_lazy_imports.py tests/unit/test_omn_14944_sys_modules_purge_regression.py`), including the new guard test.
- `ruff format` + `ruff check --fix`: clean on all 3 changed files.
- `pre-commit run --files <3 files>` (full default-stage battery, ~90 hooks): **all Passed / Skipped (no files to check)**, zero failures.
- Governed pre-push selector (`scripts/ci/detect_test_paths.py`) dry-run against this diff selects `tests/unit/models/` + the regression test file (not a full-suite escalation) -- consistent with a test-only diff.
- **Full single-process `tests/` suite proof bar (the load-bearing OMN-14944-unblock check) could not be completed in-session**: the shared .200 build host had 5+ concurrent unrelated pytest runs from other live sessions consuming all CPU during this work (confirmed via `ps aux`), driving single-process suite progress to ~2-3% per 15-20 minutes of wall time. Both a full-suite run and the governed-selector-scoped subset run were left running in the background, logged to `/tmp/omn14985_full_suite.log` and `/tmp/omn14985_selector_scope.log` on stickybeatz-studio, for follow-up readback. No red tests were observed in either log before this PR was opened.

## Ticket

OMN-14985 (related: OMN-14944, Done -- this covers its residual/incomplete scope)
