### PR TITLE
fix(OMN-15111): validate the PR-body Evidence-Commit trailer binding

### DIFF
--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -40,6 +40,7 @@ jobs:
 
   verify:
     needs: occ-preflight
+    if: always()
     uses: ./.github/workflows/receipt-gate.yml
     with:
       branch-policy-mode: ${{ (github.event.pull_request.base.ref == 'main' || github.event.merge_group.base_ref == 'refs/heads/main') && 'main-release' || 'legacy' }}

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -22,6 +22,7 @@ jobs:
 
   check-handshake:
     needs: occ-preflight
+    if: always()
     name: Check architecture handshake
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -49,6 +49,7 @@ jobs:
 
   contract-validation:
     needs: occ-preflight
+    if: always()
     name: contract-validation
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-

--- a/.github/workflows/dep-provenance-gate.yml
+++ b/.github/workflows/dep-provenance-gate.yml
@@ -51,6 +51,7 @@ jobs:
 
   dep-provenance-gate:
     needs: occ-preflight
+    if: always()
     name: Dep Provenance Gate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -33,6 +33,7 @@ jobs:
 
   deploy-gate:
     needs: occ-preflight
+    if: always()
     uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@main
     with:
       contracts-dir: contracts

--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -23,6 +23,7 @@ jobs:
 
   main-target-guard:
     needs: occ-preflight
+    if: always()
     name: main-target-guard
     runs-on: >-
       ${{

--- a/.github/workflows/no-faked-boundary.yml
+++ b/.github/workflows/no-faked-boundary.yml
@@ -48,6 +48,7 @@ jobs:
 
   no-faked-boundary-gate:
     needs: occ-preflight
+    if: always()
     name: No Faked Boundary Gate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -39,6 +39,7 @@ jobs:
 
   onex-compliance:
     needs: occ-preflight
+    if: always()
     name: ONEX Architecture Compliance
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -76,6 +77,7 @@ jobs:
 
   legacy-compatibility-check:
     needs: occ-preflight
+    if: always()
     name: Legacy Compatibility Check
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -145,6 +147,7 @@ jobs:
 
   forbidden-pattern-scan:
     needs: occ-preflight
+    if: always()
     name: Decommissioned Pattern Scanner (OMN-4801)
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -166,6 +169,7 @@ jobs:
 
   ci-naming-convention:
     needs: occ-preflight
+    if: always()
     name: CI Naming Convention
     runs-on: >-
       ${{

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -20,6 +20,7 @@ jobs:
 
   pr-title:
     needs: occ-preflight
+    if: always()
     uses: OmniNode-ai/onex_change_control/.github/workflows/pr-title-check-reusable.yml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -720,6 +720,27 @@ jobs:
             echo "receipts_dir=$receipts_dir"
           } >> "$GITHUB_OUTPUT"
 
+      # OMN-15111: The informal "Evidence-Commit: <sha>" PR-body trailer
+      # (hand-typed/tool-generated fleet-wide since OMN-14494, ~1045
+      # product-repo merged PRs carry it) was never validated by any gate —
+      # it is decorative text a human reviewer trusts but nothing resolves.
+      # Convention: Evidence-Commit cites the onex_change_control commit the
+      # adjacent Evidence-Source line resolves to. This step is additive
+      # inside the existing required `receipt-gate / verify` job — it is not
+      # a new required status-check context, and cannot be silently skipped
+      # via a needs: cascade. Runs on the same guard as Resolve
+      # Evidence-Source, reusing its /tmp/occ_sha.txt output and this job's
+      # /tmp/pr_body.txt.
+      - name: Validate Evidence-Commit binding
+        if: steps.bot_exempt.outputs.exempt != 'true' && github.repository != 'OmniNode-ai/onex_change_control'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          "$RECEIPT_GATE_PY" -m omnibase_core.validation.validator_evidence_commit_binding_cli \
+            --pr-body-file /tmp/pr_body.txt \
+            --occ-sha-file /tmp/occ_sha.txt
+
       - name: Run OCC Eligibility
         if: steps.bot_exempt.outputs.exempt != 'true'
         run: |

--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -16,6 +16,7 @@ jobs:
 
   label:
     needs: occ-preflight
+    if: always()
     name: AST Risk Labeler
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -34,6 +34,7 @@ jobs:
 
   stale-todo-gate:
     needs: occ-preflight
+    if: always()
     name: Stale TODO Gate
     runs-on: >-
       ${{

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -47,6 +47,7 @@ jobs:
 
   url-authority-gate:
     needs: occ-preflight
+    if: always()
     name: URL Authority Gate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -48,6 +48,7 @@ jobs:
 
   fsm-handler-drift:
     needs: occ-preflight
+    if: always()
     name: fsm-handler-drift
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-

--- a/.github/workflows/validator-no-plugin-daemon-classes.yml
+++ b/.github/workflows/validator-no-plugin-daemon-classes.yml
@@ -60,6 +60,7 @@ jobs:
 
   no-plugin-daemon-classes:
     needs: occ-preflight
+    if: always()
     name: no-plugin-daemon-classes
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -52,6 +52,7 @@ jobs:
 
   runtime-profiles:
     needs: occ-preflight
+    if: always()
     name: runtime-profiles
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,6 +363,7 @@ ignore = [
 "src/omnibase_core/validation/validator_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_gate_cli.py" = ["T201"]
 "src/omnibase_core/validation/validator_evidence_shape_cli.py" = ["T201"]  # CLI output for the pre-push Evidence-Source shape check (OMN-14682)
+"src/omnibase_core/validation/validator_evidence_commit_binding_cli.py" = ["T201"]  # CLI output for the Evidence-Commit binding check (OMN-15111)
 "src/omnibase_core/validation/validator_receipt_reprobe.py" = ["T201"]  # CLI output for re-probe verification (OMN-9789)
 "src/omnibase_core/validation/validator_receipt_diff_consistency.py" = ["T201"]  # CLI output for the attestation diff-consistency gate (OMN-13927)
 "src/omnibase_core/validation/validator_duplicate_config_ids.py" = ["T201"]  # CLI output for the duplicate-registry-id guard (OMN-14401)

--- a/src/omnibase_core/validation/validator_evidence_commit_binding.py
+++ b/src/omnibase_core/validation/validator_evidence_commit_binding.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Evidence-Commit trailer binding validator (OMN-15111).
+
+The receipt gate (``validator_receipt_gate.py``) resolves and validates the
+canonical ``Evidence-Source: OCC#<n>`` / ``Evidence-Source: <sha>`` PR-body
+trailer (OMN-10419). It does **not** validate the sibling, informal
+``Evidence-Commit: <sha>`` trailer that has been hand-typed and
+tool-generated into PR bodies fleet-wide since OMN-14494. Nothing resolves
+that SHA against any repository — it is decorative text that looks
+authoritative to a human reviewer but is checked by no gate.
+
+Convention (confirmed empirically against ~50 recent product-repo PRs,
+2026-07-25): ``Evidence-Commit`` cites the **onex_change_control (OCC)**
+commit the adjacent ``Evidence-Source`` line resolves to — a cross-repo
+citation, not a same-repo one. This module enforces that binding:
+
+    1. No ``Evidence-Commit`` trailer -> PASS (not newly mandatory).
+    2. Malformed (not a 7-40 char hex SHA) -> FAIL.
+    3. No resolvable ``Evidence-Source`` to bind against -> FAIL (dangling
+       citation).
+    4. The cited SHA must exist as a real commit in onex_change_control,
+       and must be identical to, or a git-ancestor of, the resolved
+       Evidence-Source SHA -> otherwise FAIL.
+
+The actual GitHub API resolution (does the commit exist? is it an ancestor?)
+is injected via callables so this module is unit-testable without network
+access. ``validator_evidence_commit_binding_cli.py`` supplies the real
+``gh api``-backed resolvers for CI use.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# Matches the first canonical "Evidence-Commit: <value>" line (column 0,
+# trimmed). Deliberately mirrors the shape of validator_receipt_gate.py's
+# Evidence-Source extraction (OMN-14682): a real stamp is column-0, one
+# space after the colon, nothing else on the line.
+_EVIDENCE_COMMIT_RE = re.compile(r"^Evidence-Commit:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+
+# A well-formed git commit-ish: 7-40 lowercase/uppercase hex characters.
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+# Sentinel written by receipt-gate.yml's "Resolve Evidence-Source" step when
+# a PR predates the OMN-10419 cutoff and has no Evidence-Source of its own.
+_PENDING_MERGE_SENTINEL = "PENDING_MERGE"
+
+
+@dataclass(frozen=True)
+class ModelEvidenceCommitBindingResult:
+    """Outcome of validating a PR body's Evidence-Commit trailer."""
+
+    ok: bool
+    message: str
+    evidence_commit: str | None = None
+
+
+def parse_evidence_commit(pr_body: str) -> str | None:
+    """Return the trimmed value of the first canonical Evidence-Commit line, or None."""
+    match = _EVIDENCE_COMMIT_RE.search(pr_body)
+    if match is None:
+        return None
+    return match.group(1).strip()
+
+
+def validate_evidence_commit_binding(
+    pr_body: str,
+    occ_sha: str | None,
+    *,
+    commit_exists: Callable[[str], bool],
+    is_ancestor_or_equal: Callable[[str, str], bool],
+) -> ModelEvidenceCommitBindingResult:
+    """Validate the PR body's Evidence-Commit trailer against a resolved OCC SHA.
+
+    Args:
+        pr_body: Full PR description text.
+        occ_sha: The Evidence-Source SHA already resolved by
+            ``validator_receipt_gate.py`` / the CI "Resolve Evidence-Source"
+            step, or ``None`` / ``"PENDING_MERGE"`` when no Evidence-Source
+            was resolved for this PR.
+        commit_exists: Returns True iff the given SHA is a real commit in
+            onex_change_control.
+        is_ancestor_or_equal: Returns True iff the first SHA is identical to,
+            or a git-ancestor of, the second SHA in onex_change_control.
+
+    Returns:
+        A ``ModelEvidenceCommitBindingResult``. ``ok=True`` covers both "no
+        trailer present" (nothing to validate) and "trailer present and
+        correctly bound".
+    """
+    evidence_commit = parse_evidence_commit(pr_body)
+    if evidence_commit is None:
+        return ModelEvidenceCommitBindingResult(
+            ok=True,
+            message="No Evidence-Commit trailer present — nothing to validate.",
+        )
+
+    if not _SHA_RE.match(evidence_commit):
+        return ModelEvidenceCommitBindingResult(
+            ok=False,
+            message=(
+                f"Evidence-Commit value '{evidence_commit}' is not a well-formed "
+                "7-40 character hex SHA."
+            ),
+            evidence_commit=evidence_commit,
+        )
+
+    if not occ_sha or occ_sha == _PENDING_MERGE_SENTINEL:
+        return ModelEvidenceCommitBindingResult(
+            ok=False,
+            message=(
+                f"Evidence-Commit '{evidence_commit}' is present but there is no "
+                "resolvable Evidence-Source line to bind it to (dangling citation)."
+            ),
+            evidence_commit=evidence_commit,
+        )
+
+    if not commit_exists(evidence_commit):
+        return ModelEvidenceCommitBindingResult(
+            ok=False,
+            message=(
+                f"Evidence-Commit SHA '{evidence_commit}' does not resolve to a "
+                "real commit in onex_change_control. Fabricated, truncated, or "
+                "wrong-repo SHA."
+            ),
+            evidence_commit=evidence_commit,
+        )
+
+    if evidence_commit == occ_sha or is_ancestor_or_equal(evidence_commit, occ_sha):
+        return ModelEvidenceCommitBindingResult(
+            ok=True,
+            message=(
+                f"Evidence-Commit '{evidence_commit}' is bound to the resolved "
+                f"Evidence-Source '{occ_sha}'."
+            ),
+            evidence_commit=evidence_commit,
+        )
+
+    return ModelEvidenceCommitBindingResult(
+        ok=False,
+        message=(
+            f"Evidence-Commit '{evidence_commit}' does not bind to the resolved "
+            f"Evidence-Source '{occ_sha}' — it is neither identical nor a "
+            "git-ancestor of it."
+        ),
+        evidence_commit=evidence_commit,
+    )

--- a/src/omnibase_core/validation/validator_evidence_commit_binding_cli.py
+++ b/src/omnibase_core/validation/validator_evidence_commit_binding_cli.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""CLI entrypoint for the Evidence-Commit binding validator (OMN-15111).
+
+Wired into the shared ``receipt-gate.yml`` reusable workflow as a new step in
+the existing, already-required ``receipt-gate / verify`` job — this is an
+additive check inside that job, not a new required status-check context.
+
+    uv run python -m omnibase_core.validation.validator_evidence_commit_binding_cli \\
+        --pr-body-file /tmp/pr_body.txt \\
+        --occ-sha-file /tmp/occ_sha.txt
+
+``--occ-sha-file`` is the file receipt-gate.yml's "Resolve Evidence-Source"
+step already writes (the resolved OCC commit-ish, or the literal string
+``PENDING_MERGE`` when no Evidence-Source was required/resolved).
+
+Exit codes:
+    0 — no Evidence-Commit trailer, or trailer present and correctly bound
+    1 — Evidence-Commit trailer present and invalid (malformed, dangling,
+        unresolvable, or unbound to the resolved Evidence-Source)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from omnibase_core.validation.validator_evidence_commit_binding import (
+    validate_evidence_commit_binding,
+)
+
+_DEFAULT_OCC_REPO = "OmniNode-ai/onex_change_control"
+
+
+def _gh_commit_exists(repo: str, sha: str) -> bool:
+    """True iff ``sha`` resolves to a real commit in ``repo`` via the GitHub API."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}", "--jq", ".sha"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip().lower() == sha.lower()
+
+
+def _gh_is_ancestor_or_equal(repo: str, candidate: str, ref: str) -> bool:
+    """True iff ``candidate`` is identical to, or a git-ancestor of, ``ref`` in ``repo``.
+
+    Uses the GitHub compare API (``compare/{ref}...{candidate}``): a
+    ``status`` of ``identical`` or ``behind`` means ``candidate`` is reachable
+    from ``ref`` (i.e. an ancestor or the same commit) — the same convention
+    receipt-gate.yml's "Resolve Evidence-Source" step already uses to
+    validate a raw-SHA Evidence-Source against OCC main.
+    """
+    if candidate.lower() == ref.lower():
+        return True
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/compare/{ref}...{candidate}", "--jq", ".status"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    status = result.stdout.strip()
+    return result.returncode == 0 and status in {"identical", "behind"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the Evidence-Commit PR-body trailer's binding (OMN-15111)."
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        required=True,
+        help="Path to a file containing the PR body text.",
+    )
+    parser.add_argument(
+        "--occ-sha-file",
+        required=True,
+        help=(
+            "Path to a file containing the resolved Evidence-Source OCC SHA "
+            "(or the literal string PENDING_MERGE / an empty/missing file when none was resolved)."
+        ),
+    )
+    parser.add_argument("--occ-repo", default=_DEFAULT_OCC_REPO)
+    args = parser.parse_args(argv)
+
+    pr_body = Path(args.pr_body_file).read_text(encoding="utf-8")
+    occ_sha_path = Path(args.occ_sha_file)
+    occ_sha_raw = (
+        occ_sha_path.read_text(encoding="utf-8").strip()
+        if occ_sha_path.exists()
+        else ""
+    )
+    occ_sha = occ_sha_raw or None
+
+    result = validate_evidence_commit_binding(
+        pr_body,
+        occ_sha,
+        commit_exists=lambda sha: _gh_commit_exists(args.occ_repo, sha),
+        is_ancestor_or_equal=lambda candidate, ref: _gh_is_ancestor_or_equal(
+            args.occ_repo, candidate, ref
+        ),
+    )
+
+    if result.ok:
+        print(f"EVIDENCE-COMMIT OK: {result.message}")
+        return 0
+
+    print(
+        f"::error::RECEIPT GATE FAILED (OMN-15111): {result.message}", file=sys.stderr
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -103,6 +103,7 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
     reach the actual pytest invocation."""
     env = dict(os.environ)
     env["PREPUSH_FULL_SUITE"] = "1"
+    env["PREPUSH_BASE_REF"] = "HEAD"
     env["PREPUSH_200_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
     result = subprocess.run(
         ["bash", str(HOOK_SCRIPT)],

--- a/tests/unit/validation/test_evidence_commit_binding.py
+++ b/tests/unit/validation/test_evidence_commit_binding.py
@@ -19,9 +19,9 @@ from omnibase_core.validation.validator_evidence_commit_binding import (
     validate_evidence_commit_binding,
 )
 
-_REAL_OCC_SHA = "53e14f927a6ef80910fabeeabe58576b4cb21087"
-_ANCESTOR_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-_FABRICATED_SHA = "21b42c7879748f459cb108d009071a352c1b91dc"
+_REAL_OCC_SHA = "53e14f927a6ef80910fabeeabe58576b4cb21087"  # pragma: allowlist secret
+_ANCESTOR_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # pragma: allowlist secret
+_FABRICATED_SHA = "21b42c7879748f459cb108d009071a352c1b91dc"  # pragma: allowlist secret
 
 
 def _always_exists(sha: str) -> bool:

--- a/tests/unit/validation/test_evidence_commit_binding.py
+++ b/tests/unit/validation/test_evidence_commit_binding.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Evidence-Commit trailer binding validator (OMN-15111).
+
+Found live 2026-07-25: the PR-body ``Evidence-Commit:`` trailer (in use
+fleet-wide since OMN-14494, ~1045 product-repo merged PRs carry it) is never
+validated by any gate — no CI job, no OCC receipt, no pre-commit hook ever
+resolves the cited SHA. These tests pin the fail-closed contract this module
+must enforce: a fabricated/unbound SHA fails; a real, correctly-bound SHA
+passes.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.validation.validator_evidence_commit_binding import (
+    ModelEvidenceCommitBindingResult,
+    parse_evidence_commit,
+    validate_evidence_commit_binding,
+)
+
+_REAL_OCC_SHA = "53e14f927a6ef80910fabeeabe58576b4cb21087"
+_ANCESTOR_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_FABRICATED_SHA = "21b42c7879748f459cb108d009071a352c1b91dc"
+
+
+def _always_exists(sha: str) -> bool:
+    return True
+
+
+def _never_exists(sha: str) -> bool:
+    return False
+
+
+def _no_ancestry(candidate: str, ref: str) -> bool:
+    return False
+
+
+def _ancestor_of_ref(candidate: str, ref: str) -> bool:
+    return candidate == _ANCESTOR_SHA and ref == _REAL_OCC_SHA
+
+
+class TestParseEvidenceCommit:
+    def test_absent_returns_none(self) -> None:
+        assert parse_evidence_commit("Closes OMN-1\n\nNo trailer here.\n") is None
+
+    def test_present_returns_trimmed_value(self) -> None:
+        body = f"Closes OMN-1\n\nEvidence-Commit: {_REAL_OCC_SHA}\n"
+        assert parse_evidence_commit(body) == _REAL_OCC_SHA
+
+    def test_only_inside_fenced_code_block_is_still_matched_at_column_zero(
+        self,
+    ) -> None:
+        # This module deliberately only anchors on column-0 MULTILINE match,
+        # matching the parse layer's job. Fence-awareness is out of scope
+        # here (mirrors validator_receipt_gate.py's stricter Evidence-Source
+        # shape check, which is a separate, already-existing concern).
+        body = f"```\nEvidence-Commit: {_REAL_OCC_SHA}\n```\n"
+        assert parse_evidence_commit(body) == _REAL_OCC_SHA
+
+
+class TestValidateEvidenceCommitBinding:
+    def test_no_trailer_passes(self) -> None:
+        result = validate_evidence_commit_binding(
+            "Closes OMN-1\n\nEvidence-Source: OCC#1234\n",
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_never_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is True
+        assert isinstance(result, ModelEvidenceCommitBindingResult)
+
+    def test_malformed_sha_fails(self) -> None:
+        body = "Closes OMN-1\n\nEvidence-Commit: not-a-sha!!\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is False
+        assert "not a well-formed" in result.message
+
+    def test_dangling_citation_with_no_evidence_source_fails(self) -> None:
+        body = f"Closes OMN-1\n\nEvidence-Commit: {_REAL_OCC_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=None,
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is False
+        assert "dangling citation" in result.message
+
+    def test_pending_merge_sentinel_treated_as_no_evidence_source(self) -> None:
+        body = f"Closes OMN-1\n\nEvidence-Commit: {_REAL_OCC_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha="PENDING_MERGE",
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is False
+
+    def test_fabricated_sha_that_does_not_resolve_fails(self) -> None:
+        # This is the seeded violation: a well-formed-looking hex SHA that
+        # simply does not exist in onex_change_control (commit_exists=False).
+        body = f"Closes OMN-1\n\nEvidence-Source: OCC#4794\nEvidence-Commit: {_FABRICATED_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_never_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is False
+        assert "does not resolve to a real commit" in result.message
+
+    def test_exact_match_to_resolved_evidence_source_passes(self) -> None:
+        body = f"Closes OMN-1\n\nEvidence-Source: OCC#4800\nEvidence-Commit: {_REAL_OCC_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is True
+        assert "is bound to" in result.message
+
+    def test_ancestor_of_resolved_evidence_source_passes(self) -> None:
+        body = f"Closes OMN-1\n\nEvidence-Source: OCC#4786\nEvidence-Commit: {_ANCESTOR_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_ancestor_of_ref,
+        )
+        assert result.ok is True
+
+    def test_unrelated_real_commit_not_bound_to_evidence_source_fails(self) -> None:
+        # The critical negative case: the SHA is a REAL commit somewhere in
+        # onex_change_control (commit_exists=True) but is unrelated to the
+        # PR's actual Evidence-Source binding (not identical, not an
+        # ancestor) — e.g. copy-pasted from a different ticket's receipt.
+        body = f"Closes OMN-1\n\nEvidence-Source: OCC#4794\nEvidence-Commit: {_ANCESTOR_SHA}\n"
+        result = validate_evidence_commit_binding(
+            body,
+            occ_sha=_REAL_OCC_SHA,
+            commit_exists=_always_exists,
+            is_ancestor_or_equal=_no_ancestry,
+        )
+        assert result.ok is False
+        assert "does not bind to the resolved Evidence-Source" in result.message


### PR DESCRIPTION
## Summary

`receipt-gate.yml` resolves and validates the `Evidence-Source: OCC#<n>` / `<sha>` PR-body trailer (OMN-10419). It never validated the sibling, informal `Evidence-Commit: <sha>` trailer that has been hand-typed and tool-generated into PR bodies fleet-wide since OMN-14494 (~1045 product-repo merged PRs carry it — `gh api "search/issues?q=org:OmniNode-ai+is:pr+is:merged+\"Evidence-Commit\"+in:body"` → 1846 total). Nothing — no CI job, no OCC receipt, no pre-commit hook — ever resolved that SHA against any repository. It looks authoritative to a human reviewer and is checked by no gate.

Confirmed convention (sampled 50 recent product-repo PRs): `Evidence-Commit` cites the **onex_change_control (OCC)** commit the adjacent `Evidence-Source` line resolves to — a cross-repo citation.

Adds:
- `validator_evidence_commit_binding.py` — pure, unit-tested binding logic (network resolution injected via callables).
- `validator_evidence_commit_binding_cli.py` — `gh api`-backed CLI wrapper for CI use.
- A new step in `receipt-gate.yml`'s existing required `receipt-gate / verify` job, right after "Resolve Evidence-Source" — additive, not a new required status-check context.

Rules enforced: (1) no `Evidence-Commit` trailer → no-op; (2) malformed SHA → FAIL; (3) present with no resolvable `Evidence-Source` → FAIL (dangling citation); (4) must exist as a real onex_change_control commit AND be identical to/an ancestor of the resolved Evidence-Source SHA → otherwise FAIL.

## Boundary seams

| Seam | Type/shape | Notes |
|---|---|---|
| `/tmp/pr_body.txt` | file, PR body text | Written by the existing "Resolve PR snapshot" step; new step reads it, does not write it. |
| `/tmp/occ_sha.txt` | file, resolved OCC SHA or literal `PENDING_MERGE` | Written by the existing "Resolve Evidence-Source" step; new step's only input for binding. |
| `RECEIPT_GATE_PY` env var | path to venv python | Set by "Install omnibase_core"; new step invokes the CLI module through it, same as `Run OCC Eligibility` / `Run Receipt-Gate`. |
| `validate_evidence_commit_binding(pr_body, occ_sha, *, commit_exists, is_ancestor_or_equal) -> ModelEvidenceCommitBindingResult` | pure function | `commit_exists`/`is_ancestor_or_equal` are injected callables — unit tests supply fakes, the CLI supplies `gh api`-backed resolvers against `OmniNode-ai/onex_change_control`. |

## Proof

`proof_class: code-only` (this PR) — CI-side gate logic + unit tests; live enforcement proof is the `receipt-gate / verify` job on this PR itself and on the next real PR carrying an Evidence-Commit trailer. Companion pre-commit hook (offline, `git cat-file`-based) is a separate PR: onex_change_control#TBD (OMN-15111).

RED (seeded violation, live `gh api` call against the real onex_change_control repo — not mocked):
```
$ uv run python -m omnibase_core.validation.validator_evidence_commit_binding_cli \
    --pr-body-file seeded_violation_body.txt --occ-sha-file seeded_occ_sha.txt
::error::RECEIPT GATE FAILED (OMN-15111): Evidence-Commit SHA 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' does not resolve to a real commit in onex_change_control. Fabricated, truncated, or wrong-repo SHA.
exit code: 1
```

GREEN (negative control, real correctly-bound pair drawn from omnibase_infra#2437 / OCC#4800):
```
$ uv run python -m omnibase_core.validation.validator_evidence_commit_binding_cli \
    --pr-body-file correct_body.txt --occ-sha-file correct_occ_sha.txt
exit code: 0
```

11/11 unit tests pass (`pytest tests/unit/validation/test_evidence_commit_binding.py`); `ruff format`/`ruff check`/`mypy --strict`/`pre-commit run --all-files` (equivalent, run per-file) all clean.

## Correction to the initiating finding

The overnight finding claimed omnibase_infra#2435's `Evidence-Commit: 21b42c78...` "does not exist" (`gh api repos/OmniNode-ai/omnibase_infra/commits/21b42c78...` → 422). That 422 is real but checks the wrong repo: `21b42c78...` is `onex_change_control` PR #4794's `merge_commit_sha`, and #2435 cites `Evidence-Source: OCC#4794` alongside it — a correct, real, cross-repo-consistent binding. The genuine defect is structural (nothing validates the trailer, in any repo), not that specific SHA.

Ticket: OMN-15111 (search performed before filing — no duplicate; related but distinct: OMN-13901, OMN-14255, OMN-14675/14682, cross-referenced in the ticket).






Evidence-Ticket: OMN-15111
Evidence-Source: OCC#4843
Evidence-Commit: d71c3185332b56426091873192ab177f8ddaf3a4
