### PR TITLE
[SEEDED-RED CONTROL — WILL CLOSE UNMERGED] X1/OMN-15011: prove RSD provenance-stamp gate hard-fails unstamped node

### DIFF
--- a/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/.rsd_provenance.json
+++ b/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/.rsd_provenance.json
@@ -1,0 +1,5 @@
+{
+  "receipt_schema": "rsd_provenance_stamp.v1",
+  "generated_by": "hand_authored",
+  "ticket": "OMN-15011"
+}

--- a/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/contract.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# SEEDED-RED PROOF ARTIFACT — X1 / OMN-15011.
+#
+# This node is a THROWAWAY control artifact for a live-CI proof that the RSD
+# provenance-stamp gate (scripts/ci/rsd_provenance_stamp.py, landed via
+# omnibase_core#1498, OMN-15011) actually HARD-FAILS a new, unstamped node in
+# real CI, not just locally/in review. It carries no `.rsd_provenance.json`
+# sidecar on purpose (the violation under test) and is otherwise built to be
+# canonical-handler-shape-clean so the "Import Layering Oracle" job reaches the
+# RSD provenance-stamp step instead of halting earlier on an unrelated failure.
+#
+# This PR will NOT be merged. It will be closed unmerged once the RED (this
+# commit) and GREEN (a follow-up commit adding a valid stamp) CI runs are
+# captured, and the branch will be deleted. See OMN-15011 for the proof record.
+
+name: node_x1_seeded_red_proof_compute
+node_id: node_x1_seeded_red_proof_compute
+node_type: compute
+node_version: {major: 1, minor: 0, patch: 0}
+contract_version: {major: 1, minor: 0, patch: 0}
+
+description: >
+  SEEDED-RED PROOF ARTIFACT (X1 / OMN-15011) — throwaway node used solely to
+  prove the RSD provenance-stamp CI gate hard-fails a new node missing a valid
+  .rsd_provenance.json. Not real business logic. This PR is closed unmerged.
+input_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+output_model: omnibase_core.models.validation.model_validation_report.ModelValidationReport
+
+handler_routing:
+  version: {major: 1, minor: 0, patch: 0}
+  default_handler: handler:NodeX1SeededRedProofCompute
+
+descriptor:
+  node_archetype: compute
+  purity: pure
+  idempotent: true
+  timeout_ms: 30000

--- a/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/handler.py
+++ b/src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/handler.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""SEEDED-RED PROOF ARTIFACT (X1 / OMN-15011) — throwaway handler.
+
+Not real business logic. Exists solely so this node classifies as canonical
+handler-shape (definition B) for the ``scripts/ci/canonical_handler_shape.py``
+ratchet, letting the "Import Layering Oracle" CI job proceed to the RSD
+provenance-stamp step under live test. This PR is closed unmerged; see
+OMN-15011.
+"""
+
+from __future__ import annotations
+
+from omnibase_core.models.validation.model_validation_report import (
+    ModelValidationReport,
+)
+
+
+class NodeX1SeededRedProofCompute:
+    """Throwaway canonical-shape-compliant handler for the seeded-RED proof."""
+
+    def handle(self, request: ModelValidationReport) -> ModelValidationReport:
+        return request


### PR DESCRIPTION
## SEEDED-RED PROOF LANE — DO NOT MERGE

This is a **throwaway control PR** for the X1/OMN-15011 proof lane: confirming
the RSD provenance-stamp fail-closed CI gate (`scripts/ci/rsd_provenance_stamp.py`,
landed via omnibase_core#1498, OMN-15011) actually hard-fails a real CI run when
a NEW node is missing a valid `.rsd_provenance.json` sidecar, not just in local
review.

**Seeded violation (commit 1, RED expected):** adds
`src/omnibase_core/nodes/node_x1_seeded_red_proof_compute/` with `contract.yaml`
+ `handler.py` — a new node NOT in the frozen `EXEMPT_UNSTAMPED` baseline, and
deliberately carrying **no** `.rsd_provenance.json`. The handler is kept
canonical-handler-shape-clean (definition-B `handle(request: ModelX) -> ModelX`)
on purpose so the "Import Layering Oracle" job's earlier steps stay green and
execution actually reaches the RSD provenance-stamp step under test.

**Planned GREEN control (follow-up commit):** adds a valid
`hand_authored` + `ticket: OMN-15011` `.rsd_provenance.json` for the same node,
to confirm the identical CI job passes once the artifact is stamped.

**Disposition:** this PR will be **closed UNMERGED** once both CI runs are
captured (run/job ids + failing log lines recorded on OMN-15011), and the
branch will be deleted. No merge, no `gh pr merge` in any form, no weakening
of the gate.

Refs: OMN-15011 (RSD provenance-stamp gate), omnibase_core#1498 (gate landing).