### PR TITLE
chore(OMN-15028): linearize main promotion prerequisites

### DIFF
--- a/.github/workflows/handshake-policy-gate.yml
+++ b/.github/workflows/handshake-policy-gate.yml
@@ -24,6 +24,7 @@ on:
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: '0 8 * * 1'
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt
+++ b/.onex_state/evidence/OMN-13132/deterministic-ir-evidence.txt
@@ -1,0 +1,19 @@
+=== DETERMINISTIC IR over >=2 REAL contracts (2 backend nodes + 1 UI component) ===
+nodes: [('compliance_status_grid', 'component'), ('node.compliance.evidence', 'effect'), ('node.compliance.report.reducer', 'reducer')]
+DETERMINISTIC (run1 JSON == run2 JSON): True
+
+=== HASH MANIFEST ===
+  ui_component  in-memory://compliance_status_grid
+      source_contract_sha256 = sha256:77b6cb763cc051afea434b84650c96958754794e727cba5b3bded1926f3f25e3
+      adapter_version_sha256 = sha256:aff0ebbd798f42325ea435bb681df7846916a47bdbbbd3268213b7389dc268f7
+  node          src/omnibase_core/nodes/node_compliance_evidence_effect/contract.yaml
+      source_contract_sha256 = sha256:5ff3915eec87f68f60d5bee4b8436eea78d42aa0485bdfa333934c9a7c995766
+      adapter_version_sha256 = sha256:a8dfea4e9625322db32399f108d10a0920aea2c11f0f645491b8e99ed2f47134
+  node          src/omnibase_core/nodes/node_compliance_report_reducer/contract.yaml
+      source_contract_sha256 = sha256:6bc01b5a506bed70de01db3738789f91ce4575fd96ece416307b2e81896c34c2
+      adapter_version_sha256 = sha256:a8dfea4e9625322db32399f108d10a0920aea2c11f0f645491b8e99ed2f47134
+
+=== NO-OP ROUND-TRIP == ZERO SEMANTIC DIFF (via cli_contract_diff) ===
+  effect node  : zero_diff=True total_changes=0
+  reducer node : zero_diff=True total_changes=0
+  ui component : zero_diff=True total_changes=0

--- a/.onex_state/evidence/omn-13197-pr-body.md
+++ b/.onex_state/evidence/omn-13197-pr-body.md
@@ -1,0 +1,50 @@
+## OMN-13197 — Remove the `onex.runtime.intents` hardcoded topic + dead intent-publisher path
+
+A-followup of **OMN-13188** (the **OMN-12803** "all topics/URLs from contracts only" family). Tracked separately per Q3 of the platform-debt plan so it does not block the A1–A5 sequence.
+
+### Decision (per DoD: contract-source the topic OR confirm-and-delete the dead path)
+
+**Confirm-and-delete the dead path.** The topic could **not** be contract-sourced:
+
+- No contract anywhere declares `onex.runtime.intents` (`find ... contract.yaml -exec grep onex.runtime.intents` → no matches). The `contracts/intent_publisher.yaml` referenced in the mixin docstring was **never authored** (phantom reference).
+- `ServiceTopicRegistry` (the contract-topic resolution mechanism) lives in `omnibase_infra`; `omnibase_core` cannot import it (repo layering: compat → core → spi → infra).
+
+The mechanism was **architecturally dead from both sides** (verified in OMN-13188 / OMN-13192):
+
+- `MixinIntentPublisher` — the **sole** publisher — had **ZERO production call sites** (never instantiated outside tests).
+- `onex.runtime.intents` had **ZERO Kafka consumers**: `IntentExecutor` is a synchronous in-memory runtime service called from `ServiceDispatchResultApplier`, not a topic subscriber.
+
+Per doctrine, a dead mechanism is debt to **delete**, not park / guard / migrate.
+
+### Changed
+
+**Removed**
+- `TOPIC_EVENT_PUBLISH_INTENT` — a duplicate of the canonical `TOPIC_RUNTIME_INTENTS` (both `= topic_name(DOMAIN_RUNTIME, TOPIC_TYPE_INTENTS)`), existing only to feed the dead mixin — plus all re-exports (`constants/__init__.py`, `models/events/__init__.py`, `models/events/model_intent_events.py`).
+- `MixinIntentPublisher` (`mixins/mixin_intent_publisher.py`) + its capability-mapping and metadata-census entries + mixins `__init__` export.
+- `ModelIntentPublishResult` (`models/reducer/model_intent_publish_result.py`) — only consumer was the deleted mixin — + reducer `__init__` export.
+- Dead tests + fixtures (`test_mixin_intent_publisher.py`, `test_intent_publisher_integration.py`, `test_model_intent_publish_result.py`, `fixture_intent_publisher.py`, `INTENT_PUBLISHER_TEST_SUMMARY.md`).
+- Intent-publisher guide docs that documented the removed mechanism (`09_TESTING_INTENT_PUBLISHER.md`, `INTENT_PUBLISHER_TESTING_DOCUMENTATION.md`) + all inbound links (node-building tutorials, guides README, topic-taxonomy standard).
+
+**Retained**
+- `TOPIC_RUNTIME_INTENTS` — the canonical taxonomy derivation (`onex.runtime.intents`), part of the public `__all__`.
+- `ModelEventPublishIntent` — has a live consumer in `utils/util_payload_migration.py`; docstring examples retargeted to `TOPIC_RUNTIME_INTENTS`.
+
+**Added**
+- `tests/unit/mixins/test_intent_publisher_removed.py` — regression guard asserting the dead symbols stay removed and the retained ones survive (TDD: red → green).
+
+### dod_evidence
+- `uv run ruff format src/ tests/` → 5567 files unchanged; `uv run ruff check --fix src/ tests/` → All checks passed.
+- `uv run mypy src/ --strict` → 0 errors on all changed files. (6 pre-existing errors remain in untouched files: `contract_loader.py`, `cli_install.py`, `model_onex_container.py` — verified present on `dev` base, not introduced here.)
+- Focused tests: `test_intent_publisher_removed.py` + `test_constants_topic_taxonomy.py` + `test_validator_hardcoded_topics.py` + `test_model_event_publish_intent.py` → **171 passed**. Full collection of `tests/unit/models` + reducer + events + intents → **1389 tests collected, 0 import errors**.
+- `pre-commit run` on all changed files → **all hooks PASS** (markdown-link validation PASS after doc cleanup; deterministic-skill-routing PASS against the omniclaude `main` snapshot — the only fail was a sibling-clone-on-dev artifact unrelated to this diff).
+
+### Receipt / OCC
+- Evidence-Source: `2322a07e139c35bbd85f131395ce07ec44200713`
+- Evidence-Ticket: OMN-13197
+
+Paired OCC receipt PR: contracts/OMN-13197.yaml + drift/dod_receipts/OMN-13197/... (linked below).
+
+Cross-reference: OMN-12803, OMN-13188, OMN-13192.
+
+
+Paired OCC receipt PR: https://github.com/OmniNode-ai/onex_change_control/pull/2706

--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -390,13 +390,14 @@ allowed_files:
 
   - file: "src/omnibase_core/nodes/node_no_io_outside_effects_check_compute/archetype_resolver.py"
     reason: >-
-      no-io-outside-effects COMPUTE archetype resolver (OMN-14694 seed / OMN-14662). Reads two optional archetype
-      fields (node_type, descriptor.node_archetype) from arbitrary node contract.yaml *strings* — the
-      bytes are read at the paired EFFECT / CLI boundary, so the COMPUTE stays pure over in-memory strings
-      (yaml.safe_load on a str is a pure parse, no I/O). contract.yaml schemas vary by node type (ModelContractCompute/Effect/Reducer/Orchestrator)
-      and no single Pydantic model round-trips every shape while reading a flat archetype fact — the same
-      pattern as operation_match_requires_operation.py and node_compliance_scan_compute/handler.py. Malformed
-      YAML raises yaml.YAMLError, which the handler surfaces as an ERROR finding (fail loud, never silent-green).
+      no-io-outside-effects COMPUTE archetype resolver (OMN-14694 seed / OMN-14662). Reads two optional
+      archetype fields (node_type, descriptor.node_archetype) from arbitrary node contract.yaml *strings*
+      — the bytes are read at the paired EFFECT / CLI boundary, so the COMPUTE stays pure over in-memory
+      strings (yaml.safe_load on a str is a pure parse, no I/O). contract.yaml schemas vary by node type
+      (ModelContractCompute/Effect/Reducer/Orchestrator) and no single Pydantic model round-trips every
+      shape while reading a flat archetype fact — the same pattern as operation_match_requires_operation.py
+      and node_compliance_scan_compute/handler.py. Malformed YAML raises yaml.YAMLError, which the handler
+      surfaces as an ERROR finding (fail loud, never silent-green).
     added: "2026-07-16"
     review: "2026-12-13"
 

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -16,9 +16,13 @@ from omnibase_core.models.delegation.wire.model_budget import (
     EnumBudgetAction,
     ModelBudgetLimits,
 )
-from omnibase_core.models.delegation.wire.model_delegation_result import (
+from omnibase_core.models.delegation.wire.model_delegation_completed import (
     ModelDelegationCompleted,
+)
+from omnibase_core.models.delegation.wire.model_delegation_failed import (
     ModelDelegationFailed,
+)
+from omnibase_core.models.delegation.wire.model_delegation_result import (
     ModelDelegationResult,
 )
 from omnibase_core.models.delegation.wire.model_delegation_wire_envelope import (

--- a/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Delegation completed terminal wire DTO."""
+
+from __future__ import annotations
+
+from omnibase_core.models.delegation.wire.model_delegation_result import (
+    ModelDelegationResult,
+)
+
+
+class ModelDelegationCompleted(ModelDelegationResult):
+    """Delegation terminal, COMPLETED outcome (OMN-14600).
+
+    Thin subclass: adds no new fields and no new validation. Class identity
+    alone is what class-name to topic routing uses to disambiguate the
+    completed terminal outcome.
+    """
+
+
+__all__: list[str] = ["ModelDelegationCompleted"]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_failed.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_failed.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Delegation failed terminal wire DTO."""
+
+from __future__ import annotations
+
+from omnibase_core.models.delegation.wire.model_delegation_result import (
+    ModelDelegationResult,
+)
+
+
+class ModelDelegationFailed(ModelDelegationResult):
+    """Delegation terminal, FAILED outcome (OMN-14600).
+
+    Thin subclass: adds no new fields and no new validation. Class identity
+    alone is what class-name to topic routing uses to disambiguate the failed
+    terminal outcome.
+    """
+
+
+__all__: list[str] = ["ModelDelegationFailed"]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -157,31 +157,4 @@ class ModelDelegationResult(BaseModel):
         return self
 
 
-class ModelDelegationCompleted(ModelDelegationResult):
-    """Delegation terminal, COMPLETED outcome (OMN-14600).
-
-    Thin subclass — adds NO new fields and no new validation. Class identity
-    alone is what class-name -> topic routing (``_outbox_topic_for`` /
-    ``DispatchResultApplier._resolve_mapped_output_topic``) uses to
-    disambiguate the completed-vs-failed terminal, replacing the earlier
-    bespoke ``ModelDelegationEventEnvelope{topic, payload}`` carrier (which
-    the routing layer could never resolve, since one wrapped class covered
-    both outcomes on one topic-per-class map). ``model_dump()`` is
-    byte-identical to a plain ``ModelDelegationResult`` — no wire consumer
-    that reads the flat payload shape needs to change.
-    """
-
-
-class ModelDelegationFailed(ModelDelegationResult):
-    """Delegation terminal, FAILED outcome (OMN-14600).
-
-    Thin subclass — see :class:`ModelDelegationCompleted` docstring; the same
-    rationale applies to the failed-outcome topic.
-    """
-
-
-__all__: list[str] = [
-    "ModelDelegationCompleted",
-    "ModelDelegationFailed",
-    "ModelDelegationResult",
-]
+__all__: list[str] = ["ModelDelegationResult"]


### PR DESCRIPTION
## Summary

Linearized the omnibase_core dev promotion prerequisite delta onto the current protected dev branch so the dev->main promotion PR can clear conflicts without a merge commit on dev.

Evidence-Ticket: OMN-15028
Evidence-Source: OCC#4844
Evidence-Commit: 475767dca526ca22496dd825233d4b7f4c4771a6
