### PR TITLE
EXPERIMENT [DO NOT MERGE] (OMN-15112): probe ANY-vs-ALL semantics for duplicate-named required context

### DIFF
--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -23,13 +23,20 @@ on:
     branches: [main, dev]
 
 jobs:
+  # EXPERIMENT (OMN-15112, throwaway PR, never merge): contracts-dir is
+  # deliberately pointed at a nonexistent path so THIS ONE occ-preflight
+  # invocation legitimately fails MISSING_CONTRACT while every other
+  # workflow's occ-preflight job (using the real "contracts" default) still
+  # succeeds — a controlled, self-limiting mixed pass/fail under the
+  # identical "occ-preflight / eligibility" required-context name, scoped to
+  # this single job in this single throwaway branch. Revert before close.
   occ-preflight:
     uses: ./.github/workflows/occ-preflight.yml
     permissions:
       contents: read
       pull-requests: read
     with:
-      contracts-dir: contracts
+      contracts-dir: nonexistent-experiment-omn-15112-any-vs-all
       receipts-dir: drift/dod_receipts
 
   stale-todo-gate:


### PR DESCRIPTION
## THROWAWAY EXPERIMENT — DO NOT MERGE, DO NOT REVIEW, DO NOT ADD TO ANY QUEUE

This PR exists only to empirically answer one question for OMN-15112: when N
GitHub Actions check-runs share the identical required-context name
(`occ-preflight / eligibility` — currently emitted by ~12-40 separate
workflow files that each define a job literally named `occ-preflight`
calling the same local `./.github/workflows/occ-preflight.yml`), does
branch protection require **ALL** of them to succeed, or is **ANY ONE**
sufficient?

### What this PR does
`stale-todo-gate.yml`'s `occ-preflight` job has `contracts-dir` pointed at a
nonexistent path (`nonexistent-experiment-omn-15112-any-vs-all`). That makes
**that one job's** eligibility check legitimately, deterministically fail
`MISSING_CONTRACT` for ticket OMN-15112 (cited below), while every other
occ-preflight invocation on this same PR/SHA — including the canonical
`call-occ-preflight.yml` producer — uses the real `contracts-dir: contracts`
default and passes normally. This seeds a real, live, mixed pass/fail under
one duplicated context name, without touching branch protection and without
disabling any check repo-wide.

### What will happen next
This session will read `mergeStateStatus` / the check-run rollup / the
branch-protection evaluation for this PR, record the raw result in OMN-15112,
then **close this PR without merging** and delete the branch. No product
code changes. No merge. No queue.

Evidence-Ticket: OMN-15112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation workflows to verify handling of missing contract definitions and mixed pass/fail outcomes.
  * No user-facing features or product behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#4810
