### PR TITLE
fix(OMN-14974): type plugin-managed event bus ownership

### DIFF
--- a/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
@@ -201,6 +201,14 @@ class ModelEventBusSubcontract(BaseModel):
         description="Default event patterns if no other patterns can be determined",
     )
 
+    plugin_managed: bool = Field(
+        default=False,
+        description=(
+            "Whether a domain plugin owns this contract's event-bus subscriptions. "
+            "Generic auto-wiring must skip subscriber creation when enabled."
+        ),
+    )
+
     # Topic-based routing configuration (OMN-1537)
     publish_topics: list[str] = Field(
         default_factory=list,

--- a/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract.py
@@ -34,6 +34,7 @@ class TestModelEventBusSubcontractInitialization:
         assert subcontract.correlation_tracking is True
         assert subcontract.max_queue_size == 10000
         assert subcontract.batch_size == 100
+        assert subcontract.plugin_managed is False
 
     def test_event_bus_subcontract_with_custom_values(self):
         """Test creating event bus subcontract with custom values."""
@@ -71,6 +72,18 @@ class TestModelEventBusSubcontractInitialization:
 @pytest.mark.unit
 class TestModelEventBusSubcontractValidation:
     """Test ModelEventBusSubcontract field validation."""
+
+    def test_plugin_managed_contract_ownership_is_typed(self):
+        """Accept plugin-owned subscription metadata from event-bus contracts."""
+        subcontract = ModelEventBusSubcontract.model_validate(
+            {
+                "version": {"major": 1, "minor": 0, "patch": 0},
+                "plugin_managed": True,
+                "subscribe_topics": ["onex.cmd.omnibase-infra.delegation-request.v1"],
+            }
+        )
+
+        assert subcontract.plugin_managed is True
 
     def test_event_bus_type_valid_values(self):
         """Test event_bus_type accepts valid values."""


### PR DESCRIPTION
Evidence-Source: OCC#5182
Evidence-Ticket: OMN-14974

## Impact

Declares event_bus.plugin_managed as an explicit typed boolean on ModelEventBusSubcontract. This restores the plugin-owned delegation consumer path while preserving extra=forbid for unknown contract fields.

## Live root cause

The staging delegation contract declares plugin_managed: true. Generic runtime wiring correctly skips that plugin-owned subscription, but PluginDelegation reloads the same event_bus section through ModelEventBusSubcontract, which rejected the declared field and started no consumer. Gateway workflows therefore published to MSK but remained published.

## Verification

- RED before fix: plugin_managed rejected with extra_forbidden
- GREEN: 43 model-event-bus tests
- GREEN: Ruff and strict mypy
- GREEN: scoped pre-commit, including the Pydantic extra=forbid ratchet
- GREEN: real omnibase_infra load_event_bus_subcontract call against the delegation contract
- GREEN: explicit unknown-field probe still rejected with extra_forbidden
- Full pre-push suite is running on the designated .200 build host; hosted CI remains authoritative.

## Deployment

Build a scanned workspace stability-candidate runtime from dev, pin its exact digest to onex-dev, restart only the staging main runtime, and prove the workflow reaches a terminal state. No prod or .201 mutation.