### PR TITLE
EXPERIMENT [DO NOT MERGE] (OMN-15112): probe ANY-vs-ALL semantics, attempt 2 (commit-bound receipt)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -67,7 +67,26 @@ gates:
     workflow: call-receipt-gate.yml
     job_path: ["verify", "verify"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15057: the 'verify'
+      job's `needs: occ-preflight` previously had no `if:` override (vector-5) — fixed by adding `if:
+      always()`, so this job can no longer skip-as-pass when occ-preflight fails. Safe because receipt-gate.yml's
+      own verify logic independently re-validates the same dod_evidence receipts occ-preflight checks
+      (redundant coupling, matching the omnimarket#1890 precedent)."
+
+  - name: "occ-preflight / eligibility"
+    mode: REQUIRED
+    producer_kind: local
+    workflow: call-occ-preflight.yml
+    job_path: ["occ-preflight", "eligibility"]
+    skip_semantics: never
+    rationale: "OMN-15057: restored 2026-07-25 as a REQUIRED context on omnibase_core dev+main via gh
+      api PATCH. A 2026-06-25 OMN-13332 receipt (onex_change_control drift/dod_receipts/OMN-13332/ dod-required-context-proof/command.yaml)
+      attested this context present at required_status_checks index 7 on dev; live readback 2026-07-25
+      showed it ABSENT on both dev and main (also regressed on omnibase_infra/dev, same class, not touched
+      here). call-occ-preflight.yml has no `needs:` and fires unconditionally on pull_request/merge_group,
+      so it cannot skip-as-pass itself. This is the compensating control that makes decoupling deploy-gate.yml's
+      `deploy-gate` job (below) safe: an occ-preflight failure still blocks merge via this independently
+      required context even though deploy-gate no longer encodes eligibility in its own result."
 
   - name: "contract-validation"
     mode: REQUIRED
@@ -91,7 +110,13 @@ gates:
     workflow: deploy-gate.yml
     job_path: ["deploy-gate", "deploy-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15057: the 'deploy-gate'
+      job's `needs: occ-preflight` previously had no `if:` override (vector-5) — fixed by adding `if:
+      always()`. UNLIKE 'verify / verify' this coupling was NOT redundant (OMN-14260: deploy-gate-reusable.yml
+      only validates deploy-evidence citation, a different concern from OCC eligibility) — decoupling
+      alone would have silently removed the only eligibility enforcement on this gate. Safe here only
+      because the 'occ-preflight / eligibility' context (row above) was restored as an independently REQUIRED
+      context in the same change; that context still blocks merge on an occ-preflight failure."
 
   - name: "Dep Provenance Gate"
     mode: REQUIRED

--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -38,8 +38,19 @@ jobs:
       contracts-dir: contracts
       receipts-dir: drift/dod_receipts
 
+  # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — an
+  # occ-preflight FAILURE would SKIP this job (GitHub's implicit job-level
+  # `if:` is `success()` over `needs:`), and a skipped required job satisfies
+  # branch protection. `if: always()` makes `verify` run unconditionally.
+  # This is safe without any compensating control: receipt-gate.yml's own
+  # `verify` job independently re-resolves Evidence-Source and validates the
+  # same dod_evidence PASS receipts occ-preflight checks (OMN-10419), so an
+  # eligibility failure that would have failed occ-preflight also fails this
+  # job's own logic directly — the needs-coupling was redundant, matching the
+  # OMN-15057/omnimarket#1890 precedent.
   verify:
     needs: occ-preflight
+    if: always()
     uses: ./.github/workflows/receipt-gate.yml
     with:
       branch-policy-mode: ${{ (github.event.pull_request.base.ref == 'main' || github.event.merge_group.base_ref == 'refs/heads/main') && 'main-release' || 'legacy' }}

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -31,8 +31,20 @@ jobs:
       contracts-dir: contracts
       receipts-dir: drift/dod_receipts
 
+  # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — GitHub's
+  # implicit job-level `if:` is `success()` over `needs:`, so an occ-preflight
+  # FAILURE makes this job SKIP rather than fail, and a skipped job satisfies
+  # GitHub branch protection (skipped counts as passing). `if: always()` makes
+  # this job run unconditionally so it can never silently skip-as-pass.
+  # Eligibility enforcement does not depend on this job's own result: the
+  # `occ-preflight / eligibility` context (produced by call-occ-preflight.yml)
+  # is independently required on this repo's dev+main branch protection
+  # (restored 2026-07-25 after a 2026-06-25 OMN-13332 wiring regressed off
+  # silently — see OMN-15057 ledger), so an occ-preflight failure still blocks
+  # merge via that separate required context even though this job decouples.
   deploy-gate:
     needs: occ-preflight
+    if: always()
     uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@main
     with:
       contracts-dir: contracts

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -23,13 +23,20 @@ on:
     branches: [main, dev]
 
 jobs:
+  # EXPERIMENT (OMN-15112, throwaway PR, never merge): contracts-dir is
+  # deliberately pointed at a nonexistent path so THIS ONE occ-preflight
+  # invocation legitimately fails MISSING_CONTRACT while every other
+  # workflow's occ-preflight job (using the real "contracts" default) still
+  # succeeds — a controlled, self-limiting mixed pass/fail under the
+  # identical "occ-preflight / eligibility" required-context name, scoped to
+  # this single job in this single throwaway branch. Revert before close.
   occ-preflight:
     uses: ./.github/workflows/occ-preflight.yml
     permissions:
       contents: read
       pull-requests: read
     with:
-      contracts-dir: contracts
+      contracts-dir: nonexistent-experiment-omn-15112-any-vs-all
       receipts-dir: drift/dod_receipts
 
   stale-todo-gate:


### PR DESCRIPTION
## THROWAWAY EXPERIMENT — DO NOT MERGE, DO NOT REVIEW, DO NOT ADD TO ANY QUEUE

Second attempt (first attempt closed as #1501 — uniform fail control, not
informative for this question). This branch is built directly on PR #1499's
own head commit (`53fe9d4f`) plus one extra commit, so this PR's commit list
includes the exact SHA the existing OCC receipt for OMN-15112 is bound to.
That should let the majority of `occ-preflight / eligibility` check-runs bind
and PASS normally (same as they do on #1499 itself), while
`stale-todo-gate.yml`'s occ-preflight job (pointed at a nonexistent
contracts-dir) legitimately fails `MISSING_CONTRACT` — a live, mixed
pass/fail on one duplicated required-context name, on one real PR/SHA,
without touching branch protection or disabling any check repo-wide.

This session will read `mergeStateStatus` / the check-run rollup for this
PR, record the raw result in OMN-15112, then close this PR without merging
and delete the branch.

Evidence-Ticket: OMN-15112
Evidence-Source: OCC#4810