### PR TITLE
fix(OMN-15058): swap Atlas-shaped test fixture domain to defeat GH scanner false-positive

### DIFF
--- a/tests/unit/validation/test_validate_secrets.py
+++ b/tests/unit/validation/test_validate_secrets.py
@@ -441,7 +441,7 @@ redis_connection_string = "redis://user:pass123@redis.example.com:6379/1"
         """Test detection of MongoDB connection strings with credentials."""
         code = """
 mongo_database_url = "mongodb://admin:mongopass123@localhost:27017/mydb"
-mongodb_url = "mongodb+srv://user:password@cluster.mongodb.net/database"
+mongodb_url = "mongodb+srv://user:password@cluster.example.com/database"  # non-Atlas domain: avoids GH mongodb_atlas_db_uri_with_credentials false-positive (validator matches on variable-name pattern, not URI domain -- see _is_hardcoded_value)
 mongo_connection_string = "mongodb://dbuser:dbpass@mongo.example.com:27017/prod"
 """
         validator = PythonSecretValidator("test.py")


### PR DESCRIPTION
## Summary
- omnibase_core's one open GitHub secret-scanning alert (`mongodb_atlas_db_uri_with_credentials`) points at `tests/unit/validation/test_validate_secrets.py`, inside a code sample string that `test_detects_mongodb_connection_strings` feeds to `ast.parse()` to exercise `PythonSecretValidator`. One of the three lines used a real MongoDB Atlas SRV scheme + `.mongodb.net` domain (`mongodb+srv://user:password@cluster.mongodb.net/database`), which structurally matches GitHub's Atlas-specific partner pattern even though the credentials were never real.
- `PythonSecretValidator._is_hardcoded_value()` (`scripts/validation/validate-secrets.py`) only requires the assigned value to be a non-empty (≥3 char) `ast.Constant` string outside a small excluded-literal set — it never inspects the URI's domain or scheme. All 3 violations this test counts come from the 3 suspiciously-named variables matching field-name regexes, not from any mongodb-specific value-format check.
- Fix: swap only the domain suffix from `cluster.mongodb.net` to a non-Atlas `cluster.example.com`, keeping the `mongodb+srv://` scheme, credential shape, and variable name unchanged.

## Why not a string-split (the technique used in the omniclaude/omniintelligence sibling PRs)
This fixture is Python source *embedded as a string* that gets `ast.parse()`'d by the test itself. Splitting the literal with `+` inside that embedded code would turn the assignment into an `ast.BinOp` instead of an `ast.Constant`, which `_is_hardcoded_value()` does not recognize as hardcoded — it would silently drop the violation and weaken the test. Changing only the non-Atlas-eligible domain suffix preserves every property the validator (and the assertion) actually checks.

## Test plan
- [x] `uv run pytest tests/unit/validation/test_validate_secrets.py -q` — 39 passed (`assert len(validator.violations) == 3` unchanged)
- [x] `uv run ruff format --check` / `uv run ruff check` clean on the touched file
- [x] `uv run mypy tests/unit/validation/test_validate_secrets.py` — 3 pre-existing unrelated errors, unchanged before/after (verified via git stash comparison)

Closes OMN-15058


Evidence-Ticket: OMN-15058
Evidence-Source: OCC#4780
Evidence-Commit: 7adb9a04d182a499ec75f8fa62ca65c9744c0e6c
