### PR TITLE
feat(OMN-15392): type DoD evidence execution scope

### DIFF
--- a/src/omnibase_core/enums/ticket/__init__.py
+++ b/src/omnibase_core/enums/ticket/__init__.py
@@ -15,6 +15,9 @@ from omnibase_core.enums.ticket.enum_definition_location import (
     EnumDefinitionLocation,
 )
 from omnibase_core.enums.ticket.enum_dod_check_type import EnumDodCheckType
+from omnibase_core.enums.ticket.enum_dod_evidence_execution_scope import (
+    EnumDodEvidenceExecutionScope,
+)
 from omnibase_core.enums.ticket.enum_interface_kind import (
     EnumInterfaceKind,
     InterfaceKind,
@@ -73,6 +76,8 @@ __all__ = [
     "EnumContractInterfaceSurface",
     # OMN-10241: DoD evidence check types
     "EnumDodCheckType",
+    # OMN-15392: explicit hosted/local evidence execution audience
+    "EnumDodEvidenceExecutionScope",
     # OMN-13338: tiered proof-packet enums
     "EnumProofTier",
     "EnumTicketClass",

--- a/src/omnibase_core/enums/ticket/enum_dod_evidence_execution_scope.py
+++ b/src/omnibase_core/enums/ticket/enum_dod_evidence_execution_scope.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Execution audience for a ticket contract DoD evidence item (OMN-15392)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDodEvidenceExecutionScope(StrEnum):
+    """Declare which contract gate is authorized to execute an evidence item.
+
+    ``HOSTED_AND_LOCAL`` is the backwards-compatible default.  It permits the
+    hosted contract-compliance gate and the local Done gate to execute the
+    item's checks. ``LOCAL_DONE_GATE`` is reserved for checks whose evidence
+    source is unavailable to hosted CI, such as a private repository. Hosted
+    consumers must report these items as not evaluated; they must never infer a
+    passing result from the declaration.
+    """
+
+    HOSTED_AND_LOCAL = "hosted_and_local"
+    LOCAL_DONE_GATE = "local_done_gate"
+
+
+__all__ = ["EnumDodEvidenceExecutionScope"]

--- a/src/omnibase_core/models/ticket/model_contract_dod_item.py
+++ b/src/omnibase_core/models/ticket/model_contract_dod_item.py
@@ -11,8 +11,9 @@ which serves the PR-gate receipt validation path.
 After Task 4 lands (OCC re-export + ModelDodCheck collision resolution),
 OCC will re-export this class as its ModelDodEvidenceItem.
 
-Field inventory (from OCC model_ticket_contract.py line 103):
-  id, description, source, linear_dod_text, checks, status, evidence_artifact
+Field inventory (from OCC model_ticket_contract.py line 103, plus OMN-15392):
+  id, description, source, linear_dod_text, checks, execution_scope, status,
+  evidence_artifact
 
 Security constraints: _MAX_STRING_LENGTH = 10000, _MAX_LIST_ITEMS = 1000.
 """
@@ -23,6 +24,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnibase_core.enums.ticket.enum_dod_evidence_execution_scope import (
+    EnumDodEvidenceExecutionScope,
+)
 from omnibase_core.models.contracts.ticket.model_dod_evidence_check import (
     ModelDodEvidenceCheck,
 )
@@ -63,6 +67,13 @@ class ModelContractDodItem(BaseModel):
         default_factory=list,
         description="Executable checks that verify this DoD item",
         max_length=_MAX_LIST_ITEMS,
+    )
+    execution_scope: EnumDodEvidenceExecutionScope = Field(
+        default=EnumDodEvidenceExecutionScope.HOSTED_AND_LOCAL,
+        description=(
+            "Gate audience authorized to execute this evidence item. "
+            "local_done_gate items are not evaluated by hosted compliance."
+        ),
     )
     status: Literal["pending", "verified", "failed", "skipped"] = Field(
         default="pending",

--- a/tests/unit/models/ticket/test_model_contract_dod_item.py
+++ b/tests/unit/models/ticket/test_model_contract_dod_item.py
@@ -9,6 +9,9 @@ import pytest
 from pydantic import ValidationError
 
 from omnibase_core.enums.ticket.enum_dod_check_type import EnumDodCheckType
+from omnibase_core.enums.ticket.enum_dod_evidence_execution_scope import (
+    EnumDodEvidenceExecutionScope,
+)
 from omnibase_core.models.contracts.ticket.model_dod_evidence_check import (
     ModelDodEvidenceCheck,
 )
@@ -17,6 +20,36 @@ from omnibase_core.models.ticket.model_contract_dod_item import ModelContractDod
 
 @pytest.mark.unit
 class TestModelContractDodItemExtendedChecks:
+    def test_execution_scope_defaults_to_hosted_and_local(self) -> None:
+        item = ModelContractDodItem(
+            id="dod-default-scope",
+            description="Default evidence is evaluated by both consumers",
+        )
+
+        assert item.execution_scope is EnumDodEvidenceExecutionScope.HOSTED_AND_LOCAL
+
+    def test_local_done_gate_execution_scope_round_trips(self) -> None:
+        item = ModelContractDodItem.model_validate(
+            {
+                "id": "dod-private-runtime-proof",
+                "description": "Private runtime evidence",
+                "execution_scope": "local_done_gate",
+            }
+        )
+
+        assert item.execution_scope is EnumDodEvidenceExecutionScope.LOCAL_DONE_GATE
+        assert item.model_dump(mode="json")["execution_scope"] == "local_done_gate"
+
+    def test_unknown_execution_scope_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelContractDodItem.model_validate(
+                {
+                    "id": "dod-invalid-scope",
+                    "description": "Unknown consumers must fail closed",
+                    "execution_scope": "hosted_maybe",
+                }
+            )
+
     def test_grep_check_type_with_dict_check_value_validates(self) -> None:
         check = ModelDodEvidenceCheck(
             check_type=EnumDodCheckType.GREP,


### PR DESCRIPTION
## Summary

- add `EnumDodEvidenceExecutionScope` with `hosted_and_local` and `local_done_gate`
- add typed `execution_scope` to `ModelContractDodItem`
- preserve backwards compatibility with `hosted_and_local` as the default
- reject unknown execution audiences and round-trip the local-only value as typed JSON

## Why

Credential-limited evidence needs a contract-owned execution audience. Hosted consumers can then report local-only evidence as not evaluated without treating that declaration as proof. The paired evaluator implementation is in OCC #5522.

## Verification

- execution-scope focused tests: 18 passed
- ticket-model suite: 257 passed
- strict mypy on changed model/enum surfaces: passed
- Ruff, enum governance, export checks, and pre-commit: passed
- governed pre-push policy/type gates on `.200`: passed through strict mypy,
  pyright, evidence shape, naming, UUID, enum governance, and node purity
- governed full non-integration suite on `.200`: **BLOCKED by pre-existing
  OMN-15431** after 7,764 passed / 5 skipped; three cold-cache semantic-diff CLI
  tests exceeded the 60-second thread timeout, killed their xdist workers, and
  produced pytest exit 3 (no product assertion)
- exact semantic-diff file with the generated cache warm: 7 passed in 161.44s

## Landing order and residuals

The paired OCC evaluator defaults omitted values compatibly and may land independently. Authoring `local_done_gate` in central contracts should wait for this schema to merge/release and for OCC to consume that release. OMN-15392 remains open for AC4 deploy-leg promotion, and this draft is additionally held on the existing OMN-15431 cold-cache xdist gate defect; this PR does not claim ticket completion.

Evidence-Source: OCC#5675
Evidence-Ticket: OMN-15392

Linear: https://linear.app/omninode/issue/OMN-15392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution-scope options for contract evidence items: hosted and local, or local-only completion.
  * Contract evidence items now include an execution scope, defaulting to hosted and local evaluation.
  * Added validation for supported execution-scope values.

* **Tests**
  * Added coverage for default values, JSON round-tripping, and invalid execution scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
