### PR TITLE
fix(OMN-15408): cover the selector's whole-tree sentinel in the pre-push host-guard target set

### DIFF
--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -104,35 +104,70 @@ guard_full_suite_host() {
 # a flag.
 #
 # SEAM -- what "heavyweight selection" means, exactly: the selection is
-# heavyweight when the paths pytest is about to be handed COVER THE ENTIRE
-# full-suite target this hook would run on a fail-closed escalation
-# (`$FULL_SUITE_TARGET`, defined next to the pytest invocation below so the
-# predicate and the actual run can never drift apart). Concretely: some
-# selected path is `$FULL_SUITE_TARGET` itself or a directory ANCESTOR of it.
-# That is "the selection failed to be a proper narrowing" expressed against the
-# selector's own output -- NOT a parallel cost model, no test counting, no
-# timing heuristic, nothing this hook does not already parse.
+# heavyweight when the paths pytest is about to be handed COVER THE ENTIRETY of
+# any HEAVY TARGET (`$HEAVY_SELECTION_TARGETS`, defined next to the pytest
+# invocation below so the predicate and the actual run can never drift apart).
+# Concretely: some selected path is a heavy target itself or a directory
+# ANCESTOR of one. Expressed against the selector's own output -- NOT a parallel
+# cost model, no test counting, no timing heuristic, nothing this hook does not
+# already parse.
 #
-# A genuine narrow selection (`tests/unit/scripts/`, a single test module) is
-# strictly below the target and stays runnable locally -- the guard must not
-# brick every push from a developer's machine, only the ones that are the
-# full-suite run wearing a different label.
+# There are exactly TWO heavy targets, and the second one is the OMN-15408
+# remediation. Round 1 measured the selection against `$FULL_SUITE_TARGET`
+# (`tests/`) alone, which made the fix INERT for this repo's own dominant
+# heavyweight shape:
 #
-# Keep this function self-contained (target passed in, no globals): it is
+#   * `$FULL_SUITE_TARGET` (`tests/`) -- what the fail-closed escalation runs.
+#     Reached when the selector sets `is_full_suite=True` (guarded on the flag
+#     branch too) or emits `selected_paths=["tests/"]`.
+#   * `$SELECTOR_WHOLE_TREE_SENTINEL` (`tests/unit/`) -- the selector's OWN
+#     fail-closed "I could not narrow this" answer. It is a DESCENDANT of
+#     `tests/`, never an ancestor, so a target set of `tests/` alone can never
+#     trip on it. Measured on host `omnibook` 2026-07-29 against the SHIPPED
+#     round-1 hook at merged commit c5b0a9e1, real selector, on round-1's own
+#     two-file diff (`PREPUSH_BASE_REF=c5b0a9e1^`):
+#     `selection: is_full_suite=False reason=None paths=[ tests/unit/ ]` ->
+#     `running impacted subset` -> guard NEVER invoked, exit 0, push allowed.
+#     That sentinel is 1452 of the 1520 test files the escalation itself would
+#     run (95.5%; `tests/` minus the always-ignored `tests/integration`), and
+#     the selector's own cost model shards it 37 ways versus 40 for the true
+#     full suite. It is the full-suite run wearing a different label, not a
+#     narrowing in any practical sense.
+#
+# This is deliberately NOT "any large selection" -- the sentinel is heavy
+# because it is the selector's declared no-narrowing-achieved answer, a signal
+# the selector already emits. A genuine narrow selection (`tests/scripts/`,
+# `tests/unit/scripts/`, a single test module) is strictly below every heavy
+# target and stays runnable locally -- the guard must not brick every push from
+# a developer's machine, only the ones that are the full-suite run relabelled.
+# Repos whose fail-closed sentinel is a genuine minority of their suite
+# (omnimarket: `tests/unit/` is 411 of 1251 files, 33%) correctly do NOT list it
+# as a heavy target; a heavy-target list is a per-repo measured claim, not a
+# constant to copy.
+#
+# Keep this function self-contained (targets passed in, no globals): it is
 # extracted and EXECUTED directly by
 # tests/scripts/test_prepush_hook_host_identity_guard.py.
 selection_is_whole_suite() {
-  local target normalized_target p normalized
-  target="$1"
+  # $1 = space-separated heavy-target list; remaining args = selected paths.
+  # Word-splitting $1 is INTENTIONAL (the target list is a hook-declared
+  # constant, never user input, and pytest directory targets contain no
+  # whitespace). A single target still behaves exactly as it did in round 1.
+  local targets normalized_target p normalized t
+  targets="$1"
   shift
-  [ -n "$target" ] || return 1
-  normalized_target="${target%/}/"
-  for p in "$@"; do
-    [ -n "$p" ] || continue
-    normalized="${p%/}/"
-    case "$normalized_target" in
-      "$normalized"*) return 0 ;;
-    esac
+  [ -n "$targets" ] || return 1
+  # shellcheck disable=SC2086
+  for t in $targets; do
+    [ -n "$t" ] || continue
+    normalized_target="${t%/}/"
+    for p in "$@"; do
+      [ -n "$p" ] || continue
+      normalized="${p%/}/"
+      case "$normalized_target" in
+        "$normalized"*) return 0 ;;
+      esac
+    done
   done
   return 1
 }
@@ -259,6 +294,22 @@ PREPUSH_TIMEOUT_FLAGS="-n4 --dist=loadgroup --timeout=60 --timeout-method=thread
 # escalation target automatically moves the guard predicate with it.
 FULL_SUITE_TARGET="tests/"
 
+# The governed selector's OWN fail-closed whole-tree sentinel -- the single-entry
+# answer it emits to mean "no narrowing achieved" (with `is_full_suite=False`,
+# which is exactly why round 1 missed it). Single-sourced from the selector:
+# `scripts/ci/test_selection_closure.py::TEST_UNIT_PREFIX`, which
+# `compute_closure_selection` returns as `selected_files=[TEST_UNIT_PREFIX]` on
+# every ambiguity, and which `scripts/ci/detect_test_paths.py` passes straight
+# through. tests/scripts/test_prepush_hook_host_identity_guard.py asserts this
+# literal still equals that constant AND that it still covers a supermajority of
+# the escalation target, so neither half of the claim can drift silently.
+SELECTOR_WHOLE_TREE_SENTINEL="tests/unit/"
+
+# The heavy-target set the selection is measured against. Space-separated; see
+# the SEAM comment on `selection_is_whole_suite` above for why there are two and
+# what each one is.
+HEAVY_SELECTION_TARGETS="${FULL_SUITE_TARGET} ${SELECTOR_WHOLE_TREE_SENTINEL}"
+
 if [ "$IS_FULL" = "True" ] || [ "$IS_FULL" = "true" ]; then
   guard_full_suite_host
   log "running FULL suite (fail-closed escalation): uv run pytest ${FULL_SUITE_TARGET} --ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
@@ -266,10 +317,10 @@ if [ "$IS_FULL" = "True" ] || [ "$IS_FULL" = "true" ]; then
   uv run pytest "${FULL_SUITE_TARGET}" --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?
 elif [ "${#PATHS[@]}" -gt 0 ]; then
   # OMN-15408: guard on the SELECTED WORK, not the is_full_suite flag. A
-  # selection that covers the whole full-suite target is the heavy run under
-  # another name and must be routed to .200 exactly as the flagged escalation is.
-  if selection_is_whole_suite "$FULL_SUITE_TARGET" "${PATHS[@]}"; then
-    guard_full_suite_host "whole-suite-equivalent impacted selection (is_full_suite=${IS_FULL}, selected paths [ ${PATHS_STR}] cover the entire '${FULL_SUITE_TARGET}' escalation target)"
+  # selection that covers a whole heavy target is the heavy run under another
+  # name and must be routed to .200 exactly as the flagged escalation is.
+  if selection_is_whole_suite "$HEAVY_SELECTION_TARGETS" "${PATHS[@]}"; then
+    guard_full_suite_host "whole-suite-equivalent impacted selection (is_full_suite=${IS_FULL}, selected paths [ ${PATHS_STR}] cover an entire heavyweight target [ ${HEAVY_SELECTION_TARGETS} ])"
   fi
   log "running impacted subset: uv run pytest ${PATHS_STR}--ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
   # shellcheck disable=SC2086

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -33,6 +33,18 @@ Three assertion classes:
    invoked -- while the identical selected work forced via
    `PREPUSH_FULL_SUITE=1` WAS refused. Assertion classes 1 and 2 above were
    green that entire time, because both only ever drove the flag-true path.
+4. Heavyweight-selection TARGET SET (OMN-15408 round 2) -- class 3 measured the
+   selection against `FULL_SUITE_TARGET` (`tests/`) alone, which made it INERT
+   for THIS repo's own dominant heavyweight shape. This repo's selector fails
+   closed to the single-entry sentinel `["tests/unit/"]` -- a DESCENDANT of
+   `tests/`, so a `tests/`-only target set can never trip on it. Measured on
+   `omnibook` 2026-07-29 against the SHIPPED round-1 hook at merged commit
+   c5b0a9e1, real selector, on round-1's own two-file diff: `is_full_suite=False
+   reason=None paths=[ tests/unit/ ]` -> `running impacted subset` -> guard never
+   invoked, exit 0, push allowed. That sentinel is 1452 of the 1520 test files
+   the escalation itself runs (95.5%). Class 3's tests were green that entire
+   time, because they only ever drove the `tests/` shape -- the one shape this
+   repo's selector reaches via the FLAG branch, which was already guarded.
 """
 
 from __future__ import annotations
@@ -42,6 +54,8 @@ import os
 import re
 import subprocess
 from pathlib import Path
+
+from scripts.ci.test_selection_closure import TEST_UNIT_PREFIX
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh"
@@ -159,10 +173,25 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
 # the fix must not brick every push from this Mac.
 
 _FULL_SUITE_TARGET = "tests/"
+# The selector's own fail-closed whole-tree sentinel (OMN-15408 round 2) -- the
+# shape this repo ACTUALLY reaches with is_full_suite=False. Asserted below to
+# still equal scripts/ci/test_selection_closure.py::TEST_UNIT_PREFIX.
+_SELECTOR_WHOLE_TREE_SENTINEL = "tests/unit/"
+# The full heavy-target set the shipped predicate must be evaluated against.
+_HEAVY_SELECTION_TARGETS = f"{_FULL_SUITE_TARGET} {_SELECTOR_WHOLE_TREE_SENTINEL}"
 # The literal production shape from the OMN-15408 evidence table.
 _WHOLE_SUITE_SELECTION = "tests/"
-# A real, genuinely-narrow subdirectory of this repo's suite.
+# Real, genuinely-narrow subdirectories of this repo's suite. `tests/scripts/`
+# is 10 of 1520 files; `tests/unit/scripts/` is a strict descendant of the
+# sentinel, so widening the target set must not swallow it.
 _NARROW_SELECTION = "tests/scripts/"
+_NARROW_SELECTION_UNDER_SENTINEL = "tests/unit/scripts/"
+# Minimum share of the escalation target the sentinel must cover for listing it
+# as a heavy target to be justified rather than overreach. Measured 95.5%
+# (1452/1520) on 2026-07-29; the floor is deliberately slack so ordinary tree
+# growth does not trip it, but a real restructuring that turned tests/unit/ into
+# a minority of the suite (as it is in omnimarket, 33%) would.
+_SENTINEL_COVERAGE_FLOOR = 0.75
 
 _PREDICATE_RE = re.compile(
     r"^selection_is_whole_suite\(\) \{.*?^\}",
@@ -312,9 +341,197 @@ def test_full_suite_target_is_single_sourced() -> None:
         "expected the fail-closed escalation to run ${FULL_SUITE_TARGET} "
         "itself, so the guard predicate cannot drift from the run it guards"
     )
-    assert 'selection_is_whole_suite "$FULL_SUITE_TARGET"' in script_text, (
-        "expected the predicate to be evaluated against the SAME "
-        "FULL_SUITE_TARGET the escalation runs"
+    assert (
+        'HEAVY_SELECTION_TARGETS="${FULL_SUITE_TARGET} ${SELECTOR_WHOLE_TREE_SENTINEL}"'
+        in script_text
+    ), (
+        "expected the heavy-target set to be DERIVED from FULL_SUITE_TARGET (the "
+        "run it guards) plus the selector's own whole-tree sentinel, not "
+        "hard-coded independently of either"
+    )
+    assert 'selection_is_whole_suite "$HEAVY_SELECTION_TARGETS"' in script_text, (
+        "expected the predicate to be evaluated against the full "
+        "HEAVY_SELECTION_TARGETS set -- evaluating it against FULL_SUITE_TARGET "
+        "alone is the OMN-15408 round-1 inertness defect (the selector's "
+        "tests/unit/ sentinel is a DESCENDANT of tests/ and can never trip it)"
+    )
+
+
+# -----------------------------------------------------------------------------
+# OMN-15408 round 2: the target SET, not just the escalation target
+# -----------------------------------------------------------------------------
+# Round 1 measured the selection against `FULL_SUITE_TARGET` (`tests/`) only.
+# This repo's selector reaches `tests/` only on the FLAG branch (`_full_suite()`
+# returns `selected_paths=["tests/"]` with `is_full_suite=True`), which was
+# already guarded. Its `is_full_suite=False` heavyweight answer is the closure
+# sentinel `["tests/unit/"]` -- a DESCENDANT of `tests/`, so the round-1
+# predicate provably never fired on it. Executed proof (host `omnibook`,
+# 2026-07-29, SHIPPED hook at merged c5b0a9e1, real selector, round-1's own
+# two-file diff as the input): `is_full_suite=False reason=None
+# paths=[ tests/unit/ ]` -> `running impacted subset` -> guard never invoked,
+# exit 0. The tests below pin both halves of the justification: the sentinel
+# LITERAL still matches the selector's constant, and the sentinel still COVERS a
+# supermajority of the escalation target (i.e. listing it as heavy is warranted,
+# not overreach).
+
+
+def test_selector_whole_tree_sentinel_matches_the_selector_constant() -> None:
+    """Anti-drift: the hook's sentinel literal must equal the selector's own.
+
+    The hook cannot import Python, so the sentinel is a bash literal. That
+    literal is only correct as long as the selector still fails closed to the
+    same path. Bind the two here: if `compute_closure_selection`'s sentinel ever
+    moves, this test fails instead of the guard silently going inert again --
+    which is exactly the failure round 1 shipped.
+    """
+    assert _SELECTOR_WHOLE_TREE_SENTINEL == TEST_UNIT_PREFIX, (
+        "this test's expected sentinel drifted from the selector's "
+        f"TEST_UNIT_PREFIX ({TEST_UNIT_PREFIX!r})"
+    )
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    assert f'SELECTOR_WHOLE_TREE_SENTINEL="{TEST_UNIT_PREFIX}"' in script_text, (
+        "expected the hook to declare SELECTOR_WHOLE_TREE_SENTINEL as the "
+        f"selector's own fail-closed sentinel {TEST_UNIT_PREFIX!r}; "
+        f"{HOOK_SCRIPT} is out of sync with "
+        "scripts/ci/test_selection_closure.py::TEST_UNIT_PREFIX"
+    )
+
+
+def test_sentinel_covers_a_supermajority_of_the_escalation_target() -> None:
+    """The measured justification for treating the sentinel as heavyweight.
+
+    A heavy-target list is a per-repo MEASURED claim, not a constant to copy
+    between repos: in omnimarket the same `tests/unit/` path is 33% of the suite
+    and listing it would be overreach. Here it is 95.5% (1452/1520 on
+    2026-07-29) of exactly what the escalation runs -- `tests/` minus the
+    always-ignored `tests/integration`. If a restructuring ever made it a
+    minority, the guard would start refusing genuine narrowings and this test
+    fails first.
+    """
+    escalation_root = REPO_ROOT / _FULL_SUITE_TARGET
+    sentinel_root = REPO_ROOT / _SELECTOR_WHOLE_TREE_SENTINEL
+    assert sentinel_root.is_dir(), f"expected the sentinel tree at {sentinel_root}"
+
+    ignored = REPO_ROOT / "tests" / "integration"
+    escalation_files = {
+        p for p in escalation_root.rglob("test_*.py") if not p.is_relative_to(ignored)
+    }
+    sentinel_files = set(sentinel_root.rglob("test_*.py"))
+
+    assert escalation_files, f"found no test files under {escalation_root}"
+    assert sentinel_files <= escalation_files, (
+        "the sentinel tree must be a subset of what the escalation runs"
+    )
+    share = len(sentinel_files) / len(escalation_files)
+    assert share >= _SENTINEL_COVERAGE_FLOOR, (
+        f"{_SELECTOR_WHOLE_TREE_SENTINEL} now covers only {share:.1%} "
+        f"({len(sentinel_files)}/{len(escalation_files)}) of the escalation "
+        f"target, below the {_SENTINEL_COVERAGE_FLOOR:.0%} floor. It is no "
+        "longer whole-suite-equivalent, so listing it in "
+        "HEAVY_SELECTION_TARGETS has become overreach -- drop it from the set "
+        "rather than lowering this floor."
+    )
+
+
+def test_predicate_flags_the_selector_whole_tree_sentinel() -> None:
+    """THE ROUND-1 INERTNESS, at predicate grain.
+
+    RED against the round-1 hook: `selection_is_whole_suite "tests/"
+    "tests/unit/"` returns false, because `tests/unit/` is a descendant of the
+    target and the predicate only matches the target itself or an ancestor.
+    """
+    assert _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, _SELECTOR_WHOLE_TREE_SENTINEL
+    ), (
+        "the selector's fail-closed whole-tree sentinel is the heaviest "
+        "is_full_suite=False selection this repo produces; it must be treated "
+        "as heavyweight"
+    )
+    assert _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, _SELECTOR_WHOLE_TREE_SENTINEL.rstrip("/")
+    ), "a trailing-slash-less sentinel must normalize to the same target"
+    assert _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, _NARROW_SELECTION, _SELECTOR_WHOLE_TREE_SENTINEL
+    ), "one heavyweight path anywhere in the selection makes it heavyweight"
+    # The round-1 target set is preserved, not replaced.
+    assert _predicate_says_whole_suite(_HEAVY_SELECTION_TARGETS, _FULL_SUITE_TARGET)
+
+
+def test_predicate_still_allows_narrowings_under_the_widened_target_set() -> None:
+    """Anti-overreach pin against the WIDENED set.
+
+    Adding a second, deeper heavy target is the change most likely to start
+    swallowing genuine narrowings. `tests/scripts/` (10 files) and
+    `tests/unit/scripts/` (a strict descendant of the sentinel) must both stay
+    ALLOWED, or the guard becomes a blanket push block.
+    """
+    assert not _predicate_says_whole_suite(_HEAVY_SELECTION_TARGETS, _NARROW_SELECTION)
+    assert not _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, _NARROW_SELECTION_UNDER_SENTINEL
+    )
+    assert not _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, f"{_NARROW_SELECTION_UNDER_SENTINEL}test_thing.py"
+    )
+    assert not _predicate_says_whole_suite(
+        _HEAVY_SELECTION_TARGETS, "tests/unit/models/", "tests/unit/cli/"
+    ), "several real subdirectories are still a proper narrowing"
+    assert not _predicate_says_whole_suite(_HEAVY_SELECTION_TARGETS)
+
+
+def test_guard_refuses_selector_whole_tree_sentinel_when_flag_is_false(
+    tmp_path: Path,
+) -> None:
+    """THE OMN-15408 ROUND-2 REGRESSION, end-to-end through the real hook.
+
+    `is_full_suite=False` + `selected_paths=["tests/unit/"]` on a non-`.200`
+    host is the shape the SHIPPED round-1 hook allowed through to pytest at
+    merged commit c5b0a9e1 (verified against the real selector on that commit's
+    own diff, not stubbed). RED against round 1; GREEN after.
+    """
+    result = _run_hook_with_stubbed_selection(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_SELECTOR_WHOLE_TREE_SENTINEL],
+    )
+    assert result.returncode != 0, (
+        "expected the host guard to refuse the selector's fail-closed "
+        "whole-tree sentinel selection even though is_full_suite=False; got "
+        f"exit {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "not the designated .200 build host" in result.stderr, (
+        f"expected the refusal message in stderr, got: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" not in result.stdout, (
+        "the guard must refuse BEFORE pytest is invoked -- found a pytest "
+        f"invocation in stdout: {result.stdout!r}"
+    )
+
+
+def test_guard_allows_a_narrow_selection_under_the_sentinel_on_a_local_host(
+    tmp_path: Path,
+) -> None:
+    """Anti-overreach pin, end-to-end, for the newly-added heavy target.
+
+    `tests/unit/scripts/` sits UNDER the sentinel. It must still run locally --
+    the widened target set must catch the sentinel itself, not everything
+    beneath it.
+    """
+    result = _run_hook_with_stubbed_selection(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_NARROW_SELECTION_UNDER_SENTINEL],
+    )
+    assert result.returncode == 0, (
+        "expected a narrow selection under the sentinel to be allowed on a "
+        f"non-.200 host; got exit {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "not the designated .200 build host" not in result.stderr, (
+        f"the guard must NOT refuse a proper narrowing; stderr: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" in result.stdout, (
+        f"expected the narrow selection to reach pytest; stdout: {result.stdout!r}"
     )
 
 


### PR DESCRIPTION
## OMN-15408 remediation — round 1's fix was INERT in the repo it shipped in

Round 1 (#1528, merged as `c5b0a9e1`) correctly re-keyed `guard_full_suite_host` from the selector's `is_full_suite` **flag** onto the **selected work**. But it measured the selection against `FULL_SUITE_TARGET` (`tests/`) **alone**, and the predicate matches only "the target itself or a directory **ancestor** of it".

`omnibase_core`'s selector fails closed to the single-entry sentinel `["tests/unit/"]` — a **DESCENDANT** of `tests/`. So in this repo the round-1 predicate provably never fired on the shape the selector actually produces.

### Executed proof (not inferred): the shipped fix did not fire

Host `omnibook`, the **SHIPPED** hook at merged commit `c5b0a9e1`, the **real** selector (no stub), driven on round-1's own two-file diff (`PREPUSH_BASE_REF=c5b0a9e1^`), with `PREPUSH_200_HOSTNAME` forced non-matching so host identity cannot be the reason it passed:

```
[prepush-smart-tests] selection: is_full_suite=False reason=None paths=[ tests/unit/ ] (feature-flag=on)
[prepush-smart-tests] running impacted subset: uv run pytest tests/unit/ --ignore=tests/integration -n4 ...
[prepush-smart-tests] impacted tests passed; allowing push.
EXIT=0
```

Guard never invoked. Push allowed. **Same command against this branch:**

```
[prepush-smart-tests] selection: is_full_suite=False reason=None paths=[ tests/unit/ ] (feature-flag=on)
[prepush-smart-tests] ERROR: whole-suite-equivalent impacted selection (is_full_suite=False, selected paths
  [ tests/unit/ ] cover an entire heavyweight target [ tests/ tests/unit/ ]) triggered on host 'omnibook',
  not the designated .200 build host
EXIT=1
```

Identical selection, identical cost, opposite outcome — the exact defect class OMN-15408 was opened to close, still open in the canary repo after round 1.

### Why `tests/unit/` is not a narrowing here (measured, this repo)

| Quantity | `tests/unit/` | escalation target (`tests/` minus always-ignored `tests/integration`) |
| --- | --- | --- |
| test files | 1452 | 1520 |
| share | **95.5%** | 100% |
| selector's own shard count | 37 | 40 |

It is the full-suite run wearing a different label. Compare `omnimarket`, where the same path is **411 of 1251 files (33%)** — a genuine narrowing. **A heavy-target list is a per-repo measured claim, not a constant to copy.**

## Seam definition — the exact predicate

**"Heavyweight selection" =** the runnable path set pytest is about to receive covers the entirety of **any** member of `HEAVY_SELECTION_TARGETS` — i.e. some selected path is a heavy target itself, or a directory **ancestor** of one.

```bash
selection_is_whole_suite() {
  # $1 = space-separated heavy-target list; remaining args = selected paths.
  targets="$1"; shift
  for t in $targets; do                    # deliberate word-split: hook-declared constant
    normalized_target="${t%/}/"
    for p in "$@"; do
      normalized="${p%/}/"
      case "$normalized_target" in
        "$normalized"*) return 0 ;;        # p == t, or p is an ancestor of t
      esac
    done
  done
  return 1
}
```

| Field | Type | Meaning |
| --- | --- | --- |
| `FULL_SUITE_TARGET` | shell string, trailing `/` | Literal target of the fail-closed escalation. `tests/` in this repo. Unchanged. |
| `SELECTOR_WHOLE_TREE_SENTINEL` | shell string, trailing `/` | The selector's **own** fail-closed "I could not narrow" answer. `tests/unit/`, single-sourced from `scripts/ci/test_selection_closure.py::TEST_UNIT_PREFIX`. **NEW.** |
| `HEAVY_SELECTION_TARGETS` | space-separated string | `"${FULL_SUITE_TARGET} ${SELECTOR_WHOLE_TREE_SENTINEL}"` — derived, never independently hard-coded. **NEW.** |
| `$1` (was: single target) | string | Now a target **list**. A single-target call behaves exactly as in round 1, so every round-1 predicate assertion still holds. |
| return 0 / 1 | heavyweight / proper narrowing | Guard invoked with a reason naming the matched target set / runs locally, unchanged. |

**Still no parallel cost model.** The sentinel is a value the selector *already emits*; the predicate reads only output the hook already parses. No test counting, no timing heuristic, no threshold in the shipped code path. The "heavyweight because it is the selector's declared no-narrowing-achieved answer" framing is what makes this principled rather than "any large selection".

### Anti-drift mechanism (a rule is not a mechanism)

The sentinel is a bash literal, so it can rot silently — which is precisely how round 1 went inert. Two tests bind it:

1. `test_selector_whole_tree_sentinel_matches_the_selector_constant` — **imports** `TEST_UNIT_PREFIX` from the selector and asserts the hook declares that exact value. If `compute_closure_selection`'s sentinel moves, this fails instead of the guard quietly going dead.
2. `test_sentinel_covers_a_supermajority_of_the_escalation_target` — walks both trees and asserts the sentinel still covers ≥75% of what the escalation runs. This pins the **justification**, not just the constant: if a restructuring made `tests/unit/` a minority (as it is in omnimarket), the guard would start refusing real narrowings, and this test fails first with "drop it from the set rather than lowering this floor".

## RED → GREEN

`tests/scripts/test_prepush_hook_host_identity_guard.py`: **13 → 19 tests.**

RED by substitution — round-1's shipped hook (`git show c5b0a9e1:...`) swapped in under the new tests, run on both `omnibook` and `.200`, identical result: **4 failed / 15 passed.**

```
FAILED test_guard_refuses_selector_whole_tree_sentinel_when_flag_is_false
   got exit 0. stdout='STUB-PYTEST-INVOKED run pytest tests/unit/ --ignore=tests/integration ...'
FAILED test_predicate_flags_the_selector_whole_tree_sentinel
   where False = _predicate_says_whole_suite('tests/ tests/unit/', 'tests/unit/')
FAILED test_selector_whole_tree_sentinel_matches_the_selector_constant
FAILED test_full_suite_target_is_single_sourced
```

GREEN after: **19 passed** (`.200` and `omnibook`). Hook restored to sha256 parity after substitution, verified.

New tests (6):

- `test_selector_whole_tree_sentinel_matches_the_selector_constant` — anti-drift bind to the selector's constant
- `test_sentinel_covers_a_supermajority_of_the_escalation_target` — anti-drift bind to the measured justification
- `test_predicate_flags_the_selector_whole_tree_sentinel` — the round-1 inertness, at predicate grain, executing the **shipped bash function** (extracted, never re-implemented)
- `test_predicate_still_allows_narrowings_under_the_widened_target_set` — anti-overreach against the widened set
- `test_guard_refuses_selector_whole_tree_sentinel_when_flag_is_false` — **the regression**, end-to-end through the real hook
- `test_guard_allows_a_narrow_selection_under_the_sentinel_on_a_local_host` — anti-overreach, end-to-end

**Anti-overreach pins pass in BOTH directions** (round-1 hook and this one): `tests/scripts/`, `tests/unit/scripts/`, `tests/unit/scripts/test_x.py`, and multi-subdirectory selections (`tests/unit/models/` + `tests/unit/cli/`) all stay ALLOWED locally. Widening the target set to include a *deeper* path is the change most likely to swallow genuine narrowings; it does not.

## Gates (`.200` / `stickybeatz-studio`, per rule 11a)

- Worktree built by **patch-transfer with sha256 parity verified in both directions** on both changed files, before and after `ruff format` (closes the edit-locality trap; `Edit`/`Write` land locally, only `ssh` Bash reaches `.200`).
- `uv run pytest tests/scripts/test_prepush_hook_host_identity_guard.py` → **19 passed**.
- `ruff format` + `ruff check` → clean. `bash -n` + `shellcheck -S warning` on the hook → clean.
- **`pre-commit run --files <this diff>` → rc=0, fully clean** (every hook Passed or Skipped).
- `pre-commit run --all-files` run **explicitly** on `.200` (its `core.hooksPath` is redirected to `scripts/git-hooks/canonical-clone`, so a clean `git commit` there proves nothing).

> **`pre-commit run --all-files` is rc=1 on this branch — and rc=1 on clean `dev` too.** Rather than assert "pre-existing" from a grep, I ran `--all-files` a second time in a **detached worktree at clean `dev` (`c5b0a9e1`)** and diffed the failing-hook sets: **22 failing hooks on the fix branch, 22 on clean dev, `comm` delta empty in both directions.** This diff introduces zero new pre-commit findings. The 22 (yamlfmt, print-statement, stub/fallback/error-raising detectors, etc.) are a pre-existing repo-wide backlog on `dev`, not this PR's, and not claimed as fixed here.

- Committed and pushed from `.200`, clean worktree (`--all-files` auto-fixed 7 unrelated YAML files as a side effect; those were reverted, **not** committed — the commit is exactly the 2 intended files).

> **Honest note on the pre-push hook, replacing the "pleasing recursion" claim in #1528's body.** The corrected guard did **not** execute during this push — and *not* because the host matched. `.200`'s `core.hooksPath` is redirected to `scripts/git-hooks/canonical-clone`, so the pre-commit-framework `pre-push` hook is orphaned there entirely (this is OMN-15071, still open). The guard's behavior on `.200` is proven by the tests and by the direct hook invocations above, not by this push. Claiming "pushed from the designated host so the guard didn't need to fire" would be reading a hooks-orphaning no-op as a passing gate.

## Honesty repairs shipped with this PR

1. **#1528's evidence table asserted an `omnibase_core` row that does not reproduce.** It recorded `is_full_suite=True reason=test_infrastructure` → "push refused, exit 1, 0 tests" for core. Against the merged selector on that PR's own file set the live output is `is_full_suite=False reason=None paths=[ tests/unit/ ]` (re-measured above). The row as written made the body read as though core were covered by the fix; it was the one repo where the fix was inert. A correction comment is posted on #1528.
2. **OMN-15428 disclosed core's hole as ABSENT rather than deferred.** It stated "core and omnimarket use `tests/`, so they do not have this hole" — false for core. OMN-15428's description now carries a dated CORRECTION at the top, the false sentence is struck through in place, and the residual it *legitimately* tracks (infra's `['tests/ci/','tests/scripts/','tests/unit/scripts/']` row — a genuine proper narrowing, 2,429 tests / 245s) is explicitly stated as **unchanged and still open**. This PR does not close OMN-15428.

## Scope: why this is a one-repo change

The round-1 fix shipped identically to three repos; this remediation touches only `omnibase_core`, by measurement:

| Repo | `FULL_SUITE_TARGET` | selector's fail-closed sentinel | relationship | `tests/unit/` share | change needed |
| --- | --- | --- | --- | --- | --- |
| omnibase_core | `tests/` | `["tests/unit/"]` | **descendant → never matched** | 1452/1520 = **95.5%** | **YES (this PR)** |
| omnibase_infra | `tests/unit/` | `["tests/unit/"]` | target **is** the sentinel | n/a (target itself) | no |
| omnimarket | `tests/` | `["tests/"]` | sentinel **is** the target | 411/1251 = 33% (genuine narrowing) | no |

Verified by reading each repo's `detect_test_paths.py` on `origin/dev` and counting test files. Adding the sentinel to omnimarket's target set would be **overreach** — it would start refusing a 33% selection — which is exactly what test 2 of the anti-drift pair exists to prevent.

## Disclosed, not fixed here

- **Stale interpreter pin.** `omnibase_infra/.git/hooks/pre-push` pins `INSTALL_PYTHON=$OMNI_HOME/omni_worktrees/OMN-12912/omnibase_infra/.venv/bin/python`. Live readback 2026-07-29: that path **currently exists and is executable**, so the pin is not dead today — but it has already migrated once (the ticket recorded an OMN-14974 path) and dies with that worktree, after which the chain survives only on the template's `elif command -v pre-commit` fallback. `hook_reinstall` = **DEFERRED to a named post-drain step**, with a live reason: `OMN-12912`'s `omnibase_infra` worktree is an **active lane** (HEAD commit `9254ed57` at 14:25 today) and its venv **is** the pin target, so re-running `pre-commit install` in the canonical clone mid-flight would mutate the hook chain of a running lane. Note also that a bare `pre-commit install` is not the durable fix — it re-pins to whichever interpreter is active at that moment, reproducing the defect. The durable fix (pin the brew interpreter per rule 11, or drop the pin for the PATH lookup) is a separate change and is deliberately not bundled here.
- **OMN-15071** (`.200` `core.hooksPath` orphaning) is load-bearing for this ticket's own goal and remains open: the guard cannot fire on `.200` at all today. See the honest note above.
- **OMN-15428** residual (heavy-but-proper-narrowing selections) — corrected, still open, not closed by this PR.

OCC companion authored separately, per the no-self-authored-evidence rule.

Refs OMN-15408

Evidence-Ticket: OMN-15408
Evidence-Source: OCC#5510
