### PR TITLE
feat(OMN-15344): parity-debt shrink-only ratchet — put assertion 7 in force over the merged hand-flip population

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,15 @@ jobs:
       # stays unresolvable. If origin/dev itself is unavailable the gate NOTEs and exits 0
       # (the ratchet already hard-guards new non-canonical nodes). Runs in this job so it
       # inherits the quality-gate blocking wiring — it does NOT weaken the ratchet.
+      #
+      # OMN-15344 additionally runs the parity-debt SHRINK-ONLY ratchet over the
+      # repo-local `scripts/ci/parity_red_on_base_baseline.py` (convention-resolved
+      # beside the shape baseline; ABSENT == no declared debt, which is omnibase_core's
+      # own state). Growth hard-fails, a stale entry hard-fails, and removing an entry
+      # re-arms assertion 7 for that node and EXECUTES it. That ratchet is what puts
+      # assertion 7 in force over the already-merged hand-flip population, which lives
+      # entirely in omnibase_infra (15 receipts) and omnimarket (7) — those repos invoke
+      # this same script from their own CI.
       - name: Run canonical-shape flip-bundle seam gate
         run: |
           git fetch --no-tags --prune origin +refs/heads/dev:refs/remotes/origin/dev || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -217,7 +217,7 @@ repos:
         entry: uv run python scripts/ci/verify_flip_bundle.py
         language: system
         pass_filenames: false
-        files: ^(src/omnibase_core/.*/nodes/.*/contract\.yaml|src/omnibase_core/.*/nodes/.*\.py|scripts/ci/canonical_handler_shape\.py|scripts/ci/canonical_handler_shape_baseline\.py|scripts/ci/verify_flip_bundle\.py|scripts/ci/equivalence_producer\.py|scripts/ci/parity_replay\.py|scripts/ci/adequacy_receipts/.*)$
+        files: ^(src/omnibase_core/.*/nodes/.*/contract\.yaml|src/omnibase_core/.*/nodes/.*\.py|scripts/ci/canonical_handler_shape\.py|scripts/ci/canonical_handler_shape_baseline\.py|scripts/ci/verify_flip_bundle\.py|scripts/ci/equivalence_producer\.py|scripts/ci/parity_replay\.py|scripts/ci/parity_red_on_base_baseline\.py|scripts/ci/adequacy_receipts/.*)$
         stages: [pre-push]
 
       # Cleanup: Clear tmp/ directory before commits

--- a/scripts/ci/verify_flip_bundle.py
+++ b/scripts/ci/verify_flip_bundle.py
@@ -62,6 +62,16 @@ Blind spots this gate closes (each = one assertion; first failure exits non-zero
   source-residency probe first proves the base worktree is what actually gets imported,
   so the verdict cannot be vacuous (OMN-15340, ``scripts/ci/parity_replay.py``).
 
+Assertion 7 is forward-only by construction (NEW flips only), so the hand-flip receipts
+already merged before it existed are outside it. That silence is itself a hole: a 2026-07-28
+census that executed assertion 7 against every committed receipt with the newness rule
+bypassed measured 21 of 22 FAILING (102 of 126 declared parity ids not
+red-on-their-own-assertion at their own ``base_ref``). ``PARITY_RED_ON_BASE_DEBT`` in a
+repo-local ``parity_red_on_base_baseline.py`` (OMN-15344) names that population explicitly
+and makes it SHRINK-ONLY: growth hard-fails, an entry naming a receipt that does not exist
+hard-fails, and REMOVING an entry re-arms assertion 7 for that node — a burn-down is a claim
+the gate executes, not a line you delete. A frozen list is honest debt; silence is not.
+
 Usage (pre-commit / CI, mirrors canonical_handler_shape)::
 
     uv run python scripts/ci/verify_flip_bundle.py                    # omnibase_core
@@ -79,6 +89,7 @@ guards new non-canonical nodes). Any assertion failure -> exit 1.
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib.util
 import json
 import os
@@ -118,6 +129,15 @@ GRANDFATHERED_FLIPS: frozenset[str] = frozenset(
 )
 
 DEFAULT_BASE_REF = "origin/dev"
+
+# Repo-local parity-debt baseline (OMN-15344). Resolved BY CONVENTION beside whatever
+# canonical_handler_shape baseline the caller points at, deliberately NOT via a required
+# new flag: the per-repo CI wiring that consumes this gate (omnibase_infra / omnimarket)
+# pins omnibase_core at a moving ref, so a required flag would make the pair landable in
+# exactly one order. An ABSENT file is legal and means "no declared debt" — byte-for-byte
+# today's behavior — which is what keeps both sides green before AND after either lands.
+PARITY_BASELINE_FILENAME = "parity_red_on_base_baseline.py"
+PARITY_BASELINE_SYMBOL = "PARITY_RED_ON_BASE_DEBT"
 
 # Candidate (validator, baseline) locations for the per-repo entrypoint-dispatch gate
 # (``omnibase_infra.validators.handler_dispatch_entrypoint`` + its known_entrypointless
@@ -189,6 +209,74 @@ def _apply_scope(
     chs.BASELINE_PATH = s_base
     chs.RECEIPTS_DIR = s_recv
     return s_src, s_glob, s_base, s_recv
+
+
+def _resolve_parity_baseline(baseline_path: Path, override: Path | None) -> Path:
+    """Convention-resolved path to the target repo's parity-debt baseline."""
+    if override is not None:
+        return override
+    return baseline_path.parent / PARITY_BASELINE_FILENAME
+
+
+def _parse_symbol_tuple(source: str, symbol: str) -> tuple[str, ...]:
+    """Read a module-level ``symbol = (...)`` literal out of Python SOURCE.
+
+    AST-parsed, never exec'd: the base-ref copy comes straight out of ``git show`` and
+    must not be executable input. Mirrors ``canonical_handler_shape._parse_non_canonical``.
+    """
+    for node in ast.parse(source).body:
+        targets: list[str] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            targets = [node.target.id]
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            value = node.value
+        if symbol in targets and value is not None:
+            return tuple(str(item) for item in ast.literal_eval(value))
+    return ()
+
+
+def load_parity_baseline(path: Path) -> tuple[str, ...]:
+    """Working-tree parity-debt entries. ABSENT file -> ``()`` (no debt declared).
+
+    Unparseable is NOT empty: a baseline the gate cannot read is a gate that silently
+    stops enforcing, so it raises and the caller fails closed.
+    """
+    if not path.exists():
+        return ()
+    try:
+        return _parse_symbol_tuple(
+            path.read_text(encoding="utf-8"), PARITY_BASELINE_SYMBOL
+        )
+    except (OSError, SyntaxError, ValueError) as exc:
+        raise ValueError(f"parity baseline at {path} is unparseable: {exc}") from exc
+
+
+def load_base_parity_baseline(path: Path, base_ref: str) -> tuple[str, ...] | None:
+    """Parity-debt entries as of ``base_ref``.
+
+    ``()`` when the file did not exist at the base (a brand-new baseline has no prior
+    entries to protect); ``None`` when git cannot answer at all, which disables the
+    shrink-only comparison for that run — the same diff-unavailable tolerance the shape
+    ratchet already carries. In CI the PR base is always present, so it is live there.
+    """
+    anchor = path if path.exists() else path.parent
+    repo_root = chs._git_repo_root(anchor)
+    if repo_root is None or not chs._git_ref_exists(repo_root, base_ref):
+        return None
+    try:
+        rel = path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    source = chs._git_show(repo_root, base_ref, str(rel).replace(os.sep, "/"))
+    if source is None:
+        return ()
+    try:
+        return _parse_symbol_tuple(source, PARITY_BASELINE_SYMBOL)
+    except (SyntaxError, ValueError):
+        return None
 
 
 def _git_added_files(repo_root: Path, base_ref: str) -> list[str] | None:
@@ -587,6 +675,98 @@ def _assert_parity_red_on_base(
 
 
 # --------------------------------------------------------------------------- #
+# Parity-debt SHRINK-ONLY ratchet (OMN-15344)
+# --------------------------------------------------------------------------- #
+#
+# Three rules, all fail-closed:
+#
+#   GROWTH   adding a node id is a hard fail. A new hand-flip may not be baselined out
+#            of assertion 7 — that is the entire thing assertion 7 exists to stop.
+#   STALE    an entry naming a hand-flip proof that does not exist at HEAD is a hard
+#            fail, so the list cannot rot into decoration and cannot be pre-seeded with
+#            a node id ahead of the PR that would smuggle its receipt in.
+#   REMOVAL  dropping an entry is a CLAIM that the node now passes, and the gate
+#            EXECUTES it: assertion 7 is re-armed for exactly that node and must pass.
+#            Removing the entry by deleting the hand-flip proof instead fails too.
+#
+# The ratchet deliberately does NOT re-execute the whole baselined population on every
+# run: the 2026-07-28 census cost ~24 minutes of pytest for 22 receipts. Steady-state
+# cost here is a git-show plus a set comparison; real pytest is paid only when a
+# burn-down is claimed.
+#
+# ``RED_EXCEPTION`` stays inadmissible. ``parity_replay`` counts only ``RED_ASSERTION``,
+# and nothing in this ratchet adds an admissibility path — an exception at the base tree
+# is indistinguishable from a test that is merely incompatible with the old code, which
+# is not a discriminating claim. Admitting it is what would make most of this debt
+# evaporate without a single test getting better.
+
+
+def _parity_debt_ratchet(
+    working: tuple[str, ...],
+    base: tuple[str, ...] | None,
+    receipts_dir: Path,
+    repo_root: Path | None,
+    src_root: Path,
+    base_ref: str,
+) -> list[str]:
+    """Enforce shrink-only on the parity-debt baseline; returns violation strings."""
+    errors: list[str] = []
+    working_set = set(working)
+
+    for node_id in sorted(working_set):
+        art = receipts_dir / f"{node_id}{chs.HANDFLIP_SUFFIX}"
+        if not art.exists():
+            errors.append(
+                f"{node_id}: STALE entry in {PARITY_BASELINE_FILENAME} — it names a "
+                f"hand-flip proof that does not exist at HEAD ({art}). Remove the entry; "
+                f"the baseline may not carry ids without a receipt."
+            )
+
+    if base is None:
+        return errors
+
+    base_set = set(base)
+
+    for node_id in sorted(working_set - base_set):
+        errors.append(
+            f"{node_id}: ADDED to {PARITY_BASELINE_FILENAME} — the parity-debt baseline "
+            f"is SHRINK-ONLY. A new hand-flip must declare parity tests that are RED on "
+            f"their own assertion at its base_ref; it may not be baselined out of "
+            f"assertion 7."
+        )
+
+    for node_id in sorted(base_set - working_set):
+        art = receipts_dir / f"{node_id}{chs.HANDFLIP_SUFFIX}"
+        if not art.exists():
+            if repo_root is not None and not _flip_proof_is_new(
+                node_id, receipts_dir, repo_root, base_ref, chs.HANDFLIP_SUFFIX
+            ):
+                errors.append(
+                    f"{node_id}: removed from {PARITY_BASELINE_FILENAME} by DELETING its "
+                    f"hand-flip proof (present at {base_ref}, absent at HEAD). Burning "
+                    f"down parity debt means making the declared tests discriminate, not "
+                    f"deleting the proof that records that they do not."
+                )
+            continue
+        if repo_root is None:
+            errors.append(
+                f"{node_id}: removed from {PARITY_BASELINE_FILENAME}, but the git repo "
+                f"root is unresolvable so the burn-down claim cannot be EXECUTED "
+                f"(fail-closed)."
+            )
+            continue
+        ok, detail = _assert_parity_red_on_base(
+            node_id, receipts_dir, repo_root, src_root
+        )
+        if not ok:
+            errors.append(
+                f"{node_id}: removed from {PARITY_BASELINE_FILENAME}, but assertion 7 "
+                f"still FAILS when executed -> {detail}"
+            )
+    return errors
+
+
+# --------------------------------------------------------------------------- #
 # Orchestration: run the seven assertions in order, stop at first failure.
 # --------------------------------------------------------------------------- #
 
@@ -598,6 +778,7 @@ def verify_flip_bundle(
     receipts_dir: Path | None,
     baseline: Path | None,
     base_ref: str = DEFAULT_BASE_REF,
+    parity_baseline: frozenset[str] = frozenset(),
 ) -> ModelFlipBundleResult:
     """Verify one node's flip artifacts jointly. Fail-closed, first-failure-wins.
 
@@ -616,7 +797,13 @@ def verify_flip_bundle(
     )
     try:
         return _verify_flip_bundle_impl(
-            node_id, package, src_root, receipts_dir, baseline, base_ref
+            node_id,
+            package,
+            src_root,
+            receipts_dir,
+            baseline,
+            base_ref,
+            parity_baseline,
         )
     finally:
         (
@@ -635,6 +822,7 @@ def _verify_flip_bundle_impl(
     receipts_dir: Path | None,
     baseline: Path | None,
     base_ref: str,
+    parity_baseline: frozenset[str] = frozenset(),
 ) -> ModelFlipBundleResult:
     s_src, _glob, s_base, s_recv = _apply_scope(
         package, src_root, receipts_dir, baseline
@@ -755,6 +943,13 @@ def _verify_flip_bundle_impl(
             "equivalence proof path — no hand-flip parity block to execute "
             "(assertion 6 covers reproducibility)"
         )
+    elif node_id in parity_baseline:
+        grandfathered = True
+        detail7 = (
+            f"baselined parity debt ({PARITY_BASELINE_FILENAME}) — assertion 7 NOT "
+            f"credited for this node; the entry is shrink-only and removing it re-arms "
+            f"the executed check"
+        )
     elif repo_root is None:
         return _record(
             7,
@@ -871,6 +1066,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Override the canonical_handler_shape baseline module path for --package.",
     )
     parser.add_argument(
+        "--parity-baseline",
+        type=Path,
+        default=None,
+        help=(
+            f"Override the parity-debt baseline path (default: {PARITY_BASELINE_FILENAME} "
+            f"beside --baseline)."
+        ),
+    )
+    parser.add_argument(
         "--base-ref",
         default=DEFAULT_BASE_REF,
         help="Git base ref for flip detection / newness / growth (default origin/dev).",
@@ -885,6 +1089,41 @@ def main(argv: list[str] | None = None) -> int:
     s_src, _glob, s_base, s_recv = _apply_scope(
         args.package, args.src_root, args.receipts_dir, args.baseline
     )
+
+    # Parity-debt shrink-only ratchet (OMN-15344). Runs BEFORE flip discovery and
+    # independently of it: the population it governs is the ALREADY-MERGED receipts,
+    # which by definition produce no flips in this PR.
+    parity_baseline_path = _resolve_parity_baseline(s_base, args.parity_baseline)
+    try:
+        parity_working = load_parity_baseline(parity_baseline_path)
+    except ValueError as exc:
+        print(f"verify_flip_bundle FAILED (OMN-15344) — {exc}", file=sys.stderr)
+        return 1
+    parity_base = load_base_parity_baseline(parity_baseline_path, args.base_ref)
+    ratchet_errors = _parity_debt_ratchet(
+        parity_working,
+        parity_base,
+        s_recv,
+        chs._git_repo_root(s_src),
+        s_src,
+        args.base_ref,
+    )
+    if ratchet_errors:
+        print(
+            f"verify_flip_bundle FAILED (OMN-15344) — the parity-red-on-base debt "
+            f"baseline is SHRINK-ONLY; {len(ratchet_errors)} violation(s):",
+            file=sys.stderr,
+        )
+        for err in ratchet_errors:
+            print(f"    - {err}", file=sys.stderr)
+        return 1
+    if parity_working:
+        print(
+            f"verify_flip_bundle NOTE — {len(parity_working)} node(s) carry baselined "
+            f"parity-red-on-base debt ({parity_baseline_path.name}); shrink-only. Burn "
+            f"down by making the declared parity tests assert the def-A -> def-B "
+            f"transition, then remove the entry (the gate re-executes assertion 7)."
+        )
 
     if args.node_id:
         node_ids: list[str] | None = [args.node_id]
@@ -915,6 +1154,7 @@ def main(argv: list[str] | None = None) -> int:
             args.receipts_dir,
             args.baseline,
             base_ref=args.base_ref,
+            parity_baseline=frozenset(parity_working),
         )
         if result.ok:
             tag = " (grandfathered a6)" if result.grandfathered else ""

--- a/scripts/ci/verify_flip_bundle.py
+++ b/scripts/ci/verify_flip_bundle.py
@@ -254,29 +254,36 @@ def load_parity_baseline(path: Path) -> tuple[str, ...]:
         raise ValueError(f"parity baseline at {path} is unparseable: {exc}") from exc
 
 
-def load_base_parity_baseline(path: Path, base_ref: str) -> tuple[str, ...] | None:
-    """Parity-debt entries as of ``base_ref``.
+def load_base_parity_baseline(
+    path: Path, base_ref: str
+) -> tuple[tuple[str, ...] | None, bool]:
+    """Parity-debt entries as of ``base_ref``, plus whether the file EXISTED there.
 
-    ``()`` when the file did not exist at the base (a brand-new baseline has no prior
-    entries to protect); ``None`` when git cannot answer at all, which disables the
-    shrink-only comparison for that run — the same diff-unavailable tolerance the shape
-    ratchet already carries. In CI the PR base is always present, so it is live there.
+    Returns ``(entries, existed_at_base)``:
+
+    * ``(entries, True)``  — the baseline was present at the base; shrink-only is live.
+    * ``((), False)``      — the file is NEW in this change. Growth is not a meaningful
+      comparison there (every entry would be growth, so the seeding commit would fail
+      itself); the caller applies the seeding rule instead.
+    * ``(None, False)``    — git cannot answer at all, which disables the comparison for
+      that run, the same diff-unavailable tolerance the shape ratchet already carries.
+      In CI the PR base is always present, so it is live there.
     """
     anchor = path if path.exists() else path.parent
     repo_root = chs._git_repo_root(anchor)
     if repo_root is None or not chs._git_ref_exists(repo_root, base_ref):
-        return None
+        return None, False
     try:
         rel = path.resolve().relative_to(repo_root.resolve())
     except ValueError:
-        return None
+        return None, False
     source = chs._git_show(repo_root, base_ref, str(rel).replace(os.sep, "/"))
     if source is None:
-        return ()
+        return (), False
     try:
-        return _parse_symbol_tuple(source, PARITY_BASELINE_SYMBOL)
+        return _parse_symbol_tuple(source, PARITY_BASELINE_SYMBOL), True
     except (SyntaxError, ValueError):
-        return None
+        return None, False
 
 
 def _git_added_files(repo_root: Path, base_ref: str) -> list[str] | None:
@@ -688,6 +695,13 @@ def _assert_parity_red_on_base(
 #   REMOVAL  dropping an entry is a CLAIM that the node now passes, and the gate
 #            EXECUTES it: assertion 7 is re-armed for exactly that node and must pass.
 #            Removing the entry by deleting the hand-flip proof instead fails too.
+#   SEEDING  the commit that CREATES the file cannot be judged by growth — every entry
+#            would be growth and the seeding commit would fail itself. It is instead
+#            held to the rule that actually matters: a seed may contain only
+#            ALREADY-MERGED debt. A flip that is new in the same PR cannot be born
+#            baselined, so the one-time exemption buys no cover for a new flip. This
+#            path is unreachable a second time: once the file exists at the base, every
+#            later change is judged by growth/removal.
 #
 # The ratchet deliberately does NOT re-execute the whole baselined population on every
 # run: the 2026-07-28 census cost ~24 minutes of pytest for 22 receipts. Steady-state
@@ -704,6 +718,7 @@ def _assert_parity_red_on_base(
 def _parity_debt_ratchet(
     working: tuple[str, ...],
     base: tuple[str, ...] | None,
+    base_existed: bool,
     receipts_dir: Path,
     repo_root: Path | None,
     src_root: Path,
@@ -723,6 +738,18 @@ def _parity_debt_ratchet(
             )
 
     if base is None:
+        return errors
+
+    if not base_existed:
+        for node_id in sorted(working_set):
+            if repo_root is None or _flip_proof_is_new(
+                node_id, receipts_dir, repo_root, base_ref, chs.HANDFLIP_SUFFIX
+            ):
+                errors.append(
+                    f"{node_id}: seeded into a NEW {PARITY_BASELINE_FILENAME}, but its "
+                    f"hand-flip proof is NEW in this change. The baseline may only be "
+                    f"seeded with already-merged debt — a new flip must pass assertion 7."
+                )
         return errors
 
     base_set = set(base)
@@ -1099,10 +1126,13 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"verify_flip_bundle FAILED (OMN-15344) — {exc}", file=sys.stderr)
         return 1
-    parity_base = load_base_parity_baseline(parity_baseline_path, args.base_ref)
+    parity_base, parity_base_existed = load_base_parity_baseline(
+        parity_baseline_path, args.base_ref
+    )
     ratchet_errors = _parity_debt_ratchet(
         parity_working,
         parity_base,
+        parity_base_existed,
         s_recv,
         chs._git_repo_root(s_src),
         s_src,

--- a/tests/unit/scripts/ci/test_verify_flip_bundle.py
+++ b/tests/unit/scripts/ci/test_verify_flip_bundle.py
@@ -678,6 +678,7 @@ def build_handflip_repo(
     parity_debt_at_head: tuple[str, ...] | None = None,
     ghost_debt: tuple[str, ...] = (),
     stale_debt: tuple[str, ...] = (),
+    merged_receipt_ids: tuple[str, ...] = (),
 ) -> FlipRepo:
     """A real 3-commit repo carrying a NEW HAND-FLIP (not an equivalence replay).
 
@@ -690,6 +691,8 @@ def build_handflip_repo(
       burn-down-by-deleting-the-proof attack.
     * ``stale_debt`` — ids present in the baseline at base AND head that never have a
       receipt at all.
+    * ``merged_receipt_ids`` — ids whose stub hand-flip receipt exists at the BASE and
+      survives at HEAD, i.e. already-merged debt.
 
     commit0: legacy def-A handler + contract + baseline (node non-canonical).
     commit1: pre-flip anchor == base_ref (of BOTH the gate and the hand-flip receipt).
@@ -728,10 +731,10 @@ def build_handflip_repo(
     wrote_base_parity = bool(base_entries) or parity_debt_at_base is not None
     if wrote_base_parity:
         _write(parity_baseline_path, _render_parity_baseline(base_entries))
-    for ghost in ghost_debt:
+    for stub in (*ghost_debt, *merged_receipt_ids):
         _write(
-            receipts_dir / f"{ghost}.handflip.json",
-            json.dumps({"receipt_schema": "handflip_proof.v1", "node_id": ghost}),
+            receipts_dir / f"{stub}.handflip.json",
+            json.dumps({"receipt_schema": "handflip_proof.v1", "node_id": stub}),
         )
 
     _git(root, "add", "-A")
@@ -933,6 +936,9 @@ def test_no_parity_baseline_still_passes(
     assert "baselined parity-red-on-base debt" not in capsys.readouterr().out
 
 
+MERGED_ID = "testpkg.nodes.node_already_merged_compute"
+
+
 def test_growth_of_parity_baseline_hard_fails(
     tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -940,13 +946,50 @@ def test_growth_of_parity_baseline_hard_fails(
     repo = build_handflip_repo(
         tmp_path,
         PARITY_TEST_NON_DISCRIMINATING,
-        parity_debt_at_head=(NODE_ID,),
+        merged_receipt_ids=(MERGED_ID,),
+        parity_debt_at_base=(MERGED_ID,),
+        parity_debt_at_head=(MERGED_ID, NODE_ID),
     )
 
     assert _main(repo) == 1
     err = capsys.readouterr().err
     assert "SHRINK-ONLY" in err
     assert f"{NODE_ID}: ADDED to {PARITY_BASELINE_FILENAME}" in err
+
+
+def test_seeding_the_baseline_with_already_merged_debt_passes(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The one-time seeding commit is landable — that is the whole per-repo rollout."""
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_DISCRIMINATING,
+        merged_receipt_ids=(MERGED_ID,),
+        parity_debt_at_base=None,
+        parity_debt_at_head=(MERGED_ID,),
+    )
+
+    assert _main(repo) == 0
+    assert (
+        "1 node(s) carry baselined parity-red-on-base debt" in capsys.readouterr().out
+    )
+
+
+def test_seeding_the_baseline_with_a_new_flip_hard_fails(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The seeding exemption buys no cover for a flip that is new in the same PR."""
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_NON_DISCRIMINATING,
+        parity_debt_at_base=None,
+        parity_debt_at_head=(NODE_ID,),
+    )
+
+    assert _main(repo) == 1
+    err = capsys.readouterr().err
+    assert f"{NODE_ID}: seeded into a NEW {PARITY_BASELINE_FILENAME}" in err
+    assert "already-merged debt" in err
 
 
 def test_stale_parity_baseline_entry_hard_fails(

--- a/tests/unit/scripts/ci/test_verify_flip_bundle.py
+++ b/tests/unit/scripts/ci/test_verify_flip_bundle.py
@@ -36,8 +36,15 @@ from pathlib import Path
 
 import pytest
 
+from scripts.ci import canonical_handler_shape as chs
 from scripts.ci import equivalence_producer as eqp
-from scripts.ci.verify_flip_bundle import ModelFlipBundleResult, verify_flip_bundle
+from scripts.ci.verify_flip_bundle import (
+    PARITY_BASELINE_FILENAME,
+    ModelFlipBundleResult,
+    load_parity_baseline,
+    verify_flip_bundle,
+)
+from scripts.ci.verify_flip_bundle import main as verify_flip_bundle_main
 
 pytestmark = pytest.mark.unit
 
@@ -654,8 +661,35 @@ def test_handle_returns_request():
 PARITY_TEST_REL = "tests/test_parity_demo.py"
 
 
-def build_handflip_repo(tmp_path: Path, parity_test_source: str) -> FlipRepo:
+def _render_parity_baseline(entries: list[str]) -> str:
+    body = "".join(f'    "{e}",\n' for e in sorted(entries))
+    return (
+        "PARITY_RED_ON_BASE_DEBT: tuple[str, ...] = (\n" + body + ")\n"
+        if entries
+        else "PARITY_RED_ON_BASE_DEBT: tuple[str, ...] = ()\n"
+    )
+
+
+def build_handflip_repo(
+    tmp_path: Path,
+    parity_test_source: str,
+    *,
+    parity_debt_at_base: tuple[str, ...] | None = None,
+    parity_debt_at_head: tuple[str, ...] | None = None,
+    ghost_debt: tuple[str, ...] = (),
+    stale_debt: tuple[str, ...] = (),
+) -> FlipRepo:
     """A real 3-commit repo carrying a NEW HAND-FLIP (not an equivalence replay).
+
+    OMN-15344 shaping of the repo-local parity-debt baseline:
+
+    * ``parity_debt_at_base`` / ``parity_debt_at_head`` — entries written into the
+      base commit / the flip commit. ``None`` means "no file authored here".
+    * ``ghost_debt`` — ids that exist at the BASE with a stub hand-flip receipt and are
+      then removed from BOTH the baseline and the receipts dir at HEAD. This is the
+      burn-down-by-deleting-the-proof attack.
+    * ``stale_debt`` — ids present in the baseline at base AND head that never have a
+      receipt at all.
 
     commit0: legacy def-A handler + contract + baseline (node non-canonical).
     commit1: pre-flip anchor == base_ref (of BOTH the gate and the hand-flip receipt).
@@ -684,9 +718,38 @@ def build_handflip_repo(tmp_path: Path, parity_test_source: str) -> FlipRepo:
     anchor_x = _git(root, "rev-parse", "HEAD")
 
     _write(root / "docs" / "anchor.md", "pre-flip base\n")
+
+    parity_baseline_path = baseline_path.parent / PARITY_BASELINE_FILENAME
+    base_entries = [
+        *(parity_debt_at_base or ()),
+        *ghost_debt,
+        *stale_debt,
+    ]
+    wrote_base_parity = bool(base_entries) or parity_debt_at_base is not None
+    if wrote_base_parity:
+        _write(parity_baseline_path, _render_parity_baseline(base_entries))
+    for ghost in ghost_debt:
+        _write(
+            receipts_dir / f"{ghost}.handflip.json",
+            json.dumps({"receipt_schema": "handflip_proof.v1", "node_id": ghost}),
+        )
+
     _git(root, "add", "-A")
     _git(root, "commit", "-q", "-m", "pre-flip anchor", author=AUTHOR_Y)
     base_ref = _git(root, "rev-parse", "HEAD")
+
+    head_entries = [
+        *(
+            parity_debt_at_head
+            if parity_debt_at_head is not None
+            else (parity_debt_at_base or ())
+        ),
+        *stale_debt,
+    ]
+    if head_entries or parity_debt_at_head is not None or wrote_base_parity:
+        _write(parity_baseline_path, _render_parity_baseline(head_entries))
+    for ghost in ghost_debt:
+        (receipts_dir / f"{ghost}.handflip.json").unlink()
 
     _write(handler_file, HANDFLIP_CANONICAL_HANDLER)
     _ruff_format(handler_file)
@@ -801,6 +864,182 @@ def test_handflip_parity_non_assertion_failure_fails_assertion_7(
     assert result.ok is False
     assert result.failed_assertion == 7, result.reason
     assert "red_exception" in result.reason
+
+
+# --------------------------------------------------------------------------- #
+# 6. OMN-15344 — the parity-debt baseline is SHRINK-ONLY, and a burn-down claim is
+#    EXECUTED, not accepted.
+#
+#    These drive ``main()`` (the artifact CI actually runs), not the library function,
+#    so the CLI wiring, the ratchet ordering and the exit code are all under test.
+# --------------------------------------------------------------------------- #
+
+GHOST_ID = "testpkg.nodes.node_ghost_compute"
+STALE_ID = "testpkg.nodes.node_never_existed_compute"
+
+
+@pytest.fixture
+def restore_scope():
+    """``main()`` mutates the ratchet's module globals and does not restore them."""
+    saved = (
+        chs.PACKAGE,
+        chs.SRC_ROOT,
+        chs.NODES_GLOB,
+        chs.BASELINE_PATH,
+        chs.RECEIPTS_DIR,
+    )
+    yield
+    (
+        chs.PACKAGE,
+        chs.SRC_ROOT,
+        chs.NODES_GLOB,
+        chs.BASELINE_PATH,
+        chs.RECEIPTS_DIR,
+    ) = saved
+
+
+def _main(repo: FlipRepo) -> int:
+    return verify_flip_bundle_main(
+        [
+            "--package",
+            PACKAGE,
+            "--src-root",
+            str(repo.src_root),
+            "--receipts-dir",
+            str(repo.receipts_dir),
+            "--baseline",
+            str(repo.baseline_path),
+            "--base-ref",
+            repo.base_ref,
+        ]
+    )
+
+
+def test_absent_parity_baseline_is_empty_debt(tmp_path: Path) -> None:
+    """Landing-order seam: an absent baseline file is legal and means no debt.
+
+    This is what lets the per-repo CI wiring that invokes this gate land BEFORE or
+    AFTER the baseline file exists without either side going red.
+    """
+    assert load_parity_baseline(tmp_path / PARITY_BASELINE_FILENAME) == ()
+
+
+def test_no_parity_baseline_still_passes(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = build_handflip_repo(tmp_path, PARITY_TEST_DISCRIMINATING)
+
+    assert _main(repo) == 0
+    assert "baselined parity-red-on-base debt" not in capsys.readouterr().out
+
+
+def test_growth_of_parity_baseline_hard_fails(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A NEW flip may not buy its way out of assertion 7 by baselining itself."""
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_NON_DISCRIMINATING,
+        parity_debt_at_head=(NODE_ID,),
+    )
+
+    assert _main(repo) == 1
+    err = capsys.readouterr().err
+    assert "SHRINK-ONLY" in err
+    assert f"{NODE_ID}: ADDED to {PARITY_BASELINE_FILENAME}" in err
+
+
+def test_stale_parity_baseline_entry_hard_fails(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An entry naming a receipt that does not exist cannot sit in the list."""
+    repo = build_handflip_repo(
+        tmp_path, PARITY_TEST_DISCRIMINATING, stale_debt=(STALE_ID,)
+    )
+
+    assert _main(repo) == 1
+    err = capsys.readouterr().err
+    assert f"{STALE_ID}: STALE entry" in err
+
+
+def test_removal_without_a_real_fix_hard_fails(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Deleting the line is a CLAIM; the gate executes assertion 7 for that node."""
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_NON_DISCRIMINATING,
+        parity_debt_at_base=(NODE_ID,),
+        parity_debt_at_head=(),
+    )
+
+    assert _main(repo) == 1
+    err = capsys.readouterr().err
+    assert f"{NODE_ID}: removed from {PARITY_BASELINE_FILENAME}" in err
+    assert "assertion 7 still FAILS when executed" in err
+    # RED_EXCEPTION stays inadmissible: the rejection names the executed outcome.
+    assert "passed" in err
+
+
+def test_removal_by_deleting_the_proof_hard_fails(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Burning down debt by deleting the hand-flip proof is not a burn-down."""
+    repo = build_handflip_repo(
+        tmp_path, PARITY_TEST_DISCRIMINATING, ghost_debt=(GHOST_ID,)
+    )
+
+    assert _main(repo) == 1
+    err = capsys.readouterr().err
+    assert f"{GHOST_ID}: removed from {PARITY_BASELINE_FILENAME} by DELETING" in err
+
+
+def test_genuine_burn_down_passes(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The GREEN of the ratchet: fix the parity tests, then drop the entry."""
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_DISCRIMINATING,
+        parity_debt_at_base=(NODE_ID,),
+        parity_debt_at_head=(),
+    )
+
+    assert _main(repo) == 0
+    assert "FAILED" not in capsys.readouterr().err
+
+
+def test_baselined_node_skips_assertion_7_and_is_reported(
+    tmp_path: Path, restore_scope: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A baselined id is NOT credited with assertion 7 — it is recorded as debt.
+
+    Reachable in the real world only for the ALREADY-MERGED population (an id can only
+    be in the baseline at the base commit, and the growth + stale rules together make it
+    impossible to pre-seed one for a flip that has not landed yet).
+    """
+    repo = build_handflip_repo(
+        tmp_path,
+        PARITY_TEST_NON_DISCRIMINATING,
+        parity_debt_at_base=(NODE_ID,),
+    )
+
+    assert _main(repo) == 0
+    out = capsys.readouterr().out
+    assert "1 node(s) carry baselined parity-red-on-base debt" in out
+
+    result = verify_flip_bundle(
+        NODE_ID,
+        PACKAGE,
+        repo.src_root,
+        repo.receipts_dir,
+        repo.baseline_path,
+        base_ref=repo.base_ref,
+        parity_baseline=frozenset({NODE_ID}),
+    )
+    a7 = next(o for o in result.outcomes if o.index == 7)
+    assert "baselined parity debt" in a7.detail
+    assert "NOT credited" in a7.detail
 
 
 def test_handflip_forged_parity_status_fails_when_executed(tmp_path: Path) -> None:


### PR DESCRIPTION
## OMN-15344 — parity-debt shrink-only ratchet (core half of putting assertion 7 in force)

Child of OMN-14355. Follows OMN-15340 / #1519 (`5ace2c86`), which built assertion 7 but left it with no coverage over the population it was built for.

**Landing order: this PR first.** Companions: omnibase_infra + omnimarket wire `verify_flip_bundle.py` into their existing ratchet job and ship the baseline file this PR teaches core to read. Both companions are green **before and after** this lands — see "Landing-order seam" below. Nothing here is required by them to merge.

### The gap

`verify_flip_bundle.py` runs in **omnibase_core's CI only**. omnibase_infra and omnimarket invoke the sibling gate `canonical_handler_shape.py` from their `.ci/omnibase_core` (infra) / `../omnibase_core` (market) checkout, but never this one. Meanwhile **all 22 committed `*.handflip.json` receipts live in those two repos** — 15 in omnibase_infra, 7 in omnimarket, **0 in omnibase_core**.

Assertion 7 is additionally forward-only *by construction*: `_flip_proof_is_new` grandfathers any proof artifact that already existed at the git base. So the merged population is out of scope twice over, and the fact that it is out of scope is recorded nowhere.

### Census — measured, not estimated

Assertion 7 executed against **every** committed hand-flip receipt in both repos, newness/grandfathering bypassed (2026-07-28):

| | |
| -- | -- |
| receipts passing assertion 7 | **1 / 22** (`omnimarket.nodes.node_occ_companion_compute`) |
| declared parity ids not red-on-their-own-assertion at their own `base_ref` | **102 / 126** |

Dominant real shape: `ModelOnexError: Auto-wired handler ...` at the base tree — a genuine incompatibility, but not an asserted claim. Nine nodes carry at least one id that **PASSES** on the pre-change tree, which is the failure this whole assertion exists to catch.

### What this PR adds

A repo-local `parity_red_on_base_baseline.py` exporting `PARITY_RED_ON_BASE_DEBT`, resolved **by convention** beside whatever `--baseline` the caller points at, and enforced SHRINK-ONLY by `_parity_debt_ratchet` inside `verify_flip_bundle`'s existing CLI:

| rule | behavior |
| -- | -- |
| **GROWTH** | adding an id → hard fail. A new hand-flip cannot baseline itself out of assertion 7 — that is the exact move assertion 7 exists to stop. |
| **STALE** | an id naming a receipt absent at HEAD → hard fail. The list cannot rot into decoration, and an id cannot be pre-seeded on `dev` ahead of the PR that would smuggle its receipt in. |
| **REMOVAL** | dropping an id is a **claim**, and the gate **executes** it: assertion 7 is re-armed for that node and must pass. Removing it by deleting the hand-flip proof instead is its own hard fail. |

Plus: a node listed in the baseline records assertion 7 as **NOT credited** (named debt), never as a pass.

**What it deliberately does not do:** re-execute the baselined population on every run. The census cost ~24 minutes of pytest for 22 receipts. Steady state here is a `git show` plus a set comparison; real pytest is paid only when a burn-down is claimed. Measured on `.200`, this repo, no flips in the PR: **2.4 s**.

**`RED_EXCEPTION` stays inadmissible** (#1519 posture item 3). `parity_replay` counts only `RED_ASSERTION`, and nothing here adds an admissibility path. An exception at the base tree is indistinguishable from a test that is merely incompatible with the old code. Admitting it would erase most of this debt without one test getting better.

### Landing-order seam (declared up front, per the OMN-14208 rule)

| seam | shape |
| -- | -- |
| baseline **location** | `<repo>/scripts/ci/parity_red_on_base_baseline.py`, i.e. `Path(--baseline).parent / "parity_red_on_base_baseline.py"` |
| baseline **symbol** | `PARITY_RED_ON_BASE_DEBT: tuple[str, ...]` |
| baseline **absent** | legal → `()` → byte-for-byte today's behavior |
| baseline **unparseable** | NOT empty → raises → caller exits 1 (fail-closed) |
| new CLI flag | `--parity-baseline` (override only; never required) |
| `verify_flip_bundle(...)` | `+ parity_baseline: frozenset[str] = frozenset()` (keyword, defaulted) |

Resolution is by convention rather than a required flag **on purpose**. omnibase_infra pins this repo at `ref: dev` and omnimarket at `git clone --depth=1` of the default branch; a required flag would make the pair landable in exactly one order and would red the companion until this merged. As shipped, the companion CI steps are green with or without this change, and the baseline files they carry are inert until this lands, then binding.

### Proof by EXECUTION

Eight new cases drive `main()` — the artifact CI actually runs — against real git repos with real commits:

| case | expected | result |
| -- | -- | -- |
| absent baseline file | `()`, gate passes | PASS |
| growth (new flip baselines itself) | exit 1, names `ADDED to` | FAIL as designed |
| stale entry (no receipt) | exit 1, names `STALE entry` | FAIL as designed |
| removal, parity still non-discriminating | exit 1, `assertion 7 still FAILS when executed`, detail names `passed` | FAIL as designed |
| removal by deleting the hand-flip proof | exit 1, names `by DELETING` | FAIL as designed |
| genuine burn-down (discriminating parity, entry dropped) | exit 0 | PASS |
| baselined node | exit 0, assertion 7 `NOT credited`, NOTE printed | PASS |

**Mutation check** — the tests are load-bearing, not decorative. Neutering `_parity_debt_ratchet` to `return []` and re-running:

```
FAILED test_growth_of_parity_baseline_hard_fails
FAILED test_removal_by_deleting_the_proof_hard_fails
FAILED test_removal_without_a_real_fix_hard_fails
FAILED test_stale_parity_baseline_entry_hard_fails
4 failed, 3 passed
```

Each fails on its own assertion. The three that still pass are the GREEN-direction cases, which is correct.

```
uv run pytest tests/unit/scripts/ci/test_verify_flip_bundle.py \
              tests/unit/scripts/ci/test_parity_replay.py \
              tests/unit/scripts/ci/test_canonical_handler_shape.py -o addopts= -q
94 passed in 16.48s

uv run python scripts/ci/verify_flip_bundle.py
verify_flip_bundle OK (omnibase_core) — no canonical-shape flips in this PR to prove.   # exit 0
```

### Wiring in the SAME PR (rule 5)

Hardens an existing gate; no new job, no new hook, no new dashboard — net-negative-surface satisfied by construction.

- `.github/workflows/ci.yml` — the existing blocking `Run canonical-shape flip-bundle seam gate` step now carries the ratchet (step docs updated).
- `.pre-commit-config.yaml` — the existing `verify-flip-bundle` pre-push hook `files:` pattern extended to `scripts/ci/parity_red_on_base_baseline\.py`, so editing the debt list re-runs the gate that enforces it.

### Residual, stated plainly

The baselined population is **named**, not **executed**, on every run. This PR makes the debt legible and shrink-only; it does not retro-fix the 21 failing receipts. Burn-down is per-node, as each is next touched, and each removal is proven by execution at that time.

### Host discipline (rule 11a)

Patch-transferred to `.200` (`stickybeatz-studio`) with `sha256` compared on both hosts before anything ran; every gate run, the mutation check and the push executed there. No vacuous green on an unedited copy (`reference_200_edits_land_locally_not_over_ssh`).

Evidence-Ticket: OMN-15344
Evidence-Source: OCC#5372
