### PR TITLE
fix(OMN-15315): Tests Gate fails closed on a skipped test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3165,38 +3165,88 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    needs: [test-parallel, tests-integration]
+    # zone-filter is in `needs:` so this gate can re-evaluate the SAME
+    # precondition the test jobs are gated on (OMN-15315). It is read for its
+    # `docs_only` output only, never for its `.result`.
+    needs: [test-parallel, tests-integration, zone-filter]
     if: always()
 
     steps:
       - name: Evaluate test results
         run: |
-          echo "## Tests Gate Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Tests Gate Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           parallel="${{ needs.test-parallel.result }}"
           integration="${{ needs.tests-integration.result }}"
+          docs_only="${{ needs.zone-filter.outputs.docs_only }}"
 
-          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Parallel Tests (dynamic splits) | $parallel |" >> $GITHUB_STEP_SUMMARY
-          echo "| Integration Tests (4 splits) | $integration |" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Parallel Tests (dynamic splits) | $parallel |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Integration Tests (4 splits) | $integration |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| zone-filter docs_only | ${docs_only:-(unset)} |" >> "$GITHUB_STEP_SUMMARY"
 
-          # Accept "success" (tests ran and passed) or "skipped" (tests correctly
-          # skipped because upstream quality-gate was skipped, e.g. dependabot PRs
-          # that only touch .github/ files and skip version-pin-check).
-          if [[ ("$parallel" == "success" || "$parallel" == "skipped") && \
-                ("$integration" == "success" || "$integration" == "skipped") ]]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Tests Gate: PASSED** (unit=$parallel integration=$integration)" >> $GITHUB_STEP_SUMMARY
-            echo "Test matrix result: unit=$parallel integration=$integration"
-            exit 0
-          else
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Tests Gate: FAILED**" >> $GITHUB_STEP_SUMMARY
-            echo "::error::tests gate failed (unit=$parallel integration=$integration)"
-            exit 1
-          fi
+          # OMN-15315 (OMN-15304 vector 6 — result triage). The previous pass
+          # condition admitted `success` OR `skipped` for both upstreams, so a
+          # SKIPPED test job rendered this gate green. `skipped` is the ABSENCE
+          # of a verdict exactly like `cancelled`, and it is precisely the state
+          # vectors 2/3/5 (conditional `if:`, needs-cascade) produce — so vector
+          # 5 and vector 6 composed into a bypass: strand the tests, and the
+          # gate that was supposed to catch it reports green with no test result
+          # in existence.
+          #
+          # PER-UPSTREAM SKIP POLICY, replacing the blanket `|| == skipped`:
+          # both `test-parallel` and `tests-integration` are gated on
+          # `always()` AND a successful quality-gate AND
+          # `needs.zone-filter.outputs.docs_only != 'true'` (see their job-level
+          # `if:` — the dotted result token is deliberately not spelled out here,
+          # because the vector-6 analyzer scans this whole `run:` blob for
+          # result tokens and a comment would register as an untriaged
+          # upstream), so exactly ONE of their skips is legitimate — a
+          # docs-only PR. This
+          # gate re-evaluates that precondition itself and admits `skipped` only
+          # when `docs_only == 'true'`. A skip caused by a non-success
+          # `quality-gate` is NOT admitted: tests that never ran because quality
+          # failed are absent tests, and this gate must say so. `zone-filter`
+          # itself is gated on `quality-gate` succeeding, so if quality fails,
+          # `docs_only` is empty and this gate fails closed on that path too.
+          #
+          # The gate stops at the first offending upstream; the per-upstream
+          # results are already written to the job summary above.
+          for check in \
+            "test-parallel=${{ needs.test-parallel.result }}" \
+            "tests-integration=${{ needs.tests-integration.result }}"; do
+            NAME="${check%%=*}"
+            RESULT="${check##*=}"
+            case "$RESULT" in
+              success)
+                echo "$NAME: success"
+                ;;
+              skipped)
+                if [ "$docs_only" != "true" ]; then
+                  echo "**Tests Gate: FAILED**" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::error::$NAME was SKIPPED on a non-docs-only change (zone-filter docs_only='${docs_only:-unset}') — the absence of a test result is not a passing one."
+                  exit 1
+                fi
+                echo "$NAME: skipped (docs-only change — declared precondition not met)"
+                ;;
+              failure|cancelled)
+                echo "**Tests Gate: FAILED**" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::$NAME did not pass (result: $RESULT)"
+                exit 1
+                ;;
+              *)
+                echo "**Tests Gate: FAILED**" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::$NAME returned unrecognised result '$RESULT' — failing closed."
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tests Gate: PASSED** (unit=$parallel integration=$integration)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Test matrix result: unit=$parallel integration=$integration"
 
   # CI Summary - final aggregator for all gates (OMN-2226)
   # Cross-repo boundary validation (OMN-6576, OMN-10978)


### PR DESCRIPTION
## OMN-15315 — `Tests Gate` vector-6 fail-open (omnibase_core)

Part of OMN-15315 (sibling of OMN-15314, which fixes the same class in omniclaude). Parent: OMN-15304.

### The defect

`tests-gate` (`Tests Gate`) aggregated `test-parallel` and `tests-integration` with a pass condition
that admitted `success` **or** `skipped` for both:

```sh
if [[ ("$parallel" == "success" || "$parallel" == "skipped") && \
      ("$integration" == "success" || "$integration" == "skipped") ]]; then ... exit 0
```

`skipped` is the ABSENCE of a verdict exactly like `cancelled`, and it is precisely the state a
conditional `if:` or a needs-cascade produces — so vector 5 and vector 6 composed into a bypass:
strand the test jobs and the gate reports green with no test result in existence.

### The fix — explicit per-upstream skip policy

The old comment documented the intent ("tests correctly skipped because upstream quality-gate was
skipped") — that is exactly the trade this ticket re-examines. Both upstreams are gated on
`always()` AND a successful `quality-gate` AND `needs.zone-filter.outputs.docs_only != 'true'`, so
exactly ONE of their skips is legitimate: a docs-only change.

The gate now re-evaluates that precondition itself and admits `skipped` **only** when
`docs_only == 'true'`. A skip caused by a red `quality-gate` is no longer admitted: tests that never
ran because quality failed are absent tests. Triage is an explicit four-way `case` with a
**default-deny `*` catch-all**, so an unrecognised future result value fails closed too. No waiver
row was added.

`zone-filter` is added to `needs:` for its `docs_only` **output** only — never for its `.result`. It
is itself gated on `quality-gate` succeeding, so on a red quality path `docs_only` is empty and the
gate falls through to strict: fail-closed on that edge as well.

**Validator (canonical `validate_no_required_check_skip_vectors.py` @ `omniclaude@dev` f992f68b2 —
the same script this repo's CI fetches at run time via the reusable workflow):**

```
# BEFORE, fresh `git archive origin/dev` (de01ec096) extraction:
FAIL: 1 required-check skip vector(s) found:
  - [vector-6-result-triage-fail-open] required context 'Tests Gate': ...
    the pass condition admits skipped, success ... for both upstreams

# AFTER (this branch):
PASS: no required-check skip vectors found.
```

**Execution RED/GREEN** — the gate's shell body run under `bash --noprofile --norc -eo pipefail`
with substituted `needs.*.result` values, old body vs new body:

| scenario | old exit | new exit |
| -- | -- | -- |
| both success, code change | 0 | 0 |
| `test-parallel` SKIPPED on a code change | **0** | **1** |
| `tests-integration` SKIPPED, `docs_only` unset (quality-gate red) | **0** | **1** |
| both skipped on a docs-only change | 0 | 0 |
| `test-parallel` cancelled / failure | 1 | 1 |
| result `neutral` (a future 5th value) | 1 | 1 |

`actionlint`: 154 findings on `origin/dev` → 144 on this branch (the touched step's
`$GITHUB_STEP_SUMMARY` redirects are now quoted; no new findings).
Pre-commit `reject-required-check-skip-vector`: **Passed** (run on `.200`).

`proof_class`: code-only → receipt-bound once this PR's own CI exercises the gate.

### Residual (not fixed here)

`.github/actions/required-check-skip-guard/*.py` in this repo is a **stale vendored copy** of the
omniclaude canonical validator — it predates vector 6, so the local pre-commit hook here does not
enforce vector 6 even though CI does (the reusable workflow checks the validator out of
`omniclaude@dev` at run time). The hook's own comment claims local and CI verdicts "can never
diverge"; today they can. Refreshing the vendored copy is out of scope for this fix.

Evidence-Ticket: OMN-15315
Evidence-Source: OCC#5292
