### PR TITLE
feat(OMN-15539): type cloud delegation inference wire contracts

### DIFF
--- a/src/omnibase_core/enums/enum_delegation_terminal_failure_cause.py
+++ b/src/omnibase_core/enums/enum_delegation_terminal_failure_cause.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed terminal failure causes for delegation wire results."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class EnumDelegationTerminalFailureCause(str, Enum):
+    """Machine-readable cause of a terminal delegation failure."""
+
+    PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+
+
+__all__: list[str] = ["EnumDelegationTerminalFailureCause"]

--- a/src/omnibase_core/enums/enum_quality_score_comparison.py
+++ b/src/omnibase_core/enums/enum_quality_score_comparison.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed comparison between a delegation quality score and its required bar."""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+
+@unique
+class EnumQualityScoreComparison(str, Enum):
+    """Machine-readable relationship between a quality score and its bar."""
+
+    BELOW_BAR = "below_bar"
+    AT_OR_ABOVE_BAR = "at_or_above_bar"
+
+
+__all__: list[str] = ["EnumQualityScoreComparison"]

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -23,6 +23,8 @@ from omnibase_core.models.delegation.wire.model_delegation_failed import (
     ModelDelegationFailed,
 )
 from omnibase_core.models.delegation.wire.model_delegation_result import (
+    EnumDelegationTerminalFailureCause,
+    EnumQualityScoreComparison,
     ModelDelegationResult,
 )
 from omnibase_core.models.delegation.wire.model_delegation_wire_envelope import (
@@ -68,8 +70,10 @@ __all__: list[str] = [
     "SUPPORTED_ACCEPTANCE_CRITERIA",
     "TASK_DELEGATED_TOPIC_V1",
     "EnumBudgetAction",
+    "EnumDelegationTerminalFailureCause",
     "EnumQualityContractMode",
     "EnumQualityGateCategory",
+    "EnumQualityScoreComparison",
     "EnumTierCostType",
     "ModelBaselineIntent",
     "ModelBifrostDelegationConfig",

--- a/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
@@ -5,6 +5,10 @@
 
 from __future__ import annotations
 
+from typing import Self
+
+from pydantic import model_validator
+
 from omnibase_core.models.delegation.wire.model_delegation_result import (
     ModelDelegationResult,
 )
@@ -13,10 +17,18 @@ from omnibase_core.models.delegation.wire.model_delegation_result import (
 class ModelDelegationCompleted(ModelDelegationResult):
     """Delegation terminal, COMPLETED outcome (OMN-14600).
 
-    Thin subclass: adds no new fields and no new validation. Class identity
-    alone is what class-name to topic routing uses to disambiguate the
-    completed terminal outcome.
+    Thin subclass: adds no new fields. Class identity disambiguates the
+    completed topic from the failed topic, while validation rejects terminal
+    failure causes on completed outcomes.
     """
+
+    @model_validator(mode="after")
+    def validate_no_terminal_failure_cause(self) -> Self:
+        """A completed terminal cannot simultaneously name a failure cause."""
+        if self.terminal_failure_cause is not None:
+            msg = "completed delegation cannot carry terminal_failure_cause"
+            raise ValueError(msg)
+        return self
 
 
 __all__: list[str] = ["ModelDelegationCompleted"]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_completed.py
@@ -23,10 +23,19 @@ class ModelDelegationCompleted(ModelDelegationResult):
     """
 
     @model_validator(mode="after")
-    def validate_no_terminal_failure_cause(self) -> Self:
-        """A completed terminal cannot simultaneously name a failure cause."""
+    def validate_completed_terminal_truth(self) -> Self:
+        """Keep the completed topic identity consistent with its payload."""
         if self.terminal_failure_cause is not None:
             msg = "completed delegation cannot carry terminal_failure_cause"
+            raise ValueError(msg)
+        if self.terminal_failure_reason is not None:
+            msg = "completed delegation cannot carry terminal_failure_reason"
+            raise ValueError(msg)
+        if self.failure_reason:
+            msg = "completed delegation cannot carry failure_reason"
+            raise ValueError(msg)
+        if not self.quality_passed:
+            msg = "completed delegation requires quality_passed"
             raise ValueError(msg)
         return self
 

--- a/src/omnibase_core/models/delegation/wire/model_delegation_failed.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_failed.py
@@ -5,6 +5,10 @@
 
 from __future__ import annotations
 
+from typing import Self
+
+from pydantic import model_validator
+
 from omnibase_core.models.delegation.wire.model_delegation_result import (
     ModelDelegationResult,
 )
@@ -13,10 +17,18 @@ from omnibase_core.models.delegation.wire.model_delegation_result import (
 class ModelDelegationFailed(ModelDelegationResult):
     """Delegation terminal, FAILED outcome (OMN-14600).
 
-    Thin subclass: adds no new fields and no new validation. Class identity
-    alone is what class-name to topic routing uses to disambiguate the failed
-    terminal outcome.
+    Thin subclass: adds no new fields. Class identity disambiguates the failed
+    topic from the completed topic, while validation rejects an accepted
+    quality verdict on a failed terminal.
     """
+
+    @model_validator(mode="after")
+    def validate_failed_terminal_truth(self) -> Self:
+        """Keep the failed topic identity consistent with its payload."""
+        if self.quality_passed:
+            msg = "failed delegation requires quality_passed=false"
+            raise ValueError(msg)
+        return self
 
 
 __all__: list[str] = ["ModelDelegationFailed"]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -10,6 +10,13 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
+    EnumDelegationTerminalFailureCause,
+)
+from omnibase_core.enums.enum_quality_score_comparison import (
+    EnumQualityScoreComparison,
+)
+
 
 class ModelDelegationResult(BaseModel):
     """Delegation outcome: content, quality status, model info, and metrics."""
@@ -38,6 +45,29 @@ class ModelDelegationResult(BaseModel):
         ge=0.0,
         le=1.0,
         description="Quality score from 0.0 to 1.0.",
+    )
+    required_quality_bar: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Authoritative minimum quality score applied to this result. None when "
+            "no quality bar was evaluated."
+        ),
+    )
+    score_vs_required_bar: EnumQualityScoreComparison | None = Field(
+        default=None,
+        description=(
+            "Typed comparison of quality_score to required_quality_bar. None when "
+            "no quality bar was evaluated."
+        ),
+    )
+    failed_acceptance_criteria: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Authoritative quality-gate failure details. Empty when no acceptance "
+            "criterion failed or no quality gate ran."
+        ),
     )
     latency_ms: int = Field(
         ..., ge=0, description="End-to-end latency in milliseconds."
@@ -81,6 +111,13 @@ class ModelDelegationResult(BaseModel):
     terminal_failure_reason: str | None = Field(
         default=None,
         description="Terminal failure reason when delegation fails after escalation.",
+    )
+    terminal_failure_cause: EnumDelegationTerminalFailureCause | None = Field(
+        default=None,
+        description=(
+            "Stable machine-readable cause for a terminal delegation failure. "
+            "None for completed results and legacy failure producers."
+        ),
     )
     routing_tiers_hash: str | None = Field(
         default=None,
@@ -156,5 +193,36 @@ class ModelDelegationResult(BaseModel):
             raise ValueError(msg)
         return self
 
+    @model_validator(mode="after")
+    def validate_quality_score_comparison(self) -> Self:
+        """Reject a structured comparison that contradicts its numeric evidence."""
+        if self.required_quality_bar is None or self.score_vs_required_bar is None:
+            return self
 
-__all__: list[str] = ["ModelDelegationResult"]
+        expected = (
+            EnumQualityScoreComparison.BELOW_BAR
+            if self.quality_score < self.required_quality_bar
+            else EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+        )
+        if self.score_vs_required_bar is not expected:
+            msg = (
+                "score_vs_required_bar must match quality_score and "
+                "required_quality_bar"
+            )
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_terminal_failure_cause(self) -> Self:
+        """Prevent an accepted/completed result from naming a failure cause."""
+        if self.quality_passed and self.terminal_failure_cause is not None:
+            msg = "completed delegation cannot carry terminal_failure_cause"
+            raise ValueError(msg)
+        return self
+
+
+__all__: list[str] = [
+    "EnumDelegationTerminalFailureCause",
+    "EnumQualityScoreComparison",
+    "ModelDelegationResult",
+]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -198,27 +198,34 @@ class ModelDelegationResult(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_quality_score_comparison(self) -> Self:
-        """Reject a structured comparison that contradicts its numeric evidence."""
-        if self.required_quality_bar is None or self.score_vs_required_bar is None:
-            return self
-
-        expected = (
-            EnumQualityScoreComparison.BELOW_BAR
-            if self.quality_score < self.required_quality_bar
-            else EnumQualityScoreComparison.AT_OR_ABOVE_BAR
-        )
-        if self.score_vs_required_bar is not expected:
+    def validate_structured_terminal_evidence(self) -> Self:
+        """Reject incomplete or contradictory structured terminal evidence."""
+        required_bar = self.required_quality_bar
+        comparison = self.score_vs_required_bar
+        if (required_bar is None) != (comparison is None):
             msg = (
-                "score_vs_required_bar must match quality_score and "
-                "required_quality_bar"
+                "required_quality_bar and score_vs_required_bar must be "
+                "provided together"
             )
             raise ValueError(msg)
-        return self
 
-    @model_validator(mode="after")
-    def validate_terminal_failure_cause(self) -> Self:
-        """Prevent an accepted/completed result from naming a failure cause."""
+        if required_bar is not None and comparison is not None:
+            expected = (
+                EnumQualityScoreComparison.BELOW_BAR
+                if self.quality_score < required_bar
+                else EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+            )
+            if comparison is not expected:
+                msg = (
+                    "score_vs_required_bar must match quality_score and "
+                    "required_quality_bar"
+                )
+                raise ValueError(msg)
+
+        if self.quality_passed and self.failed_acceptance_criteria:
+            msg = "quality_passed result cannot carry failed_acceptance_criteria"
+            raise ValueError(msg)
+
         if self.quality_passed and self.terminal_failure_cause is not None:
             msg = "completed delegation cannot carry terminal_failure_cause"
             raise ValueError(msg)

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -48,6 +48,7 @@ class ModelDelegationResult(BaseModel):
     )
     required_quality_bar: float | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         ge=0.0,
         le=1.0,
         description=(
@@ -57,6 +58,7 @@ class ModelDelegationResult(BaseModel):
     )
     score_vs_required_bar: EnumQualityScoreComparison | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Typed comparison of quality_score to required_quality_bar. None when "
             "no quality bar was evaluated."
@@ -64,6 +66,7 @@ class ModelDelegationResult(BaseModel):
     )
     failed_acceptance_criteria: tuple[str, ...] = Field(
         default=(),
+        exclude_if=lambda value: not value,
         description=(
             "Authoritative quality-gate failure details. Empty when no acceptance "
             "criterion failed or no quality gate ran."
@@ -114,6 +117,7 @@ class ModelDelegationResult(BaseModel):
     )
     terminal_failure_cause: EnumDelegationTerminalFailureCause | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Stable machine-readable cause for a terminal delegation failure. "
             "None for completed results and legacy failure producers."

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -200,6 +200,10 @@ class ModelDelegationResult(BaseModel):
     @model_validator(mode="after")
     def validate_structured_terminal_evidence(self) -> Self:
         """Reject incomplete or contradictory structured terminal evidence."""
+        if any(not item.strip() for item in self.failed_acceptance_criteria):
+            msg = "failed_acceptance_criteria entries must not be blank"
+            raise ValueError(msg)
+
         required_bar = self.required_quality_bar
         comparison = self.score_vs_required_bar
         if (required_bar is None) != (comparison is None):
@@ -219,6 +223,24 @@ class ModelDelegationResult(BaseModel):
                 msg = (
                     "score_vs_required_bar must match quality_score and "
                     "required_quality_bar"
+                )
+                raise ValueError(msg)
+
+            if (
+                comparison is EnumQualityScoreComparison.BELOW_BAR
+                and self.quality_passed
+            ):
+                msg = "quality_passed result cannot be below required_quality_bar"
+                raise ValueError(msg)
+
+            if (
+                comparison is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+                and not self.quality_passed
+                and not self.failed_acceptance_criteria
+            ):
+                msg = (
+                    "quality-failed result at or above required_quality_bar must "
+                    "carry failed_acceptance_criteria"
                 )
                 raise ValueError(msg)
 

--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime
 from typing import Literal, Self
@@ -66,12 +67,31 @@ def validate_response_format(
             f"{sorted(response_format)!r}"
         )
     response_type = response_format["type"]
+    if not isinstance(response_type, str):
+        raise ValueError(  # error-ok: Pydantic field validator requires ValueError
+            "response_format type must be a string"
+        )
     if response_type not in SUPPORTED_RESPONSE_FORMAT_TYPES:
         raise ValueError(  # error-ok: Pydantic field validator requires ValueError
             f"unsupported response_format type {response_type!r}; supported: "
             f"{sorted(SUPPORTED_RESPONSE_FORMAT_TYPES)!r}"
         )
     return response_format
+
+
+def validate_response_contract(
+    response_contract: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Require response contracts to survive the JSON wire boundary."""
+    if response_contract is None:
+        return None
+    try:
+        json.dumps(response_contract, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(  # error-ok: Pydantic field validator requires ValueError
+            "response_contract must be JSON-serializable"
+        ) from exc
+    return response_contract
 
 
 def validate_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
@@ -252,6 +272,24 @@ class ModelDelegationRequest(BaseModel):
     ) -> dict[str, object] | None:
         return validate_response_format(response_format)
 
+    @field_validator("backend_id")
+    @classmethod
+    def _validate_backend_id(cls, backend_id: str | None) -> str | None:
+        if backend_id is not None and (
+            not backend_id.strip() or backend_id != backend_id.strip()
+        ):
+            raise ValueError(  # error-ok: Pydantic field validator requires ValueError
+                "backend_id must not be blank or contain surrounding whitespace"
+            )
+        return backend_id
+
+    @field_validator("response_contract")
+    @classmethod
+    def _validate_response_contract(
+        cls, response_contract: dict[str, object] | None
+    ) -> dict[str, object] | None:
+        return validate_response_contract(response_contract)
+
     @model_validator(mode="after")
     def _validate_compliance_loop_config(self) -> Self:
         if self.output_schema_key is not None and self.compliance_budget is None:
@@ -272,5 +310,6 @@ __all__: list[str] = [
     "EnumQualityContractMode",
     "ModelDelegationRequest",
     "validate_acceptance_criteria",
+    "validate_response_contract",
     "validate_response_format",
 ]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -201,6 +201,7 @@ class ModelDelegationRequest(BaseModel):
     backend_id: str | None = (
         Field(  # string-id-ok: backend references are named contract slugs, not UUIDs
             default=None,
+            exclude_if=lambda value: value is None,
             min_length=1,
             description=(
                 "Optional exact routing backend reference. None preserves normal "
@@ -210,6 +211,7 @@ class ModelDelegationRequest(BaseModel):
     )
     response_contract: dict[str, object] | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Optional caller-declared JSON Schema used by the quality gate. "
             "It is never sent to the inference provider."
@@ -217,6 +219,7 @@ class ModelDelegationRequest(BaseModel):
     )
     system_prompt: str | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         min_length=1,
         description=(
             "Optional caller system message. None preserves the task-class "
@@ -225,6 +228,7 @@ class ModelDelegationRequest(BaseModel):
     )
     temperature: float | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         ge=0.0,
         le=2.0,
         description=(
@@ -234,6 +238,7 @@ class ModelDelegationRequest(BaseModel):
     )
     response_format: dict[str, object] | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Optional provider response-format directive. Distinct from the "
             "quality-gate response_contract."

--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -10,11 +10,13 @@ from datetime import datetime
 from typing import Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.models.delegation.wire.model_budget import ModelBudgetLimits
 
 EnumQualityContractMode = Literal["extend_task_class", "replace_task_class"]
+
+SUPPORTED_RESPONSE_FORMAT_TYPES = frozenset({"json_object"})
 
 SUPPORTED_ACCEPTANCE_CRITERIA = frozenset(
     {
@@ -45,6 +47,31 @@ SUPPORTED_ACCEPTANCE_CRITERIA = frozenset(
     }
 )
 MAX_WORDS_PER_SENTENCE_RE = re.compile(r"^max_words_per_sentence_([1-9]\d*)$")
+
+
+def validate_response_format(
+    response_format: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Validate the provider response-format subset carried by delegation.
+
+    The canonical wire accepts only the mode the delegation provider boundary
+    implements. Schema-shaped output requirements belong on
+    ``response_contract`` and are evaluated by the quality gate instead.
+    """
+    if response_format is None:
+        return None
+    if set(response_format) != {"type"}:
+        raise ValueError(  # error-ok: Pydantic field validator requires ValueError
+            "response_format must contain exactly the key 'type'; got "
+            f"{sorted(response_format)!r}"
+        )
+    response_type = response_format["type"]
+    if response_type not in SUPPORTED_RESPONSE_FORMAT_TYPES:
+        raise ValueError(  # error-ok: Pydantic field validator requires ValueError
+            f"unsupported response_format type {response_type!r}; supported: "
+            f"{sorted(SUPPORTED_RESPONSE_FORMAT_TYPES)!r}"
+        )
+    return response_format
 
 
 def validate_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
@@ -170,6 +197,55 @@ class ModelDelegationRequest(BaseModel):
             "The durable per-tenant identity design is OMN-14107."
         ),
     )
+    # string-id-ok: backend references are named contract slugs, not UUIDs
+    backend_id: str | None = (
+        Field(  # string-id-ok: backend references are named contract slugs, not UUIDs
+            default=None,
+            min_length=1,
+            description=(
+                "Optional exact routing backend reference. None preserves normal "
+                "contract-driven tier selection."
+            ),
+        )
+    )
+    response_contract: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Optional caller-declared JSON Schema used by the quality gate. "
+            "It is never sent to the inference provider."
+        ),
+    )
+    system_prompt: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Optional caller system message. None preserves the task-class "
+            "routing prompt."
+        ),
+    )
+    temperature: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=2.0,
+        description=(
+            "Optional provider sampling temperature. None preserves the "
+            "task-class default."
+        ),
+    )
+    response_format: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Optional provider response-format directive. Distinct from the "
+            "quality-gate response_contract."
+        ),
+    )
+
+    @field_validator("response_format")
+    @classmethod
+    def _validate_response_format(
+        cls, response_format: dict[str, object] | None
+    ) -> dict[str, object] | None:
+        return validate_response_format(response_format)
 
     @model_validator(mode="after")
     def _validate_compliance_loop_config(self) -> Self:
@@ -187,7 +263,9 @@ class ModelDelegationRequest(BaseModel):
 __all__: list[str] = [
     "MAX_WORDS_PER_SENTENCE_RE",
     "SUPPORTED_ACCEPTANCE_CRITERIA",
+    "SUPPORTED_RESPONSE_FORMAT_TYPES",
     "EnumQualityContractMode",
     "ModelDelegationRequest",
     "validate_acceptance_criteria",
+    "validate_response_format",
 ]

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -77,6 +77,7 @@ class ModelInferenceIntent(BaseModel):
     correlation_id: UUID
     inference_attempt_id: UUID | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Identity of this specific inference attempt within the delegation "
             "workflow. The inference effect echoes it on the response so the "
@@ -105,6 +106,7 @@ class ModelInferenceIntent(BaseModel):
     )
     response_format: dict[str, object] | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Optional provider response-format directive carried separately "
             "from provider_request_options so callers cannot override core "
@@ -180,6 +182,7 @@ class ModelInferenceResponseData(BaseModel):
     correlation_id: UUID = Field(..., description="Workflow correlation ID.")
     inference_attempt_id: UUID | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Inference-attempt identity echoed from ModelInferenceIntent. "
             "Optional for backward-compatible parsing of pre-OMN-15542 events."

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -75,6 +75,14 @@ class ModelInferenceIntent(BaseModel):
         description="Backend-owned timeout for the downstream inference call.",
     )
     correlation_id: UUID
+    inference_attempt_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Identity of this specific inference attempt within the delegation "
+            "workflow. The inference effect echoes it on the response so the "
+            "orchestrator can reject a late response from an earlier route."
+        ),
+    )
     api_key_ref: str | None = Field(
         default=None,
         description=(
@@ -170,6 +178,13 @@ class ModelInferenceResponseData(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     correlation_id: UUID = Field(..., description="Workflow correlation ID.")
+    inference_attempt_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Inference-attempt identity echoed from ModelInferenceIntent. "
+            "Optional for backward-compatible parsing of pre-OMN-15542 events."
+        ),
+    )
     content: str = Field(..., description="Generated text from the LLM.")
     model_used: str = Field(
         ..., description="Model identifier that produced the response."

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -5,14 +5,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_core.enums.enum_budget_action import EnumBudgetAction
 from omnibase_core.models.delegation.wire.model_delegation_wire_request import (
     ModelDelegationRequest,
+    validate_response_format,
 )
 from omnibase_core.models.delegation.wire.model_quality_gate import (
     ModelQualityGateInput,
@@ -86,12 +87,20 @@ class ModelInferenceIntent(BaseModel):
         default=None,
         description="Additional HTTP headers required by the selected backend.",
     )
-    provider_request_options: dict[str, Any] | None = Field(
+    provider_request_options: dict[str, object] | None = Field(
         default=None,
         description=(
             "Additional OpenAI-compatible request body options required by the "
             "selected model protocol. The inference effect merges these at the "
             "provider-call boundary after core fields are constructed."
+        ),
+    )
+    response_format: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Optional provider response-format directive carried separately "
+            "from provider_request_options so callers cannot override core "
+            "request fields through an untyped options mapping."
         ),
     )
     # string-id-ok: tenant identity is a named slug (e.g. "omninode"), not a UUID.
@@ -102,16 +111,26 @@ class ModelInferenceIntent(BaseModel):
     # correlation_id -> tenant lookup. Optional now (backward-compatible wire);
     # the fail-closed wire==topic-tenant guard + required-flip is A-enforce,
     # gated behind the gateway topic-tenant stamp (deferred, not this slice).
-    tenant_id: str | None = Field(
-        default=None,
-        description=(
-            "Owning tenant for this inference call. Set by the delegation "
-            "orchestrator from the workflow tenant identity; the inference "
-            "effect reads it to tenant-tag its logs/metrics and round-trips it "
-            "onto ModelInferenceResponseData. Isolation-ready wire (not yet "
-            "isolation-enforced)."
-        ),
+    # string-id-ok: tenant identity is a named slug, not a UUID
+    tenant_id: str | None = (
+        Field(  # string-id-ok: tenant identity is a named slug, not a UUID
+            default=None,
+            description=(
+                "Owning tenant for this inference call. Set by the delegation "
+                "orchestrator from the workflow tenant identity; the inference "
+                "effect reads it to tenant-tag its logs/metrics and round-trips it "
+                "onto ModelInferenceResponseData. Isolation-ready wire (not yet "
+                "isolation-enforced)."
+            ),
+        )
     )
+
+    @field_validator("response_format")
+    @classmethod
+    def _validate_response_format(
+        cls, response_format: dict[str, object] | None
+    ) -> dict[str, object] | None:
+        return validate_response_format(response_format)
 
 
 class ModelQualityGateIntent(BaseModel):
@@ -177,12 +196,15 @@ class ModelInferenceResponseData(BaseModel):
     # by the inference effect so the tenant that owned the call is auditable on
     # the response and the orchestrator can observability-cross-check it against
     # the workflow tenant. Optional now; required-flip is A-enforce (deferred).
-    tenant_id: str | None = Field(
-        default=None,
-        description=(
-            "Owning tenant echoed back from the inference intent by the "
-            "inference effect. Isolation-ready wire (not yet isolation-enforced)."
-        ),
+    # string-id-ok: tenant identity is a named slug, not a UUID
+    tenant_id: str | None = (
+        Field(  # string-id-ok: tenant identity is a named slug, not a UUID
+            default=None,
+            description=(
+                "Owning tenant echoed back from the inference intent by the "
+                "inference effect. Isolation-ready wire (not yet isolation-enforced)."
+            ),
+        )
     )
 
 

--- a/src/omnibase_core/models/delegation/wire/model_quality_gate.py
+++ b/src/omnibase_core/models/delegation/wire/model_quality_gate.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_core.enums.enum_quality_gate_result import EnumQualityGateResult
 from omnibase_core.models.delegation.wire.model_delegation_wire_request import (
     EnumQualityContractMode,
+    validate_response_contract,
 )
 
 EnumQualityGateCategory = EnumQualityGateResult
@@ -74,6 +75,13 @@ class ModelQualityGateInput(BaseModel):
             "task-class default contract."
         ),
     )
+
+    @field_validator("response_contract")
+    @classmethod
+    def _validate_response_contract(
+        cls, response_contract: dict[str, object] | None
+    ) -> dict[str, object] | None:
+        return validate_response_contract(response_contract)
 
 
 class ModelQualityGateResult(BaseModel):

--- a/src/omnibase_core/models/delegation/wire/model_quality_gate.py
+++ b/src/omnibase_core/models/delegation/wire/model_quality_gate.py
@@ -67,6 +67,7 @@ class ModelQualityGateInput(BaseModel):
     )
     response_contract: dict[str, object] | None = Field(
         default=None,
+        exclude_if=lambda value: value is None,
         description=(
             "Optional caller-declared JSON Schema used as the structural "
             "acceptance authority. None lets the consumer resolve the "

--- a/src/omnibase_core/models/delegation/wire/model_quality_gate.py
+++ b/src/omnibase_core/models/delegation/wire/model_quality_gate.py
@@ -65,6 +65,14 @@ class ModelQualityGateInput(BaseModel):
         default=(),
         description="Request-level quality checks enforced by the quality gate.",
     )
+    response_contract: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Optional caller-declared JSON Schema used as the structural "
+            "acceptance authority. None lets the consumer resolve the "
+            "task-class default contract."
+        ),
+    )
 
 
 class ModelQualityGateResult(BaseModel):

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -142,6 +142,35 @@ class TestModelDelegationRequest:
         with pytest.raises(ValidationError, match="unsupported response_format"):
             self._make(response_format={"type": "json_schema"})
 
+    def test_cloud_completion_shaping_rejects_non_string_response_format_type(
+        self,
+    ) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="response_format type must be a string",
+        ):
+            self._make(response_format={"type": []})
+
+    @pytest.mark.parametrize("backend_id", [" ", " cloud-gemini-pro"])
+    def test_cloud_completion_shaping_rejects_whitespace_backend_id(
+        self,
+        backend_id: str,
+    ) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="backend_id must not be blank or contain surrounding whitespace",
+        ):
+            self._make(backend_id=backend_id)
+
+    def test_cloud_completion_shaping_rejects_non_json_response_contract(
+        self,
+    ) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="response_contract must be JSON-serializable",
+        ):
+            self._make(response_contract={"type": object()})
+
     def test_context_pack_hash_defaults_to_off_arm(self) -> None:
         r = self._make()
         assert r.context_pack == ""
@@ -461,6 +490,69 @@ class TestModelDelegationResult:
                 fallback_to_claude=False,
             )
 
+    def test_rejects_quality_passed_when_score_is_below_required_bar(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="quality_passed result cannot be below required_quality_bar",
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=True,
+                quality_score=0.5,
+                required_quality_bar=0.8,
+                score_vs_required_bar=EnumQualityScoreComparison.BELOW_BAR,
+                latency_ms=100,
+                fallback_to_claude=False,
+            )
+
+    def test_rejects_failed_quality_above_bar_without_failed_criteria(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "quality-failed result at or above required_quality_bar must "
+                "carry failed_acceptance_criteria"
+            ),
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=0.9,
+                required_quality_bar=0.8,
+                score_vs_required_bar=(EnumQualityScoreComparison.AT_OR_ABOVE_BAR),
+                latency_ms=100,
+                fallback_to_claude=True,
+                failure_reason="legacy prose must not replace structured truth",
+            )
+
+    @pytest.mark.parametrize("criterion", ["", "  "])
+    def test_rejects_blank_failed_acceptance_criterion(self, criterion: str) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="failed_acceptance_criteria entries must not be blank",
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=0.9,
+                required_quality_bar=0.8,
+                score_vs_required_bar=(EnumQualityScoreComparison.AT_OR_ABOVE_BAR),
+                failed_acceptance_criteria=(criterion,),
+                latency_ms=100,
+                fallback_to_claude=True,
+            )
+
     @pytest.mark.parametrize(
         ("score", "bar", "comparison"),
         [
@@ -569,6 +661,76 @@ class TestModelDelegationResult:
                 terminal_failure_cause=(
                     EnumDelegationTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED
                 ),
+            )
+
+    def test_completed_terminal_rejects_quality_failed_verdict(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="completed delegation requires quality_passed",
+        ):
+            ModelDelegationCompleted(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=0.9,
+                latency_ms=100,
+                fallback_to_claude=False,
+            )
+
+    @pytest.mark.parametrize(
+        ("field_name", "field_value", "message"),
+        [
+            (
+                "failure_reason",
+                "provider failed",
+                "completed delegation cannot carry failure_reason",
+            ),
+            (
+                "terminal_failure_reason",
+                "no_higher_tier_available",
+                "completed delegation cannot carry terminal_failure_reason",
+            ),
+        ],
+    )
+    def test_completed_terminal_rejects_failure_state_fields(
+        self,
+        field_name: str,
+        field_value: str,
+        message: str,
+    ) -> None:
+        payload: dict[str, object] = {
+            "correlation_id": uuid.uuid4(),
+            "task_type": "reasoning",
+            "model_used": "qwen3",
+            "endpoint_url": "http://localhost:8000",
+            "content": "result",
+            "quality_passed": True,
+            "quality_score": 0.9,
+            "latency_ms": 100,
+            "fallback_to_claude": False,
+            field_name: field_value,
+        }
+        with pytest.raises(ValidationError, match=message):
+            ModelDelegationCompleted.model_validate(payload)
+
+    def test_failed_terminal_rejects_quality_passed_verdict(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="failed delegation requires quality_passed=false",
+        ):
+            ModelDelegationFailed(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=True,
+                quality_score=0.9,
+                latency_ms=100,
+                fallback_to_claude=False,
             )
 
     def test_quality_passed_base_result_rejects_terminal_failure_cause(self) -> None:
@@ -1026,6 +1188,18 @@ class TestModelQualityGate:
 
         assert inp.response_contract == response_contract
         assert inp.model_dump()["response_contract"] == response_contract
+
+    def test_gate_input_rejects_non_json_response_contract(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="response_contract must be JSON-serializable",
+        ):
+            ModelQualityGateInput(
+                correlation_id=uuid.uuid4(),
+                task_type="test",
+                llm_response_content='{"answer": "ok"}',
+                response_contract={"type": object()},
+            )
 
     def test_gate_input_rejects_negative_min_response_length(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -750,6 +750,28 @@ class TestModelInferenceIntent:
         assert tenant_intent.tenant_id == "tenant-alpha"
         assert tenant_intent.model_dump()["tenant_id"] == "tenant-alpha"
 
+    def test_inference_attempt_id_is_optional_and_round_trips_as_uuid(self) -> None:
+        correlation_id = uuid.uuid4()
+        default_intent = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=correlation_id,
+        )
+        assert default_intent.inference_attempt_id is None
+
+        attempt_id = uuid.uuid4()
+        parsed_intent = ModelInferenceIntent.model_validate(
+            {
+                **default_intent.model_dump(),
+                "inference_attempt_id": str(attempt_id),
+            }
+        )
+        assert parsed_intent.inference_attempt_id == attempt_id
+        assert isinstance(parsed_intent.inference_attempt_id, uuid.UUID)
+
     def test_response_format_is_typed_and_optional(self) -> None:
         default_intent = ModelInferenceIntent(
             base_url="http://localhost:8000",
@@ -1286,6 +1308,24 @@ class TestModelInferenceResponseData:
             tenant_id="tenant-alpha",
         )
         assert tenant_resp.tenant_id == "tenant-alpha"
+
+    def test_inference_attempt_id_is_optional_and_round_trips_as_uuid(self) -> None:
+        default_resp = ModelInferenceResponseData(
+            correlation_id=uuid.uuid4(),
+            content="Generated response.",
+            model_used="qwen3-14b",
+        )
+        assert default_resp.inference_attempt_id is None
+
+        attempt_id = uuid.uuid4()
+        parsed_resp = ModelInferenceResponseData.model_validate(
+            {
+                **default_resp.model_dump(),
+                "inference_attempt_id": str(attempt_id),
+            }
+        )
+        assert parsed_resp.inference_attempt_id == attempt_id
+        assert isinstance(parsed_resp.inference_attempt_id, uuid.UUID)
 
 
 @pytest.mark.unit

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -15,14 +15,18 @@ from pydantic import ValidationError
 from omnibase_core.models.delegation.wire import (
     TASK_DELEGATED_TOPIC_V1,
     EnumBudgetAction,
+    EnumDelegationTerminalFailureCause,
+    EnumQualityScoreComparison,
     EnumTierCostType,
     ModelBaselineIntent,
     ModelBifrostDelegationConfig,
     ModelBudgetLimits,
     ModelComplianceLoopResult,
     ModelDelegationBackendConfig,
+    ModelDelegationCompleted,
     ModelDelegationConfig,
     ModelDelegationEventEnvelope,
+    ModelDelegationFailed,
     ModelDelegationFallbackPolicy,
     ModelDelegationRequest,
     ModelDelegationResult,
@@ -329,6 +333,184 @@ class TestModelDelegationResult:
         assert r.escalation_history == ()
         assert r.terminal_failure_reason is None
         assert r.attempts_count == 1
+
+    def test_structured_quality_evidence_defaults_for_release_compatibility(
+        self,
+    ) -> None:
+        """Older producers can omit the additive quality-evidence fields."""
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+
+        assert r.required_quality_bar is None
+        assert r.score_vs_required_bar is None
+        assert r.failed_acceptance_criteria == ()
+
+    def test_structured_quality_evidence_round_trips_exact_live_case(self) -> None:
+        """The 0.867/0.800 canary evidence is machine-readable on the wire."""
+        failure = "TASK_MISMATCH: failed step_by_step_explanation"
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="reasoning",
+            model_used="gemini-2.5-flash",
+            endpoint_url="https://generativelanguage.googleapis.com",
+            content="result",
+            quality_passed=False,
+            quality_score=0.867,
+            required_quality_bar=0.800,
+            score_vs_required_bar=EnumQualityScoreComparison.AT_OR_ABOVE_BAR,
+            failed_acceptance_criteria=(failure,),
+            latency_ms=100,
+            fallback_to_claude=True,
+            failure_reason=(
+                "acceptance_criteria_failed: actual_score=0.867 "
+                "required_bar=0.800 score_vs_bar=at_or_above_bar"
+            ),
+        )
+
+        dumped = r.model_dump(mode="json")
+        assert dumped["required_quality_bar"] == pytest.approx(0.800)
+        assert dumped["score_vs_required_bar"] == "at_or_above_bar"
+        assert dumped["failed_acceptance_criteria"] == [failure]
+        assert ModelDelegationResult.model_validate(dumped) == r
+
+    @pytest.mark.parametrize(
+        ("score", "bar", "comparison"),
+        [
+            (0.867, 0.800, EnumQualityScoreComparison.BELOW_BAR),
+            (0.500, 0.800, EnumQualityScoreComparison.AT_OR_ABOVE_BAR),
+        ],
+    )
+    def test_rejects_inconsistent_quality_score_comparison(
+        self,
+        score: float,
+        bar: float,
+        comparison: EnumQualityScoreComparison,
+    ) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="score_vs_required_bar must match quality_score",
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=score,
+                required_quality_bar=bar,
+                score_vs_required_bar=comparison,
+                latency_ms=100,
+                fallback_to_claude=True,
+            )
+
+    def test_score_equal_to_bar_is_at_or_above(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="reasoning",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.8,
+            required_quality_bar=0.8,
+            score_vs_required_bar=EnumQualityScoreComparison.AT_OR_ABOVE_BAR,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+
+        assert r.score_vs_required_bar is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+
+    def test_terminal_failure_cause_defaults_for_release_compatibility(self) -> None:
+        r = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="",
+            quality_passed=False,
+            quality_score=0.0,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+
+        assert r.terminal_failure_cause is None
+
+    def test_failed_terminal_round_trips_provider_quota_exhausted_cause(
+        self,
+    ) -> None:
+        r = ModelDelegationFailed(
+            correlation_id=uuid.uuid4(),
+            task_type="refactor",
+            model_used="gemini-2.5-flash",
+            endpoint_url="https://generativelanguage.googleapis.com",
+            content="",
+            quality_passed=False,
+            quality_score=0.0,
+            latency_ms=100,
+            fallback_to_claude=False,
+            failure_reason="429 RESOURCE_EXHAUSTED",
+            terminal_failure_reason="no_higher_tier_available",
+            terminal_failure_cause=(
+                EnumDelegationTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED
+            ),
+        )
+
+        dumped = r.model_dump(mode="json")
+        assert dumped["terminal_failure_cause"] == "provider_quota_exhausted"
+        assert ModelDelegationFailed.model_validate(dumped) == r
+
+    def test_completed_terminal_rejects_terminal_failure_cause(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="completed delegation cannot carry terminal_failure_cause",
+        ):
+            ModelDelegationCompleted(
+                correlation_id=uuid.uuid4(),
+                task_type="refactor",
+                model_used="gemini-2.5-flash",
+                endpoint_url="https://generativelanguage.googleapis.com",
+                content="result",
+                # Exercise the terminal-class invariant independently of the
+                # base quality_passed invariant below.
+                quality_passed=False,
+                quality_score=0.0,
+                latency_ms=100,
+                fallback_to_claude=False,
+                terminal_failure_cause=(
+                    EnumDelegationTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED
+                ),
+            )
+
+    def test_quality_passed_base_result_rejects_terminal_failure_cause(self) -> None:
+        """Base-model consumers retain the completed-result invariant."""
+        with pytest.raises(
+            ValidationError,
+            match="completed delegation cannot carry terminal_failure_cause",
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="refactor",
+                model_used="gemini-2.5-flash",
+                endpoint_url="https://generativelanguage.googleapis.com",
+                content="result",
+                quality_passed=True,
+                quality_score=0.9,
+                latency_ms=100,
+                fallback_to_claude=False,
+                terminal_failure_cause=(
+                    EnumDelegationTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED
+                ),
+            )
 
     def test_context_pack_hash_defaults_to_off_arm(self) -> None:
         r = ModelDelegationResult(

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -401,6 +401,66 @@ class TestModelDelegationResult:
         assert dumped["failed_acceptance_criteria"] == [failure]
         assert ModelDelegationResult.model_validate(dumped) == r
 
+    def test_rejects_required_quality_bar_without_comparison(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "required_quality_bar and score_vs_required_bar must be "
+                "provided together"
+            ),
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=0.5,
+                required_quality_bar=0.8,
+                latency_ms=100,
+                fallback_to_claude=True,
+            )
+
+    def test_rejects_quality_comparison_without_required_bar(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "required_quality_bar and score_vs_required_bar must be "
+                "provided together"
+            ),
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=False,
+                quality_score=0.5,
+                score_vs_required_bar=EnumQualityScoreComparison.BELOW_BAR,
+                latency_ms=100,
+                fallback_to_claude=True,
+            )
+
+    def test_rejects_failed_acceptance_criteria_when_quality_passed(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="quality_passed result cannot carry failed_acceptance_criteria",
+        ):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="reasoning",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=True,
+                quality_score=0.9,
+                failed_acceptance_criteria=("criterion_failed",),
+                latency_ms=100,
+                fallback_to_claude=False,
+            )
+
     @pytest.mark.parametrize(
         ("score", "bar", "comparison"),
         [

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -87,6 +87,15 @@ class TestModelDelegationRequest:
         assert request.system_prompt is None
         assert request.temperature is None
         assert request.response_format is None
+        dumped = request.model_dump()
+        for field_name in (
+            "backend_id",
+            "response_contract",
+            "system_prompt",
+            "temperature",
+            "response_format",
+        ):
+            assert field_name not in dumped
 
     def test_cloud_completion_shaping_round_trips_on_canonical_wire(self) -> None:
         response_contract: dict[str, object] = {
@@ -109,6 +118,12 @@ class TestModelDelegationRequest:
         assert request.system_prompt == "Return one JSON object."
         assert request.temperature == 0.2
         assert request.response_format == response_format
+        dumped = request.model_dump()
+        assert dumped["backend_id"] == "cloud-gemini-pro"
+        assert dumped["response_contract"] == response_contract
+        assert dumped["system_prompt"] == "Return one JSON object."
+        assert dumped["temperature"] == pytest.approx(0.2)
+        assert dumped["response_format"] == response_format
         assert (
             ModelDelegationRequest.model_validate_json(request.model_dump_json())
             == request
@@ -353,6 +368,10 @@ class TestModelDelegationResult:
         assert r.required_quality_bar is None
         assert r.score_vs_required_bar is None
         assert r.failed_acceptance_criteria == ()
+        dumped = r.model_dump()
+        assert "required_quality_bar" not in dumped
+        assert "score_vs_required_bar" not in dumped
+        assert "failed_acceptance_criteria" not in dumped
 
     def test_structured_quality_evidence_round_trips_exact_live_case(self) -> None:
         """The 0.867/0.800 canary evidence is machine-readable on the wire."""
@@ -444,6 +463,7 @@ class TestModelDelegationResult:
         )
 
         assert r.terminal_failure_cause is None
+        assert "terminal_failure_cause" not in r.model_dump()
 
     def test_failed_terminal_round_trips_provider_quota_exhausted_cause(
         self,
@@ -761,6 +781,7 @@ class TestModelInferenceIntent:
             correlation_id=correlation_id,
         )
         assert default_intent.inference_attempt_id is None
+        assert "inference_attempt_id" not in default_intent.model_dump()
 
         attempt_id = uuid.uuid4()
         parsed_intent = ModelInferenceIntent.model_validate(
@@ -782,6 +803,7 @@ class TestModelInferenceIntent:
             correlation_id=uuid.uuid4(),
         )
         assert default_intent.response_format is None
+        assert "response_format" not in default_intent.model_dump()
 
         response_format = {"type": "json_object"}
         json_intent = default_intent.model_copy(
@@ -928,6 +950,7 @@ class TestModelQualityGate:
         )
         assert inp.min_response_length == 60
         assert inp.response_contract is None
+        assert "response_contract" not in inp.model_dump()
 
     def test_gate_input_carries_caller_response_contract(self) -> None:
         response_contract: dict[str, object] = {
@@ -942,6 +965,7 @@ class TestModelQualityGate:
         )
 
         assert inp.response_contract == response_contract
+        assert inp.model_dump()["response_contract"] == response_contract
 
     def test_gate_input_rejects_negative_min_response_length(self) -> None:
         with pytest.raises(ValidationError):
@@ -1316,6 +1340,7 @@ class TestModelInferenceResponseData:
             model_used="qwen3-14b",
         )
         assert default_resp.inference_attempt_id is None
+        assert "inference_attempt_id" not in default_resp.model_dump()
 
         attempt_id = uuid.uuid4()
         parsed_resp = ModelInferenceResponseData.model_validate(

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -75,6 +75,54 @@ class TestModelDelegationRequest:
         r = self._make()
         assert r.task_type == "test"
 
+    def test_cloud_completion_shaping_defaults_are_backward_compatible(self) -> None:
+        request = self._make()
+
+        assert request.backend_id is None
+        assert request.response_contract is None
+        assert request.system_prompt is None
+        assert request.temperature is None
+        assert request.response_format is None
+
+    def test_cloud_completion_shaping_round_trips_on_canonical_wire(self) -> None:
+        response_contract: dict[str, object] = {
+            "type": "object",
+            "required": ["answer"],
+            "properties": {"answer": {"type": "string"}},
+        }
+        response_format: dict[str, object] = {"type": "json_object"}
+
+        request = self._make(
+            backend_id="cloud-gemini-pro",
+            response_contract=response_contract,
+            system_prompt="Return one JSON object.",
+            temperature=0.2,
+            response_format=response_format,
+        )
+
+        assert request.backend_id == "cloud-gemini-pro"
+        assert request.response_contract == response_contract
+        assert request.system_prompt == "Return one JSON object."
+        assert request.temperature == 0.2
+        assert request.response_format == response_format
+        assert (
+            ModelDelegationRequest.model_validate_json(request.model_dump_json())
+            == request
+        )
+
+    @pytest.mark.parametrize("temperature", [-0.01, 2.01])
+    def test_cloud_completion_shaping_rejects_invalid_temperature(
+        self, temperature: float
+    ) -> None:
+        with pytest.raises(ValidationError):
+            self._make(temperature=temperature)
+
+    def test_cloud_completion_shaping_rejects_unsupported_response_format(
+        self,
+    ) -> None:
+        with pytest.raises(ValidationError, match="unsupported response_format"):
+            self._make(response_format={"type": "json_schema"})
+
     def test_context_pack_hash_defaults_to_off_arm(self) -> None:
         r = self._make()
         assert r.context_pack == ""
@@ -520,6 +568,31 @@ class TestModelInferenceIntent:
         assert tenant_intent.tenant_id == "tenant-alpha"
         assert tenant_intent.model_dump()["tenant_id"] == "tenant-alpha"
 
+    def test_response_format_is_typed_and_optional(self) -> None:
+        default_intent = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=uuid.uuid4(),
+        )
+        assert default_intent.response_format is None
+
+        response_format = {"type": "json_object"}
+        json_intent = default_intent.model_copy(
+            update={"response_format": response_format}
+        )
+        # model_copy(update=...) does not revalidate, so prove the actual wire
+        # parser accepts and round-trips the typed directive.
+        json_intent = ModelInferenceIntent.model_validate(json_intent.model_dump())
+        assert json_intent.response_format == response_format
+
+        with pytest.raises(ValidationError, match="unsupported response_format"):
+            ModelInferenceIntent.model_validate(
+                {**default_intent.model_dump(), "response_format": {"type": "text"}}
+            )
+
 
 @pytest.mark.unit
 class TestModelRoutingTier:
@@ -650,6 +723,21 @@ class TestModelQualityGate:
             llm_response_content="This is the response.",
         )
         assert inp.min_response_length == 60
+        assert inp.response_contract is None
+
+    def test_gate_input_carries_caller_response_contract(self) -> None:
+        response_contract: dict[str, object] = {
+            "type": "object",
+            "required": ["answer"],
+        }
+        inp = ModelQualityGateInput(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            llm_response_content='{"answer": "ok"}',
+            response_contract=response_contract,
+        )
+
+        assert inp.response_contract == response_contract
 
     def test_gate_input_rejects_negative_min_response_length(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
Evidence-Ticket: OMN-15539

Summary:
- add typed optional inference request shaping and per-attempt identity fields
- add structured terminal failure, quality comparison, and quota evidence
- validate terminal and input combinations while omitting unset additive fields for compatibility

Impact:
- package-only contract change; no runtime deployment
- downstream Infra and Market pins remain gated on the authoritative 0.46.8 release

Verification:
- governed .200 pre-push suite: 43,527 passed, 53 skipped, 3 xpassed
- focused Core wire suite: 128 passed
- downstream Market changed-surface matrix: 354 passed
- Ruff format/check and strict MyPy passed

OCC evidence will be bound after this product PR number and exact head are available.

Evidence-Source: OCC#5727
