### PR TITLE
chore(OMN-15112): THROWAWAY seeded-eligibility-fail proof for vector-5 enforcement (do not merge, will be closed+deleted)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -80,29 +80,37 @@ gates:
     job_path: ["occ-preflight", "eligibility"]
     skip_semantics: never
     rationale: "OMN-15057: restored 2026-07-25 as a REQUIRED context on omnibase_core dev+main via gh
-      api PATCH. A 2026-06-25 OMN-13332 receipt (onex_change_control drift/dod_receipts/OMN-13332/ dod-required-context-proof/command.yaml)
-      attested this context present at required_status_checks index 7 on dev; live readback 2026-07-25
-      showed it ABSENT on both dev and main (also regressed on omnibase_infra/dev, same class, not touched
-      here). call-occ-preflight.yml has no `needs:` and fires unconditionally on pull_request/merge_group,
-      so it cannot skip-as-pass itself. NOT a single producer (this row is misleading, kept for the primary/canonical
-      instance only — OMN-15112): the identical context name 'occ-preflight / eligibility' is ALSO emitted
-      by ~40 other omnibase_core workflows, each of which defines its own job literally named `occ-preflight`
-      calling `./.github/workflows/occ-preflight.yml` (now pinned to `@main` as of this PR — previously
-      unpinned, meaning a PR branch could have run a tampered local copy of the eligibility validator
-      under this same required name). A live, seeded OMN-15112 experiment (PR #1502, closed, never merged)
-      confirmed ~20+ simultaneous check-runs share this exact name on one commit with a genuine mixed
-      pass/fail (1 seeded failure, ~21 real successes) and did NOT determine that GitHub's required-status-check
-      matching treats this as 'ALL producers must succeed' — the failing run did not complete last among
-      the duplicates (an earlier failure, later superseded in completion order by successes), consistent
-      with GitHub's documented recency-based matching for duplicate same-named checks/statuses, which
-      is order/timing-dependent, not a deterministic ALL-must-succeed gate. Full terminal mergeable_state
-      confirmation was not reached (unrelated required checks queued on a congested self-hosted runner
-      fleet for 20+ minutes; the run was cancelled rather than keep burning shared CI capacity on a throwaway
-      probe). Treat this context as UNVERIFIED to safely gate on duplicate-producer failures until either
-      (a) the ~40 duplicate producers are collapsed to the single canonical instance (matching the omnimarket/
-      omniclaude poller pattern that avoids re-emitting this name at all), or (b) GitHub's matching semantics
-      for this specific context are confirmed ALL-must-succeed by a completed live test. See OMN-15112
-      for the full experiment record."
+      api PATCH. call-occ-preflight.yml has no `needs:` and fires unconditionally on pull_request/merge_group,
+      so it cannot skip-as-pass itself. COLLAPSE PROGRESS (OMN-15112, same-day follow-up): rather than
+      resolve the ANY-vs-ALL duplicate-name matching question (left open below), this context's ~40 duplicate
+      producers are being collapsed to ONE — the omnimarket/omniclaude poller pattern (a job named `occ-preflight`
+      that polls this context's check-runs via the Checks API instead of re-invoking the reusable occ-preflight.yml
+      workflow) has now been applied to 23 of the ~40 duplicate-producing workflow files (auto-merge,
+      call-receipt-gate, call-reject-skip, canonical-inference-gate, check-handshake, cr-thread-gate-caller,
+      contract-validation, deploy-gate, no-faked-boundary, main-target-guard, dep-provenance-gate, pr-title-check,
+      omni-standards-compliance, receipt-honesty, semantic-diff-labeler, security-scan, url-authority-gate,
+      required-check-skip-guard-caller, stale-todo-gate, validator-fsm-handler-drift, validator-no-plugin-daemon-classes,
+      validator-no-unguarded-git-subprocess, validator-runtime-profiles — the full set that fires unconditionally
+      on every PR with no `if:`/`paths:` filter on its own trigger). This is a behavior-preserving mechanical
+      change: the poller job still exposes the same success/failure/ skipped `result` to its file's own
+      `needs: occ-preflight` downstream job, so vector-5 exposure (fixed or unfixed) on any of these 23
+      files is unaffected by this PR. NOT YET a single producer: 21 callers remain unconverted — 15 are
+      dormant `workflow_dispatch`-only validators that do not fire on pull_request today (zero live duplicate-emission
+      risk, follow-up only), 3 are path-filtered (check-db-ownership.yml, check-llm-refs-drift.yml, propagate-config.yml
+      — fire only when their filtered paths change), 1 is schedule/dispatch-only (handshake-policy-gate.yml),
+      1 is the intentionally-untouched cross-repo nested reusable (cr-thread-gate.yml, invoked by omniclaude's
+      copy of the same file — touching a multi-repo-consumed reusable workflow is a separate risk class,
+      deliberately out of scope here), and 1 is this row's own canonical call-occ-preflight.yml. Observed
+      count before this PR: 27 check-runs on omnibase_core PR #1499 commit 42ecb63 (26 success, 1 failure
+      — the failure a genuine propagate-config.yml push-event eligibility miss, not a flake). Expected
+      count after this PR on an unfiltered PR: 27 minus the 23 converted producers that would have fired
+      on that same PR — see the PR body for the observed post-change count. The original ANY-vs-ALL open
+      question (a live, seeded OMN-15112 experiment, PR #1502, closed never merged, confirmed ~20+ simultaneous
+      check-runs sharing this exact name with a genuine mixed pass/fail and did NOT determine whether
+      GitHub's required-status-check matching demands ALL-must-succeed or is order/timing-dependent) is
+      now MOOT for the converted subset, since only one producer remains among them. It is still LIVE
+      for the 21 unconverted producers until they are converted or retired — full experiment record and
+      remaining risk in OMN-15112."
 
   - name: "contract-validation"
     mode: REQUIRED
@@ -131,20 +139,23 @@ gates:
       always()`. UNLIKE 'verify / verify' this coupling was NOT redundant (OMN-14260: deploy-gate-reusable.yml
       only validates deploy-evidence citation, a different concern from OCC eligibility) — decoupling
       alone would have silently removed the only eligibility enforcement on this gate. RESIDUAL RISK,
-      NOT fully closed (OMN-15112): this job's `if: always()` means it can never skip-as-pass on ITS OWN
-      occ-preflight instance, but deploy-gate-reusable.yml (omniclaude, a cross-repo `uses:` reusable-workflow
+      PARTIALLY NARROWED (OMN-15112): this job's `if: always()` means it can never skip-as-pass on ITS
+      OWN occ-preflight instance, but deploy-gate-reusable.yml (omniclaude, a cross-repo `uses:` reusable-workflow
       call with no room for an inline result check — a job body is either `uses:` or `steps:`, never both)
       does not itself consume or fail on occ-preflight's result. The only remaining enforcement is the
-      separately-required 'occ-preflight / eligibility' context — and OMN-15112's experiment (see that
-      row above) did NOT confirm GitHub enforces ALL-must-succeed across that context's ~40 duplicate
-      producers. A prior attempt to close this gap by nesting occ-preflight inside deploy-gate-reusable.yml
+      separately-required 'occ-preflight / eligibility' context. This file's own `occ-preflight` job is
+      now one of the 23 converted to the poller pattern (see that row above) — it no longer re-invokes
+      the reusable workflow, so it no longer contributes to the duplicate-producer count; the file's downstream
+      `deploy-gate` job's `needs: occ-preflight` / `if: always()` semantics are unchanged (behavior-preserving
+      conversion). The ANY-vs-ALL question is still open for the 21 producers not yet converted — until
+      they are, this row's enforcement still ultimately rests on the same open question the row above
+      tracks. A prior attempt to close this gap by nesting occ-preflight inside deploy-gate-reusable.yml
       itself (PR #1879 / OMN-14249) caused a repo-wide Deploy-Gate startup failure (OMN-14260: nested
       reusable workflows cannot escalate permissions beyond what the caller job granted) and was reverted
       — do not retry that shape without first granting `pull-requests: read` down through the caller chain.
-      Closing this residual requires either a deliberate, permissions-aware change to deploy-gate-reusable.yml
-      to accept and hard-fail on an explicit occ-preflight-result input, or collapsing the ~40 duplicate
-      'occ-preflight / eligibility' producers to the single canonical instance (poller pattern, matching
-      omnimarket/omniclaude). Neither is done here."
+      Closing this residual fully requires either a deliberate, permissions-aware change to deploy-gate-reusable.yml
+      to accept and hard-fail on an explicit occ-preflight-result input, or finishing the collapse of
+      the remaining 21 producers."
 
   - name: "Dep Provenance Gate"
     mode: REQUIRED

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -84,9 +84,25 @@ gates:
       attested this context present at required_status_checks index 7 on dev; live readback 2026-07-25
       showed it ABSENT on both dev and main (also regressed on omnibase_infra/dev, same class, not touched
       here). call-occ-preflight.yml has no `needs:` and fires unconditionally on pull_request/merge_group,
-      so it cannot skip-as-pass itself. This is the compensating control that makes decoupling deploy-gate.yml's
-      `deploy-gate` job (below) safe: an occ-preflight failure still blocks merge via this independently
-      required context even though deploy-gate no longer encodes eligibility in its own result."
+      so it cannot skip-as-pass itself. NOT a single producer (this row is misleading, kept for the primary/canonical
+      instance only — OMN-15112): the identical context name 'occ-preflight / eligibility' is ALSO emitted
+      by ~40 other omnibase_core workflows, each of which defines its own job literally named `occ-preflight`
+      calling `./.github/workflows/occ-preflight.yml` (now pinned to `@main` as of this PR — previously
+      unpinned, meaning a PR branch could have run a tampered local copy of the eligibility validator
+      under this same required name). A live, seeded OMN-15112 experiment (PR #1502, closed, never merged)
+      confirmed ~20+ simultaneous check-runs share this exact name on one commit with a genuine mixed
+      pass/fail (1 seeded failure, ~21 real successes) and did NOT determine that GitHub's required-status-check
+      matching treats this as 'ALL producers must succeed' — the failing run did not complete last among
+      the duplicates (an earlier failure, later superseded in completion order by successes), consistent
+      with GitHub's documented recency-based matching for duplicate same-named checks/statuses, which
+      is order/timing-dependent, not a deterministic ALL-must-succeed gate. Full terminal mergeable_state
+      confirmation was not reached (unrelated required checks queued on a congested self-hosted runner
+      fleet for 20+ minutes; the run was cancelled rather than keep burning shared CI capacity on a throwaway
+      probe). Treat this context as UNVERIFIED to safely gate on duplicate-producer failures until either
+      (a) the ~40 duplicate producers are collapsed to the single canonical instance (matching the omnimarket/
+      omniclaude poller pattern that avoids re-emitting this name at all), or (b) GitHub's matching semantics
+      for this specific context are confirmed ALL-must-succeed by a completed live test. See OMN-15112
+      for the full experiment record."
 
   - name: "contract-validation"
     mode: REQUIRED
@@ -114,9 +130,21 @@ gates:
       job's `needs: occ-preflight` previously had no `if:` override (vector-5) — fixed by adding `if:
       always()`. UNLIKE 'verify / verify' this coupling was NOT redundant (OMN-14260: deploy-gate-reusable.yml
       only validates deploy-evidence citation, a different concern from OCC eligibility) — decoupling
-      alone would have silently removed the only eligibility enforcement on this gate. Safe here only
-      because the 'occ-preflight / eligibility' context (row above) was restored as an independently REQUIRED
-      context in the same change; that context still blocks merge on an occ-preflight failure."
+      alone would have silently removed the only eligibility enforcement on this gate. RESIDUAL RISK,
+      NOT fully closed (OMN-15112): this job's `if: always()` means it can never skip-as-pass on ITS OWN
+      occ-preflight instance, but deploy-gate-reusable.yml (omniclaude, a cross-repo `uses:` reusable-workflow
+      call with no room for an inline result check — a job body is either `uses:` or `steps:`, never both)
+      does not itself consume or fail on occ-preflight's result. The only remaining enforcement is the
+      separately-required 'occ-preflight / eligibility' context — and OMN-15112's experiment (see that
+      row above) did NOT confirm GitHub enforces ALL-must-succeed across that context's ~40 duplicate
+      producers. A prior attempt to close this gap by nesting occ-preflight inside deploy-gate-reusable.yml
+      itself (PR #1879 / OMN-14249) caused a repo-wide Deploy-Gate startup failure (OMN-14260: nested
+      reusable workflows cannot escalate permissions beyond what the caller job granted) and was reverted
+      — do not retry that shape without first granting `pull-requests: read` down through the caller chain.
+      Closing this residual requires either a deliberate, permissions-aware change to deploy-gate-reusable.yml
+      to accept and hard-fail on an explicit occ-preflight-result input, or collapsing the ~40 duplicate
+      'occ-preflight / eligibility' producers to the single canonical instance (poller pattern, matching
+      omnimarket/omniclaude). Neither is done here."
 
   - name: "Dep Provenance Gate"
     mode: REQUIRED

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -67,7 +67,26 @@ gates:
     workflow: call-receipt-gate.yml
     job_path: ["verify", "verify"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15057: the 'verify'
+      job's `needs: occ-preflight` previously had no `if:` override (vector-5) — fixed by adding `if:
+      always()`, so this job can no longer skip-as-pass when occ-preflight fails. Safe because receipt-gate.yml's
+      own verify logic independently re-validates the same dod_evidence receipts occ-preflight checks
+      (redundant coupling, matching the omnimarket#1890 precedent)."
+
+  - name: "occ-preflight / eligibility"
+    mode: REQUIRED
+    producer_kind: local
+    workflow: call-occ-preflight.yml
+    job_path: ["occ-preflight", "eligibility"]
+    skip_semantics: never
+    rationale: "OMN-15057: restored 2026-07-25 as a REQUIRED context on omnibase_core dev+main via gh
+      api PATCH. A 2026-06-25 OMN-13332 receipt (onex_change_control drift/dod_receipts/OMN-13332/ dod-required-context-proof/command.yaml)
+      attested this context present at required_status_checks index 7 on dev; live readback 2026-07-25
+      showed it ABSENT on both dev and main (also regressed on omnibase_infra/dev, same class, not touched
+      here). call-occ-preflight.yml has no `needs:` and fires unconditionally on pull_request/merge_group,
+      so it cannot skip-as-pass itself. This is the compensating control that makes decoupling deploy-gate.yml's
+      `deploy-gate` job (below) safe: an occ-preflight failure still blocks merge via this independently
+      required context even though deploy-gate no longer encodes eligibility in its own result."
 
   - name: "contract-validation"
     mode: REQUIRED
@@ -91,7 +110,13 @@ gates:
     workflow: deploy-gate.yml
     job_path: ["deploy-gate", "deploy-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15057: the 'deploy-gate'
+      job's `needs: occ-preflight` previously had no `if:` override (vector-5) — fixed by adding `if:
+      always()`. UNLIKE 'verify / verify' this coupling was NOT redundant (OMN-14260: deploy-gate-reusable.yml
+      only validates deploy-evidence citation, a different concern from OCC eligibility) — decoupling
+      alone would have silently removed the only eligibility enforcement on this gate. Safe here only
+      because the 'occ-preflight / eligibility' context (row above) was restored as an independently REQUIRED
+      context in the same change; that context still blocks merge on an occ-preflight failure."
 
   - name: "Dep Provenance Gate"
     mode: REQUIRED

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -118,7 +118,7 @@ gates:
     workflow: contract-validation.yml
     job_path: ["contract-validation"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "URL Authority Gate"
     mode: REQUIRED
@@ -126,7 +126,7 @@ gates:
     workflow: url-authority-gate.yml
     job_path: ["url-authority-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "deploy-gate / deploy-gate"
     mode: REQUIRED
@@ -163,7 +163,7 @@ gates:
     workflow: dep-provenance-gate.yml
     job_path: ["dep-provenance-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Canonical Inference Gate"
     mode: REQUIRED
@@ -179,7 +179,7 @@ gates:
     workflow: no-faked-boundary.yml
     job_path: ["no-faked-boundary-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "reason-graph"
     mode: REQUIRED
@@ -209,7 +209,18 @@ gates:
     cross_repo_ref: "OmniNode-ai/onex_change_control/.github/workflows/pr-title-check-reusable.yml@main"
     skip_semantics: never
     rationale: "Live required status check on omnibase_core dev branch protection (cross-repo reusable
-      caller)."
+      caller). OMN-15112 vector-5, PARTIAL fix (same residual shape as 'deploy-gate / deploy-gate' above):
+      added `if: always()` to the 'pr-title' caller job, which stops the skip-as-pass path. This is
+      NOT the full two-part fix used on the other 15 OMN-15112 findings, because a reusable-workflow-call
+      job body is either `uses:` or `steps:`, never both -- there is no way to insert an inline
+      `needs.occ-preflight.result` check ahead of the call, and pr-title-check-reusable.yml (owned by
+      onex_change_control) declares no `workflow_call.inputs`, so it cannot be told to consume or fail on
+      occ-preflight's result without a cross-repo change. `if: always()` therefore makes this job run
+      unconditionally regardless of occ-preflight's outcome -- decorative w.r.t. eligibility, exactly like
+      deploy-gate. Real enforcement for this path still rests entirely on the separately-required
+      'occ-preflight / eligibility' context. Closing this residual fully requires adding a gating input
+      (e.g. `occ-preflight-result`) to pr-title-check-reusable.yml in onex_change_control and hard-failing
+      on it -- tracked as a follow-up, not completed in this PR."
 
   - name: "no-plugin-daemon-classes"
     mode: REQUIRED
@@ -217,7 +228,7 @@ gates:
     workflow: validator-no-plugin-daemon-classes.yml
     job_path: ["no-plugin-daemon-classes"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "receipt-honesty"
     mode: REQUIRED
@@ -233,7 +244,7 @@ gates:
     workflow: validator-runtime-profiles.yml
     job_path: ["runtime-profiles"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "fsm-handler-drift"
     mode: REQUIRED
@@ -241,7 +252,7 @@ gates:
     workflow: validator-fsm-handler-drift.yml
     job_path: ["fsm-handler-drift"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Check architecture handshake"
     mode: REQUIRED
@@ -249,7 +260,7 @@ gates:
     workflow: check-handshake.yml
     job_path: ["check-handshake"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Stale TODO Gate"
     mode: REQUIRED
@@ -257,7 +268,7 @@ gates:
     workflow: stale-todo-gate.yml
     job_path: ["stale-todo-gate"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "AST Risk Labeler"
     mode: REQUIRED
@@ -265,7 +276,7 @@ gates:
     workflow: semantic-diff-labeler.yml
     job_path: ["label"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Precommit Parity Gate"
     mode: REQUIRED
@@ -281,7 +292,7 @@ gates:
     workflow: omni-standards-compliance.yml
     job_path: ["onex-compliance"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Legacy Compatibility Check"
     mode: REQUIRED
@@ -289,7 +300,7 @@ gates:
     workflow: omni-standards-compliance.yml
     job_path: ["legacy-compatibility-check"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Decommissioned Pattern Scanner (OMN-4801)"
     mode: REQUIRED
@@ -297,7 +308,7 @@ gates:
     workflow: omni-standards-compliance.yml
     job_path: ["forbidden-pattern-scan"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "CI Naming Convention"
     mode: REQUIRED
@@ -305,7 +316,7 @@ gates:
     workflow: omni-standards-compliance.yml
     job_path: ["ci-naming-convention"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "Zone Filter (docs-only check)"
     mode: REQUIRED
@@ -627,7 +638,7 @@ gates:
     workflow: main-target-guard.yml
     job_path: ["main-target-guard"]
     skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
+    rationale: "Live required status check on omnibase_core dev branch protection. OMN-15112 vector-5 fix: added `if: always()` on the producing job plus an explicit first step that fails when `needs.occ-preflight.result != 'success'`, so the job can neither silently skip-as-pass nor decouple from occ-preflight's result."
 
   - name: "required-check-skip-guard / check-skip-vectors"
     mode: ADVISORY

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -67,7 +67,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -67,13 +67,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   pre-check:
     needs: occ-preflight

--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -30,13 +30,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — an
   # occ-preflight FAILURE would SKIP this job (GitHub's implicit job-level

--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/call-receipt-gate.yml
+++ b/.github/workflows/call-receipt-gate.yml
@@ -38,8 +38,19 @@ jobs:
       contracts-dir: contracts
       receipts-dir: drift/dod_receipts
 
+  # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — an
+  # occ-preflight FAILURE would SKIP this job (GitHub's implicit job-level
+  # `if:` is `success()` over `needs:`), and a skipped required job satisfies
+  # branch protection. `if: always()` makes `verify` run unconditionally.
+  # This is safe without any compensating control: receipt-gate.yml's own
+  # `verify` job independently re-resolves Evidence-Source and validates the
+  # same dod_evidence PASS receipts occ-preflight checks (OMN-10419), so an
+  # eligibility failure that would have failed occ-preflight also fails this
+  # job's own logic directly — the needs-coupling was redundant, matching the
+  # OMN-15057/omnimarket#1890 precedent.
   verify:
     needs: occ-preflight
+    if: always()
     uses: ./.github/workflows/receipt-gate.yml
     with:
       branch-policy-mode: ${{ (github.event.pull_request.base.ref == 'main' || github.event.merge_group.base_ref == 'refs/heads/main') && 'main-release' || 'legacy' }}

--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -25,13 +25,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   call-reject-skip-token:
     needs: occ-preflight

--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -40,13 +40,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   canonical-inference-gate:
     needs: occ-preflight

--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/check-db-ownership.yml
+++ b/.github/workflows/check-db-ownership.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -116,6 +116,7 @@ jobs:
 
   check-handshake:
     needs: occ-preflight
+    if: always()
     name: Check architecture handshake
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -127,6 +128,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run Check architecture handshake."
+          exit 1
+
       - name: Checkout repo
         uses: actions/checkout@v7
 

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -12,13 +12,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   check-handshake:
     needs: occ-preflight

--- a/.github/workflows/check-llm-refs-drift.yml
+++ b/.github/workflows/check-llm-refs-drift.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -143,6 +143,7 @@ jobs:
 
   contract-validation:
     needs: occ-preflight
+    if: always()
     name: contract-validation
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -154,6 +155,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run contract-validation."
+          exit 1
+
       - name: Auth preflight — confirm onex_change_control action is accessible
         id: auth-preflight
         env:

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -39,13 +39,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   contract-validation:
     needs: occ-preflight

--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -16,13 +16,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   gate:
     needs: occ-preflight

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/dep-provenance-gate.yml
+++ b/.github/workflows/dep-provenance-gate.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/dep-provenance-gate.yml
+++ b/.github/workflows/dep-provenance-gate.yml
@@ -145,9 +145,23 @@ jobs:
 
   dep-provenance-gate:
     needs: occ-preflight
+    if: always()
     name: Dep Provenance Gate
     runs-on: ubuntu-latest
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run Dep Provenance Gate."
+          exit 1
+
       - name: Skip on merge_group
         if: ${{ github.event_name == 'merge_group' }}
         run: |

--- a/.github/workflows/dep-provenance-gate.yml
+++ b/.github/workflows/dep-provenance-gate.yml
@@ -41,13 +41,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   dep-provenance-gate:
     needs: occ-preflight

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -23,13 +23,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — GitHub's
   # implicit job-level `if:` is `success()` over `needs:`, so an occ-preflight

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -31,8 +31,20 @@ jobs:
       contracts-dir: contracts
       receipts-dir: drift/dod_receipts
 
+  # OMN-15057: `needs: occ-preflight` with no `if:` override is vector-5 — GitHub's
+  # implicit job-level `if:` is `success()` over `needs:`, so an occ-preflight
+  # FAILURE makes this job SKIP rather than fail, and a skipped job satisfies
+  # GitHub branch protection (skipped counts as passing). `if: always()` makes
+  # this job run unconditionally so it can never silently skip-as-pass.
+  # Eligibility enforcement does not depend on this job's own result: the
+  # `occ-preflight / eligibility` context (produced by call-occ-preflight.yml)
+  # is independently required on this repo's dev+main branch protection
+  # (restored 2026-07-25 after a 2026-06-25 OMN-13332 wiring regressed off
+  # silently — see OMN-15057 ledger), so an occ-preflight failure still blocks
+  # merge via that separate required context even though this job decouples.
   deploy-gate:
     needs: occ-preflight
+    if: always()
     uses: OmniNode-ai/omniclaude/.github/workflows/deploy-gate-reusable.yml@main
     with:
       contracts-dir: contracts

--- a/.github/workflows/handshake-policy-gate.yml
+++ b/.github/workflows/handshake-policy-gate.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -117,6 +117,7 @@ jobs:
 
   main-target-guard:
     needs: occ-preflight
+    if: always()
     name: main-target-guard
     runs-on: >-
       ${{
@@ -127,6 +128,19 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run main-target-guard."
+          exit 1
+
       - name: Check PR target branch
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/main-target-guard.yml
+++ b/.github/workflows/main-target-guard.yml
@@ -13,13 +13,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   main-target-guard:
     needs: occ-preflight

--- a/.github/workflows/no-faked-boundary.yml
+++ b/.github/workflows/no-faked-boundary.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/no-faked-boundary.yml
+++ b/.github/workflows/no-faked-boundary.yml
@@ -142,9 +142,23 @@ jobs:
 
   no-faked-boundary-gate:
     needs: occ-preflight
+    if: always()
     name: No Faked Boundary Gate
     runs-on: ubuntu-latest
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run No Faked Boundary Gate."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/no-faked-boundary.yml
+++ b/.github/workflows/no-faked-boundary.yml
@@ -38,13 +38,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   no-faked-boundary-gate:
     needs: occ-preflight

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -133,6 +133,7 @@ jobs:
 
   onex-compliance:
     needs: occ-preflight
+    if: always()
     name: ONEX Architecture Compliance
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -142,6 +143,19 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run ONEX Architecture Compliance."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -170,6 +184,7 @@ jobs:
 
   legacy-compatibility-check:
     needs: occ-preflight
+    if: always()
     name: Legacy Compatibility Check
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -179,6 +194,19 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run Legacy Compatibility Check."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -239,6 +267,7 @@ jobs:
 
   forbidden-pattern-scan:
     needs: occ-preflight
+    if: always()
     name: Decommissioned Pattern Scanner (OMN-4801)
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -248,6 +277,19 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run Decommissioned Pattern Scanner."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -260,6 +302,7 @@ jobs:
 
   ci-naming-convention:
     needs: occ-preflight
+    if: always()
     name: CI Naming Convention
     runs-on: >-
       ${{
@@ -268,6 +311,19 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run CI Naming Convention."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v7
 

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -29,13 +29,107 @@ env:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   onex-compliance:
     needs: occ-preflight

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -114,6 +114,23 @@ jobs:
 
   pr-title:
     needs: occ-preflight
+    # OMN-15112 vector-5, PARTIAL fix only (documented residual, see
+    # .github/required-checks.yaml "pr-title / check-title" row): a
+    # reusable-workflow-call job body is either `uses:` or `steps:`, never
+    # both, so there is no way to insert an inline `needs.occ-preflight.result`
+    # check ahead of the call the way the other 15 OMN-15112 findings do.
+    # `if: always()` still closes the SKIP-side of the bug (this job can no
+    # longer silently skip-as-pass when occ-preflight fails), matching the
+    # deploy-gate.yml precedent in this same repo, but it does not make
+    # pr-title-check-reusable.yml itself consume or fail on the occ-preflight
+    # result -- that reusable workflow (owned by onex_change_control) exposes
+    # no gating input today. Real enforcement for this path still rests on the
+    # independently-required "occ-preflight / eligibility" context, same as
+    # deploy-gate. Closing this fully requires a cross-repo change to
+    # onex_change_control/pr-title-check-reusable.yml to accept and hard-fail
+    # on an explicit occ-preflight-result input -- tracked as a follow-up, not
+    # done in this PR.
+    if: always()
     uses: OmniNode-ai/onex_change_control/.github/workflows/pr-title-check-reusable.yml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,13 +10,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   pr-title:
     needs: occ-preflight

--- a/.github/workflows/propagate-config.yml
+++ b/.github/workflows/propagate-config.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -42,13 +42,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   receipt-honesty:
     needs: occ-preflight

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/required-check-skip-guard-caller.yml
+++ b/.github/workflows/required-check-skip-guard-caller.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/required-check-skip-guard-caller.yml
+++ b/.github/workflows/required-check-skip-guard-caller.yml
@@ -38,13 +38,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   required-check-skip-guard:
     needs: occ-preflight

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,13 +18,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   codeql:
     needs: occ-preflight

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -110,6 +110,7 @@ jobs:
 
   label:
     needs: occ-preflight
+    if: always()
     name: AST Risk Labeler
     runs-on: ubuntu-latest
     permissions:
@@ -118,6 +119,19 @@ jobs:
       pull-requests: write
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run AST Risk Labeler."
+          exit 1
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0

--- a/.github/workflows/semantic-diff-labeler.yml
+++ b/.github/workflows/semantic-diff-labeler.yml
@@ -6,13 +6,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   label:
     needs: occ-preflight

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -128,6 +128,7 @@ jobs:
 
   stale-todo-gate:
     needs: occ-preflight
+    if: always()
     name: Stale TODO Gate
     runs-on: >-
       ${{
@@ -137,6 +138,19 @@ jobs:
       }}
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run Stale TODO Gate."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -24,13 +24,107 @@ on:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   stale-todo-gate:
     needs: occ-preflight

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -141,9 +141,23 @@ jobs:
 
   url-authority-gate:
     needs: occ-preflight
+    if: always()
     name: URL Authority Gate
     runs-on: ubuntu-latest
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run URL Authority Gate."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -37,13 +37,107 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   url-authority-gate:
     needs: occ-preflight

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-backend-secret-discipline.yml
+++ b/.github/workflows/validator-backend-secret-discipline.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-banned-compose-vars.yml
+++ b/.github/workflows/validator-banned-compose-vars.yml
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-bypass-token-blocklist.yml
+++ b/.github/workflows/validator-bypass-token-blocklist.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-command-category-event-model.yml
+++ b/.github/workflows/validator-command-category-event-model.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-dispatched-contract-operation.yml
+++ b/.github/workflows/validator-dispatched-contract-operation.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -142,6 +142,7 @@ jobs:
 
   fsm-handler-drift:
     needs: occ-preflight
+    if: always()
     name: fsm-handler-drift
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -153,6 +154,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run fsm-handler-drift."
+          exit 1
+
       - name: Checkout omnibase_core
         uses: actions/checkout@v7
 

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -38,13 +38,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   fsm-handler-drift:
     needs: occ-preflight

--- a/.github/workflows/validator-fsm-handler-drift.yml
+++ b/.github/workflows/validator-fsm-handler-drift.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-generated-node-model-class-exists.yml
+++ b/.github/workflows/validator-generated-node-model-class-exists.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-gitignore-baseline.yml
+++ b/.github/workflows/validator-gitignore-baseline.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-hardcoded-topic.yml
+++ b/.github/workflows/validator-hardcoded-topic.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-no-except-swallow.yml
+++ b/.github/workflows/validator-no-except-swallow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-no-import-none-fallback.yml
+++ b/.github/workflows/validator-no-import-none-fallback.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-no-none-guard-publish.yml
+++ b/.github/workflows/validator-no-none-guard-publish.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-no-plugin-daemon-classes.yml
+++ b/.github/workflows/validator-no-plugin-daemon-classes.yml
@@ -50,7 +50,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-no-plugin-daemon-classes.yml
+++ b/.github/workflows/validator-no-plugin-daemon-classes.yml
@@ -154,6 +154,7 @@ jobs:
 
   no-plugin-daemon-classes:
     needs: occ-preflight
+    if: always()
     name: no-plugin-daemon-classes
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -165,6 +166,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run no-plugin-daemon-classes."
+          exit 1
+
       - name: Checkout omnibase_core
         uses: actions/checkout@v7
 

--- a/.github/workflows/validator-no-plugin-daemon-classes.yml
+++ b/.github/workflows/validator-no-plugin-daemon-classes.yml
@@ -50,13 +50,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   no-plugin-daemon-classes:
     needs: occ-preflight

--- a/.github/workflows/validator-no-unguarded-git-subprocess.yml
+++ b/.github/workflows/validator-no-unguarded-git-subprocess.yml
@@ -64,13 +64,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   no-unguarded-git-subprocess:
     needs: occ-preflight

--- a/.github/workflows/validator-no-unguarded-git-subprocess.yml
+++ b/.github/workflows/validator-no-unguarded-git-subprocess.yml
@@ -64,7 +64,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-operation-match.yml
+++ b/.github/workflows/validator-operation-match.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-pin-hygiene.yml
+++ b/.github/workflows/validator-pin-hygiene.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-release-identity.yml
+++ b/.github/workflows/validator-release-identity.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -42,13 +42,107 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    # Poller, not a re-emitter (OMN-15112 collapse-to-one-producer): this job
+    # does NOT call the reusable occ-preflight.yml workflow. It polls the ONE
+    # canonical "occ-preflight / eligibility" check-run -- produced solely by
+    # call-occ-preflight.yml, the repo's single unconditional-on-every-PR
+    # caller -- via the Checks API, and blocks/fails this workflow's downstream
+    # job accordingly. Copied from the pattern omnimarket and omniclaude already
+    # run safely to avoid re-emitting the shared context name from every
+    # workflow file that needs to gate on it (GH Actions `needs:` cannot cross
+    # workflow files, so each file still needs its own gate -- but the gate
+    # does not have to be its own duplicate emission of the reusable workflow).
+    name: OCC Preflight Dependency
+    runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
+    steps:
+      - name: Wait for required OCC preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "OCC preflight dependency is enforced by the pull_request gate; continuing for ${GITHUB_EVENT_NAME}."
+            exit 0
+          fi
+
+          # OMN-15112: desynchronize same-PR pollers across workflow files (GH
+          # Actions `needs:` can't cross workflow-file boundaries) so they
+          # don't all hit the Checks API in the same instant every 10s and
+          # exhaust the shared per-repo GitHub App installation rate-limit
+          # bucket (same rationale as omnimarket's OMN-14343).
+          sleep "$(( RANDOM % 15 ))"
+
+          backoff=5
+          elapsed=0
+          deadline=720
+
+          while [ "$elapsed" -lt "$deadline" ]; do
+            # GH Actions runs `run:` steps under `bash -e {0}` by default --
+            # that -e is already active before this script's own
+            # `set -uo pipefail` runs, and `set -uo pipefail` does NOT clear
+            # an inherited -e. A bare `response="$(gh api ...)"; status=$?`
+            # would therefore abort the whole step on ANY gh api failure
+            # before status is ever checked, silently defeating the retry
+            # logic below. Using the command substitution as the condition of
+            # this `if` is the errexit-safe form -- bash does not trigger -e
+            # for a command that is part of an if/while/until condition,
+            # regardless of ambient -e state.
+            response=""
+            status=0
+            if response="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=latest&check_name=occ-preflight%20%2F%20eligibility&per_page=1" \
+                --jq 'first(.check_runs[] | .conclusion) // ""' \
+                2>&1
+            )"; then
+              status=0
+            else
+              status=$?
+            fi
+
+            if [ "$status" -ne 0 ]; then
+              if echo "$response" | grep -qi "rate limit"; then
+                echo "::warning::gh api rate-limited waiting for occ-preflight; backing off ${backoff}s."
+                sleep "$backoff"
+                elapsed=$((elapsed + backoff))
+                backoff=$(( backoff * 2 < 60 ? backoff * 2 : 60 ))
+                continue
+              fi
+              echo "::error::gh api call failed (non-rate-limit): ${response}"
+              exit 1
+            fi
+            backoff=5
+
+            conclusion="$response"
+
+            case "$conclusion" in
+              success)
+                echo "OCC preflight passed for ${HEAD_SHA}."
+                exit 0
+                ;;
+              failure|cancelled|timed_out|action_required|startup_failure)
+                echo "::error::OCC preflight concluded ${conclusion}; refusing to start this workflow."
+                exit 1
+                ;;
+              "")
+                echo "Waiting for occ-preflight / eligibility to post for ${HEAD_SHA}..."
+                ;;
+              *)
+                echo "OCC preflight is ${conclusion}; waiting."
+                ;;
+            esac
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "::error::Timed out waiting for occ-preflight / eligibility on ${HEAD_SHA}."
+          exit 1
 
   runtime-profiles:
     needs: occ-preflight

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -146,6 +146,7 @@ jobs:
 
   runtime-profiles:
     needs: occ-preflight
+    if: always()
     name: runtime-profiles
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
@@ -157,6 +158,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # OMN-15112 vector-5 fix: `needs: occ-preflight` alone lets GitHub's
+      # implicit `success()`-over-needs skip this job when occ-preflight
+      # fails/cancels, and a skipped job satisfies branch protection as
+      # passing. `if: always()` above stops the skip; this step is the other
+      # required half — it explicitly fails the job when occ-preflight did
+      # not succeed, so the job's own conclusion is FAILURE, never a
+      # decorative pass.
+      - name: Fail when OCC preflight fails
+        if: needs.occ-preflight.result != 'success'
+        run: |
+          echo "::error::occ-preflight result was ${{ needs.occ-preflight.result }}; refusing to run runtime-profiles."
+          exit 1
+
       - name: Checkout omnibase_core
         uses: actions/checkout@v7
 

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validator-todo-marker.yml
+++ b/.github/workflows/validator-todo-marker.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
     permissions:
       contents: read
       pull-requests: read

--- a/.throwaway_omn15112/marker.txt
+++ b/.throwaway_omn15112/marker.txt
@@ -1,0 +1,1 @@
+# throwaway seed for OMN-15112 vector-5 enforcement proof — will be deleted


### PR DESCRIPTION
THROWAWAY test PR for OMN-15112 vector-5 enforcement proof. Deliberately omits an Evidence-Source line so occ-preflight/eligibility fails for real, to observe whether contract-validation (and the other fixed jobs) now FAIL rather than SKIP. Will be closed and the branch deleted immediately after evidence is captured. No merge intended.