### PR TITLE
fix(OMN-15028): satisfy extra forbid ratchet

### DIFF
--- a/src/omnibase_core/errors/model_fail_fast_details.py
+++ b/src/omnibase_core/errors/model_fail_fast_details.py
@@ -37,4 +37,4 @@ class ModelFailFastDetails(BaseModel):
         description="Any additional structured information as string",
     )
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")

--- a/src/omnibase_core/errors/model_onex_error_data.py
+++ b/src/omnibase_core/errors/model_onex_error_data.py
@@ -30,6 +30,7 @@ class _ModelOnexErrorData(BaseModel):
     """
 
     model_config = ConfigDict(
+        extra="forbid",
         json_schema_extra={
             "example": {
                 "message": "File not found: config.yaml",

--- a/src/omnibase_core/models/contracts/model_handler_contract.py
+++ b/src/omnibase_core/models/contracts/model_handler_contract.py
@@ -383,7 +383,7 @@ class ModelHandlerContract(BaseModel):
 
     model_config = ConfigDict(
         frozen=True,
-        extra="ignore",
+        extra="forbid",
         from_attributes=True,
         str_strip_whitespace=True,
     )

--- a/src/omnibase_core/models/contracts/model_handler_contract_extended.py
+++ b/src/omnibase_core/models/contracts/model_handler_contract_extended.py
@@ -10,8 +10,8 @@ operation_bindings, activation, dict-form input_model/output_model).
 
 The base ``ModelHandlerContract`` stays strict (``extra="forbid"``) so
 all other consumers aren't forced to know about infra-specific fields.
-This extended variant uses ``extra="ignore"`` to silently discard any
-additional fields not declared here.
+This extended variant declares the infra-specific fields it accepts and
+rejects any additional undeclared fields.
 
 See Also:
     - OMN-6483: Create ModelHandlerContractExtended
@@ -46,7 +46,7 @@ class ModelHandlerContractExtended(ModelHandlerContract):
 
     model_config = ConfigDict(
         frozen=True,
-        extra="ignore",
+        extra="forbid",
         from_attributes=True,
         str_strip_whitespace=True,
     )

--- a/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
@@ -337,7 +337,7 @@ class ModelEventBusSubcontract(BaseModel):
         return self
 
     model_config = ConfigDict(
-        extra="ignore",  # Allow extra fields from YAML contracts
+        extra="forbid",
         use_enum_values=False,  # Keep enum objects, don't convert to strings
         validate_assignment=True,
     )

--- a/src/omnibase_core/models/contracts/subcontracts/model_reply_topics.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_reply_topics.py
@@ -50,7 +50,7 @@ class ModelReplyTopics(BaseModel):
         return topic
 
     model_config = ConfigDict(
-        extra="ignore",  # Allow extra fields from YAML contracts for forward compatibility
+        extra="forbid",
         frozen=True,
         from_attributes=True,
     )

--- a/src/omnibase_core/models/contracts/subcontracts/model_request_response_instance.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_request_response_instance.py
@@ -81,7 +81,7 @@ class ModelRequestResponseInstance(BaseModel):
         return topic
 
     model_config = ConfigDict(
-        extra="ignore",  # Allow extra fields from YAML contracts for forward compatibility
+        extra="forbid",
         frozen=True,
         from_attributes=True,
     )

--- a/src/omnibase_core/models/core/model_cli_command_registry.py
+++ b/src/omnibase_core/models/core/model_cli_command_registry.py
@@ -35,7 +35,7 @@ class ModelCliCommandRegistry(BaseModel):
     enabling third-party nodes to automatically expose their functionality.
     """
 
-    model_config = ConfigDict(extra="ignore", frozen=False)
+    model_config = ConfigDict(extra="forbid", frozen=False)
 
     commands: dict[str, ModelCliCommandDefinition] = Field(
         default_factory=dict,
@@ -336,9 +336,12 @@ def get_global_command_registry() -> ModelCliCommandRegistry:
         registry_obj = container.command_registry()
         registry = _coerce_reloaded_command_registry(registry_obj, container)
         if registry is None:
-            raise TypeError(
-                f"command_registry() returned {type(registry_obj).__name__}, "
-                "expected ModelCliCommandRegistry"
+            raise ModelOnexError(
+                message=(
+                    f"command_registry() returned {type(registry_obj).__name__}, "
+                    "expected ModelCliCommandRegistry"
+                ),
+                error_code=EnumCoreErrorCode.CONFIGURATION_ERROR,
             )
         return registry
     except (AttributeError, KeyError, TypeError, ValueError) as e:

--- a/src/omnibase_core/validators/extra_forbid_baseline.yaml
+++ b/src/omnibase_core/validators/extra_forbid_baseline.yaml
@@ -14,8 +14,6 @@
 #     --write-baseline src/omnibase_core
 
 violations:
-  - "omnibase_core.errors.model_fail_fast_details:ModelFailFastDetails"
-  - "omnibase_core.errors.model_onex_error_data:_ModelOnexErrorData"
   - "omnibase_core.models.agents.model_activation_patterns:ModelActivationPatterns"
   - "omnibase_core.models.agents.model_agent_capabilities:ModelAgentCapabilities"
   - "omnibase_core.models.agents.model_agent_definition:ModelAgentDefinition"
@@ -209,8 +207,6 @@ violations:
   - "omnibase_core.models.contracts.model_event_registry_config:ModelEventRegistryConfig"
   - "omnibase_core.models.contracts.model_event_subscription:ModelEventSubscription"
   - "omnibase_core.models.contracts.model_filter_conditions:ModelFilterConditions"
-  - "omnibase_core.models.contracts.model_handler_contract:ModelHandlerContract"
-  - "omnibase_core.models.contracts.model_handler_contract_extended:ModelHandlerContractExtended"
   - "omnibase_core.models.contracts.model_input_validation_config:ModelInputValidationConfig"
   - "omnibase_core.models.contracts.model_io_operation_config:ModelIOOperationConfig"
   - "omnibase_core.models.contracts.model_lifecycle_config:ModelLifecycleConfig"
@@ -260,7 +256,6 @@ violations:
   - "omnibase_core.models.contracts.subcontracts.model_envelope_template:ModelEnvelopeTemplate"
   - "omnibase_core.models.contracts.subcontracts.model_environment_validation_rule:ModelEnvironmentValidationRule"
   - "omnibase_core.models.contracts.subcontracts.model_environment_validation_rules:ModelEnvironmentValidationRules"
-  - "omnibase_core.models.contracts.subcontracts.model_event_bus_subcontract:ModelEventBusSubcontract"
   - "omnibase_core.models.contracts.subcontracts.model_event_definition:ModelEventDefinition"
   - "omnibase_core.models.contracts.subcontracts.model_event_handling_subcontract:ModelEventHandlingSubcontract"
   - "omnibase_core.models.contracts.subcontracts.model_event_mapping_rule:ModelEventMappingRule"
@@ -292,9 +287,7 @@ violations:
   - "omnibase_core.models.contracts.subcontracts.model_operation_mapping:ModelOperationMapping"
   - "omnibase_core.models.contracts.subcontracts.model_progress_status:ModelProgressStatus"
   - "omnibase_core.models.contracts.subcontracts.model_query_parameter_rule:ModelQueryParameterRule"
-  - "omnibase_core.models.contracts.subcontracts.model_reply_topics:ModelReplyTopics"
   - "omnibase_core.models.contracts.subcontracts.model_request_response_config:ModelRequestResponseConfig"
-  - "omnibase_core.models.contracts.subcontracts.model_request_response_instance:ModelRequestResponseInstance"
   - "omnibase_core.models.contracts.subcontracts.model_request_transformation:ModelRequestTransformation"
   - "omnibase_core.models.contracts.subcontracts.model_resource_usage_metric:ModelResourceUsageMetric"
   - "omnibase_core.models.contracts.subcontracts.model_response_header_rule:ModelResponseHeaderRule"
@@ -350,7 +343,6 @@ violations:
   - "omnibase_core.models.core.model_cli_argument:ModelCLIArgument"
   - "omnibase_core.models.core.model_cli_command:ModelCLICommand"
   - "omnibase_core.models.core.model_cli_command_definition:ModelCliCommandDefinition"
-  - "omnibase_core.models.core.model_cli_command_registry:ModelCliCommandRegistry"
   - "omnibase_core.models.core.model_cli_discovery_stats:ModelCliDiscoveryStats"
   - "omnibase_core.models.core.model_cli_interface:ModelCLIInterface"
   - "omnibase_core.models.core.model_cli_output:ModelCLIOutput"

--- a/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract.py
@@ -8,6 +8,7 @@ Comprehensive tests for event bus subcontract configuration and validation.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_core.models.contracts.subcontracts.model_event_bus_subcontract import (
     ModelEventBusSubcontract,
@@ -327,16 +328,15 @@ class TestModelEventBusSubcontractEdgeCases:
         assert subcontract.correlation_tracking is False
         assert subcontract.enable_lifecycle_events is False
 
-    def test_extra_fields_ignored(self):
-        """Test that extra fields are ignored per ConfigDict."""
+    def test_extra_fields_rejected(self):
+        """Test that extra fields are rejected per ConfigDict."""
         data = {
             "version": {"major": 1, "minor": 0, "patch": 0},
             "event_bus_type": "memory",
             "extra_unknown_field": "should_be_ignored",
         }
-        subcontract = ModelEventBusSubcontract.model_validate(data)
-        assert subcontract.event_bus_type == "memory"
-        assert not hasattr(subcontract, "extra_unknown_field")
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ModelEventBusSubcontract.model_validate(data)
 
     def test_empty_default_event_patterns(self):
         """Test creating subcontract with empty event patterns."""
@@ -424,16 +424,16 @@ class TestModelEventBusSubcontractAttributes:
 class TestModelEventBusSubcontractConfigDict:
     """Test ModelEventBusSubcontract ConfigDict settings."""
 
-    def test_extra_fields_are_ignored(self):
-        """Test that extra='ignore' allows extra fields."""
+    def test_extra_fields_are_rejected(self):
+        """Test that extra='forbid' rejects extra fields."""
         data = {
             "version": {"major": 1, "minor": 0, "patch": 0},
             "event_bus_type": "memory",
             "unknown_field_1": "value1",
             "unknown_field_2": "value2",
         }
-        subcontract = ModelEventBusSubcontract.model_validate(data)
-        assert subcontract.event_bus_type == "memory"
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ModelEventBusSubcontract.model_validate(data)
 
     def test_validate_assignment_enabled(self):
         """Test that validate_assignment=True validates on assignment."""

--- a/tests/unit/models/contracts/subcontracts/test_model_request_response.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_request_response.py
@@ -827,8 +827,8 @@ class TestModelEventBusSubcontractRequestResponseIntegration:
 class TestModelEventBusSubcontractRequestResponseEdgeCases:
     """Test edge cases for request_response integration."""
 
-    def test_extra_fields_in_request_response_config_ignored(self):
-        """Test that extra fields in request_response config are ignored."""
+    def test_extra_fields_in_request_response_config_rejected(self):
+        """Test that extra fields in request_response config are rejected."""
         data = {
             "version": {"major": 1, "minor": 0, "patch": 0},
             "request_response": {
@@ -846,9 +846,8 @@ class TestModelEventBusSubcontractRequestResponseEdgeCases:
                 "another_extra_field": "ignored",
             },
         }
-        subcontract = ModelEventBusSubcontract.model_validate(data)
-        assert subcontract.request_response is not None
-        assert len(subcontract.request_response.instances) == 1
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ModelEventBusSubcontract.model_validate(data)
 
     def test_request_response_coexists_with_topic_lists(self):
         """Test that request_response works with publish/subscribe topics."""

--- a/tests/unit/models/contracts/test_handler_contract_extended.py
+++ b/tests/unit/models/contracts/test_handler_contract_extended.py
@@ -81,8 +81,8 @@ def test_extended_contract_accepts_dict_output_model() -> None:
 
 
 @pytest.mark.unit
-def test_base_contract_ignores_extra_fields() -> None:
-    """Base contract silently ignores extra fields (extra='ignore').
+def test_base_contract_rejects_extra_fields() -> None:
+    """Base contract rejects extra fields.
 
     Uses a field name that is genuinely unknown to ModelHandlerContract.
     ``handler_routing`` itself became a declared field on the base model
@@ -95,9 +95,8 @@ def test_base_contract_ignores_extra_fields() -> None:
         **_base_data(),
         "some_infra_specific_extra_field": {"strategy": "round-robin"},
     }
-    contract = ModelHandlerContract(**data)
-    # extra="ignore" means the field is accepted but not stored
-    assert not hasattr(contract, "some_infra_specific_extra_field")
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        ModelHandlerContract(**data)
 
 
 @pytest.mark.unit

--- a/tests/unit/models/contracts/test_model_handler_contract.py
+++ b/tests/unit/models/contracts/test_model_handler_contract.py
@@ -588,15 +588,15 @@ class TestImmutability:
         with pytest.raises(ValidationError):
             contract.name = "New Name"  # type: ignore[misc]
 
-    def test_extra_fields_ignored(self) -> None:
-        """Test that extra fields are silently ignored (extra='ignore')."""
-        contract = ModelHandlerContract(
-            handler_id="node.test",
-            name="Test",
-            contract_version=ModelSemVer(major=1, minor=0, patch=0),
-            descriptor=ModelHandlerBehavior(node_archetype="compute"),
-            input_model="a.Input",
-            output_model="a.Output",
-            unknown_field="value",  # type: ignore[call-arg]
-        )
-        assert not hasattr(contract, "unknown_field")
+    def test_extra_fields_rejected(self) -> None:
+        """Test that extra fields are rejected."""
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ModelHandlerContract(
+                handler_id="node.test",
+                name="Test",
+                contract_version=ModelSemVer(major=1, minor=0, patch=0),
+                descriptor=ModelHandlerBehavior(node_archetype="compute"),
+                input_model="a.Input",
+                output_model="a.Output",
+                unknown_field="value",  # type: ignore[call-arg]
+            )

--- a/tests/unit/models/core/test_model_cli_command_registry.py
+++ b/tests/unit/models/core/test_model_cli_command_registry.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_core.models.core.model_cli_command_definition import (
     ModelCliCommandDefinition,
@@ -50,7 +51,6 @@ class TestModelCliCommandRegistryCreation:
         """Test registry initialization with provided data."""
         commands = {"test_cmd": self._create_test_command("test_cmd", "test_node")}
         registry = ModelCliCommandRegistry(
-            version=DEFAULT_VERSION,
             commands=commands,
             commands_by_node={"test_node": ["test_cmd"]},
             commands_by_category={"general": ["test_cmd"]},
@@ -62,6 +62,11 @@ class TestModelCliCommandRegistryCreation:
         assert len(registry.commands_by_node) == 1
         assert len(registry.commands_by_category) == 1
         assert len(registry.discovery_paths) == 1
+
+    def test_registry_rejects_extra_fields(self):
+        """Test registry rejects undeclared fields."""
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            ModelCliCommandRegistry(version=DEFAULT_VERSION)
 
     def _create_test_command(
         self, command_name: str, node_name: str, category: str = "general"


### PR DESCRIPTION
## Summary
- set the eight promotion-touched Pydantic models to `extra="forbid"`
- remove those resolved models from `extra_forbid_baseline.yaml`
- replace a touched-file standard `TypeError` with `ModelOnexError` for hook compliance

## Verification
- `uv run python -m omnibase_core.validators.pydantic_extra_forbid --check-stale --enforce-modified origin/main src/omnibase_core`
- `uv run pre-commit run --files src/omnibase_core/errors/model_fail_fast_details.py src/omnibase_core/errors/model_onex_error_data.py src/omnibase_core/models/contracts/model_handler_contract.py src/omnibase_core/models/contracts/model_handler_contract_extended.py src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py src/omnibase_core/models/contracts/subcontracts/model_reply_topics.py src/omnibase_core/models/contracts/subcontracts/model_request_response_instance.py src/omnibase_core/models/core/model_cli_command_registry.py src/omnibase_core/validators/extra_forbid_baseline.yaml`

Refs OMN-15028

Evidence-Source: OCC#4970
Evidence-Ticket: OMN-15028
Evidence-Commit: 0da14e1e0db097315c10fa74b0e3b22599550d2b
