### PR TITLE
fix(OMN-15028): satisfy core promotion CodeQL gates

### DIFF
--- a/src/omnibase_core/errors/__init__.py
+++ b/src/omnibase_core/errors/__init__.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     )
     from omnibase_core.errors.model_onex_error import ModelOnexError
 
+    OnexError = ModelOnexError
+
 """Core error handling for ONEX framework."""
 
 # Core error system - comprehensive implementation

--- a/src/omnibase_core/models/container/model_onex_container.py
+++ b/src/omnibase_core/models/container/model_onex_container.py
@@ -97,11 +97,6 @@ from omnibase_core.models.logging.model_stdlib_log_emit import (
 )
 
 
-# Import context-based container management
-from omnibase_core.context.context_application import (
-    get_current_container,
-    set_current_container,
-)
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_log_level import EnumLogLevel as LogLevel
 from omnibase_core.models.common.model_schema_value import ModelSchemaValue
@@ -1091,6 +1086,11 @@ async def get_model_onex_container() -> ModelONEXContainer:
         # Legacy usage (still works):
         container = await get_model_onex_container()  # Creates if needed
     """
+    from omnibase_core.context.context_application import (
+        get_current_container,
+        set_current_container,
+    )
+
     container = get_current_container()
     if container is None:
         container = await create_model_onex_container()
@@ -1116,6 +1116,11 @@ def get_model_onex_container_sync() -> ModelONEXContainer:
     Returns:
         ModelONEXContainer: The container instance for the current context
     """
+    from omnibase_core.context.context_application import (
+        get_current_container,
+        set_current_container,
+    )
+
     # Check contextvar for existing container
     container = get_current_container()
     if container is not None:

--- a/src/omnibase_core/nodes/node_service_effect.py
+++ b/src/omnibase_core/nodes/node_service_effect.py
@@ -112,6 +112,7 @@ class ModelServiceEffect(  # type: ignore[misc]  # MRO method signature conflict
             container: ONEX container providing service dependencies
         """
         super().__init__(container)
+        MixinMetrics.__init__(self)
 
     def cleanup_event_handlers(self) -> None:
         """

--- a/src/omnibase_core/nodes/node_service_orchestrator.py
+++ b/src/omnibase_core/nodes/node_service_orchestrator.py
@@ -129,3 +129,4 @@ class ModelServiceOrchestrator(  # type: ignore[misc]
             container: ONEX container providing service dependencies
         """
         super().__init__(container)
+        MixinMetrics.__init__(self)

--- a/src/omnibase_core/types/__init__.py
+++ b/src/omnibase_core/types/__init__.py
@@ -26,6 +26,8 @@ error_codes → types.__init__ → constraints → (circular back to error_codes
 Solution: Use TYPE_CHECKING and __getattr__ for lazy loading, similar to ModelBaseCollection.
 """
 
+from typing import TYPE_CHECKING
+
 # type_constraints and type_core are NOT imported eagerly here (OMN-14624).
 # Both import UP into ``omnibase_core.protocols``; importing them at package-init
 # time closes a ``protocols -> types -> protocols`` cycle whenever ``protocols`` is
@@ -359,6 +361,47 @@ from .typed_dict_workflow_outputs import TypedDictWorkflowOutputsDict
 from .typed_dict_workflow_state import TypedDictWorkflowState
 from .typed_dict_yaml_dump_kwargs import TypedDictYamlDumpKwargs
 from .typed_dict_yaml_dump_options import TypedDictYamlDumpOptions
+
+if TYPE_CHECKING:
+    from .type_constraints import (
+        BasicValueType,
+        CollectionItemType,
+        ComplexContextValueType,
+        Configurable,
+        ConfigurableType,
+        ContextValueType,
+        ErrorType,
+        Executable,
+        ExecutableType,
+        Identifiable,
+        IdentifiableType,
+        MetadataType,
+        ModelType,
+        Nameable,
+        NameableType,
+        NumericType,
+        PrimitiveValueType,
+        ProtocolMetadataProvider,
+        ProtocolValidatable,
+        Serializable,
+        SerializableType,
+        SimpleValueType,
+        SuccessType,
+        ValidatableType,
+        is_complex_context_value,
+        is_configurable,
+        is_context_value,
+        is_executable,
+        is_identifiable,
+        is_metadata_provider,
+        is_nameable,
+        is_primitive_value,
+        is_serializable,
+        is_validatable,
+        validate_context_value,
+        validate_primitive_value,
+    )
+    from .type_core import ProtocolSchemaValue, TypedDictBasicErrorContext
 
 __all__ = [
     # Core types (no dependencies)

--- a/src/omnibase_core/validation/__init__.py
+++ b/src/omnibase_core/validation/__init__.py
@@ -29,6 +29,7 @@ Usage Examples:
 """
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Import models and enums
 from omnibase_core.enums.enum_import_status import EnumImportStatus
@@ -86,6 +87,17 @@ from omnibase_core.services.service_contract_validation_invariant_checker import
 # ModelValidationSuite is available via __getattr__ (emits deprecation warning)
 # Import directly from source module to satisfy mypy explicit-export requirement
 from omnibase_core.services.service_validation_suite import ServiceValidationSuite
+
+if TYPE_CHECKING:
+    from omnibase_core.services.service_contract_validator import (
+        ServiceContractValidator,
+    )
+    from omnibase_core.services.service_protocol_auditor import ServiceProtocolAuditor
+    from omnibase_core.services.service_protocol_migrator import ServiceProtocolMigrator
+    from omnibase_core.validation.validator_contract_linter import (
+        CONTRACT_MODELS,
+        ValidatorContractLinter,
+    )
 
 # Import validation functions for easy access
 # Import Architecture validator (OMN-1291)


### PR DESCRIPTION
Refs OMN-15028

Evidence-Source: OCC#4976
Evidence-Ticket: OMN-15028
Evidence-Commit: b0fc45a93dd10694db6880cd3e0c9a9de2a1acb6


Summary:
- Add TYPE_CHECKING-only explicit imports for lazy-exported type and validation names so static analysis can resolve __all__ members without changing runtime import order.
- Move context container imports into accessors to break the module-level container/context cycle.
- Explicitly initialize MixinMetrics in effect/orchestrator service wrappers flagged by CodeQL.

Verification:
- uv run ruff format --check src/omnibase_core/types/__init__.py src/omnibase_core/validation/__init__.py src/omnibase_core/errors/__init__.py src/omnibase_core/models/container/model_onex_container.py src/omnibase_core/nodes/node_service_effect.py src/omnibase_core/nodes/node_service_orchestrator.py
- uv run ruff check src/omnibase_core/types/__init__.py src/omnibase_core/validation/__init__.py src/omnibase_core/errors/__init__.py src/omnibase_core/models/container/model_onex_container.py src/omnibase_core/nodes/node_service_effect.py src/omnibase_core/nodes/node_service_orchestrator.py
- uv run pytest tests/unit/models/nodes/node_services/test_model_service_effect_lifecycle.py::TestModelServiceEffectInitialization tests/unit/models/nodes/node_services/test_model_service_orchestrator_lifecycle.py::TestModelServiceOrchestratorInitialization -q
- uv run pre-commit run --files src/omnibase_core/types/__init__.py src/omnibase_core/validation/__init__.py src/omnibase_core/errors/__init__.py src/omnibase_core/models/container/model_onex_container.py src/omnibase_core/nodes/node_service_effect.py src/omnibase_core/nodes/node_service_orchestrator.py
- push executed from .200 build lane per governed selector
