### PR TITLE
fix(OMN-15408): key the pre-push .200 host guard on the selected work, not the is_full_suite flag

### DIFF
--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -64,7 +64,11 @@ die() {
 # to prevent is a stalled/contended local machine, not an untrusted push.
 PREPUSH_200_HOSTNAME="${PREPUSH_200_HOSTNAME:-stickybeatz-studio}"
 guard_full_suite_host() {
-  local host lc_host lc_target
+  local host lc_host lc_target heavy_what
+  # OMN-15408: the caller names WHICH heavyweight run is being guarded, so the
+  # refusal names the real cause. Default preserves the OMN-15059 wording for
+  # the flag-driven escalation call sites, which pass no argument.
+  heavy_what="${1:-heavy fail-closed full-suite escalation}"
   host="$(hostname -s 2>/dev/null || true)"
   if [ -z "$host" ]; then
     log "WARNING: could not determine local hostname -- unable to verify this is the .200 build host; proceeding locally (fail-open: this guard is a routing optimization, not a security gate)."
@@ -76,11 +80,61 @@ guard_full_suite_host() {
     return 0
   fi
   if [ -n "${PREPUSH_ALLOW_LOCAL_FULL_SUITE:-}" ]; then
-    log "WARNING: DEGRADED-HOST OVERRIDE IN EFFECT (PREPUSH_ALLOW_LOCAL_FULL_SUITE set) -- running the full-suite fail-closed escalation on '${host}', NOT the designated .200 host ('${PREPUSH_200_HOSTNAME}'). This host has weaker isolation/headroom than .200; treat any evidence from this run as WEAKER than a .200-run gate. See docs/runbooks/200-build-lane-execution-pattern.md."
+    log "WARNING: DEGRADED-HOST OVERRIDE IN EFFECT (PREPUSH_ALLOW_LOCAL_FULL_SUITE set) -- running ${heavy_what} on '${host}', NOT the designated .200 host ('${PREPUSH_200_HOSTNAME}'). This host has weaker isolation/headroom than .200; treat any evidence from this run as WEAKER than a .200-run gate. See docs/runbooks/200-build-lane-execution-pattern.md."
     return 0
   fi
-  die "heavy fail-closed full-suite escalation triggered on host '${host}', not the designated .200 build host ('${PREPUSH_200_HOSTNAME}')" \
+  die "${heavy_what} triggered on host '${host}', not the designated .200 build host ('${PREPUSH_200_HOSTNAME}')" \
       "push from .200 instead (ssh jonah@stickybeatz-studio.tail75df5e.ts.net, wrap remote commands as zsh -lc \"...\"; see docs/runbooks/200-build-lane-execution-pattern.md for the full pattern), OR set PREPUSH_ALLOW_LOCAL_FULL_SUITE=1 to run the full suite on this host anyway (visible, degraded-evidence override -- do not use as a routine bypass)"
+}
+
+# -----------------------------------------------------------------------------
+# Heavyweight-SELECTION predicate (OMN-15408)
+# -----------------------------------------------------------------------------
+# The OMN-15059 guard above was wired to fire on the selector's `is_full_suite`
+# FLAG. That is the wrong key: the selector routinely emits
+# `is_full_suite=False` with `selected_paths=["tests/"]` -- the entire suite
+# arriving as an "impacted subset" -- and those runs sail straight past the
+# guard. Measured on host `omnibook` through real `git push` runs on
+# 2026-07-29, against the identical predicate in the sibling copies of this
+# hook: omnimarket selected `is_full_suite=False paths=[ tests/ ]` and executed
+# 13,898 tests in 506s locally with the guard never invoked; omnibase_infra
+# likewise ran 2,429 tests in 245s unguarded. The SAME selected work forced via
+# `PREPUSH_FULL_SUITE=1` (`is_full_suite=True reason=feature_flag_off
+# paths=[ tests/ ]`) WAS refused. Identical cost, opposite outcome, decided by
+# a flag.
+#
+# SEAM -- what "heavyweight selection" means, exactly: the selection is
+# heavyweight when the paths pytest is about to be handed COVER THE ENTIRE
+# full-suite target this hook would run on a fail-closed escalation
+# (`$FULL_SUITE_TARGET`, defined next to the pytest invocation below so the
+# predicate and the actual run can never drift apart). Concretely: some
+# selected path is `$FULL_SUITE_TARGET` itself or a directory ANCESTOR of it.
+# That is "the selection failed to be a proper narrowing" expressed against the
+# selector's own output -- NOT a parallel cost model, no test counting, no
+# timing heuristic, nothing this hook does not already parse.
+#
+# A genuine narrow selection (`tests/unit/scripts/`, a single test module) is
+# strictly below the target and stays runnable locally -- the guard must not
+# brick every push from a developer's machine, only the ones that are the
+# full-suite run wearing a different label.
+#
+# Keep this function self-contained (target passed in, no globals): it is
+# extracted and EXECUTED directly by
+# tests/scripts/test_prepush_hook_host_identity_guard.py.
+selection_is_whole_suite() {
+  local target normalized_target p normalized
+  target="$1"
+  shift
+  [ -n "$target" ] || return 1
+  normalized_target="${target%/}/"
+  for p in "$@"; do
+    [ -n "$p" ] || continue
+    normalized="${p%/}/"
+    case "$normalized_target" in
+      "$normalized"*) return 0 ;;
+    esac
+  done
+  return 1
 }
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
@@ -199,12 +253,24 @@ RC=0
 # per-test timeout applies regardless of which ini file pytest resolves.
 PREPUSH_TIMEOUT_FLAGS="-n4 --dist=loadgroup --timeout=60 --timeout-method=thread"
 
+# SINGLE SOURCE OF TRUTH for "what the heavy run is" (OMN-15408): the
+# fail-closed escalation runs exactly this target, and `selection_is_whole_suite`
+# measures the impacted-subset selection against this same value. Changing the
+# escalation target automatically moves the guard predicate with it.
+FULL_SUITE_TARGET="tests/"
+
 if [ "$IS_FULL" = "True" ] || [ "$IS_FULL" = "true" ]; then
   guard_full_suite_host
-  log "running FULL suite (fail-closed escalation): uv run pytest tests/ --ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
+  log "running FULL suite (fail-closed escalation): uv run pytest ${FULL_SUITE_TARGET} --ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
   # shellcheck disable=SC2086
-  uv run pytest tests/ --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?
+  uv run pytest "${FULL_SUITE_TARGET}" --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?
 elif [ "${#PATHS[@]}" -gt 0 ]; then
+  # OMN-15408: guard on the SELECTED WORK, not the is_full_suite flag. A
+  # selection that covers the whole full-suite target is the heavy run under
+  # another name and must be routed to .200 exactly as the flagged escalation is.
+  if selection_is_whole_suite "$FULL_SUITE_TARGET" "${PATHS[@]}"; then
+    guard_full_suite_host "whole-suite-equivalent impacted selection (is_full_suite=${IS_FULL}, selected paths [ ${PATHS_STR}] cover the entire '${FULL_SUITE_TARGET}' escalation target)"
+  fi
   log "running impacted subset: uv run pytest ${PATHS_STR}--ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
   # shellcheck disable=SC2086
   uv run pytest "${PATHS[@]}" --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -13,7 +13,7 @@ a 2026-07-24 session drove the local Mac to load ~55 with 93% swap running
 this exact escalation for 115+ minutes before `.200` was invoked as a rescue
 rather than having been the execution target from the start.
 
-Two assertion classes:
+Three assertion classes:
 
 1. Static wiring -- `guard_full_suite_host` is defined and is the first
    statement inside EVERY `IS_FULL` (full-suite) branch, so a future edit
@@ -24,10 +24,20 @@ Two assertion classes:
    real pytest invocation. The override makes this host-independent: it must
    hold true no matter which host runs the test suite (including `.200`
    itself), so the test does not rely on the ambient hostname.
+3. Heavyweight-SELECTION (OMN-15408) -- the guard must key on the work the
+   selector actually picked, not on the `is_full_suite` flag. The selector
+   routinely emits `is_full_suite=False` with `selected_paths=["tests/"]`, and
+   before OMN-15408 those runs bypassed the guard outright: 13,898 tests /
+   506s in omnimarket and 2,429 tests / 245s in omnibase_infra, executed on
+   `omnibook` through real `git push` runs on 2026-07-29 with the guard never
+   invoked -- while the identical selected work forced via
+   `PREPUSH_FULL_SUITE=1` WAS refused. Assertion classes 1 and 2 above were
+   green that entire time, because both only ever drove the flag-true path.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -125,4 +135,283 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
     assert "collected" not in result.stdout, (
         "the guard must refuse BEFORE pytest ever collects tests -- found a "
         f"pytest collection banner in stdout: {result.stdout!r}"
+    )
+
+
+# =============================================================================
+# OMN-15408: the guard must key on the SELECTED WORK, not the is_full_suite flag
+# =============================================================================
+# The OMN-15059 guard above was called ONLY from inside the `IS_FULL` branch, so
+# it fired on the selector's `is_full_suite` FLAG. The selector routinely emits
+# `is_full_suite=False` with `selected_paths=["tests/"]` -- the whole suite
+# arriving as an "impacted subset" -- and those runs bypassed the guard
+# entirely. Measured on host `omnibook` through real `git push` runs on
+# 2026-07-29: omnimarket ran 13,898 tests in 506s and omnibase_infra 2,429 tests
+# in 245s, locally, with the guard never invoked; the SAME selected work forced
+# via `PREPUSH_FULL_SUITE=1` was refused. Identical cost, opposite outcome,
+# decided by a flag. The tests below drive the flag-FALSE path, which is the one
+# that reaches production behavior -- the pre-existing tests in this file only
+# ever exercised the flag-TRUE path, and were green while the hole was open.
+#
+# `test_guard_refuses_whole_suite_equivalent_selection_when_flag_is_false` is
+# RED against the pre-fix hook (it proceeds to pytest, exit 0) and GREEN after.
+# `test_guard_allows_a_genuinely_narrow_selection` is the anti-overreach pin:
+# the fix must not brick every push from this Mac.
+
+_FULL_SUITE_TARGET = "tests/"
+# The literal production shape from the OMN-15408 evidence table.
+_WHOLE_SUITE_SELECTION = "tests/"
+# A real, genuinely-narrow subdirectory of this repo's suite.
+_NARROW_SELECTION = "tests/scripts/"
+
+_PREDICATE_RE = re.compile(
+    r"^selection_is_whole_suite\(\) \{.*?^\}",
+    re.DOTALL | re.MULTILINE,
+)
+_WHOLE_SUITE_GUARD_CALL_RE = re.compile(
+    r"if selection_is_whole_suite .*?\n(.*?)\n\s*fi",
+    re.DOTALL,
+)
+
+
+def _extract_predicate_source() -> str:
+    """Return the literal `selection_is_whole_suite` bash function from the hook.
+
+    Extract-and-execute (the pattern already used for the hook's other pure
+    shell helpers) so these assertions run THE function that ships, never a
+    Python re-implementation of it -- a re-implementation would pass happily
+    while the shipped predicate was broken.
+    """
+    match = _PREDICATE_RE.search(HOOK_SCRIPT.read_text(encoding="utf-8"))
+    assert match is not None, (
+        "expected a selection_is_whole_suite() function in "
+        f"{HOOK_SCRIPT} -- the OMN-15408 heavyweight-selection predicate"
+    )
+    return match.group(0)
+
+
+def _predicate_says_whole_suite(target: str, *paths: str) -> bool:
+    """Execute the real bash predicate; True == 'this selection is heavyweight'."""
+    script = f'{_extract_predicate_source()}\nselection_is_whole_suite "$@"\n'
+    completed = subprocess.run(
+        ["bash", "-c", script, "selection_is_whole_suite", target, *paths],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode in (0, 1), (
+        "predicate exited abnormally "
+        f"({completed.returncode}): stderr={completed.stderr!r}"
+    )
+    return completed.returncode == 0
+
+
+def _run_hook_with_stubbed_selection(
+    tmp_path: Path,
+    *,
+    is_full_suite: bool,
+    selected_paths: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the REAL hook end-to-end with a stubbed selector + stubbed pytest.
+
+    A shim `uv` earlier on PATH answers the selector invocation with a chosen
+    selection JSON and turns the pytest invocation into an observable sentinel,
+    so the test can assert both `did the guard refuse` and `did execution ever
+    reach pytest` against the actual script rather than a surrogate. Everything
+    else (`uv run python - <heredoc>` for JSON parsing) is delegated to the
+    real interpreter.
+
+    `PREPUSH_BASE_REF=HEAD` keeps the pre-selector preamble deterministic and
+    offline: it always resolves, `merge-base HEAD HEAD` is HEAD, and the diff is
+    empty -- the stub supplies the selection regardless.
+    """
+    selection_file = tmp_path / "selection.json"
+    selection_file.write_text(
+        json.dumps(
+            {
+                "is_full_suite": is_full_suite,
+                "full_suite_reason": None,
+                "selected_paths": selected_paths,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    stub_bin = tmp_path / "stub-bin"
+    stub_bin.mkdir(parents=True, exist_ok=True)
+    uv_stub = stub_bin / "uv"
+    uv_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'args="$*"\n'
+        'case "$args" in\n'
+        "  *detect_test_paths*)\n"
+        '    cat "$PREPUSH_TEST_SELECTION_JSON"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "  *pytest*)\n"
+        '    echo "STUB-PYTEST-INVOKED $args"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+        "shift\n"
+        'if [ "$1" = "python" ]; then\n'
+        "  shift\n"
+        '  exec python3 "$@"\n'
+        "fi\n"
+        'exec "$@"\n',
+        encoding="utf-8",
+    )
+    uv_stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["PREPUSH_TEST_SELECTION_JSON"] = str(selection_file)
+    env["PREPUSH_BASE_REF"] = "HEAD"
+    env["PREPUSH_200_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
+    for leaky in (
+        "PREPUSH_FULL_SUITE",
+        "PREPUSH_ALLOW_LOCAL_FULL_SUITE",
+        "ENABLE_SMART_TESTS",
+        "PREPUSH_ADJACENCY",
+        "PREPUSH_PYTEST_ARGS",
+    ):
+        env.pop(leaky, None)
+
+    return subprocess.run(
+        ["bash", str(HOOK_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+def test_heavyweight_selection_predicate_is_defined() -> None:
+    assert "selection_is_whole_suite()" in HOOK_SCRIPT.read_text(encoding="utf-8"), (
+        "expected a selection_is_whole_suite() predicate so the guard can key "
+        "on the selected work rather than the is_full_suite flag (OMN-15408)"
+    )
+
+
+def test_full_suite_target_is_single_sourced() -> None:
+    """The predicate and the escalation must read the SAME target.
+
+    If the guard hard-coded its own notion of 'the whole suite' it would drift
+    from whatever the escalation actually runs -- a second cost model, which is
+    the thing this fix explicitly avoids.
+    """
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    assert f'FULL_SUITE_TARGET="{_FULL_SUITE_TARGET}"' in script_text, (
+        f"expected FULL_SUITE_TARGET to be set to {_FULL_SUITE_TARGET!r} in "
+        f"{HOOK_SCRIPT}"
+    )
+    assert 'uv run pytest "${FULL_SUITE_TARGET}"' in script_text, (
+        "expected the fail-closed escalation to run ${FULL_SUITE_TARGET} "
+        "itself, so the guard predicate cannot drift from the run it guards"
+    )
+    assert 'selection_is_whole_suite "$FULL_SUITE_TARGET"' in script_text, (
+        "expected the predicate to be evaluated against the SAME "
+        "FULL_SUITE_TARGET the escalation runs"
+    )
+
+
+def test_guard_is_called_when_the_selection_is_whole_suite_equivalent() -> None:
+    """Static wiring: the impacted-subset branch must consult the guard.
+
+    Pairs with the pre-existing IS_FULL-branch assertion above; together they
+    pin BOTH call sites, so a future edit cannot silently drop either one.
+    """
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    guarded_blocks = _WHOLE_SUITE_GUARD_CALL_RE.findall(script_text)
+    assert guarded_blocks, (
+        "expected an `if selection_is_whole_suite ...` block in the "
+        "impacted-subset branch (OMN-15408)"
+    )
+    assert any("guard_full_suite_host" in block for block in guarded_blocks), (
+        "expected guard_full_suite_host to be called when the selection is "
+        f"whole-suite-equivalent; found blocks: {guarded_blocks!r}"
+    )
+
+
+def test_predicate_flags_a_whole_suite_selection() -> None:
+    """A selection covering the entire escalation target is heavyweight."""
+    assert _predicate_says_whole_suite(_FULL_SUITE_TARGET, _WHOLE_SUITE_SELECTION)
+    assert _predicate_says_whole_suite(_FULL_SUITE_TARGET, _FULL_SUITE_TARGET)
+    assert _predicate_says_whole_suite(
+        _FULL_SUITE_TARGET, _FULL_SUITE_TARGET.rstrip("/")
+    ), "a trailing-slash-less path must normalize to the same target"
+    assert _predicate_says_whole_suite(
+        _FULL_SUITE_TARGET, _NARROW_SELECTION, _WHOLE_SUITE_SELECTION
+    ), "one whole-suite path anywhere in the selection makes it heavyweight"
+
+
+def test_predicate_allows_a_genuinely_narrow_selection() -> None:
+    """Real narrowing stays runnable -- the guard is not a blanket push block."""
+    assert not _predicate_says_whole_suite(_FULL_SUITE_TARGET, _NARROW_SELECTION)
+    assert not _predicate_says_whole_suite(
+        _FULL_SUITE_TARGET, f"{_NARROW_SELECTION}test_something.py"
+    )
+    assert not _predicate_says_whole_suite(_FULL_SUITE_TARGET)
+
+
+def test_guard_refuses_whole_suite_equivalent_selection_when_flag_is_false(
+    tmp_path: Path,
+) -> None:
+    """THE OMN-15408 REGRESSION.
+
+    `is_full_suite=False` + `selected_paths=["tests/"]` on a non-`.200` host is
+    the exact shape that ran 13,898 tests locally with the guard never invoked.
+    RED against the pre-fix hook (it reached pytest and exited 0); GREEN after.
+    """
+    result = _run_hook_with_stubbed_selection(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_WHOLE_SUITE_SELECTION],
+    )
+    assert result.returncode != 0, (
+        "expected the host guard to refuse a whole-suite-equivalent selection "
+        "even though is_full_suite=False; got exit "
+        f"{result.returncode}. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "not the designated .200 build host" in result.stderr, (
+        f"expected the refusal message in stderr, got: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" not in result.stdout, (
+        "the guard must refuse BEFORE pytest is invoked -- found a pytest "
+        f"invocation in stdout: {result.stdout!r}"
+    )
+
+
+def test_guard_allows_a_genuinely_narrow_selection_on_a_local_host(
+    tmp_path: Path,
+) -> None:
+    """Anti-overreach pin.
+
+    A real narrow selection must still run locally on a non-`.200` host. If
+    this ever fails, the fix has become a blanket push block and will be
+    disabled within a week -- which is worse than no guard at all.
+    """
+    result = _run_hook_with_stubbed_selection(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_NARROW_SELECTION],
+    )
+    assert result.returncode == 0, (
+        "expected a genuinely narrow selection to be allowed on a non-.200 "
+        f"host; got exit {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "not the designated .200 build host" not in result.stderr, (
+        f"the guard must NOT refuse a proper narrowing; stderr: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" in result.stdout, (
+        "expected the narrow selection to actually reach pytest; stdout: "
+        f"{result.stdout!r}"
+    )
+    assert _NARROW_SELECTION in result.stdout, (
+        "expected the narrow selection's own path to be handed to pytest; "
+        f"stdout: {result.stdout!r}"
     )


### PR DESCRIPTION
## OMN-15408 — the OMN-15059 host guard was keyed on the wrong thing

`guard_full_suite_host()` (OMN-15059) is wired and live, but it was called **only from inside the `IS_FULL` branch**, so it fired on the selector's `is_full_suite` **flag**. The selector routinely emits `is_full_suite=False` with `selected_paths=["tests/"]` — the entire suite arriving as an "impacted subset" — and every one of those runs bypassed the guard.

### Execution evidence (host `omnibook`, real `git push`, 2026-07-29)

| Repo | selection | guard fired? | local pytest actually run |
| --- | --- | --- | --- |
| omnibase_core | `is_full_suite=True reason=test_infrastructure` | YES — push refused, exit 1 | 0 tests |
| omnibase_infra | `is_full_suite=False` | **NO** | 2,429 passed / 45 failed, **245s** |
| omnimarket | `is_full_suite=False paths=[tests/]` | **NO** | **13,898 passed, 506s (8m26s)** |

Same repo, same work, opposite outcome: forcing the flag with `PREPUSH_FULL_SUITE=1` in `omnibase_infra` yields `is_full_suite=True reason=feature_flag_off paths=[ tests/ ]` and the guard **does** refuse. Identical selected work, identical cost, decided by a flag. That is the defect.

This is the exact contended-Mac harm OMN-15059 exists to prevent (root `CLAUDE.md` rule 11a; the 2026-07-24 load-~55 / 93%-swap / 115-minute incident), occurring with the guard installed, loaded, and passing its own tests — because those tests only ever drove the flag-true path.

## Seam definition — what "heavyweight selection" means, exactly

**Predicate:** the selection is heavyweight when the runnable path set pytest is about to receive **covers the entire `FULL_SUITE_TARGET`** this hook would run on a fail-closed escalation — i.e. some selected path is `FULL_SUITE_TARGET` itself, or a directory **ancestor** of it.

```bash
selection_is_whole_suite() {          # target=$1, then the selected paths
  normalized_target="${target%/}/"
  for p in "$@"; do
    normalized="${p%/}/"
    case "$normalized_target" in
      "$normalized"*) return 0 ;;     # p == target, or p is an ancestor of target
    esac
  done
  return 1
}
```

Field-by-field:

| Field | Type | Meaning |
| --- | --- | --- |
| `FULL_SUITE_TARGET` | shell string, trailing `/` | The literal target of the fail-closed escalation. **``tests/`` in this repo.** |
| input paths | `"${PATHS[@]}"` | The **runnable** selection — exactly the argv pytest receives, post-filtering — never the pre-filter selection. |
| return 0 | heavyweight | Guard is invoked with a descriptive reason. |
| return 1 | proper narrowing | Runs locally, unchanged. |

Normalization is trailing-slash-insensitive (`tests` ≡ `tests/`), and matching is **directory-prefix**, so `tests/unit/scripts/test_x.py` is never mistaken for a whole-suite selection.

`FULL_SUITE_TARGET` is now the **single source of truth**: the escalation runs `uv run pytest "${FULL_SUITE_TARGET}"` and the predicate is evaluated against the same variable, so the guard cannot drift from the run it guards. This deliberately derives "heavyweight" from the selection output the script already parses — **no parallel cost model**, no test counting, no timing heuristic.

Existing flag-true behavior is unchanged (it was correct, just incomplete). `guard_full_suite_host` gained an optional description argument; call sites that pass nothing keep the original OMN-15059 wording.

## RED → GREEN proof (run on `.200`)

Behavioral, against the real script: a stub `uv` earlier on `PATH` supplies a chosen selection JSON and turns the pytest invocation into an observable sentinel, so the test asserts both *did the guard refuse* and *did execution ever reach pytest*.

**RED — pre-fix hook + new tests (`6 failed, 7 passed` in all three repos):**

```
E  AssertionError: expected the host guard to refuse a whole-suite-equivalent
   selection even though is_full_suite=False; got exit 0.
   stdout='STUB-PYTEST-INVOKED run pytest tests/ --ignore=tests/integration ...'
   stderr='[prepush-smart-tests] selection: is_full_suite=False reason=None paths=[ tests/ ]
           [prepush-smart-tests] running impacted subset: uv run pytest tests/ ...
           [prepush-smart-tests] impacted tests passed; allowing push.'
```

**GREEN — post-fix: `13 passed` in all three repos.**

The anti-overreach test (`test_guard_allows_a_genuinely_narrow_selection_on_a_local_host`) passes in **both** directions — it must, or the fix would be a blanket push block that gets disabled within a week.

New tests (7 per repo):

- `test_heavyweight_selection_predicate_is_defined`
- `test_full_suite_target_is_single_sourced` — pins the no-drift property
- `test_guard_is_called_when_the_selection_is_whole_suite_equivalent` — static wiring for the second call site
- `test_predicate_flags_a_whole_suite_selection` / `test_predicate_allows_a_genuinely_narrow_selection` — the shipped bash function is **extracted and executed**, never re-implemented in Python
- `test_guard_refuses_whole_suite_equivalent_selection_when_flag_is_false` — **the regression**
- `test_guard_allows_a_genuinely_narrow_selection_on_a_local_host` — the anti-overreach pin

## Gates (all on `.200` / `stickybeatz-studio`, per rule 11a)

- Worktree built via patch-transfer with **sha256 parity verified both directions** on every changed file (closes the edit-locality trap).
- `uv run pytest <guard test file>` — **13 passed**, each repo.
- Adjacent suites: core `tests/scripts/ tests/unit/scripts/ci/test_detect_test_paths.py` → **157 passed**; infra `test_prepush_hook_pinned_interpreter.py` + `test_prepush_smart_tests_seam.py` + guard → **20 passed**.
- `ruff check` + `ruff format --check` clean on the changed files.
- `pre-commit run --all-files` run **explicitly** on `.200` (its `core.hooksPath` makes commit-time hooks a no-op, so a clean `git commit` there proves nothing). Also `pre-commit run --files <this diff>` → **fully clean, zero findings, all three repos**.
- Pushed from `.200`. Pleasing recursion: pushing this fix from the designated host means the corrected guard never had to fire — the tests prove it would have.

> `pre-commit run --all-files` reports pre-existing repo-wide findings (print statements and yamlfmt/end-of-file drift in files this PR never touches). **Zero of them name either file in this diff** — verified by grepping the full `--all-files` log for `prepush_smart_tests.sh` / `test_prepush_hook_host_identity_guard` (0 hits). The file-scoped run over this diff is completely clean.

## Disclosed, not fixed here

- **Stale interpreter pin (secondary finding on the ticket).** `omnibase_infra/.git/hooks/pre-push` pins `INSTALL_PYTHON` to a **worktree venv** path (live readback 2026-07-29: `omni_worktrees/OMN-12912/omnibase_infra/.venv/bin/python`; the ticket recorded an OMN-14974 path, so this pin has already moved once and will again). It survives only via the template's `elif command -v pre-commit` fallback — if `pre-commit` ever leaves `PATH`, infra's whole pre-push chain becomes a hard error instead of a gate. The repair (`pre-commit install --install-hooks` in the canonical clone) mutates a canonical clone's hook chain, and the rolling ledger currently carries **un-terminated lane claims pushing `omnibase_infra` and `omnimarket`**, so it is **deferred to a named post-drain step** rather than executed mid-flight. The durable fix — making the installed hook not depend on any worktree venv path — is a separate change from this predicate fix and is not bundled here.
- **`omnibase_infra` canonical clone has `core.bare=true`** set on this Mac despite having a full working tree on disk, so `git -C omnibase_infra pull`/`status` hard-error with *"this operation must be run in a work tree"*. Adding a linked worktree still works, so this lane was unaffected, but it is a live environment defect.

OCC companion authored separately, per the no-self-authored-evidence rule.

Closes OMN-15408

Evidence-Ticket: OMN-15408
Evidence-Source: OCC#5490
