### PR TITLE
ci(OMN-15571): trusted-matrix capacity repair + 11 no-dev job execution contracts (gates Core 0.46.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,16 @@ env:
   UV_VERSION: "0.8.3"
   PYTHON_VERSION: "3.12"
   # GitHub-hosted PR runners and merge-queue self-hosted runners have reproduced
-  # xdist worker crashes under the default four-worker split load. PRs stay at
-  # one worker; merge_group uses two workers to finish inside the queue window.
+  # xdist worker crashes under the former four-worker split load. Every full
+  # matrix already fans out across many runners, so the trusted-event default is
+  # one worker per shard; merge_group may opt into two inside its queue window.
   PYTEST_XDIST_WORKERS: >-
     ${{
       github.event_name == 'pull_request'
       && (vars.OMNI_PUBLIC_PR_PYTEST_XDIST_WORKERS || '1')
       || github.event_name == 'merge_group'
       && (vars.OMNI_MERGE_GROUP_PYTEST_XDIST_WORKERS || '2')
-      || (vars.OMNI_PYTEST_XDIST_WORKERS || '4')
+      || (vars.OMNI_PYTEST_XDIST_WORKERS || '1')
     }}
 
 jobs:
@@ -206,18 +207,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@c6081965dd0577ae48820cb8c288e12509571f0c
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Validate __all__ exports
-        run: uv run python scripts/validation/validate-all-exports.py
+        run: python3 scripts/validation/validate-all-exports.py
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Separate job for validation scripts mypy (not blocking test-parallel)
@@ -231,7 +222,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -248,9 +239,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen
 
       - name: Run mypy on architectural validation scripts (strict)
         run: |
@@ -644,21 +636,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Run Node Purity Check
         run: |
           # Node Purity Check (OMN-203)
           # Validates declarative nodes (COMPUTE, REDUCER) maintain purity guarantees
-          uv run python scripts/check_node_purity.py --verbose
+          python3 scripts/check_node_purity.py --verbose
 
       - name: Node purity check summary
         if: always()
@@ -686,7 +668,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -703,12 +685,13 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Run enum governance validator
-        run: uv run python -m omnibase_core.validation.checker_enum_governance src/omnibase_core/
+        run: .venv/bin/python -m omnibase_core.validation.checker_enum_governance src/omnibase_core/
 
       - name: Enum governance summary
         if: always()
@@ -731,7 +714,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -748,12 +731,13 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Run contract-config compliance validator
-        run: uv run python -m omnibase_core.validators.contract_config_compliance src/omnibase_core/ scripts/
+        run: .venv/bin/python -m omnibase_core.validators.contract_config_compliance src/omnibase_core/ scripts/
         # CI runners don't have ambient PYTHONPATH; runs cleanly without env -u PYTHONPATH
 
       - name: Contract-config compliance summary
@@ -777,7 +761,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -794,12 +778,13 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Run breaking-schema-change validator
-        run: uv run python -m omnibase_core.validators.breaking_schema_change src/omnibase_core/
+        run: .venv/bin/python -m omnibase_core.validators.breaking_schema_change src/omnibase_core/
         # CI runners don't have ambient PYTHONPATH; runs cleanly without env -u PYTHONPATH
 
       - name: Breaking-schema-change summary
@@ -832,18 +817,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Run no-env-fallbacks validator
-        run: uv run python scripts/validate_no_env_fallbacks.py
+        run: python3 scripts/validate_no_env_fallbacks.py
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Baseline security scan using detect-secrets (OMN-2226)
@@ -857,7 +832,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout code
@@ -986,7 +961,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -1003,9 +978,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen
 
       - name: Check SDK boundary (no internal hard deps)
         run: uv run pytest tests/unit/test_no_internal_deps.py -v
@@ -1061,7 +1037,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -1078,9 +1054,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Run demo-path topic coherence gate
         run: |
@@ -1088,7 +1065,7 @@ jobs:
           # Scans contracts with metadata.demo_path: true across the repo.
           # Fails on orphan topics, pub/sub mismatches, missing widget producers,
           # and hand-authored topic literals in source files.
-          uv run onex-demo-path-topic-gate src/
+          .venv/bin/onex-demo-path-topic-gate src/
 
       - name: Gate summary
         if: always()
@@ -1112,7 +1089,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -1131,9 +1108,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Resolve base ref
         id: base
@@ -1147,7 +1125,7 @@ jobs:
 
       - name: Run dispatch-surface-test-required validator
         run: |
-          uv run python -m omnibase_core.validators.dispatch_surface_test_required \
+          .venv/bin/python -m omnibase_core.validators.dispatch_surface_test_required \
             --base "${{ steps.base.outputs.ref }}"
 
       - name: Dispatch-surface gate summary
@@ -1186,18 +1164,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Validate class naming conventions
-        run: uv run python scripts/validate_class_naming.py
+        run: python3 scripts/validate_class_naming.py
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Pydantic Patterns (OMN-13574: Model B failing-rollup enforcement)
@@ -1226,16 +1194,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
       - name: Validate Pydantic patterns
         run: |
           # Match the pre-commit file scope: src/ excluding tests/, archived/,
@@ -1247,7 +1205,7 @@ jobs:
             exit 0
           fi
           # shellcheck disable=SC2086
-          uv run python scripts/validation/validate-pydantic-patterns.py $files
+          python3 scripts/validation/validate-pydantic-patterns.py $files
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # AI-Slop Patterns (OMN-13574: Model B failing-rollup enforcement)
@@ -1266,7 +1224,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -1283,9 +1241,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Check tracked tree for AI-slop patterns (strict)
         run: |
@@ -1298,7 +1257,7 @@ jobs:
             exit 0
           fi
           # shellcheck disable=SC2086
-          uv run python scripts/validation/check_ai_slop.py --strict $files
+          .venv/bin/python scripts/validation/check_ai_slop.py --strict $files
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # Doc-Content Scan (OMN-13572: wire doc_content_scan as a required gate)
@@ -1320,7 +1279,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout code
@@ -1337,9 +1296,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Scan documentation for local-env traces + ticket refs (OMN-13572)
         run: |
@@ -1354,7 +1314,7 @@ jobs:
             exit 0
           fi
           # shellcheck disable=SC2086
-          uv run python -m omnibase_core.validation.doc_content_scan.runtime_doc_content_scan $files
+          .venv/bin/python -m omnibase_core.validation.doc_content_scan.runtime_doc_content_scan $files
 
   # Phase 1 validation job - runs in parallel with all other Phase 1 jobs
   # SPDX Headers (OMN-13576: burn down validator-requirements baseline ratchet)
@@ -1375,7 +1335,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout code
@@ -1392,9 +1352,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Validate SPDX headers (OMN-13576)
         run: |
@@ -1412,7 +1373,7 @@ jobs:
             exit 0
           fi
           # shellcheck disable=SC2086
-          uv run python scripts/validation/validate_spdx_headers.py $files
+          .venv/bin/python scripts/validation/validate_spdx_headers.py $files
 
   # No-new-os-environ gate (OMN-13566) — canonical AST-based env-read enforcement.
   # Blocks ALL os.environ/os.getenv reads outside KEEP_ALLOWLIST. Feeds quality-gate
@@ -1428,7 +1389,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout code
@@ -1445,13 +1406,14 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Scan src/ for os.environ/os.getenv reads outside KEEP_ALLOWLIST (OMN-13566)
         run: |
-          uv run python -m omnibase_core.validators.no_new_os_environ --all --src src/
+          .venv/bin/python -m omnibase_core.validators.no_new_os_environ --all --src src/
 
   # Duplicate registry id guard (OMN-14401). Rejects config/registry YAML files
   # declaring duplicate ids over a key that is not guaranteed unique (the
@@ -1470,7 +1432,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -1487,9 +1449,10 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen
 
       - name: Run ValidatorDuplicateConfigIds unit tests
         run: |
@@ -2419,7 +2382,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout code
@@ -2436,13 +2399,14 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Ratchet non-canonical lifecycle-word classes against frozen allowlist (OMN-14350)
         run: |
-          uv run python -m omnibase_core.validators.no_noncanonical_lifecycle_classes --check-stale src/omnibase_core
+          .venv/bin/python -m omnibase_core.validators.no_noncanonical_lifecycle_classes --check-stale src/omnibase_core
 
   # Pydantic extra="forbid" ratchet (OMN-14515, parent OMN-14208)
   # Asserts the POSITIVE: every Pydantic model must resolve to an explicit
@@ -2511,7 +2475,7 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 5
+    timeout-minutes: 6
 
     steps:
       - name: Checkout code
@@ -2528,13 +2492,14 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          save-cache: false
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --no-dev
 
       - name: Ratchet pull_request-triggered workflow files against the frozen budget (OMN-14907)
         run: |
-          uv run python -m omnibase_core.validation.validator_pull_request_workflow_ratchet --repo-root .
+          .venv/bin/python -m omnibase_core.validation.validator_pull_request_workflow_ratchet --repo-root .
 
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
@@ -2938,6 +2903,9 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Forty shards restore the cache after Phase 1 has populated it. They
+          # must not race to reserve and save the same key during teardown.
+          save-cache: false
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/docs/audits/2026-07-31-omn-15571-ci-capacity.md
+++ b/docs/audits/2026-07-31-omn-15571-ci-capacity.md
@@ -163,16 +163,20 @@ structural replacement. It is not claimed as mypy-clean.
 
 ### Workflow and representative shard
 
-`tests/unit/validation/test_ci_workflow_shape.py` passed 71 tests. The tests lock:
+`tests/unit/validation/test_ci_workflow_shape.py` passed 76 tests. The tests lock:
 
 - the trusted-event one-worker default;
 - the test-shard restore-only setup-uv cache policy;
 - the exact five dependency-free jobs and commands;
 - the exact sync profile, cache policy, and six/seven-minute budget for every
   dependency-bearing guard;
+- the complete canonical job definition for all 23 audited guards, with no
+  excluded job keys: ordered steps, `run`/`uses`/`with`/`env`/`if`, container,
+  runner, strategy, needs, permissions, advisory controls, and future job-level
+  keys all require a readable contract update;
 - exact equality between every job containing literal `--no-dev` and the 11
-  declared contract keys, plus a canonical digest of each job's complete ordered
-  step list, step `run`/`uses`/`with`/`env` fields, job env, and defaults;
+  declared contract keys, with one exact no-dev sync followed by a direct
+  environment executable;
 - the complete workflow env/defaults surface and an explicit ban on workflow or
   job `BASH_ENV`, `ENV`, and `PATH` indirection; and
 - the complete set of jobs still allowed to use a five-minute timeout.
@@ -181,9 +185,10 @@ Synthetic mutation coverage rejects every reproduced parser evasion: variable
 executables behind `if`, `time`, and `find -exec`; builtin/conditional
 `eval`/`source`; `env -S` hidden sync; bash script/stdin and conditional dash;
 custom action steps; step `with`/`env` and ordering changes; workflow/job env and
-default-shell changes; later sync; renamed jobs; and undeclared new no-dev jobs.
-Only the exact declared surface is green. The expected job profiles and timeout
-budgets remain independently count-locked.
+default-shell changes; later sync; renamed jobs; undeclared new no-dev jobs; bare
+guard `if: false`, `continue-on-error`, and masked-command changes; and job
+container/environment injection. Only the exact declared surface is green. The
+expected job profiles and timeout budgets remain independently count-locked.
 
 The exact full-suite split command was then run with
 `CI_RUNNER_TYPE=self-hosted`, `--splits 40`, `--group 21`, and `-n 1`:

--- a/docs/audits/2026-07-31-omn-15571-ci-capacity.md
+++ b/docs/audits/2026-07-31-omn-15571-ci-capacity.md
@@ -1,0 +1,213 @@
+# Core CI Capacity Audit
+
+**Date:** 2026-07-31
+**Repository:** `OmniNode-ai/omnibase_core`
+**Audited head:** `ac1743877cebac73556be2e5a6d8dc4a3e05da98` (`dev`)
+**Scope:** recurrent Core CI timeouts and worker loss; no runtime or deployment mutation
+
+## Outcome
+
+The failing run is a fleet-concurrency failure, not a deterministic unit-test
+regression. A trusted push expanded the 40-way unit matrix into 160 concurrent
+pytest workers (`40 shards * xdist 4`) on the shared self-hosted fleet. Thirty-nine
+unit shards reached the fixed 35-minute limit, and the remaining shard lost an
+xdist worker. The same representative shard passes with one worker in 6:44
+locally, including the test area where the cloud worker exited.
+
+The workflow now:
+
+- uses one xdist worker per shard by default for trusted push events;
+- keeps the merge-queue override at two workers and all operator overrides intact;
+- runs five AST/text validators directly with the runner's Python, without
+  installing the project;
+- uses locked, minimal dependency profiles for the validators that really import
+  project or test dependencies, with direct `.venv/bin/` executables preserving
+  every explicitly installed no-dev environment;
+- prevents the short validator jobs and all 40 test shards from racing to save an
+  identical setup-uv cache key; and
+- gives dependency-bearing five-minute guards a measured six- or seven-minute
+  budget instead of allowing successful validation to be cancelled during setup
+  or cache teardown.
+
+No validator was deleted, made advisory, or given a bypass.
+
+## Cloud evidence and diagnosis
+
+The failed source run was
+[run 30612365839](https://github.com/OmniNode-ai/omnibase_core/actions/runs/30612365839),
+a `push` to `dev` at the audited SHA.
+
+Attempt 3 exercised the complete matrix. All four integration splits succeeded,
+but the unit matrix ended with 39 cancelled shards and one failed shard. Every
+cancelled unit job carried the fixed-limit annotation that the job exceeded
+`35m0s`.
+
+[Split 21](https://github.com/OmniNode-ai/omnibase_core/actions/runs/30612365839/job/91105554821)
+started four xdist workers, collected 1,089 tests, and lost `gw0` near 92 percent.
+The test process reported 1,089 passes and four skips in 1,908.14 seconds (31:48)
+before the worker-loss failure. There was no assertion traceback for
+`test_get_name_with_name_field`; it was merely the item assigned to the worker
+that exited.
+
+The comparable successful
+[2026-07-04 split 21](https://github.com/OmniNode-ai/omnibase_core/actions/runs/28693448351/job/85099214152)
+also used four workers, but on a GitHub-hosted runner: 1,056 tests passed with four
+skips in 425.80 seconds (7:05), and the complete job took 7:23. The test-count
+increase is 33 tests (3.1 percent), while elapsed test time increased about 4.5x.
+That mismatch, the simultaneous 39-shard timeout, and the worker process exit
+distinguish shared-fleet oversubscription from a single slow or failing test.
+
+Attempt 4 reran only the original five-minute guards. Twelve were cancelled at
+the hard limit. Logs showed three distinct forms of capacity waste:
+
+1. full `uv sync --all-extras` installation for scripts that use only the Python
+   standard library;
+2. full extras installation where production or dev dependencies are sufficient;
+3. concurrent setup-uv post steps attempting to reserve/save the same cache key,
+   including restore aborts and failed cache reservations after validation had
+   already completed.
+
+`astral-sh/setup-uv@v7` declares `save-cache` as a supported boolean input. The
+affected consumers therefore retain cache restore but set `save-cache: false`.
+Other, longer Phase 1 jobs remain eligible to populate the shared cache; test
+shards no longer become 40 competing writers.
+
+## Audit of every original five-minute job
+
+Wall time is GitHub's job start-to-completion interval for attempt 4. A cancelled
+job can exceed five minutes by a few seconds while cancellation and post-step
+teardown complete.
+
+| Job id | Attempt 4 | Dependency finding | New disposition |
+|---|---:|---|---|
+| `exports-validation` | 5:01, cancelled | standard library only | bare `python3`, 5m |
+| `mypy-validation-scripts` | 4:48, success | dev tools required | `uv sync --frozen`, restore-only cache, 7m |
+| `core-infra-boundary` | 0:53, success | already self-contained | unchanged, 5m |
+| `check-deterministic-skills` | 1:04, success | already self-contained | unchanged, 5m |
+| `node-purity-check` | 5:00, success | standard library only | bare `python3`, 5m |
+| `enum-governance` | 5:15, cancelled | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `contract-config-compliance` | 4:59, success | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `breaking-schema-change` | 5:18, cancelled | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `no-env-fallbacks` | 5:17, cancelled | standard library only | bare `python3`, 5m |
+| `detect-secrets` | 4:03, success | pinned scanner dependency | retain focused install, 6m |
+| `version-pin-check` | 1:49, success | two focused parser dependencies | unchanged, 5m |
+| `sdk-boundary-check` | 5:17, cancelled | pytest/dev tools required | `uv sync --frozen`, restore-only cache, 7m |
+| `demo-path-topic-coherence` | 4:01, success | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `dispatch-surface-test-required` | 5:08, cancelled | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `naming-conventions` | 1:01, success | standard library only | bare `python3`, 5m |
+| `pydantic-patterns` | 5:08, cancelled | parses source; does not import Pydantic | bare `python3`, 5m |
+| `aislop-patterns` | 5:11, cancelled | imports the repository rule loader | no-dev sync/run, restore-only cache, 7m |
+| `doc-content-scan` | 2:28, success | package runtime required | no-dev sync/run, restore-only cache, 6m |
+| `spdx-headers` | 5:17, cancelled | package CLI/config required | no-dev sync/run, restore-only cache, 6m |
+| `no-new-os-environ` | 5:17, cancelled | package runtime required | no-dev sync/run, restore-only cache, 6m |
+| `duplicate-registry-ids` | 5:08, cancelled | pytest/dev tools required | `uv sync --frozen`, restore-only cache, 7m |
+| `no-noncanonical-lifecycle-classes` | 4:03, success | package runtime required | no-dev sync/run, restore-only cache, 7m |
+| `pull-request-workflow-ratchet` | 5:18, cancelled | package runtime required | no-dev sync/run, restore-only cache, 6m |
+
+In this table, no-dev sync/run means one exact `uv sync --frozen --no-dev`
+followed by direct `.venv/bin/python` or `.venv/bin/<console>` invocations. Plain
+`uv run` is not equivalent: it reconciles the environment against the project's
+default dev group.
+
+The five bare candidates were selected by a full AST import audit, including
+imports nested below module top level. `check_ai_slop.py` was deliberately not
+made bare: it dynamically imports
+`omnibase_core.validation.aislop_rule_loader`, and removing its environment would
+silently omit repository-configured rules.
+
+## Local proof
+
+### Dependency-free validators
+
+The five bare commands were run with CPython 3.12 using both `-I` and `-S`.
+`sys.path` contained only the standard-library zip, standard library, and dynamic
+library directories, and `importlib.util.find_spec("pydantic")` returned `None`.
+
+| Validator | Positive corpus result | Elapsed |
+|---|---:|---:|
+| all-exports | 3,889 files scanned; 2,366 `__all__` declarations; pass | 1.38s |
+| node purity | 11 files scanned; zero pure nodes analyzed; pass | 0.03s |
+| no environment fallbacks | repository scan; pass | 0.75s |
+| class naming | 3,228 classes in 3,080 files; pass | 0.93s |
+| Pydantic patterns | repository scan, 4,207 files; zero errors; pass | 1.50s |
+
+Each validator was also run against a temporary planted violation under the same
+isolated interpreter. The planted cases were a missing export, networking import
+in a compute node, localhost environment fallback, invalid model name, and legacy
+`.dict()` call. Exit codes were respectively `1, 1, 1, 1, 1`. The fixtures were
+removed after the proof.
+
+### Minimal locked environments
+
+A fresh `uv sync --frozen --no-dev` environment installed 30 production packages
+with pytest absent. A diagnostic plain `uv run` reproduced the original defect:
+it installed 48 packages from the default dev group, growing the environment to
+78 packages and making pytest importable.
+
+The environment was recreated at 30 packages and all 11 production-profile
+guards were then executed directly from `.venv/bin/`: enum governance,
+contract-config, breaking-schema, demo-path, dispatch-surface, AI-slop,
+documentation content, SPDX, environment reads, lifecycle classes, and workflow
+ratchet. Package count remained 30 and pytest remained absent after a Python
+module command, after the console-script command, and after all 11 guards.
+
+A separate fresh `uv sync --frozen` environment installed 78 packages. Strict
+mypy on all four validation scripts, the SDK boundary test, duplicate-id tests,
+and the duplicate manifest scan all passed. Neither profile installed optional
+extras.
+
+That strict-mypy claim is deliberately scoped to the four workflow validation
+scripts. The workflow-shape test module is an inherited non-gate: direct strict
+mypy reported 14 errors at the reviewed `d8a41f046` baseline and 9 after the
+structural replacement. It is not claimed as mypy-clean.
+
+### Workflow and representative shard
+
+`tests/unit/validation/test_ci_workflow_shape.py` passed 71 tests. The tests lock:
+
+- the trusted-event one-worker default;
+- the test-shard restore-only setup-uv cache policy;
+- the exact five dependency-free jobs and commands;
+- the exact sync profile, cache policy, and six/seven-minute budget for every
+  dependency-bearing guard;
+- exact equality between every job containing literal `--no-dev` and the 11
+  declared contract keys, plus a canonical digest of each job's complete ordered
+  step list, step `run`/`uses`/`with`/`env` fields, job env, and defaults;
+- the complete workflow env/defaults surface and an explicit ban on workflow or
+  job `BASH_ENV`, `ENV`, and `PATH` indirection; and
+- the complete set of jobs still allowed to use a five-minute timeout.
+
+Synthetic mutation coverage rejects every reproduced parser evasion: variable
+executables behind `if`, `time`, and `find -exec`; builtin/conditional
+`eval`/`source`; `env -S` hidden sync; bash script/stdin and conditional dash;
+custom action steps; step `with`/`env` and ordering changes; workflow/job env and
+default-shell changes; later sync; renamed jobs; and undeclared new no-dev jobs.
+Only the exact declared surface is green. The expected job profiles and timeout
+budgets remain independently count-locked.
+
+The exact full-suite split command was then run with
+`CI_RUNNER_TYPE=self-hosted`, `--splits 40`, `--group 21`, and `-n 1`:
+
+```text
+1090 passed, 4 skipped, 9 warnings in 404.39s (0:06:44)
+real 405.46
+```
+
+The local run had no restored duration cache, so its 1,090-item membership is not
+byte-for-byte identical to the cloud shard's 1,089-item membership. It is still a
+representative full-size shard and passed through the same typed-configuration
+test area where the four-worker cloud process disappeared. Its 28-minute margin
+to the 35-minute limit is the concrete latency proof required before lowering the
+default worker count.
+
+## Residual risk and cloud acceptance
+
+This audit does not claim a local Apple Silicon run reproduces shared Linux runner
+load. A fresh hosted run on the changed workflow is still required. Acceptance is:
+
+1. all 40 unit shards finish below 35 minutes with no xdist worker loss;
+2. all 23 audited guard jobs complete within their recorded budgets;
+3. no affected job attempts to save an identical setup-uv cache key; and
+4. `Quality Gate`, `Tests Gate`, and `CI Summary` all conclude successfully.
+
+No push or workflow rerun was performed as part of this local audit.

--- a/docs/audits/2026-07-31-omn-15571-ci-capacity.md
+++ b/docs/audits/2026-07-31-omn-15571-ci-capacity.md
@@ -163,6 +163,10 @@ structural replacement. It is not claimed as mypy-clean.
 
 ### Workflow and representative shard
 
+This subsection records the pre-final local proof at the then-current branch
+head. The later exact implementation-tree proof is recorded separately below;
+the historical counts here are retained rather than silently rewritten.
+
 `tests/unit/validation/test_ci_workflow_shape.py` passed 76 tests. The tests lock:
 
 - the trusted-event one-worker default;
@@ -205,14 +209,41 @@ test area where the four-worker cloud process disappeared. Its 28-minute margin
 to the 35-minute limit is the concrete latency proof required before lowering the
 default worker count.
 
+### Final exact implementation-tree proof
+
+After the final structural repair, mandatory remote-host validation ran against
+implementation head `a4f121bb178f1d990867d658e91e04e47d82f9bc`, tree
+`74363f22e64b6ad7dcb3148cfd10e6c04a41a5c6`, under Python 3.12:
+
+```text
+workflow-shape + required-check suite: 79 passed
+split 21/40, one worker: 1092 passed, 4 skipped, 0 failed in 457.14s
+```
+
+The final representative shard had no worker loss and retained 27 minutes 23
+seconds of margin to the 35-minute hosted ceiling.
+
+The normal, non-bypassed push hook then selected the complete unit subset on the
+same implementation tree and passed:
+
+```text
+42767 passed, 53 skipped, 3 xpassed, 175 warnings in 4130.82s (1:08:50)
+```
+
+That aggregate push proof establishes source integrity; it is not substituted
+for the hosted capacity acceptance below.
+
 ## Residual risk and cloud acceptance
 
 This audit does not claim a local Apple Silicon run reproduces shared Linux runner
 load. A fresh hosted run on the changed workflow is still required. Acceptance is:
 
-1. all 40 unit shards finish below 35 minutes with no xdist worker loss;
+1. all 40 unit shards show an effective `PYTEST_XDIST_WORKERS=1` in the hosted
+   run and finish below 35 minutes with no xdist worker loss;
 2. all 23 audited guard jobs complete within their recorded budgets;
 3. no affected job attempts to save an identical setup-uv cache key; and
 4. `Quality Gate`, `Tests Gate`, and `CI Summary` all conclude successfully.
 
-No push or workflow rerun was performed as part of this local audit.
+At the initial local-audit freeze, no push or workflow rerun had been performed.
+The later normal push proof is recorded above; hosted workflow acceptance remains
+external to this document.

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -47,44 +47,88 @@ NO_DEV_WORKFLOW_EXECUTION_CONTRACT = (
     "d7dfb006ec524bc384a900b284fc56cbf2a3d7d00a9e1709906ed4e5aebb0d8e"
 )
 
-# SHA-256 over canonical JSON of each job's complete ordered steps plus inherited
-# job env/defaults. This locks every run/uses step and every step key, including
-# with/env/if/id/shell, without attempting to interpret shell syntax. Updating a
-# digest requires auditing the readable workflow diff first.
-NO_DEV_JOB_EXECUTION_CONTRACTS = {
+# SHA-256 over canonical JSON of each complete audited guard job. No job key is
+# excluded: steps, env, defaults, container, runs-on, if, continue-on-error,
+# strategy, needs, permissions, timeout, and future job-level keys are all part
+# of the contract. Updating a digest requires auditing the readable workflow
+# diff first; this deliberately avoids another partial execution-surface list.
+AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
+    "exports-validation": (
+        "54ac4c9daa5992acfd905b46e1d994db0091303b779bc179da509a9ed9184f4e"
+    ),
+    "mypy-validation-scripts": (
+        "05cb980f356187d9a359d068b136553085243698d2286fe55e8800b68138d79d"
+    ),
+    "core-infra-boundary": (
+        "403fa52e3d6f4b8954bc692c6ec40d133278cc00cc34807fa7552732866275ad"
+    ),
+    "check-deterministic-skills": (
+        "8f0e02654254289640c6298ed043de77e3b3ce203421c8e1e4f229a9afd2e717"
+    ),
+    "node-purity-check": (
+        "b633627655c01a98bcce39c4e998529c976659f10cdd70f1a5969772bf8444eb"
+    ),
     "enum-governance": (
-        "4f9d527f1dbc432d05852d1e86d006adbb92cbeb1445cbc5aedb4275d2db7b6b"
+        "b2e4c2e5fc424c462712c9b4d48aea0cb85af1c67d4000f556f4b6ddf56bc215"
     ),
     "contract-config-compliance": (
-        "856550ce6318cf4e5ef2c623561019f2b1d389f57f7277aa65df421913cf74b3"
+        "83cd9a9099bc9f063e98b64bc03cb576290ebc545ae310ee7e41fbe73e29f95c"
     ),
     "breaking-schema-change": (
-        "5b3d3a100c83ff8d5cccf5cc316c17e1c2cf888be3555fbf23fd2bcfd20c89f9"
+        "ee0658f793f00e8e6f179d913343d37504e128dcf73a459b075230adae4a64d8"
+    ),
+    "no-env-fallbacks": (
+        "a0f24383df3a8974b1615035d4df05eb67924a1cda40d9c7a7f85379d816a475"
+    ),
+    "detect-secrets": (
+        "e52c18585e93fd68b8ea8e1db1689fb5bd255e352e176e362b359ede4f346d9b"
+    ),
+    "version-pin-check": (
+        "ade3ee77ab47c64b1cfc44f135116eec3d290c7505a30e54d8093c27a56f59bb"
+    ),
+    "sdk-boundary-check": (
+        "75dc4af7bbf72d5b9cf033d906ebefa51b95bd43c2c89acac430e526e3af923e"
     ),
     "demo-path-topic-coherence": (
-        "ac6c4c93b7b73ca86ffb9079b3f704a7bf4ed0722a2816e3e9f8150d96bb1d13"
+        "94bf6dfc92a03f6c281789316292e59c61ef6d7cd3aca07aae1f2e710d5da094"
     ),
     "dispatch-surface-test-required": (
-        "e3ab562dbc0eea02827d3203928ffbb63b8f05224f6f58f97579c8a0f80690a8"
+        "7f292453c6e38618c81f8e39e6361183e936ed6fbcdf9823b3a4b6cb1d1fcd81"
+    ),
+    "naming-conventions": (
+        "4c018ad075660fc1c8d68c65c84c00b5c7bcd82ba4a70267baa7f6e2ce377aa7"
+    ),
+    "pydantic-patterns": (
+        "0c69ccc1414177fc6b8ce43a34990d8fbd3c63de3ad58a0dc0eb735cf95d8f1b"
     ),
     "aislop-patterns": (
-        "3a89cbab7e77abb9f4d1d16ad6ce2f99b13340889b38e75e745f7c9cea74ec8c"
+        "677edc4eb5c9e263658b04262fc5830a80a9888fbe03b365c76ceb8d58be8319"
     ),
     "doc-content-scan": (
-        "ec5409c441f9a9db7cbb452626de866d111a95daad9b2f4e39fd8a7d1f4c61ef"
+        "83527bb968e8fec272ecb192139b9d941fc8247ae70ec4dbd446a7a1adaddff4"
     ),
     "spdx-headers": (
-        "8efdce9449a64b7759ab9cefd6a88c35133ddc964a27d8e3cf345b6d4fb81cdb"
+        "5ba1941f8549116b224e51ea893864bae25febdbb0e0eafae8f5cf268d7613f0"
     ),
     "no-new-os-environ": (
-        "405eb439e6c2c4861eddf69c0b0bd628fa4af77f1aa4942c30507c9e366e4ebc"
+        "486c2017dc4561d97747ff09d30819011a8aee9a1f30e844ff3b40ca97c2bcdf"
+    ),
+    "duplicate-registry-ids": (
+        "c457353e5aa56dda35a5d34b968e393024e84c3ac60a64bb964fbf52c304e691"
     ),
     "no-noncanonical-lifecycle-classes": (
-        "c98604598238d5543f1f6786f6b540d8eeeba0a825cb6747fb84d97784d65664"
+        "5cae23b307954cd43c5e17198715700a045986a07bb3f5a2941c334936de6b5a"
     ),
     "pull-request-workflow-ratchet": (
-        "ed0d0b95a8a02f19d98526cf9255443c7782cf8da72e4b00587f6781853ff412"
+        "4e10b330674d98df5a7341802e88b8471ff2e4e675c510a37e745373e362e91b"
     ),
+}
+
+OTHER_AUDITED_GUARD_JOBS = {
+    "core-infra-boundary",
+    "check-deterministic-skills",
+    "detect-secrets",
+    "version-pin-check",
 }
 
 NO_DEV_DIRECT_EXECUTABLES = {
@@ -182,12 +226,46 @@ def _workflow_execution_surface(workflow: dict[str, object]) -> dict[str, object
     }
 
 
-def _job_execution_surface(job: dict[str, object]) -> dict[str, object]:
-    return {
-        "steps": job.get("steps", []),
-        "env": job.get("env", {}),
-        "defaults": job.get("defaults", {}),
-    }
+def _guard_job_contract_violations(
+    workflow: dict[str, object], job_names: set[str] | None = None
+) -> list[str]:
+    """Return audited guard jobs whose complete job definition changed."""
+    selected_names = (
+        set(AUDITED_GUARD_JOB_EXECUTION_CONTRACTS) if job_names is None else job_names
+    )
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return sorted(selected_names)
+
+    violations: list[str] = []
+    for job_name in sorted(selected_names):
+        job = jobs.get(job_name)
+        expected_digest = AUDITED_GUARD_JOB_EXECUTION_CONTRACTS.get(job_name)
+        if (
+            not isinstance(job, dict)
+            or expected_digest is None
+            or _execution_contract_digest(job) != expected_digest
+        ):
+            violations.append(job_name)
+    return violations
+
+
+def _guard_contract_diagnostics(
+    workflow: dict[str, object], violations: list[str]
+) -> str:
+    """Render expected and actual digests for an intentional contract update."""
+    jobs = workflow.get("jobs")
+    details = ["Audited guard job execution contract mismatch:"]
+    for job_name in violations:
+        expected = AUDITED_GUARD_JOB_EXECUTION_CONTRACTS.get(job_name, "<undeclared>")
+        job = jobs.get(job_name) if isinstance(jobs, dict) else None
+        actual = (
+            _execution_contract_digest(job)
+            if isinstance(job, dict)
+            else "<missing-or-invalid-job>"
+        )
+        details.append(f"- {job_name}: expected={expected} actual={actual}")
+    return "\n".join(details)
 
 
 def _env_keys(container: dict[str, object]) -> set[str] | None:
@@ -215,9 +293,10 @@ def _no_dev_contract_violations(workflow: dict[str, object]) -> list[str]:
     if not isinstance(jobs, dict):
         return [WORKFLOW_CONTRACT_SCOPE]
 
-    declared_jobs = set(NO_DEV_JOB_EXECUTION_CONTRACTS)
+    declared_jobs = set(NO_DEV_DIRECT_EXECUTABLES)
     discovered_jobs = _literal_no_dev_job_names(workflow)
     violations.update(declared_jobs.symmetric_difference(discovered_jobs))
+    violations.update(_guard_job_contract_violations(workflow, declared_jobs))
 
     workflow_env_keys = _env_keys(workflow)
     if (
@@ -228,19 +307,14 @@ def _no_dev_contract_violations(workflow: dict[str, object]) -> list[str]:
     ):
         violations.add(WORKFLOW_CONTRACT_SCOPE)
 
-    for job_name, expected_digest in NO_DEV_JOB_EXECUTION_CONTRACTS.items():
+    for job_name in declared_jobs:
         job = jobs.get(job_name)
         if not isinstance(job, dict):
             violations.add(job_name)
             continue
 
         job_env_keys = _env_keys(job)
-        if (
-            job_env_keys is None
-            or job_env_keys & FORBIDDEN_EXECUTION_ENV_KEYS
-            or _execution_contract_digest(_job_execution_surface(job))
-            != expected_digest
-        ):
+        if job_env_keys is None or job_env_keys & FORBIDDEN_EXECUTION_ENV_KEYS:
             violations.add(job_name)
 
     return sorted(violations)
@@ -301,6 +375,19 @@ def test_test_shards_restore_uv_cache_without_competing_to_save_it() -> None:
     assert setup_uv_steps[0]["with"]["save-cache"] is False
 
 
+def test_audited_guard_jobs_match_complete_execution_contracts() -> None:
+    workflow = _ci_workflow()
+    expected_jobs = (
+        set(STDLIB_ONLY_GUARD_COMMANDS)
+        | set(DEPENDENCY_GUARD_PROFILES)
+        | OTHER_AUDITED_GUARD_JOBS
+    )
+    violations = _guard_job_contract_violations(workflow)
+
+    assert set(AUDITED_GUARD_JOB_EXECUTION_CONTRACTS) == expected_jobs
+    assert violations == [], _guard_contract_diagnostics(workflow, violations)
+
+
 @pytest.mark.parametrize(
     ("job_name", "expected_command"), STDLIB_ONLY_GUARD_COMMANDS.items()
 )
@@ -316,6 +403,46 @@ def test_stdlib_only_guards_do_not_build_a_project_environment(
     assert "uv sync" not in rendered
     assert expected_command in rendered
     assert _ci_job(job_name)["timeout-minutes"] == 5
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["if-false", "continue-on-error", "mask-command-failure"],
+)
+def test_bare_guard_contract_rejects_advisory_or_masked_execution(
+    mutation: str,
+) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "exports-validation")
+    validation_step = next(
+        step for step in steps if step.get("name") == "Validate __all__ exports"
+    )
+
+    if mutation == "if-false":
+        validation_step["if"] = "${{ false }}"
+    elif mutation == "continue-on-error":
+        validation_step["continue-on-error"] = True
+    else:
+        run = validation_step.get("run")
+        assert isinstance(run, str)
+        validation_step["run"] = f"{run} || true"
+
+    assert _guard_job_contract_violations(workflow) == ["exports-validation"]
+
+
+def test_no_dev_contract_rejects_job_container_environment_injection() -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs["enum-governance"]
+    assert isinstance(job, dict)
+    job["container"] = {
+        "image": "ubuntu:24.04",
+        "env": {"PYTHONPATH": "${{ github.workspace }}/ci_injection"},
+    }
+
+    assert _guard_job_contract_violations(workflow) == ["enum-governance"]
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
 
 
 @pytest.mark.parametrize(
@@ -351,9 +478,8 @@ def test_dependency_guards_use_minimal_locked_sync_and_measured_budgets(
 def test_no_dev_execution_surface_matches_declared_contract() -> None:
     workflow = _ci_workflow()
 
-    assert _literal_no_dev_job_names(workflow) == set(NO_DEV_JOB_EXECUTION_CONTRACTS)
-    assert set(NO_DEV_DIRECT_EXECUTABLES) == set(NO_DEV_JOB_EXECUTION_CONTRACTS)
-    for job_name in NO_DEV_JOB_EXECUTION_CONTRACTS:
+    assert _literal_no_dev_job_names(workflow) == set(NO_DEV_DIRECT_EXECUTABLES)
+    for job_name in NO_DEV_DIRECT_EXECUTABLES:
         assert all(("run" in step) ^ ("uses" in step) for step in _job_steps(job_name))
     assert _no_dev_contract_violations(workflow) == []
 

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -12,10 +15,235 @@ pytestmark = pytest.mark.unit
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
 
+STDLIB_ONLY_GUARD_COMMANDS = {
+    "exports-validation": "python3 scripts/validation/validate-all-exports.py",
+    "node-purity-check": "python3 scripts/check_node_purity.py --verbose",
+    "no-env-fallbacks": "python3 scripts/validate_no_env_fallbacks.py",
+    "naming-conventions": "python3 scripts/validate_class_naming.py",
+    "pydantic-patterns": (
+        "python3 scripts/validation/validate-pydantic-patterns.py $files"
+    ),
+}
+
+DEPENDENCY_GUARD_PROFILES = {
+    # job id: (sync command, measured timeout budget in minutes)
+    "mypy-validation-scripts": ("uv sync --frozen", 7),
+    "enum-governance": ("uv sync --frozen --no-dev", 7),
+    "contract-config-compliance": ("uv sync --frozen --no-dev", 7),
+    "breaking-schema-change": ("uv sync --frozen --no-dev", 7),
+    "sdk-boundary-check": ("uv sync --frozen", 7),
+    "demo-path-topic-coherence": ("uv sync --frozen --no-dev", 7),
+    "dispatch-surface-test-required": ("uv sync --frozen --no-dev", 7),
+    "aislop-patterns": ("uv sync --frozen --no-dev", 7),
+    "doc-content-scan": ("uv sync --frozen --no-dev", 6),
+    "spdx-headers": ("uv sync --frozen --no-dev", 6),
+    "no-new-os-environ": ("uv sync --frozen --no-dev", 6),
+    "duplicate-registry-ids": ("uv sync --frozen", 7),
+    "no-noncanonical-lifecycle-classes": ("uv sync --frozen --no-dev", 7),
+    "pull-request-workflow-ratchet": ("uv sync --frozen --no-dev", 6),
+}
+
+NO_DEV_WORKFLOW_EXECUTION_CONTRACT = (
+    "d7dfb006ec524bc384a900b284fc56cbf2a3d7d00a9e1709906ed4e5aebb0d8e"
+)
+
+# SHA-256 over canonical JSON of each job's complete ordered steps plus inherited
+# job env/defaults. This locks every run/uses step and every step key, including
+# with/env/if/id/shell, without attempting to interpret shell syntax. Updating a
+# digest requires auditing the readable workflow diff first.
+NO_DEV_JOB_EXECUTION_CONTRACTS = {
+    "enum-governance": (
+        "4f9d527f1dbc432d05852d1e86d006adbb92cbeb1445cbc5aedb4275d2db7b6b"
+    ),
+    "contract-config-compliance": (
+        "856550ce6318cf4e5ef2c623561019f2b1d389f57f7277aa65df421913cf74b3"
+    ),
+    "breaking-schema-change": (
+        "5b3d3a100c83ff8d5cccf5cc316c17e1c2cf888be3555fbf23fd2bcfd20c89f9"
+    ),
+    "demo-path-topic-coherence": (
+        "ac6c4c93b7b73ca86ffb9079b3f704a7bf4ed0722a2816e3e9f8150d96bb1d13"
+    ),
+    "dispatch-surface-test-required": (
+        "e3ab562dbc0eea02827d3203928ffbb63b8f05224f6f58f97579c8a0f80690a8"
+    ),
+    "aislop-patterns": (
+        "3a89cbab7e77abb9f4d1d16ad6ce2f99b13340889b38e75e745f7c9cea74ec8c"
+    ),
+    "doc-content-scan": (
+        "ec5409c441f9a9db7cbb452626de866d111a95daad9b2f4e39fd8a7d1f4c61ef"
+    ),
+    "spdx-headers": (
+        "8efdce9449a64b7759ab9cefd6a88c35133ddc964a27d8e3cf345b6d4fb81cdb"
+    ),
+    "no-new-os-environ": (
+        "405eb439e6c2c4861eddf69c0b0bd628fa4af77f1aa4942c30507c9e366e4ebc"
+    ),
+    "no-noncanonical-lifecycle-classes": (
+        "c98604598238d5543f1f6786f6b540d8eeeba0a825cb6747fb84d97784d65664"
+    ),
+    "pull-request-workflow-ratchet": (
+        "ed0d0b95a8a02f19d98526cf9255443c7782cf8da72e4b00587f6781853ff412"
+    ),
+}
+
+NO_DEV_DIRECT_EXECUTABLES = {
+    "enum-governance": ".venv/bin/python",
+    "contract-config-compliance": ".venv/bin/python",
+    "breaking-schema-change": ".venv/bin/python",
+    "demo-path-topic-coherence": ".venv/bin/onex-demo-path-topic-gate",
+    "dispatch-surface-test-required": ".venv/bin/python",
+    "aislop-patterns": ".venv/bin/python",
+    "doc-content-scan": ".venv/bin/python",
+    "spdx-headers": ".venv/bin/python",
+    "no-new-os-environ": ".venv/bin/python",
+    "no-noncanonical-lifecycle-classes": ".venv/bin/python",
+    "pull-request-workflow-ratchet": ".venv/bin/python",
+}
+
+FORBIDDEN_EXECUTION_ENV_KEYS = {"BASH_ENV", "ENV", "PATH"}
+WORKFLOW_CONTRACT_SCOPE = "<workflow>"
+
+EXPECTED_FIVE_MINUTE_JOBS = {
+    "exports-validation",
+    "core-infra-boundary",
+    "check-deterministic-skills",
+    "node-purity-check",
+    "no-env-fallbacks",
+    "version-pin-check",
+    "naming-conventions",
+    "pydantic-patterns",
+}
+
+
+def _ci_workflow() -> dict[str, object]:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+def _workflow_job_steps(
+    workflow: dict[str, object], name: str
+) -> list[dict[str, object]]:
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[name]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    assert all(isinstance(step, dict) for step in steps)
+    return steps
+
 
 def _ci_job(name: str) -> dict[str, object]:
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
-    return data["jobs"][name]
+    jobs = _ci_workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[name]
+    assert isinstance(job, dict)
+    return job
+
+
+def _job_steps(name: str) -> list[dict[str, object]]:
+    return _workflow_job_steps(_ci_workflow(), name)
+
+
+def _job_run_commands(name: str) -> list[str]:
+    return [str(step["run"]).strip() for step in _job_steps(name) if "run" in step]
+
+
+def _contains_literal(value: object, literal: str) -> bool:
+    if isinstance(value, str):
+        return literal in value
+    if isinstance(value, dict):
+        return any(
+            _contains_literal(key, literal) or _contains_literal(item, literal)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_literal(item, literal) for item in value)
+    return False
+
+
+def _execution_contract_digest(value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _workflow_execution_surface(workflow: dict[str, object]) -> dict[str, object]:
+    return {
+        "env": workflow.get("env", {}),
+        "defaults": workflow.get("defaults", {}),
+    }
+
+
+def _job_execution_surface(job: dict[str, object]) -> dict[str, object]:
+    return {
+        "steps": job.get("steps", []),
+        "env": job.get("env", {}),
+        "defaults": job.get("defaults", {}),
+    }
+
+
+def _env_keys(container: dict[str, object]) -> set[str] | None:
+    env = container.get("env", {})
+    if not isinstance(env, dict):
+        return None
+    return {str(key) for key in env}
+
+
+def _literal_no_dev_job_names(workflow: dict[str, object]) -> set[str]:
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return set()
+    return {
+        str(job_name)
+        for job_name, job in jobs.items()
+        if _contains_literal(job, "--no-dev")
+    }
+
+
+def _no_dev_contract_violations(workflow: dict[str, object]) -> list[str]:
+    """Return scopes that differ from the audited no-dev execution contract."""
+    violations: set[str] = set()
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return [WORKFLOW_CONTRACT_SCOPE]
+
+    declared_jobs = set(NO_DEV_JOB_EXECUTION_CONTRACTS)
+    discovered_jobs = _literal_no_dev_job_names(workflow)
+    violations.update(declared_jobs.symmetric_difference(discovered_jobs))
+
+    workflow_env_keys = _env_keys(workflow)
+    if (
+        workflow_env_keys is None
+        or workflow_env_keys & FORBIDDEN_EXECUTION_ENV_KEYS
+        or _execution_contract_digest(_workflow_execution_surface(workflow))
+        != NO_DEV_WORKFLOW_EXECUTION_CONTRACT
+    ):
+        violations.add(WORKFLOW_CONTRACT_SCOPE)
+
+    for job_name, expected_digest in NO_DEV_JOB_EXECUTION_CONTRACTS.items():
+        job = jobs.get(job_name)
+        if not isinstance(job, dict):
+            violations.add(job_name)
+            continue
+
+        job_env_keys = _env_keys(job)
+        if (
+            job_env_keys is None
+            or job_env_keys & FORBIDDEN_EXECUTION_ENV_KEYS
+            or _execution_contract_digest(_job_execution_surface(job))
+            != expected_digest
+        ):
+            violations.add(job_name)
+
+    return sorted(violations)
 
 
 def _boundary_validation_step() -> dict[str, object]:
@@ -52,6 +280,298 @@ def test_pr_and_merge_queue_use_bounded_xdist_workers() -> None:
     assert "github.event_name == 'merge_group'" in workers
     assert "OMNI_PUBLIC_PR_PYTEST_XDIST_WORKERS || '1'" in workers
     assert "OMNI_MERGE_GROUP_PYTEST_XDIST_WORKERS || '2'" in workers
+
+
+def test_trusted_full_matrix_uses_one_xdist_worker_per_shard() -> None:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    workers = data["env"]["PYTEST_XDIST_WORKERS"]
+
+    assert "OMNI_PYTEST_XDIST_WORKERS || '1'" in workers
+
+
+def test_test_shards_restore_uv_cache_without_competing_to_save_it() -> None:
+    setup_uv_steps = [
+        step
+        for step in _job_steps("test-parallel")
+        if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+    ]
+
+    assert len(setup_uv_steps) == 1
+    assert setup_uv_steps[0]["with"]["enable-cache"] is True
+    assert setup_uv_steps[0]["with"]["save-cache"] is False
+
+
+@pytest.mark.parametrize(
+    ("job_name", "expected_command"), STDLIB_ONLY_GUARD_COMMANDS.items()
+)
+def test_stdlib_only_guards_do_not_build_a_project_environment(
+    job_name: str, expected_command: str
+) -> None:
+    steps = _job_steps(job_name)
+    rendered = "\n".join(
+        str(step.get("uses", "")) + "\n" + str(step.get("run", "")) for step in steps
+    )
+
+    assert "astral-sh/setup-uv" not in rendered
+    assert "uv sync" not in rendered
+    assert expected_command in rendered
+    assert _ci_job(job_name)["timeout-minutes"] == 5
+
+
+@pytest.mark.parametrize(
+    ("job_name", "expected_sync", "expected_timeout"),
+    (
+        (job_name, expected_sync, expected_timeout)
+        for job_name, (
+            expected_sync,
+            expected_timeout,
+        ) in DEPENDENCY_GUARD_PROFILES.items()
+    ),
+)
+def test_dependency_guards_use_minimal_locked_sync_and_measured_budgets(
+    job_name: str, expected_sync: str, expected_timeout: int
+) -> None:
+    job = _ci_job(job_name)
+    setup_uv_steps = [
+        step
+        for step in _job_steps(job_name)
+        if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+    ]
+    sync_commands = [
+        command for command in _job_run_commands(job_name) if "uv sync" in command
+    ]
+
+    assert len(setup_uv_steps) == 1
+    assert setup_uv_steps[0]["with"]["save-cache"] is False
+    assert sync_commands == [expected_sync]
+    assert "--all-extras" not in sync_commands[0]
+    assert job["timeout-minutes"] == expected_timeout
+
+
+def test_no_dev_execution_surface_matches_declared_contract() -> None:
+    workflow = _ci_workflow()
+
+    assert _literal_no_dev_job_names(workflow) == set(NO_DEV_JOB_EXECUTION_CONTRACTS)
+    assert set(NO_DEV_DIRECT_EXECUTABLES) == set(NO_DEV_JOB_EXECUTION_CONTRACTS)
+    for job_name in NO_DEV_JOB_EXECUTION_CONTRACTS:
+        assert all(("run" in step) ^ ("uses" in step) for step in _job_steps(job_name))
+    assert _no_dev_contract_violations(workflow) == []
+
+
+@pytest.mark.parametrize(
+    ("job_name", "expected_executable"), NO_DEV_DIRECT_EXECUTABLES.items()
+)
+def test_no_dev_jobs_sync_once_then_use_direct_environment_executable(
+    job_name: str, expected_executable: str
+) -> None:
+    run_steps = _job_run_commands(job_name)
+    run_lines = [
+        line.strip()
+        for run_step in run_steps
+        for line in run_step.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    sync_lines = [line for line in run_lines if line.startswith("uv sync")]
+    direct_lines = [line for line in run_lines if line.startswith(".venv/bin/")]
+
+    assert sync_lines == ["uv sync --frozen --no-dev"]
+    assert all("uv run" not in run_step for run_step in run_steps)
+    assert len(direct_lines) == 1
+    assert direct_lines[0].startswith(f"{expected_executable} ")
+
+
+def _workflow_with_enum_execution(run: str) -> dict[str, object]:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "enum-governance")
+    execution_step = next(
+        step for step in steps if step.get("name") == "Run enum governance validator"
+    )
+    execution_step["run"] = run
+    return workflow
+
+
+@pytest.mark.parametrize(
+    "opaque_execution",
+    [
+        'UV_BIN=uv\nif true; then "$UV_BIN" --offline run python; fi',
+        'UV_BIN=uv\n/usr/bin/time "$UV_BIN" --offline run python',
+        'UV_BIN=uv\nfind . -maxdepth 0 -exec "$UV_BIN" --offline run python \\;',
+        "builtin eval 'uv --offline run python'",
+        "if true; then eval 'uv --offline run python'; fi",
+        "builtin source /dev/stdin <<'SCRIPT'\nuv --offline run python\nSCRIPT",
+        "if true; then source /dev/stdin <<'SCRIPT'\nuv --offline run python\nSCRIPT\nfi",
+        "env -S 'uv --offline sync --frozen'",
+        "bash scripts/ci/hidden-uv.sh",
+        "bash /dev/stdin <<'SCRIPT'\nuv --offline run python\nSCRIPT",
+        "if true; then dash -c 'uv --offline run python'; fi",
+    ],
+)
+def test_no_dev_contract_rejects_reviewer_execution_evasions(
+    opaque_execution: str,
+) -> None:
+    assert _no_dev_contract_violations(
+        _workflow_with_enum_execution(opaque_execution)
+    ) == ["enum-governance"]
+
+
+def test_no_dev_contract_rejects_plain_uv_run() -> None:
+    workflow = _workflow_with_enum_execution(
+        "uv run python -m omnibase_core.validation.checker_enum_governance"
+    )
+
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
+
+
+def test_no_dev_contract_rejects_custom_action_step() -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "enum-governance")
+    steps.append(
+        {
+            "name": "Opaque dependency action",
+            "uses": "example/hidden-uv@0123456789abcdef",
+            "with": {"command": "sync --frozen"},
+        }
+    )
+
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
+
+
+@pytest.mark.parametrize("scope", ["workflow", "job"])
+@pytest.mark.parametrize("env_name", ["BASH_ENV", "ENV", "PATH"])
+def test_no_dev_contract_forbids_execution_environment_indirection(
+    scope: str, env_name: str
+) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    if scope == "workflow":
+        target = workflow
+    else:
+        jobs = workflow["jobs"]
+        assert isinstance(jobs, dict)
+        target = jobs["enum-governance"]
+        assert isinstance(target, dict)
+    env = target.setdefault("env", {})
+    assert isinstance(env, dict)
+    env[env_name] = "/tmp/opaque-execution-hook"
+
+    expected = [WORKFLOW_CONTRACT_SCOPE] if scope == "workflow" else ["enum-governance"]
+    assert _no_dev_contract_violations(workflow) == expected
+
+
+@pytest.mark.parametrize("scope", ["workflow", "job"])
+def test_no_dev_contract_rejects_any_inherited_env_change(scope: str) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    if scope == "workflow":
+        target = workflow
+    else:
+        jobs = workflow["jobs"]
+        assert isinstance(jobs, dict)
+        target = jobs["enum-governance"]
+        assert isinstance(target, dict)
+    env = target.setdefault("env", {})
+    assert isinstance(env, dict)
+    env["AUDITED_CONTEXT"] = "changed"
+
+    expected = [WORKFLOW_CONTRACT_SCOPE] if scope == "workflow" else ["enum-governance"]
+    assert _no_dev_contract_violations(workflow) == expected
+
+
+@pytest.mark.parametrize("scope", ["workflow", "job"])
+def test_no_dev_contract_rejects_default_shell_changes(scope: str) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    if scope == "workflow":
+        target = workflow
+    else:
+        jobs = workflow["jobs"]
+        assert isinstance(jobs, dict)
+        target = jobs["enum-governance"]
+        assert isinstance(target, dict)
+    target["defaults"] = {"run": {"shell": "bash -c 'source /tmp/hook; {0}'"}}
+
+    expected = [WORKFLOW_CONTRACT_SCOPE] if scope == "workflow" else ["enum-governance"]
+    assert _no_dev_contract_violations(workflow) == expected
+
+
+@pytest.mark.parametrize("step_field", ["env", "with"])
+def test_no_dev_contract_rejects_step_env_and_with_changes(
+    step_field: str,
+) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "enum-governance")
+    if step_field == "env":
+        execution_step = next(
+            step
+            for step in steps
+            if step.get("name") == "Run enum governance validator"
+        )
+        execution_step["env"] = {"UV_BIN": "uv"}
+    else:
+        setup_step = next(
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+        )
+        setup_with = setup_step["with"]
+        assert isinstance(setup_with, dict)
+        setup_with["version"] = "9.9.9"
+
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
+
+
+def test_no_dev_contract_rejects_step_reordering() -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "enum-governance")
+    steps[0], steps[1] = steps[1], steps[0]
+
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
+
+
+@pytest.mark.parametrize(
+    "later_sync",
+    ["uv sync --frozen", "uv sync --frozen --no-dev"],
+)
+def test_no_dev_contract_rejects_any_later_sync(later_sync: str) -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    steps = _workflow_job_steps(workflow, "enum-governance")
+    steps.append({"name": "Later dependency sync", "run": later_sync})
+
+    assert _no_dev_contract_violations(workflow) == ["enum-governance"]
+
+
+def test_no_dev_contract_rejects_undeclared_safe_no_dev_job() -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    jobs["future-no-dev-job"] = {
+        "steps": [
+            {"run": "uv sync --frozen --no-dev"},
+            {"run": ".venv/bin/python -m example"},
+        ]
+    }
+
+    assert _no_dev_contract_violations(workflow) == ["future-no-dev-job"]
+
+
+def test_no_dev_contract_rejects_renamed_no_dev_job() -> None:
+    workflow = copy.deepcopy(_ci_workflow())
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    jobs["renamed-enum-governance"] = jobs.pop("enum-governance")
+
+    assert _no_dev_contract_violations(workflow) == [
+        "enum-governance",
+        "renamed-enum-governance",
+    ]
+
+
+def test_five_minute_job_set_is_dependency_free_and_count_locked() -> None:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    five_minute_jobs = {
+        job_name
+        for job_name, job in data["jobs"].items()
+        if job.get("timeout-minutes") == 5
+    }
+
+    assert five_minute_jobs == EXPECTED_FIVE_MINUTE_JOBS
 
 
 def test_cross_repo_boundary_validation_job_is_blocking() -> None:

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -43,9 +43,7 @@ DEPENDENCY_GUARD_PROFILES = {
     "pull-request-workflow-ratchet": ("uv sync --frozen --no-dev", 6),
 }
 
-NO_DEV_WORKFLOW_EXECUTION_CONTRACT = (
-    "d7dfb006ec524bc384a900b284fc56cbf2a3d7d00a9e1709906ed4e5aebb0d8e"
-)
+NO_DEV_WORKFLOW_EXECUTION_CONTRACT = "d7dfb006ec524bc384a900b284fc56cbf2a3d7d00a9e1709906ed4e5aebb0d8e"  # pragma: allowlist secret
 
 # SHA-256 over canonical JSON of each complete audited guard job. No job key is
 # excluded: steps, env, defaults, container, runs-on, if, continue-on-error,
@@ -54,73 +52,73 @@ NO_DEV_WORKFLOW_EXECUTION_CONTRACT = (
 # diff first; this deliberately avoids another partial execution-surface list.
 AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
     "exports-validation": (
-        "54ac4c9daa5992acfd905b46e1d994db0091303b779bc179da509a9ed9184f4e"
+        "54ac4c9daa5992acfd905b46e1d994db0091303b779bc179da509a9ed9184f4e"  # pragma: allowlist secret
     ),
     "mypy-validation-scripts": (
-        "05cb980f356187d9a359d068b136553085243698d2286fe55e8800b68138d79d"
+        "05cb980f356187d9a359d068b136553085243698d2286fe55e8800b68138d79d"  # pragma: allowlist secret
     ),
     "core-infra-boundary": (
-        "403fa52e3d6f4b8954bc692c6ec40d133278cc00cc34807fa7552732866275ad"
+        "403fa52e3d6f4b8954bc692c6ec40d133278cc00cc34807fa7552732866275ad"  # pragma: allowlist secret
     ),
     "check-deterministic-skills": (
-        "8f0e02654254289640c6298ed043de77e3b3ce203421c8e1e4f229a9afd2e717"
+        "8f0e02654254289640c6298ed043de77e3b3ce203421c8e1e4f229a9afd2e717"  # pragma: allowlist secret
     ),
     "node-purity-check": (
-        "b633627655c01a98bcce39c4e998529c976659f10cdd70f1a5969772bf8444eb"
+        "b633627655c01a98bcce39c4e998529c976659f10cdd70f1a5969772bf8444eb"  # pragma: allowlist secret
     ),
     "enum-governance": (
-        "b2e4c2e5fc424c462712c9b4d48aea0cb85af1c67d4000f556f4b6ddf56bc215"
+        "b2e4c2e5fc424c462712c9b4d48aea0cb85af1c67d4000f556f4b6ddf56bc215"  # pragma: allowlist secret
     ),
     "contract-config-compliance": (
-        "83cd9a9099bc9f063e98b64bc03cb576290ebc545ae310ee7e41fbe73e29f95c"
+        "83cd9a9099bc9f063e98b64bc03cb576290ebc545ae310ee7e41fbe73e29f95c"  # pragma: allowlist secret
     ),
     "breaking-schema-change": (
-        "ee0658f793f00e8e6f179d913343d37504e128dcf73a459b075230adae4a64d8"
+        "ee0658f793f00e8e6f179d913343d37504e128dcf73a459b075230adae4a64d8"  # pragma: allowlist secret
     ),
     "no-env-fallbacks": (
-        "a0f24383df3a8974b1615035d4df05eb67924a1cda40d9c7a7f85379d816a475"
+        "a0f24383df3a8974b1615035d4df05eb67924a1cda40d9c7a7f85379d816a475"  # pragma: allowlist secret
     ),
     "detect-secrets": (
-        "e52c18585e93fd68b8ea8e1db1689fb5bd255e352e176e362b359ede4f346d9b"
+        "e52c18585e93fd68b8ea8e1db1689fb5bd255e352e176e362b359ede4f346d9b"  # pragma: allowlist secret
     ),
     "version-pin-check": (
-        "ade3ee77ab47c64b1cfc44f135116eec3d290c7505a30e54d8093c27a56f59bb"
+        "ade3ee77ab47c64b1cfc44f135116eec3d290c7505a30e54d8093c27a56f59bb"  # pragma: allowlist secret
     ),
     "sdk-boundary-check": (
-        "75dc4af7bbf72d5b9cf033d906ebefa51b95bd43c2c89acac430e526e3af923e"
+        "75dc4af7bbf72d5b9cf033d906ebefa51b95bd43c2c89acac430e526e3af923e"  # pragma: allowlist secret
     ),
     "demo-path-topic-coherence": (
-        "94bf6dfc92a03f6c281789316292e59c61ef6d7cd3aca07aae1f2e710d5da094"
+        "94bf6dfc92a03f6c281789316292e59c61ef6d7cd3aca07aae1f2e710d5da094"  # pragma: allowlist secret
     ),
     "dispatch-surface-test-required": (
-        "7f292453c6e38618c81f8e39e6361183e936ed6fbcdf9823b3a4b6cb1d1fcd81"
+        "7f292453c6e38618c81f8e39e6361183e936ed6fbcdf9823b3a4b6cb1d1fcd81"  # pragma: allowlist secret
     ),
     "naming-conventions": (
-        "4c018ad075660fc1c8d68c65c84c00b5c7bcd82ba4a70267baa7f6e2ce377aa7"
+        "4c018ad075660fc1c8d68c65c84c00b5c7bcd82ba4a70267baa7f6e2ce377aa7"  # pragma: allowlist secret
     ),
     "pydantic-patterns": (
-        "0c69ccc1414177fc6b8ce43a34990d8fbd3c63de3ad58a0dc0eb735cf95d8f1b"
+        "0c69ccc1414177fc6b8ce43a34990d8fbd3c63de3ad58a0dc0eb735cf95d8f1b"  # pragma: allowlist secret
     ),
     "aislop-patterns": (
-        "677edc4eb5c9e263658b04262fc5830a80a9888fbe03b365c76ceb8d58be8319"
+        "677edc4eb5c9e263658b04262fc5830a80a9888fbe03b365c76ceb8d58be8319"  # pragma: allowlist secret
     ),
     "doc-content-scan": (
-        "83527bb968e8fec272ecb192139b9d941fc8247ae70ec4dbd446a7a1adaddff4"
+        "83527bb968e8fec272ecb192139b9d941fc8247ae70ec4dbd446a7a1adaddff4"  # pragma: allowlist secret
     ),
     "spdx-headers": (
-        "5ba1941f8549116b224e51ea893864bae25febdbb0e0eafae8f5cf268d7613f0"
+        "5ba1941f8549116b224e51ea893864bae25febdbb0e0eafae8f5cf268d7613f0"  # pragma: allowlist secret
     ),
     "no-new-os-environ": (
-        "486c2017dc4561d97747ff09d30819011a8aee9a1f30e844ff3b40ca97c2bcdf"
+        "486c2017dc4561d97747ff09d30819011a8aee9a1f30e844ff3b40ca97c2bcdf"  # pragma: allowlist secret
     ),
     "duplicate-registry-ids": (
-        "c457353e5aa56dda35a5d34b968e393024e84c3ac60a64bb964fbf52c304e691"
+        "c457353e5aa56dda35a5d34b968e393024e84c3ac60a64bb964fbf52c304e691"  # pragma: allowlist secret
     ),
     "no-noncanonical-lifecycle-classes": (
-        "5cae23b307954cd43c5e17198715700a045986a07bb3f5a2941c334936de6b5a"
+        "5cae23b307954cd43c5e17198715700a045986a07bb3f5a2941c334936de6b5a"  # pragma: allowlist secret
     ),
     "pull-request-workflow-ratchet": (
-        "4e10b330674d98df5a7341802e88b8471ff2e4e675c510a37e745373e362e91b"
+        "4e10b330674d98df5a7341802e88b8471ff2e4e675c510a37e745373e362e91b"  # pragma: allowlist secret
     ),
 }
 


### PR DESCRIPTION
Evidence-Ticket: OMN-15571
Evidence-Source: 05ebae88c73f177ef793348675376191111526e0

## Ticket

**OMN-15571** — omnibase_core CI release gate exhausts fixed job budgets under runner/cache saturation (parent OMN-13999; blocks the OMN-15539 Core promotion).

This is the CI-capacity repair that gates the `omnibase-core` 0.46.8 release chain. PyPI latest is `0.46.7`; `dev` already declares `0.46.8`, so nothing downstream can consume the typed surfaces below until this lands and 0.46.8 publishes.

## Exact-head requirement (read before re-running or amending)

- **Exact head under test: `626d6e062a574882ebd3d969bf392782bfa4d202`.** Hosted green must be taken at this SHA, never at the parent `a4f121bb`.
- **Reviewed tree: `289909900b461e1889f4c497a515b37918046cfd`.** Independent review completed at this tree with 0 P0 / 0 P1. `626d6e06` is a doc-only commit that carries the *identical* tree as the implementation commit `a4f121bb` — the reviewed source surface and the merge-candidate source surface are the same bytes.
- **This branch must not be amended or force-pushed.** Any new commit invalidates both the completed review and the exact-head evidence binding in the merged OCC companion. If CI fails for a real (non-infrastructure) reason, the correct action is to report BLOCKED, not to repair in place.

Commits (3 ahead of `dev`, 0 behind):

| SHA | Subject |
|---|---|
| `71d39210` | ci: reduce trusted matrix contention |
| `a4f121bb` | test(OMN-15571): close CI guard execution bypasses (tree `74363f22`) |
| `626d6e06` | docs(OMN-15571): record final .200 capacity proof (tree `28990990`) |

## What changed

Root cause is fleet concurrency, not a deterministic test regression: a trusted push expanded the 40-way unit matrix into 160 concurrent pytest workers (`40 shards x xdist 4`) on the shared self-hosted fleet. 39 unit shards hit the fixed 35-minute limit and the remaining shard lost an xdist worker mid-run with no assertion traceback. In parallel, 12 standalone 5-minute guards were cancelled during dependency/cache setup, several of which were installing full extras to run stdlib-only scripts.

The workflow now:

- uses **one xdist worker per shard** for trusted push events (merge-queue override stays at two; all operator overrides intact);
- runs **5 stdlib-only validators** with the runner's bare `python3`, installing nothing;
- gives dependency-bearing guards **locked minimal profiles** — one exact `uv sync --frozen [--no-dev]` followed by a direct `.venv/bin/` executable;
- sets `save-cache: false` on the affected consumers so 40 shards plus the short guards stop racing to save an identical `setup-uv` cache key (restore is retained; longer Phase 1 jobs still populate the cache);
- replaces the cancelled 5-minute budgets with **measured 6- or 7-minute budgets** only where evidence supports it.

**No validator was deleted, made advisory, weakened, or given a bypass. No test skips, no coverage reduction, no required-context removal, no blanket timeout inflation, no skip token.**

## Boundary seams

Scope is exactly three files — workflow, audit, tests. No `src/` change, no runtime surface, no deploy.

| File | Delta |
|---|---|
| `.github/workflows/ci.yml` | +66 / -98 |
| `docs/audits/2026-07-31-omn-15571-ci-capacity.md` | +249 / -0 (new) |
| `tests/unit/validation/test_ci_workflow_shape.py` | +648 / -2 |

**Seam 1 — 11 literal no-dev job execution contracts.** `ci.yml` contains exactly **11** literal `--no-dev` occurrences, and `NO_DEV_DIRECT_EXECUTABLES` in the test module declares exactly **11** keys. The test asserts *exact set equality* between the two, so an undeclared new no-dev job and a renamed no-dev job both fail closed. Each of the 11 must perform one exact `uv sync --frozen --no-dev` followed by a direct `.venv/bin/python` or `.venv/bin/<console>` invocation. Plain `uv run` is explicitly rejected: it reconciles against the default dev group and was proven to grow a fresh environment from 30 to 78 packages with pytest becoming importable — the exact defect this contract exists to prevent.

**Seam 2 — whole-job structural hashing across all 23 audited guards.** `AUDITED_GUARD_JOB_EXECUTION_CONTRACTS` holds **23** SHA-256 digests over canonical JSON of each *complete* job. No job key is excluded — ordered steps, `run`/`uses`/`with`/`env`/`if`, container, `runs-on`, `strategy`, `needs`, `permissions`, `continue-on-error`, timeout, and any future job-level key are all inside the digest. This replaced an earlier token-inference parser that a hostile review proved fail-open (4 reproduced P1 execution bypasses). Companion surfaces: `NO_DEV_WORKFLOW_EXECUTION_CONTRACT` (workflow-level env/defaults digest), `FORBIDDEN_EXECUTION_ENV_KEYS = {BASH_ENV, ENV, PATH}` (indirection ban at both workflow and job scope), `STDLIB_ONLY_GUARD_COMMANDS` (5 count-locked bare commands), `DEPENDENCY_GUARD_PROFILES` (14 sync-profile + budget pairs), `EXPECTED_FIVE_MINUTE_JOBS` (8 count-locked). 28 tests in the module; synthetic mutation coverage rejects every reproduced evasion class — variable executables behind `if`/`time`/`find -exec`, builtin/conditional `eval`/`source`, `env -S` hidden sync, bash script/stdin and conditional dash, custom action steps, step `with`/`env`/ordering changes, workflow and job env and default-shell changes, later sync, renamed jobs, undeclared no-dev jobs, `if: false` / `continue-on-error` / masked commands, and job container injection.

**Seam 3 — release seam: 0.46.8 and `EnumDodEvidenceExecutionScope`.** This PR does **not** modify `pyproject.toml` and does **not** add the enum. Both are already on `dev` and are byte-identical on this branch (`pyproject.toml` version `0.46.8` on both; `src/omnibase_core/enums/ticket/enum_dod_evidence_execution_scope.py` blob `fc600f45` on both). The seam is a *consumer* seam, stated here because this PR is the gate on it: released Core `0.46.7` lacks `omnibase_core.enums.ticket.enum_dod_evidence_execution_scope`, so OCC's typed `local_done_gate` raises `ModuleNotFoundError` and `dod_verify` fails before evidence collection (observed 2026-07-31T19:00Z on OMN-15581). Landing this PR unblocks the dev→main promotion and the 0.46.8 publish that closes that seam. Deliberate consequence for this PR's own evidence: the OCC companion below uses only public hosted content probes executable under released `0.46.7`, so it does not depend on the artifact it is helping to release.

## Evidence

**dod_evidence — note on where it lives.** The Linear ticket body carries the acceptance criteria and the preserved RED evidence, but does **not** carry an inline `dod_evidence` block. The durable dod_evidence for OMN-15571 is the **merged OCC companion**, cited explicitly:

- **onex_change_control#5752** — `evidence(OMN-15571): bind Core CI capacity repair at exact head 626d6e06`. **MERGED** 2026-07-31T19:14:33Z, squash commit `05ebae88c73f177ef793348675376191111526e0`, base `dev`, verified an ancestor of `origin/dev`. Net-new files only: 8 files, 357 insertions, 0 deletions — `contracts/OMN-15571.yaml` plus 7 receipts under `drift/dod_receipts/OMN-15571/`.
- **Falsifiability proven, not asserted:** the 6 substantive probes are 6/6 GREEN at `626d6e06` and 6/6 RED (exit 1) at the parent `ac1743877`. An independent verifier re-resolved all 3 cited blobs via `git/trees` → `git/blobs` and recomputed blob SHA-1: 3/3 match.
- Post-merge readback against the merged `dev` snapshot: `validator_occ_merge_eligibility` for a product PR carrying head `626d6e06` returns `eligible=true` with 7 PASS receipts.

**Local and governed-host proof at the reviewed tree** (full detail in `docs/audits/2026-07-31-omn-15571-ci-capacity.md`):

- 5 bare validators run under CPython 3.12 with `-I -S` (`sys.path` = stdlib only, `find_spec("pydantic")` is `None`): all pass on the clean tree, and all 5 exit non-zero against planted representative violations (missing export, networking import in a compute node, localhost env fallback, invalid model name, legacy `.dict()`).
- Fresh `uv sync --frozen --no-dev` installs 30 production packages with pytest absent; all 11 production-profile guards then run from `.venv/bin/` and the environment stays at 30 packages with pytest still absent afterward. The diagnostic plain-`uv run` control reproduces the defect at 78 packages with pytest present.
- Governed `.200` host, Python 3.12, at implementation head `a4f121bb` / tree `74363f22` (identical source tree to `626d6e06`): workflow-shape + required-check suite **79 passed**; representative `--splits 40 --group 21 -n 1` → **1,092 passed, 4 skipped, 0 failed in 457.14s**, no worker loss, **27m23s of headroom** to the 35-minute hosted ceiling. Non-bypassed push hook then selected the full unit subset on the same tree: **42,767 passed, 53 skipped, 3 xpassed in 4,130.82s**.
- Review history: four successive hostile reviews, the last of which forced the token-parser → structural-contract replacement (RED 20 failed / 3 passed → GREEN). Final independent review at tree `28990990`: **0 P0 / 0 P1**.

**Known and disclosed, not claimed green:** strict mypy on `tests/unit/validation/test_ci_workflow_shape.py` reports 9 errors (down from 14 at the `d8a41f04` baseline). This module is an inherited non-gate; the strict-mypy-clean claim in the audit is scoped to the four workflow validation scripts only.

## Hosted acceptance criteria for this PR

Per the audit's stated residual risk — a local Apple Silicon run does not reproduce shared Linux runner load, so hosted acceptance is external to the audit and is exactly this run:

1. All 40 unit shards show an effective `PYTEST_XDIST_WORKERS=1` and finish under 35 minutes with no xdist worker loss.
2. All 23 audited guard jobs complete within their recorded budgets.
3. No affected job attempts to save an identical `setup-uv` cache key.
4. `Quality Gate`, `Tests Gate`, and `CI Summary` all conclude successfully, with zero `cancelled` / `timed_out` conclusions.

## Merge posture

`omnibase_core` is squash-only with auto-merge disabled — this lands via plain `gh pr merge <n> --squash` at exact head `626d6e06`, with no `--merge`, `--rebase`, or `--auto`. No runtime deploy or restart is in scope for this PR.