### PR TITLE
feat(OMN-14990): wire OCC-companion-effect born-path caller into omnibase_core

### DIFF
--- a/.github/workflows/call-occ-companion-effect.yml
+++ b/.github/workflows/call-occ-companion-effect.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# call-occ-companion-effect.yml
+#
+# Per-repo occ-companion-effect trigger for omnibase_core (OMN-14990, fan-out
+# of the OMN-14941 omnibase_infra canary — its discriminating readback
+# passed, comment on OMN-14941, infra#2393 -> OCC#4618). Thin caller — all
+# publish logic lives in the omniclaude reusable, which runs omnimarket's
+# canonical publisher.
+#
+# On a ticketed product PR the reusable publishes
+# `onex.cmd.omnimarket.occ-companion-effect-requested.v1`; the .201 dev-lane
+# effects runtime (node_occ_companion_effect — the canonical RSD-3 write-
+# EFFECT) mints the OCC evidence companion and stamps
+# `Evidence-Source: OCC#<n>` onto this PR. Only this path produces
+# `occ:machine-minted` + `minted_by_node=true`.
+#
+# NOT call-occ-autobind.yml: OMN-14941 explicitly supersedes resurrecting the
+# legacy occ-autobind path for infra/core ("net-negative-surface: the
+# contract's own note targets retiring OccCompanionEmitter"). omnibase_core
+# gets only the current canonical born path, not the path being retired.
+#
+# TRIGGER COVERAGE (OMN-14987, applied here from the start rather than
+# patched in later the way omnibase_infra had to): opened/synchronize alone
+# miss two born-path holes. (1) draft->ready_for_review WITHOUT an
+# intervening push never re-fires either event — GitHub emits a distinct
+# ready_for_review event neither original omnibase_infra caller listened for,
+# so a PR opened as draft and later marked ready was permanently stranded
+# unbound (live case: infra#2407). (2) closed-then-reopened has the same hole
+# via the reopened event. Both are listed from the start here. The F-17
+# draft-suppression guard is NOT a trigger-level gate — it lives downstream in
+# node_occ_companion_compute (handler_occ_companion_compute.py), which checks
+# live pr_is_draft state at compute time, so listening for ready_for_review
+# here cannot cause a mint while the PR is still a draft; it only unblocks the
+# mint for the transition OUT of draft.
+#
+# TRIGGER — NO base-branch filter, deliberately (the #2377 stacked-PR
+# vector): a trigger-level `branches: [main, dev, hotfix/**]` filter means a
+# PR whose base is a feature branch never fires, and when that base later
+# retargets dev the opened/synchronize events have already passed — the PR
+# silently never gets a companion. Every pull_request fires here; the
+# reusable's own bot/OMN gate (plus this caller's copy of it) filters what
+# should not publish, and any future base filtering must be IN-JOB with a
+# logged skip, never at the trigger.
+#
+# ADDITIVE / REJECTS NOTHING: this workflow is NOT a required status check. It
+# publishes a command; it never fails a PR's merge. A fail-loud exit 1 on the
+# trusted runner (unreachable dev broker) is a non-blocking red signal, not a
+# merge gate.
+#
+# PIN CHOICE (OMN-14939/E1 failure class): the reusable is pinned `@dev`
+# because that is the ref that resolves — the reusable exists only on
+# omniclaude dev (verified 2026-07-23:
+# `gh api repos/OmniNode-ai/omniclaude/contents/.github/workflows/call-occ-companion-effect-reusable.yml?ref=dev`
+# resolves; `?ref=main` does not, the exact shape that silently killed the
+# infra autobind caller for weeks). `tests/ci/test_workflow_uses_refs_resolve.py`
+# + `tests/integration/ci/test_workflow_uses_refs_resolve_live.py` (ported
+# from omnibase_infra, OMN-14941/E1) fail closed if this pin — or any other
+# cross-repo `uses:@ref` pin in this repo — stops resolving live.
+#
+# RE-PIN FOLLOW-UP: once the reusable promotes to omniclaude main, re-pin this
+# `uses:` to `@main` or a main SHA so the caller no longer tracks a moving dev
+# branch (same follow-up named in the infra caller and in OMN-14812, which is
+# a separate ticket about the legacy autobind publisher's own promotion).
+#
+# SECRET-FREE: no `secrets: inherit` — the dev-lane broker comes from
+# omnimarket's committed config/ci_bus_lanes.yaml overlay (OMN-14813), and the
+# dev-lane listener is plaintext. This repo needs no Kafka secrets for this
+# workflow.
+#
+# Ticket: OMN-14990 (OMN-14941 / OMN-14811 / OMN-14987 lineage)
+
+name: OCC Companion Effect Publisher
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  occ-companion-effect:
+    # Skip dependency bots and PRs with no OMN ticket token (same gate the
+    # reusable enforces defensively). Gating here means the reusable is not
+    # even invoked for non-OMN / bot PRs.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
+      (contains(github.event.pull_request.title, 'OMN-') ||
+       contains(github.event.pull_request.head.ref, 'OMN-'))
+    uses: OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev
+    with:
+      lane: dev

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -110,7 +110,22 @@ waivers:
     retires: >-
       The recurring manual post-incident .git/config + index forensics-and-repair step for hook-context
       test corruption, and the per-file hand-fix pattern of OMN-14744 that demonstrably did not hold.
-
+  - workflow_file: call-occ-companion-effect.yml
+    ticket: OMN-14990
+    expires: "2026-08-23"
+    justification: >-
+      Fan-out of the proven omnibase_infra OCC-companion-effect born-path caller (OMN-14941 canary, PR
+      #2394, discriminating readback passed on infra#2393 -> OCC#4618). This is an additive, non-required,
+      thin caller (own concurrency group, no interaction with ci.yml's job graph) that publishes a Kafka
+      command for the .201 dev-lane effects runtime to consume out of band -- it does not add a check
+      to the PR's required-status surface or block merges. Waived rather than budget-bumped so the count
+      lock stays flat; the slot regularizes either when a future PR retires an existing allowlisted workflow
+      (OMN-14877-style drain) and this takes the freed slot, or the waiver is renewed with fresh evidence
+      of continued live use.
+    retires: >-
+      The manual, implementer-adjacent OCC evidence-companion authoring step for every omnibase_core PR
+      (Codex hand-authoring every companion because the born path could never fire -- no call-occ-autobind.yml
+      or call-occ-companion-effect.yml existed in this repo before this ticket). #magic___^_^___line
 metadata:
   generated_by: "C7 / OMN-14907, 2026-07-21"
   baseline_ref: "origin/dev@d09128fc"

--- a/tests/ci/test_workflow_uses_refs_resolve.py
+++ b/tests/ci/test_workflow_uses_refs_resolve.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Fail-closed resolution gate for cross-repo ``uses: OmniNode-ai/...@ref`` pins.
+
+Ported from omnibase_infra (OMN-14941/E1 root-cause, OMN-14990 fan-out): a
+caller workflow pinned a reusable ``@main`` while that file existed only on
+omniclaude ``dev``. GitHub fails such a workflow at parse time ("workflow was
+not found") — no job runs, nothing publishes, and because the caller was not
+a required check the breakage was a silent green-by-absence for weeks. No
+gate anywhere resolved the pinned refs against the live remotes.
+
+This module is that gate:
+
+* ``_extract_cross_repo_uses`` statically extracts every cross-repo
+  ``uses: OmniNode-ai/<repo>/<path>@<ref>`` from ``.github/workflows/*.yml``
+  (job-level reusable-workflow pins AND step-level action pins), via YAML
+  parsing so commented-out lines are never counted (unit-tested below).
+* The integration test (``tests/integration/ci/
+  test_workflow_uses_refs_resolve_live.py`` — under ``tests/integration``
+  because the pre-push selector always ignores that tree by design and the
+  gate's enforcement surface is the CI full-suite job) resolves each
+  extracted pin live via the GitHub contents API
+  (``/repos/OmniNode-ai/<repo>/contents/<path>?ref=<ref>``) and FAILS on any
+  HTTP 404 — the exact E1 shape.
+
+Design point (recorded, deliberate, carried over from the infra original):
+the CI pytest steps carry no GH token and ``gh`` hard-refuses unauthenticated
+use — a gh-only gate would be permanently red in CI for transport reasons
+rather than for broken pins. All OmniNode-ai repos referenced here are
+PUBLIC, so this gate calls the REST API directly via urllib, attaching
+``GH_TOKEN``/``GITHUB_TOKEN`` as a bearer token when present (for rate-limit
+headroom). Fail-closed posture per the optional-input-silent-skip trap: when
+resolution CANNOT be performed (no network / rate-limited), the test FAILS in
+CI and skips only on a local machine; a definitive 404 fails everywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+_ORG_PREFIX = "OmniNode-ai/"
+_REQUEST_TIMEOUT_SECONDS = 5.0
+# After this many consecutive transport (non-HTTP-status) failures, stop
+# probing and report the remainder as undetermined — keeps the worst case
+# bounded well under the CI per-test timeout.
+_TRANSPORT_FAILURE_CIRCUIT_BREAKER = 2
+
+
+class UsesRef(NamedTuple):
+    """One cross-repo ``uses:`` pin extracted from a workflow file."""
+
+    workflow: str  # workflow filename the pin appears in
+    repo: str  # repo name under OmniNode-ai/
+    path: str  # in-repo path ("" for a repo-root action pin)
+    ref: str  # pinned git ref (branch, tag, or SHA)
+
+
+def _extract_cross_repo_uses(workflows_dir: Path) -> list[UsesRef]:
+    """Extract every cross-repo OmniNode-ai ``uses:`` pin, via YAML parsing.
+
+    Covers both job-level reusable-workflow pins (``jobs.<id>.uses``) and
+    step-level action pins (``jobs.<id>.steps[].uses``). YAML parsing (not a
+    line regex) means commented-out ``uses:`` lines are structurally ignored.
+    Local (``./``), docker (``docker://``) and third-party (``actions/...``)
+    pins are out of scope — this gate owns only the OmniNode-ai cross-repo
+    surface, where a moving-branch/deleted-file pin is a silent outage.
+    """
+    refs: list[UsesRef] = []
+    for workflow_path in sorted(workflows_dir.glob("*.yml")) + sorted(
+        workflows_dir.glob("*.yaml")
+    ):
+        loaded = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            continue
+        jobs = loaded.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        uses_values: list[str] = []
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            job_uses = job.get("uses")
+            if isinstance(job_uses, str):
+                uses_values.append(job_uses)
+            steps = job.get("steps")
+            if isinstance(steps, list):
+                for step in steps:
+                    if isinstance(step, dict) and isinstance(step.get("uses"), str):
+                        uses_values.append(step["uses"])
+        for value in uses_values:
+            if not value.startswith(_ORG_PREFIX) or "@" not in value:
+                continue
+            spec, _, ref = value.rpartition("@")
+            remainder = spec[len(_ORG_PREFIX) :]
+            repo, _, path = remainder.partition("/")
+            refs.append(
+                UsesRef(workflow=workflow_path.name, repo=repo, path=path, ref=ref)
+            )
+    return refs
+
+
+def _resolve_ref_live(repo: str, path: str, ref: str) -> tuple[bool | None, str]:
+    """Resolve one pin against the live GitHub contents API.
+
+    Returns ``(True, detail)`` when the path exists at the ref,
+    ``(False, detail)`` on a definitive HTTP 404 (the E1 failure shape), and
+    ``(None, detail)`` when resolution could not be performed (no network,
+    rate-limited, unexpected status) — the caller decides fail-vs-skip.
+    """
+    quoted_path = urllib.parse.quote(path)
+    quoted_ref = urllib.parse.quote(ref, safe="")
+    url = (
+        f"https://api.github.com/repos/OmniNode-ai/{repo}/contents/"
+        f"{quoted_path}?ref={quoted_ref}"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "omnibase-core-uses-ref-resolution-gate (OMN-14990)",
+    }
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)  # noqa: S310 - fixed https host
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - fixed https host
+            request, timeout=_REQUEST_TIMEOUT_SECONDS
+        ) as response:
+            return (response.status == 200), f"HTTP {response.status}"
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False, "HTTP 404 (path/ref does not resolve)"
+        detail = f"HTTP {exc.code}"
+        try:
+            body = json.loads(exc.read().decode("utf-8", errors="replace"))
+            message = body.get("message", "")
+            if message:
+                detail = f"HTTP {exc.code}: {message}"
+        except (ValueError, OSError):
+            pass
+        # 403/429 (rate limit) and anything else non-404: cannot determine.
+        return None, detail
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        return None, f"transport error: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Extraction — unit, no network
+# ---------------------------------------------------------------------------
+
+_FIXTURE_WORKFLOW = """\
+name: fixture
+on:
+  pull_request:
+# uses: OmniNode-ai/omniclaude/.github/workflows/commented-out.yml@main
+jobs:
+  reusable-caller:
+    uses: OmniNode-ai/omniclaude/.github/workflows/real-reusable.yml@dev
+    with:
+      lane: dev
+  step-user:
+    runs-on: ubuntu-latest
+    steps:
+      - name: third-party action (out of scope)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: local composite (out of scope)
+        uses: ./.github/actions/setup-python-uv
+      - name: cross-repo step action
+        uses: OmniNode-ai/omnimarket/some/action@abc1234
+      - name: repo-root action pin
+        uses: OmniNode-ai/omnibase_infra@main
+"""
+
+
+@pytest.mark.unit
+def test_extraction_covers_job_and_step_level_pins(tmp_path: Path) -> None:
+    (tmp_path / "fixture.yml").write_text(_FIXTURE_WORKFLOW, encoding="utf-8")
+    refs = _extract_cross_repo_uses(tmp_path)
+    assert refs == [
+        UsesRef(
+            workflow="fixture.yml",
+            repo="omniclaude",
+            path=".github/workflows/real-reusable.yml",
+            ref="dev",
+        ),
+        UsesRef(
+            workflow="fixture.yml",
+            repo="omnimarket",
+            path="some/action",
+            ref="abc1234",
+        ),
+        UsesRef(workflow="fixture.yml", repo="omnibase_infra", path="", ref="main"),
+    ]
+
+
+@pytest.mark.unit
+def test_extraction_ignores_commented_out_uses_lines(tmp_path: Path) -> None:
+    """A workflow can carry a commented-out @main usage example in its header
+    docs — a line regex would extract it and fail the gate on documentation."""
+    (tmp_path / "fixture.yml").write_text(_FIXTURE_WORKFLOW, encoding="utf-8")
+    refs = _extract_cross_repo_uses(tmp_path)
+    assert not any(r.path.endswith("commented-out.yml") for r in refs)
+
+
+@pytest.mark.unit
+def test_real_tree_extraction_is_nonempty() -> None:
+    """Guard against the optional-input-silent-skip trap: if the extractor
+    silently returned nothing (glob typo, schema drift), the live gate below
+    would pass vacuously. This repo is known to carry cross-repo pins."""
+    refs = _extract_cross_repo_uses(WORKFLOWS_DIR)
+    assert len(refs) >= 1, (
+        f"expected at least 1 cross-repo uses: pin in {WORKFLOWS_DIR}, "
+        f"got {len(refs)} — extractor is likely broken, not the tree"
+    )
+
+
+@pytest.mark.unit
+def test_occ_companion_effect_pin_is_dev_not_main() -> None:
+    """OMN-14941 F1 regression pin, carried into omnibase_core (OMN-14990):
+    the occ-companion-effect reusable exists only on omniclaude dev; an
+    @main pin is a parse-time 404 on every PR (the E1 failure class)."""
+    refs = _extract_cross_repo_uses(WORKFLOWS_DIR)
+    occ_pins = {
+        r.path: r.ref for r in refs if r.repo == "omniclaude" and "call-occ-" in r.path
+    }
+    assert occ_pins == {
+        ".github/workflows/call-occ-companion-effect-reusable.yml": "dev",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live resolution — relocated (OMN-14941 pattern, OMN-14990 fan-out)
+# ---------------------------------------------------------------------------
+# test_every_cross_repo_uses_ref_resolves_live lives in
+# tests/integration/ci/test_workflow_uses_refs_resolve_live.py: it needs the
+# live GitHub API, the pre-push selector always ignores tests/integration by
+# design, and its enforcement surface is the CI full-suite job (fail-closed
+# there, including on unverifiable pins). It imports the helpers above.

--- a/tests/integration/ci/__init__.py
+++ b/tests/integration/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/integration/ci/test_workflow_uses_refs_resolve_live.py
+++ b/tests/integration/ci/test_workflow_uses_refs_resolve_live.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Live half of the cross-repo ``uses:`` pin resolution gate.
+
+Ported from omnibase_infra (OMN-14941/E1, OMN-14990 fan-out). Static
+extraction + pin-expectation regression tests live in
+``tests/ci/test_workflow_uses_refs_resolve.py`` (hermetic, run at pre-push by
+the governed impacted-test selector). This module holds ONLY the live GitHub
+contents-API resolution test, and lives under ``tests/integration/`` because:
+
+* the pre-push selector ALWAYS ignores ``tests/integration`` by design (it
+  needs live infra), and this test needs the live GitHub API;
+* the enforcement surface of this gate is CI (the ``tests-integration`` job
+  runs the full ``tests/integration/`` tree unconditionally on every PR),
+  where it FAILS CLOSED: a definitive 404 fails, and an unverifiable pin (no
+  network / rate-limited) also fails when ``CI`` is set.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.ci.test_workflow_uses_refs_resolve import (
+    _ORG_PREFIX,
+    _TRANSPORT_FAILURE_CIRCUIT_BREAKER,
+    WORKFLOWS_DIR,
+    _extract_cross_repo_uses,
+    _resolve_ref_live,
+)
+
+# Pre-existing, dormant broken pin discovered by this gate on first run
+# (OMN-14992): `deploy-gate-reusable.yml` (relocated from omniclaude under
+# OMN-14277, never wired to any live caller — 0 hits org-wide via
+# `gh api search/code`) self-references `.github/actions/deploy-gate@main`,
+# which exists on omnibase_core `dev` but was never promoted to `main`. It
+# is unrelated to the OMN-14990 occ-companion-effect change this test suite
+# ships alongside, and grandfathering it here (rather than silently failing
+# this PR on someone else's pre-existing debt) follows the same
+# documented-exception pattern as e.g. deploy_gate_legacy_grandfather.yaml.
+# Remove this entry the moment OMN-14992 closes — do NOT add further
+# entries without an equally-cited ticket; this is a single, named
+# exception, not a blanket allowlist mechanism.
+_KNOWN_BROKEN_PINS_PENDING_FIX: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        ("omnibase_core", ".github/actions/deploy-gate", "main"),  # OMN-14992
+    }
+)
+
+
+@pytest.mark.integration
+def test_every_cross_repo_uses_ref_resolves_live() -> None:
+    refs = _extract_cross_repo_uses(WORKFLOWS_DIR)
+    assert refs, "no cross-repo uses: pins extracted — extractor is broken"
+
+    unique_targets = sorted(
+        {(r.repo, r.path, r.ref) for r in refs} - _KNOWN_BROKEN_PINS_PENDING_FIX
+    )
+    broken: list[str] = []
+    undetermined: list[str] = []
+    transport_failures = 0
+
+    for repo, path, ref in unique_targets:
+        if transport_failures >= _TRANSPORT_FAILURE_CIRCUIT_BREAKER:
+            undetermined.append(
+                f"{_ORG_PREFIX}{repo}/{path}@{ref} (not probed: circuit "
+                "breaker open after repeated transport failures)"
+            )
+            continue
+        resolved, detail = _resolve_ref_live(repo, path, ref)
+        pin = f"{_ORG_PREFIX}{repo}/{path}@{ref}"
+        if resolved is False:
+            broken.append(f"{pin} -> {detail}")
+        elif resolved is None:
+            undetermined.append(f"{pin} -> {detail}")
+            if detail.startswith("transport error"):
+                transport_failures += 1
+
+    if broken:
+        pinned_by = {f"{r.repo}/{r.path}@{r.ref}": r.workflow for r in refs}
+        lines = [
+            f"  {entry}  (pinned in "
+            f"{pinned_by.get(entry.split(' -> ')[0][len(_ORG_PREFIX) :], '?')})"
+            for entry in broken
+        ]
+        pytest.fail(
+            "cross-repo `uses:` pins that DO NOT resolve on the live remote "
+            "(the OMN-14941/E1 silent-outage class — the workflow fails at "
+            "parse time and no job ever runs):\n" + "\n".join(lines)
+        )
+
+    if undetermined:
+        detail = "\n".join(f"  {entry}" for entry in undetermined)
+        if os.environ.get("CI"):
+            pytest.fail(
+                "could not resolve these cross-repo `uses:` pins against the "
+                "live GitHub API — failing CLOSED in CI (an unverifiable pin "
+                "is not a passing pin; thread GH_TOKEN into the test step or "
+                "fix runner egress):\n" + detail
+            )
+        pytest.skip(
+            "GitHub API unreachable from this local machine; live resolution "
+            "gate enforced in CI. Unverified pins:\n" + detail
+        )


### PR DESCRIPTION
## Summary

`omnibase_core` had **no** `call-occ-autobind.yml` and **no** `call-occ-companion-effect.yml` — only `call-occ-preflight.yml` (the consumer/eligibility side). Every core PR's OCC evidence companion was hand-authored by Codex because the born path could never fire. This wires the current canonical born path (OMN-14941) into `omnibase_core`, mirroring the proven `omnibase_infra` caller (PR #2394).

Fan-out ticket: OMN-14990. OMN-14941 (E2, Done) deliberately scoped itself to the omnibase_infra canary and deferred core/omniclaude callers to "AFTER the discriminating readback passes on one real PR" — that readback passed (infra#2393 → OCC#4618, `occ:machine-minted` + bot commit identity + `completed.v1` HW 0→1, verified 2026-07-23).

**Not** OMN-14812 — that ticket covers promoting the *legacy* `--lane`/overlay autobind publisher (OMN-14801) from omnimarket dev→main and re-pinning `call-occ-autobind-reusable.yml`'s `omnimarket-ref`. OMN-14941 explicitly supersedes resurrecting that legacy occ-autobind path for infra/core, so this PR does not add `call-occ-autobind.yml`.

## What changed

* `.github/workflows/call-occ-companion-effect.yml` — thin caller, `uses: OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev` (the only ref that resolves today — `@main` is the exact OMN-14939/E1 silent-404 failure class). `with: lane: dev`. Same bot/OMN-ticket `if:` gate as the infra caller. No `secrets: inherit` (secret-free lane per OMN-14813).
* **Trigger types set correctly from the start**: `[opened, synchronize, reopened, ready_for_review]` — folds in the OMN-14987 lesson (infra shipped `[opened, synchronize]` first and had to patch in the other two after infra#2407 was observed permanently stranded on a draft→ready transition with no intervening push; core doesn't repeat that gap).
* **No base-branch filter** on the trigger — the #2377 stacked-PR vector: a `branches: [main, dev, hotfix/**]` filter means a PR based on a feature branch never fires the trigger even after later retargeting dev.
* `tests/ci/test_workflow_uses_refs_resolve.py` + `tests/integration/ci/test_workflow_uses_refs_resolve_live.py` — ported the fail-closed cross-repo `uses:@ref` resolution guard (OMN-14941/E1 pattern) from omnibase_infra so a bad pin can't silently 404 at workflow-parse time the way the infra autobind caller did for weeks. No bespoke CI job needed: this repo's existing `test-parallel` (`tests/`, `--ignore=tests/integration`) and `tests-integration` (`tests/integration/`) jobs already collect these paths automatically (delta vs infra, which added a dedicated `ci.yml` step).
* `architecture-handshakes/pull-request-workflow-budget.yaml` — the local `pull-request-workflow-ratchet` pre-commit hook (OMN-14907, count-locked at `budget: 31`) correctly rejected the new PR-triggered workflow file as UNREGISTERED. Added a tracked, expiring waiver (ticket OMN-14990, expires 2026-08-23, justification + `retires`: removes the manual Codex-authored-OCC-companion step for every core PR) per the file's documented escape hatch — did not retire another workflow (out of scope for this ticket).

### Drive-by finding (not fixed here)

The new live resolution test runs against **every** cross-repo `uses:` pin in this repo's workflow tree, not just the new one, and found a real pre-existing dormant broken pin: `deploy-gate-reusable.yml`'s own internal `OmniNode-ai/omnibase_core/.github/actions/deploy-gate@main` — that action dir exists on `omnibase_core@dev` (added under OMN-14277) but was never promoted to `main`, and it currently has **zero live callers org-wide** (verified via `gh api search/code` across all sibling repos), so it's dormant, not an active outage. Filed **OMN-14992** and grandfathered it as a single, cited exception (`_KNOWN_BROKEN_PINS_PENDING_FIX`) in the live test rather than silently swallowing it or failing this PR on unrelated pre-existing debt.

## What remains unproven

End-to-end machine mint is **not yet proven live for omnibase_core**. Proof rides on a canary PR after this merges, mirroring the infra E2 discriminating-readback:

1. `onex.cmd.omnimarket.occ-companion-effect-requested.v1` topic HW 0→1
2. `.201` dev-lane effects log line with correlation_id
3. OCC PR carrying `occ:machine-minted` label + branch commits authored `node-occ-companion-effect <occ-companion-effect@omninode.ai>`
4. `occ-companion-effect-completed.v1` HW 0→1 with `product_body_stamped=true`
5. Negative control vs a same-day legacy/hand mint

This PR only lands the wiring. Do not treat this as proof that core minting works.

## Local gates

* `uv run pytest tests/ci/test_workflow_uses_refs_resolve.py -v` — 4/4 unit tests pass (extraction, commented-line ignore, nonempty-tree guard, pin-is-dev regression)
* `uv run pytest tests/integration/ci/test_workflow_uses_refs_resolve_live.py -v -m integration` — passes live against the real GitHub API (found + grandfathered the OMN-14992 pin, then green)
* `uv run pytest tests/validation/test_pull_request_workflow_ratchet.py -v` — 15/15 pass, including `test_live_ratchet_holds` against the updated budget file
* `ruff format --check` / `ruff check` / `mypy` — clean on all new files
* `pre-commit run --files <changed>` — full suite green (yamlfmt auto-reflowed the waiver block scalar; re-committed)
* Pushed clean through the governed pre-push selector (narrow diff: workflow + test + config files only, no `pyproject.toml`/shared-module touch)

occ-preflight will be red on this PR (no Evidence-Source yet) — expected per doctrine, not self-authored, held for Codex/the canonical OccCompanionEmitter.

Refs OMN-14990. Drive-by: OMN-14992 (filed, not fixed here — unrelated pre-existing debt this PR's new gate surfaced).

Evidence-Ticket: OMN-14990
Evidence-Source: OCC#4660
Evidence-Commit: 4aa01a1f7fb58f1534b166376c4ab0e33adfbf2e