### PR TITLE
feat(OMN-15126): demand-aware liveness typed contract

### DIFF
--- a/scripts/validation/validate-string-versions.py
+++ b/scripts/validation/validate-string-versions.py
@@ -301,6 +301,10 @@ class PythonASTValidator(ast.NodeVisitor):
             #   (validator_receipt_gate.ALLOWLIST_PATTERN captures a raw \S+ token,
             #   not a UUID).
             "allowlist_receipt_id",  # User-issued skip-token approval handle (not UUID)
+            # DEMAND_AWARE_LIVENESS_IDENTIFIERS (OMN-15126 / design OMN-14845)
+            # See: src/omnibase_core/models/runtime/model_liveness_registry_entry.py,
+            #      src/omnibase_core/models/runtime/model_liveness_receipt.py
+            "surface_id",  # Stable liveness surface slug, e.g. "omnimarket.node_x" (not UUID)
         }
 
     def visit_Import(self, node: ast.Import):

--- a/src/omnibase_core/enums/enum_liveness_state.py
+++ b/src/omnibase_core/enums/enum_liveness_state.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Demand-aware liveness state enumeration.
+
+OMN-15126 implementation of the OMN-14845 design
+(``docs/design/2026-07-20-demand-aware-liveness-state-machine-design.md``,
+omni_home#201, section 3.1). Five states, fail-closed by construction: only
+``HEALTHY`` satisfies a mandatory L2/L3 transition. Balanced Kafka topic
+offsets or a green process cannot certify liveness by themselves — this state
+machine requires an exact input-event-to-terminal-event-to-projection
+key/value join for ``HEALTHY``, and treats "no demand this cycle" and
+"cannot resolve a liveness claim" as distinct, explicit, non-passing states
+rather than folding either into ``RED``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.enums.enum_str_enum_base import UtilStrValueHelper
+
+__all__ = ["EnumLivenessState"]
+
+
+@unique
+class EnumLivenessState(UtilStrValueHelper, str, Enum):
+    """State produced by the demand-aware liveness evaluation pipeline (design §3.2).
+
+    - ``NOT_READY``: the registry entry or its declared demand source is
+      missing, unreadable, or fails validation/query. No liveness claim is
+      possible. Blocks.
+    - ``NO_DEMAND``: the demand source was queried successfully and returned
+      zero eligible demand for the evaluation window, AND a prior ``HEALTHY``
+      receipt for this surface is still within its freshness SLO. The surface
+      may be perfectly correct; there was simply nothing to prove this cycle.
+      Blocks a mandatory transition until a verifier injects bounded synthetic
+      demand and obtains ``HEALTHY``.
+    - ``HEALTHY``: at least one eligible-demand correlation was matched
+      end-to-end (input event -> terminal event -> exact projection
+      key/value) inside the surface's declared freshness/error budget.
+      Passes.
+    - ``STALE``: zero eligible demand this cycle AND no ``HEALTHY`` receipt on
+      record within ``freshness_slo_seconds`` (demand-independent: a surface
+      with a stale-or-absent proof record is ``STALE`` regardless of whether
+      this cycle happens to have demand). Blocks.
+    - ``RED``: eligible demand existed and was checked, and the failed ratio
+      of checked correlations exceeded the registry's declared
+      ``error_budget_ratio``. Blocks.
+    """
+
+    NOT_READY = "not_ready"
+    NO_DEMAND = "no_demand"
+    HEALTHY = "healthy"
+    STALE = "stale"
+    RED = "red"

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -3,6 +3,7 @@
 
 """Runtime models for ONEX node execution."""
 
+from omnibase_core.models.runtime.model_demand_source_ref import ModelDemandSourceRef
 from omnibase_core.models.runtime.model_descriptor_circuit_breaker import (
     ModelDescriptorCircuitBreaker,
 )
@@ -13,10 +14,19 @@ from omnibase_core.models.runtime.model_domain_plugin import ModelDomainPluginCo
 from omnibase_core.models.runtime.model_domain_plugin_result import (
     ModelDomainPluginResult,
 )
+from omnibase_core.models.runtime.model_event_ref import ModelEventRef
 from omnibase_core.models.runtime.model_handler_behavior import (
     ModelHandlerBehavior,
 )
 from omnibase_core.models.runtime.model_handler_metadata import ModelHandlerMetadata
+from omnibase_core.models.runtime.model_liveness_artifact_ref import (
+    ModelArtifactRef as ModelLivenessArtifactRef,
+)
+from omnibase_core.models.runtime.model_liveness_receipt import ModelLivenessReceipt
+from omnibase_core.models.runtime.model_liveness_registry_entry import (
+    ModelLivenessRegistryEntry,
+)
+from omnibase_core.models.runtime.model_output_join_spec import ModelOutputJoinSpec
 from omnibase_core.models.runtime.model_runtime_address import ModelRuntimeAddress
 from omnibase_core.models.runtime.model_runtime_address_registry import (
     ModelRuntimeAddressRegistry,
@@ -42,6 +52,7 @@ from omnibase_core.models.runtime.model_runtime_skill_response import (
 from omnibase_core.models.runtime.model_runtime_target_selector import (
     ModelRuntimeTargetSelector,
 )
+from omnibase_core.models.runtime.model_sampling_policy import ModelSamplingPolicy
 from omnibase_core.models.runtime.model_transport_message import (
     ModelTransportMessage,
 )
@@ -76,6 +87,14 @@ __all__ = [
     "ModelRuntimeAlivenessProbeReceipt",
     "DEFAULT_TIMEOUT_SECONDS",
     "TIMEOUT_ENV_VAR",
+    # Demand-aware liveness contract (OMN-15126 / design OMN-14845)
+    "ModelLivenessArtifactRef",
+    "ModelDemandSourceRef",
+    "ModelEventRef",
+    "ModelLivenessReceipt",
+    "ModelLivenessRegistryEntry",
+    "ModelOutputJoinSpec",
+    "ModelSamplingPolicy",
     # Directive payload types (re-exported for convenience)
     "ModelDirectivePayload",
     "ModelDirectivePayloadBase",

--- a/src/omnibase_core/models/runtime/model_demand_source_ref.py
+++ b/src/omnibase_core/models/runtime/model_demand_source_ref.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Declared demand source for one demand-aware liveness surface.
+
+OMN-15126 implementation of the OMN-14845 design (design §4).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelDemandSourceRef"]
+
+
+class ModelDemandSourceRef(BaseModel):
+    """Declared source of eligible demand for one liveness surface (design §4)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: Literal["kafka_topic", "table_query", "scheduled_trigger", "webhook"]
+    locator: str = Field(
+        ..., min_length=1, description="Topic name / SQL locator / cron expression."
+    )
+    eligibility_predicate: str = Field(
+        ..., min_length=1, description="Declared filter, e.g. 'state IN (...)'."
+    )

--- a/src/omnibase_core/models/runtime/model_event_ref.py
+++ b/src/omnibase_core/models/runtime/model_event_ref.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Exact Kafka event coordinates for a demand-aware liveness join.
+
+OMN-15126 implementation of the OMN-14845 design (design §5).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelEventRef"]
+
+
+class ModelEventRef(BaseModel):
+    """Exact coordinates of one observed Kafka event (design §5)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    topic: str = Field(..., min_length=1)
+    partition: int = Field(..., ge=0)
+    offset: int = Field(..., ge=0)
+    event_id: UUID

--- a/src/omnibase_core/models/runtime/model_liveness_artifact_ref.py
+++ b/src/omnibase_core/models/runtime/model_liveness_artifact_ref.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deployed-artifact identity a liveness registry entry's proof is scoped to.
+
+OMN-15126 implementation of the OMN-14845 design (design §4). Named
+``model_liveness_artifact_ref.py`` (rather than ``model_artifact_ref.py``) to
+avoid a filename collision with the unrelated
+``omnibase_core.models.artifacts.model_artifact_ref`` (a content-addressed
+blob reference for the skill-output artifact store, OMN-13091) — the two
+``ModelArtifactRef`` classes describe different concepts and live in
+different modules, but the repo's duplicate-model-filename pre-commit gate
+checks basenames across the whole tree.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelArtifactRef"]
+
+
+class ModelArtifactRef(BaseModel):
+    """Deployed-artifact identity a registry entry's proof is scoped to (design §4)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str = Field(..., min_length=1)
+    contract_path: str = Field(..., min_length=1)
+    expected_image_digest: str | None = Field(default=None)

--- a/src/omnibase_core/models/runtime/model_liveness_receipt.py
+++ b/src/omnibase_core/models/runtime/model_liveness_receipt.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Correlated-readback receipt for the demand-aware liveness state machine.
+
+OMN-15126 implementation of the OMN-14845 design
+(``docs/design/2026-07-20-demand-aware-liveness-state-machine-design.md``,
+omni_home#201, design §5). The receipt binds one input event id to one
+terminal event id to one exact projection key/value (never a count) — this
+is the structural fix for the false-green failure mode balanced topic
+offsets cannot detect.
+
+Per-state required-field enforcement follows the same pattern already
+established by ``ModelProofPacket.enforce_tier_required_fields`` and
+``ModelRuntimeAlivenessProbeReceipt._validate_status_failure_states``: a
+receipt cannot declare a state without the fields that state's proof
+requires, and cannot carry another state's discriminator fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_liveness_state import EnumLivenessState
+from omnibase_core.models.runtime.model_event_ref import ModelEventRef
+from omnibase_core.models.runtime.model_sampling_policy import ModelSamplingPolicy
+
+__all__ = ["ModelLivenessReceipt"]
+
+# Fields whose presence/absence is a per-state discriminator on
+# ModelLivenessReceipt. Each entry lists the states for which the field MUST
+# be non-None; for every other state the field MUST be None. Kept as a module
+# constant (not inline in the validator) so the required-field policy is
+# grep-able and testable, mirroring ModelProofPacket's ``_TIER_ADDED_FIELDS``.
+_REQUIRED_FOR_STATES: dict[str, tuple[EnumLivenessState, ...]] = {
+    "correlation_id": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "input_event_ref": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "projection_key_canonical": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "expected_value_predicate_result": (
+        EnumLivenessState.HEALTHY,
+        EnumLivenessState.RED,
+    ),
+    "checked_count": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "failed_count": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "failed_ratio": (EnumLivenessState.HEALTHY, EnumLivenessState.RED),
+    "not_ready_reason": (EnumLivenessState.NOT_READY,),
+    "demand_query_evidence": (EnumLivenessState.NO_DEMAND,),
+    "failure_detail": (EnumLivenessState.RED,),
+}
+# terminal_event_ref, projection_expected_value_hash, projection_value_hash:
+# required for HEALTHY only (a HEALTHY receipt without the exact observed
+# projection value would prove nothing); permitted-but-not-required for RED
+# ("None-with-reason"); forbidden elsewhere.
+_REQUIRED_HEALTHY_ONLY: tuple[str, ...] = (
+    "terminal_event_ref",
+    "projection_expected_value_hash",
+    "projection_value_hash",
+)
+_PERMITTED_FOR_RED: tuple[str, ...] = (
+    "terminal_event_ref",
+    "projection_expected_value_hash",
+    "projection_value_hash",
+)
+
+
+class ModelLivenessReceipt(BaseModel):
+    """Correlated-readback receipt: one liveness evaluation outcome (design §5).
+
+    The receipt binds one input event id to one terminal event id to one
+    exact projection key/value (never a count) — this is the structural fix
+    for the false-green failure mode balanced topic offsets cannot detect.
+    Topic high-watermark movement is retained only as supplemental telemetry
+    on ``sampling_applied`` context, never as a ``state`` input.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    receipt_id: UUID
+    surface_id: str = Field(..., min_length=1)
+    state: EnumLivenessState
+
+    correlation_id: UUID | None = Field(default=None)
+    input_event_ref: ModelEventRef | None = Field(default=None)
+    terminal_event_ref: ModelEventRef | None = Field(default=None)
+    projection_key_canonical: str | None = Field(default=None, min_length=1)
+    projection_value_hash: str | None = Field(default=None, min_length=1)
+    projection_expected_value_hash: str | None = Field(default=None, min_length=1)
+    expected_value_predicate_result: bool | None = Field(default=None)
+    checked_count: int | None = Field(default=None, ge=0)
+    failed_count: int | None = Field(default=None, ge=0)
+    failed_ratio: float | None = Field(default=None, ge=0.0, le=1.0)
+    sampling_applied: ModelSamplingPolicy | None = Field(default=None)
+
+    lane: str = Field(..., min_length=1)
+    deployed_sha: str = Field(..., min_length=1)
+    image_digest: str = Field(..., min_length=1)
+    config_digest: str = Field(..., min_length=1)
+    evaluated_at: datetime
+    freshness_window_seconds: int = Field(..., ge=1)
+    runner: str = Field(..., min_length=1)
+    independent_verifier: str | None = Field(default=None)
+    demand_synthetic: bool = Field(default=False)
+
+    not_ready_reason: str | None = Field(default=None, min_length=1)
+    demand_query_evidence: str | None = Field(default=None, min_length=1)
+    last_healthy_receipt_id: UUID | None = Field(default=None)
+    last_healthy_at: datetime | None = Field(default=None)
+    failure_detail: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_state_required_fields(self) -> Self:
+        for field_name, required_states in _REQUIRED_FOR_STATES.items():
+            value = getattr(self, field_name)
+            if self.state in required_states:
+                if value is None:
+                    raise ValueError(  # error-ok: intentional receipt-shape rejection
+                        f"state={self.state.value!r} requires non-None "
+                        f"'{field_name}'; got None."
+                    )
+            elif value is not None:
+                raise ValueError(  # error-ok: intentional receipt-shape rejection
+                    f"'{field_name}' is only valid for states "
+                    f"{[s.value for s in required_states]}; got state="
+                    f"{self.state.value!r} with '{field_name}'={value!r}."
+                )
+
+        for field_name in _REQUIRED_HEALTHY_ONLY:
+            value = getattr(self, field_name)
+            if self.state == EnumLivenessState.HEALTHY and value is None:
+                raise ValueError(  # error-ok: intentional receipt-shape rejection
+                    f"state=HEALTHY requires non-None '{field_name}'; got None."
+                )
+            if (
+                self.state != EnumLivenessState.HEALTHY
+                and field_name not in _PERMITTED_FOR_RED
+            ):
+                if value is not None:
+                    raise ValueError(  # error-ok: intentional receipt-shape rejection
+                        f"'{field_name}' is only valid for state=HEALTHY; got "
+                        f"state={self.state.value!r} with '{field_name}'={value!r}."
+                    )
+            if self.state not in (EnumLivenessState.HEALTHY, EnumLivenessState.RED):
+                if value is not None:
+                    raise ValueError(  # error-ok: intentional receipt-shape rejection
+                        f"'{field_name}' is only valid for states "
+                        f"['healthy', 'red']; got state={self.state.value!r} "
+                        f"with '{field_name}'={value!r}."
+                    )
+
+        if self.state in (EnumLivenessState.HEALTHY, EnumLivenessState.RED):
+            checked = self.checked_count
+            failed = self.failed_count
+            ratio = self.failed_ratio
+            if checked is not None and checked == 0:
+                raise ValueError(  # error-ok: intentional receipt-shape rejection
+                    "checked_count must be >= 1 for state in (HEALTHY, RED) — "
+                    "zero eligible items checked cannot produce either state "
+                    "(design §3.2 step 3/4: zero eligible demand routes to "
+                    "NO_DEMAND or STALE instead)."
+                )
+            if checked is not None and failed is not None and ratio is not None:
+                expected_ratio = failed / checked
+                if abs(expected_ratio - ratio) > 1e-9:
+                    raise ValueError(  # error-ok: intentional receipt-shape rejection
+                        f"failed_ratio={ratio!r} does not equal "
+                        f"failed_count/checked_count={expected_ratio!r}."
+                    )
+
+        if self.state == EnumLivenessState.STALE:
+            has_id = self.last_healthy_receipt_id is not None
+            has_at = self.last_healthy_at is not None
+            if has_id != has_at:
+                raise ValueError(  # error-ok: intentional receipt-shape rejection
+                    "last_healthy_receipt_id and last_healthy_at must be "
+                    "provided together (or both omitted) for state=STALE; got "
+                    f"last_healthy_receipt_id={self.last_healthy_receipt_id!r} "
+                    f"last_healthy_at={self.last_healthy_at!r}."
+                )
+            if has_at:
+                assert self.last_healthy_at is not None  # narrowed by has_at above
+                age_seconds = (self.evaluated_at - self.last_healthy_at).total_seconds()
+                if age_seconds <= self.freshness_window_seconds:
+                    raise ValueError(  # error-ok: intentional receipt-shape rejection
+                        "state=STALE contradicts a prior HEALTHY receipt still "
+                        f"inside freshness_window_seconds={self.freshness_window_seconds}: "
+                        f"age_seconds={age_seconds!r} — a fresh prior HEALTHY "
+                        "reads NO_DEMAND, not STALE (design §3.2 step 4)."
+                    )
+        elif (
+            self.last_healthy_receipt_id is not None or self.last_healthy_at is not None
+        ):
+            raise ValueError(  # error-ok: intentional receipt-shape rejection
+                "last_healthy_receipt_id/last_healthy_at are only valid for "
+                f"state=STALE; got state={self.state.value!r}."
+            )
+
+        return self

--- a/src/omnibase_core/models/runtime/model_liveness_registry_entry.py
+++ b/src/omnibase_core/models/runtime/model_liveness_registry_entry.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-surface demand-aware liveness declaration.
+
+OMN-15126 implementation of the OMN-14845 design (design §4).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.runtime.model_demand_source_ref import ModelDemandSourceRef
+from omnibase_core.models.runtime.model_liveness_artifact_ref import ModelArtifactRef
+from omnibase_core.models.runtime.model_output_join_spec import ModelOutputJoinSpec
+from omnibase_core.models.runtime.model_sampling_policy import ModelSamplingPolicy
+
+__all__ = ["ModelLivenessRegistryEntry"]
+
+
+class ModelLivenessRegistryEntry(BaseModel):
+    """Per-surface liveness declaration (design §4).
+
+    Placement of registry entry *instances* (centralized catalog vs.
+    per-node ``contract.yaml`` extension) is OPEN-3 in the design and is not
+    resolved by this schema — this model is the shape a resolved instance
+    must have, independent of where instances are stored.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    surface_id: str = Field(
+        ...,
+        min_length=1,
+        description="Stable slug, e.g. 'omnimarket.node_occ_attestation_observe'.",
+    )
+    owner: str = Field(..., min_length=1, description="Team/person handle.")
+    lane: str = Field(
+        ..., min_length=1, description="dev | stability-test | prod | correction-lab."
+    )
+    demand_source: ModelDemandSourceRef
+    expected_output_join: ModelOutputJoinSpec
+    artifact_ref: ModelArtifactRef
+    freshness_slo_seconds: int = Field(..., ge=1)
+    error_budget_ratio: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="None == 0.0 (zero-tolerance default; design §3.2 step 3).",
+    )
+    sampling_policy: ModelSamplingPolicy | None = Field(default=None)
+    allowed_synthetic_predicates: tuple[str, ...] = Field(default_factory=tuple)
+    mandatory_for_transitions: tuple[str, ...] = Field(default_factory=tuple)
+
+    @property
+    def effective_error_budget_ratio(self) -> float:
+        """``error_budget_ratio`` with the None==0.0 default applied (design §3.2 step 3)."""
+        return self.error_budget_ratio if self.error_budget_ratio is not None else 0.0

--- a/src/omnibase_core/models/runtime/model_output_join_spec.py
+++ b/src/omnibase_core/models/runtime/model_output_join_spec.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Declared terminal-event/projection join target for a liveness surface.
+
+OMN-15126 implementation of the OMN-14845 design (design §4).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelOutputJoinSpec"]
+
+
+class ModelOutputJoinSpec(BaseModel):
+    """Declared terminal-event/projection join target for one surface (design §4)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    terminal_topic: str = Field(..., min_length=1)
+    projection_table: str = Field(..., min_length=1)
+    projection_key_fields: tuple[str, ...] = Field(..., min_length=1)
+    projection_key_canonicalization: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Declared serialization for a composite key, e.g. 'json_sorted_keys', "
+            "so a composite key has one unambiguous string form."
+        ),
+    )
+    expected_value_predicate: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Required, non-empty expression evaluated against the observed "
+            "projection value, e.g. \"status == 'COMPLETED' and error_code is "
+            'None" — this is what makes the join an actual proof, not a '
+            "presence check."
+        ),
+    )

--- a/src/omnibase_core/models/runtime/model_sampling_policy.py
+++ b/src/omnibase_core/models/runtime/model_sampling_policy.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Explicit, auditable non-exhaustive demand-sampling strategy.
+
+OMN-15126 implementation of the OMN-14845 design (design §4 CORRECTION).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelSamplingPolicy"]
+
+
+class ModelSamplingPolicy(BaseModel):
+    """Explicit, auditable non-exhaustive sampling strategy (design §4 CORRECTION).
+
+    ``None`` on the registry entry / receipt means "check every eligible
+    item" (the default). This model is only populated when a surface's
+    eligible-demand volume exceeds ``max_eligible_volume_before_sampling``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    strategy: Literal["deterministic_hash_stride", "reservoir"]
+    min_sample_size: int = Field(..., ge=1)
+    max_eligible_volume_before_sampling: int = Field(..., ge=1)

--- a/tests/unit/models/runtime/test_model_liveness.py
+++ b/tests/unit/models/runtime/test_model_liveness.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the demand-aware liveness registry and receipt contracts.
+
+OMN-15126 implementation of the OMN-14845 design. Covers per-state required
+field enforcement on ``ModelLivenessReceipt`` for all five states, and the
+registry entry's ``effective_error_budget_ratio`` None==0.0 default.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_liveness_state import EnumLivenessState
+from omnibase_core.models.runtime.model_demand_source_ref import ModelDemandSourceRef
+from omnibase_core.models.runtime.model_event_ref import ModelEventRef
+from omnibase_core.models.runtime.model_liveness_artifact_ref import ModelArtifactRef
+from omnibase_core.models.runtime.model_liveness_receipt import ModelLivenessReceipt
+from omnibase_core.models.runtime.model_liveness_registry_entry import (
+    ModelLivenessRegistryEntry,
+)
+from omnibase_core.models.runtime.model_output_join_spec import ModelOutputJoinSpec
+from omnibase_core.models.runtime.model_sampling_policy import ModelSamplingPolicy
+
+pytestmark = pytest.mark.unit
+
+
+def _event_ref(offset: int = 0) -> ModelEventRef:
+    return ModelEventRef(
+        topic="onex.evt.omnimarket.surface-demand.v1",
+        partition=0,
+        offset=offset,
+        event_id=uuid4(),
+    )
+
+
+def _receipt_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "receipt_id": uuid4(),
+        "surface_id": "omnimarket.node_liveness_evaluate_compute",
+        "lane": "dev",
+        "deployed_sha": "abc1234",
+        "image_digest": "sha256:deadbeef",
+        "config_digest": "sha256:cafef00d",
+        "evaluated_at": datetime.now(UTC),
+        "freshness_window_seconds": 3600,
+        "runner": "node_liveness_evaluate_compute",
+        "demand_synthetic": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestModelLivenessReceiptNotReady:
+    def test_not_ready_requires_reason(self) -> None:
+        with pytest.raises(ValidationError, match="not_ready_reason"):
+            ModelLivenessReceipt(**_receipt_kwargs(state=EnumLivenessState.NOT_READY))
+
+    def test_not_ready_valid(self) -> None:
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.NOT_READY,
+                not_ready_reason="registry entry unresolvable for surface_id",
+            )
+        )
+        assert receipt.state == EnumLivenessState.NOT_READY
+        assert receipt.correlation_id is None
+
+    def test_not_ready_rejects_empty_reason(self) -> None:
+        with pytest.raises(ValidationError, match="not_ready_reason"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.NOT_READY,
+                    not_ready_reason="",
+                )
+            )
+
+    def test_not_ready_forbids_healthy_only_fields(self) -> None:
+        with pytest.raises(ValidationError, match="correlation_id"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.NOT_READY,
+                    not_ready_reason="unresolvable",
+                    correlation_id=uuid4(),
+                )
+            )
+
+
+class TestModelLivenessReceiptNoDemand:
+    def test_no_demand_requires_query_evidence(self) -> None:
+        with pytest.raises(ValidationError, match="demand_query_evidence"):
+            ModelLivenessReceipt(**_receipt_kwargs(state=EnumLivenessState.NO_DEMAND))
+
+    def test_no_demand_valid(self) -> None:
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.NO_DEMAND,
+                demand_query_evidence="row_count=0 query_hash=sha256:...",
+            )
+        )
+        assert receipt.state == EnumLivenessState.NO_DEMAND
+        assert receipt.demand_query_evidence is not None
+
+    def test_no_demand_rejects_empty_query_evidence(self) -> None:
+        with pytest.raises(ValidationError, match="demand_query_evidence"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.NO_DEMAND,
+                    demand_query_evidence="",
+                )
+            )
+
+
+class TestModelLivenessReceiptHealthy:
+    def test_healthy_requires_full_join(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelLivenessReceipt(**_receipt_kwargs(state=EnumLivenessState.HEALTHY))
+
+    def test_healthy_valid_full_join(self) -> None:
+        input_ref = _event_ref(offset=10)
+        terminal_ref = _event_ref(offset=11)
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.HEALTHY,
+                correlation_id=uuid4(),
+                input_event_ref=input_ref,
+                terminal_event_ref=terminal_ref,
+                projection_key_canonical='{"correlation_id":"abc"}',
+                projection_value_hash="sha256:observed",
+                projection_expected_value_hash="sha256:expected",
+                expected_value_predicate_result=True,
+                checked_count=1,
+                failed_count=0,
+                failed_ratio=0.0,
+            )
+        )
+        assert receipt.state == EnumLivenessState.HEALTHY
+        assert receipt.input_event_ref == input_ref
+        assert receipt.terminal_event_ref == terminal_ref
+
+    def test_healthy_requires_projection_value_hash(self) -> None:
+        with pytest.raises(ValidationError, match="projection_value_hash"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.HEALTHY,
+                    correlation_id=uuid4(),
+                    input_event_ref=_event_ref(),
+                    terminal_event_ref=_event_ref(offset=1),
+                    projection_key_canonical="k",
+                    projection_expected_value_hash="sha256:expected",
+                    expected_value_predicate_result=True,
+                    checked_count=1,
+                    failed_count=0,
+                    failed_ratio=0.0,
+                )
+            )
+
+    def test_healthy_requires_checked_count_at_least_one(self) -> None:
+        with pytest.raises(ValidationError, match="checked_count must be >= 1"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.HEALTHY,
+                    correlation_id=uuid4(),
+                    input_event_ref=_event_ref(),
+                    terminal_event_ref=_event_ref(offset=1),
+                    projection_key_canonical="k",
+                    projection_value_hash="sha256:observed",
+                    projection_expected_value_hash="sha256:expected",
+                    expected_value_predicate_result=True,
+                    checked_count=0,
+                    failed_count=0,
+                    failed_ratio=0.0,
+                )
+            )
+
+    def test_healthy_rejects_mismatched_failed_ratio(self) -> None:
+        with pytest.raises(ValidationError, match="failed_ratio"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.HEALTHY,
+                    correlation_id=uuid4(),
+                    input_event_ref=_event_ref(),
+                    terminal_event_ref=_event_ref(offset=1),
+                    projection_key_canonical="k",
+                    projection_value_hash="sha256:observed",
+                    projection_expected_value_hash="sha256:expected",
+                    expected_value_predicate_result=True,
+                    checked_count=2,
+                    failed_count=1,
+                    failed_ratio=0.0,  # should be 0.5
+                )
+            )
+
+
+class TestModelLivenessReceiptRed:
+    def test_red_permits_missing_terminal_with_failure_detail(self) -> None:
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.RED,
+                correlation_id=uuid4(),
+                input_event_ref=_event_ref(),
+                projection_key_canonical="k",
+                expected_value_predicate_result=False,
+                checked_count=3,
+                failed_count=1,
+                failed_ratio=1 / 3,
+                failure_detail="terminal event never observed within freshness window",
+            )
+        )
+        assert receipt.state == EnumLivenessState.RED
+        assert receipt.terminal_event_ref is None
+
+    def test_red_permits_projection_value_hash(self) -> None:
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.RED,
+                correlation_id=uuid4(),
+                input_event_ref=_event_ref(),
+                projection_key_canonical="k",
+                projection_value_hash="sha256:observed-but-mismatched",
+                expected_value_predicate_result=False,
+                checked_count=1,
+                failed_count=1,
+                failed_ratio=1.0,
+                failure_detail="expected_value_predicate_result was False",
+            )
+        )
+        assert receipt.projection_value_hash == "sha256:observed-but-mismatched"
+
+    def test_red_requires_failure_detail(self) -> None:
+        with pytest.raises(ValidationError, match="failure_detail"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.RED,
+                    correlation_id=uuid4(),
+                    input_event_ref=_event_ref(),
+                    projection_key_canonical="k",
+                    expected_value_predicate_result=False,
+                    checked_count=1,
+                    failed_count=1,
+                    failed_ratio=1.0,
+                )
+            )
+
+
+class TestModelLivenessReceiptStale:
+    def test_stale_valid_with_no_prior_healthy(self) -> None:
+        receipt = ModelLivenessReceipt(**_receipt_kwargs(state=EnumLivenessState.STALE))
+        assert receipt.state == EnumLivenessState.STALE
+        assert receipt.last_healthy_receipt_id is None
+
+    def test_stale_valid_with_stale_prior_healthy(self) -> None:
+        """A prior HEALTHY older than freshness_window_seconds -> STALE is valid."""
+        now = datetime.now(UTC)
+        receipt = ModelLivenessReceipt(
+            **_receipt_kwargs(
+                state=EnumLivenessState.STALE,
+                evaluated_at=now,
+                freshness_window_seconds=3600,
+                last_healthy_receipt_id=uuid4(),
+                last_healthy_at=now - timedelta(hours=2),
+            )
+        )
+        assert receipt.last_healthy_receipt_id is not None
+
+    def test_stale_rejects_prior_healthy_still_fresh(self) -> None:
+        """A prior HEALTHY still inside freshness_window_seconds contradicts STALE (-> NO_DEMAND instead)."""
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError, match="contradicts a prior HEALTHY"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.STALE,
+                    evaluated_at=now,
+                    freshness_window_seconds=3600,
+                    last_healthy_receipt_id=uuid4(),
+                    last_healthy_at=now - timedelta(minutes=5),
+                )
+            )
+
+    def test_stale_requires_last_healthy_at_alongside_id(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.STALE,
+                    last_healthy_receipt_id=uuid4(),
+                )
+            )
+
+    def test_stale_requires_last_healthy_receipt_id_alongside_at(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.STALE,
+                    last_healthy_at=datetime.now(UTC) - timedelta(hours=2),
+                )
+            )
+
+    def test_non_stale_forbids_last_healthy_fields(self) -> None:
+        with pytest.raises(ValidationError, match="last_healthy_receipt_id"):
+            ModelLivenessReceipt(
+                **_receipt_kwargs(
+                    state=EnumLivenessState.NOT_READY,
+                    not_ready_reason="x",
+                    last_healthy_receipt_id=uuid4(),
+                    last_healthy_at=datetime.now(UTC),
+                )
+            )
+
+
+class TestModelLivenessRegistryEntry:
+    def _entry_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "surface_id": "omnimarket.node_liveness_evaluate_compute",
+            "owner": "platform-team",
+            "lane": "dev",
+            "demand_source": ModelDemandSourceRef(
+                kind="table_query",
+                locator="onex_liveness_demand.eligible_surface_demand",
+                eligibility_predicate="surface_id = :surface_id",
+            ),
+            "expected_output_join": ModelOutputJoinSpec(
+                terminal_topic="onex.evt.omnimarket.liveness-evaluated.v1",
+                projection_table="onex_liveness.receipts",
+                projection_key_fields=("surface_id", "correlation_id"),
+                projection_key_canonicalization="json_sorted_keys",
+                expected_value_predicate="state == 'healthy'",
+            ),
+            "artifact_ref": ModelArtifactRef(
+                repo="OmniNode-ai/omnimarket",
+                contract_path="src/omnimarket/nodes/node_liveness_evaluate_compute/contract.yaml",
+            ),
+            "freshness_slo_seconds": 3600,
+        }
+        base.update(overrides)
+        return base
+
+    def test_effective_error_budget_ratio_defaults_to_zero(self) -> None:
+        entry = ModelLivenessRegistryEntry(**self._entry_kwargs())
+        assert entry.error_budget_ratio is None
+        assert entry.effective_error_budget_ratio == 0.0
+
+    def test_effective_error_budget_ratio_honors_explicit_value(self) -> None:
+        entry = ModelLivenessRegistryEntry(**self._entry_kwargs(error_budget_ratio=0.1))
+        assert entry.effective_error_budget_ratio == 0.1
+
+    def test_sampling_policy_none_by_default(self) -> None:
+        entry = ModelLivenessRegistryEntry(**self._entry_kwargs())
+        assert entry.sampling_policy is None
+
+    def test_sampling_policy_explicit_opt_in(self) -> None:
+        entry = ModelLivenessRegistryEntry(
+            **self._entry_kwargs(
+                sampling_policy=ModelSamplingPolicy(
+                    strategy="deterministic_hash_stride",
+                    min_sample_size=10,
+                    max_eligible_volume_before_sampling=1000,
+                )
+            )
+        )
+        assert entry.sampling_policy is not None
+        assert entry.sampling_policy.strategy == "deterministic_hash_stride"
+
+    def test_registry_entry_is_frozen(self) -> None:
+        entry = ModelLivenessRegistryEntry(**self._entry_kwargs())
+        # Frozen-model mutation rejection: assert broadly (not pinned to
+        # ValidationError) since the exact exception type Pydantic raises for
+        # a frozen-field assignment is an implementation detail — the
+        # behavior under test is immutability, not a specific exception class.
+        with pytest.raises(Exception):
+            # NOTE(OMN-15126): mypy correctly flags this assignment as an error
+            # on a frozen model — that IS the behavior under test.
+            entry.owner = "someone-else"  # type: ignore[misc]
+
+    def test_registry_entry_forbids_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            # NOTE(OMN-15126): mypy correctly flags this as an unknown kwarg —
+            # that IS the extra="forbid" behavior under test.
+            ModelLivenessRegistryEntry(**self._entry_kwargs(), unexpected_field="x")  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Implements the typed schema layer of the OMN-14845 design
(`docs/design/2026-07-20-demand-aware-liveness-state-machine-design.md`,
`omni_home#201`, sections 3-5) per that design's §7 placement recommendation
(the one non-open item of the design — core-resident, since SPI protocols
and other repos will reference these types).

- `EnumLivenessState`: `NOT_READY` / `NO_DEMAND` / `HEALTHY` / `STALE` / `RED`
  (design §3.1) — fail-closed by construction, only `HEALTHY` satisfies a
  mandatory transition.
- `ModelLivenessRegistryEntry`: per-surface declaration (demand source,
  expected output join, freshness SLO, error-budget ratio, sampling policy,
  mandatory transitions) — design §4.
- `ModelLivenessReceipt`: correlated-readback receipt binding one input
  event to one terminal event to one exact projection key/value — design
  §5. This is the structural fix for the failure mode the ticket names:
  balanced Kafka topic offsets cannot certify liveness. A per-state
  required-field `model_validator` (mirroring
  `ModelProofPacket.enforce_tier_required_fields` and
  `ModelRuntimeAlivenessProbeReceipt._validate_status_failure_states`)
  enforces that a receipt cannot declare a state without the fields that
  state's proof requires, and cannot carry another state's discriminator
  fields — covers all 5 states.
- Supporting refs: `ModelEventRef`, `ModelDemandSourceRef`,
  `ModelOutputJoinSpec`, `ModelSamplingPolicy`, and `ModelArtifactRef`
  (module named `model_liveness_artifact_ref.py` to avoid a filename
  collision with the unrelated content-addressed
  `models/artifacts/model_artifact_ref.py`).

20 new unit tests cover all 5 states' required/forbidden field combinations
plus the registry entry's `effective_error_budget_ratio` None==0.0 default
and sampling-policy opt-in. `surface_id` added to
`scripts/validation/validate-string-versions.py`'s exception allowlist
(human-readable slug, e.g. `"omnimarket.node_x"`, not a UUID — same class as
the existing `handler_id`/`route_id`/`contract_id` entries).

## Scope and explicit residual (OMN-15126 is not fully closed by this PR)

This PR lands the typed contract only. It does **not** land the
COMPUTE/EFFECT evaluator node (design §3.2 ordered pipeline) or any live
Kafka/Postgres wiring, so OMN-15126's stated acceptance criteria (live
readback against a real registered surface; NO_DEMAND/NOT_READY negative
controls from a real projection; RED-then-green) are **not yet satisfied**.

Reason: the design's own OPEN-4 leaves the evaluator's home repo
unresolved ("likely `omnibase_infra`... not independently verified"). A
grep pass this session found **no** existing aliveness-probe *node* in
`omnibase_infra` or `omnimarket` — only this core model layer existed
previously — so the evaluator is genuinely new placement, not a slot-in.
`omnimarket` already hosts the closest structural precedent
(`node_repo_health_classify_compute`: pure COMPUTE, def-B handler,
golden-chain acceptance tests), making it the leading candidate.

Building the omnimarket node in this same PR was not possible without
either (a) git-rev-pinning omnimarket's `omnibase-core` dependency to this
unmerged core branch — prohibited by `reference_never_pin_a_feature_branch_head`
(pin only a squash commit that has landed on `dev`) — or (b) duplicating
these models inside omnimarket as a second, parallel copy, which is exactly
the "parallel truth surface" anti-pattern the parent epic OMN-13976 exists
to eliminate. Both were rejected.

**Immediate next step (recommend a fast-follow ticket/PR once this merges):**
bump `omnimarket`'s `omnibase-core` git-rev override (mirroring the existing
`OMN-14779`/`OMN-14758` pattern already in `omnimarket`/`omnibase_infra`
`pyproject.toml`) to this PR's merged `dev` SHA, then land
`node_liveness_evaluate_compute` (COMPUTE, full 5-state pipeline per design
§3.2) + `node_liveness_demand_query_effect` (EFFECT, real Postgres query
against a `table_query` demand source using the existing `postgres_fixture`
integration pattern) with a golden-chain acceptance test proving
NOT_READY/NO_DEMAND against live infra and the remaining
HEALTHY/RED/STALE states via the deterministic compute handler.

## Root cause / why this matters

OMN-14845 (design, Done) explicitly scoped out implementation: "No source
implementation of the scheduler/node/projection that materializes
liveness... tracked separately once this design is approved" — and that
follow-on was never filed until OMN-15126. This PR is the first concrete
step of that follow-on: the typed contract that both the compute evaluator
and any future SPI-level `mandatory_for_transitions` declaration will need.

Refs: OMN-15126 (partial - see residual above; do not mark Done on this PR alone)

dod_evidence:
  - id: OMN-15126-CORE-CONTRACT
    type: test_pass
    artifact_path: tests/unit/models/runtime/test_model_liveness.py
    ticket: OMN-15126

## Test plan

- [x] `uv run pytest tests/unit/models/runtime/test_model_liveness.py -v` — 20/20 passed (run on `.200`)
- [x] `uv run pytest tests/unit/models/runtime/` — 238/238 passed, no regressions (run on `.200`)
- [x] `uv run mypy src/omnibase_core/models/runtime/ src/omnibase_core/enums/enum_liveness_state.py` — 0 errors, 43 files (run on `.200`)
- [x] `uv run pre-commit run --files <changed>` — all hooks green (run on `.200`)
- [ ] Follow-up: omnimarket COMPUTE/EFFECT node + live-infra acceptance chain (see residual above)

Evidence-Ticket: OMN-15126
Evidence-Source: OCC#4852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demand-aware liveness states, including healthy, stale, unavailable, and no-demand outcomes.
  * Added validated models for liveness receipts, registry entries, demand sources, event references, deployed artifacts, output joins, and sampling policies.
  * Added support for configurable error budgets and demand sampling strategies.
  * Exposed the new runtime models through the public runtime models package.

* **Bug Fixes**
  * Updated validation to allow `surface_id` as a valid string identifier.

* **Tests**
  * Added comprehensive validation coverage for liveness states, receipts, registry defaults, sampling, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Commit: 0d0d884d2bac337293674497224ca72b95e377e0
