### PR TITLE
feat(OMN-15340): verify_flip_bundle assertion 7 — execute declared parity tests against the receipt's own base_ref (RED-for-the-right-reason mechanism)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,18 +477,21 @@ jobs:
       - name: Run RSD provenance-stamp gate
         run: uv run python scripts/ci/rsd_provenance_stamp.py
 
-      # Fail-closed pre-PR SEAM gate for canonical-shape flips (OMN-14809). Re-invokes
-      # the canonical-shape gate above (verify_flip_receipt / classify_node — imported,
-      # not reimplemented) and adds six fail-closed assertions per NEWLY-flipped node
-      # that the ratchet is structurally blind to (full ModelAdequacyReceipt invariants,
-      # per-binding canonicality, twin shape+entrypoint baseline shrink, receipt minted
-      # post-format, and a git-anchored independent-author attestation for new
-      # equivalence goldens). Canary scope = omnibase_core; fan-out to
+      # Fail-closed pre-PR SEAM gate for canonical-shape flips (OMN-14809 + OMN-15340).
+      # Re-invokes the canonical-shape gate above (verify_flip_receipt / classify_node —
+      # imported, not reimplemented) and adds seven fail-closed assertions per
+      # NEWLY-flipped node that the ratchet is structurally blind to (full
+      # ModelAdequacyReceipt invariants, per-binding canonicality, twin shape+entrypoint
+      # baseline shrink, receipt minted post-format, a deterministic producer rerun +
+      # byte-compare for new equivalence goldens, and — OMN-15340 — the declared
+      # hand-flip parity tests EXECUTED against the receipt's own base_ref, each of which
+      # must fail there on its own assertion). Canary scope = omnibase_core; fan-out to
       # omnibase_infra/omnimarket is wired per-repo. The inline fetch makes origin/dev's
-      # tip available for flip-discovery vs base (the checkout is shallow); if it is
-      # still unavailable the gate NOTEs and exits 0 (the ratchet already hard-guards new
-      # non-canonical nodes). Runs in this job so it inherits the quality-gate blocking
-      # wiring — it does NOT weaken the ratchet.
+      # tip available for flip-discovery vs base (the checkout is shallow); assertion 7
+      # additionally fetches a receipt's own base_ref on demand and FAILS CLOSED if it
+      # stays unresolvable. If origin/dev itself is unavailable the gate NOTEs and exits 0
+      # (the ratchet already hard-guards new non-canonical nodes). Runs in this job so it
+      # inherits the quality-gate blocking wiring — it does NOT weaken the ratchet.
       - name: Run canonical-shape flip-bundle seam gate
         run: |
           git fetch --no-tags --prune origin +refs/heads/dev:refs/remotes/origin/dev || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -199,12 +199,16 @@ repos:
       # Fail-closed pre-PR SEAM gate for canonical-shape flips (OMN-14809). The
       # canonical-handler-shape ratchet (above) DECIDES a flip is proven; this gate
       # re-invokes that gate (verify_flip_receipt / classify_node — imported, not
-      # reimplemented) and adds six fail-closed assertions per NEWLY-flipped node that
+      # reimplemented) and adds seven fail-closed assertions per NEWLY-flipped node that
       # the CI ratchet is structurally blind to: full ModelAdequacyReceipt invariants
       # (A1), per-binding canonicality so a multi-handler node cannot partial-flip (B5),
       # twin shape+entrypoint baseline shrink (B6), receipt-minted-post-format ordering
-      # (S1), and a deterministic producer rerun + byte-compare for new equivalence
-      # goldens (E1, OMN-14905 — replaces the earlier author-identity attestation).
+      # (S1), a deterministic producer rerun + byte-compare for new equivalence
+      # goldens (E1, OMN-14905 — replaces the earlier author-identity attestation), and
+      # the declared hand-flip parity tests EXECUTED against the receipt's own base_ref,
+      # where each must fail on its own assertion (P1, OMN-15340 — a test that is already
+      # green on the pre-change tree discriminates nothing, and one that cannot even
+      # import there proves nothing either).
       # Runs at PRE-PUSH (flip-discovery diffs the whole branch vs origin/dev, which is
       # present locally) — it does its OWN git discovery, so pass_filenames is false.
       # No committed flip in the diff -> exit 0.
@@ -213,7 +217,7 @@ repos:
         entry: uv run python scripts/ci/verify_flip_bundle.py
         language: system
         pass_filenames: false
-        files: ^(src/omnibase_core/.*/nodes/.*/contract\.yaml|src/omnibase_core/.*/nodes/.*\.py|scripts/ci/canonical_handler_shape\.py|scripts/ci/canonical_handler_shape_baseline\.py|scripts/ci/verify_flip_bundle\.py|scripts/ci/equivalence_producer\.py|scripts/ci/adequacy_receipts/.*)$
+        files: ^(src/omnibase_core/.*/nodes/.*/contract\.yaml|src/omnibase_core/.*/nodes/.*\.py|scripts/ci/canonical_handler_shape\.py|scripts/ci/canonical_handler_shape_baseline\.py|scripts/ci/verify_flip_bundle\.py|scripts/ci/equivalence_producer\.py|scripts/ci/parity_replay\.py|scripts/ci/adequacy_receipts/.*)$
         stages: [pre-push]
 
       # Cleanup: Clear tmp/ directory before commits

--- a/scripts/ci/canonical_handler_shape.py
+++ b/scripts/ci/canonical_handler_shape.py
@@ -82,6 +82,7 @@ import ast
 import importlib.util
 import os
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
@@ -585,6 +586,96 @@ HANDFLIP_SUFFIX = ".handflip.json"
 EXPECTED_HANDFLIP_SCHEMA = "handflip_proof.v1"
 
 
+# --------------------------------------------------------------------------- #
+# Executed-parity seam (OMN-15340)
+# --------------------------------------------------------------------------- #
+#
+# Until OMN-15340 the hand-flip path credited ``parity.status == "pass"`` — a string
+# the flip author wrote — and merely COUNTED ``parity.test_ids``. Nothing executed
+# them, so "the parity tests are green" was an assertion about a file, not about the
+# code. The status string is no longer evidence in the positive direction: a claimed
+# ``pass`` must be EXECUTED (green on HEAD) or the proof is REJECTED. A self-declared
+# non-``pass`` stays a hard fail — a confession is trustworthy only in the negative
+# direction.
+#
+# The executor is injected so tests can state exactly what they are proving and so
+# the pre-PR seam gate (``verify_flip_bundle``) can reuse one execution. The default
+# executor really runs pytest (``scripts/ci/parity_replay.py``), imported lazily to
+# keep this module's import cost and dependency surface unchanged for every caller
+# that never touches a hand-flip receipt.
+
+
+class ModelParityVerdict(BaseModel):
+    """An EXECUTED verdict over a hand-flip receipt's declared parity test ids."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    executed: bool
+    green: bool
+    detail: str
+
+
+#: ``(node_id, test_ids) -> ModelParityVerdict``.
+ParityExecutor = Callable[[str, tuple[str, ...]], ModelParityVerdict]
+
+#: Memoized per-process: assertion 2 (via ``verify_flip_receipt``) and any later
+#: caller must not pay for the same pytest run twice within one gate invocation. The
+#: key carries the active ``SRC_ROOT`` because the same node_id + test ids under a
+#: different fan-out scope is a DIFFERENT tree and must be re-executed.
+_PARITY_CACHE: dict[tuple[str, str, tuple[str, ...]], ModelParityVerdict] = {}
+
+
+def default_parity_executor(
+    node_id: str, test_ids: tuple[str, ...]
+) -> ModelParityVerdict:
+    """Execute the declared parity ids against the working tree; all must PASS."""
+    cache_key = (str(SRC_ROOT), node_id, test_ids)
+    cached = _PARITY_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        try:  # pragma: no cover - import shim (mirrors this module's own dual import)
+            from scripts.ci import parity_replay
+        except ImportError:  # pragma: no cover - script-dir invocation
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            import parity_replay  # type: ignore[import-not-found, no-redef]
+    except ImportError as exc:  # pragma: no cover - defensive, fail-closed
+        return ModelParityVerdict(
+            executed=False, green=False, detail=f"parity engine unavailable: {exc}"
+        )
+    repo_root = _git_repo_root(SRC_ROOT)
+    if repo_root is None:
+        verdict = ModelParityVerdict(
+            executed=False,
+            green=False,
+            detail=f"cannot resolve a git repo root from {SRC_ROOT} to run parity tests",
+        )
+        _PARITY_CACHE[cache_key] = verdict
+        return verdict
+    run = parity_replay.run_on_head(repo_root, SRC_ROOT, test_ids)
+    if not run.executed:
+        verdict = ModelParityVerdict(executed=False, green=False, detail=run.detail)
+    elif run.all_passed:
+        verdict = ModelParityVerdict(
+            executed=True,
+            green=True,
+            detail=f"{len(run.results)} declared parity id(s) executed GREEN on HEAD",
+        )
+    else:
+        offenders = "; ".join(
+            f"{r.test_id} -> {r.outcome.value}"
+            for r in run.results
+            if r.outcome.value != "passed"
+        )
+        verdict = ModelParityVerdict(
+            executed=True,
+            green=False,
+            detail=f"declared parity id(s) NOT green on HEAD: {offenders}",
+        )
+    _PARITY_CACHE[cache_key] = verdict
+    return verdict
+
+
 def _resolve_module_file(module: str) -> Path | None:
     candidate = SRC_ROOT / (module.replace(".", "/") + ".py")
     return candidate if candidate.exists() else None
@@ -859,7 +950,10 @@ def _module_repo_rel(module: str) -> tuple[Path, str] | None:
 
 
 def verify_handflip_proof(
-    node_id: str, handler_module: str | None
+    node_id: str,
+    handler_module: str | None,
+    *,
+    parity_executor: ParityExecutor | None = None,
 ) -> tuple[bool, str, list[str]]:
     """Sanctioned proof for a HAND-authored def-B flip (no fabricated replay).
 
@@ -867,8 +961,15 @@ def verify_handflip_proof(
     business-logic symbols from the git-BASE legacy module AND the HEAD canonical
     module and requires them byte-identical (post AST-normalization). This cannot
     be faked by writing a JSON file: the symbols must genuinely be unchanged across
-    the flip. Parity tests (green, bound to the selected input set) attest behavior;
-    the input-set binding is enforced by ``verify_flip_receipt``.
+    the flip.
+
+    Parity tests attest the behavior the verbatim check cannot cover, and since
+    OMN-15340 they are EXECUTED rather than credited from ``parity.status``: the
+    declared ids must run GREEN on HEAD through ``parity_executor`` (default:
+    ``default_parity_executor``, which really runs pytest). The complementary half —
+    that those same ids are RED on the receipt's own ``base_ref``, i.e. that they
+    discriminate the flip at all — is assertion 7 of ``verify_flip_bundle``. The
+    input-set binding is enforced by ``verify_flip_receipt``.
 
     Returns ``(ok, reason, selected_input_hashes)``.
     """
@@ -935,27 +1036,53 @@ def verify_handflip_proof(
     if not isinstance(parity, dict):
         return False, "hand-flip proof missing parity block", []
     if parity.get("status") != "pass":
+        # A self-declared failure is a confession — trusted in the negative direction
+        # only. A self-declared ``pass`` earns nothing; it must be executed below.
         return False, f"parity tests status={parity.get('status')!r}", []
     test_ids = parity.get("test_ids")
     if not isinstance(test_ids, list) or not test_ids:
         return False, "hand-flip parity block names no test_ids", []
+
+    # OMN-15340: run them or reject them. The recorded ``status`` never survives as
+    # evidence on its own.
+    executor = (
+        parity_executor if parity_executor is not None else default_parity_executor
+    )
+    verdict = executor(node_id, tuple(str(t) for t in test_ids))
+    if not verdict.executed:
+        return (
+            False,
+            f"parity claim UNEXECUTED — a recorded status string is not evidence "
+            f"({verdict.detail})",
+            [],
+        )
+    if not verdict.green:
+        return False, f"parity tests NOT GREEN when executed: {verdict.detail}", []
+
     hashes = parity.get("selected_input_hashes")
     selected = [str(h) for h in hashes] if isinstance(hashes, list) else []
     return (
         True,
-        f"handflip-verbatim-preserved({len(symbols)} symbol(s))",
+        f"handflip-verbatim-preserved({len(symbols)} symbol(s))"
+        f"+parity-executed-green({len(test_ids)} test id(s))",
         selected,
     )
 
 
-def verify_flip_receipt(node_id: str, handler_module: str | None) -> tuple[bool, str]:
+def verify_flip_receipt(
+    node_id: str,
+    handler_module: str | None,
+    *,
+    parity_executor: ParityExecutor | None = None,
+) -> tuple[bool, str]:
     """Return (ok, reason) for a non-canonical -> canonical baseline flip.
 
     Requires an adequacy receipt (re-derived verdict) AND one of two sanctioned
     behavior proofs, each bound to the SAME selected input set as the receipt:
       * RSD regen path: a GREEN regen-vs-legacy equivalence-replay artifact; OR
       * HAND-flip path (OMN-14781): a hand-flip proof whose verbatim-preservation
-        the gate re-derives from git and whose parity tests are green.
+        the gate re-derives from git and whose declared parity tests it EXECUTES
+        green on HEAD (OMN-15340 — the recorded status string is not evidence).
     Fail-closed: no adequacy, or neither proof, or a mismatched input set -> RED.
     """
     ok_a, reason_a, sel_receipt = verify_adequacy_receipt(node_id, handler_module)
@@ -963,7 +1090,9 @@ def verify_flip_receipt(node_id: str, handler_module: str | None) -> tuple[bool,
         return False, f"adequacy: {reason_a}"
 
     ok_e, reason_e, sel_equiv = verify_equivalence_replay(node_id)
-    ok_h, reason_h, sel_hand = verify_handflip_proof(node_id, handler_module)
+    ok_h, reason_h, sel_hand = verify_handflip_proof(
+        node_id, handler_module, parity_executor=parity_executor
+    )
     if not ok_e and not ok_h:
         return (
             False,

--- a/scripts/ci/parity_replay.py
+++ b/scripts/ci/parity_replay.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Executed-parity engine for the canonical-shape flip gate (OMN-15340).
+
+"RED to GREEN for the right reason" was prose until this module existed: nothing in
+CI ever executed a candidate test against the PRE-change tree. The hand-flip proof
+path (``canonical_handler_shape.verify_handflip_proof``) read a self-authored
+``parity.status == "pass"`` string and counted ``parity.test_ids`` without ever
+running them — on either tree. Two failure modes were therefore invisible:
+
+1. the declared parity tests are not green on HEAD (the string is fabricated); and
+2. the declared parity tests are ALREADY GREEN on the pre-change tree — they do not
+   discriminate the flip at all, so their green run proves nothing about the
+   def-A -> def-B behavior transfer.
+
+This module executes them. Two entry points:
+
+* :func:`run_on_head` — run the declared ids against the working tree; every id must
+  PASS. Consumed by ``canonical_handler_shape``'s default parity executor, which is
+  what replaces the credited-but-unexecuted ``status`` string.
+* :func:`red_on_base` — materialize the receipt's OWN ``base_ref`` as a detached git
+  worktree, overlay the HEAD copies of the declared test files onto that pre-change
+  tree, and require every declared id to be RED **on its own assertion**.
+
+Exit reasons are distinguished, never collapsed into "non-zero" (see
+:class:`EnumParityOutcome`). A test that cannot even import on the base tree proves
+nothing — an ``ImportError`` at collection is the same evidence as no test at all, so
+it is rejected with its own reason rather than counted as RED. Likewise a call-phase
+``AttributeError`` is NOT an assertion: it is indistinguishable from a test that is
+merely incompatible with the base tree, so the discriminating claim must be asserted
+(``AssertionError``/``pytest.fail``) to count.
+
+Non-vacuity (the load-bearing part): the base-tree run only means something if the
+BASE source is the source actually imported. A canonical clone's editable install
+resolves the package to the HEAD tree, so a base run that silently imports HEAD
+source is a vacuous RED/GREEN either way. :func:`red_on_base` prepends the base
+worktree's source root to ``PYTHONPATH`` and then PROBES the legacy handler module's
+resolved ``__file__``, failing closed unless it lives under the base worktree.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Sequence
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+#: A failure whose junit ``message`` starts with one of these is the test's OWN
+#: assertion (``pytest.fail`` raises ``Failed``, which is an explicit assertion).
+#: Anything else that reaches the ``<failure>`` element (AttributeError, TypeError,
+#: ...) is a non-assertion exception and is reported as its own outcome class.
+ASSERTION_MESSAGE_PREFIXES: tuple[str, ...] = ("AssertionError", "Failed:", "Failed\n")
+
+#: Per-test subprocess ceiling. A hung parity test must fail the gate, not hang CI.
+DEFAULT_TEST_TIMEOUT_S = 300
+
+#: Git env keys that silently retarget a subprocess at another repository
+#: (memory ``reference_git_env_vars_override_c_and_cwd``); pre-commit exports several
+#: of these, so every git call here runs with them stripped.
+_GIT_ENV_BLOCKLIST: tuple[str, ...] = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+
+class EnumParityOutcome(str, Enum):
+    """What actually happened when one declared parity test id was executed."""
+
+    PASSED = "passed"
+    RED_ASSERTION = "red_assertion"  # ran; failed on its OWN assertion
+    RED_EXCEPTION = "red_exception"  # ran; failed on a non-assertion exception
+    SKIPPED = "skipped"
+    COLLECTION_ERROR = "collection_error"  # could not import/collect (proves nothing)
+    NOT_COLLECTED = "not_collected"  # the id does not exist in that tree
+    RUNNER_ERROR = "runner_error"  # pytest could not be launched / timed out
+
+
+class ModelParityTestResult(BaseModel):
+    """One declared parity test id's executed outcome on one tree."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    # A pytest node id ("path::test[param]") is pytest's own identifier format, not
+    # an ONEX entity id — a UUID here would name nothing runnable.
+    # string-id-ok: external (pytest) identifier format
+    test_id: str
+    outcome: EnumParityOutcome
+    detail: str
+
+
+class ModelParityRun(BaseModel):
+    """The executed verdict over a receipt's declared ``parity.test_ids``."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    tree: str
+    executed: bool
+    results: tuple[ModelParityTestResult, ...]
+    detail: str
+
+    @property
+    def all_passed(self) -> bool:
+        return bool(self.results) and all(
+            r.outcome is EnumParityOutcome.PASSED for r in self.results
+        )
+
+    @property
+    def all_red_on_assertion(self) -> bool:
+        return bool(self.results) and all(
+            r.outcome is EnumParityOutcome.RED_ASSERTION for r in self.results
+        )
+
+    def offenders(
+        self, accepted: EnumParityOutcome
+    ) -> tuple[ModelParityTestResult, ...]:
+        return tuple(r for r in self.results if r.outcome is not accepted)
+
+
+# --------------------------------------------------------------------------- #
+# Process primitives
+# --------------------------------------------------------------------------- #
+
+
+def _git_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for key in _GIT_ENV_BLOCKLIST:
+        env.pop(key, None)
+    return env
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_git_env(),
+    )
+
+
+def resolve_interpreter(repo_root: Path) -> Path:
+    """The target repo's own venv python when present, else this interpreter.
+
+    The BASE tree carries no installed environment of its own, so dependencies come
+    from the target repo's venv while the SOURCE comes from the base worktree via
+    ``PYTHONPATH`` (proven by the residency probe). The assertion is about the source
+    transition, not about dependency pinning.
+    """
+    candidate = repo_root / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return candidate
+    return Path(sys.executable)
+
+
+#: Inherited env that would silently reconfigure the inner pytest run. ``PYTEST_ADDOPTS``
+#: is the dangerous one: an ambient ``--reruns`` can turn the RED being measured into a
+#: PASS, and ``PYTHONPATH`` leftovers can shadow the tree under test.
+_RUN_ENV_BLOCKLIST: tuple[str, ...] = (
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTEST_ADDOPTS",
+    "PYTEST_PLUGINS",
+    "PYTEST_CURRENT_TEST",
+    "PYTEST_XDIST_WORKER",
+    "PYTEST_XDIST_WORKER_COUNT",
+)
+
+
+def _run_env(source_root: Path) -> dict[str, str]:
+    blocked = set(_RUN_ENV_BLOCKLIST) | set(_GIT_ENV_BLOCKLIST)
+    env = {k: v for k, v in os.environ.items() if k not in blocked}
+    env["PYTHONPATH"] = str(source_root)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return env
+
+
+# --------------------------------------------------------------------------- #
+# One test id -> one typed outcome
+# --------------------------------------------------------------------------- #
+
+
+def _classify_junit(
+    xml_path: Path, test_id: str, returncode: int
+) -> ModelParityTestResult:
+    """Map one single-id pytest run to a typed outcome.
+
+    Single-id invocation is deliberate: a collection error aborts a whole pytest
+    session (``Interrupted``), so batching ids would let one broken file mask every
+    other id's real outcome. One id per process makes each verdict independent.
+    """
+    if not xml_path.exists():
+        return ModelParityTestResult(
+            test_id=test_id,
+            outcome=EnumParityOutcome.NOT_COLLECTED,
+            detail=(
+                f"pytest produced no report for {test_id!r} (rc={returncode}) — the id "
+                f"does not exist in that tree"
+            ),
+        )
+    try:
+        # Suppression rationale mirrors scripts/ci/test_selection_shadow.py: the
+        # document is the junit report the pytest process launched two frames up just
+        # wrote into a private temp dir — it is not untrusted input.
+        root = ET.parse(xml_path).getroot()  # noqa: S314 (self-produced junit report)
+    except ET.ParseError as exc:
+        return ModelParityTestResult(
+            test_id=test_id,
+            outcome=EnumParityOutcome.RUNNER_ERROR,
+            detail=f"unparseable junit report: {exc}",
+        )
+    cases = list(root.iter("testcase"))
+    if not cases:
+        return ModelParityTestResult(
+            test_id=test_id,
+            outcome=EnumParityOutcome.NOT_COLLECTED,
+            detail=f"no testcase recorded for {test_id!r} (rc={returncode})",
+        )
+    case = cases[0]
+    for child in case:
+        message = (child.get("message") or "").strip()
+        if child.tag == "error":
+            return ModelParityTestResult(
+                test_id=test_id,
+                outcome=EnumParityOutcome.COLLECTION_ERROR,
+                detail=f"collection/setup error: {message[:200]}",
+            )
+        if child.tag == "skipped":
+            return ModelParityTestResult(
+                test_id=test_id,
+                outcome=EnumParityOutcome.SKIPPED,
+                detail=f"skipped: {message[:200]}",
+            )
+        if child.tag == "failure":
+            if message.startswith(ASSERTION_MESSAGE_PREFIXES):
+                return ModelParityTestResult(
+                    test_id=test_id,
+                    outcome=EnumParityOutcome.RED_ASSERTION,
+                    detail=f"failed on its own assertion: {message[:200]}",
+                )
+            return ModelParityTestResult(
+                test_id=test_id,
+                outcome=EnumParityOutcome.RED_EXCEPTION,
+                detail=(
+                    f"failed on a NON-assertion exception: {message[:200]} — an "
+                    f"exception is not a discriminating claim; assert it"
+                ),
+            )
+    return ModelParityTestResult(
+        test_id=test_id,
+        outcome=EnumParityOutcome.PASSED,
+        detail="passed",
+    )
+
+
+def run_test_id(
+    test_id: str,
+    *,
+    interpreter: Path,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int = DEFAULT_TEST_TIMEOUT_S,
+) -> ModelParityTestResult:
+    """Execute exactly one pytest id and classify its outcome.
+
+    ``-o addopts=`` neutralizes the repo's ini addopts (xdist / reruns / coverage),
+    which would otherwise make a single-id verdict non-deterministic — a ``--reruns``
+    retry can turn a RED into a PASS, and that is the exact signal being measured.
+    """
+    report_dir = Path(tempfile.mkdtemp(prefix="parity-junit-"))
+    xml_path = report_dir / "report.xml"
+    argv = [
+        str(interpreter),
+        "-m",
+        "pytest",
+        test_id,
+        "-o",
+        "addopts=",
+        "-p",
+        "no:cacheprovider",
+        "-p",
+        "no:randomly",
+        "--continue-on-collection-errors",
+        f"--junitxml={xml_path}",
+        "-q",
+    ]
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(report_dir, ignore_errors=True)
+        return ModelParityTestResult(
+            test_id=test_id,
+            outcome=EnumParityOutcome.RUNNER_ERROR,
+            detail=f"timed out after {timeout}s",
+        )
+    except OSError as exc:
+        shutil.rmtree(report_dir, ignore_errors=True)
+        return ModelParityTestResult(
+            test_id=test_id,
+            outcome=EnumParityOutcome.RUNNER_ERROR,
+            detail=f"pytest could not be launched: {exc}",
+        )
+    try:
+        return _classify_junit(xml_path, test_id, proc.returncode)
+    finally:
+        shutil.rmtree(report_dir, ignore_errors=True)
+
+
+def _run_ids(
+    test_ids: Sequence[str],
+    *,
+    interpreter: Path,
+    cwd: Path,
+    source_root: Path,
+    tree: str,
+    timeout: int,
+) -> ModelParityRun:
+    env = _run_env(source_root)
+    results = tuple(
+        run_test_id(test_id, interpreter=interpreter, cwd=cwd, env=env, timeout=timeout)
+        for test_id in test_ids
+    )
+    return ModelParityRun(
+        tree=tree,
+        executed=True,
+        results=results,
+        detail=f"{len(results)} declared parity id(s) executed against the {tree} tree",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# HEAD side — "run them or reject them"
+# --------------------------------------------------------------------------- #
+
+
+def run_on_head(
+    repo_root: Path,
+    source_root: Path,
+    test_ids: Sequence[str],
+    *,
+    timeout: int = DEFAULT_TEST_TIMEOUT_S,
+) -> ModelParityRun:
+    """Execute the declared ids against the working tree; all must PASS.
+
+    ``PYTHONPATH`` is pinned to ``source_root`` even here: inside a git worktree the
+    canonical clone's editable ``.pth`` otherwise resolves the package to the
+    CANONICAL checkout, so the run would grade a tree nobody edited
+    (memory ``reference_pythonpath_shadows_worktree_source``).
+    """
+    if not test_ids:
+        return ModelParityRun(
+            tree="head",
+            executed=False,
+            results=(),
+            detail="no parity test ids declared",
+        )
+    return _run_ids(
+        test_ids,
+        interpreter=resolve_interpreter(repo_root),
+        cwd=repo_root,
+        source_root=source_root,
+        tree="head",
+        timeout=timeout,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BASE side — the RED-for-the-right-reason mechanism
+# --------------------------------------------------------------------------- #
+
+
+def _test_files(test_ids: Iterable[str]) -> list[str]:
+    seen: list[str] = []
+    for test_id in test_ids:
+        rel = test_id.split("::", 1)[0].strip()
+        if rel and rel not in seen:
+            seen.append(rel)
+    return seen
+
+
+def _ensure_ref(repo_root: Path, base_ref: str) -> bool:
+    if (
+        _git(
+            repo_root, "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"
+        ).returncode
+        == 0
+    ):
+        return True
+    # Shallow CI checkouts legitimately lack an older receipt base_ref; try once to
+    # fetch exactly it before failing closed.
+    _git(repo_root, "fetch", "--no-tags", "--depth=1", "origin", base_ref)
+    return (
+        _git(
+            repo_root, "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"
+        ).returncode
+        == 0
+    )
+
+
+def _probe_source_residency(
+    module: str,
+    *,
+    interpreter: Path,
+    cwd: Path,
+    env: dict[str, str],
+    expected_root: Path,
+) -> tuple[bool, str]:
+    """Prove the module the tests will import resolves INSIDE ``expected_root``."""
+    script = (
+        "import importlib.util,sys\n"
+        f"spec = importlib.util.find_spec({module!r})\n"
+        "print(spec.origin if spec is not None else '')\n"
+    )
+    try:
+        proc = subprocess.run(
+            [str(interpreter), "-c", script],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"residency probe could not run: {exc}"
+    origin = proc.stdout.strip().splitlines()[-1].strip() if proc.stdout.strip() else ""
+    if not origin:
+        return (
+            False,
+            f"{module} does not resolve on the base tree "
+            f"({(proc.stderr or '').strip()[:200]})",
+        )
+    try:
+        Path(origin).resolve().relative_to(expected_root.resolve())
+    except ValueError:
+        return (
+            False,
+            f"VACUOUS BASE RUN — {module} resolved to {origin}, OUTSIDE the base "
+            f"worktree {expected_root}; the base-tree run would have graded HEAD "
+            f"source (editable install shadowing)",
+        )
+    return True, f"{module} resolves inside the base worktree ({origin})"
+
+
+def red_on_base(
+    node_id: str,
+    test_ids: Sequence[str],
+    base_ref: str,
+    legacy_module: str,
+    repo_root: Path,
+    source_root: Path,
+    *,
+    timeout: int = DEFAULT_TEST_TIMEOUT_S,
+) -> tuple[bool, str]:
+    """Every declared parity test must fail ON ITS OWN ASSERTION at ``base_ref``.
+
+    Fail-closed at every step: an unresolvable ref, an un-materializable worktree, a
+    declared test file missing at HEAD, a failed residency probe, or ANY id that is
+    not ``RED_ASSERTION`` returns ``(False, reason)``.
+    """
+    if not test_ids:
+        return False, "hand-flip parity block declares no test_ids to execute"
+    if not _ensure_ref(repo_root, base_ref):
+        return False, f"receipt base_ref {base_ref!r} unresolvable in {repo_root}"
+    try:
+        rel_src = source_root.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return (
+            False,
+            f"source root {source_root} is outside the repo {repo_root}; cannot map it "
+            f"onto the base worktree",
+        )
+
+    work_dir = Path(tempfile.mkdtemp(prefix=f"flipbase-{node_id.split('.')[-1]}-"))
+    base_tree = work_dir / "base"
+    try:
+        add = _git(repo_root, "worktree", "add", "--detach", str(base_tree), base_ref)
+        if add.returncode != 0:
+            return (
+                False,
+                f"could not materialize base worktree at {base_ref}: "
+                f"{(add.stderr or add.stdout).strip()[:300]}",
+            )
+
+        # Overlay the CANDIDATE tests onto the PRE-change tree. The tests are new in
+        # the flip PR, so without the overlay there is nothing to run at base.
+        for rel in _test_files(test_ids):
+            head_file = repo_root / rel
+            if not head_file.is_file():
+                return False, f"declared parity test file absent at HEAD: {rel}"
+            target = base_tree / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(head_file, target)
+
+        base_src = base_tree / rel_src
+        env = _run_env(base_src)
+        interpreter = resolve_interpreter(repo_root)
+        ok_probe, probe_detail = _probe_source_residency(
+            legacy_module,
+            interpreter=interpreter,
+            cwd=base_tree,
+            env=env,
+            expected_root=base_tree,
+        )
+        if not ok_probe:
+            return False, probe_detail
+
+        run = _run_ids(
+            test_ids,
+            interpreter=interpreter,
+            cwd=base_tree,
+            source_root=base_src,
+            tree=f"base({base_ref[:12]})",
+            timeout=timeout,
+        )
+    finally:
+        _git(repo_root, "worktree", "remove", "--force", str(base_tree))
+        _git(repo_root, "worktree", "prune")
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+    offenders = run.offenders(EnumParityOutcome.RED_ASSERTION)
+    if offenders:
+        rendered = "; ".join(
+            f"{r.test_id} -> {r.outcome.value} ({r.detail[:120]})"
+            for r in offenders[:5]
+        )
+        return (
+            False,
+            f"parity tests are NOT RED-for-the-right-reason at base_ref {base_ref[:12]}: "
+            f"{len(offenders)}/{len(run.results)} id(s) did not fail on their own "
+            f"assertion -> {rendered}",
+        )
+    return (
+        True,
+        f"all {len(run.results)} declared parity id(s) RED on their own assertion at "
+        f"base_ref {base_ref[:12]} ({probe_detail})",
+    )

--- a/scripts/ci/verify_flip_bundle.py
+++ b/scripts/ci/verify_flip_bundle.py
@@ -10,7 +10,7 @@ that only surface when the FIVE flip artifacts are checked jointly against live 
 the live handler source, and the full typed-receipt invariants. This gate RE-INVOKES
 the real consuming gate (it imports ``canonical_handler_shape`` and calls
 ``verify_flip_receipt`` / ``classify_node`` / the git + baseline helpers — it does NOT
-reimplement them) and adds six fail-closed assertions per flipped node that close the
+reimplement them) and adds seven fail-closed assertions per flipped node that close the
 blind spots enumerated below. It mirrors the ratchet's fan-out CLI
 (``--package`` / ``--src-root`` / ``--receipts-dir`` / ``--baseline``) so it points at
 omnibase_infra / omnimarket identically.
@@ -51,6 +51,16 @@ Blind spots this gate closes (each = one assertion; first failure exits non-zero
   (omnibase_core#1472): identity is not evidence — any second git identity satisfies an
   author check while proving nothing — whereas byte-equality with a deterministic rerun
   proves the artifact is mechanically reproducible (OMN-14905).
+* **P1 — parity tests that discriminate nothing.** Assertions 1-6 all grade artifacts
+  against the HEAD tree; nothing here or anywhere else in CI ever executed a candidate
+  test against the PRE-change tree, so "RED to GREEN for the right reason" was prose.
+  A hand-flip proof could declare parity tests that are ALREADY GREEN at its own
+  ``base_ref``. Assertion 7 (HAND-FLIP path only, NEW flips only) materializes that
+  ``base_ref`` as a detached worktree, overlays the HEAD copies of the declared test
+  files, and requires every declared id to fail there ON ITS OWN ASSERTION — a
+  collection/import error is not RED, it is the same evidence as no test at all. A
+  source-residency probe first proves the base worktree is what actually gets imported,
+  so the verdict cannot be vacuous (OMN-15340, ``scripts/ci/parity_replay.py``).
 
 Usage (pre-commit / CI, mirrors canonical_handler_shape)::
 
@@ -62,7 +72,7 @@ Usage (pre-commit / CI, mirrors canonical_handler_shape)::
 
 The gate discovers the nodes NEWLY flipped in this PR (removed from ``NON_CANONICAL``
 vs origin/dev and canonical now, or carrying a newly-added adequacy receipt) and runs
-all six assertions on each. Zero flips -> exit 0 (nothing to prove; the ratchet already
+all seven assertions on each. Zero flips -> exit 0 (nothing to prove; the ratchet already
 guards new non-canonical nodes). Any assertion failure -> exit 1.
 """
 
@@ -84,11 +94,13 @@ from pydantic import BaseModel, ConfigDict
 try:  # pragma: no cover - import shim
     from scripts.ci import canonical_handler_shape as chs
     from scripts.ci import equivalence_producer as eqp
+    from scripts.ci import parity_replay as prp
     from scripts.ci.adequacy_receipt import ModelAdequacyReceipt
 except ImportError:  # pragma: no cover - script-dir invocation
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     import canonical_handler_shape as chs  # type: ignore[import-not-found, no-redef]
     import equivalence_producer as eqp  # type: ignore[import-not-found, no-redef]
+    import parity_replay as prp  # type: ignore[import-not-found, no-redef]
     from adequacy_receipt import (  # type: ignore[import-not-found, no-redef]
         ModelAdequacyReceipt,
     )
@@ -138,7 +150,7 @@ class ModelAssertionOutcome(BaseModel):
 
 
 class ModelFlipBundleResult(BaseModel):
-    """The joint verdict over one node's five flip artifacts."""
+    """The joint verdict over one node's flip artifacts."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
 
@@ -497,14 +509,18 @@ def _assert_reproducible_equivalence(
 
 
 def _flip_proof_is_new(
-    node_id: str, receipts_dir: Path, repo_root: Path, base_ref: str
+    node_id: str,
+    receipts_dir: Path,
+    repo_root: Path,
+    base_ref: str,
+    suffix: str | None = None,
 ) -> bool:
-    """A flip is NEW when its equivalence proof artifact is ABSENT at the git base.
+    """A flip is NEW when its proof artifact is ABSENT at the git base.
 
     Fail-closed: any inability to prove the artifact PRE-EXISTED at the base (artifact
-    outside the repo, base unresolvable) returns True -> assertion 6 is applied.
+    outside the repo, base unresolvable) returns True -> the assertion is applied.
     """
-    art = receipts_dir / f"{node_id}{chs.EQUIVALENCE_SUFFIX}"
+    art = receipts_dir / f"{node_id}{suffix or chs.EQUIVALENCE_SUFFIX}"
     try:
         rel = art.resolve().relative_to(repo_root.resolve())
     except ValueError:
@@ -516,7 +532,62 @@ def _flip_proof_is_new(
 
 
 # --------------------------------------------------------------------------- #
-# Orchestration: run the six assertions in order, stop at first failure.
+# Assertion 7 — declared parity tests RED on the receipt's own base_ref (OMN-15340)
+# --------------------------------------------------------------------------- #
+#
+# Assertions 1-6 all grade artifacts against the HEAD tree. None of them — and no
+# other mechanism in CI — ever executed a candidate test against the PRE-change tree,
+# so "RED to GREEN for the right reason" was prose. A hand-flip proof can therefore
+# declare parity tests that are ALREADY GREEN at ``base_ref``: they run, they pass,
+# they discriminate nothing, and the flip is credited with a behavior proof it never
+# earned.
+#
+# Assertion 7 materializes the receipt's OWN ``base_ref`` as a detached worktree,
+# overlays the HEAD copies of the declared test files onto that pre-change tree, and
+# requires EVERY declared id to fail there ON ITS OWN ASSERTION. Exit reasons are
+# distinguished, never collapsed into "non-zero": a collection/import error means the
+# test cannot even run against the old code, which is exactly as much evidence as no
+# test at all (``feedback_prove_red_against_exists_but_wrong``). Before any of that
+# counts, a residency probe proves the base worktree's source is what actually gets
+# imported — otherwise an editable install silently grades HEAD and every verdict,
+# RED or GREEN, is vacuous.
+
+
+def _assert_parity_red_on_base(
+    node_id: str,
+    receipts_dir: Path,
+    repo_root: Path,
+    src_root: Path,
+) -> tuple[bool, str]:
+    raw = chs._load_json(receipts_dir / f"{node_id}{chs.HANDFLIP_SUFFIX}")
+    if raw is None:
+        return False, "hand-flip proof unreadable for the parity RED-on-base check"
+    parity = raw.get("parity")
+    if not isinstance(parity, dict):
+        return False, "hand-flip proof missing parity block"
+    test_ids_raw = parity.get("test_ids")
+    if not isinstance(test_ids_raw, list) or not test_ids_raw:
+        return False, "hand-flip parity block names no test_ids to execute"
+    base_ref = raw.get("base_ref")
+    if not isinstance(base_ref, str) or not base_ref:
+        return False, "hand-flip proof missing base_ref"
+    legacy_module = raw.get("legacy_handler_module") or raw.get(
+        "canonical_handler_module"
+    )
+    if not isinstance(legacy_module, str) or not legacy_module:
+        return False, "hand-flip proof names no module for the residency probe"
+    return prp.red_on_base(
+        node_id,
+        tuple(str(t) for t in test_ids_raw),
+        base_ref,
+        legacy_module,
+        repo_root,
+        src_root,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration: run the seven assertions in order, stop at first failure.
 # --------------------------------------------------------------------------- #
 
 
@@ -528,10 +599,10 @@ def verify_flip_bundle(
     baseline: Path | None,
     base_ref: str = DEFAULT_BASE_REF,
 ) -> ModelFlipBundleResult:
-    """Verify one node's five flip artifacts jointly. Fail-closed, first-failure-wins.
+    """Verify one node's flip artifacts jointly. Fail-closed, first-failure-wins.
 
     Absence, unparseability, a None from any git probe, or an import failure all
-    evaluate to FAIL (never SKIP). Runs the six assertions in numeric order and stops at
+    evaluate to FAIL (never SKIP). Runs the seven assertions in numeric order and stops at
     the first failure so a seeded defect surfaces on its intended assertion, not
     incidentally on a later one. Snapshots + restores the ratchet's module globals so a
     fan-out call leaves no scope state behind for other callers/tests.
@@ -675,13 +746,47 @@ def _verify_flip_bundle_impl(
         )
     )
 
+    # Assertion 7 — declared parity tests RED-on-their-own-assertion at the receipt's
+    # own base_ref (OMN-15340). Hand-flip path only: the equivalence path carries no
+    # parity block and is covered by assertion 6's deterministic rerun.
+    handflip_path = s_recv / f"{node_id}{chs.HANDFLIP_SUFFIX}"
+    if not handflip_path.exists():
+        detail7 = (
+            "equivalence proof path — no hand-flip parity block to execute "
+            "(assertion 6 covers reproducibility)"
+        )
+    elif repo_root is None:
+        return _record(
+            7,
+            "parity-red-on-base",
+            False,
+            "cannot resolve git repo root to materialize the receipt's base_ref",
+        )
+    elif not _flip_proof_is_new(
+        node_id, s_recv, repo_root, base_ref, chs.HANDFLIP_SUFFIX
+    ):
+        grandfathered = True
+        detail7 = (
+            "grandfathered — hand-flip proof pre-existing at base (not new vs "
+            f"{base_ref})"
+        )
+    else:
+        ok7, detail7 = _assert_parity_red_on_base(node_id, s_recv, repo_root, s_src)
+        if not ok7:
+            return _record(7, "parity-red-on-base", False, detail7)
+    outcomes.append(
+        ModelAssertionOutcome(
+            index=7, name="parity-red-on-base", ok=True, detail=detail7
+        )
+    )
+
     return ModelFlipBundleResult(
         node_id=node_id,
         ok=True,
         failed_assertion=None,
         grandfathered=grandfathered,
         outcomes=tuple(outcomes),
-        reason="all six flip-bundle assertions hold",
+        reason="all seven flip-bundle assertions hold",
     )
 
 
@@ -837,7 +942,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     print(
         f"verify_flip_bundle OK ({args.package}) — {len(node_ids)} flip bundle(s) "
-        f"coherent across all six assertions."
+        f"coherent across all seven assertions."
     )
     return 0
 

--- a/tests/unit/scripts/ci/test_canonical_handler_shape.py
+++ b/tests/unit/scripts/ci/test_canonical_handler_shape.py
@@ -586,6 +586,23 @@ def _write_handflip(dir_path, node_id: str, **overrides) -> None:
     )
 
 
+def _parity_executor(*, executed: bool = True, green: bool = True):
+    """An INJECTED parity verdict.
+
+    OMN-15340 made the executed verdict the evidence, so a hand-flip unit test must
+    say which verdict it is assuming instead of leaning on the receipt's ``status``
+    string. Without an injected executor the real one runs pytest against the working
+    tree — correct in production, meaningless against these synthetic receipts.
+    """
+
+    def _executor(node_id: str, test_ids: tuple[str, ...]):
+        return mod.ModelParityVerdict(
+            executed=executed, green=green, detail=f"stubbed verdict for {test_ids}"
+        )
+
+    return _executor
+
+
 def _handflip_env(tmp_path, monkeypatch, head_src: str, base_src: str) -> None:
     monkeypatch.setattr(mod, "RECEIPTS_DIR", tmp_path)
     head_file = tmp_path / "head_handler.py"
@@ -601,7 +618,9 @@ def _handflip_env(tmp_path, monkeypatch, head_src: str, base_src: str) -> None:
 def test_handflip_proof_verbatim_preserved_passes(tmp_path, monkeypatch) -> None:
     _handflip_env(tmp_path, monkeypatch, _CANONICAL_HANDLER_SAME_LOGIC, _LEGACY_HANDLER)
     _write_handflip(tmp_path, "n.hand")
-    ok, reason, selected = verify_handflip_proof("n.hand", handler_module="pkg.handler")
+    ok, reason, selected = verify_handflip_proof(
+        "n.hand", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
     assert ok is True, reason
     assert "verbatim" in reason
     assert selected == ["h1"]
@@ -613,7 +632,9 @@ def test_handflip_proof_diverged_logic_fails(tmp_path, monkeypatch) -> None:
         tmp_path, monkeypatch, _CANONICAL_HANDLER_CHANGED_LOGIC, _LEGACY_HANDLER
     )
     _write_handflip(tmp_path, "n.hand")
-    ok, reason, _ = verify_handflip_proof("n.hand", handler_module="pkg.handler")
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
     assert ok is False
     assert "verbatim-preservation FAILED" in reason
 
@@ -621,7 +642,9 @@ def test_handflip_proof_diverged_logic_fails(tmp_path, monkeypatch) -> None:
 def test_handflip_proof_missing_symbol_in_head_fails(tmp_path, monkeypatch) -> None:
     _handflip_env(tmp_path, monkeypatch, _CANONICAL_HANDLER_SAME_LOGIC, _LEGACY_HANDLER)
     _write_handflip(tmp_path, "n.hand", preserved_symbols=["_does_not_exist"])
-    ok, reason, _ = verify_handflip_proof("n.hand", handler_module="pkg.handler")
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
     assert ok is False
     assert "not all found in HEAD" in reason
 
@@ -633,15 +656,82 @@ def test_handflip_proof_parity_not_pass_fails(tmp_path, monkeypatch) -> None:
         "n.hand",
         parity={"test_ids": ["t::x"], "status": "fail", "selected_input_hashes": []},
     )
-    ok, reason, _ = verify_handflip_proof("n.hand", handler_module="pkg.handler")
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
     assert ok is False
     assert "parity" in reason
 
 
 def test_handflip_proof_missing_artifact_fails() -> None:
-    ok, reason, _ = verify_handflip_proof("n.absent", handler_module="pkg.handler")
+    ok, reason, _ = verify_handflip_proof(
+        "n.absent", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
     assert ok is False
     assert "no hand-flip proof artifact" in reason
+
+
+def test_handflip_proof_rejects_unexecuted_parity_claim(tmp_path, monkeypatch) -> None:
+    """OMN-15340: a recorded ``status: pass`` earns nothing on its own.
+
+    The receipt is otherwise perfect — verbatim-preserved symbols, a well-formed
+    parity block, ``status: pass``. Before OMN-15340 that was accepted. Now an
+    executor that could not run the declared ids rejects it.
+    """
+    _handflip_env(tmp_path, monkeypatch, _CANONICAL_HANDLER_SAME_LOGIC, _LEGACY_HANDLER)
+    _write_handflip(tmp_path, "n.hand")
+
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand",
+        handler_module="pkg.handler",
+        parity_executor=_parity_executor(executed=False, green=False),
+    )
+
+    assert ok is False
+    assert "UNEXECUTED" in reason
+    assert "not evidence" in reason
+
+
+def test_handflip_proof_rejects_executed_but_red_parity(tmp_path, monkeypatch) -> None:
+    """status=pass over tests that are actually RED on HEAD -> rejected."""
+    _handflip_env(tmp_path, monkeypatch, _CANONICAL_HANDLER_SAME_LOGIC, _LEGACY_HANDLER)
+    _write_handflip(tmp_path, "n.hand")
+
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand",
+        handler_module="pkg.handler",
+        parity_executor=_parity_executor(executed=True, green=False),
+    )
+
+    assert ok is False
+    assert "NOT GREEN when executed" in reason
+
+
+def test_handflip_proof_reason_names_the_executed_parity(tmp_path, monkeypatch) -> None:
+    """The success reason must record that parity was EXECUTED, not just declared."""
+    _handflip_env(tmp_path, monkeypatch, _CANONICAL_HANDLER_SAME_LOGIC, _LEGACY_HANDLER)
+    _write_handflip(tmp_path, "n.hand")
+
+    ok, reason, _ = verify_handflip_proof(
+        "n.hand", handler_module="pkg.handler", parity_executor=_parity_executor()
+    )
+
+    assert ok is True, reason
+    assert "parity-executed-green" in reason
+
+
+def test_default_parity_executor_fails_closed_without_a_git_root(
+    tmp_path, monkeypatch
+) -> None:
+    """No repo -> no execution -> no credit (never a silent skip)."""
+    monkeypatch.setattr(mod, "SRC_ROOT", tmp_path / "src")
+    monkeypatch.setattr(mod, "_git_repo_root", lambda path: None)
+    monkeypatch.setattr(mod, "_PARITY_CACHE", {})
+
+    verdict = mod.default_parity_executor("n.hand", ("tests/t.py::test_x",))
+
+    assert verdict.executed is False
+    assert verdict.green is False
 
 
 def test_flip_accepts_handflip_path(tmp_path, monkeypatch) -> None:
@@ -658,7 +748,11 @@ def test_flip_accepts_handflip_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         mod,
         "verify_handflip_proof",
-        lambda node_id, handler_module: (True, "handflip-verbatim-preserved", ["h1"]),
+        lambda node_id, handler_module, **kwargs: (
+            True,
+            "handflip-verbatim-preserved",
+            ["h1"],
+        ),
     )
     ok, reason = verify_flip_receipt("n.hand", handler_module="pkg.handler")
     assert ok is True
@@ -677,7 +771,7 @@ def test_flip_handflip_pair_incompatible_when_input_sets_differ(monkeypatch) -> 
     monkeypatch.setattr(
         mod,
         "verify_handflip_proof",
-        lambda node_id, handler_module: (True, "handflip", ["hX"]),
+        lambda node_id, handler_module, **kwargs: (True, "handflip", ["hX"]),
     )
     ok, reason = verify_flip_receipt("n.hand", handler_module="pkg.handler")
     assert ok is False

--- a/tests/unit/scripts/ci/test_parity_replay.py
+++ b/tests/unit/scripts/ci/test_parity_replay.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the executed-parity engine (OMN-15340).
+
+The engine's whole value is that it DISTINGUISHES exit reasons. "The test exited
+non-zero on the base tree" is not the claim — "the test executed on the base tree and
+failed on its own assertion" is. These tests pin the classification matrix by really
+running pytest, and pin the non-vacuity probe that stops a base-tree run from silently
+grading HEAD source.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.parity_replay import (
+    EnumParityOutcome,
+    _probe_source_residency,
+    _run_env,
+    red_on_base,
+    resolve_interpreter,
+    run_test_id,
+)
+
+pytestmark = pytest.mark.unit
+
+TEST_MODULE = """
+import pytest
+
+
+def test_assertion_fails():
+    assert 1 == 2, "discriminating claim"
+
+
+def test_passes():
+    assert True
+
+
+def test_explicit_fail():
+    pytest.fail("explicit")
+
+
+def test_non_assertion_exception():
+    None.handle(1)
+
+
+@pytest.mark.skip(reason="not here")
+def test_skipped():
+    assert False
+"""
+
+BROKEN_MODULE = """
+import a_module_that_does_not_exist_anywhere  # noqa: F401
+
+
+def test_never_runs():
+    assert True
+"""
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_kinds.py").write_text(TEST_MODULE, encoding="utf-8")
+    (tmp_path / "tests" / "test_broken.py").write_text(BROKEN_MODULE, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("test_id", "expected"),
+    [
+        ("tests/test_kinds.py::test_assertion_fails", EnumParityOutcome.RED_ASSERTION),
+        ("tests/test_kinds.py::test_explicit_fail", EnumParityOutcome.RED_ASSERTION),
+        ("tests/test_kinds.py::test_passes", EnumParityOutcome.PASSED),
+        (
+            "tests/test_kinds.py::test_non_assertion_exception",
+            EnumParityOutcome.RED_EXCEPTION,
+        ),
+        ("tests/test_kinds.py::test_skipped", EnumParityOutcome.SKIPPED),
+        ("tests/test_broken.py::test_never_runs", EnumParityOutcome.COLLECTION_ERROR),
+        ("tests/test_kinds.py::test_absent", EnumParityOutcome.NOT_COLLECTED),
+    ],
+)
+def test_exit_reasons_are_distinguished(
+    sandbox: Path, test_id: str, expected: EnumParityOutcome
+) -> None:
+    """Only RED_ASSERTION counts as RED; the other four non-pass reasons are distinct.
+
+    An ImportError at collection and a missing test id both exit non-zero, and both
+    prove exactly nothing about the pre-change tree — collapsing them into "non-zero"
+    is the failure mode this engine exists to prevent.
+    """
+    result = run_test_id(
+        test_id,
+        interpreter=resolve_interpreter(sandbox),
+        cwd=sandbox,
+        env=_run_env(sandbox),
+    )
+    assert result.outcome is expected, result.detail
+
+
+def test_residency_probe_accepts_module_inside_the_expected_root(
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "src"
+    (src / "probepkg").mkdir(parents=True)
+    (src / "probepkg" / "__init__.py").write_text("", encoding="utf-8")
+    (src / "probepkg" / "mod.py").write_text("X = 1\n", encoding="utf-8")
+
+    ok, detail = _probe_source_residency(
+        "probepkg.mod",
+        interpreter=resolve_interpreter(tmp_path),
+        cwd=tmp_path,
+        env=_run_env(src),
+        expected_root=tmp_path,
+    )
+    assert ok is True, detail
+
+
+def test_residency_probe_rejects_module_resolved_outside_the_base_tree(
+    tmp_path: Path,
+) -> None:
+    """The vacuity guard: an editable install resolving to HEAD must FAIL the run.
+
+    Without this the base-tree execution grades HEAD source, so both the RED and the
+    GREEN it reports are meaningless.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / "probepkg").mkdir(parents=True)
+    (elsewhere / "probepkg" / "__init__.py").write_text("", encoding="utf-8")
+    (elsewhere / "probepkg" / "mod.py").write_text("X = 1\n", encoding="utf-8")
+    base_tree = tmp_path / "base"
+    base_tree.mkdir()
+
+    ok, detail = _probe_source_residency(
+        "probepkg.mod",
+        interpreter=resolve_interpreter(tmp_path),
+        cwd=base_tree,
+        env=_run_env(elsewhere),
+        expected_root=base_tree,
+    )
+    assert ok is False
+    assert "VACUOUS BASE RUN" in detail
+
+
+def test_residency_probe_fails_closed_when_module_absent(tmp_path: Path) -> None:
+    ok, detail = _probe_source_residency(
+        "no_such_module_at_all",
+        interpreter=resolve_interpreter(tmp_path),
+        cwd=tmp_path,
+        env=_run_env(tmp_path),
+        expected_root=tmp_path,
+    )
+    assert ok is False
+    assert "does not resolve" in detail
+
+
+def test_red_on_base_fails_closed_on_unresolvable_base_ref(tmp_path: Path) -> None:
+    ok, detail = red_on_base(
+        "pkg.nodes.node_x",
+        ("tests/test_x.py::test_y",),
+        "0" * 40,
+        "pkg.handler",
+        tmp_path,
+        tmp_path / "src",
+    )
+    assert ok is False
+    assert "unresolvable" in detail
+
+
+def test_red_on_base_fails_closed_without_test_ids(tmp_path: Path) -> None:
+    ok, detail = red_on_base(
+        "pkg.nodes.node_x", (), "HEAD", "pkg.handler", tmp_path, tmp_path / "src"
+    )
+    assert ok is False
+    assert "no test_ids" in detail
+
+
+def test_run_env_strips_inherited_pytest_and_git_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Inherited PYTEST_ADDOPTS / GIT_DIR would silently retarget the inner run."""
+    monkeypatch.setenv("PYTEST_ADDOPTS", "-x --reruns 5")
+    monkeypatch.setenv("GIT_DIR", "/somewhere/else/.git")
+    monkeypatch.setenv("PYTHONPATH", "/leftover")
+
+    env = _run_env(tmp_path / "src")
+
+    assert "PYTEST_ADDOPTS" not in env
+    assert "GIT_DIR" not in env
+    assert env["PYTHONPATH"] == str(tmp_path / "src")
+    assert os.environ["PYTEST_ADDOPTS"] == "-x --reruns 5"  # caller env untouched

--- a/tests/unit/scripts/ci/test_verify_flip_bundle.py
+++ b/tests/unit/scripts/ci/test_verify_flip_bundle.py
@@ -386,9 +386,12 @@ def test_passes_on_coherent_new_flip(tmp_path: Path) -> None:
     a6 = next(o for o in result.outcomes if o.index == 6)
     assert a6.name == "reproducible-equivalence"
     assert "byte-identical" in a6.detail
-    # All six assertions recorded ok.
-    assert [o.index for o in result.outcomes] == [1, 2, 3, 4, 5, 6]
+    # All seven assertions recorded ok; 7 records the equivalence-path branch (a
+    # replay-proven flip carries no hand-flip parity block to execute).
+    assert [o.index for o in result.outcomes] == [1, 2, 3, 4, 5, 6, 7]
     assert all(o.ok for o in result.outcomes)
+    a7 = next(o for o in result.outcomes if o.index == 7)
+    assert "equivalence proof path" in a7.detail
 
 
 # --------------------------------------------------------------------------- #
@@ -576,3 +579,248 @@ def test_missing_adequacy_receipt_fails_closed_assertion_1(tmp_path: Path) -> No
     assert result.ok is False
     assert result.failed_assertion == 1
     assert "absent" in result.reason
+
+
+# --------------------------------------------------------------------------- #
+# 5. Assertion 7 (OMN-15340) — the declared parity tests must be RED on the
+#    receipt's OWN base_ref, and RED for the right reason.
+#
+# These cases prove the mechanism by EXECUTION, not by inspection: each builds a real
+# git repo, really materializes base_ref as a worktree, and really runs pytest there.
+# --------------------------------------------------------------------------- #
+
+# Hand-flip pair: `_compute` is byte-identical across the flip (verbatim-preserved);
+# only the entrypoint moves from def-A `run` to def-B `handle`.
+HANDFLIP_LEGACY_HANDLER = """# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+
+class HandlerDemoCompute:
+    def run(self, payload):
+        return self._compute(payload)
+
+    def _compute(self, payload):
+        return payload
+"""
+
+HANDFLIP_CANONICAL_HANDLER = """# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+
+class HandlerDemoCompute:
+    def handle(self, request):
+        return self._compute(request)
+
+    def _compute(self, payload):
+        return payload
+"""
+
+_PARITY_IMPORT = (
+    "from testpkg.nodes.node_demo_compute.handler import HandlerDemoCompute"
+)
+
+# GREEN case: the claim is ASSERTED, and the pre-change tree cannot satisfy it.
+PARITY_TEST_DISCRIMINATING = f"""{_PARITY_IMPORT}
+
+
+def test_handler_exposes_handle_entrypoint():
+    assert hasattr(HandlerDemoCompute, "handle"), "def-B handler must expose handle()"
+"""
+
+# RED case 1: green on HEAD *and* green on base — it discriminates nothing.
+PARITY_TEST_NON_DISCRIMINATING = f"""{_PARITY_IMPORT}
+
+
+def test_handler_class_exists():
+    assert HandlerDemoCompute is not None
+"""
+
+# RED case 2: the test cannot even be imported on the base tree.
+PARITY_TEST_IMPORT_ONLY_AT_HEAD = """from testpkg.nodes.node_demo_compute.only_at_head import MARKER
+
+
+def test_marker():
+    assert MARKER == "head"
+"""
+
+# RED case 3: fails on the base tree with AttributeError — an exception, not a claim.
+PARITY_TEST_NON_ASSERTION = f"""{_PARITY_IMPORT}
+
+
+def test_handle_returns_request():
+    assert HandlerDemoCompute().handle("x") == "x"
+"""
+
+PARITY_TEST_REL = "tests/test_parity_demo.py"
+
+
+def build_handflip_repo(tmp_path: Path, parity_test_source: str) -> FlipRepo:
+    """A real 3-commit repo carrying a NEW HAND-FLIP (not an equivalence replay).
+
+    commit0: legacy def-A handler + contract + baseline (node non-canonical).
+    commit1: pre-flip anchor == base_ref (of BOTH the gate and the hand-flip receipt).
+    commit2: the flip — def-B handler, the candidate parity test, the adequacy receipt
+             and the hand-flip proof, and the baseline shrink.
+
+    No equivalence artifact is written, so ``verify_flip_receipt`` takes the hand-flip
+    path and assertion 6 records the exempt branch — assertion 7 is the one under test.
+    """
+    root = tmp_path / "repo"
+    src_root = root / "src"
+    node_dir = src_root / "testpkg" / "nodes" / "node_demo_compute"
+    receipts_dir = root / "scripts" / "ci" / "adequacy_receipts"
+    baseline_path = root / "scripts" / "ci" / "canonical_handler_shape_baseline.py"
+    handler_file = node_dir / "handler.py"
+    contract_file = node_dir / "contract.yaml"
+
+    root.mkdir(parents=True)
+    _git(root, "init", "-q")
+
+    _write(contract_file, SINGLE_BINDING_CONTRACT)
+    _write(handler_file, HANDFLIP_LEGACY_HANDLER)
+    _write(baseline_path, 'NON_CANONICAL = ("testpkg.nodes.node_demo_compute",)\n')
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base state (def-A)", author=AUTHOR_X)
+    anchor_x = _git(root, "rev-parse", "HEAD")
+
+    _write(root / "docs" / "anchor.md", "pre-flip base\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "pre-flip anchor", author=AUTHOR_Y)
+    base_ref = _git(root, "rev-parse", "HEAD")
+
+    _write(handler_file, HANDFLIP_CANONICAL_HANDLER)
+    _ruff_format(handler_file)
+    _write(node_dir / "only_at_head.py", 'MARKER = "head"\n')
+    _write(root / PARITY_TEST_REL, parity_test_source)
+    handler_sha = _sha256_file(handler_file)
+    _write(
+        receipts_dir / f"{NODE_ID}.json",
+        json.dumps(_adequacy_receipt(handler_sha, [_DUMMY_INPUT_HASH]), indent=2),
+    )
+    _write(
+        receipts_dir / f"{NODE_ID}.handflip.json",
+        json.dumps(
+            {
+                "receipt_schema": "handflip_proof.v1",
+                "node_id": NODE_ID,
+                "canonical_handler_module": "testpkg.nodes.node_demo_compute.handler",
+                "legacy_handler_module": "testpkg.nodes.node_demo_compute.handler",
+                "base_ref": base_ref,
+                "preserved_symbols": ["HandlerDemoCompute._compute"],
+                "parity": {
+                    "test_ids": [
+                        f"{PARITY_TEST_REL}::{_first_test_name(parity_test_source)}"
+                    ],
+                    "status": "pass",
+                    "selected_input_hashes": [_DUMMY_INPUT_HASH],
+                },
+            },
+            indent=2,
+        ),
+    )
+    _write(baseline_path, "NON_CANONICAL = ()\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "hand-flip to canonical def-B", author=AUTHOR_X)
+    def_b_commit = _git(root, "rev-parse", "HEAD")
+
+    return FlipRepo(
+        root=root,
+        src_root=src_root,
+        receipts_dir=receipts_dir,
+        baseline_path=baseline_path,
+        handler_file=handler_file,
+        contract_file=contract_file,
+        base_ref=base_ref,
+        anchor_x=anchor_x,
+        def_b_commit=def_b_commit,
+    )
+
+
+def _first_test_name(source: str) -> str:
+    for line in source.splitlines():
+        if line.startswith("def test_"):
+            return line[len("def ") : line.index("(")]
+    raise AssertionError("fixture parity test declares no test function")
+
+
+def test_handflip_with_red_on_base_parity_passes_assertion_7(tmp_path: Path) -> None:
+    """GENUINE RED-on-base bundle -> assertion 7 PASSES (the mechanism's GREEN)."""
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_DISCRIMINATING)
+
+    result = _run(repo)
+
+    assert result.ok, result.reason
+    assert [o.index for o in result.outcomes] == [1, 2, 3, 4, 5, 6, 7]
+    a6 = next(o for o in result.outcomes if o.index == 6)
+    assert "hand-flip proof path" in a6.detail
+    a7 = next(o for o in result.outcomes if o.index == 7)
+    assert a7.name == "parity-red-on-base"
+    assert "RED on their own assertion" in a7.detail
+    assert "resolves inside the base worktree" in a7.detail  # non-vacuity proven
+
+
+def test_handflip_with_already_green_parity_fails_assertion_7(tmp_path: Path) -> None:
+    """The attack: a parity test that is ALREADY GREEN on base proves nothing.
+
+    It passes on HEAD, so assertions 1-6 (including the executed HEAD parity run) are
+    all satisfied. Only assertion 7 can see that it never discriminated the flip.
+    """
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_NON_DISCRIMINATING)
+
+    result = _run(repo)
+
+    assert result.ok is False
+    assert result.failed_assertion == 7, result.reason
+    assert "passed" in result.reason
+    assert "NOT RED-for-the-right-reason" in result.reason
+
+
+def test_handflip_parity_uncollectable_on_base_fails_assertion_7(
+    tmp_path: Path,
+) -> None:
+    """A test that cannot even import on the base tree is not RED — it is absent."""
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_IMPORT_ONLY_AT_HEAD)
+
+    result = _run(repo)
+
+    assert result.ok is False
+    assert result.failed_assertion == 7, result.reason
+    assert "collection_error" in result.reason
+    # Distinct from the already-green rejection above.
+    assert "passed" not in result.reason
+
+
+def test_handflip_parity_non_assertion_failure_fails_assertion_7(
+    tmp_path: Path,
+) -> None:
+    """AttributeError on the base tree is an incompatibility, not a discriminating claim."""
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_NON_ASSERTION)
+
+    result = _run(repo)
+
+    assert result.ok is False
+    assert result.failed_assertion == 7, result.reason
+    assert "red_exception" in result.reason
+
+
+def test_handflip_forged_parity_status_fails_when_executed(tmp_path: Path) -> None:
+    """OMN-15340 half 2: a ``status: pass`` string over a RED HEAD test is rejected.
+
+    The declared test is edited to fail on HEAD while the receipt still claims
+    ``pass``. Pre-OMN-15340 the gate credited the string; now the executed HEAD run
+    is the evidence and assertion 2 (``verify_flip_receipt``) rejects.
+    """
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_DISCRIMINATING)
+    (repo.root / PARITY_TEST_REL).write_text(
+        PARITY_TEST_DISCRIMINATING.replace(
+            'assert hasattr(HandlerDemoCompute, "handle")',
+            'assert hasattr(HandlerDemoCompute, "never_exists")',
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(repo)
+
+    assert result.ok is False
+    assert result.failed_assertion == 2, result.reason
+    assert "NOT GREEN when executed" in result.reason


### PR DESCRIPTION
## OMN-15340 — assertion 7: execute the declared parity tests against the receipt's own `base_ref`

Child of OMN-14355. Sibling of OMN-14809 (the six assertions) and OMN-14905 (assertion 6 rework).

### The gap this closes

"RED to GREEN for the right reason" was **prose**. Nothing in CI — in any repo — executed a
candidate test against the pre-change tree. On the hand-flip proof path the gate read a string:

```python
# scripts/ci/canonical_handler_shape.py, verify_handflip_proof (before)
if parity.get("status") != "pass":
    return False, f"parity tests status={parity.get('status')!r}", []
test_ids = parity.get("test_ids")          # counted, never executed
```

`status` is written by the flip author. `test_ids` were counted for non-emptiness. So two failure
modes were invisible:

1. the declared tests are not green on HEAD at all (the string is fabricated);
2. the declared tests are **already green on the pre-change tree** — they never discriminated the
   def-A → def-B transition, so their green run proves nothing about behavior transfer.

Mode 2 is the one that matters, and the census below shows it is the *normal* state of the existing
population, not a hypothetical.

### What ships

**1. `scripts/ci/parity_replay.py` — the executed-parity engine.**

- One pytest process per declared id, with **distinguished** exit reasons
  (`EnumParityOutcome`): `RED_ASSERTION` / `RED_EXCEPTION` / `PASSED` / `SKIPPED` /
  `COLLECTION_ERROR` / `NOT_COLLECTED` / `RUNNER_ERROR`. One process per id is deliberate — a
  collection error aborts a whole pytest session (`Interrupted`), so batching would let one broken
  file mask every other id's real outcome.
- Only `RED_ASSERTION` counts. An `ImportError` at collection means the test cannot even run
  against the old code, which is exactly as much evidence as no test at all
  (`feedback_prove_red_against_exists_but_wrong`). A call-phase `AttributeError` is likewise not a
  discriminating claim — it is indistinguishable from a test that is merely incompatible with the
  base tree — so it is rejected with its own reason rather than counted as RED.
- `-o addopts=` neutralizes the repo's ini addopts. An ambient `--reruns` would retry the exact
  RED being measured into a PASS.
- **Non-vacuity probe (load-bearing).** The base run only means something if the BASE source is
  what actually gets imported; a canonical clone's editable `.pth` otherwise resolves the package
  to HEAD and *both* the RED and the GREEN become meaningless
  (`reference_pythonpath_shadows_worktree_source`). `red_on_base` pins `PYTHONPATH` to the base
  worktree's source root and then probes the legacy handler module's resolved `__file__`, failing
  closed unless it lives under the base worktree.
- Inherited `PYTEST_ADDOPTS` / `PYTHONPATH` / `GIT_DIR`-class env is stripped from every
  subprocess (`reference_git_env_vars_override_c_and_cwd`).

**2. `canonical_handler_shape.verify_handflip_proof` stops crediting `parity.status`.** A
`ParityExecutor` seam is injected; the default executor really runs pytest on HEAD. A claimed
`pass` must EXECUTE green or the hand-flip proof is REJECTED (`UNEXECUTED` / `NOT GREEN when
executed`). A self-declared **non**-`pass` remains a hard fail — a confession is trustworthy in the
negative direction only. The success reason now names it: `parity-executed-green(N test id(s))`.

**3. `verify_flip_bundle` assertion 7 `parity-red-on-base`.** Hand-flip path only (the equivalence
path carries no parity block and is covered by assertion 6's deterministic rerun), NEW flips only
(same newness rule as assertion 6 — a proof artifact present at the git base is grandfathered).
Materializes the receipt's own `base_ref` as a detached worktree, overlays the HEAD copies of the
declared test files onto that pre-change tree, and requires every declared id to be
RED-on-its-own-assertion there.

### Proof by EXECUTION, not inspection

Every case below builds a real git repo, really materializes `base_ref` as a worktree, and really
runs pytest there (`tests/unit/scripts/ci/test_verify_flip_bundle.py`):

| Seeded bundle | Declared parity test at `base_ref` | Expected | Result |
| -- | -- | -- | -- |
| genuine hand-flip | `assert hasattr(Handler, "handle")` → fails on its own assertion | assertion 7 PASSES | PASS |
| **already-green-on-base** | `assert Handler is not None` → passes | assertion 7 FAILS | FAIL, reason names `passed` |
| new-module import | `from ...only_at_head import MARKER` → ImportError | FAILS, distinct reason | FAIL, `collection_error` |
| non-assertion failure | `Handler().handle("x")` → AttributeError | FAILS, distinct reason | FAIL, `red_exception` |
| forged `status: pass` over a RED HEAD test | — | assertion 2 rejects | FAIL, `NOT GREEN when executed` |

Plus `tests/unit/scripts/ci/test_parity_replay.py`: the full 7-way classification matrix pinned by
real pytest runs, both directions of the residency probe (including the explicit
`VACUOUS BASE RUN` rejection), and the fail-closed paths (unresolvable `base_ref`, no `test_ids`,
no git root, inherited-env stripping).

```
uv run pytest tests/unit/scripts/ci/test_parity_replay.py \
              tests/unit/scripts/ci/test_verify_flip_bundle.py \
              tests/unit/scripts/ci/test_canonical_handler_shape.py -o addopts= -q
86 passed in 21.06s          # run on .200 (stickybeatz-studio), rule 11a
```

Host discipline: edits were made on the Mac and **patch-transferred** to `.200`; the three gate
modules were `sha256`-compared across hosts before the suite ran there, so the green is not a
vacuous green on an unedited copy (`reference_200_edits_land_locally_not_over_ssh`). The push came
from `.200`.

### Wiring in the SAME PR (rule 5)

This **hardens an existing gate** rather than minting a new surface, so the net-negative-surface
rule is satisfied by construction — no new CI job, no new hook, no new dashboard. Assertion 7 ships
inside the already-required `verify_flip_bundle` invocation:

- `.github/workflows/ci.yml` — the existing `Run canonical-shape flip-bundle seam gate` step in the
  blocking quality-gate job now carries assertion 7 (step docs updated).
- `.pre-commit-config.yaml` — the existing `verify-flip-bundle` pre-push hook likewise; its `files:`
  pattern is extended to `scripts/ci/parity_replay\.py` so editing the engine re-runs the gate.

### Advisory census — 21 of 22 existing hand-flip receipts would FAIL assertion 7

Measured, not estimated: assertion 7 executed against **every** committed `*.handflip.json` in
omnibase_infra (15) and omnimarket (7), newness/grandfathering bypassed.

| | |
| -- | -- |
| receipts passing assertion 7 | **1 / 22** (`omnimarket.nodes.node_occ_companion_compute`) |
| declared parity ids that are NOT red-on-their-own-assertion at their own `base_ref` | **102 / 126** |
| nodes with ≥1 id that **PASSES** on the pre-change tree | ≥ 9 |
| nodes with ≥1 id that fails on a non-assertion exception | ≥ 13 |
| nodes with ≥1 id that cannot be collected on the base tree | ≥ 5 |

(The last three are lower bounds: the failure detail renders the first five offenders per node and
8 nodes truncated. The 1/22 and 102/126 figures are exact.)

The dominant real-world shape is `ModelOnexError: Auto-wired handler ...` raised at the base tree —
a genuine incompatibility, but not an asserted claim. **Nothing in this PR retro-fails these.**
Assertion 7 only runs on flips that are NEW versus the git base, so the existing population is out
of scope by construction.

**Proposed ratchet posture (not implemented here — needs a decision):**

1. Land assertion 7 forward-only, as here. Every NEW hand-flip must carry parity tests that assert
   the transition.
2. Then ratchet the existing population shrink-only: freeze the 21 failing node ids in an explicit
   baseline (mirroring `NON_CANONICAL`), hard-fail any growth, and burn the list down as those
   nodes are next touched. A frozen list is honest debt; silence is not.
3. Decide separately whether `RED_EXCEPTION` should ever be admitted. This PR says no — an
   exception is not a discriminating claim — and that single choice accounts for the largest slice
   of the census. Admitting it would raise the pass rate substantially and weaken the assertion;
   the strict line is the recommendation.

### Seams touched

| Seam | Before | After |
| -- | -- | -- |
| `verify_handflip_proof(node_id, handler_module)` | positional 2-arg | `+ keyword-only parity_executor: ParityExecutor \| None` |
| `verify_flip_receipt(node_id, handler_module)` | positional 2-arg | `+ keyword-only parity_executor` (pass-through) |
| hand-flip proof acceptance | `parity.status == "pass"` | executed green-on-HEAD verdict |
| `ModelFlipBundleResult.outcomes` | indices 1..6 | indices 1..7 |
| `_flip_proof_is_new(...)` | equivalence suffix hardcoded | `+ optional suffix` param |

Cross-repo blast radius: omnibase_infra and omnimarket invoke `canonical_handler_shape.py` from
this repo in their own CI, so their **next hand-flip PR** must have executable, green parity tests.
Non-flipping PRs are unaffected (`verify_flip_receipt` runs only for nodes leaving the baseline).

### Residuals (explicitly open)

- `verify_flip_bundle` itself is wired in omnibase_core only; omnibase_infra/omnimarket run the
  ratchet but not the bundle gate, and omnibase_core has zero hand-flip receipts — so assertion 7 is
  a no-op inside *this* repo's CI today. It becomes load-bearing on the fan-out lanes, which is a
  per-repo wiring follow-up, not something this PR can land alone.
- Assertion 7 needs the receipt's `base_ref` object present. On a shallow CI checkout it attempts a
  targeted `git fetch --depth=1 origin <ref>` and then FAILS CLOSED. That is the intended posture,
  but a repo whose CI cannot reach an old base_ref will see a red gate rather than a skip.
- Dependencies for the base-tree run come from the target repo's HEAD venv while the *source* comes
  from the base worktree. The assertion is about the source transition; a dependency-version-driven
  behavior change at base is out of its reach.
- Pre-existing, NOT caused by this change: 8 `tests/unit/scripts/ci/test_detect_test_paths*` tests
  fail in a fresh worktree at `origin/dev` with this branch's changes stashed, and pass in the
  canonical clone. Recorded here as an observation; unrelated to this diff.

`proof_class`: **code-only** at authoring → **receipt-bound** once this PR's own CI runs the gate.

Evidence-Ticket: OMN-15340
Evidence-Source: OCC#5366
