### PR TITLE
fix(OMN-15143): close 2 vector-5 needs-cascade skip vectors (unblock #1508)

### DIFF
--- a/.github/workflows/required-check-skip-guard-caller.yml
+++ b/.github/workflows/required-check-skip-guard-caller.yml
@@ -48,5 +48,6 @@ jobs:
 
   required-check-skip-guard:
     needs: occ-preflight
+    if: always()
     # pinned to omniclaude dev commit carrying the current reusable guard.
     uses: OmniNode-ai/omniclaude/.github/workflows/required-check-skip-guard-reusable.yml@6c909d21f58b031e7cf74bebd9776ae2654fa36f

--- a/.github/workflows/validator-no-unguarded-git-subprocess.yml
+++ b/.github/workflows/validator-no-unguarded-git-subprocess.yml
@@ -74,6 +74,7 @@ jobs:
 
   no-unguarded-git-subprocess:
     needs: occ-preflight
+    if: always()
     name: no-unguarded-git-subprocess
     # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-


### PR DESCRIPTION
## Summary

Closes the 2 new `vector-5-ungated-needs-cascade` findings surfaced live by omnibase_core#1508 (OMN-15120 manifest fan-out). #1508 correctly flipped `required-check-skip-guard / check-skip-vectors` and `no-unguarded-git-subprocess` from ADVISORY to REQUIRED in `.github/required-checks.yaml` to match live branch protection (both rows were already REQUIRED on live `dev`/`main` branch protection; the manifest had not followed). Because the vector-5 check only evaluates REQUIRED rows, that flip is what made these 2 pre-existing skip vectors checkable for the first time — this PR fixes them, not a regression #1508 introduced.

## Fix

Adds `if: always()` to the two affected jobs, identical to the merged remediation pattern in omnibase_core#1500 (OMN-15111, 16 workflow files):

- `.github/workflows/required-check-skip-guard-caller.yml` — job `required-check-skip-guard`
- `.github/workflows/validator-no-unguarded-git-subprocess.yml` — job `no-unguarded-git-subprocess`

Both jobs had `needs: occ-preflight` with no unconditional `if:`. GitHub's implicit job-level `if:` is `success()` evaluated over `needs:`, so a failed/cancelled/skipped `occ-preflight` upstream silently SKIPS these required jobs, and branch protection treats skipped as passing. `occ-preflight / eligibility` stays independently required — no gating strength lost, only the false-green coupling (same precedent as OMN-14668/OMN-15057).

## Local validator proof (2 -> 0)

The canonical skip-vector validator lives in `omniclaude` (`.github/actions/required-check-skip-guard/validate_no_required_check_skip_vectors.py`) — omnibase_core's own vendored copy predates the vector-5 check and is stale, so it was run directly from a fresh `omniclaude` dev pull, pointed at omnibase_core's `.github/workflows/`, against a `required-checks.yaml` copy with these 2 rows simulated `REQUIRED` (matching #1508's post-merge manifest state, since that flip lands in a separate PR):

```
# before this PR's fix (pre-patch tree):
FAIL: 2 required-check skip vector(s) found:
  - [vector-5-ungated-needs-cascade] required context 'required-check-skip-guard / check-skip-vectors': ...
  - [vector-5-ungated-needs-cascade] required context 'no-unguarded-git-subprocess': ...

# after this PR's fix:
PASS: no required-check skip vectors found.
```

This is the exact same failure text emitted live on #1508's `required-check-skip-guard / check-skip-vectors` CI run (job 89735798422).

## Sequencing / what unblocks what

This PR (workflow-file fix) and #1508 (manifest ADVISORY->REQUIRED flip) are independent diffs that must both land for the fleet-wide picture to be correct:

- This PR alone: fixes the workflow files. The (still-ADVISORY-on-dev-today) manifest rows mean the vector-5 check doesn't evaluate them yet on `dev` until #1508 also lands, but the underlying skip vector is closed either way.
- #1508 alone: is blocked today because its own manifest flip makes these 2 real gaps checkable and failing.
- Once both land: `validate_no_required_check_skip_vectors.py` against live `dev` (expanded manifest + fixed workflows) must return 0 findings for both rows.

OMN-15143 (parent OMN-15057; sibling findings, not a duplicate, of the already-Done OMN-15112 which covered a different 18 deploy-gate/verify findings).

Evidence-Ticket: OMN-15143
Evidence-Source: OCC#4901
Evidence-Commit: cc8afa2deda2c34a6d47840a24892fc7073ceb31