### PR TITLE
feat(topology): add typed application database contracts (OMN-15417)

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -123,6 +123,9 @@ from .enum_data_classification import EnumDataClassification
 
 # Database engine enum (OMN-1782)
 from .enum_database_engine import EnumDatabaseEngine
+from .enum_database_grant_object_type import EnumDatabaseGrantObjectType
+from .enum_database_privilege import EnumDatabasePrivilege
+from .enum_database_schema_domain import EnumDatabaseSchemaDomain
 
 # Decision type enums (OMN-1235)
 from .enum_decision_type import EnumDecisionType
@@ -712,6 +715,9 @@ __all__ = [
     "EnumAuthType",
     "EnumBackoffStrategy",
     "EnumDatabaseEngine",
+    "EnumDatabaseGrantObjectType",
+    "EnumDatabasePrivilege",
+    "EnumDatabaseSchemaDomain",
     "EnumNotificationMethod",
     # Binding function domain (Operation Bindings DSL - OMN-1410)
     "EnumBindingFunction",

--- a/src/omnibase_core/enums/enum_database_grant_object_type.py
+++ b/src/omnibase_core/enums/enum_database_grant_object_type.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""PostgreSQL object types supported by explicit topology grants."""
+
+from enum import StrEnum, unique
+
+__all__ = ["EnumDatabaseGrantObjectType"]
+
+
+@unique
+class EnumDatabaseGrantObjectType(StrEnum):
+    """Object scope for one explicit workload-principal grant."""
+
+    DATABASE = "DATABASE"
+    SCHEMA = "SCHEMA"
+    TABLE = "TABLE"
+    SEQUENCE = "SEQUENCE"
+    FUNCTION = "FUNCTION"
+    TYPE = "TYPE"

--- a/src/omnibase_core/enums/enum_database_privilege.py
+++ b/src/omnibase_core/enums/enum_database_privilege.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""PostgreSQL privileges supported by typed deployment topology grants."""
+
+from enum import StrEnum, unique
+
+__all__ = ["EnumDatabasePrivilege"]
+
+
+@unique
+class EnumDatabasePrivilege(StrEnum):
+    """Explicit privilege that may be granted to a workload principal."""
+
+    CONNECT = "CONNECT"
+    CREATE = "CREATE"
+    TEMPORARY = "TEMPORARY"
+    USAGE = "USAGE"
+    SELECT = "SELECT"
+    INSERT = "INSERT"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+    TRUNCATE = "TRUNCATE"
+    REFERENCES = "REFERENCES"
+    TRIGGER = "TRIGGER"
+    EXECUTE = "EXECUTE"

--- a/src/omnibase_core/enums/enum_database_schema_domain.py
+++ b/src/omnibase_core/enums/enum_database_schema_domain.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Application-database schema domain classification."""
+
+from enum import StrEnum, unique
+
+__all__ = ["EnumDatabaseSchemaDomain"]
+
+
+@unique
+class EnumDatabaseSchemaDomain(StrEnum):
+    """Authoritative security and tenancy domain for a database schema."""
+
+    TENANT = "TENANT"
+    OMNINODE_INTERNAL = "OMNINODE_INTERNAL"
+    PLATFORM_CATALOG = "PLATFORM_CATALOG"

--- a/src/omnibase_core/models/contracts/subcontracts/model_db_table_declaration.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_db_table_declaration.py
@@ -5,7 +5,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = ["ModelDbTableDeclaration"]
 
@@ -13,10 +13,28 @@ __all__ = ["ModelDbTableDeclaration"]
 class ModelDbTableDeclaration(BaseModel):
     """Declaration of a DB table owned or accessed by this node."""
 
-    model_config = ConfigDict(frozen=True, extra="ignore", from_attributes=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    name: str
-    migration: str
+    name: str = Field(..., min_length=1, max_length=63, pattern=r"^[a-z_][a-z0-9_]*$")
+    database_ref: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=r"^[a-z_][a-z0-9_]*$",
+        description="Logical database reference from ModelDeploymentTopology.",
+    )
+    # Pydantic v2 keeps BaseModel.schema as a deprecated compatibility callable.
+    schema: str = Field(  # type: ignore[assignment]
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=r"^[a-z_][a-z0-9_]*$",
+        description="Schema reference whose topology domain is authoritative.",
+    )
+    migration: str = Field(..., min_length=1)
     access: Literal["read", "write", "read_write"] = "write"
-    database: str = "omnidash_analytics"
-    role: str
+    role: str = Field(
+        ...,
+        min_length=1,
+        description="Semantic table role; never a PostgreSQL principal.",
+    )

--- a/src/omnibase_core/models/core/__init__.py
+++ b/src/omnibase_core/models/core/__init__.py
@@ -20,6 +20,25 @@ from .model_custom_properties import ModelCustomProperties
 
 # Deployment topology models (OMN-3490)
 from .model_deployment_topology import ModelDeploymentTopology
+from .model_deployment_topology_database import ModelDeploymentTopologyDatabase
+from .model_deployment_topology_database_binding import (
+    ModelDeploymentTopologyDatabaseBinding,
+)
+from .model_deployment_topology_database_grant import (
+    ModelDeploymentTopologyDatabaseGrant,
+)
+from .model_deployment_topology_database_migration_ledger import (
+    ModelDeploymentTopologyDatabaseMigrationLedger,
+)
+from .model_deployment_topology_database_owner import (
+    ModelDeploymentTopologyDatabaseOwner,
+)
+from .model_deployment_topology_database_principal import (
+    ModelDeploymentTopologyDatabasePrincipal,
+)
+from .model_deployment_topology_database_schema import (
+    ModelDeploymentTopologyDatabaseSchema,
+)
 from .model_deployment_topology_local_config import ModelDeploymentTopologyLocalConfig
 from .model_deployment_topology_service import ModelDeploymentTopologyService
 
@@ -140,6 +159,13 @@ __all__ = [
     "ModelStorageCheckpointMetadata",
     # Deployment topology models (OMN-3490)
     "ModelDeploymentTopology",
+    "ModelDeploymentTopologyDatabase",
+    "ModelDeploymentTopologyDatabaseBinding",
+    "ModelDeploymentTopologyDatabaseGrant",
+    "ModelDeploymentTopologyDatabaseMigrationLedger",
+    "ModelDeploymentTopologyDatabaseOwner",
+    "ModelDeploymentTopologyDatabasePrincipal",
+    "ModelDeploymentTopologyDatabaseSchema",
     "ModelDeploymentTopologyLocalConfig",
     "ModelDeploymentTopologyService",
     # Configuration base classes

--- a/src/omnibase_core/models/core/model_deployment_topology.py
+++ b/src/omnibase_core/models/core/model_deployment_topology.py
@@ -15,13 +15,18 @@ Invariants:
 from __future__ import annotations
 
 import io
+import re
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_database_schema_domain import EnumDatabaseSchemaDomain
 from omnibase_core.enums.enum_deployment_mode import EnumDeploymentMode
+from omnibase_core.models.core.model_deployment_topology_database import (
+    ModelDeploymentTopologyDatabase,
+)
 from omnibase_core.models.core.model_deployment_topology_local_config import (
     ModelDeploymentTopologyLocalConfig,
 )
@@ -30,7 +35,14 @@ from omnibase_core.models.core.model_deployment_topology_service import (
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 
+if TYPE_CHECKING:
+    from omnibase_core.models.contracts.subcontracts.model_db_table_declaration import (
+        ModelDbTableDeclaration,
+    )
+
 __all__ = ["ModelDeploymentTopology"]
+
+_LOGICAL_DATABASE_REFERENCE_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 
 def _sort_dict_recursively(obj: Any) -> Any:
@@ -51,7 +63,7 @@ class ModelDeploymentTopology(BaseModel):
     to activate together.
     """
 
-    model_config = {"frozen": True, "extra": "forbid"}
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     # string-version-ok: YAML-deserialization boundary; topology files on disk carry plain strings
     schema_version: str = Field(
@@ -61,6 +73,13 @@ class ModelDeploymentTopology(BaseModel):
         default_factory=dict,
         description="Map of service name to its deployment service config.",
     )
+    databases: dict[str, ModelDeploymentTopologyDatabase] = Field(
+        default_factory=dict,
+        description=(
+            "Logical application-database resources. Checked-in environment topology "
+            "instances populate this map; host-local topology files are projections."
+        ),
+    )
     presets: dict[str, list[str]] = Field(
         default_factory=dict,
         description="Named presets mapping preset name to list of service names.",
@@ -69,6 +88,34 @@ class ModelDeploymentTopology(BaseModel):
         default=None,
         description="Currently active preset name (or None for no active preset).",
     )
+
+    @model_validator(mode="after")
+    def validate_database_references(self) -> ModelDeploymentTopology:
+        """Ensure nested consumer bindings resolve to their containing database."""
+        for database_ref, database in self.databases.items():
+            if (
+                len(database_ref) > 63
+                or _LOGICAL_DATABASE_REFERENCE_PATTERN.fullmatch(database_ref) is None
+            ):
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError(
+                    "databases keys must be lowercase logical SQL identifiers, "
+                    f"got '{database_ref}'"
+                )
+            for consumer, binding in database.bindings.items():
+                if binding.database_ref not in self.databases:
+                    # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                    raise ValueError(
+                        f"Binding '{consumer}' references unknown database_ref "
+                        f"'{binding.database_ref}'"
+                    )
+                if binding.database_ref != database_ref:
+                    # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                    raise ValueError(
+                        f"Binding '{consumer}' database_ref '{binding.database_ref}' "
+                        f"does not match containing database '{database_ref}'"
+                    )
+        return self
 
     # -----------------------------------------------------------------
     # Query helpers
@@ -92,6 +139,31 @@ class ModelDeploymentTopology(BaseModel):
     def services_for_preset(self, preset_name: str) -> list[str]:
         """Return the list of service names for a named preset."""
         return self.presets.get(preset_name, [])
+
+    def schema_domain(
+        self,
+        database_ref: str,
+        schema: str,
+    ) -> EnumDatabaseSchemaDomain:
+        """Resolve the authoritative domain for a logical database/schema pair."""
+        database = self.databases.get(database_ref)
+        if database is None:
+            # error-ok: Public lookup helper reports unresolved contract references.
+            raise ValueError(f"Unknown database_ref '{database_ref}'")
+        schema_config = database.schemas.get(schema)
+        if schema_config is None:
+            # error-ok: Public lookup helper reports unresolved contract references.
+            raise ValueError(
+                f"Unknown schema '{schema}' for database_ref '{database_ref}'"
+            )
+        return schema_config.domain
+
+    def table_domain(
+        self,
+        declaration: ModelDbTableDeclaration,
+    ) -> EnumDatabaseSchemaDomain:
+        """Derive a table domain solely from its topology-owned schema location."""
+        return self.schema_domain(declaration.database_ref, declaration.schema)
 
     # -----------------------------------------------------------------
     # Factory methods
@@ -162,6 +234,7 @@ class ModelDeploymentTopology(BaseModel):
         return cls(
             schema_version=base.schema_version,
             services=new_services,
+            databases=base.databases,
             presets=new_presets,
             active_preset="standard",
         )
@@ -196,6 +269,7 @@ class ModelDeploymentTopology(BaseModel):
         return cls(
             schema_version=base.schema_version,
             services=new_services,
+            databases=base.databases,
             presets=new_presets,
             active_preset="full",
         )

--- a/src/omnibase_core/models/core/model_deployment_topology_database.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed application-database resource for deployment topology."""
+
+import re
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.core.model_deployment_topology_database_binding import (
+    ModelDeploymentTopologyDatabaseBinding,
+)
+from omnibase_core.models.core.model_deployment_topology_database_migration_ledger import (
+    ModelDeploymentTopologyDatabaseMigrationLedger,
+)
+from omnibase_core.models.core.model_deployment_topology_database_owner import (
+    ModelDeploymentTopologyDatabaseOwner,
+)
+from omnibase_core.models.core.model_deployment_topology_database_principal import (
+    ModelDeploymentTopologyDatabasePrincipal,
+)
+from omnibase_core.models.core.model_deployment_topology_database_schema import (
+    ModelDeploymentTopologyDatabaseSchema,
+)
+
+__all__ = ["ModelDeploymentTopologyDatabase"]
+
+_SQL_IDENTIFIER_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
+_MIGRATION_STREAM_PATTERN = r"^[A-Za-z][A-Za-z0-9_.:/-]*$"
+
+
+def _validate_mapping_keys(label: str, values: Mapping[str, object]) -> None:
+    invalid = [
+        key
+        for key in values
+        if len(key) > 63 or _SQL_IDENTIFIER_PATTERN.fullmatch(key) is None
+    ]
+    if invalid:
+        # error-ok: Called only from a Pydantic validator to produce ValidationError.
+        raise ValueError(f"{label} keys must be SQL identifiers, got {invalid!r}")
+
+
+class ModelDeploymentTopologyDatabase(BaseModel):
+    """Logical database, identities, grants, bindings, and selected ledger."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    physical_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=r"^[a-z_][a-z0-9_]*$",
+    )
+    schemas: dict[str, ModelDeploymentTopologyDatabaseSchema] = Field(
+        ...,
+        min_length=1,
+    )
+    owners: dict[str, ModelDeploymentTopologyDatabaseOwner] = Field(
+        ...,
+        min_length=1,
+    )
+    principals: dict[str, ModelDeploymentTopologyDatabasePrincipal] = Field(
+        ...,
+        min_length=1,
+    )
+    bindings: dict[str, ModelDeploymentTopologyDatabaseBinding] = Field(
+        ...,
+        min_length=1,
+    )
+    migration_stream: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        pattern=_MIGRATION_STREAM_PATTERN,
+    )
+    checksum_ledgers: dict[str, ModelDeploymentTopologyDatabaseMigrationLedger] = Field(
+        ..., min_length=1
+    )
+    checksum_ledger: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=r"^[a-z_][a-z0-9_]*$",
+        description="Selected checksum-capable ledger reference.",
+    )
+
+    @model_validator(mode="after")
+    def validate_references(self) -> "ModelDeploymentTopologyDatabase":
+        """Resolve every nested owner, principal, schema, and ledger reference."""
+        for label, values in (
+            ("schemas", self.schemas),
+            ("owners", self.owners),
+            ("principals", self.principals),
+            ("bindings", self.bindings),
+            ("checksum_ledgers", self.checksum_ledgers),
+        ):
+            _validate_mapping_keys(label, values)
+
+        for schema_ref, schema in self.schemas.items():
+            if schema.owner not in self.owners:
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError(
+                    f"Schema '{schema_ref}' references unknown owner '{schema.owner}'"
+                )
+
+        conflicting_roles = sorted(self.owners.keys() & self.principals.keys())
+        if conflicting_roles:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                "Database roles cannot be both NOLOGIN owners and LOGIN principals: "
+                f"{conflicting_roles!r}"
+            )
+
+        for principal_ref, principal in self.principals.items():
+            for grant in principal.grants:
+                if grant.schema is not None and grant.schema not in self.schemas:
+                    # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                    raise ValueError(
+                        f"Principal '{principal_ref}' grant references unknown schema "
+                        f"'{grant.schema}'"
+                    )
+
+        for consumer, binding in self.bindings.items():
+            if binding.principal not in self.principals:
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError(
+                    f"Binding '{consumer}' references unknown principal "
+                    f"'{binding.principal}'"
+                )
+
+        if self.checksum_ledger not in self.checksum_ledgers:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                f"checksum_ledger references unknown ledger '{self.checksum_ledger}'"
+            )
+        for ledger_ref, ledger in self.checksum_ledgers.items():
+            if ledger.schema not in self.schemas:
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError(
+                    f"Checksum ledger '{ledger_ref}' references unknown schema "
+                    f"'{ledger.schema}'"
+                )
+        return self

--- a/src/omnibase_core/models/core/model_deployment_topology_database_binding.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_binding.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Secret-free consumer binding for a deployment database."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelDeploymentTopologyDatabaseBinding"]
+
+_REFERENCE_PATTERN = r"^[a-z_][a-z0-9_]*$"
+_ENVIRONMENT_VARIABLE_PATTERN = r"^[A-Z][A-Z0-9_]*$"
+
+
+class ModelDeploymentTopologyDatabaseBinding(BaseModel):
+    """Map a consumer to a LOGIN principal and DSN environment-variable name."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    database_ref: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_REFERENCE_PATTERN,
+        description="Logical database reference, never a physical DSN.",
+    )
+    principal: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_REFERENCE_PATTERN,
+        description="LOGIN workload-principal reference.",
+    )
+    dsn_env: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        pattern=_ENVIRONMENT_VARIABLE_PATTERN,
+        description="Environment-variable name holding the DSN; never the DSN value.",
+    )

--- a/src/omnibase_core/models/core/model_deployment_topology_database_grant.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_grant.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Explicit workload-principal grant in a deployment database topology."""
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_database_grant_object_type import (
+    EnumDatabaseGrantObjectType,
+)
+from omnibase_core.enums.enum_database_privilege import EnumDatabasePrivilege
+
+__all__ = ["ModelDeploymentTopologyDatabaseGrant"]
+
+_SQL_IDENTIFIER_PATTERN = r"^[a-z_][a-z0-9_]*$"
+_SQL_IDENTIFIER = re.compile(_SQL_IDENTIFIER_PATTERN)
+
+_ALLOWED_PRIVILEGES: dict[
+    EnumDatabaseGrantObjectType, frozenset[EnumDatabasePrivilege]
+] = {
+    EnumDatabaseGrantObjectType.DATABASE: frozenset(
+        {
+            EnumDatabasePrivilege.CONNECT,
+            EnumDatabasePrivilege.CREATE,
+            EnumDatabasePrivilege.TEMPORARY,
+        }
+    ),
+    EnumDatabaseGrantObjectType.SCHEMA: frozenset(
+        {EnumDatabasePrivilege.USAGE, EnumDatabasePrivilege.CREATE}
+    ),
+    EnumDatabaseGrantObjectType.TABLE: frozenset(
+        {
+            EnumDatabasePrivilege.SELECT,
+            EnumDatabasePrivilege.INSERT,
+            EnumDatabasePrivilege.UPDATE,
+            EnumDatabasePrivilege.DELETE,
+            EnumDatabasePrivilege.TRUNCATE,
+            EnumDatabasePrivilege.REFERENCES,
+            EnumDatabasePrivilege.TRIGGER,
+        }
+    ),
+    EnumDatabaseGrantObjectType.SEQUENCE: frozenset(
+        {
+            EnumDatabasePrivilege.USAGE,
+            EnumDatabasePrivilege.SELECT,
+            EnumDatabasePrivilege.UPDATE,
+        }
+    ),
+    EnumDatabaseGrantObjectType.FUNCTION: frozenset({EnumDatabasePrivilege.EXECUTE}),
+    EnumDatabaseGrantObjectType.TYPE: frozenset({EnumDatabasePrivilege.USAGE}),
+}
+
+
+class ModelDeploymentTopologyDatabaseGrant(BaseModel):
+    """One explicit grant without wildcard or implicit ``ALL`` semantics."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    object_type: EnumDatabaseGrantObjectType
+    # Pydantic v2 keeps BaseModel.schema as a deprecated compatibility callable.
+    schema: str | None = Field(  # type: ignore[assignment]
+        default=None,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+        description="Schema reference for every scope except DATABASE.",
+    )
+    objects: tuple[str, ...] = Field(
+        default=(),
+        description="Explicit object identifiers for relation-level scopes.",
+    )
+    privileges: tuple[EnumDatabasePrivilege, ...] = Field(
+        ...,
+        min_length=1,
+        description="Non-empty, object-compatible privilege set.",
+    )
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> "ModelDeploymentTopologyDatabaseGrant":
+        """Reject ambiguous targets, wildcards, and incompatible privileges."""
+        invalid_privileges = (
+            set(self.privileges) - _ALLOWED_PRIVILEGES[self.object_type]
+        )
+        if invalid_privileges:
+            names = ", ".join(
+                sorted(privilege.value for privilege in invalid_privileges)
+            )
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                f"Privileges {names} are invalid for {self.object_type.value} objects"
+            )
+        if len(set(self.privileges)) != len(self.privileges):
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError("Grant privileges must be unique")
+
+        relation_scopes = {
+            EnumDatabaseGrantObjectType.TABLE,
+            EnumDatabaseGrantObjectType.SEQUENCE,
+            EnumDatabaseGrantObjectType.FUNCTION,
+            EnumDatabaseGrantObjectType.TYPE,
+        }
+        if self.object_type is EnumDatabaseGrantObjectType.DATABASE:
+            if self.schema is not None or self.objects:
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError("DATABASE grants cannot declare schema or objects")
+            return self
+
+        if self.schema is None:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(f"{self.object_type.value} grants require a schema")
+
+        if self.object_type is EnumDatabaseGrantObjectType.SCHEMA:
+            if self.objects:
+                # error-ok: Pydantic validators require ValueError to produce ValidationError.
+                raise ValueError("SCHEMA grants cannot declare objects")
+            return self
+
+        if self.object_type in relation_scopes and not self.objects:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                f"{self.object_type.value} grants require explicit object names"
+            )
+        invalid_objects = [
+            name
+            for name in self.objects
+            if len(name) > 63 or _SQL_IDENTIFIER.fullmatch(name) is None
+        ]
+        if invalid_objects:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                f"Grant objects must be SQL identifiers, got {invalid_objects!r}"
+            )
+        if len(set(self.objects)) != len(self.objects):
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError("Grant objects must be unique")
+        return self

--- a/src/omnibase_core/models/core/model_deployment_topology_database_migration_ledger.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_migration_ledger.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Checksum-aware migration-ledger declaration for a deployment database."""
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = ["ModelDeploymentTopologyDatabaseMigrationLedger"]
+
+_SQL_IDENTIFIER_PATTERN = r"^[a-z_][a-z0-9_]*$"
+
+
+class ModelDeploymentTopologyDatabaseMigrationLedger(BaseModel):
+    """Typed shape of an existing ledger selected for a migration stream."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # Pydantic v2 keeps BaseModel.schema as a deprecated compatibility callable.
+    schema: str = Field(  # type: ignore[assignment]
+        ..., min_length=1, max_length=63, pattern=_SQL_IDENTIFIER_PATTERN
+    )
+    relation: str = Field(
+        ..., min_length=1, max_length=63, pattern=_SQL_IDENTIFIER_PATTERN
+    )
+    stream_column: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+    )
+    domain_column: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+    )
+    # string-version-ok: SQL identifier naming a ledger column, not a version value.
+    version_column: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+    )
+    checksum_column: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+    )
+
+    @model_validator(mode="after")
+    def ledger_columns_are_distinct(
+        self,
+    ) -> "ModelDeploymentTopologyDatabaseMigrationLedger":
+        """Each required migration identity dimension needs its own column."""
+        columns = {
+            self.stream_column,
+            self.domain_column,
+            self.version_column,
+            self.checksum_column,
+        }
+        if len(columns) != 4:
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError("Migration ledger columns must be distinct")
+        return self

--- a/src/omnibase_core/models/core/model_deployment_topology_database_owner.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_owner.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""NOLOGIN schema-owner declaration for a deployment database."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelDeploymentTopologyDatabaseOwner"]
+
+
+class ModelDeploymentTopologyDatabaseOwner(BaseModel):
+    """Schema-owner role which is structurally prohibited from logging in."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    login: Literal[False] = Field(
+        ...,
+        description="Must be false: schema owners are NOLOGIN roles.",
+    )

--- a/src/omnibase_core/models/core/model_deployment_topology_database_principal.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_principal.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""LOGIN workload-principal declaration for a deployment database."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_database_privilege import EnumDatabasePrivilege
+from omnibase_core.models.core.model_deployment_topology_database_grant import (
+    ModelDeploymentTopologyDatabaseGrant,
+)
+
+__all__ = ["ModelDeploymentTopologyDatabasePrincipal"]
+
+
+class ModelDeploymentTopologyDatabasePrincipal(BaseModel):
+    """Non-owner application principal with explicit, least-privilege grants."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    login: Literal[True] = Field(
+        ...,
+        description="Must be true: workload principals are LOGIN roles.",
+    )
+    bypass_rls: Literal[False] = Field(
+        ...,
+        description="Must be false: application principals cannot bypass RLS.",
+    )
+    grants: tuple[ModelDeploymentTopologyDatabaseGrant, ...] = Field(
+        ...,
+        min_length=1,
+        description="Explicit database, schema, and object grants.",
+    )
+
+    @model_validator(mode="after")
+    def workload_principal_has_no_ddl(
+        self,
+    ) -> "ModelDeploymentTopologyDatabasePrincipal":
+        """Keep runtime workload identities out of database/schema creation paths."""
+        prohibited = {
+            EnumDatabasePrivilege.CREATE,
+            EnumDatabasePrivilege.TEMPORARY,
+        }
+        granted = {
+            privilege
+            for grant in self.grants
+            for privilege in grant.privileges
+            if privilege in prohibited
+        }
+        if granted:
+            names = ", ".join(sorted(privilege.value for privilege in granted))
+            # error-ok: Pydantic validators require ValueError to produce ValidationError.
+            raise ValueError(
+                f"Workload principals cannot receive DDL privileges: {names}"
+            )
+        return self

--- a/src/omnibase_core/models/core/model_deployment_topology_database_schema.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_schema.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Schema declaration for a typed deployment database resource."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_database_schema_domain import EnumDatabaseSchemaDomain
+
+__all__ = ["ModelDeploymentTopologyDatabaseSchema"]
+
+_SQL_IDENTIFIER_PATTERN = r"^[a-z_][a-z0-9_]*$"
+
+
+class ModelDeploymentTopologyDatabaseSchema(BaseModel):
+    """Database schema with an authoritative domain and NOLOGIN owner reference."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    domain: EnumDatabaseSchemaDomain = Field(
+        ...,
+        description="Authoritative tenant, internal, or platform-catalog domain.",
+    )
+    owner: str = Field(
+        ...,
+        min_length=1,
+        max_length=63,
+        pattern=_SQL_IDENTIFIER_PATTERN,
+        description="Reference to a NOLOGIN owner declared on the database resource.",
+    )

--- a/src/omnibase_core/validators/extra_forbid_baseline.yaml
+++ b/src/omnibase_core/validators/extra_forbid_baseline.yaml
@@ -250,7 +250,6 @@ violations:
   - "omnibase_core.models.contracts.subcontracts.model_correlation_config:ModelCorrelationConfig"
   - "omnibase_core.models.contracts.subcontracts.model_data_grouping:ModelDataGrouping"
   - "omnibase_core.models.contracts.subcontracts.model_db_ownership_subcontract:ModelDbOwnershipSubcontract"
-  - "omnibase_core.models.contracts.subcontracts.model_db_table_declaration:ModelDbTableDeclaration"
   - "omnibase_core.models.contracts.subcontracts.model_dependency_health:ModelDependencyHealth"
   - "omnibase_core.models.contracts.subcontracts.model_discovery_subcontract:ModelDiscoverySubcontract"
   - "omnibase_core.models.contracts.subcontracts.model_envelope_template:ModelEnvelopeTemplate"

--- a/tests/test_db_ownership_subcontract.py
+++ b/tests/test_db_ownership_subcontract.py
@@ -4,6 +4,7 @@
 """Tests for ModelDbOwnershipSubcontract and ModelDbTableDeclaration."""
 
 import pytest
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.unit
 
@@ -18,6 +19,8 @@ def test_db_tables_field_exists():
         db_tables=[
             {
                 "name": "delegation_events",
+                "database_ref": "application",
+                "schema": "tenant",
                 "migration": "0007_delegation_events.sql",
                 "access": "write",
                 "role": "events",
@@ -39,12 +42,16 @@ def test_db_tables_role_lookup():
         db_tables=[
             {
                 "name": "delegation_events",
+                "database_ref": "application",
+                "schema": "tenant",
                 "migration": "0007_delegation_events.sql",
                 "access": "write",
                 "role": "events",
             },
             {
                 "name": "delegation_shadow_comparisons",
+                "database_ref": "application",
+                "schema": "tenant",
                 "migration": "0007_delegation_events.sql",
                 "access": "write",
                 "role": "shadow_comparisons",
@@ -74,6 +81,8 @@ def test_db_table_declaration_access_literal():
 
     t = ModelDbTableDeclaration(
         name="llm_cost_aggregates",
+        database_ref="application",
+        schema="omninode_internal",
         migration="0003_llm_cost_aggregates.sql",
         access="read_write",
         role="aggregates",
@@ -83,24 +92,43 @@ def test_db_table_declaration_access_literal():
     with pytest.raises(Exception):
         ModelDbTableDeclaration(
             name="llm_cost_aggregates",
+            database_ref="application",
+            schema="omninode_internal",
             migration="0003_llm_cost_aggregates.sql",
             access="invalid_access",  # type: ignore[arg-type]
             role="aggregates",
         )
 
 
-def test_db_table_declaration_default_database():
-    """database field must default to omnidash_analytics."""
+def test_db_table_declaration_requires_database_ref_and_schema():
+    """Table location must be explicit; no physical-database default is allowed."""
     from omnibase_core.models.contracts.subcontracts.model_db_ownership_subcontract import (
         ModelDbTableDeclaration,
     )
 
-    t = ModelDbTableDeclaration(
-        name="session_outcomes",
-        migration="0021_session_outcomes.sql",
-        role="outcomes",
+    with pytest.raises(ValidationError):
+        ModelDbTableDeclaration(
+            name="session_outcomes",
+            migration="0021_session_outcomes.sql",
+            role="outcomes",
+        )
+
+
+def test_db_table_declaration_rejects_retired_database_field():
+    """The retired physical database field cannot coexist with database_ref."""
+    from omnibase_core.models.contracts.subcontracts.model_db_ownership_subcontract import (
+        ModelDbTableDeclaration,
     )
-    assert t.database == "omnidash_analytics"
+
+    with pytest.raises(ValidationError, match="database"):
+        ModelDbTableDeclaration(
+            name="session_outcomes",
+            database_ref="application",
+            schema="tenant",
+            migration="0021_session_outcomes.sql",
+            role="outcomes",
+            database="omnidash_analytics",  # type: ignore[call-arg]
+        )
 
 
 def test_exports_from_subcontracts_init():

--- a/tests/unit/models/core/test_model_deployment_topology_database.py
+++ b/tests/unit/models/core/test_model_deployment_topology_database.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for typed application-database deployment topology contracts."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_database_grant_object_type import (
+    EnumDatabaseGrantObjectType,
+)
+from omnibase_core.enums.enum_database_privilege import EnumDatabasePrivilege
+from omnibase_core.enums.enum_database_schema_domain import EnumDatabaseSchemaDomain
+from omnibase_core.models.contracts.subcontracts.model_db_table_declaration import (
+    ModelDbTableDeclaration,
+)
+from omnibase_core.models.core.model_deployment_topology import ModelDeploymentTopology
+
+pytestmark = pytest.mark.unit
+
+
+def _database_payload() -> dict[str, Any]:
+    return {
+        "physical_name": "omnidash_analytics",
+        "schemas": {
+            "tenant": {"domain": "TENANT", "owner": "owner_onex_tenant"},
+            "omninode_internal": {
+                "domain": "OMNINODE_INTERNAL",
+                "owner": "owner_omninode_internal",
+            },
+            "platform_catalog": {
+                "domain": "PLATFORM_CATALOG",
+                "owner": "owner_platform_catalog",
+            },
+        },
+        "owners": {
+            "owner_onex_tenant": {"login": False},
+            "owner_omninode_internal": {"login": False},
+            "owner_platform_catalog": {"login": False},
+        },
+        "principals": {
+            "onex_api": {
+                "login": True,
+                "bypass_rls": False,
+                "grants": [
+                    {
+                        "object_type": "SCHEMA",
+                        "schema": "tenant",
+                        "privileges": ["USAGE"],
+                    },
+                    {
+                        "object_type": "TABLE",
+                        "schema": "tenant",
+                        "objects": ["delegation_events"],
+                        "privileges": ["SELECT", "INSERT"],
+                    },
+                ],
+            }
+        },
+        "bindings": {
+            "onex_api": {
+                "database_ref": "application",
+                "principal": "onex_api",
+                "dsn_env": "OMNINODE_CLOUD_DB_URL",
+            }
+        },
+        "migration_stream": "omnibase_infra.application",
+        "checksum_ledgers": {
+            "canonical": {
+                "schema": "platform_catalog",
+                "relation": "schema_migrations",
+                "stream_column": "migration_stream",
+                "domain_column": "domain",
+                "version_column": "version",
+                "checksum_column": "checksum",
+            }
+        },
+        "checksum_ledger": "canonical",
+    }
+
+
+def _topology_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "2.0",
+        "services": {},
+        "presets": {},
+        "active_preset": None,
+        "databases": {"application": _database_payload()},
+    }
+
+
+def test_database_topology_parses_typed_resource_and_resolves_table_domain() -> None:
+    topology = ModelDeploymentTopology.model_validate(_topology_payload())
+    declaration = ModelDbTableDeclaration(
+        name="delegation_events",
+        database_ref="application",
+        schema="tenant",
+        migration="nodes/node_projection_delegation/0001.sql",
+        access="read_write",
+        role="events",
+    )
+
+    database = topology.databases["application"]
+    assert database.physical_name == "omnidash_analytics"
+    assert database.schemas["tenant"].domain is EnumDatabaseSchemaDomain.TENANT
+    assert topology.table_domain(declaration) is EnumDatabaseSchemaDomain.TENANT
+    assert (
+        database.principals["onex_api"].grants[0].object_type
+        is EnumDatabaseGrantObjectType.SCHEMA
+    )
+    assert (
+        EnumDatabasePrivilege.USAGE
+        in database.principals["onex_api"].grants[0].privileges
+    )
+
+
+def test_database_topology_yaml_roundtrip_is_stable() -> None:
+    topology = ModelDeploymentTopology.model_validate(_topology_payload())
+
+    restored = ModelDeploymentTopology._from_yaml_string(topology._to_yaml_string())
+
+    assert restored == topology
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "message"),
+    [
+        (
+            ("databases", "application", "schemas", "tenant", "owner"),
+            "missing_owner",
+            "owner",
+        ),
+        (
+            (
+                "databases",
+                "application",
+                "bindings",
+                "onex_api",
+                "database_ref",
+            ),
+            "missing_database",
+            "database_ref",
+        ),
+        (
+            ("databases", "application", "bindings", "onex_api", "principal"),
+            "missing_principal",
+            "principal",
+        ),
+        (
+            ("databases", "application", "checksum_ledger"),
+            "missing_ledger",
+            "checksum_ledger",
+        ),
+        (
+            (
+                "databases",
+                "application",
+                "principals",
+                "onex_api",
+                "grants",
+                0,
+                "schema",
+            ),
+            "missing_schema",
+            "schema",
+        ),
+    ],
+)
+def test_unknown_database_cross_references_fail_closed(
+    path: tuple[str | int, ...], value: str, message: str
+) -> None:
+    payload = _topology_payload()
+    target: Any = payload
+    for part in path[:-1]:
+        target = target[part]
+    target[path[-1]] = value
+
+    with pytest.raises(ValidationError, match=message):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_binding_cannot_reference_a_different_database() -> None:
+    payload = _topology_payload()
+    payload["databases"]["reporting"] = _database_payload()
+
+    with pytest.raises(ValidationError, match="database_ref"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("login", False), ("bypass_rls", True)],
+)
+def test_workload_principal_must_be_login_without_bypass_rls(
+    field: str, value: bool
+) -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["principals"]["onex_api"][field] = value
+
+    with pytest.raises(ValidationError, match=field):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_schema_owner_must_be_nologin() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["owners"]["owner_onex_tenant"]["login"] = True
+
+    with pytest.raises(ValidationError, match="login"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_owner_and_login_principal_role_names_cannot_overlap() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["owners"]["onex_api"] = {"login": False}
+
+    with pytest.raises(
+        ValidationError, match="both NOLOGIN owners and LOGIN principals"
+    ):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_workload_principal_cannot_receive_ddl_privileges() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["principals"]["onex_api"]["grants"].append(
+        {
+            "object_type": "SCHEMA",
+            "schema": "tenant",
+            "privileges": ["CREATE"],
+        }
+    )
+
+    with pytest.raises(ValidationError, match="DDL privileges: CREATE"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_dsn_binding_accepts_only_an_environment_variable_name() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["bindings"]["onex_api"]["dsn_env"] = (
+        "postgresql://runtime@example.invalid/application"
+    )
+
+    with pytest.raises(ValidationError, match="dsn_env"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_unknown_fields_and_secret_material_are_rejected() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["principals"]["onex_api"]["password"] = (
+        "not-allowed"
+    )
+
+    with pytest.raises(ValidationError, match="password"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_grant_privileges_must_match_object_type() -> None:
+    payload = _topology_payload()
+    payload["databases"]["application"]["principals"]["onex_api"]["grants"][0][
+        "privileges"
+    ] = ["SELECT"]
+
+    with pytest.raises(ValidationError, match="SELECT"):
+        ModelDeploymentTopology.model_validate(payload)
+
+
+def test_unknown_table_location_fails_closed() -> None:
+    topology = ModelDeploymentTopology.model_validate(_topology_payload())
+    declaration = ModelDbTableDeclaration(
+        name="delegation_events",
+        database_ref="application",
+        schema="unknown_schema",
+        migration="nodes/node_projection_delegation/0001.sql",
+        role="events",
+    )
+
+    with pytest.raises(ValueError, match="unknown_schema"):
+        topology.table_domain(declaration)
+
+
+def test_table_cannot_override_topology_owned_domain() -> None:
+    with pytest.raises(ValidationError, match="domain"):
+        ModelDbTableDeclaration(
+            name="delegation_events",
+            database_ref="application",
+            schema="tenant",
+            migration="nodes/node_projection_delegation/0001.sql",
+            role="events",
+            domain="OMNINODE_INTERNAL",  # type: ignore[call-arg]
+        )
+
+
+def test_database_resource_is_frozen() -> None:
+    topology = ModelDeploymentTopology.model_validate(_topology_payload())
+
+    with pytest.raises(ValidationError):
+        topology.databases["application"].physical_name = "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Adds the frozen, typed application-database resource to `ModelDeploymentTopology` and makes every `ModelDbTableDeclaration` carry an explicit logical database and schema location.

This intentionally retires the legacy physical `database` field and its silent `omnidash_analytics` default. The change is fail-closed and is the model foundation for the dependent topology-instance, loader/ownership-validation, and inventory-manifest tickets.

## Changes

- add typed schema domains: `TENANT`, `OMNINODE_INTERNAL`, and `PLATFORM_CATALOG`
- add typed logical database resources with physical names, NOLOGIN owners, LOGIN/NOBYPASSRLS workload principals, scope-compatible explicit grants, secret-free DSN-environment bindings, migration streams, and selectable checksum ledgers
- validate all database/schema/owner/principal/binding/ledger references and reject contradictory LOGIN/NOLOGIN roles or workload DDL privileges
- expose topology-owned schema and table-domain resolution; table declarations cannot override domain classification
- require `database_ref` and `schema` on `ModelDbTableDeclaration`, remove `database`, reject unknown fields, and shrink the extra-forbid baseline
- add seeded invalid fixtures covering missing/unknown references, role invariants, secret material, incompatible grants, old/new field coexistence, frozen models, and YAML stability

## Test plan

- [x] Seeded RED captured before model implementation
- [x] `uv run pytest tests/unit/models/core/test_model_deployment_topology_database.py tests/unit/models/core/test_model_deployment_topology.py tests/test_db_ownership_subcontract.py -q` — 41 passed
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/omnibase_core` — 4,204 source files clean
- [x] `uv run pyright src/omnibase_core` — 0 errors (repository-existing warnings only)
- [x] export validation, enum governance, and Pydantic extra-forbid ratchet
- [x] full pre-commit hook chain
- [x] warm-cache semantic-diff isolation on canonical `.200`: `uv run pytest tests/scripts/test_semantic_diff_cli.py -q -n4 --dist=loadgroup --timeout=60 --timeout-method=thread` — 7 passed in 39.09s
- [ ] cold-cache full non-integration suite on canonical `.200`: 7,550 passed / 5 skipped before four pre-existing semantic-diff CLI workers timed out together and xdist exited with an internal scheduler error; tracked separately as OMN-15431

The failure is deterministic and independent of this diff's topology behavior. A cold-cache isolated reproduction dies with four workers at 63.94s; the identical warm-cache command passes 7/7, and one cold consumer-graph CLI invocation succeeds in 58.69s against the suite's 60s per-test timeout. The earlier local full-suite attempt stopped at the same semantic-diff group after 7,548 passed / 5 skipped. No product assertion failed in either full-suite attempt. OMN-15431 carries the root-cause fix so this topology PR does not absorb unrelated test-harness work.

## Type safety checklist

- [x] No new `metadata["key"]` or `metadata.get("key")` string literal access on Pydantic model fields
- [x] No new `metadata: dict[str, Any]` fields without TypedDict or exclusion
- [x] No new bare `except Exception`
- [x] No metadata dictionary keys added

## Scope boundaries

- No topology rendering or environment instances (OMN-15414)
- No runtime typed loader/global ownership validation (OMN-15418)
- No node/service manifest migration (OMN-15423)
- No database, grant, RLS, deployment, or runtime mutation
- Worktree is retained pending review/merge; cleanup is not yet eligible
- OCC companion/evidence remains a separate verifier lane if Receipt Gate requires it

## Related issues

- OMN-15417
- OMN-15431 (pre-existing cold-cache xdist regression)
- Parent: OMN-15354
- Enables: OMN-15414, OMN-15418, OMN-15423

Evidence-Ticket: OMN-15417
Evidence-Source: OCC#5692
