### PR TITLE
feat(OMN-15222): OCC companion-merged STRICT gate — companion must merge before product PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3309,6 +3309,51 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
+  occ-companion-merged:
+    name: OCC Companion Merged Gate (OMN-15214)
+    # OMN-15222 (port of the OMN-15214 canary, omnibase_infra #2486): makes the
+    # 2026-07-26 OCC hygiene-sweep trigger state — an OPEN onex_change_control
+    # evidence companion whose product PR already MERGED — unreachable via the
+    # CI Summary merge path on this repo. The sweep closed five open companions
+    # (OCC#5012–#5016) whose product PRs had merged, destroying three evidence
+    # chains (OMN-15199/OMN-15200/OMN-15203). The durable fix is ordering: the
+    # companion must MERGE BEFORE the product PR can. This job polls the PR's
+    # live Evidence-Source (live body, not event payload — occ-autobind PATCHes
+    # it in after open) and greens ONLY when the cited OCC companion PR is
+    # MERGED or the cited OCC commit SHA is an ancestor of onex_change_control
+    # dev/main. A companion CLOSED without merging fails immediately (that IS
+    # the incident state).
+    #
+    # CI Summary GATE_JOB + STRICT_SUCCESS_JOB (scripts/ci/ci_summary_gate.py)
+    # — deliberately NOT a new top-level required context: a context that does
+    # not report on every PR shape wedges merges indefinitely under branch
+    # protection, and occ-autobind itself is network-flaky (omninode_infra#679,
+    # 2026-07-26). Unconditional (no needs/if) so CI Summary always WAITS for
+    # it and a skip/cancel fails closed; internal event scoping no-ops on
+    # push/workflow_dispatch (mirrors occ-preflight). GitHub-hosted + pure gh
+    # API polling: zero self-hosted/LAN dependency, and the poll window absorbs
+    # autobind mint + companion auto-merge latency instead of converting them
+    # into instant reds.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+      # Poll window (seconds) — bounded well under ci-summary's 90m deadline so
+      # this gate reaches a terminal state first; PENDING converts to FAIL.
+      DEADLINE_SECONDS: "1500"
+      POLL_INTERVAL_SECONDS: "30"
+    steps:
+      - name: Checkout (gate script)
+        uses: actions/checkout@v7
+      - name: Require cited OCC evidence to be merged/durable before product merge
+        run: python3 scripts/ci/check_occ_companion_merged.py
+
   ci-summary:
     name: CI Summary
     # OMN-14127: REQUIRED branch-protection context, implemented as a NO-`needs`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3132,6 +3132,8 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run integration tests (split ${{ matrix.split }}/4)
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || github.token }}
         run: |
           uv run pytest tests/integration/ \
             --splits 4 --group ${{ matrix.split }} \
@@ -3340,7 +3342,7 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || github.token }}
       GH_REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,6 +378,7 @@ ignore = [
 "scripts/validation/validate-exception-handling.py" = ["T201", "BLE001"]
 "scripts/check_dep_provenance.py" = ["T201"]  # CLI output for dep-provenance gate (OMN-13873/OMN-13877)
 "scripts/ci/check_import_ratchet.py" = ["T201"]  # CLI output for import-layering growth-ratchet gate (OMN-14340)
+"scripts/ci/check_occ_companion_merged.py" = ["T201"]  # CLI verdict/annotation output for the OCC companion-merged gate (OMN-15222)
 "scripts/ci/canonical_handler_shape.py" = ["T201", "BLE001"]  # CLI output + fail-closed catches for canonical handler-shape ratchet gate (OMN-14355)
 "scripts/ci/rsd_provenance_stamp.py" = ["T201"]  # CLI output for RSD provenance-stamp gate (OMN-15011)
 "scripts/ci/verify_flip_bundle.py" = ["T201", "BLE001"]  # CLI output + fail-closed ValidationError catch for the flip-bundle seam gate (OMN-14809)

--- a/scripts/ci/adequacy_receipt.py
+++ b/scripts/ci/adequacy_receipt.py
@@ -29,6 +29,7 @@ import functools
 import hashlib
 import io
 import json
+import tempfile
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
@@ -159,20 +160,25 @@ def _measured_arcs(
 ) -> set[tuple[str, int, int]]:
     """Branch arcs exercised by ``run()``, restricted to files matching ``source_match``."""
     # config_file=False so the repo's [tool.coverage] source/omit does not scope us.
-    cov = coverage.Coverage(branch=True, config_file=False)
-    cov.start()
-    try:
-        run()
-    finally:
-        cov.stop()
-    data = cov.get_data()
-    arcs: set[tuple[str, int, int]] = set()
-    for filename in data.measured_files():
-        if source_match not in filename:
-            continue
-        for a0, a1 in data.arcs(filename) or []:
-            arcs.add((filename, a0, a1))
-    return arcs
+    with tempfile.TemporaryDirectory(prefix="adequacy-coverage-") as tmpdir:
+        cov = coverage.Coverage(
+            branch=True,
+            config_file=False,
+            data_file=str(Path(tmpdir) / ".coverage"),
+        )
+        cov.start()
+        try:
+            run()
+        finally:
+            cov.stop()
+        data = cov.get_data()
+        arcs: set[tuple[str, int, int]] = set()
+        for filename in data.measured_files():
+            if source_match not in filename:
+                continue
+            for a0, a1 in data.arcs(filename) or []:
+                arcs.add((filename, a0, a1))
+        return arcs
 
 
 def select_covering(
@@ -218,20 +224,25 @@ def coverage_pct_for(*, run: Callable[[], object], source_match: str) -> float:
     # config_file=False so the repo's [tool.coverage] source does not scope us;
     # report() is then given the explicit measured handler files (morfs) so the
     # percent is for the handler alone, not diluted across the package.
-    cov = coverage.Coverage(branch=True, config_file=False)
-    cov.start()
-    try:
-        run()
-    finally:
-        cov.stop()
-    morfs = [f for f in cov.get_data().measured_files() if source_match in f]
-    if not morfs:
-        return 0.0
-    sink = io.StringIO()
-    try:
-        return round(float(cov.report(morfs=morfs, file=sink)), 2)
-    except coverage.exceptions.NoDataError:
-        return 0.0
+    with tempfile.TemporaryDirectory(prefix="adequacy-coverage-") as tmpdir:
+        cov = coverage.Coverage(
+            branch=True,
+            config_file=False,
+            data_file=str(Path(tmpdir) / ".coverage"),
+        )
+        cov.start()
+        try:
+            run()
+        finally:
+            cov.stop()
+        morfs = [f for f in cov.get_data().measured_files() if source_match in f]
+        if not morfs:
+            return 0.0
+        sink = io.StringIO()
+        try:
+            return round(float(cov.report(morfs=morfs, file=sink)), 2)
+        except coverage.exceptions.NoDataError:
+            return 0.0
 
 
 def build_receipt(

--- a/scripts/ci/check_occ_companion_merged.py
+++ b/scripts/ci/check_occ_companion_merged.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OCC companion-merged gate (OMN-15214, ported to omnibase_core per OMN-15222) —
+a strict ``CI Summary`` gate.
+
+Why this exists
+---------------
+On 2026-07-26 an automated "OCC queue hygiene" pass closed five OPEN
+onex_change_control evidence companions (#5012-#5016) whose product PRs had
+already MERGED, destroying three evidence chains (OMN-15199 / OMN-15200 /
+OMN-15203) with no successor. The sweep's trigger state is exactly
+"OPEN companion + MERGED product PR".
+
+This gate makes that state unreachable at the merge boundary for this repo:
+a product PR's ``CI Summary`` (a required branch-protection context on
+omnibase_core ``main``; the 2026-07-25 reconciliation note in
+``.github/required-checks.yaml`` records that ``dev`` protection was narrowed
+to drop the aggregators — on ``dev`` the umbrella currently binds any
+all-checks-green merge flow rather than branch protection) cannot go green
+until the OCC evidence cited by the PR's
+``Evidence-Source:`` line is DURABLE — i.e. the cited companion PR is MERGED,
+or the cited commit SHA is an ancestor of an onex_change_control durable
+branch (dev/main). Because the product PR cannot merge before its companion
+does, "merged product + open companion" can no longer arise via the merge
+path, and a companion-closing sweep has nothing load-bearing to destroy.
+
+Deliberately NOT a new required status check: this job is registered in
+:data:`scripts.ci.ci_summary_gate.GATE_JOBS` (completeness anchor — the
+umbrella WAITS for it) and :data:`scripts.ci.ci_summary_gate.STRICT_SUCCESS_JOBS`
+(a skip/cancel conclusion fails closed) and enforced through the existing
+fail-closed ``CI Summary`` umbrella poller. Adding a new top-level
+required context that does not report on every PR shape wedges merges
+indefinitely (see CLAUDE.md, deploy-gate section); the umbrella pattern has no
+such failure mode because its check-run always instantiates.
+
+Verdict model (mirrors ci_summary_gate exit codes)
+--------------------------------------------------
+* ``PASS`` (0)    — evidence is durable, or the gate does not apply
+  (non-PR event; trusted dependency-bot author, mirroring occ-preflight's
+  OMN-13762 exemption).
+* ``PENDING`` (2) — evidence may still become durable without a new commit:
+  Evidence-Source not yet PATCHed onto the body by occ-autobind, companion
+  still OPEN (auto-merge in flight), or a transient API error. The runner
+  entrypoint polls; at the deadline PENDING converts to FAIL (fail-closed).
+* ``FAIL`` (1)    — evidence can never become durable in this state:
+  companion CLOSED without merging (the incident state), cited SHA not an
+  ancestor of an OCC durable branch (squash-only merges guarantee a
+  feature-branch head SHA never becomes one — the OMN-15216 defect), or a
+  malformed Evidence-Source value.
+
+The companion-must-merge-first ordering is safe: onex_change_control PRs have
+no reverse dependency on product-PR merge state (occ-preflight validates OCC's
+own PRs from their in-tree diff), and repo-level auto-merge is enabled there.
+The incident's canary lane proved the ordering live: companion OCC#5008 merged
+40+ minutes before its product PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess  # fixed argv, no shell, trusted gh binary
+import sys
+import time
+from dataclasses import dataclass
+
+OCC_REPO_DEFAULT = "OmniNode-ai/onex_change_control"
+
+# Branches on which an OCC commit SHA counts as durable evidence.
+OCC_DURABLE_BRANCHES: tuple[str, ...] = ("dev", "main")
+
+# Mirrors occ-preflight's OMN-13762 dependency-bot exemption
+# (validator_receipt_gate.DEPENDENCY_BOT_AUTHORS): bot-authored dependency
+# bumps structurally cannot cite OCC evidence.
+DEPENDENCY_BOT_AUTHORS: frozenset[str] = frozenset(
+    {
+        "dependabot[bot]",
+        "app/dependabot",
+        "dependabot",
+        "renovate[bot]",
+        "app/renovate",
+        "renovate",
+    }
+)
+
+# Events on which the gate enforces (mirrors occ-preflight's event scope).
+ENFORCED_EVENTS: frozenset[str] = frozenset({"pull_request", "merge_group"})
+
+EVIDENCE_SOURCE_RE = re.compile(
+    r"^Evidence-Source:\s+(\S.*)$", re.IGNORECASE | re.MULTILINE
+)
+OCC_PR_REF_RE = re.compile(r"^OCC#(\d+)$", re.IGNORECASE)
+HEX_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+MERGE_GROUP_PR_RE = re.compile(r"/pr-(\d+)-")
+
+EXIT_PASS = 0
+EXIT_FAIL = 1
+EXIT_PENDING = 2
+
+_VERDICT_NAMES = {EXIT_PASS: "PASS", EXIT_FAIL: "FAIL", EXIT_PENDING: "PENDING"}
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Terminal or poll-again outcome of a single gate evaluation."""
+
+    code: int  # EXIT_PASS | EXIT_FAIL | EXIT_PENDING
+    reason: str
+
+    @property
+    def name(self) -> str:
+        return _VERDICT_NAMES[self.code]
+
+
+class GhFetcher:
+    """Live GitHub reads via the ``gh`` CLI. Every failure returns ``None``
+    so the caller decides between PENDING (retryable) and FAIL (terminal)."""
+
+    def _run(self, argv: list[str]) -> str | None:
+        try:
+            result = subprocess.run(  # fixed argv, no shell
+                argv, capture_output=True, text=True, timeout=60, check=False
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            print(f"::warning::gh invocation failed: {exc}", file=sys.stderr)
+            return None
+        if result.returncode != 0:
+            print(
+                f"::warning::{' '.join(argv[:4])}... exited "
+                f"{result.returncode}: {result.stderr.strip()[:300]}",
+                file=sys.stderr,
+            )
+            return None
+        return result.stdout
+
+    def pr_view(self, repo: str, number: str, fields: str) -> dict[str, object] | None:
+        raw = self._run(
+            ["gh", "pr", "view", str(number), "--repo", repo, "--json", fields]
+        )
+        if raw is None:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def compare_status(self, repo: str, base: str, head_sha: str) -> str | None:
+        """``identical``/``behind`` ⇒ ``head_sha`` is an ancestor of ``base``."""
+        raw = self._run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/compare/{base}...{head_sha}",
+                "--jq",
+                ".status",
+            ]
+        )
+        return raw.strip() if raw is not None else None
+
+
+def parse_evidence_source(body: str) -> str | None:
+    """First ``Evidence-Source:`` value in the PR body, or ``None``."""
+    match = EVIDENCE_SOURCE_RE.search(body or "")
+    return match.group(1).strip() if match else None
+
+
+def resolve_pr_number(
+    event_name: str, pr_number: str, merge_group_head_ref: str
+) -> str:
+    """PR number for pull_request or merge_group events ('' if unresolvable)."""
+    if pr_number:
+        return pr_number
+    if event_name == "merge_group" and merge_group_head_ref:
+        match = MERGE_GROUP_PR_RE.search(merge_group_head_ref)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def evaluate_once(
+    fetcher: GhFetcher,
+    *,
+    event_name: str,
+    repo: str,
+    pr_number: str,
+    occ_repo: str = OCC_REPO_DEFAULT,
+    evidence_source_override: str | None = None,
+) -> Verdict:
+    """One poll iteration. PENDING means the state may still resolve itself
+    (poll again); FAIL means it never can (terminal)."""
+
+    if event_name not in ENFORCED_EVENTS:
+        return Verdict(
+            EXIT_PASS,
+            f"event '{event_name}' is not a merge-gating event; gate not applicable",
+        )
+
+    if not pr_number:
+        return Verdict(
+            EXIT_FAIL,
+            "could not resolve a PR number for this run — failing closed",
+        )
+
+    if evidence_source_override is None:
+        # Live body, never the event payload: occ-autobind PATCHes
+        # Evidence-Source onto the body AFTER the triggering event fired.
+        pr_data = fetcher.pr_view(repo, pr_number, "body,author")
+        if pr_data is None:
+            return Verdict(
+                EXIT_PENDING, f"could not fetch {repo}#{pr_number} (retryable)"
+            )
+
+        author_raw = pr_data.get("author")
+        author = ""
+        if isinstance(author_raw, dict):
+            author = str(author_raw.get("login") or "")
+        if author in DEPENDENCY_BOT_AUTHORS:
+            return Verdict(
+                EXIT_PASS,
+                f"trusted dependency-bot author '{author}' — occ-preflight OMN-13762 "
+                "exemption mirrored; no OCC evidence applicable",
+            )
+
+        evidence_source = parse_evidence_source(str(pr_data.get("body") or ""))
+    else:
+        evidence_source = evidence_source_override
+
+    if not evidence_source:
+        return Verdict(
+            EXIT_PENDING,
+            f"{repo}#{pr_number} body has no 'Evidence-Source:' line yet "
+            "(occ-autobind mint may still be in flight)",
+        )
+
+    occ_ref = OCC_PR_REF_RE.match(evidence_source)
+    if occ_ref:
+        occ_pr = occ_ref.group(1)
+        occ_data = fetcher.pr_view(occ_repo, occ_pr, "state,mergeCommit")
+        if occ_data is None:
+            return Verdict(
+                EXIT_PENDING,
+                f"could not fetch companion {occ_repo}#{occ_pr} (retryable)",
+            )
+        state = str(occ_data.get("state") or "").upper()
+        if state == "MERGED":
+            merge_commit = occ_data.get("mergeCommit")
+            merge_oid = ""
+            if isinstance(merge_commit, dict):
+                merge_oid = str(merge_commit.get("oid") or "")
+            return Verdict(
+                EXIT_PASS,
+                f"companion OCC#{occ_pr} is MERGED (merge commit {merge_oid or 'unknown'}) "
+                "— evidence is durable",
+            )
+        if state == "OPEN":
+            return Verdict(
+                EXIT_PENDING,
+                f"companion OCC#{occ_pr} is still OPEN — the companion must MERGE "
+                "before this product PR may merge (OMN-15214). Land the companion "
+                "on onex_change_control, then re-run this job.",
+            )
+        # CLOSED without merging: the exact state the 2026-07-26 hygiene sweep
+        # minted — the evidence was destroyed. Never poll; fail loudly.
+        return Verdict(
+            EXIT_FAIL,
+            f"companion OCC#{occ_pr} is {state or 'UNRESOLVED'} without merging — "
+            "the cited evidence no longer exists. Re-cut the companion (bind it to "
+            "this PR) and update Evidence-Source before merging.",
+        )
+
+    if HEX_SHA_RE.match(evidence_source.lower()):
+        sha = evidence_source.lower()
+        saw_api_error = False
+        for branch in OCC_DURABLE_BRANCHES:
+            status = fetcher.compare_status(occ_repo, branch, sha)
+            if status is None:
+                saw_api_error = True
+                continue
+            if status in ("identical", "behind"):
+                return Verdict(
+                    EXIT_PASS,
+                    f"Evidence-Source SHA {sha} is an ancestor of {occ_repo}@{branch} "
+                    "— evidence is durable",
+                )
+        if saw_api_error:
+            return Verdict(
+                EXIT_PENDING,
+                f"could not resolve Evidence-Source SHA {sha} against "
+                f"{occ_repo} durable branches (retryable)",
+            )
+        # onex_change_control is squash-only: a feature-branch head SHA can
+        # NEVER become an ancestor of dev/main, so this is terminal — it is the
+        # strandable pre-merge pin OMN-15216 describes.
+        return Verdict(
+            EXIT_FAIL,
+            f"Evidence-Source SHA {sha} is not an ancestor of any durable "
+            f"{occ_repo} branch {OCC_DURABLE_BRANCHES} — cite 'OCC#<pr>' (which "
+            "must be MERGED) or a merged OCC commit SHA, never a feature-branch head.",
+        )
+
+    return Verdict(
+        EXIT_FAIL,
+        f"Evidence-Source value '{evidence_source}' is neither 'OCC#<number>' nor a "
+        "hex commit SHA — fix the PR body.",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GH_REPO", ""))
+    parser.add_argument("--pr-number", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument(
+        "--event-name", default=os.environ.get("GITHUB_EVENT_NAME", "pull_request")
+    )
+    parser.add_argument(
+        "--merge-group-head-ref", default=os.environ.get("MERGE_GROUP_HEAD_REF", "")
+    )
+    parser.add_argument(
+        "--occ-repo", default=os.environ.get("OCC_REPO", OCC_REPO_DEFAULT)
+    )
+    parser.add_argument(
+        "--evidence-source",
+        default=None,
+        help="Override: evaluate this Evidence-Source value directly instead of "
+        "reading the PR body (diagnostics / dry-run).",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Single evaluation, no polling; exits 0/1/2 (PASS/FAIL/PENDING).",
+    )
+    parser.add_argument(
+        "--deadline-seconds",
+        type=int,
+        default=int(os.environ.get("DEADLINE_SECONDS", "1500")),
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=int,
+        default=int(os.environ.get("POLL_INTERVAL_SECONDS", "30")),
+    )
+    args = parser.parse_args(argv)
+
+    pr_number = resolve_pr_number(
+        args.event_name, args.pr_number, args.merge_group_head_ref
+    )
+    fetcher = GhFetcher()
+    deadline = time.monotonic() + args.deadline_seconds
+
+    while True:
+        verdict = evaluate_once(
+            fetcher,
+            event_name=args.event_name,
+            repo=args.repo,
+            pr_number=pr_number,
+            occ_repo=args.occ_repo,
+            evidence_source_override=args.evidence_source,
+        )
+        print(f"occ-companion-merged gate: {verdict.name} — {verdict.reason}")
+
+        if verdict.code != EXIT_PENDING or args.once:
+            if verdict.code == EXIT_FAIL:
+                print(f"::error::{verdict.reason}")
+            return verdict.code
+
+        if time.monotonic() >= deadline:
+            print(
+                f"::error::occ-companion-merged gate: poll deadline "
+                f"({args.deadline_seconds}s) reached while still PENDING — failing "
+                f"closed. Last state: {verdict.reason}"
+            )
+            return EXIT_FAIL
+
+        time.sleep(args.poll_interval_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/ci_summary_gate.py
+++ b/scripts/ci/ci_summary_gate.py
@@ -69,6 +69,19 @@ GATE_JOBS: tuple[str, ...] = (
     "Tests Gate",  # tests-gate: aggregates test-parallel + tests-integration
     "Contract Compliance Check",  # contract-compliance job (NOT "Contract Compliance")
     "Cross-repo boundary validation",  # boundary-validation job
+    "OCC Companion Merged Gate (OMN-15214)",  # occ-companion-merged — cited OCC evidence must be MERGED before product merge (OMN-15222 port)
+)
+
+# OMN-15222 (port of the omnibase_infra OMN-15214 canary, mirroring omniclaude's
+# OMN-14350 STRICT_SUCCESS_JOBS precedent): jobs that must be EXACTLY
+# ``success`` — stricter than GATE_JOBS membership, whose completeness anchor
+# accepts ``success``||``skipped``. Each of these runs UNCONDITIONALLY in ci.yml
+# (no ``if:``, no ``needs:``), so a SKIPPED or CANCELLED conclusion is anomalous
+# un-enforcement and must fail closed, not pass.
+STRICT_SUCCESS_JOBS: frozenset[str] = frozenset(
+    {
+        "OCC Companion Merged Gate (OMN-15214)",
+    }
 )
 
 # Jobs that do NOT gate merge today (verified against ci.yml ``needs`` graph on
@@ -242,6 +255,21 @@ def evaluate(
             and state.conclusion not in GOOD_CONCLUSIONS
         }
     )
+
+    # (1b) Strict-success jobs (OMN-15222): unconditional ci.yml jobs whose
+    #     SKIPPED/CANCELLED conclusion is anomalous un-enforcement and must fail
+    #     closed. The GATE_JOBS completeness anchor accepts ``skipped``, so
+    #     without this a skip would silently un-enforce the gate (mirrors
+    #     omniclaude's OMN-14350 STRICT_SUCCESS_JOBS and the omnibase_infra
+    #     STRICT_GATE_JOBS posture of the OMN-15214 canary).
+    strict_success_failures = sorted(
+        name
+        for name in STRICT_SUCCESS_JOBS
+        if (st := latest.get(name)) is not None
+        and st.status == "completed"
+        and st.conclusion != "success"
+    )
+    sweep_failures = sorted(set(sweep_failures) | set(strict_success_failures))
 
     # (2) Spec-required-validator anchor (OMN-14127 load-bearing): each covering
     #     job runs unconditionally in ci.yml, so it must be present + completed +

--- a/tests/unit/scripts/ci/test_check_occ_companion_merged.py
+++ b/tests/unit/scripts/ci/test_check_occ_companion_merged.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Verdict tests for the occ-companion-merged STRICT gate (OMN-15214).
+
+The gate makes the 2026-07-26 hygiene-sweep trigger state — an OPEN
+onex_change_control companion whose product PR has already MERGED —
+unreachable via the merge path: the product PR's required ``CI Summary``
+context cannot go green until the cited companion is MERGED (or the cited
+SHA is already an ancestor of an OCC durable branch).
+
+These tests pin the fail-closed verdict table:
+
+* companion MERGED            → PASS
+* companion OPEN              → PENDING (poll; deadline converts to FAIL)
+* companion CLOSED unmerged   → FAIL immediately (the incident state)
+* SHA ancestor of dev/main    → PASS
+* SHA not an ancestor         → FAIL (OMN-15216 strandable pre-merge pin)
+* missing Evidence-Source     → PENDING (autobind mint may be in flight)
+* malformed Evidence-Source   → FAIL
+* dependency-bot author       → PASS (mirrors occ-preflight OMN-13762)
+* non-PR event                → PASS (gate not applicable)
+* unresolvable PR number      → FAIL (fail closed)
+* API errors                  → PENDING (retryable), never PASS
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci.check_occ_companion_merged import (
+    EXIT_FAIL,
+    EXIT_PASS,
+    EXIT_PENDING,
+    evaluate_once,
+    main,
+    parse_evidence_source,
+    resolve_pr_number,
+)
+
+pytestmark = pytest.mark.unit
+
+PRODUCT_REPO = "OmniNode-ai/omnibase_core"
+OCC_REPO = "OmniNode-ai/onex_change_control"
+
+
+class FakeFetcher:
+    """Deterministic stand-in for GhFetcher."""
+
+    def __init__(
+        self,
+        *,
+        prs: dict[tuple[str, str], dict[str, object] | None] | None = None,
+        compare: dict[tuple[str, str], str | None] | None = None,
+    ) -> None:
+        self._prs = prs or {}
+        self._compare = compare or {}
+
+    def pr_view(self, repo: str, number: str, fields: str) -> dict[str, object] | None:
+        return self._prs.get((repo, str(number)))
+
+    def compare_status(self, repo: str, base: str, head_sha: str) -> str | None:
+        return self._compare.get((base, head_sha))
+
+
+def _product_pr(body: str, author: str = "jonahgabriel") -> dict[str, object]:
+    return {"body": body, "author": {"login": author}}
+
+
+def _evaluate(fetcher: FakeFetcher, **kwargs: object):
+    defaults: dict[str, object] = {
+        "event_name": "pull_request",
+        "repo": PRODUCT_REPO,
+        "pr_number": "2500",
+        "occ_repo": OCC_REPO,
+    }
+    defaults.update(kwargs)
+    return evaluate_once(fetcher, **defaults)  # type: ignore[arg-type]
+
+
+class TestEvidenceSourceParsing:
+    def test_first_line_wins_and_is_case_insensitive(self) -> None:
+        body = "intro\nevidence-source:  OCC#5032 \nEvidence-Source: OCC#9999\n"
+        assert parse_evidence_source(body) == "OCC#5032"
+
+    def test_absent_returns_none(self) -> None:
+        assert parse_evidence_source("no evidence here") is None
+        assert parse_evidence_source("") is None
+
+    def test_indented_line_is_not_matched(self) -> None:
+        # occ-preflight anchors at line start; mirror it.
+        assert parse_evidence_source("  Evidence-Source: OCC#1") is None
+
+
+class TestPrNumberResolution:
+    def test_pull_request_number_passthrough(self) -> None:
+        assert resolve_pr_number("pull_request", "123", "") == "123"
+
+    def test_merge_group_head_ref_parse(self) -> None:
+        ref = "refs/heads/gh-readonly-queue/dev/pr-456-0123abc"
+        assert resolve_pr_number("merge_group", "", ref) == "456"
+
+    def test_unresolvable_returns_empty(self) -> None:
+        assert resolve_pr_number("merge_group", "", "refs/heads/whatever") == ""
+
+
+class TestCompanionPrVerdicts:
+    def _fetcher_with_companion(self, occ_state: dict[str, object]) -> FakeFetcher:
+        return FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "2500"): _product_pr("Evidence-Source: OCC#5032"),
+                (OCC_REPO, "5032"): occ_state,
+            }
+        )
+
+    def test_merged_companion_is_pass(self) -> None:
+        fetcher = self._fetcher_with_companion(
+            {"state": "MERGED", "mergeCommit": {"oid": "abc123"}}
+        )
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_PASS
+        assert "abc123" in verdict.reason
+
+    def test_open_companion_is_pending_not_fail(self) -> None:
+        # OPEN may still auto-merge; the poll loop absorbs the latency and the
+        # deadline converts PENDING to FAIL.
+        fetcher = self._fetcher_with_companion({"state": "OPEN", "mergeCommit": None})
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_PENDING
+        assert "OPEN" in verdict.reason
+
+    def test_closed_unmerged_companion_is_immediate_fail(self) -> None:
+        # The 2026-07-26 incident state: hygiene sweep closed the companion
+        # without merging. Evidence destroyed — terminal, never poll.
+        fetcher = self._fetcher_with_companion({"state": "CLOSED", "mergeCommit": None})
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_FAIL
+        assert "CLOSED" in verdict.reason
+
+    def test_companion_fetch_error_is_pending_never_pass(self) -> None:
+        fetcher = FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "2500"): _product_pr("Evidence-Source: OCC#5032"),
+                (OCC_REPO, "5032"): None,
+            }
+        )
+        assert _evaluate(fetcher).code == EXIT_PENDING
+
+
+class TestShaVerdicts:
+    SHA = "a" * 40
+
+    def test_sha_ancestor_of_dev_is_pass(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr(f"Evidence-Source: {self.SHA}")},
+            compare={("dev", self.SHA): "behind"},
+        )
+        assert _evaluate(fetcher).code == EXIT_PASS
+
+    def test_sha_identical_to_main_is_pass(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr(f"Evidence-Source: {self.SHA}")},
+            compare={("dev", self.SHA): "diverged", ("main", self.SHA): "identical"},
+        )
+        assert _evaluate(fetcher).code == EXIT_PASS
+
+    def test_floating_sha_is_fail(self) -> None:
+        # A feature-branch head SHA on squash-only OCC can never become an
+        # ancestor of dev/main — terminal (OMN-15216).
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr(f"Evidence-Source: {self.SHA}")},
+            compare={("dev", self.SHA): "diverged", ("main", self.SHA): "ahead"},
+        )
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_FAIL
+        assert "ancestor" in verdict.reason
+
+    def test_compare_api_error_is_pending_never_fail(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr(f"Evidence-Source: {self.SHA}")},
+            compare={("dev", self.SHA): None, ("main", self.SHA): None},
+        )
+        assert _evaluate(fetcher).code == EXIT_PENDING
+
+
+class TestBodyAndScopeVerdicts:
+    def test_missing_evidence_source_is_pending(self) -> None:
+        fetcher = FakeFetcher(prs={(PRODUCT_REPO, "2500"): _product_pr("no line yet")})
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_PENDING
+        assert "Evidence-Source" in verdict.reason
+
+    def test_malformed_evidence_source_is_fail(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr("Evidence-Source: not-a-ref!")}
+        )
+        assert _evaluate(fetcher).code == EXIT_FAIL
+
+    def test_dependency_bot_author_is_exempt(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(PRODUCT_REPO, "2500"): _product_pr("", author="dependabot[bot]")}
+        )
+        verdict = _evaluate(fetcher)
+        assert verdict.code == EXIT_PASS
+        assert "dependency-bot" in verdict.reason
+
+    def test_non_pr_event_is_not_applicable_pass(self) -> None:
+        verdict = _evaluate(FakeFetcher(), event_name="push")
+        assert verdict.code == EXIT_PASS
+        assert "not applicable" in verdict.reason
+
+    def test_unresolvable_pr_number_fails_closed(self) -> None:
+        verdict = _evaluate(FakeFetcher(), pr_number="")
+        assert verdict.code == EXIT_FAIL
+
+    def test_product_pr_fetch_error_is_pending(self) -> None:
+        fetcher = FakeFetcher(prs={(PRODUCT_REPO, "2500"): None})
+        assert _evaluate(fetcher).code == EXIT_PENDING
+
+    def test_evidence_source_override_skips_body_fetch(self) -> None:
+        fetcher = FakeFetcher(
+            prs={(OCC_REPO, "5032"): {"state": "MERGED", "mergeCommit": {"oid": "x"}}}
+        )
+        verdict = _evaluate(fetcher, evidence_source_override="OCC#5032")
+        assert verdict.code == EXIT_PASS
+
+
+class TestMainEntrypoint:
+    def test_once_mode_returns_pending_exit_code(self, monkeypatch) -> None:
+        # --once with an OPEN companion must surface PENDING (2), not PASS.
+        import scripts.ci.check_occ_companion_merged as mod
+
+        fetcher = FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "77"): _product_pr("Evidence-Source: OCC#5032"),
+                (OCC_REPO, "5032"): {"state": "OPEN", "mergeCommit": None},
+            }
+        )
+        monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
+        rc = main(
+            [
+                "--once",
+                "--repo",
+                PRODUCT_REPO,
+                "--pr-number",
+                "77",
+                "--occ-repo",
+                OCC_REPO,
+            ]
+        )
+        assert rc == EXIT_PENDING
+
+    def test_deadline_converts_pending_to_fail(self, monkeypatch) -> None:
+        import scripts.ci.check_occ_companion_merged as mod
+
+        fetcher = FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "77"): _product_pr("Evidence-Source: OCC#5032"),
+                (OCC_REPO, "5032"): {"state": "OPEN", "mergeCommit": None},
+            }
+        )
+        monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
+        rc = main(
+            [
+                "--repo",
+                PRODUCT_REPO,
+                "--pr-number",
+                "77",
+                "--occ-repo",
+                OCC_REPO,
+                "--deadline-seconds",
+                "0",
+                "--poll-interval-seconds",
+                "0",
+            ]
+        )
+        assert rc == EXIT_FAIL

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -26,6 +26,7 @@ from scripts.ci.ci_summary_gate import (
     EXIT_SUCCESS,
     GATE_JOBS,
     SPEC_REQUIRED_VALIDATOR_JOBS,
+    STRICT_SUCCESS_JOBS,
     evaluate,
 )
 
@@ -237,6 +238,32 @@ class TestCiSummaryGate:
         jobs = _all_good() + [_job("Some New Job", "neutral")]
         code, _ = evaluate(jobs)
         assert code == EXIT_FAILURE
+
+    def test_occ_companion_merged_gate_is_strict_and_fails_closed(self) -> None:
+        # OMN-15222 (OMN-15214 canary port): the companion-merged gate makes the
+        # 2026-07-26 hygiene-sweep trigger state (OPEN companion + MERGED product
+        # PR) unreachable via the merge path. It must be a GATE_JOB (CI Summary
+        # WAITS for it) AND strict-success (a skip/cancel fails closed) so a
+        # red/absent/skipped result can never green the "CI Summary" umbrella —
+        # folding into the umbrella instead of adding a new top-level required
+        # context avoids the never-reports wedge.
+        gate = "OCC Companion Merged Gate (OMN-15214)"
+        assert gate in GATE_JOBS
+        assert gate in STRICT_SUCCESS_JOBS
+        jobs = [j for j in _all_good() if j["name"] != gate]
+        jobs.append(_job(gate, "failure"))
+        code, report = evaluate(jobs)
+        assert code == EXIT_FAILURE
+        assert gate in report
+        # A skip must also fail closed — the job is unconditional in ci.yml.
+        jobs = [j for j in _all_good() if j["name"] != gate]
+        jobs.append(_job(gate, "skipped"))
+        code, _ = evaluate(jobs)
+        assert code == EXIT_FAILURE
+        # Absent entirely → PENDING (completeness anchor), never a vacuous green.
+        jobs = [j for j in _all_good() if j["name"] != gate]
+        code, _ = evaluate(jobs)
+        assert code == EXIT_PENDING
 
     def test_spec_required_validator_jobs_match_spec(self) -> None:
         # SYNC GUARD (OMN-14127): SPEC_REQUIRED_VALIDATOR_JOBS must equal the set


### PR DESCRIPTION
## Summary

Port of the **OMN-15214 canary** (omnibase_infra #2486, merge commit `6e5ce5377c98dd5bb43c5d66b7c159d1d3f12f27`) to omnibase_core — the largest occ-preflight surface on the fleet (53 workflow files invoke the reusable occ-preflight; highest PR/companion volume). Closes OMN-15222 (child of OMN-15214). Second port after omniclaude#1951 (OMN-15221).

The 2026-07-26 OCC hygiene sweep closed nine open onex_change_control evidence companions whose product PRs had already merged, destroying three evidence chains (OMN-15199/OMN-15200/OMN-15203). The durable fix is ordering: the companion must MERGE **before** the product PR can. This gate greens only when the PR's live `Evidence-Source:` cites a MERGED OCC companion (or an OCC commit SHA that is an ancestor of OCC dev/main); a companion CLOSED without merging fails immediately (that IS the incident state).

## Design (adapted to this repo's umbrella model)

- New unconditional (no `needs`/`if`) `occ-companion-merged` job in `ci.yml` — GitHub-hosted, pure gh-API polling, 25m poll window under ci-summary's 90m deadline; PENDING converts to FAIL at deadline (fail-closed).
- Registered in `scripts/ci/ci_summary_gate.py` **GATE_JOBS** (completeness anchor — the `CI Summary` umbrella WAITS for it) plus a **new `STRICT_SUCCESS_JOBS` set** (skip/cancel fails closed), mirroring omniclaude's OMN-14350 precedent and the canary's STRICT posture. The spec-locked `SPEC_REQUIRED_VALIDATOR_JOBS` is deliberately untouched (it is pinned to `architecture-handshakes/validator-requirements.yaml`).
- Deliberately NOT a new top-level required context — a context that does not always report wedges merges indefinitely, and occ-autobind is network-flaky (omninode_infra#679, 2026-07-26).
- **Enforcement caveat (pre-existing, flagged not fixed here):** live readback this session shows `CI Summary` required on core **main** but absent from core **dev** required contexts — the dev narrowing is already recorded in `.github/required-checks.yaml` (2026-07-25 OMN-15120 reconciliation note). On dev the umbrella currently binds any all-checks-green merge flow (e.g. merge-sweep red-check discipline) rather than branch protection; it binds mechanically at the dev→main boundary. Re-wiring dev protection is out of scope for this PR.

## Seams

- ci.yml job display name `OCC Companion Merged Gate (OMN-15214)` == the registration string in `GATE_JOBS` + `STRICT_SUCCESS_JOBS` — pinned by `tests/unit/scripts/ci/test_ci_summary_gate.py::test_occ_companion_merged_gate_is_strict_and_fails_closed`, which drives `evaluate()` across the failed/skipped/absent states of the real seam string.
- `Evidence-Source:` parsing anchors at line start, first match, case-insensitive — mirrors occ-preflight; verdict table pinned in `tests/unit/scripts/ci/test_check_occ_companion_merged.py`.
- `pyproject.toml` per-file-ignore `T201` for the gate script follows the existing OMN-5080 convention block.

## dod_evidence

- **Unit gates on .200** (Stickybeatz-Studio, worktree at pushed SHA `e38f885d`, bundle-transferred and SHA-verified; push executed FROM .200 after local pre-push exceeded 10m): `uv run pytest tests/unit/scripts/ci/test_check_occ_companion_merged.py tests/unit/scripts/ci/test_ci_summary_gate.py` → **55 passed**; `ruff format --check` + `ruff check` clean.
- **Live dry-runs** (real gh API, this session):
  - `--evidence-source OCC#5012` (incident companion, closed unmerged) → **FAIL (exit 1)**
  - `--evidence-source OCC#5032` (merged OMN-15199 repair) → **PASS (exit 0)**, merge commit `edf290d1`
  - `--evidence-source OCC#5059` (open) → **PENDING (exit 2)**
- **Self-proving:** this PR's own `CI Summary` now waits for the new gate — it cannot go green until this PR's occ-autobind companion merges.

Evidence-Ticket: OMN-15222
Evidence-Source: OCC#5067
Evidence-Commit: 984830728a8afdc20c31aa5add7cf18e28d34a7a
