### PR TITLE
ci(OMN-15063): stop detect-secrets live-verification from silently dropping Slack/Stripe leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -862,8 +862,22 @@ jobs:
           #   FQNs; a "module.path:ClassName" entry is key:value-shaped, so the
           #   Secret Keyword detector fires on names like model_network_restrictions
           #   — same false-positive class as the two baselines above)
+          #
+          # -n/--no-verify (OMN-15063): several plugins (SlackDetector,
+          # StripeDetector, ...) call the live vendor API to "verify" each
+          # regex-matched candidate, then silently drop anything that comes
+          # back VERIFIED_FALSE. RED-proven against this exact invocation: a
+          # synthetic Slack incoming-webhook URL and a synthetic Slack bot
+          # token, both matching the dedicated SlackDetector regex, are
+          # silently absent from the report without -n even though the
+          # regex matches — only the generic entropy/keyword plugins that
+          # don't verify still catch anything nearby. A negative/uncertain
+          # live-verification result must not silently remove a finding
+          # (fail-closed). Never remove this flag without re-proving the
+          # miss is fixed another way.
           set +e
           git ls-files -z | xargs -0 detect-secrets-hook \
+            --no-verify \
             --baseline .secrets.baseline \
             --exclude-files 'uv\.lock' \
             --exclude-files '\.venv/' \
@@ -887,7 +901,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "If these are false positives, regenerate the baseline:" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            echo 'detect-secrets scan --all-files --exclude-files "uv\.lock" --exclude-files "\.venv/" --exclude-files "tests/fixtures/" --exclude-files "\.git/" --exclude-files "\.secrets\.baseline" --exclude-files "\.github/workflows/.*\.yml" --exclude-files "url_authority_baseline\.json" --exclude-files "canonical_inference_baseline\.json" --force-use-all-plugins > .secrets.baseline' >> $GITHUB_STEP_SUMMARY
+            echo 'detect-secrets scan --all-files --no-verify --exclude-files "uv\.lock" --exclude-files "\.venv/" --exclude-files "tests/fixtures/" --exclude-files "\.git/" --exclude-files "\.secrets\.baseline" --exclude-files "\.github/workflows/.*\.yml" --exclude-files "url_authority_baseline\.json" --exclude-files "canonical_inference_baseline\.json" --force-use-all-plugins > .secrets.baseline' >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,14 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -155,24 +147,6 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
         "line_number": 309
-      }
-    ],
-    "docs/architecture/CAPABILITY_RESOLUTION.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/architecture/CAPABILITY_RESOLUTION.md",
-        "hashed_secret": "68cea0a01cb3d6ed81d938a99ee8af5bbb0ee10e",
-        "is_verified": false,
-        "line_number": 441
-      }
-    ],
-    "docs/architecture/REGISTRATION_FSM_CONTRACT.md": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/architecture/REGISTRATION_FSM_CONTRACT.md",
-        "hashed_secret": "71091027b01171a56c721ff3aea8688cbd2b3776",
-        "is_verified": false,
-        "line_number": 3949
       }
     ],
     "docs/demo/BETA_DEMO_GUIDE.md": [
@@ -608,15 +582,6 @@
         "hashed_secret": "aeb502fd0d7fb3041d65b6a4ec882d6afd15c7e2",
         "is_verified": false,
         "line_number": 64
-      }
-    ],
-    "src/omnibase_core/models/core/model_onex_envelope.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "src/omnibase_core/models/core/model_onex_envelope.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 274
       }
     ],
     "src/omnibase_core/models/core/model_state_contract.py": [
@@ -1654,15 +1619,6 @@
         "line_number": 59
       }
     ],
-    "tests/unit/services/invariant/test_security_measures.py": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "tests/unit/services/invariant/test_security_measures.py",
-        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
-        "is_verified": false,
-        "line_number": 370
-      }
-    ],
     "tests/unit/types/test_typed_dict_migration_duplicate_conflict_dict.py": [
       {
         "type": "Hex High Entropy String",
@@ -1789,6 +1745,13 @@
       {
         "type": "AWS Access Key",
         "filename": "tests/unit/validation/test_validate_secrets.py",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "AWS Access Key",
+        "filename": "tests/unit/validation/test_validate_secrets.py",
         "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
         "is_verified": false,
         "line_number": 201
@@ -1855,13 +1818,6 @@
         "hashed_secret": "e1528ab28b5ab47ea514f383a9894649d9711c11",
         "is_verified": false,
         "line_number": 258
-      },
-      {
-        "type": "AWS Access Key",
-        "filename": "tests/unit/validation/test_validate_secrets.py",
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_verified": false,
-        "line_number": 271
       },
       {
         "type": "AWS Access Key",
@@ -2196,5 +2152,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-23T22:52:23Z"
+  "generated_at": "2026-07-25T00:20:11Z"
 }


### PR DESCRIPTION
## Correction (2026-07-25)

**This PR fixes the CI-time detect-secrets layer only.** Diff is `.github/workflows/ci.yml` + `.secrets.baseline` — no `.pre-commit-config.yaml` change. The commit-time (pre-commit) layer remains an open gap in this repo; there is no blocking detect-secrets pre-commit hook here at all. Tracked as a named residual on OMN-15063; sibling ticket for commit-time enforcement to be filed and cited here once it exists.

**Evidence-strength caveat:** the RED proof below used a synthetic (randomly-generated, non-functional) Slack webhook/bot-token — invalid by construction, so it legitimately returns `VERIFIED_FALSE` and legitimately hits the suppression path this PR fixes. Whether a genuinely live/active credential would also be silently dropped by this code path is untested here.

## Summary
- `detect-secrets`' `SlackDetector`/`StripeDetector` etc. make a live outbound call to the vendor API to "verify" each regex-matched candidate, then silently drop anything that comes back `VERIFIED_FALSE` (`detect_secrets/filters/common.py::is_ignored_due_to_verification_policies`).
- RED-proven against the exact `detect-secrets-hook` invocation this repo's CI uses: a synthetic Slack incoming-webhook URL and a synthetic Slack bot token, both matching the dedicated `SlackDetector` regex, are silently absent from the report without `-n`/`--no-verify`, even though the regex matches. Adding the flag makes both surface immediately, correctly typed as `Slack Token`.
- This is squarely the failure shape behind OMN-15063 (parent: a Google API key public 290 days, a Slack webhook public 260 days — three independent detection layers all missed both). CodeRabbit caught the Slack webhook in a human/LLM PR review; a live-verification-gated pattern matcher would not have.
- Adds `--no-verify` to the CI `detect-secrets-hook` invocation and regenerates `.secrets.baseline` with the same flag: **0 added, 4 removed** (stale baseline entries, content no longer present — ratchet-safe, baseline only shrinks).

## Test plan
- [x] RED: planted synthetic Slack webhook/bot-token fixtures (randomly generated, non-functional, no live account) and ran the exact `detect-secrets-hook` CI invocation — both silently missing.
- [x] GREEN: same invocation with `--no-verify` — both surface, correctly typed `Slack Token`.
- [x] Regenerated `.secrets.baseline` with `--no-verify`; re-ran `detect-secrets-hook --no-verify --baseline .secrets.baseline <all git-tracked files>` — exit 0.
- [x] `pre-commit run --files .github/workflows/ci.yml .secrets.baseline` — all hooks pass.

OMN-15063


Evidence-Ticket: OMN-15063
Evidence-Source: OCC#4757
Evidence-Commit: 74da33b27ea331fd850f63b88bf6de88b3205187
