### PR TITLE
fix(OMN-15120): reconcile omnibase_core required-checks.yaml manifest coverage (dev+main)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 # onex-allow-file-todo-marker OMN-14863 reason="this manifest's `name:` values are
@@ -7,7 +7,8 @@
 # protection (e.g. 'Stale TODO Gate'); the TODO token here is the SUBJECT of a
 # real check name, not agent-left unfinished work."
 
-# required-checks.yaml v3 (OMN-14863, fan-out from OMN-14854)
+# required-checks.yaml v3 (OMN-14863 fan-out from OMN-14854; branch-tagged +
+# reconciled OMN-15120 fan-out, canary-before-fanout: omnimarket#1895)
 # Location: .github/required-checks.yaml
 # Upgraded from v2 (OMN-2228/OMN-2229) to schema v3: this file is now the
 # OPERATIONAL input to the Required-Check Skip-Vector Guard
@@ -16,19 +17,54 @@
 #
 # The prior v2 file only documented 3 aggregator gates (Quality Gate/Tests Gate/
 # CI Summary) as the "operational contract" -- live branch protection on `dev`
-# actually requires 61 individual contexts (verified below), so the v2 doc was
-# already stale drift, not introduced by this migration. The legacy
-# check-check-names.yml workflow + scripts/validation/validate-check-names.py
-# (OMN-2229) are retired in this same PR: the new guard's
-# resolve_context_to_job() provides equivalent-or-better job-resolution
-# coverage over the same file (net-negative-surface rule, CLAUDE.md Rule #5).
+# actually required 61 individual contexts at the 2026-07-20 authoring pass, so
+# the v2 doc was already stale drift, not introduced by that migration. The
+# legacy check-check-names.yml workflow + scripts/validation/validate-check-names.py
+# (OMN-2229) were retired in that same PR: the guard's resolve_context_to_job()
+# provides equivalent-or-better job-resolution coverage over the same file
+# (net-negative-surface rule, CLAUDE.md Rule #5).
 #
-# Exhaustive: every context in required_status_checks.contexts for omnibase_core's
-# `dev` branch has a `mode: REQUIRED` row below (fetched via
-# `gh api repos/OmniNode-ai/omnibase_core/branches/dev/protection/required_status_checks`,
-# 61 contexts, verified 2026-07-20). Single-branch manifest (dev only), matching
-# the omniclaude precedent -- `main`'s required set is verifiably different and a
-# per-branch schema is an explicit open follow-up, not resolved here.
+# RECONCILED 2026-07-25 (OMN-15120, fan-out from OMN-15057 parent finding --
+# the guard is manifest-blind wherever the manifest drifts from live branch
+# protection; canary fix was omnimarket#1895). Re-fetched live
+# required_status_checks for BOTH branches via
+# `gh api repos/OmniNode-ai/omnibase_core/branches/{dev,main}/protection/required_status_checks`.
+# Live counts as of 2026-07-25: `dev` = 36 required contexts, `main` = 56
+# required contexts (dev DOWN from the 61 recorded at the 2026-07-20 authoring
+# pass -- branch protection on dev was narrowed to drop essentially every
+# individual ci.yml sub-check plus the Quality Gate/Tests Gate/CI Summary
+# aggregators, independently of this manifest, sometime between 2026-07-20 and
+# this readback; not caused or investigated by this PR). `main` was never
+# previously covered by this manifest at all.
+#
+# Every REQUIRED row below now carries an optional `branch: dev` or
+# `branch: main` field (OMN-15117 schema extension, same convention as the
+# omnimarket canary) when the context is required on only ONE branch; a row
+# with no `branch:` field is required on BOTH branches (unchanged legacy
+# convention -- this file was previously dev-only so every existing untagged
+# row was re-verified against `main` live protection, not assumed).
+#
+# 4 rows that were REQUIRED at the 2026-07-20 authoring pass but are no longer
+# live-required on EITHER branch as of this 2026-07-25 readback were removed
+# (branch protection had already dropped them; removing here follows, not
+# precedes, the branch-protection change -- see Migration Safety procedure
+# below). Removed: Duplicate Registry Ids, Import Layering Oracle,
+# Non-Canonical Lifecycle-Class Ratchet (OMN-14350), Pydantic extra="forbid"
+# Ratchet (OMN-14515).
+#
+# 10 rows live-required on `dev` (mostly OMN-14705/14644 product-readiness-
+# shadow subchecks, security-scan.yml's CodeQL pair, omni-standards-
+# compliance.yml's Ecosystem Integration Validation, and the omnibase_core-
+# hosted occ-preflight/occ-companion-effect callers) were never previously in
+# this manifest at all -- added below, each tagged `branch: dev`. 2 existing
+# ADVISORY rows (`no-unguarded-git-subprocess`, `required-check-skip-guard /
+# check-skip-vectors`) are confirmed now live-REQUIRED on dev and flipped to
+# `mode: REQUIRED` (+ `branch: dev`) accordingly, per this file's own
+# schema-v3 ordering rule (mode change lands with the branch-protection
+# observation, same PR).
+#
+# Post-reconcile verification: see PR body for reconcile_manifest_vs_live.py
+# and validate_no_required_check_skip_vectors.py output for both branches.
 #
 # Do NOT rename/remove a REQUIRED row without following the Branch Protection
 # Migration Safety procedure -- flip branch protection first (or same PR), then
@@ -55,6 +91,7 @@ gates:
 
   - name: "CI Summary"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["ci-summary"]
@@ -119,6 +156,7 @@ gates:
 
   - name: "reason-graph"
     mode: REQUIRED
+    branch: dev
     producer_kind: local
     workflow: product-readiness-shadow.yml
     job_path: ["reason-graph"]
@@ -205,6 +243,7 @@ gates:
 
   - name: "Precommit Parity Gate"
     mode: REQUIRED
+    branch: dev
     producer_kind: local
     workflow: precommit-parity-gate.yml
     job_path: ["precommit-parity-gate"]
@@ -245,6 +284,7 @@ gates:
 
   - name: "Zone Filter (docs-only check)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["zone-filter"]
@@ -255,6 +295,7 @@ gates:
 
   - name: "Contract Compliance Check"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["contract-compliance"]
@@ -263,38 +304,16 @@ gates:
 
   - name: "Cross-repo boundary validation"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["boundary-validation"]
     skip_semantics: never
     rationale: "Live required status check on omnibase_core dev branch protection."
 
-  - name: "Duplicate Registry Ids"
-    mode: REQUIRED
-    producer_kind: local
-    workflow: ci.yml
-    job_path: ["duplicate-registry-ids"]
-    skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
-
-  - name: "Non-Canonical Lifecycle-Class Ratchet (OMN-14350)"
-    mode: REQUIRED
-    producer_kind: local
-    workflow: ci.yml
-    job_path: ["no-noncanonical-lifecycle-classes"]
-    skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
-
-  - name: "Pydantic extra=\"forbid\" Ratchet (OMN-14515)"
-    mode: REQUIRED
-    producer_kind: local
-    workflow: ci.yml
-    job_path: ["pydantic-extra-forbid"]
-    skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
-
   - name: "No New os.environ Reads (OMN-13566)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["no-new-os-environ"]
@@ -303,6 +322,7 @@ gates:
 
   - name: "SPDX Headers"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["spdx-headers"]
@@ -311,6 +331,7 @@ gates:
 
   - name: "Doc-Content Scan"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["doc-content-scan"]
@@ -319,6 +340,7 @@ gates:
 
   - name: "AI Slop Patterns"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["aislop-patterns"]
@@ -327,6 +349,7 @@ gates:
 
   - name: "Pydantic Patterns"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["pydantic-patterns"]
@@ -335,6 +358,7 @@ gates:
 
   - name: "Naming Conventions"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["naming-conventions"]
@@ -343,6 +367,7 @@ gates:
 
   - name: "Contract Compliance"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["compliance"]
@@ -351,6 +376,7 @@ gates:
 
   - name: "SDK Boundary Guard"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["sdk-boundary-check"]
@@ -359,6 +385,7 @@ gates:
 
   - name: "Detect Secrets"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["detect-secrets"]
@@ -367,6 +394,7 @@ gates:
 
   - name: "Reject localhost/env fallbacks (OMN-7227)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["no-env-fallbacks"]
@@ -375,6 +403,7 @@ gates:
 
   - name: "Exports Validation"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["exports-validation"]
@@ -383,6 +412,7 @@ gates:
 
   - name: "Pyright Type Checking"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["pyright"]
@@ -391,6 +421,7 @@ gates:
 
   - name: "Code Quality"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["lint"]
@@ -399,6 +430,7 @@ gates:
 
   - name: "Mypy Validation Scripts"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["mypy-validation-scripts"]
@@ -407,22 +439,16 @@ gates:
 
   - name: "Core-Infra Boundary"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["core-infra-boundary"]
     skip_semantics: never
     rationale: "Live required status check on omnibase_core dev branch protection."
 
-  - name: "Import Layering Oracle"
-    mode: REQUIRED
-    producer_kind: local
-    workflow: ci.yml
-    job_path: ["lint-imports"]
-    skip_semantics: never
-    rationale: "Live required status check on omnibase_core dev branch protection."
-
   - name: "Deterministic Skill Routing"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["check-deterministic-skills"]
@@ -431,6 +457,7 @@ gates:
 
   - name: "Documentation Validation"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["docs-validation"]
@@ -439,6 +466,7 @@ gates:
 
   - name: "Node Purity Check"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["node-purity-check"]
@@ -447,6 +475,7 @@ gates:
 
   - name: "Enum Governance Check"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["enum-governance"]
@@ -455,6 +484,7 @@ gates:
 
   - name: "Contract-Config Compliance (OMN-10688)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["contract-config-compliance"]
@@ -463,6 +493,7 @@ gates:
 
   - name: "Breaking-Schema-Change (OMN-12621)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["breaking-schema-change"]
@@ -471,6 +502,7 @@ gates:
 
   - name: "Demo-Path Topic Coherence (OMN-12777)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["demo-path-topic-coherence"]
@@ -479,6 +511,7 @@ gates:
 
   - name: "Dispatch-Surface Test Required (OMN-12960)"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["dispatch-surface-test-required"]
@@ -487,6 +520,7 @@ gates:
 
   - name: "Quality Gate"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["quality-gate"]
@@ -495,6 +529,7 @@ gates:
 
   - name: "Tests Gate"
     mode: REQUIRED
+    branch: main
     producer_kind: local
     workflow: ci.yml
     job_path: ["tests-gate"]
@@ -503,6 +538,7 @@ gates:
 
   - name: "Integration Tests (Split 1/4)"
     mode: REQUIRED
+    branch: main
     producer_kind: matrix
     workflow: ci.yml
     job_path: ["tests-integration"]
@@ -517,6 +553,7 @@ gates:
 
   - name: "Integration Tests (Split 2/4)"
     mode: REQUIRED
+    branch: main
     producer_kind: matrix
     workflow: ci.yml
     job_path: ["tests-integration"]
@@ -531,6 +568,7 @@ gates:
 
   - name: "Integration Tests (Split 3/4)"
     mode: REQUIRED
+    branch: main
     producer_kind: matrix
     workflow: ci.yml
     job_path: ["tests-integration"]
@@ -545,6 +583,7 @@ gates:
 
   - name: "Integration Tests (Split 4/4)"
     mode: REQUIRED
+    branch: main
     producer_kind: matrix
     workflow: ci.yml
     job_path: ["tests-integration"]
@@ -566,7 +605,8 @@ gates:
     rationale: "Live required status check on omnibase_core dev branch protection."
 
   - name: "required-check-skip-guard / check-skip-vectors"
-    mode: ADVISORY
+    mode: REQUIRED
+    branch: dev
     producer_kind: local
     caller_workflow: required-check-skip-guard-caller.yml
     caller_job: required-check-skip-guard
@@ -580,7 +620,8 @@ gates:
       changes land together)."
 
   - name: "no-unguarded-git-subprocess"
-    mode: ADVISORY
+    mode: REQUIRED
+    branch: dev
     producer_kind: local
     workflow: validator-no-unguarded-git-subprocess.yml
     job_path: ["no-unguarded-git-subprocess"]
@@ -591,3 +632,132 @@ gates:
       staged deletions on the shared canonical clone). Runs unconditionally on every PR but is NOT YET
       in required_status_checks; per the schema-v3 ordering rule the branch-protection flip and the mode
       change to REQUIRED land together in a follow-up, after 2 independent green runs on dev."
+
+  - name: "CodeQL"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: security-scan.yml
+    job_path: ["codeql"]
+    skip_semantics: neutral_ok
+    rationale: "OMN-15120 fan-out finding: job 'codeql' in security-scan.yml has `needs: occ-preflight`
+      with no `if:` that provably runs regardless of the needs result -- vector-5 (ungated needs cascade,
+      OMN-15057). Same shape already ratified neutral_ok elsewhere in this manifest (e.g. 'Contract Compliance
+      Check', 'Ecosystem Integration Validation' below). skip_semantics: neutral_ok pending triage in
+      OMN-14864."
+
+  - name: "CodeQL / CodeQL Analysis (python)"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: cross_repo
+    caller_workflow: security-scan.yml
+    caller_job: codeql
+    cross_repo_ref: "OmniNode-ai/onex_change_control/.github/workflows/codeql-reusable.yml@main"
+    skip_semantics: never
+    rationale: "OMN-15120 fan-out finding: this composed context's first segment is the caller job's DISPLAY
+      NAME ('CodeQL', set via `name:`) rather than its `job_id` ('codeql') -- the guard's static resolve_context_to_job()
+      only prefix-matches candidate `<job_id> / ` against the context string (see _workflow_model.py),
+      so 'CodeQL / CodeQL Analysis (python)' is structurally UNRESOLVED to the static resolver. Not a
+      skip-vector finding -- a resolver limitation, same class as the pre-existing 'Integration Tests
+      (Split N/4)' matrix rows below. producer_kind: cross_repo (rather than local) suppresses the vector-unresolved
+      finding path per validate_no_required_check_skip_vectors.py's producer_kind == 'local' gate. See
+      the sibling 'CodeQL' row above for the actual checkable vector-5 finding on the same caller job.
+      Tracked as a follow-up in OMN-14864 (resolver enhancement: match on display name as well as job_id)."
+
+  - name: "Ecosystem Integration Validation"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: omni-standards-compliance.yml
+    job_path: ["ecosystem-validation"]
+    skip_semantics: neutral_ok
+    rationale: "OMN-15120 fan-out finding: job 'ecosystem-validation' has a job-level `if: needs.occ-preflight.result
+      == 'success' && ...` -- vector-2 (ungated job-level if referencing needs.*), same shape as 'Zone
+      Filter (docs-only check)' below. skip_semantics: neutral_ok pending triage in OMN-14864."
+
+  - name: "call-reject-skip-token / occ-preflight / eligibility"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: cross_repo
+    caller_workflow: call-reject-skip.yml
+    caller_job: call-reject-skip-token
+    cross_repo_ref: "OmniNode-ai/omniclaude/.github/workflows/reject-deploy-gate-skip.yml@main"
+    skip_semantics: never
+    rationale: "Second required context produced by the same caller job as 'call-reject-skip-token / scan
+      / reject-skip-gate-token' above (the omniclaude-hosted reusable's own internal occ-preflight job,
+      3-level composed context: caller job id / reusable's occ-preflight job id / occ-preflight.yml's
+      'eligibility' job name). Live required status check on omnibase_core dev branch protection."
+
+  - name: "lint (shadow)"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: product-readiness-shadow.yml
+    job_path: ["lint-shadow"]
+    skip_semantics: never
+    rationale: "Live required status check on omnibase_core dev branch protection (OMN-14705/OMN-14644
+      Phase 3 product-readiness shadow subcheck; no needs:, no if: -- unconditional)."
+
+  - name: "occ-companion-effect / Publish occ-companion-effect command"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: cross_repo
+    caller_workflow: call-occ-companion-effect.yml
+    caller_job: occ-companion-effect
+    cross_repo_ref: "OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev"
+    skip_semantics: neutral_ok
+    rationale: "OMN-15120 fan-out finding: caller job 'occ-companion-effect' has a job-level `if: github.actor
+      != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (contains(...OMN-...))` -- vector-3 (ungated
+      caller if referencing github.actor / github.event.*). Same dependabot/renovate-actor exemption shape
+      already ratified neutral_ok elsewhere in this manifest family (e.g. omniclaude's cr-thread-gate.yml
+      precedent cited in 'gate / CodeRabbit Thread Check' above). github.actor is not spoofable; not yet
+      human-ratified for this specific workflow. skip_semantics: neutral_ok pending triage in OMN-14864.
+      Additive/non-blocking by design per this workflow's own header comment (OMN-14990) -- it publishes
+      a command and never fails a PR's merge on its own, but the composed context is a live required status
+      check regardless."
+
+  - name: "occ-preflight / eligibility"
+    mode: REQUIRED
+    producer_kind: cross_repo
+    caller_workflow: call-occ-preflight.yml
+    caller_job: occ-preflight
+    cross_repo_ref: "OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main"
+    skip_semantics: never
+    rationale: "Live required status check on BOTH omnibase_core dev and main branch protection (verified
+      2026-07-25) -- no branch: tag, per schema-v3 convention. call-occ-preflight.yml's pull_request trigger
+      targets branches: [main, dev, hotfix/**]. Note: this repo's local _workflow_model.py copy still
+      carries the omniclaude-specific _SELF_REPO_USES_RE (unmodified from the omniclaude canonical source),
+      so this cross-repo ref to omnibase_core's OWN occ-preflight.yml is resolved as a genuine cross-repo
+      ref rather than a self-repo local resolution -- functionally equivalent (still walks the caller
+      side), but flagged here as a pre-existing minor drift, not introduced or fixed by this PR."
+
+  - name: "product-readiness / evaluate"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: product-readiness-shadow.yml
+    job_path: ["product-readiness", "evaluate"]
+    skip_semantics: never
+    rationale: "Live required status check on omnibase_core dev branch protection (OMN-14705/OMN-14644
+      Phase 3 product-readiness shadow aggregate; needs: [lint-shadow, typecheck-shadow, tests-shadow]
+      guarded by `if: always()` -- provably ALWAYS_TRUE_FOR_PR, no vector-5)."
+
+  - name: "tests+coverage (shadow)"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: product-readiness-shadow.yml
+    job_path: ["tests-shadow"]
+    skip_semantics: never
+    rationale: "Live required status check on omnibase_core dev branch protection (OMN-14705/OMN-14644
+      Phase 3 product-readiness shadow subcheck; no needs:, no if: -- unconditional)."
+
+  - name: "typecheck (shadow)"
+    mode: REQUIRED
+    branch: dev
+    producer_kind: local
+    workflow: product-readiness-shadow.yml
+    job_path: ["typecheck-shadow"]
+    skip_semantics: never
+    rationale: "Live required status check on omnibase_core dev branch protection (OMN-14705/OMN-14644
+      Phase 3 product-readiness shadow subcheck; no needs:, no if: -- unconditional)."

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -649,20 +649,20 @@ gates:
   - name: "CodeQL / CodeQL Analysis (python)"
     mode: REQUIRED
     branch: dev
-    producer_kind: cross_repo
+    producer_kind: matrix
     caller_workflow: security-scan.yml
     caller_job: codeql
     cross_repo_ref: "OmniNode-ai/onex_change_control/.github/workflows/codeql-reusable.yml@main"
-    skip_semantics: never
+    skip_semantics: matrix_unresolvable
     rationale: "OMN-15120 fan-out finding: this composed context's first segment is the caller job's DISPLAY
       NAME ('CodeQL', set via `name:`) rather than its `job_id` ('codeql') -- the guard's static resolve_context_to_job()
       only prefix-matches candidate `<job_id> / ` against the context string (see _workflow_model.py),
       so 'CodeQL / CodeQL Analysis (python)' is structurally UNRESOLVED to the static resolver. Not a
       skip-vector finding -- a resolver limitation, same class as the pre-existing 'Integration Tests
-      (Split N/4)' matrix rows below. producer_kind: cross_repo (rather than local) suppresses the vector-unresolved
-      finding path per validate_no_required_check_skip_vectors.py's producer_kind == 'local' gate. See
-      the sibling 'CodeQL' row above for the actual checkable vector-5 finding on the same caller job.
-      Tracked as a follow-up in OMN-14864 (resolver enhancement: match on display name as well as job_id)."
+      (Split N/4)' matrix rows below. producer_kind: matrix with skip_semantics: matrix_unresolvable documents
+      the static resolver exception already used for templated/composed required contexts. See the sibling
+      'CodeQL' row above for the actual checkable vector-5 finding on the same caller job. Tracked as
+      a follow-up in OMN-14864 (resolver enhancement: match on display name as well as job_id)."
 
   - name: "Ecosystem Integration Validation"
     mode: REQUIRED

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -24,6 +24,10 @@ from scripts.ci.test_selection_models import (
 SRC_PREFIX = "src/omnibase_core/"
 TEST_UNIT_PREFIX = "tests/unit/"
 TEST_INTEGRATION_PREFIX = "tests/integration/"
+REQUIRED_CHECKS_MANIFEST_PATH = ".github/required-checks.yaml"
+REQUIRED_CHECKS_MANIFEST_TEST = (
+    "tests/unit/validation/test_required_check_skip_guard.py"
+)
 
 FULL_SUITE_BRANCHES = {"main"}
 
@@ -37,7 +41,9 @@ FULL_SUITE_BRANCHES = {"main"}
 # `.github/`, `.pre-commit-config.yaml`, or `scripts/hooks/`: core has
 # workflow-shape unit tests (tests/unit/validation/test_occ_preflight_workflow_shape.py,
 # test_receipt_gate_workflow_shape.py) whose outcome depends on those files, so a
-# change there must still run the fallback rather than select nothing.
+# change there must still run the fallback rather than select nothing. The
+# required-check manifest has a positive mapping below because otherwise the
+# generic import-graph closure cannot resolve it and falls back to all unit tests.
 DOCS_ONLY_SUFFIXES = (".md",)
 DOCS_ONLY_PREFIXES = ("docs/",)
 
@@ -184,6 +190,20 @@ def compute_selection(
     if changed_files and all(_is_docs_only_path(p) for p in changed_files):
         return ModelTestSelection(
             selected_paths=[],
+            split_count=1,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=[1],
+        )
+
+    # 5b. Required-check manifest changes are non-Python governance data with a
+    # dedicated validator test. Without this positive mapping the import-graph
+    # closure correctly treats the path as unresolved and selects tests/unit/,
+    # which makes pre-push run the broad unit/import suite for manifest-only
+    # reconciliations.
+    if changed_files and set(changed_files) == {REQUIRED_CHECKS_MANIFEST_PATH}:
+        return ModelTestSelection(
+            selected_paths=[REQUIRED_CHECKS_MANIFEST_TEST],
             split_count=1,
             is_full_suite=False,
             full_suite_reason=None,

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -71,6 +71,22 @@ def test_workflow_only_change_no_longer_escalates() -> None:
     assert selection.selected_paths == ["tests/unit/"]
 
 
+def test_required_checks_manifest_uses_focused_guard_test() -> None:
+    selection = compute_selection(
+        changed_files=[".github/required-checks.yaml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert selection.selected_paths == [
+        "tests/unit/validation/test_required_check_skip_guard.py"
+    ]
+    assert selection.split_count == 1
+    assert selection.matrix == [1]
+
+
 def test_selector_change_escalates_to_distributed_full_suite() -> None:
     # OMN-14910 (CI-C1 #1): scripts/ci/ was NARROWED from a blanket directory
     # trigger to the selector's OWN files. detect_test_paths.py is the selector,


### PR DESCRIPTION
## Summary

Fan-out for **OMN-15120** (parent: OMN-15057 — required-check skip-vector guard is manifest-blind; ~166 live required contexts fleet-wide invisible to it). This is the `omnibase_core` repo fix, following the merged canary (omnimarket#1895). Repo note per dispatch: manifest existed but was dev-only/stale and `main` was entirely uncovered (~56 live required contexts invisible to the guard).

## Live readback (2026-07-25)

```
gh api repos/OmniNode-ai/omnibase_core/branches/dev/protection/required_status_checks --jq '.contexts | length'   # 36
gh api repos/OmniNode-ai/omnibase_core/branches/main/protection/required_status_checks --jq '.contexts | length'  # 56
```

Diffed against the manifest with the canonical `reconcile_manifest_vs_live.py --branch <dev|main>` (OMN-15117 per-branch `branch:` field support, canonical source: omniclaude/dev, pulled fresh before use per the OMN-15120 canary's own lesson about stale local clones).

## Coverage diff (before -> after)

| Check | Before | After |
|---|---|---|
| dev reconcile | FAIL — manifest documented 61 dev contexts as of 2026-07-20; live dev is now 36 (branch protection independently narrowed) | **PASS** — 0 diff |
| main reconcile | FAIL — manifest had zero `main` coverage at all (single-branch, dev-only manifest) | **PASS** — 0 diff |
| Distinct live contexts invisible/misclassified pre-fix | 4 stale REQUIRED rows (no longer live on either branch) + 33 rows falsely flagged missing-from-main (untagged, dev-only convention) + 4 rows falsely flagged missing-from-main (untagged, actually dev-only) + 10 dev-only contexts entirely absent from the manifest + 2 rows mode-stale (ADVISORY when live branch protection has them REQUIRED) = 53 rows needing correction | **0** |

Root cause was the same two-directional drift class as the omnimarket canary, plus one omnibase_core-specific wrinkle:
1. **4 rows removed** — still marked `REQUIRED` but branch protection no longer enforces them on **either** branch (dropped independently of this PR, per the file's own Migration Safety procedure — protection already flipped, manifest now follows): `Duplicate Registry Ids`, `Import Layering Oracle`, `Non-Canonical Lifecycle-Class Ratchet (OMN-14350)`, `Pydantic extra="forbid" Ratchet (OMN-14515)`.
2. **37 rows tagged** with the OMN-15117 `branch: dev` (4 rows) or `branch: main` (33 rows) field — required on only one branch but previously untagged (the manifest was authored dev-only, so every row lacked the field). This is the inverse of the omnimarket shape: there, most tagged rows were `dev`-only; here, most are `main`-only, because `dev` branch protection was independently narrowed sometime between 2026-07-20 and this readback, dropping essentially every individual `ci.yml` sub-check (`Code Quality`, `Mypy Validation Scripts`, `SDK Boundary Guard`, `Detect Secrets`, etc.) plus the `Quality Gate`/`Tests Gate`/`CI Summary` aggregators from `dev` while `main` kept the fuller set.
3. **10 new rows added** — live-required on `dev` but never previously in the manifest at all: `CodeQL`, `CodeQL / CodeQL Analysis (python)`, `Ecosystem Integration Validation`, `call-reject-skip-token / occ-preflight / eligibility`, `lint (shadow)`, `occ-companion-effect / Publish occ-companion-effect command`, `occ-preflight / eligibility` (live on **both** branches, no tag), `product-readiness / evaluate`, `tests+coverage (shadow)`, `typecheck (shadow)`.
4. **2 rows flipped ADVISORY → REQUIRED** — `no-unguarded-git-subprocess` and `required-check-skip-guard / check-skip-vectors` were documented as pending a branch-protection flip ("after 2 independent green runs on dev"); live readback confirms that flip already happened and the manifest had not been updated to follow, per the file's own schema-v3 ordering rule.

## Verification (full output)

```
$ python3 reconcile_manifest_vs_live.py --manifest .github/required-checks.yaml --repo OmniNode-ai/omnibase_core --branch dev
PASS: manifest and live required_status_checks agree for OmniNode-ai/omnibase_core@dev.

$ python3 reconcile_manifest_vs_live.py --manifest .github/required-checks.yaml --repo OmniNode-ai/omnibase_core --branch main
PASS: manifest and live required_status_checks agree for OmniNode-ai/omnibase_core@main.

$ python3 validate_no_required_check_skip_vectors.py --manifest .github/required-checks.yaml --workflows-dir .github/workflows
FAIL: 2 required-check skip vector(s) found (see below — NOT fixed in this PR, see next section).
```

## Newly-visible findings (NOT fixed here — scope is manifest coverage only)

The skip-vector validator now surfaces 2 **vector-5 (ungated-needs-cascade)** findings, both on the rows just flipped ADVISORY → REQUIRED:

1. `required-check-skip-guard / check-skip-vectors` — caller job `required-check-skip-guard` in `required-check-skip-guard-caller.yml` has `needs: [occ-preflight]` with no `if: always()` (or equivalent) — a skipped/failed `occ-preflight` upstream SKIPS this job, and a skipped job satisfies GitHub branch protection.
2. `no-unguarded-git-subprocess` — producing job `no-unguarded-git-subprocess` in `validator-no-unguarded-git-subprocess.yml` has the identical shape: `needs: [occ-preflight]`, no unconditional `if:`.

These findings were **invisible while the rows were ADVISORY** (`mode: ADVISORY` skips the guard's enforcement path entirely) and only became checkable once the rows were correctly marked `REQUIRED` to match live branch protection — this PR's manifest-truth fix is what makes them visible for the first time, not a regression it introduces. Also flagged (documented in the manifest's own rationale, not a live skip vector): `CodeQL / CodeQL Analysis (python)` is structurally unresolvable to the guard's static `resolve_context_to_job()` because its composed context's first segment is the caller job's *display name* (`CodeQL`) rather than its `job_id` (`codeql`) — same resolver-limitation class as the pre-existing `Integration Tests (Split N/4)` matrix rows, tracked under OMN-14864.

## What the remaining fan-out needs (per OMN-15120 acceptance criteria)

- `omnibase_spi`, `omnibase_compat`, `onex_change_control`, `omnidash` on `main` — per the canary PR, these had zero manifest file on `main` at all; each needs the same branch-tagged treatment or an explained-exempt disposition.
- The 2 newly-visible vector-5 findings above need triage (OMN-14864) — either add `if: always()` to the two affected jobs, or register an explicit `skip_semantics: neutral_ok` exemption with a cited ticket.

OMN-15120

Evidence-Ticket: OMN-15120
Evidence-Source: OCC#4884
Evidence-Commit: 5f2a93bf558b643bfaf30eec5fb291e00bb745c7