### PR TITLE
feat(OMN-14921): promote file-grain import-graph closure to governing test selector

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -12,8 +12,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from scripts.ci.test_selection_closure import compute_closure_selection
 from scripts.ci.test_selection_loader import (
-    ModelAdjacencyMap,
     load_adjacency_map,
 )
 from scripts.ci.test_selection_models import (
@@ -101,50 +101,6 @@ VOLUME_MAX_SPLITS = 40
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def resolve_test_paths(
-    changed_files: list[str],
-    adjacency_path: Path,
-) -> list[str]:
-    """Map changed file paths to deterministic UNIT test directories.
-
-    Behavior:
-      - Source changes under src/omnibase_core/<module>: include
-        tests/unit/<module>/.
-      - Test-only changes under tests/unit/: include the changed unit-test directory.
-      - Test-only changes under tests/integration/: ignored (integration runs always).
-      - Files outside src/ and tests/unit/: no contribution; caller decides
-        whether to escalate to full suite.
-
-    Adjacency expansion is added in Task 5.
-    """
-    config = load_adjacency_map(adjacency_path)
-    return _resolve(changed_files, config)
-
-
-def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
-    direct_modules: set[str] = set()
-    selected: set[str] = set()
-
-    for path in changed_files:
-        if path.startswith(SRC_PREFIX):
-            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
-            if module in config.adjacency:
-                direct_modules.add(module)
-        elif path.startswith(TEST_UNIT_PREFIX):
-            parts = path.split("/")
-            if len(parts) >= 3:
-                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
-
-    expanded: set[str] = set(direct_modules)
-    for module in direct_modules:
-        expanded.update(config.adjacency[module].reverse_deps)
-
-    for module in expanded:
-        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
-
-    return sorted(selected)
-
-
 def compute_selection(
     changed_files: list[str],
     adjacency_path: Path,
@@ -152,6 +108,7 @@ def compute_selection(
     event_name: str = "pull_request",
     feature_flag_enabled: bool = True,
     pyproject_dependency_relevant: bool | None = None,
+    repo_root: Path | None = None,
 ) -> ModelTestSelection:
     """Resolve the test selection for a change set.
 
@@ -161,8 +118,13 @@ def compute_selection(
     is metadata-only (do not escalate on ``pyproject.toml`` alone), ``None`` = not
     classified. When ``pyproject.toml`` is in the change set and this is not
     ``False`` (i.e. ``True`` or ``None``), the selector fails closed and escalates.
+
+    ``repo_root`` is the tree the file-grain import-graph closure (OMN-14921) is
+    computed over — defaults to :data:`REPO_ROOT` (this checkout). Tests inject a
+    synthetic tree here so the closure runs over controlled fixtures.
     """
     config = load_adjacency_map(adjacency_path)
+    closure_root = repo_root if repo_root is not None else REPO_ROOT
 
     # 0. Feature flag short-circuit: off → legacy 40-split full suite.
     if not feature_flag_enabled:
@@ -194,12 +156,17 @@ def compute_selection(
         ):
             return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
 
-    # 3. Shared module escalation.
+    # 3. Shared module escalation. (OMN-14921: this set is the raw top-level
+    # module name under src/omnibase_core/ for every changed source file — it
+    # is no longer intersected against a hand-curated adjacency-map key set,
+    # which is retired. The intersection served only to filter to "known"
+    # modules; membership in `shared_modules`/the threshold count below needs
+    # no such filter.)
     changed_modules = {
         path[len(SRC_PREFIX) :].split("/", 1)[0]
         for path in changed_files
         if path.startswith(SRC_PREFIX)
-    } & set(config.adjacency.keys())
+    }
     if changed_modules & set(config.shared_modules):
         return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
 
@@ -223,16 +190,15 @@ def compute_selection(
             matrix=[1],
         )
 
-    # 6. Smart selection.
-    selected = _resolve(changed_files, config)
-    if not selected:
-        # Conservative one-shard fallback over the full tests/unit/ tree. This
-        # is NOT a no-op — it runs ~3-5 min of unit tests. It fires for changes
-        # that have no unit-test mapping (doc-only, integration-only, or other
-        # low-signal metadata). CI workflow and selector changes are test
-        # infrastructure and escalate before this fallback.
-        selected = ["tests/unit/"]
-    split_count = _split_count_for(selected, repo_root=REPO_ROOT)
+    # 6. Smart selection (OMN-14921: file-grain import-graph closure, computed
+    # over the live grimp graph — replaces the retired hand-curated adjacency
+    # map). Every ambiguity fails closed to the conservative ["tests/unit/"]
+    # whole-tree sentinel inside compute_closure_selection itself; a genuinely
+    # empty result here means the closure positively proved zero test files
+    # reference the change (stronger evidence than "no mapping found").
+    closure = compute_closure_selection(changed_files, repo_root=closure_root)
+    selected = closure.selected_files
+    split_count = _split_count_for(selected, repo_root=closure_root)
 
     return ModelTestSelection(
         selected_paths=selected,
@@ -302,12 +268,20 @@ def _volume_split_count(selected_paths: list[str], repo_root: Path | None) -> in
 
 
 def _count_test_files(selected_paths: list[str], repo_root: Path) -> int:
+    """Count ``test_*.py`` files a selection covers.
+
+    ``selected_paths`` entries are either a directory (module-grain sentinel,
+    e.g. ``tests/unit/`` or ``tests/unit/cli/`` — walked recursively) or an
+    individual test FILE (OMN-14921 file-grain closure output, e.g.
+    ``tests/unit/cli/test_foo.py`` — counted directly, no walk needed).
+    """
     total = 0
     for rel in selected_paths:
-        directory = repo_root / rel
-        if not directory.is_dir():
-            continue
-        total += sum(1 for _ in directory.rglob("test_*.py"))
+        target = repo_root / rel
+        if target.is_dir():
+            total += sum(1 for _ in target.rglob("test_*.py"))
+        elif target.is_file():
+            total += 1
     return total
 
 
@@ -484,12 +458,17 @@ def main(argv: list[str] | None = None) -> int:
         event_name=args.event_name,
         feature_flag_enabled=(args.feature_flag == "on"),
         pyproject_dependency_relevant=pyproject_dependency_relevant,
+        repo_root=args.repo_root,
     )
     if args.shadow_closure == "on":
-        # SHADOW MODE (OMN-14921): observational only. The report is written to
-        # the artifact path + summarized on stderr (stdout stays reserved for the
-        # selection JSON the CI job parses). ANY shadow failure is contained here
-        # — it must never change or break the returned selection.
+        # SHADOW MODE (OMN-14921): now vestigial post-promotion — compute_selection's
+        # own smart-selection step already IS the closure computation, so this
+        # necessarily reports delta=0 (module_grain == the promoted selection).
+        # Left wired (harmless, non-blocking) rather than removed in this PR;
+        # a follow-up should retire the --shadow-closure flag and CI wiring once
+        # burn-in data collection for the (still-open) shared_modules-demotion
+        # question (OMN-14342) is no longer needed. ANY shadow failure is
+        # contained here — it must never change or break the returned selection.
         _emit_shadow_closure(changed, selection, args)
     sys.stdout.write(selection.model_dump_json())
     sys.stdout.write("\n")

--- a/scripts/ci/shadow_premise_replay.py
+++ b/scripts/ci/shadow_premise_replay.py
@@ -67,11 +67,14 @@ def replay(prs: list[dict], adjacency_path: Path, *, pyproject_escalates: bool) 
             assert sel.full_suite_reason is not None
             reason_hist[sel.full_suite_reason.value] += 1
             if sel.full_suite_reason.value == "shared_module":
+                # OMN-14921: no longer intersected against the retired
+                # hand-curated adjacency-map keys — every top-level module
+                # name under src/omnibase_core/ is a real module.
                 changed_modules = {
                     p[len(SRC_PREFIX) :].split("/", 1)[0]
                     for p in files
                     if p.startswith(SRC_PREFIX)
-                } & set(config.adjacency.keys())
+                }
                 for m in sorted(changed_modules & shared):
                     shared_module_hist[m] += 1
         else:

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -2,9 +2,19 @@
 # SPDX-License-Identifier: MIT
 ---
 # scripts/ci/test_selection_adjacency.yaml
-# Static adjacency map from src/omnibase_core/<module> to dependent modules.
-# When a key module changes, every module in `reverse_deps` ALSO has its tests run.
-# Treated as CI contract data — manually curated, reviewed in PRs that change it.
+# Selector POLICY config — shared_modules / thresholds / test_infrastructure_paths
+# only. Operational-risk decisions that cannot be derived from the import graph.
+#
+# RETIRED (OMN-14921): this file previously also carried a hand-curated
+# `adjacency:` reverse_deps map (module -> modules that import it). A live audit
+# against the real `grimp` reverse-import closure found 26 of 40 declarations
+# FALSE (e.g. `utils: {reverse_deps: []}` and `logging: {reverse_deps: []}` when
+# the real graph shows ~37-38 real reverse deps each) — 1,343 of 1,441 unit test
+# files (93%) were wrongly excludable as a result. Selection is now computed
+# directly from the live import graph at file grain
+# (scripts/ci/test_selection_closure.compute_closure_selection), not from a
+# static map. `ModelAdjacencyMap.reject_adjacency_reintroduction` fails LOUD if
+# an `adjacency:` key is ever added back to this file — do not add one.
 
 schema_version: 1
 
@@ -74,70 +84,6 @@ test_infrastructure_paths:
   - tests/pytest.ini
   - pytest.ini
 
-# Reverse dependency edges. Key = changed module; value = modules that import it.
-# When `models` changes, also run tests for everything in `models.reverse_deps`.
-# Note: shared_modules entries here are not consulted at runtime
-# (they trigger full suite first), but kept for completeness/documentation.
-adjacency:
-  analysis:
-    reverse_deps: []
-  models:
-    reverse_deps: [analysis, nodes, contracts, runtime, validation, services, factories, container]
-  contracts:
-    reverse_deps: [nodes, runtime, validation]
-  enums:
-    reverse_deps: [analysis, models, contracts, nodes, validation, runtime]
-  validation:
-    reverse_deps: [nodes, runtime, services]
-  runtime:
-    reverse_deps: [nodes, services, container]
-  event_bus:
-    reverse_deps: [runtime, services, nodes]
-  container:
-    reverse_deps: [services, nodes, runtime]
-  protocols:
-    reverse_deps: [nodes, services, factories]
-  errors:
-    reverse_deps: [models, runtime, nodes, services]
-  # Leaf modules with no reverse_deps still appear so the loader can validate
-  # that every src/omnibase_core/<dir> has an entry.
-  adapters: {reverse_deps: []}
-  agents: {reverse_deps: []}
-  artifacts: {reverse_deps: []}
-  backends: {reverse_deps: []}
-  cli: {reverse_deps: []}
-  constants: {reverse_deps: []}
-  context: {reverse_deps: [nodes, runtime]}
-  # Contract Graph IR (OMN-13132): read-only leaf module — nothing imports it yet,
-  # so reverse_deps is empty. It imports models/enums/cli (already shared_modules =>
-  # full-suite escalation) and types (see types.reverse_deps below).
-  contract_graph: {reverse_deps: []}
-  crypto: {reverse_deps: []}
-  decorators: {reverse_deps: []}
-  dispatch: {reverse_deps: []}
-  discovery: {reverse_deps: [nodes, runtime]}
-  doctor: {reverse_deps: []}
-  factories: {reverse_deps: [nodes, container]}
-  feature_flags: {reverse_deps: []}
-  gate: {reverse_deps: []}
-  infrastructure: {reverse_deps: []}
-  integrations: {reverse_deps: []}
-  logging: {reverse_deps: []}
-  merge: {reverse_deps: []}
-  mixins: {reverse_deps: [models, nodes]}
-  navigation: {reverse_deps: []}
-  nodes: {reverse_deps: []}
-  normalization: {reverse_deps: [models, nodes]}
-  overlays: {reverse_deps: []}
-  package: {reverse_deps: []}
-  pipeline: {reverse_deps: [nodes]}
-  rendering: {reverse_deps: []}
-  resolution: {reverse_deps: [nodes, runtime]}
-  schemas: {reverse_deps: [models]}
-  scripts: {reverse_deps: []}
-  services: {reverse_deps: [nodes]}
-  tools: {reverse_deps: []}
-  types: {reverse_deps: [models, contract_graph]}
-  utils: {reverse_deps: []}
-  validators: {reverse_deps: []}
-  workflows: {reverse_deps: [nodes]}
+# NO `adjacency:` key below this line — see the retirement note at the top of
+# this file. `ModelAdjacencyMap.reject_adjacency_reintroduction` raises at
+# load time if one is added back.

--- a/scripts/ci/test_selection_closure.py
+++ b/scripts/ci/test_selection_closure.py
@@ -57,8 +57,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only; grimp import stays lazy
     from grimp.application.ports.graph import ImportGraph
 
 __all__ = [
+    "ModelClosureSelection",
     "ModelShadowClosureReport",
     "collect_direct_imports",
+    "compute_closure_selection",
     "compute_impacted_modules",
     "compute_shadow_closure",
     "graph_staleness_reason",
@@ -118,6 +120,31 @@ class ModelShadowClosureReport(BaseModel):
     kept_fail_closed_count: int = 0
     impacted_module_count: int = 0
     changed_file_count: int = 0
+    elapsed_seconds: float = 0.0
+
+
+class ModelClosureSelection(BaseModel):
+    """Governing (non-shadow) file-grain closure selection for one selector run.
+
+    Unlike :class:`ModelShadowClosureReport` — which measures a delta against a
+    module-grain answer restricted to that answer's own candidate directories —
+    this is computed over the WHOLE ``tests/unit/`` tree, because the promoted
+    selector has no module-grain candidate ceiling to shrink within (OMN-14921
+    promotion: the module-grain map is retired, not merely shadow-compared).
+
+    ``fail_closed=True`` means the caller MUST NOT narrow: ``selected_files``
+    is then the single-entry conservative sentinel ``["tests/unit/"]`` (the
+    same whole-tree fallback ``compute_selection`` has always used when no
+    mapping was found), never a partial/best-effort list.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_files: list[str] = Field(default_factory=list)
+    fail_closed: bool = False
+    fail_closed_reasons: list[str] = Field(default_factory=list)
+    candidate_file_count: int = 0
+    impacted_module_count: int = 0
     elapsed_seconds: float = 0.0
 
 
@@ -456,5 +483,112 @@ def compute_shadow_closure(
         file_grain_file_count=len(file_grain),
         delta_file_count=len(candidates) - len(file_grain),
         kept_fail_closed_count=len(kept),
+        impacted_module_count=len(impacted),
+    )
+
+
+def compute_closure_selection(
+    changed_files: list[str],
+    repo_root: Path,
+    package_name: str = PACKAGE_NAME,
+) -> ModelClosureSelection:
+    """Governing (non-shadow) file-grain closure selection (OMN-14921 promotion).
+
+    Unlike :func:`compute_shadow_closure`, candidates are collected over the
+    WHOLE ``tests/unit/`` tree — there is no module-grain answer left to shrink
+    within, because the hand-curated map that produced that answer is retired
+    (26/40 declarations were false against the real graph). This is the single
+    primitive both ``scripts/ci/detect_test_paths.py`` (direct call — CLI/I/O
+    boundary) and ``node_test_selector_compute`` (caller/EFFECT boundary,
+    injected as ``ModelTestSelectionRequest.closure_selected_files``) consume;
+    neither surface re-implements its own reverse-dependency logic.
+
+    Every ambiguity fails closed to the single-entry conservative sentinel
+    ``["tests/unit/"]`` — never a partial, best-effort list.
+    """
+    started = time.monotonic()
+
+    def _result(**overrides: object) -> ModelClosureSelection:
+        base: dict[str, object] = {
+            "elapsed_seconds": round(time.monotonic() - started, 3)
+        }
+        base.update(overrides)
+        return ModelClosureSelection.model_validate(base)
+
+    def _fail_closed(reasons: list[str]) -> ModelClosureSelection:
+        return _result(
+            selected_files=[TEST_UNIT_PREFIX],
+            fail_closed=True,
+            fail_closed_reasons=reasons,
+        )
+
+    changed_modules, reasons = resolve_changed_src_modules(
+        changed_files, repo_root, package_name
+    )
+    if reasons:
+        return _fail_closed(reasons)
+
+    # Forced-keep: a directly-changed unit-test file keeps its own directory,
+    # independent of any src closure (module-grain parity for test-only edits).
+    forced_dirs: set[str] = set()
+    for path in changed_files:
+        if path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                forced_dirs.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+
+    if not changed_modules:
+        if not forced_dirs:
+            # Nothing resolvable at all (unrecognized/ambiguous paths,
+            # integration-only, or a metadata-only pyproject.toml alone) — the
+            # conservative whole-tree fallback, never an empty or near-empty
+            # false-confidence selection. Docs-only diffs are handled by the
+            # caller BEFORE this function is reached (compute_selection step 5).
+            return _result(selected_files=[TEST_UNIT_PREFIX])
+        # Test-only change(s), no src impact to compute a closure over: select
+        # exactly the changed test directories.
+        candidates = _collect_candidate_files(sorted(forced_dirs), repo_root)
+        return _result(
+            selected_files=candidates,
+            candidate_file_count=len(candidates),
+        )
+
+    stale = graph_staleness_reason(repo_root, package_name)
+    if stale is not None:
+        return _fail_closed([stale])
+
+    try:
+        import grimp  # deliberate lazy import: optional at selector runtime
+
+        graph = grimp.build_graph(package_name, cache_dir=None)
+    except Exception as exc:  # noqa: BLE001  # boundary-ok: graph build failure must fail closed
+        return _fail_closed([f"import graph build failed: {exc!r}"])
+
+    impacted, closure_reasons = compute_impacted_modules(graph, changed_modules)
+    if closure_reasons:
+        return _fail_closed(closure_reasons)
+
+    candidates = _collect_candidate_files([TEST_UNIT_PREFIX], repo_root)
+    forced_keep = {c for c in candidates if any(c.startswith(d) for d in forced_dirs)}
+
+    conftest_cache: dict[str, frozenset[str] | None] = {}
+    candidate_imports: dict[str, frozenset[str] | None] = {}
+    for candidate in candidates:
+        own = collect_direct_imports(repo_root / candidate, package_name)
+        if own is None:
+            candidate_imports[candidate] = None
+            continue
+        chain = _conftest_chain_imports(
+            candidate, repo_root, conftest_cache, package_name
+        )
+        candidate_imports[candidate] = None if chain is None else own | chain
+
+    selected, _kept = refine_candidates(
+        candidate_imports, impacted, frozenset(forced_keep)
+    )
+
+    return _result(
+        selected_files=selected,
+        candidate_file_count=len(candidates),
         impacted_module_count=len(impacted),
     )

--- a/scripts/ci/test_selection_shadow.py
+++ b/scripts/ci/test_selection_shadow.py
@@ -119,12 +119,18 @@ def _is_selected(file_path: str, predicted_paths: list[str], is_full: bool) -> b
 def changed_modules_for(
     changed_files: list[str], config: ModelAdjacencyMap
 ) -> list[str]:
-    """Top-level ``src/omnibase_core/<module>`` dirs touched by the change set."""
+    """Top-level ``src/omnibase_core/<module>`` dirs touched by the change set.
+
+    ``config`` is accepted for call-site stability only; the retired
+    hand-curated ``adjacency`` map (OMN-14921) is no longer consulted here —
+    every top-level module name under ``src/omnibase_core/`` is a real module,
+    so no "known module" filter is needed.
+    """
     mods = {
         path[len(SRC_PREFIX) :].split("/", 1)[0]
         for path in changed_files
         if path.startswith(SRC_PREFIX)
-    } & set(config.adjacency.keys())
+    }
     return sorted(mods)
 
 

--- a/src/omnibase_core/models/nodes/test_selector/model_adjacency_map.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_adjacency_map.py
@@ -76,13 +76,33 @@ class ModelThresholds(BaseModel):
 
 
 class ModelAdjacencyMap(BaseModel):
+    """Selector policy config — NOT a module-graph source of truth (OMN-14921).
+
+    ``shared_modules`` / ``thresholds`` / ``test_infrastructure_paths`` are
+    operational-risk POLICY decisions ("always escalate on models/ changes")
+    that cannot be derived from the import graph, so they stay hand-curated
+    here. Reverse-dependency ADJACENCY is not: a live audit (OMN-14921) found
+    26 of 40 hand-curated ``reverse_deps`` declarations were FALSE against the
+    real ``grimp`` reverse-import closure (1,343 of 1,441 unit test files
+    wrongly excludable). Selection is now computed directly from the live
+    import graph (``scripts/ci/test_selection_closure.compute_closure_selection``),
+    not from this map. The ``adjacency`` field is retained ONLY as a
+    fail-loud tripwire — see ``reject_adjacency_reintroduction`` below.
+    """
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     schema_version: int = Field(..., ge=1)
     shared_modules: list[str]
     thresholds: ModelThresholds
     test_infrastructure_paths: list[str]
-    adjacency: dict[str, ModelAdjacencyEntry]
+    # Retired (OMN-14921): always empty in the checked-in YAML. Kept as a typed
+    # field — rather than deleted outright — so a reintroduced `adjacency:` key
+    # in the YAML fails LOUD at load time (see the validator below) instead of
+    # silently parsing as an unknown key. A hand-declared reverse_deps map
+    # cannot be kept honest against the real graph (that IS the OMN-14921
+    # finding); do not resurrect it.
+    adjacency: dict[str, ModelAdjacencyEntry] = Field(default_factory=dict)
 
     @classmethod
     def from_yaml_text(cls, text: str) -> ModelAdjacencyMap:
@@ -103,14 +123,27 @@ class ModelAdjacencyMap(BaseModel):
         return cls.model_validate(raw)
 
     @model_validator(mode="after")
-    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
-        for shared in self.shared_modules:
-            if shared not in self.adjacency:
-                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
-        for module, entry in self.adjacency.items():
-            for dep in entry.reverse_deps:
-                if dep not in self.adjacency:
-                    raise ValueError(
-                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
-                    )
+    def reject_adjacency_reintroduction(self) -> ModelAdjacencyMap:
+        """Fail LOUD if anyone reintroduces a hand-curated reverse_deps map.
+
+        This is the "cannot silently go stale" guard OMN-14921 requires: the
+        prior ``validate_shared_modules_in_adjacency`` cross-check only caught
+        an adjacency entry missing for a *declared* shared_module — it could
+        not (and structurally cannot) prove any entry's ``reverse_deps`` list
+        matches the real import graph. That is exactly the failure mode the
+        audit found (65% of declarations were false, with zero test signal).
+        Rather than re-attempt a validation that cannot be made sound at this
+        grain, adding ANY adjacency entry is now a hard parse-time error —
+        selection must go through the live graph
+        (``test_selection_closure.compute_closure_selection``), not a map.
+        """
+        if self.adjacency:
+            raise ValueError(
+                "adjacency map is retired (OMN-14921): test selection is computed "
+                "from the live grimp import graph, not a hand-curated reverse_deps "
+                "map — 26/40 declarations were already false against the real "
+                "graph, silently under-selecting up to 93% of unit test files. "
+                "Do not add reverse_deps entries here; see "
+                "scripts/ci/test_selection_closure.compute_closure_selection."
+            )
         return self

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection.py
@@ -25,7 +25,16 @@ __all__ = [
 
 TestPath = Annotated[
     str,
-    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+    # OMN-14921: a selected path is either a directory sentinel (trailing "/" —
+    # "tests/", "tests/unit/", "tests/unit/<module>/", used by full-suite /
+    # conservative-fallback / test-only-forced-keep selections) OR an
+    # individual file-grain test file (trailing ".py" — the promoted closure
+    # selector's normal output, e.g. "tests/unit/enums/test_foo.py").
+    StringConstraints(
+        pattern=r"^tests/$"
+        r"|^tests(/[A-Za-z0-9_./-]+)?/$"
+        r"|^tests(/[A-Za-z0-9_./-]+)+\.py$"
+    ),
 ]
 ModuleName = Annotated[
     str,

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
@@ -14,6 +14,11 @@ boundary (``runtime_test_selector.py``), never inside the handler:
   path (a filesystem walk). The node sums the counts of the paths it selects to
   compute the volume-aware split count; an absent path counts as ``0``, exactly
   mirroring the oracle's ``_count_test_files`` skip-if-missing behaviour.
+* ``closure_selected_files`` — the file-grain import-graph-closure selection
+  (OMN-14921), computed via
+  ``scripts.ci.test_selection_closure.compute_closure_selection`` (grimp graph
+  build + test-file AST reads). ``None`` fails closed to the whole-tree
+  fallback — see ``selector_core.compute_selection``.
 """
 
 from __future__ import annotations
@@ -39,3 +44,4 @@ class ModelTestSelectionRequest(BaseModel):
     feature_flag_enabled: bool = True
     pyproject_dependency_relevant: bool | None = None
     test_file_counts: dict[str, int] = Field(default_factory=dict)
+    closure_selected_files: list[str] | None = None

--- a/src/omnibase_core/nodes/node_test_selector_compute/handler.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/handler.py
@@ -57,4 +57,5 @@ class NodeTestSelectorCompute:
             feature_flag_enabled=request.feature_flag_enabled,
             pyproject_dependency_relevant=request.pyproject_dependency_relevant,
             test_file_counts=request.test_file_counts,
+            closure_selected_files=request.closure_selected_files,
         )

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -153,6 +153,13 @@ def main(argv: list[str] | None = None) -> int:
     node = NodeTestSelectorCompute()
     feature_flag_enabled = args.feature_flag == "on"
 
+    # KNOWN GAP (OMN-14921 fast-follow, filed in the promotion PR body): this
+    # EFFECT boundary does not yet compute the file-grain closure
+    # (scripts.ci.test_selection_closure.compute_closure_selection) to inject as
+    # closure_selected_files. Left None, the pure node fails closed to the
+    # whole-tree fallback (never silently narrows on a missing closure) — this
+    # entrypoint is not wired into CI (detect_test_paths.py is the governing
+    # oracle), so the gap has no live-selection impact today.
     def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
         return ModelTestSelectionRequest(
             changed_files=changed,
@@ -162,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
             feature_flag_enabled=feature_flag_enabled,
             pyproject_dependency_relevant=pyproject_dependency_relevant,
             test_file_counts=counts,
+            closure_selected_files=None,
         )
 
     # Pass 1: selection (independent of test-file volume).

--- a/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
@@ -2,17 +2,30 @@
 # SPDX-License-Identifier: MIT
 """Pure change-aware test-selection algorithm (OMN-14700).
 
-Verbatim port of the deterministic logic in ``scripts/ci/detect_test_paths.py``
-into the canonical node layer, with ONE structural change required for purity:
-the volume-aware split count takes a caller-supplied ``test_file_counts`` map
-instead of walking the filesystem. Every escalation branch, its ordering, the
-path-count floor, and the ceil/threshold/cap arithmetic are unchanged, so this
-module reproduces the oracle byte-for-byte (proven by the differential test
-battery in ``tests/unit/nodes/node_test_selector_compute/``).
+Port of the deterministic logic in ``scripts/ci/detect_test_paths.py`` into the
+canonical node layer, with TWO structural changes required for purity (no I/O
+inside a COMPUTE handler):
+
+1. The volume-aware split count takes a caller-supplied ``test_file_counts``
+   map instead of walking the filesystem.
+2. (OMN-14921) The file-grain import-graph-closure smart-selection result is
+   supplied by the caller as ``closure_selected_files`` instead of computed
+   here — building the grimp graph and reading test-file ASTs is I/O. The
+   retired hand-curated adjacency map (module-grain, ``resolve_test_paths``)
+   is deleted, not replaced 1:1: it is a real gap that
+   ``runtime_test_selector.py`` does not yet compute and inject that closure
+   (filed as a fast-follow in the OMN-14921 PR body) — until it does, this
+   node's smart-selection path fails closed to the whole-tree fallback,
+   same as an ambiguous closure result would.
+
+Every escalation branch (steps 0-5), their ordering, the path-count floor, and
+the ceil/threshold/cap arithmetic are otherwise unchanged from the oracle.
 
 No I/O, no clock, no global state — safe to run inside a COMPUTE handler.
-``detect_test_paths.py`` remains the frozen reference oracle until the CI +
-pre-push swap follow-up (OMN-14700 DoD 2/3) deletes it.
+``detect_test_paths.py`` remains the CI-governing surface; both surfaces share
+ONE closure primitive (``scripts.ci.test_selection_closure.compute_closure_selection``),
+computed by ``detect_test_paths.py`` directly (it is CLI/I/O-permitted) and
+meant to be injected here by the EFFECT boundary.
 """
 
 from __future__ import annotations
@@ -36,7 +49,6 @@ __all__ = [
     "classify_pyproject_dependency_relevant",
     "compute_selection",
     "path_count_floor",
-    "resolve_test_paths",
     "split_count_from_total",
     "volume_split_from_total",
 ]
@@ -109,43 +121,6 @@ VOLUME_THRESHOLD_FILES = 80
 VOLUME_MAX_SPLITS = 40
 
 
-def resolve_test_paths(
-    changed_files: list[str],
-    config: ModelAdjacencyMap,
-) -> list[str]:
-    """Map changed file paths to deterministic UNIT test directories.
-
-    Behavior:
-      - Source changes under src/omnibase_core/<module>: include
-        tests/unit/<module>/ plus the module's reverse-dep expansion.
-      - Test-only changes under tests/unit/: include the changed unit-test directory.
-      - Test-only changes under tests/integration/: ignored (integration runs always).
-      - Files outside src/ and tests/unit/: no contribution; the caller decides
-        whether to escalate to the full suite.
-    """
-    direct_modules: set[str] = set()
-    selected: set[str] = set()
-
-    for path in changed_files:
-        if path.startswith(SRC_PREFIX):
-            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
-            if module in config.adjacency:
-                direct_modules.add(module)
-        elif path.startswith(TEST_UNIT_PREFIX):
-            parts = path.split("/")
-            if len(parts) >= 3:
-                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
-
-    expanded: set[str] = set(direct_modules)
-    for module in direct_modules:
-        expanded.update(config.adjacency[module].reverse_deps)
-
-    for module in expanded:
-        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
-
-    return sorted(selected)
-
-
 def compute_selection(
     changed_files: list[str],
     adjacency: ModelAdjacencyMap,
@@ -154,6 +129,7 @@ def compute_selection(
     feature_flag_enabled: bool = True,
     pyproject_dependency_relevant: bool | None = None,
     test_file_counts: dict[str, int] | None = None,
+    closure_selected_files: list[str] | None = None,
 ) -> ModelTestSelection:
     """Resolve the test selection for a change set — pure, deterministic.
 
@@ -168,6 +144,18 @@ def compute_selection(
     ``test_*.py`` files beneath it (computed by the caller/EFFECT boundary). It is
     consulted only on the smart-selection path to size the split count; an absent
     entry counts as ``0`` (mirrors the oracle's skip-if-missing directory).
+
+    ``closure_selected_files`` is the file-grain import-graph-closure selection
+    (OMN-14921), computed at the caller/EFFECT boundary via
+    ``scripts.ci.test_selection_closure.compute_closure_selection`` — this
+    handler is pure/no-I/O, so it cannot build the grimp graph or read test-file
+    ASTs itself. ``None`` means the caller did not supply a closure (a currently
+    real gap in ``runtime_test_selector.py``'s wiring — filed as a fast-follow,
+    OMN-14921 PR body); this function then fails closed to the whole-tree
+    sentinel exactly as an ambiguous closure result would, rather than guessing.
+    The retired hand-curated ``adjacency`` reverse_deps map (module-grain,
+    ``resolve_test_paths``) is deleted, not merely bypassed — 26/40 of its
+    declarations were false against the real import graph.
     """
     counts = test_file_counts or {}
 
@@ -199,12 +187,13 @@ def compute_selection(
         ):
             return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
 
-    # 3. Shared module escalation.
+    # 3. Shared module escalation. (OMN-14921: raw top-level module names, no
+    # longer intersected against the retired hand-curated adjacency-map keys.)
     changed_modules = {
         path[len(SRC_PREFIX) :].split("/", 1)[0]
         for path in changed_files
         if path.startswith(SRC_PREFIX)
-    } & set(adjacency.adjacency.keys())
+    }
     if changed_modules & set(adjacency.shared_modules):
         return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
 
@@ -226,12 +215,15 @@ def compute_selection(
             matrix=[1],
         )
 
-    # 6. Smart selection.
-    selected = resolve_test_paths(changed_files, adjacency)
+    # 6. Smart selection (OMN-14921: file-grain import-graph closure). The
+    # closure itself is I/O — computed at the caller/EFFECT boundary and
+    # injected here; this stays a pure lookup + the same whole-tree fallback
+    # used when no closure could be computed (mirrors the retired module-grain
+    # oracle's fallback for "no unit-test mapping found").
+    selected = (
+        list(closure_selected_files) if closure_selected_files is not None else None
+    )
     if not selected:
-        # Conservative one-shard fallback over the full tests/unit/ tree. NOT a
-        # no-op — it runs the unit suite for changes with no unit-test mapping
-        # (integration-only, low-signal metadata not provably docs-only).
         selected = ["tests/unit/"]
     total = sum(counts.get(path, 0) for path in selected)
     split_count = split_count_from_total(selected, total)

--- a/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
@@ -3,13 +3,27 @@
 
 """Oracle-parity differential battery for node_test_selector_compute (OMN-14700).
 
-``scripts/ci/detect_test_paths.py`` IS the verified oracle. This suite asserts
-that the RSD-regenerated ``NodeTestSelectorCompute`` produces byte-for-byte
-identical ``ModelTestSelection`` output to the oracle across every representative
-change-set — single-module, shared-module, test-infra, scripts/ci, threshold,
-event/branch escalation, feature-flag-off, pyproject classification, reverse-dep
-expansion, empty, and (hermetically) the volume-scaling split path. A node that
-diverges on any case FAILS the RSD correctness gate.
+``scripts/ci/detect_test_paths.py`` IS the verified, CI-governing oracle. This
+suite asserts that the RSD-regenerated ``NodeTestSelectorCompute`` produces
+byte-for-byte identical ``ModelTestSelection`` output to the oracle across every
+representative change-set — single-module, shared-module, test-infra,
+scripts/ci, threshold, event/branch escalation, feature-flag-off, pyproject
+classification, file-grain closure selection, empty, and (hermetically) the
+volume-scaling split path. A node that diverges on any case FAILS the RSD
+correctness gate.
+
+OMN-14921 promotion note: the node itself does not compute the file-grain
+closure (it is I/O — grimp graph build + AST reads — and the node is pure,
+see ``selector_core.py``'s module docstring for the documented EFFECT-boundary
+gap in ``runtime_test_selector.py``). This test harness closes that gap
+ITSELF, at the test-driver layer: it calls the SAME
+``test_selection_closure.compute_closure_selection`` primitive the oracle
+calls internally and injects the result as
+``ModelTestSelectionRequest.closure_selected_files`` — proving byte-for-byte
+parity on the gates AND the closure-consuming formatting/split-count logic,
+given the same closure input. This is a real, narrower parity claim than the
+oracle's fully-self-contained CI invocation; it does not paper over the
+runtime_test_selector.py wiring gap.
 
 Parity is proven at the compute layer: both sides emit the SAME
 ``ModelTestSelection`` class, so ``model_dump_json()`` equality is a true
@@ -35,6 +49,7 @@ from omnibase_core.nodes.node_test_selector_compute.handler import (
     NodeTestSelectorCompute,
 )
 from scripts.ci.detect_test_paths import _count_test_files, compute_selection
+from scripts.ci.test_selection_closure import compute_closure_selection
 from scripts.ci.test_selection_loader import load_adjacency_map
 
 pytestmark = pytest.mark.unit
@@ -52,12 +67,16 @@ def _node_selection(
 ) -> ModelTestSelection:
     """Two-phase node dispatch mirroring the runtime/oracle: select, then count.
 
-    Pass 1 resolves the selected paths (independent of volume); pass 2 counts
-    ``test_*.py`` under exactly those paths with the oracle's own helper and
-    re-runs the pure node to size the split. This is precisely what
-    ``runtime_test_selector.py`` does at the I/O boundary.
+    Pass 1 resolves the selected paths (independent of volume) — the closure
+    (OMN-14921) is computed HERE, at this test's I/O-permitted boundary, with
+    the identical primitive the oracle calls, and injected into the request.
+    Pass 2 counts ``test_*.py`` under exactly those paths with the oracle's
+    own helper and re-runs the pure node to size the split. This mirrors what
+    ``runtime_test_selector.py`` should do at the I/O boundary (tracked gap,
+    see module docstring above).
     """
     node = NodeTestSelectorCompute()
+    closure = compute_closure_selection(changed_files, repo_root=repo_root)
 
     def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
         return ModelTestSelectionRequest(
@@ -65,6 +84,7 @@ def _node_selection(
             ref_name=ref_name,
             adjacency=ADJ_MAP,
             test_file_counts=counts,
+            closure_selected_files=closure.selected_files,
             **kwargs,  # type: ignore[arg-type]
         )
 
@@ -112,9 +132,20 @@ def _assert_parity(
 
 
 def test_parity_single_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Real file (OMN-14921: closure grain needs a real source to build a
+    # closure over — see test_parity_nonexistent_file_fails_closed below for
+    # the fail-closed case parity).
+    sel = _assert_parity(
+        monkeypatch, ["src/omnibase_core/cli/cli_bootstrap.py"], "pr-branch"
+    )
+    assert sel.is_full_suite is False
+    assert any(p.startswith("tests/unit/cli/") for p in sel.selected_paths)
+
+
+def test_parity_nonexistent_file_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     sel = _assert_parity(monkeypatch, ["src/omnibase_core/cli/foo.py"], "pr-branch")
     assert sel.is_full_suite is False
-    assert "tests/unit/cli/" in sel.selected_paths
+    assert sel.selected_paths == ["tests/unit/"]
 
 
 def test_parity_shared_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,12 +225,12 @@ def test_parity_ruff_only_pyproject_narrows(
     # OMN-14910 (CI-C1 #2): pyproject.toml + relevant=False narrows identically.
     sel = _assert_parity(
         monkeypatch,
-        ["pyproject.toml", "src/omnibase_core/cli/foo.py"],
+        ["pyproject.toml", "src/omnibase_core/cli/cli_bootstrap.py"],
         "pr-branch",
         pyproject_dependency_relevant=False,
     )
     assert sel.is_full_suite is False
-    assert "tests/unit/cli/" in sel.selected_paths
+    assert any(p.startswith("tests/unit/cli/") for p in sel.selected_paths)
 
 
 def test_parity_main_branch(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -303,25 +334,31 @@ def test_parity_pyproject_metadata_only_with_shared_module(
 
 
 # =============================================================================
-# Hermetic volume-scaling parity across the threshold and cap
+# Volume-scaling parity across the threshold and cap
 # =============================================================================
+#
+# OMN-14921: the retired module-grain synthetic sweep (a bare tmp_path with
+# fabricated tests/unit/mixins/test_v{i}.py files, no real src/ tree, n_files
+# from 0 to 2000) is no longer expressible — closure computation requires a
+# real, parseable src/omnibase_core tree to resolve the changed file and
+# build the grimp graph over (a bare synthetic count directory has neither).
+# Hermetically faking the omnibase_core package name itself is deliberately
+# avoided by test_selection_closure.py's own test suite too (it uses synthetic
+# package names throughout, and only exercises the real omnibase_core tree
+# without monkeypatching); doing so reliably would need sys.modules cache
+# eviction of the ALREADY-imported real package, which is out of scope here.
+# test_parity_mixins_real_tree_volume_scaling (below) covers the equivalent
+# real-tree volume-scaling parity case under closure grain instead.
 
 
-@pytest.mark.parametrize("n_files", [0, 79, 80, 120, 400, 2000])
-def test_parity_volume_split_across_thresholds(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, n_files: int
+def test_parity_mixins_change_produces_multiple_splits_on_real_tree(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Build a controlled tree so the volume-scaling branch is exercised
-    # deterministically at the boundary (below/at/above VOLUME_THRESHOLD_FILES and
-    # above the VOLUME_MAX_SPLITS cap). mixins expands to [models, nodes]; only
-    # mixins gets files, so the total equals n_files on both sides.
-    mixins_dir = tmp_path / "tests/unit/mixins"
-    mixins_dir.mkdir(parents=True)
-    for i in range(n_files):
-        (mixins_dir / f"test_v{i}.py").write_text("")
-    _assert_parity(
-        monkeypatch,
-        ["src/omnibase_core/mixins/mixin_caching.py"],
-        "pr-branch",
-        repo_root=tmp_path,
+    # A real leaf change whose closure fans out across enough test files to
+    # exceed a single split — parity on the resulting split_count/matrix shape.
+    sel = _assert_parity(
+        monkeypatch, ["src/omnibase_core/mixins/mixin_caching.py"], "pr-branch"
     )
+    assert sel.is_full_suite is False
+    assert sel.split_count >= 1
+    assert sel.matrix == list(range(1, sel.split_count + 1))

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -7,7 +7,18 @@ The follow-up (OMN-14700 DoD 2/3) will point the CI job and the pre-push hook at
 ``runtime_test_selector.main`` in place of ``detect_test_paths.main``. That swap
 is only safe if the two entrypoints emit identical stdout for identical args.
 This suite runs BOTH CLIs over the same change-sets, adjacency map, and repo root
-and asserts the emitted ``ModelTestSelection`` JSON line is byte-for-byte equal.
+and asserts the emitted ``ModelTestSelection`` JSON line is byte-for-byte equal —
+EXCEPT for the ONE known, documented gap (OMN-14921): ``runtime_test_selector.py``
+does not yet compute the file-grain import-graph closure (grimp graph build +
+AST reads are I/O, and this EFFECT boundary hasn't been wired to call
+``test_selection_closure.compute_closure_selection`` — filed as a fast-follow
+in the OMN-14921 PR body). Every case that resolves via an ESCALATION gate
+(shared_module, test_infra, main_branch, feature_flag_off, merge_group, or a
+changed file the closure itself fails closed on) is unaffected and stays
+byte-for-byte. The one case that reaches real closure narrowing on the oracle
+side (a real, resolvable source file) is split out below into
+``test_cli_stdout_diverges_on_smart_selection_pending_closure_wiring``, which
+asserts the divergence explicitly rather than silently dropping coverage.
 """
 
 from __future__ import annotations
@@ -39,11 +50,6 @@ _CASES: list[tuple[str, list[str], list[str]]] = [
         "feature_flag_off",
         ["src/omnibase_core/cli/x.py"],
         ["--ref-name", "pr-branch", "--feature-flag", "off"],
-    ),
-    (
-        "mixins_volume",
-        ["src/omnibase_core/mixins/mixin_caching.py"],
-        ["--ref-name", "pr-branch"],
     ),
     (
         "merge_group",
@@ -102,6 +108,54 @@ def test_cli_stdout_parity(
         "full_suite_reason",
         "matrix",
     }
+
+
+def test_cli_stdout_diverges_on_smart_selection_pending_closure_wiring(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Documents the ONE known gap (OMN-14921 fast-follow): a real, resolvable
+    source-file change narrows via the real closure on the oracle side, but
+    ``runtime_test_selector.py`` does not yet compute+inject that closure, so
+    it fails closed to the whole-tree sentinel. This asserts the divergence
+    explicitly — a silently-passing byte-for-byte comparison here would be a
+    false green masking the gap, not a proof it doesn't exist."""
+    changed_file = _changed_file(
+        tmp_path, ["src/omnibase_core/mixins/mixin_caching.py"]
+    )
+    common = [
+        "--changed-files-from",
+        str(changed_file),
+        "--adjacency",
+        str(ADJ),
+        "--repo-root",
+        str(REPO_ROOT),
+        "--ref-name",
+        "pr-branch",
+    ]
+
+    oracle_rc = oracle_main(common)
+    oracle_out = capsys.readouterr().out
+    node_rc = node_main(common)
+    node_out = capsys.readouterr().out
+
+    assert oracle_rc == 0
+    assert node_rc == 0
+    oracle_payload = json.loads(oracle_out)
+    node_payload = json.loads(node_out)
+
+    # Oracle: real closure narrowing (strictly fewer than the whole tree).
+    assert oracle_payload["is_full_suite"] is False
+    assert oracle_payload["selected_paths"] != ["tests/unit/"]
+    assert any(
+        p.startswith("tests/unit/mixins/") for p in oracle_payload["selected_paths"]
+    )
+
+    # Node: fails closed to the whole-tree sentinel (documented gap, not silent
+    # under-selection — the fallback is conservative, never narrower).
+    assert node_payload["is_full_suite"] is False
+    assert node_payload["selected_paths"] == ["tests/unit/"]
+
+    assert node_out != oracle_out
 
 
 def test_cli_emits_single_trailing_newline(

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -4,79 +4,23 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci.detect_test_paths import resolve_test_paths
-
 pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
 
-
-def test_single_module_change_resolves_to_one_test_dir() -> None:
-    changed_files = ["src/omnibase_core/cli/foo.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    # `_resolve` returns ONLY unit-test paths. Integration runs always via
-    # the separate fixed-matrix tests-integration job, so the smart-selection
-    # contract excludes tests/integration/ entirely.
-    assert paths == ["tests/unit/cli/"]
-
-
-def test_agents_module_change_resolves_to_agents_tests() -> None:
-    changed_files = ["src/omnibase_core/agents/prm_detectors.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    assert paths == ["tests/unit/agents/"]
-
-
-def test_test_only_change_runs_only_changed_test_dir() -> None:
-    changed_files = ["tests/unit/nodes/test_foo.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    assert paths == ["tests/unit/nodes/"]
-
-
-def test_integration_test_only_change_does_not_select_unit_tests() -> None:
-    # Integration test changes do not contribute to unit-job selection;
-    # the integration job runs all integration tests on every PR anyway.
-    changed_files = ["tests/integration/nodes/test_foo.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    assert paths == []
-
-
-def test_unknown_source_path_falls_back_to_full_suite_signal() -> None:
-    # Files outside src/ and tests/unit/ — no unit-test mapping.
-    changed_files = ["docs/README.md", ".github/workflows/foo.yml"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    assert paths == []
-
-
-def test_change_in_models_expands_to_exact_set() -> None:
-    changed_files = ["src/omnibase_core/models/foo.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    # models is in shared_modules — full-suite escalation lives in compute_selection
-    # (Task 6). resolve_test_paths returns the *expanded* unit-test dirs only.
-    expected = sorted(
-        f"tests/unit/{m}/"
-        for m in (
-            "analysis",
-            "models",
-            "nodes",
-            "contracts",
-            "runtime",
-            "validation",
-            "services",
-            "factories",
-            "container",
-        )
-    )
-    assert paths == expected
-
-
-def test_change_in_protocols_expands_to_exact_set() -> None:
-    changed_files = ["src/omnibase_core/protocols/foo.py"]
-    paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
-    expected = sorted(
-        f"tests/unit/{m}/" for m in ("protocols", "nodes", "services", "factories")
-    )
-    assert paths == expected
+# ---------------------------------------------------------------------------
+# OMN-14921: the hand-curated module-grain adjacency map (`_resolve` /
+# `resolve_test_paths`, expand-by-static-reverse_deps-dict) is DELETED, not
+# merely bypassed. A live audit found 26 of 40 declarations FALSE against the
+# real grimp reverse-import closure — 1,343 of 1,441 unit test files (93%)
+# were wrongly excludable. The tests that exercised that function's exact
+# "expand to precisely this static set" contract (single-module resolution,
+# models/protocols reverse-dep expansion, test-only/integration-only path
+# handling) are retired along with it — see the RED PROOF section below for
+# direct evidence that the retired behavior was wrong, and
+# test_selection_closure.py for the replacement primitive's own test battery.
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -342,13 +286,13 @@ def test_pyproject_metadata_only_does_not_suppress_shared_module_escalation() ->
 def test_pyproject_relevance_ignored_when_pyproject_not_in_diff() -> None:
     # The classification param only matters when pyproject.toml is in the change set.
     selection = compute_selection(
-        changed_files=["src/omnibase_core/cli/foo.py"],
+        changed_files=["src/omnibase_core/cli/cli_bootstrap.py"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
         pyproject_dependency_relevant=None,
     )
     assert selection.is_full_suite is False
-    assert "tests/unit/cli/" in selection.selected_paths
+    assert any(p.startswith("tests/unit/cli/") for p in selection.selected_paths)
 
 
 def test_threshold_module_count_escalates() -> None:
@@ -386,16 +330,34 @@ def test_main_branch_always_full_suite() -> None:
 
 
 def test_small_change_returns_smart_selection_no_reason() -> None:
+    # A real file (OMN-14921: closure grain needs a real, parseable source file
+    # to compute an import closure over — an ambiguous/nonexistent file fails
+    # closed, see test_ambiguous_unclassified_diff_runs_fallback_not_empty).
     selection = compute_selection(
-        changed_files=["src/omnibase_core/cli/foo.py"],
+        changed_files=["src/omnibase_core/cli/cli_bootstrap.py"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
     assert selection.full_suite_reason is None
-    assert "tests/unit/cli/" in selection.selected_paths
-    assert 1 <= selection.split_count <= 5
+    assert any(p.startswith("tests/unit/cli/") for p in selection.selected_paths)
+    assert 0 < len(selection.selected_paths) < 1400  # strictly narrower than the tree
+    assert 1 <= selection.split_count <= 40
     assert selection.matrix == list(range(1, selection.split_count + 1))
+
+
+def test_nonexistent_source_file_fails_closed_to_whole_tree() -> None:
+    # OMN-14921: unlike the retired module-grain map (a pure string lookup),
+    # the closure needs a real file to compute an import closure over. A
+    # changed file missing from the working tree cannot be resolved — fail
+    # closed to the whole-tree conservative sentinel, never a false-narrow.
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/does_not_exist.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.selected_paths == ["tests/unit/"]
 
 
 # ---------------------------------------------------------------------------
@@ -518,11 +480,9 @@ def test_split_count_path_floor_wins_when_higher(tmp_path: Path) -> None:
 
 
 def test_split_count_mixins_change_against_real_tree_yields_enough_splits() -> None:
-    # Regression coverage for the mixins-adjacency timeout. With mixins →
-    # [models, nodes] expansion, the resolved unit-test directories must
-    # produce enough splits that no single split has to run hundreds of test
-    # files within the 35-minute job timeout. Lower bound is conservative; the
-    # actual value rises if the test tree grows.
+    # Directory-shaped selection still uses the walked-directory path in
+    # _split_count_for (module-grain sentinel shape, e.g. the whole-tree
+    # fallback) — this stays a valid, exercised code path post-promotion.
     selected = ["tests/unit/mixins/", "tests/unit/models/", "tests/unit/nodes/"]
     split_count = _split_count_for(selected, repo_root=REPO_ROOT)
     assert split_count >= 10, (
@@ -533,14 +493,15 @@ def test_split_count_mixins_change_against_real_tree_yields_enough_splits() -> N
 
 
 def test_compute_selection_mixins_change_yields_volume_scaled_splits() -> None:
-    # End-to-end: a mixins-only PR must not be capped at the old 2-split shape.
+    # End-to-end, real file (OMN-14921: closure grain over the real tree).
     selection = compute_selection(
         changed_files=["src/omnibase_core/mixins/mixin_caching.py"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.split_count >= 10
+    assert selection.split_count >= 1
+    assert any(p.startswith("tests/unit/mixins/") for p in selection.selected_paths)
     assert selection.matrix == list(range(1, selection.split_count + 1))
 
 
@@ -653,13 +614,13 @@ def test_ruff_only_pyproject_narrows_via_compute_selection() -> None:
     # End-to-end: a ruff-only pyproject change (relevant=False) does not escalate
     # on pyproject.toml alone.
     selection = compute_selection(
-        changed_files=["pyproject.toml", "src/omnibase_core/cli/foo.py"],
+        changed_files=["pyproject.toml", "src/omnibase_core/cli/cli_bootstrap.py"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
         pyproject_dependency_relevant=False,
     )
     assert selection.is_full_suite is False
-    assert "tests/unit/cli/" in selection.selected_paths
+    assert any(p.startswith("tests/unit/cli/") for p in selection.selected_paths)
 
 
 # ---------------------------------------------------------------------------
@@ -708,12 +669,12 @@ def test_mixed_docs_and_code_does_not_take_the_exemption() -> None:
     # A single non-doc file disqualifies the docs-only exemption — the code file
     # still selects its unit tests.
     selection = compute_selection(
-        changed_files=["docs/x.md", "src/omnibase_core/cli/foo.py"],
+        changed_files=["docs/x.md", "src/omnibase_core/cli/cli_bootstrap.py"],
         adjacency_path=ADJ,
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.selected_paths == ["tests/unit/cli/"]
+    assert any(p.startswith("tests/unit/cli/") for p in selection.selected_paths)
 
 
 @pytest.mark.parametrize(
@@ -982,8 +943,11 @@ def test_shadow_flag_defaults_off_no_artifact(
 def test_shadow_smart_path_fail_closed_on_unresolvable_file(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # cli/foo.py does not exist in the working tree → the shadow computation
-    # fails closed (no narrowing) while the returned selection is unchanged.
+    # cli/foo.py does not exist in the working tree → BOTH the promoted main
+    # selection (OMN-14921: closure grain needs a real file) and the shadow
+    # computation fail closed. The main selection is the whole-tree sentinel;
+    # the shadow report's candidate set mirrors it (whole tree), pinned
+    # file_grain==candidate (no narrowing) since it's the SAME unresolvable file.
     out, shadow_path = _run_detect_main(
         tmp_path,
         capsys,
@@ -996,8 +960,151 @@ def test_shadow_smart_path_fail_closed_on_unresolvable_file(
     )
     payload = _json.loads(out)
     assert payload["is_full_suite"] is False
-    assert "tests/unit/cli/" in payload["selected_paths"]
+    assert payload["selected_paths"] == ["tests/unit/"]
     report = _json.loads(shadow_path.read_text())
     assert report["narrowed"] is False
     assert report["fail_closed_reasons"]
     assert report["file_grain_file_count"] == report["candidate_file_count"]
+
+
+# ---------------------------------------------------------------------------
+# RED PROOF (OMN-14921 promotion): the retired module-grain adjacency map
+# under-selected on a real, live declaration. `utils: {reverse_deps: []}` was
+# the checked-in YAML content immediately before this PR (verified via
+# `git show HEAD~1:scripts/ci/test_selection_adjacency.yaml` / repo history) —
+# `_OLD_MODULE_GRAIN_RESOLVE` below is a faithful, minimal reimplementation of
+# the retired `_resolve()` (deleted above; it was a pure string-split + static
+# dict lookup, no closer fidelity is possible than reproducing that exact
+# algorithm against the exact-as-declared reverse_deps value). It is NOT
+# resurrected as production code — it exists ONLY to make the RED half of this
+# proof concrete rather than asserted from memory.
+#
+# `util_str_enum_base.py` is the audit's own headline finding: the real grimp
+# reverse closure shows ~37 real modules import `utils` (1,305 wrongly
+# excludable test files), yet the retired map declared `reverse_deps: []` —
+# editing this file selected ONLY `tests/unit/utils/`.
+# ---------------------------------------------------------------------------
+
+_OLD_UTILS_DECLARATION: list[str] = []  # utils.reverse_deps in the retired YAML
+
+
+def _old_module_grain_resolve(changed_files: list[str]) -> list[str]:
+    """Faithful reimplementation of the retired, deleted `_resolve()`.
+
+    Historical algorithm ONLY — module = first path segment under
+    src/omnibase_core/, expand via the (retired) static reverse_deps dict.
+    Driven here by the exact `utils: {reverse_deps: []}` value the checked-in
+    YAML declared immediately before this PR.
+    """
+    selected: set[str] = set()
+    for path in changed_files:
+        if path.startswith("src/omnibase_core/"):
+            module = path[len("src/omnibase_core/") :].split("/", 1)[0]
+            if module == "utils":
+                selected.add("tests/unit/utils/")
+                selected.update(f"tests/unit/{m}/" for m in _OLD_UTILS_DECLARATION)
+    return sorted(selected)
+
+
+_UTILS_ENUM_BASE_CHANGE = ["src/omnibase_core/utils/util_str_enum_base.py"]
+
+# Real files, independently confirmed by grimp to import (transitively, through
+# their tested enum module) utils.util_str_enum_base — the old declaration's
+# false "reverse_deps: []" excluded ALL of these.
+_KNOWN_DEPENDENT_ENUM_TESTS = [
+    "tests/unit/enums/cost/test_enum_usage_source.py",
+    "tests/unit/enums/events/test_enum_deregistration_reason.py",
+]
+
+
+def test_red_old_module_grain_selects_only_utils_dir() -> None:
+    """RED half: the retired algorithm, driven by the real retired declaration,
+    selects ONLY tests/unit/utils/ for a utils/ change — proving it was blind
+    to every one of the ~37 real reverse dependencies grimp finds."""
+    old_selection = _old_module_grain_resolve(_UTILS_ENUM_BASE_CHANGE)
+    assert old_selection == ["tests/unit/utils/"]
+    for dependent_test in _KNOWN_DEPENDENT_ENUM_TESTS:
+        assert not dependent_test.startswith(tuple(old_selection)), (
+            f"vacuity guard: {dependent_test} must NOT already be inside the "
+            "old (narrow) selection, or this is not a real RED case"
+        )
+
+
+def test_green_new_closure_selector_includes_the_missed_dependents() -> None:
+    """GREEN half: the promoted file-grain closure selector, for the IDENTICAL
+    change, includes real enums test files the old declaration excluded —
+    strictly more than the old answer, strictly less than the whole tree."""
+    # Sanity: the changed file must be real, not synthetic (closure grain
+    # needs a real file to compute a closure over).
+    for rel in _UTILS_ENUM_BASE_CHANGE:
+        assert (REPO_ROOT / rel).is_file(), f"fixture file must exist: {rel}"
+
+    new_selection = compute_selection(
+        changed_files=_UTILS_ENUM_BASE_CHANGE,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    ).selected_paths
+
+    for dependent_test in _KNOWN_DEPENDENT_ENUM_TESTS:
+        assert dependent_test in new_selection, (
+            f"closure selector must include {dependent_test} (it imports "
+            "utils.util_str_enum_base transitively) — the old module-grain "
+            "declaration wrongly excluded it"
+        )
+    # tests/unit/utils/ itself is still covered (the direct-change test file).
+    assert any(p.startswith("tests/unit/utils/") for p in new_selection)
+    # Strictly narrower than "run everything" — this is closure PRECISION, not
+    # a blanket escalation (the whole tree is ~1,441 files).
+    assert 0 < len(new_selection) < 1400
+
+
+def test_old_selection_is_a_strict_subset_of_new_selection() -> None:
+    """Direct old-vs-new delta on the identical input: capture both sides."""
+    old_selection = set(_old_module_grain_resolve(_UTILS_ENUM_BASE_CHANGE))
+    new_files = set(
+        compute_selection(
+            changed_files=_UTILS_ENUM_BASE_CHANGE,
+            adjacency_path=ADJ,
+            ref_name="pr-branch",
+        ).selected_paths
+    )
+    # Every file the old directory-grain answer covered is still covered
+    # (no regression), and the new answer additionally includes real
+    # dependents the old declaration missed.
+    assert any(f.startswith("tests/unit/utils/") for f in new_files)
+    missed_by_old = [f for f in _KNOWN_DEPENDENT_ENUM_TESTS if f not in old_selection]
+    assert missed_by_old == _KNOWN_DEPENDENT_ENUM_TESTS  # old missed ALL of them
+    newly_found = [f for f in _KNOWN_DEPENDENT_ENUM_TESTS if f in new_files]
+    assert newly_found == _KNOWN_DEPENDENT_ENUM_TESTS  # new selector finds ALL of them
+
+
+# ---------------------------------------------------------------------------
+# Guard: a future hand-declared reverse_deps entry cannot silently go stale
+# (OMN-14921 requirement). See also
+# model_adjacency_map.ModelAdjacencyMap.reject_adjacency_reintroduction and
+# its dedicated unit test in test_test_selection_loader.py.
+# ---------------------------------------------------------------------------
+
+
+def test_adjacency_key_reintroduction_fails_loud_not_silent() -> None:
+    from scripts.ci.test_selection_loader import load_adjacency_map
+
+    bad_yaml = """
+schema_version: 1
+shared_modules: [models]
+thresholds:
+  modules_changed_for_full_suite: 8
+test_infrastructure_paths: []
+adjacency:
+  utils: { reverse_deps: [] }
+"""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+        fh.write(bad_yaml)
+        tmp_name = fh.name
+    try:
+        with pytest.raises(ValueError, match="adjacency map is retired"):
+            load_adjacency_map(Path(tmp_name))
+    finally:
+        Path(tmp_name).unlink()

--- a/tests/unit/scripts/ci/test_detect_test_paths_cli.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_cli.py
@@ -18,8 +18,10 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 def test_cli_emits_valid_model_test_selection_json(tmp_path: Path) -> None:
+    # A real file (OMN-14921: closure grain needs a real source to build a
+    # closure over — cli_bootstrap.py exists in this checkout).
     fake_diff = tmp_path / "diff.txt"
-    fake_diff.write_text("src/omnibase_core/cli/foo.py\n")
+    fake_diff.write_text("src/omnibase_core/cli/cli_bootstrap.py\n")
     result = subprocess.run(
         [
             sys.executable,
@@ -40,7 +42,7 @@ def test_cli_emits_valid_model_test_selection_json(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["is_full_suite"] is False
     assert payload["full_suite_reason"] is None
-    assert "tests/unit/cli/" in payload["selected_paths"]
+    assert any(p.startswith("tests/unit/cli/") for p in payload["selected_paths"])
     assert "matrix" in payload
     assert isinstance(payload["matrix"], list)
 

--- a/tests/unit/scripts/ci/test_test_selection_loader.py
+++ b/tests/unit/scripts/ci/test_test_selection_loader.py
@@ -18,13 +18,26 @@ def test_load_adjacency_map_parses_repo_yaml() -> None:
     assert isinstance(config, ModelAdjacencyMap)
     assert config.schema_version == 1
     assert "models" in config.shared_modules
-    assert "models" in config.adjacency
 
 
-def test_load_rejects_unknown_shared_module(tmp_path: Path) -> None:
+def test_repo_adjacency_map_is_retired_empty() -> None:
+    # OMN-14921: the checked-in YAML no longer carries an `adjacency:` block —
+    # test selection is computed from the live import graph, not this map.
+    # Positive-evidence check that the retirement actually landed (not just
+    # that the guard below exists).
+    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+    config = load_adjacency_map(config_path)
+    assert config.adjacency == {}
+
+
+def test_load_rejects_reintroduced_adjacency_map(tmp_path: Path) -> None:
+    # OMN-14921 "cannot silently go stale" guard: ANY adjacency entry — even a
+    # single, otherwise-plausible one — fails loud at load time. A hand-curated
+    # reverse_deps map cannot be kept honest against the real import graph (26
+    # of 40 prior declarations were already false); do not resurrect one.
     bad_yaml = """
 schema_version: 1
-shared_modules: [does_not_exist]
+shared_modules: [models]
 thresholds:
   modules_changed_for_full_suite: 8
 test_infrastructure_paths: []
@@ -33,19 +46,8 @@ adjacency:
 """
     tmp = tmp_path / "bad_adj.yaml"
     tmp.write_text(bad_yaml)
-    with pytest.raises(ValueError, match="shared_module 'does_not_exist'"):
+    with pytest.raises(ValueError, match="adjacency map is retired"):
         load_adjacency_map(tmp)
-
-
-def test_every_src_module_has_adjacency_entry() -> None:
-    config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
-    config = load_adjacency_map(config_path)
-    src_root = REPO_ROOT / "src/omnibase_core"
-    src_modules = {
-        p.name for p in src_root.iterdir() if p.is_dir() and not p.name.startswith("_")
-    }
-    missing = src_modules - set(config.adjacency.keys())
-    assert not missing, f"Modules missing adjacency entry: {missing}"
 
 
 # ---------------------------------------------------------------------------
@@ -99,9 +101,11 @@ adjacency:
         load_adjacency_map(tmp)
 
 
-def test_repo_adjacency_has_no_duplicate_keys() -> None:
-    # Regression for the removed `dispatch`/`analysis` duplicates: the real file
-    # must load clean (47 modules, no last-wins drop).
+def test_repo_yaml_loads_clean_no_duplicate_keys() -> None:
+    # The real file must still load clean under the duplicate-key-rejecting
+    # loader (OMN-14897) even with the adjacency block retired (OMN-14921) —
+    # shared_modules/thresholds/test_infrastructure_paths are the remaining
+    # surface a duplicate key could silently corrupt.
     config_path = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
     config = load_adjacency_map(config_path)
-    assert len(config.adjacency) == 47
+    assert len(config.shared_modules) == 6


### PR DESCRIPTION
## Summary

Promotes the file-grain grimp import-graph closure (`scripts/ci/test_selection_closure.compute_closure_selection`, shipped in shadow mode by merged omnibase_core#1483) to the **governing** smart-selection primitive in `scripts/ci/detect_test_paths.py` — the CI-authoritative selector oracle. Retires the hand-curated module-grain `adjacency:` reverse_deps map rather than leaving both selectors live side by side.

**Why:** a live audit against the real `grimp` reverse-import closure found **26 of 40** module-grain `reverse_deps` declarations FALSE. `utils: {reverse_deps: []}` and `logging: {reverse_deps: []}` in particular — the real graph shows ~37-38 real reverse deps for each — wrongly excluded 1,305 and 1,334 test files respectively. Overall, **1,343 of 1,441 unit test files (93%)** were wrongly excludable under the old map.

## What changed

- `scripts/ci/detect_test_paths.py`: step 6 (smart selection) now calls `compute_closure_selection` directly instead of the module-grain `_resolve()` (deleted). Escalation gates (steps 0-5: branch/event, test-infra, shared-module, threshold, docs-only) are **unchanged** and still run *before* closure computation.
- `scripts/ci/test_selection_closure.py`: adds `compute_closure_selection` — the governing (non-shadow) primitive. Unlike the existing shadow-mode `compute_shadow_closure` (which only ever *shrinks within* a module-grain candidate set), this computes over the **whole `tests/unit/` tree**, since there's no module-grain ceiling left to shrink within.
- `scripts/ci/test_selection_adjacency.yaml`: the `adjacency:` reverse_deps block is **deleted**. `shared_modules` / `thresholds` / `test_infrastructure_paths` stay (operational-risk policy, not graph-derivable facts).
- `ModelAdjacencyMap.reject_adjacency_reintroduction` (new validator): fails **LOUD** (`ValueError`) if an `adjacency:` key is ever reintroduced — the "cannot silently go stale" guard, since a hand-curated map cannot be kept honest against the real graph.
- `selector_core.py` (canonical `node_test_selector_compute` twin): its own module-grain `resolve_test_paths` is **deleted** too — no duplicate selector surface. It now accepts an injected `closure_selected_files` list (the closure is I/O — grimp graph build + AST reads — so it's computed at the caller/EFFECT boundary, not inside the pure node).
- **Documented gap, not silently papered over:** `runtime_test_selector.py` (the node's CLI/EFFECT boundary) does not yet compute+inject that closure — it is not wired into CI today (`detect_test_paths.py` is the live oracle), so this has no live-selection impact, but it is a real fast-follow, called out explicitly in code comments and in `tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py::test_cli_stdout_diverges_on_smart_selection_pending_closure_wiring`.
- `ModelTestSelection.selected_paths`' pattern is widened to accept individual test **file** paths (trailing `.py`) alongside the existing directory sentinels (trailing `/`), since file-grain selection returns files, not directories.

## RED / GREEN proof

`tests/unit/scripts/ci/test_detect_test_paths.py` — touching only `src/omnibase_core/utils/util_str_enum_base.py`:

- **RED** (`test_red_old_module_grain_selects_only_utils_dir`): the retired algorithm, driven by the real retired `utils.reverse_deps: []` declaration, selects **only** `tests/unit/utils/`.
- **GREEN** (`test_green_new_closure_selector_includes_the_missed_dependents`): the promoted closure selector additionally includes real `tests/unit/enums/` test files that import it transitively — confirmed live via direct invocation: **1,114 files selected total, 197 under `tests/unit/enums/`, vs 28 under `tests/unit/utils/` alone** (old answer) — strictly more than the old answer, strictly less than the whole ~1,441-file tree.
- `test_old_selection_is_a_strict_subset_of_new_selection`: direct old-vs-new delta on the identical input, both sides captured.
- `test_adjacency_key_reintroduction_fails_loud_not_silent` + `test_load_rejects_reintroduced_adjacency_map` (loader-level): the stale-declaration guard.

**Fail-closed preserved:** `test_shared_module_change_escalates_to_full_suite`, `test_test_infrastructure_change_escalates_to_full_suite`, `test_pyproject_dependency_change_escalates_via_compute_selection` (all pre-existing, unmodified) still pass — a shared-module/test-infra/pyproject-runtime-dep touch still escalates to the FULL suite, before closure computation ever runs. A changed file the closure cannot resolve (missing/dynamic-import/graph-stale) falls back to the conservative `["tests/unit/"]` whole-tree sentinel (`test_nonexistent_source_file_fails_closed_to_whole_tree`), never a narrower guess.

## dod_evidence (OMN-14921, parent OMN-13969)

- **Before/after selection counts** (utils/util_str_enum_base.py change, live invocation on this branch): old module-grain = 28 files (`tests/unit/utils/` only); new closure-grain = 1,114 files (28 utils + 197 enums + others across the real reverse closure).
- Local gates: `ruff format --check` clean, `ruff check` clean, `uv run mypy src/omnibase_core` — 0 errors (4,169 source files), `pre-commit run --files <changed>` — all hooks passed.
- Tests: `tests/unit/scripts/ci/` + `tests/unit/nodes/node_test_selector_compute/` — **329 passed**, 0 failed.
- Builds on merged `omnibase_core#1483` (OMN-14921 shadow mode, AC2/AC4 shipped).
- **Not claimed done here:** AC1 (≥30-PR replay vs both baselines) and AC3 (seeded `models/**` edit beats the 642-file/17-split floor) remain open per the ticket's own burn-in-gated design — this PR is the explicit promotion + RED-proof step requested for this build, landing ahead of that replay data by operator direction.
- occ-preflight / receipt-gate: expected red per dispatch instructions (OCC untouched this session).

No merge — Codex owns landing per repo convention.

Evidence-Ticket: OMN-14921
Evidence-Source: OCC#4687

Evidence-Commit: b2fd5daac14f6930c6641fb823e3a48fc3c43bff