### PR TITLE
fix(OMN-15603): resumable + retried PyPI publish, hosted release runner, loud partial-state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,22 +125,53 @@ jobs:
       # The retry loop absorbs the 5xx that upload.pypi.org returns on a
       # request that overruns its server-side deadline. Retries are cheap
       # because --check-url skips whatever already landed.
+      #
+      # AC3 says "retry on 5xx", so the loop READS the failure instead of
+      # retrying every non-zero exit. A 4xx (bad token, malformed metadata,
+      # rejected filename) is deterministic: retrying it burns the full
+      # 15s + 45s backoff and then reports a permanent fault in the language
+      # of a transient one. Only an upstream 5xx or a transport-level fault
+      # -- the classes that a second attempt can actually clear -- is retried.
       - name: Publish to PyPI
         run: |
           set -uo pipefail
           attempt=1
           max_attempts=3
           backoff=15
-          until uv publish \
-            --check-url https://pypi.org/simple/ \
-            --token "$UV_PUBLISH_TOKEN" \
-            dist/*.whl dist/*.tar.gz
-          do
+          publish_log="$(mktemp)"
+
+          # upload.pypi.org returns 500 when a request overruns its ~240s
+          # server-side deadline; 502/503/504 are the other transient upstream
+          # classes. The transport patterns cover a connection dropped before
+          # any HTTP status was seen, which is the same "try again" class.
+          # `\b` is not portable across GNU and BSD grep, and this shell is
+          # executed verbatim by the tests on both -- so the patterns stay in
+          # plain POSIX ERE.
+          is_retryable() {
+            grep -Eqi \
+              -e 'status code 5[0-9][0-9]' \
+              -e '(internal server error|bad gateway|service unavailable|gateway time-?out)' \
+              -e '(error sending request|connection (reset|closed|refused)|operation timed out|timed out|broken pipe)' \
+              "$1"
+          }
+
+          while true; do
+            if uv publish \
+              --check-url https://pypi.org/simple/ \
+              --token "$UV_PUBLISH_TOKEN" \
+              dist/*.whl dist/*.tar.gz 2>&1 | tee "$publish_log"
+            then
+              exit 0
+            fi
+            if ! is_retryable "$publish_log"; then
+              echo "ERROR: uv publish failed with a non-retryable error (no 5xx or transport fault in the output); not retrying" >&2
+              exit 1
+            fi
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "ERROR: uv publish failed after ${max_attempts} attempts" >&2
               exit 1
             fi
-            echo "uv publish attempt ${attempt}/${max_attempts} failed; retrying in ${backoff}s" >&2
+            echo "uv publish attempt ${attempt}/${max_attempts} failed with a retryable 5xx/transport fault; retrying in ${backoff}s" >&2
             sleep "$backoff"
             attempt=$((attempt + 1))
             backoff=$((backoff * 3))
@@ -159,22 +190,78 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
 
-      # OMN-15603 (AC4): a failed release used to be silent about its own
-      # wreckage -- the downstream steps just showed "skipped" and nothing said
-      # which artifacts had already landed on the public index. This step names
-      # the partial state and the canonical recovery command.
-      # The tag arrives through `env:` rather than inline `${{ }}` so the
-      # committed shell is executable verbatim -- that is what lets
-      # test_release_workflow_shape.py RUN this block under `bash -e` instead
-      # of pattern-matching the string and shipping a shell bug green.
+  # ---------------------------------------------------------------------------
+  # Post-release: open dependency bump PRs in downstream repos (OMN-5109)
+  # ---------------------------------------------------------------------------
+  # When omnibase_core is released, downstream repos (omnibase_infra,
+  # omniintelligence, omnimemory, omniclaude) need their lockfiles updated.
+  dependency-cascade:
+    name: Dependency Cascade
+    needs: release
+    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
+    uses: ./.github/workflows/dependency-cascade.yml
+    with:
+      package: omnibase_core
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      cross-repo-pat: ${{ secrets.CROSS_REPO_PAT }}
+
+  # ---------------------------------------------------------------------------
+  # OMN-15603 (AC4): a failed release used to be silent about its own wreckage
+  # -- the downstream steps just showed "skipped" and nothing said which
+  # artifacts had already landed on the public index. This names the partial
+  # state and the canonical recovery command.
+  #
+  # It is a JOB rather than a step inside `release` because AC4 names the
+  # Dependency Cascade among the things that must "either run, or the run fails
+  # loudly naming which artifacts landed" -- and a step inside `release` cannot
+  # observe a cascade failure. With `release` green and a cascade matrix job
+  # red, the run went red and nothing emitted the artifact census. As a job
+  # with `needs: [release, dependency-cascade]` it covers every way this
+  # workflow ends badly, with ONE copy of the shell rather than two.
+  #
+  # The tag and the upstream job results arrive through `env:` rather than
+  # inline `${{ }}` so the committed shell is executable verbatim -- that is
+  # what lets test_release_workflow_shape.py RUN this block under `bash -e`
+  # instead of pattern-matching the string and shipping a shell bug green.
+  # ---------------------------------------------------------------------------
+  report-partial-state:
+    name: Report partial release state
+    runs-on: ubuntu-latest
+    needs: [release, dependency-cascade]
+    # `skipped` is deliberately NOT a trigger. dependency-cascade is skipped by
+    # design on an rc tag, so a `!= 'success'` condition would fire this report
+    # on a perfectly good rc release.
+    if: ${{ always() && (needs.release.result == 'failure' || needs.release.result == 'cancelled' || needs['dependency-cascade'].result == 'failure' || needs['dependency-cascade'].result == 'cancelled') }}
+    steps:
+      # Best-effort: when `release` died before `Upload dist artifacts` there is
+      # nothing to download and the report must still emit, so a missing
+      # artifact must not fail this job. The shell below handles an empty
+      # dist/ (see test_partial_release_state_survives_an_unresolved_tag_...).
+      - name: Download preserved dist artifacts
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: dist-${{ needs.release.outputs.version }}
+          path: dist/
+
       - name: Report partial release state
-        if: failure()
         env:
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_TAG: ${{ needs.release.outputs.version }}
+          RELEASE_RESULT: ${{ needs.release.result }}
+          CASCADE_RESULT: ${{ needs['dependency-cascade'].result }}
         run: |
           set -uo pipefail
           RELEASE_TAG="${RELEASE_TAG:-}"
-          echo "::error::RELEASE INCOMPLETE for ${RELEASE_TAG:-<tag unresolved>} -- GitHub Release and Dependency Cascade did NOT run."
+          RELEASE_RESULT="${RELEASE_RESULT:-unknown}"
+          CASCADE_RESULT="${CASCADE_RESULT:-unknown}"
+          echo "::error::RELEASE INCOMPLETE for ${RELEASE_TAG:-<tag unresolved>} -- release job: ${RELEASE_RESULT}, dependency cascade: ${CASCADE_RESULT}."
+          if [ "$RELEASE_RESULT" != "success" ]; then
+            echo "::error::GitHub Release and Dependency Cascade did NOT run."
+          fi
+          if [ "$CASCADE_RESULT" = "failure" ] || [ "$CASCADE_RESULT" = "cancelled" ]; then
+            echo "::error::Dependency Cascade did NOT complete (${CASCADE_RESULT}) -- downstream lockfile bump PRs were NOT opened."
+          fi
           # An unreachable index means the landed/missing question is UNKNOWN.
           # Reporting "MISSING" there would be a false claim about a public
           # index, which is the opposite of what this step exists to do.
@@ -203,19 +290,3 @@ jobs:
             echo "::error::No dist artifact can be claimed for an unresolved release tag."
             echo "::error::Recover by determining the intended tag, then run: gh workflow run release.yml --repo OmniNode-ai/omnibase_core --ref dev -f tag=<tag>"
           fi
-
-  # ---------------------------------------------------------------------------
-  # Post-release: open dependency bump PRs in downstream repos (OMN-5109)
-  # ---------------------------------------------------------------------------
-  # When omnibase_core is released, downstream repos (omnibase_infra,
-  # omniintelligence, omnimemory, omniclaude) need their lockfiles updated.
-  dependency-cascade:
-    name: Dependency Cascade
-    needs: release
-    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
-    uses: ./.github/workflows/dependency-cascade.yml
-    with:
-      package: omnibase_core
-      version: ${{ needs.release.outputs.version }}
-    secrets:
-      cross-repo-pat: ${{ secrets.CROSS_REPO_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,17 +163,34 @@ jobs:
       # wreckage -- the downstream steps just showed "skipped" and nothing said
       # which artifacts had already landed on the public index. This step names
       # the partial state and the canonical recovery command.
+      # The tag arrives through `env:` rather than inline `${{ }}` so the
+      # committed shell is executable verbatim -- that is what lets
+      # test_release_workflow_shape.py RUN this block under `bash -e` instead
+      # of pattern-matching the string and shipping a shell bug green.
       - name: Report partial release state
         if: failure()
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -uo pipefail
-          RELEASE_TAG="${{ steps.tag.outputs.tag }}"
+          RELEASE_TAG="${RELEASE_TAG:-}"
           echo "::error::RELEASE INCOMPLETE for ${RELEASE_TAG:-<tag unresolved>} -- GitHub Release and Dependency Cascade did NOT run."
-          index=$(curl -sSL --max-time 60 https://pypi.org/simple/omnibase-core/ || true)
+          # An unreachable index means the landed/missing question is UNKNOWN.
+          # Reporting "MISSING" there would be a false claim about a public
+          # index, which is the opposite of what this step exists to do.
+          if index=$(curl -sSL --max-time 60 https://pypi.org/simple/omnibase-core/); then
+            index_read=1
+          else
+            index_read=0
+            index=""
+            echo "::error::Could not read the PyPI simple index -- landed/missing state is UNKNOWN."
+          fi
           for path in dist/*.whl dist/*.tar.gz; do
             [ -e "$path" ] || continue
             name=$(basename "$path")
-            if printf '%s' "$index" | grep -qF -- "$name"; then
+            if [ "$index_read" -eq 0 ]; then
+              echo "::error::UNKNOWN on PyPI: ${name}"
+            elif printf '%s' "$index" | grep -qF -- "$name"; then
               echo "::error::LANDED on PyPI: ${name}"
             else
               echo "::error::MISSING from PyPI: ${name}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,17 @@ concurrency:
 
 jobs:
   release:
-    runs-on: >-
-      ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-      }}
+    # OMN-15603: this job used to run on the trusted self-hosted `omnibase-ci`
+    # runner. Measured egress from that runner to upload.pypi.org is
+    # 30-39 KiB/s, and upload.pypi.org enforces a hard ~240s server-side
+    # request deadline. The 6.4 MiB wheel clears it (170-216s); the 9.2 MiB
+    # sdist deterministically does not (241.4s -> HTTP 500 after the full body
+    # transferred, identical to the tenth of a second on two attempts of run
+    # 30674223657), which stranded omnibase-core 0.46.8 wheel-only. The job
+    # publishes to a public index and reads no LAN service, so nothing here
+    # needs the self-hosted runner; it moves to a GitHub-hosted runner whose
+    # egress clears the deadline (AC2).
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.tag }}
     steps:
@@ -78,12 +83,10 @@ jobs:
             exit 1
           }
 
-      - name: Publish to PyPI
-        run: |
-          uv publish --token "$UV_PUBLISH_TOKEN" dist/*.whl dist/*.tar.gz
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
+      # OMN-15603 (AC4): checksums and the release tag are derived BEFORE the
+      # publish attempt. They are pure local computations that used to sit
+      # behind the single non-idempotent publish step, so a publish failure
+      # silently skipped them along with the GitHub Release and the cascade.
       - name: Generate checksums
         run: sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS.txt
 
@@ -96,6 +99,55 @@ jobs:
             echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
           fi
 
+      # OMN-15603 (AC4): preserve the built artifacts BEFORE publishing. Run
+      # 30674223657 ended with total_count=0 artifacts, so the only way to
+      # recover the stranded sdist was to rebuild it from the tag.
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-${{ steps.tag.outputs.tag }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 90
+
+      # OMN-15603 (AC1 + AC3): resumable, retried publish.
+      #
+      # --check-url makes the upload idempotent: uv queries the PyPI simple
+      # index and skips every file already present, so a retry re-transfers
+      # only what is still missing. The URL must be the simple index ROOT --
+      # uv appends the package name itself. Verified empirically against uv
+      # 0.12.1 (the version astral-sh/setup-uv@v7 resolves) with the published
+      # 0.46.8 wheel: `--check-url https://pypi.org/simple/` prints
+      # "File omnibase_core-0.46.8-py3-none-any.whl already exists, skipping",
+      # while the package-scoped `https://pypi.org/simple/omnibase-core/`
+      # re-uploads exactly as if no --check-url had been passed at all.
+      #
+      # The retry loop absorbs the 5xx that upload.pypi.org returns on a
+      # request that overruns its server-side deadline. Retries are cheap
+      # because --check-url skips whatever already landed.
+      - name: Publish to PyPI
+        run: |
+          set -uo pipefail
+          attempt=1
+          max_attempts=3
+          backoff=15
+          until uv publish \
+            --check-url https://pypi.org/simple/ \
+            --token "$UV_PUBLISH_TOKEN" \
+            dist/*.whl dist/*.tar.gz
+          do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "ERROR: uv publish failed after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+            echo "uv publish attempt ${attempt}/${max_attempts} failed; retrying in ${backoff}s" >&2
+            sleep "$backoff"
+            attempt=$((attempt + 1))
+            backoff=$((backoff * 3))
+          done
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -106,6 +158,28 @@ jobs:
             dist/SHA256SUMS.txt
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
+
+      # OMN-15603 (AC4): a failed release used to be silent about its own
+      # wreckage -- the downstream steps just showed "skipped" and nothing said
+      # which artifacts had already landed on the public index. This step names
+      # the partial state and the canonical recovery command.
+      - name: Report partial release state
+        if: failure()
+        run: |
+          set -uo pipefail
+          RELEASE_TAG="${{ steps.tag.outputs.tag }}"
+          echo "::error::RELEASE INCOMPLETE for ${RELEASE_TAG:-<tag unresolved>} -- GitHub Release and Dependency Cascade did NOT run."
+          index=$(curl -sSL --max-time 60 https://pypi.org/simple/omnibase-core/ || true)
+          for path in dist/*.whl dist/*.tar.gz; do
+            name=$(basename "$path")
+            if printf '%s' "$index" | grep -qF -- "$name"; then
+              echo "::error::LANDED on PyPI: ${name}"
+            else
+              echo "::error::MISSING from PyPI: ${name}"
+            fi
+          done
+          echo "::error::Built artifacts preserved as workflow artifact 'dist-${RELEASE_TAG}'."
+          echo "::error::Recover with: gh workflow run release.yml --repo OmniNode-ai/omnibase_core --ref dev -f tag=${RELEASE_TAG}"
 
   # ---------------------------------------------------------------------------
   # Post-release: open dependency bump PRs in downstream repos (OMN-5109)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
           echo "::error::RELEASE INCOMPLETE for ${RELEASE_TAG:-<tag unresolved>} -- GitHub Release and Dependency Cascade did NOT run."
           index=$(curl -sSL --max-time 60 https://pypi.org/simple/omnibase-core/ || true)
           for path in dist/*.whl dist/*.tar.gz; do
+            [ -e "$path" ] || continue
             name=$(basename "$path")
             if printf '%s' "$index" | grep -qF -- "$name"; then
               echo "::error::LANDED on PyPI: ${name}"
@@ -178,8 +179,13 @@ jobs:
               echo "::error::MISSING from PyPI: ${name}"
             fi
           done
-          echo "::error::Built artifacts preserved as workflow artifact 'dist-${RELEASE_TAG}'."
-          echo "::error::Recover with: gh workflow run release.yml --repo OmniNode-ai/omnibase_core --ref dev -f tag=${RELEASE_TAG}"
+          if [ -n "$RELEASE_TAG" ] && ls dist/*.whl dist/*.tar.gz >/dev/null 2>&1; then
+            echo "::error::Built artifacts preserved as workflow artifact 'dist-${RELEASE_TAG}'."
+            echo "::error::Recover with: gh workflow run release.yml --repo OmniNode-ai/omnibase_core --ref dev -f tag=${RELEASE_TAG}"
+          else
+            echo "::error::No dist artifact can be claimed for an unresolved release tag."
+            echo "::error::Recover by determining the intended tag, then run: gh workflow run release.yml --repo OmniNode-ai/omnibase_core --ref dev -f tag=<tag>"
+          fi
 
   # ---------------------------------------------------------------------------
   # Post-release: open dependency bump PRs in downstream repos (OMN-5109)

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -118,40 +120,84 @@ def test_explicit_changed_file_overrides_base(mod, monkeypatch):
     assert mod.main(["--changed-file", "docs/foo.md"]) == 0
 
 
-@pytest.mark.unit
-def test_live_invocation_smoke():
-    """Real subprocess run against the actual repo must succeed (version ahead).
+def _isolated_checkout(tmp_path: Path, *, published_tag: str) -> Path:
+    """Stand the REAL script up in a throwaway repo whose tag set we own.
 
-    The subprocess sees a local published-version tag regardless of checkout tag
-    depth, so the strict-mode run proves the script is importable and wired
-    correctly end to end.
+    ``check_release_identity`` derives its repo root from its own file location
+    (``Path(__file__).resolve().parents[1]``) and shells out to ``git`` there,
+    so copying the real script + the real ``pyproject.toml`` into
+    ``<tmp>/scripts/`` + ``<tmp>/`` makes ``<tmp>`` the root it inspects. Every
+    input the gate reads is then under the test's control -- no tags are
+    written into, or deleted from, the developer's actual checkout.
     """
-    repo = _SCRIPT.resolve().parents[1]
-    smoke_tag = "v0.45.999999"
-    # OMN-14891: this test deliberately targets the real repo, but it must do so
-    # via cwd= rather than whatever GIT_DIR a git hook exported — otherwise the
-    # tag lands in an unrelated worktree's gitdir and the finally: below deletes
-    # a tag it never created.
-    subprocess.run(
-        ["git", "tag", "-f", smoke_tag, "HEAD"],
-        cwd=repo,
-        check=True,
-        env=scrub_git_location_env(os.environ),
+    root = tmp_path / "repo"
+    (root / "scripts").mkdir(parents=True)
+    shutil.copy2(_SCRIPT, root / "scripts" / _SCRIPT.name)
+    shutil.copy2(
+        _SCRIPT.resolve().parents[1] / "pyproject.toml", root / "pyproject.toml"
     )
-    try:
-        result = subprocess.run(
-            ["python", str(_SCRIPT)],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=repo,
-        )
-        assert result.returncode == 0, result.stderr
-        assert "ahead of latest published" in result.stdout
-    finally:
-        subprocess.run(
-            ["git", "tag", "-d", smoke_tag],
-            cwd=repo,
-            check=False,
-            env=scrub_git_location_env(os.environ),
-        )
+
+    # Must stay named `scrubbed_git_env`: no_unguarded_git_subprocess keys on a
+    # canonical scrub name appearing in the `env=` expression itself, so a
+    # differently-named local reads as an unscrubbed ambient env and fails
+    # closed -- which is exactly what it did to the first cut of this helper.
+    scrubbed_git_env = scrub_git_location_env(os.environ)
+    for args in (
+        ["init", "-q"],
+        ["add", "-A"],
+        ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "smoke"],
+        ["tag", published_tag],
+    ):
+        subprocess.run(["git", *args], cwd=root, check=True, env=scrubbed_git_env)
+    return root
+
+
+def _run_gate(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(root / "scripts" / _SCRIPT.name)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=root,
+    )
+
+
+@pytest.mark.unit
+def test_live_invocation_smoke(tmp_path):
+    """Real subprocess run of the real script, end to end: version ahead => 0.
+
+    OMN-15603: this smoke used to force a ``v0.45.999999`` tag into the ACTUAL
+    repo and assert strict mode exited 0. That fixture was version-fragile by
+    construction -- ``_latest_published_version`` takes the MAX over all tags,
+    so the synthetic tag only decides the comparison while it outranks every
+    real tag. Once ``v0.46.x`` was cut the synthetic tag went inert, the real
+    tag became the maximum, and the assertion inverted: with dev's
+    ``project.version`` equal to the newest tag (the normal state of the tree
+    in the whole window between a release and the next bump) strict mode
+    correctly exits 1 and this test failed on every open PR. The gate was
+    right; the fixture was wrong. Owning the tag set outright fixes it for
+    good, and drops the mutate-then-restore dance on the real checkout that
+    OMN-14891 had to harden.
+    """
+    root = _isolated_checkout(tmp_path, published_tag="v0.0.1")
+
+    result = _run_gate(root)
+
+    assert result.returncode == 0, result.stderr
+    assert "ahead of latest published" in result.stdout
+
+
+@pytest.mark.unit
+def test_live_invocation_fails_when_version_is_not_ahead(tmp_path):
+    """Live negative: the gate must FAIL, not merely be absent, when behind.
+
+    Exists-but-wrong, end to end through the real subprocess -- a script that
+    silently exited 0 on an un-bumped version would pass the positive smoke
+    above and still let the OMN-13405 footgun through.
+    """
+    root = _isolated_checkout(tmp_path, published_tag="v99.0.0")
+
+    result = _run_gate(root)
+
+    assert result.returncode == 1, result.stdout
+    assert "is NOT ahead of the latest published version" in result.stderr

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -153,12 +153,22 @@ def _isolated_checkout(tmp_path: Path, *, published_tag: str) -> Path:
 
 
 def _run_gate(root: Path) -> subprocess.CompletedProcess[str]:
+    """Run the gate against ``root`` only.
+
+    The scrub is load-bearing, not ceremony: GIT_DIR / GIT_WORK_TREE override
+    ``cwd``, so an ambient one (a git hook exports exactly these -- the
+    OMN-14891 case) would make the gate's internal ``git tag --list`` read the
+    developer's real checkout instead of the isolated repo, and the isolation
+    this whole helper exists to provide would silently evaporate.
+    """
+    scrubbed_git_env = scrub_git_location_env(os.environ)
     return subprocess.run(
         [sys.executable, str(root / "scripts" / _SCRIPT.name)],
         capture_output=True,
         text=True,
         check=False,
         cwd=root,
+        env=scrubbed_git_env,
     )
 
 

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -18,11 +18,15 @@ The tests below are deliberately split into two kinds:
 
 * **Shape** assertions, parsing the real workflow YAML (job graph, step order,
   runner, recovery inputs).
-* **Behaviour** assertions, which extract the publish step's real ``run:``
-  script out of the real workflow file and *execute it* under ``bash -e`` (the
-  shell GitHub Actions uses) against a stubbed ``uv``/``sleep`` on ``PATH``.
-  Nothing is re-implemented here -- a regression in the committed shell is a
-  regression in these tests.
+* **Behaviour** assertions, which extract a step's real ``run:`` script out of
+  the real workflow file and *execute it* under ``bash -e`` (the shell GitHub
+  Actions uses) against stubbed ``uv``/``sleep``/``curl`` on ``PATH``. Both
+  shell steps -- ``Publish to PyPI`` and ``Report partial release state`` --
+  are covered this way. Nothing is re-implemented here: a regression in the
+  committed shell is a regression in these tests. Both steps therefore have to
+  stay free of inline ``${{ }}`` expressions (values arrive through ``env:``),
+  which the harnesses assert -- an expression would make the committed shell
+  unrunnable here and quietly turn these tests into string matching.
 """
 
 from __future__ import annotations
@@ -197,6 +201,108 @@ def _run_publish_script(tmp_path: Path, *, fail_times: int) -> _PublishRun:
 
 
 # --------------------------------------------------------------------------
+# behaviour harness: run the REAL partial-state script with a stubbed curl
+# --------------------------------------------------------------------------
+_STUB_CURL = """#!/bin/bash
+printf '%s\\n' "$*" >> "$CURL_STUB_ARGV_LOG"
+if [ "$CURL_STUB_FAIL" = "1" ]; then
+  exit 6
+fi
+cat "$CURL_STUB_BODY"
+exit 0
+"""
+
+
+@dataclass(frozen=True)
+class _PartialStateRun:
+    returncode: int
+    stdout: str
+    stderr: str
+    curl_invocations: list[str]
+
+
+def _run_partial_state_script(
+    tmp_path: Path,
+    *,
+    release_tag: str,
+    dist_files: tuple[str, ...],
+    index_files: tuple[str, ...] = (),
+    curl_fails: bool = False,
+) -> _PartialStateRun:
+    """Execute the committed partial-state shell with ``curl`` stubbed out.
+
+    This block is the one thing a stranded release has left to tell a human
+    what happened, and it only ever runs on the failure path -- so it is
+    exactly the shell most likely to ship a latent ``set -u`` / glob / errexit
+    bug unnoticed. Asserting on the ``run:`` string cannot catch that; running
+    it can.
+    """
+    step = _step(_PARTIAL_STATE_STEP)
+    script = str(step["run"])
+    # The tag must arrive via `env:`, not an inline expression -- otherwise the
+    # committed shell is unexecutable here and this harness goes vacuous.
+    assert "${{" not in script, (
+        "the partial-state step must contain no ${{ }} expressions so that its "
+        "real shell can be executed under test"
+    )
+    step_env = _as_mapping(step["env"], f"{_PARTIAL_STATE_STEP} `env:`")
+    assert step_env["RELEASE_TAG"] == "${{ steps.tag.outputs.tag }}"
+
+    script_path = tmp_path / "partial_state_step.sh"
+    script_path.write_text(script)
+
+    workdir = tmp_path / "work"
+    (workdir / "dist").mkdir(parents=True)
+    for name in dist_files:
+        (workdir / "dist" / name).write_text("artifact")
+
+    body = tmp_path / "index.html"
+    body.write_text(
+        "<html><body>"
+        + "".join(f'<a href="/x/{name}">{name}</a>' for name in index_files)
+        + "</body></html>"
+    )
+
+    stub_bin = tmp_path / "stub_bin"
+    stub_bin.mkdir()
+    stub = stub_bin / "curl"
+    stub.write_text(_STUB_CURL)
+    stub.chmod(0o755)
+
+    argv_log = tmp_path / "curl_argv.log"
+    argv_log.write_text("")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{stub_bin}{os.pathsep}{env['PATH']}",
+            "CURL_STUB_ARGV_LOG": str(argv_log),
+            "CURL_STUB_BODY": str(body),
+            "CURL_STUB_FAIL": "1" if curl_fails else "0",
+            "RELEASE_TAG": release_tag,
+        }
+    )
+
+    proc = subprocess.run(
+        ["bash", "-e", str(script_path)],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    return _PartialStateRun(
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        curl_invocations=[
+            line for line in argv_log.read_text().splitlines() if line.strip()
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
 # AC1 -- resumable publish
 # --------------------------------------------------------------------------
 def test_publish_passes_check_url_so_already_landed_files_are_skipped(
@@ -324,23 +430,88 @@ def test_dist_artifacts_are_preserved_before_publish() -> None:
     assert with_["if-no-files-found"] == "error"
 
 
-def test_partial_release_state_is_reported_loudly_on_failure() -> None:
-    """AC4: a stranded release must name which artifacts landed."""
+def test_partial_release_state_step_is_wired_to_the_failure_path() -> None:
+    """AC4 (shape): the report must fire on failure, after the release step."""
     step = _step(_PARTIAL_STATE_STEP)
 
     assert str(step["if"]).strip() == "failure()"
     assert _step_index(_PARTIAL_STATE_STEP) > _step_index(_RELEASE_STEP)
 
-    run = str(step["run"])
-    assert "::error::" in run
-    assert "RELEASE INCOMPLETE" in run
-    assert "LANDED on PyPI" in run
-    assert "MISSING from PyPI" in run
-    assert "gh workflow run release.yml" in run
-    assert '[ -e "$path" ] || continue' in run
-    assert '[ -n "$RELEASE_TAG" ]' in run
-    assert "tag=${RELEASE_TAG}" in run
-    assert "tag=<tag>" in run
+
+def test_partial_release_state_names_landed_and_missing_artifacts(
+    tmp_path: Path,
+) -> None:
+    """AC4 (behaviour): the exact 0.46.8 wreckage, executed, not pattern-matched.
+
+    Wheel on the index, sdist not, tag resolved -- the report must say which is
+    which and hand back a runnable recovery command.
+    """
+    run = _run_partial_state_script(
+        tmp_path,
+        release_tag="v0.46.8",
+        dist_files=(
+            "omnibase_core-0.46.8-py3-none-any.whl",
+            "omnibase_core-0.46.8.tar.gz",
+        ),
+        index_files=("omnibase_core-0.46.8-py3-none-any.whl",),
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert "::error::RELEASE INCOMPLETE for v0.46.8" in run.stdout
+    assert (
+        "::error::LANDED on PyPI: omnibase_core-0.46.8-py3-none-any.whl" in run.stdout
+    )
+    assert "::error::MISSING from PyPI: omnibase_core-0.46.8.tar.gz" in run.stdout
+    assert "dist-v0.46.8" in run.stdout
+    assert "gh workflow run release.yml" in run.stdout
+    assert "-f tag=v0.46.8" in run.stdout
+    # It must actually consult the real public index, not a placeholder.
+    assert any(
+        "https://pypi.org/simple/omnibase-core/" in call
+        for call in run.curl_invocations
+    ), run.curl_invocations
+
+
+def test_partial_release_state_survives_an_unresolved_tag_and_empty_dist(
+    tmp_path: Path,
+) -> None:
+    """AC4 (behaviour, negative): failing before `Set release tag` is the case
+    most likely to trip `set -u` -- the report must still emit, not crash."""
+    run = _run_partial_state_script(tmp_path, release_tag="", dist_files=())
+
+    assert run.returncode == 0, run.stderr
+    assert "::error::RELEASE INCOMPLETE for <tag unresolved>" in run.stdout
+    assert "No dist artifact can be claimed" in run.stdout
+    assert "-f tag=<tag>" in run.stdout
+    assert "LANDED on PyPI" not in run.stdout
+    assert "MISSING from PyPI" not in run.stdout
+
+
+def test_partial_release_state_reports_unknown_when_the_index_is_unreachable(
+    tmp_path: Path,
+) -> None:
+    """AC4 (behaviour, negative): an unreadable index must not be reported as
+    proof of absence -- claiming MISSING there is a false statement about a
+    public index, and the recovery decision differs."""
+    run = _run_partial_state_script(
+        tmp_path,
+        release_tag="v0.46.8",
+        dist_files=(
+            "omnibase_core-0.46.8-py3-none-any.whl",
+            "omnibase_core-0.46.8.tar.gz",
+        ),
+        index_files=("omnibase_core-0.46.8-py3-none-any.whl",),
+        curl_fails=True,
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert "landed/missing state is UNKNOWN" in run.stdout
+    assert (
+        "::error::UNKNOWN on PyPI: omnibase_core-0.46.8-py3-none-any.whl" in run.stdout
+    )
+    assert "::error::UNKNOWN on PyPI: omnibase_core-0.46.8.tar.gz" in run.stdout
+    assert "LANDED on PyPI" not in run.stdout
+    assert "MISSING from PyPI" not in run.stdout
 
 
 def test_dependency_cascade_still_runs_off_the_release_output() -> None:

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shape + behaviour gate for ``.github/workflows/release.yml`` (OMN-15603).
+
+omnibase-core 0.46.8 shipped as a **wheel-only** release: the single
+non-idempotent ``Publish to PyPI`` step uploaded the 6.4 MiB wheel in 170-216s,
+then died on the 9.2 MiB sdist at 241.4s -- identical to the tenth of a second
+across two attempts of run 30674223657 -- with an HTTP 500 returned *after* the
+full body had been transferred. That is upload.pypi.org's ~240s server-side
+request deadline meeting the self-hosted runner's measured 30-39 KiB/s egress,
+not a flake. Because every downstream step was sequenced behind that one step,
+``Generate checksums`` / ``Set release tag`` / ``Create GitHub Release`` /
+``Dependency Cascade`` all skipped, the run preserved zero artifacts, and no
+re-run could make progress because the publish re-transferred the wheel it had
+already landed.
+
+The tests below are deliberately split into two kinds:
+
+* **Shape** assertions, parsing the real workflow YAML (job graph, step order,
+  runner, recovery inputs).
+* **Behaviour** assertions, which extract the publish step's real ``run:``
+  script out of the real workflow file and *execute it* under ``bash -e`` (the
+  shell GitHub Actions uses) against a stubbed ``uv``/``sleep`` on ``PATH``.
+  Nothing is re-implemented here -- a regression in the committed shell is a
+  regression in these tests.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "release.yml"
+)
+
+# The simple-index ROOT, not the package page. uv appends the package name
+# itself; see test_publish_uses_the_simple_index_root_not_the_package_page.
+_EXPECTED_CHECK_URL = "--check-url https://pypi.org/simple/"
+
+_PUBLISH_STEP = "Publish to PyPI"
+_CHECKSUMS_STEP = "Generate checksums"
+_TAG_STEP = "Set release tag"
+_UPLOAD_STEP = "Upload dist artifacts"
+_RELEASE_STEP = "Create GitHub Release"
+_PARTIAL_STATE_STEP = "Report partial release state"
+
+
+# --------------------------------------------------------------------------
+# workflow parsing helpers
+# --------------------------------------------------------------------------
+def _as_mapping(value: object, what: str) -> dict[object, object]:
+    assert isinstance(value, dict), f"{what} must be a mapping, got {type(value)}"
+    return value
+
+
+def _workflow() -> dict[object, object]:
+    return _as_mapping(yaml.safe_load(WORKFLOW_PATH.read_text()), "release.yml")
+
+
+def _triggers() -> dict[object, object]:
+    """YAML 1.1 parses a bare ``on:`` key as the boolean ``True``."""
+    workflow = _workflow()
+    key: object = True if True in workflow else "on"
+    return _as_mapping(workflow[key], "release.yml `on:`")
+
+
+def _release_job() -> dict[object, object]:
+    jobs = _as_mapping(_workflow()["jobs"], "release.yml `jobs:`")
+    return _as_mapping(jobs["release"], "the `release` job")
+
+
+def _steps() -> list[dict[object, object]]:
+    steps = _release_job()["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step_index(name: str) -> int:
+    for index, step in enumerate(_steps()):
+        if step.get("name") == name:
+            return index
+    raise AssertionError(f"release job must have a step named {name!r}")
+
+
+def _step(name: str) -> dict[object, object]:
+    return _steps()[_step_index(name)]
+
+
+def _publish_script() -> str:
+    run = _step(_PUBLISH_STEP)["run"]
+    assert isinstance(run, str)
+    return run
+
+
+# --------------------------------------------------------------------------
+# behaviour harness: run the REAL publish script with a stubbed uv + sleep
+# --------------------------------------------------------------------------
+_STUB_UV = """#!/bin/bash
+printf '%s\\n' "$*" >> "$UV_STUB_ARGV_LOG"
+printf 'x' >> "$UV_STUB_COUNTER"
+attempts=$(($(wc -c < "$UV_STUB_COUNTER")))
+if [ "$attempts" -le "$UV_STUB_FAIL_TIMES" ]; then
+  echo "Server returned status code 500 Internal Server Error" >&2
+  exit 1
+fi
+echo "Uploaded ok"
+exit 0
+"""
+
+_STUB_SLEEP = """#!/bin/bash
+printf '%s\\n' "$1" >> "$SLEEP_STUB_LOG"
+exit 0
+"""
+
+
+@dataclass(frozen=True)
+class _PublishRun:
+    returncode: int
+    stdout: str
+    stderr: str
+    uv_invocations: list[str]
+    sleep_seconds: list[int]
+
+
+def _run_publish_script(tmp_path: Path, *, fail_times: int) -> _PublishRun:
+    """Execute the committed publish shell with ``uv``/``sleep`` stubbed out."""
+    script = _publish_script()
+    # A GH expression would make the committed shell unexecutable here and the
+    # harness silently vacuous, so the step must stay expression-free.
+    assert "${{" not in script, (
+        "the publish step must contain no ${{ }} expressions so that its real "
+        "shell can be executed under test"
+    )
+
+    script_path = tmp_path / "publish_step.sh"
+    script_path.write_text(script)
+
+    workdir = tmp_path / "work"
+    (workdir / "dist").mkdir(parents=True)
+    (workdir / "dist" / "omnibase_core-9.9.9-py3-none-any.whl").write_text("wheel")
+    (workdir / "dist" / "omnibase_core-9.9.9.tar.gz").write_text("sdist")
+
+    stub_bin = tmp_path / "stub_bin"
+    stub_bin.mkdir()
+    for name, body in (("uv", _STUB_UV), ("sleep", _STUB_SLEEP)):
+        stub = stub_bin / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+
+    argv_log = tmp_path / "uv_argv.log"
+    counter = tmp_path / "uv_counter"
+    sleep_log = tmp_path / "sleep.log"
+    for artifact in (argv_log, counter, sleep_log):
+        artifact.write_text("")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{stub_bin}{os.pathsep}{env['PATH']}",
+            "UV_STUB_ARGV_LOG": str(argv_log),
+            "UV_STUB_COUNTER": str(counter),
+            "UV_STUB_FAIL_TIMES": str(fail_times),
+            "SLEEP_STUB_LOG": str(sleep_log),
+            "UV_PUBLISH_TOKEN": "pypi-test-token",
+        }
+    )
+
+    # `bash -e <file>` is exactly the shell GitHub Actions runs `run:` under.
+    proc = subprocess.run(
+        ["bash", "-e", str(script_path)],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    return _PublishRun(
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        uv_invocations=[
+            line for line in argv_log.read_text().splitlines() if line.strip()
+        ],
+        sleep_seconds=[
+            int(line) for line in sleep_log.read_text().splitlines() if line.strip()
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# AC1 -- resumable publish
+# --------------------------------------------------------------------------
+def test_publish_passes_check_url_so_already_landed_files_are_skipped(
+    tmp_path: Path,
+) -> None:
+    """AC1: every real uv invocation carries --check-url."""
+    run = _run_publish_script(tmp_path, fail_times=0)
+
+    assert run.returncode == 0, run.stderr
+    assert run.uv_invocations, "publish step never invoked uv"
+    for invocation in run.uv_invocations:
+        assert invocation.startswith("publish "), invocation
+        assert _EXPECTED_CHECK_URL in invocation, invocation
+
+
+def test_publish_uses_the_simple_index_root_not_the_package_page(
+    tmp_path: Path,
+) -> None:
+    """AC1, exists-but-wrong guard.
+
+    OMN-15603 names ``--check-url https://pypi.org/simple/omnibase-core/`` as a
+    candidate. Measured against uv 0.12.1 -- the version
+    ``astral-sh/setup-uv@v7`` resolves -- with the already-published 0.46.8
+    wheel:
+
+    * ``--check-url https://pypi.org/simple/`` ->
+      ``File omnibase_core-0.46.8-py3-none-any.whl already exists, skipping``
+    * ``--check-url https://pypi.org/simple/omnibase-core/`` -> ``Uploading
+      omnibase_core-0.46.8-py3-none-any.whl (6.4MiB)``, byte-identical to
+      passing no ``--check-url`` at all.
+
+    uv joins the package name onto the URL itself, so the package-scoped form
+    resolves ``/simple/omnibase-core/omnibase-core/`` and silently degrades to
+    a full re-upload. A "present but wrong" --check-url is exactly the failure
+    this test exists to catch -- AC1 is unmet without this assertion.
+    """
+    run = _run_publish_script(tmp_path, fail_times=0)
+
+    for invocation in run.uv_invocations:
+        assert "https://pypi.org/simple/omnibase-core" not in invocation, (
+            "package-scoped --check-url does not skip existing files on uv "
+            f"0.12.1; use the simple index root: {invocation}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC3 -- retry with backoff, fail-closed
+# --------------------------------------------------------------------------
+def test_publish_retries_at_least_twice_with_increasing_backoff(
+    tmp_path: Path,
+) -> None:
+    """AC3: >= 2 retries (3 attempts total) with a growing backoff."""
+    run = _run_publish_script(tmp_path, fail_times=99)
+
+    assert len(run.uv_invocations) >= 3, run.uv_invocations
+    assert len(run.sleep_seconds) >= 2, run.sleep_seconds
+    assert all(seconds > 0 for seconds in run.sleep_seconds), run.sleep_seconds
+    assert run.sleep_seconds == sorted(run.sleep_seconds), run.sleep_seconds
+    assert run.sleep_seconds[-1] > run.sleep_seconds[0], run.sleep_seconds
+
+
+def test_publish_fails_closed_when_every_attempt_fails(tmp_path: Path) -> None:
+    """Negative case: exhausted retries must fail the job, not swallow the 5xx."""
+    run = _run_publish_script(tmp_path, fail_times=99)
+
+    assert run.returncode != 0, (
+        "publish must propagate failure after exhausting retries; "
+        f"stdout={run.stdout!r} stderr={run.stderr!r}"
+    )
+    assert "failed after" in run.stderr, run.stderr
+
+    script = _publish_script()
+    assert "|| true" not in script, script
+    assert "continue-on-error" not in str(_step(_PUBLISH_STEP)), _step(_PUBLISH_STEP)
+
+
+def test_publish_recovers_when_a_transient_5xx_clears(tmp_path: Path) -> None:
+    """AC3: a retry that succeeds must succeed the step, not just log."""
+    run = _run_publish_script(tmp_path, fail_times=1)
+
+    assert run.returncode == 0, run.stderr
+    assert len(run.uv_invocations) == 2, run.uv_invocations
+    assert len(run.sleep_seconds) == 1, run.sleep_seconds
+
+
+def test_publish_stops_retrying_once_it_succeeds(tmp_path: Path) -> None:
+    """Negative case: no unconditional retry loop -- one clean attempt is one."""
+    run = _run_publish_script(tmp_path, fail_times=0)
+
+    assert len(run.uv_invocations) == 1, run.uv_invocations
+    assert run.sleep_seconds == [], run.sleep_seconds
+
+
+# --------------------------------------------------------------------------
+# AC2 -- runner egress
+# --------------------------------------------------------------------------
+def test_release_job_runs_on_a_hosted_runner_with_pypi_egress() -> None:
+    """AC2: the self-hosted runner cannot clear PyPI's ~240s deadline."""
+    runs_on = str(_release_job()["runs-on"])
+
+    assert "self-hosted" not in runs_on, runs_on
+    assert "omnibase-ci" not in runs_on, runs_on
+    assert "ubuntu" in runs_on, runs_on
+
+
+# --------------------------------------------------------------------------
+# AC4 -- post-publish work is not silently lost
+# --------------------------------------------------------------------------
+def test_checksums_and_release_tag_are_computed_before_publish() -> None:
+    """AC4: pure local steps must not sit behind the non-idempotent publish."""
+    publish = _step_index(_PUBLISH_STEP)
+
+    assert _step_index(_CHECKSUMS_STEP) < publish
+    assert _step_index(_TAG_STEP) < publish
+
+
+def test_dist_artifacts_are_preserved_before_publish() -> None:
+    """AC4: run 30674223657 kept zero artifacts, so recovery meant a rebuild."""
+    upload = _step(_UPLOAD_STEP)
+
+    assert _step_index(_UPLOAD_STEP) < _step_index(_PUBLISH_STEP)
+    assert "actions/upload-artifact@" in str(upload["uses"])
+    with_ = _as_mapping(upload["with"], f"{_UPLOAD_STEP} `with:`")
+    assert with_["path"] == "dist/"
+    assert with_["if-no-files-found"] == "error"
+
+
+def test_partial_release_state_is_reported_loudly_on_failure() -> None:
+    """AC4: a stranded release must name which artifacts landed."""
+    step = _step(_PARTIAL_STATE_STEP)
+
+    assert str(step["if"]).strip() == "failure()"
+    assert _step_index(_PARTIAL_STATE_STEP) > _step_index(_RELEASE_STEP)
+
+    run = str(step["run"])
+    assert "::error::" in run
+    assert "RELEASE INCOMPLETE" in run
+    assert "LANDED on PyPI" in run
+    assert "MISSING from PyPI" in run
+    assert "gh workflow run release.yml" in run
+
+
+def test_dependency_cascade_still_runs_off_the_release_output() -> None:
+    """AC4 regression guard: the cascade wiring must survive the reorder."""
+    jobs = _as_mapping(_workflow()["jobs"], "release.yml `jobs:`")
+    cascade = _as_mapping(jobs["dependency-cascade"], "the `dependency-cascade` job")
+
+    assert cascade["needs"] == "release"
+    assert "./.github/workflows/dependency-cascade.yml" in str(cascade["uses"])
+    assert _release_job()["outputs"] == {"version": "${{ steps.tag.outputs.tag }}"}
+
+
+# --------------------------------------------------------------------------
+# AC5 -- the recovery path a stranded version is repaired through
+# --------------------------------------------------------------------------
+def test_workflow_dispatch_recovery_checks_out_the_requested_tag() -> None:
+    """AC5: a tag-triggered run uses the workflow AT THE TAG, so the repair for
+    an already-cut version has to come through workflow_dispatch on a branch
+    that carries the fix, checking out the stranded tag's tree."""
+    triggers = _triggers()
+
+    dispatch = _as_mapping(triggers["workflow_dispatch"], "`workflow_dispatch:`")
+    inputs = _as_mapping(dispatch["inputs"], "`workflow_dispatch.inputs:`")
+    tag_input = _as_mapping(inputs["tag"], "the `tag` dispatch input")
+    assert tag_input["required"] is True
+
+    checkout = _steps()[0]
+    assert "actions/checkout@" in str(checkout["uses"])
+    ref = str(_as_mapping(checkout["with"], "checkout `with:`")["ref"])
+    assert "workflow_dispatch" in ref
+    assert "inputs.tag" in ref

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -337,6 +337,10 @@ def test_partial_release_state_is_reported_loudly_on_failure() -> None:
     assert "LANDED on PyPI" in run
     assert "MISSING from PyPI" in run
     assert "gh workflow run release.yml" in run
+    assert '[ -e "$path" ] || continue' in run
+    assert '[ -n "$RELEASE_TAG" ]' in run
+    assert "tag=${RELEASE_TAG}" in run
+    assert "tag=<tag>" in run
 
 
 def test_dependency_cascade_still_runs_off_the_release_output() -> None:

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -27,6 +27,10 @@ The tests below are deliberately split into two kinds:
   stay free of inline ``${{ }}`` expressions (values arrive through ``env:``),
   which the harnesses assert -- an expression would make the committed shell
   unrunnable here and quietly turn these tests into string matching.
+
+``Report partial release state`` is a **job**, not a step inside ``release``:
+AC4 names the Dependency Cascade among the things that must either run or fail
+loudly, and a step inside ``release`` cannot observe a cascade failure.
 """
 
 from __future__ import annotations
@@ -56,6 +60,10 @@ _UPLOAD_STEP = "Upload dist artifacts"
 _RELEASE_STEP = "Create GitHub Release"
 _PARTIAL_STATE_STEP = "Report partial release state"
 
+_RELEASE_JOB = "release"
+_CASCADE_JOB = "dependency-cascade"
+_PARTIAL_STATE_JOB = "report-partial-state"
+
 
 # --------------------------------------------------------------------------
 # workflow parsing helpers
@@ -76,15 +84,28 @@ def _triggers() -> dict[object, object]:
     return _as_mapping(workflow[key], "release.yml `on:`")
 
 
+def _jobs() -> dict[object, object]:
+    return _as_mapping(_workflow()["jobs"], "release.yml `jobs:`")
+
+
+def _job(name: str) -> dict[object, object]:
+    jobs = _jobs()
+    assert name in jobs, f"release.yml must define a `{name}` job; has {list(jobs)}"
+    return _as_mapping(jobs[name], f"the `{name}` job")
+
+
 def _release_job() -> dict[object, object]:
-    jobs = _as_mapping(_workflow()["jobs"], "release.yml `jobs:`")
-    return _as_mapping(jobs["release"], "the `release` job")
+    return _job(_RELEASE_JOB)
+
+
+def _job_steps(job: dict[object, object]) -> list[dict[object, object]]:
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
 
 
 def _steps() -> list[dict[object, object]]:
-    steps = _release_job()["steps"]
-    assert isinstance(steps, list)
-    return [step for step in steps if isinstance(step, dict)]
+    return _job_steps(_release_job())
 
 
 def _step_index(name: str) -> int:
@@ -96,6 +117,21 @@ def _step_index(name: str) -> int:
 
 def _step(name: str) -> dict[object, object]:
     return _steps()[_step_index(name)]
+
+
+def _partial_state_step() -> dict[object, object]:
+    """The partial-state report lives in its own job, not in ``release``.
+
+    A step inside ``release`` cannot observe a ``dependency-cascade`` failure,
+    which AC4 names explicitly; see
+    ``test_partial_release_state_job_also_covers_a_dependency_cascade_failure``.
+    """
+    for step in _job_steps(_job(_PARTIAL_STATE_JOB)):
+        if step.get("name") == _PARTIAL_STATE_STEP:
+            return step
+    raise AssertionError(
+        f"the `{_PARTIAL_STATE_JOB}` job must have a step named {_PARTIAL_STATE_STEP!r}"
+    )
 
 
 def _publish_script() -> str:
@@ -112,12 +148,27 @@ printf '%s\\n' "$*" >> "$UV_STUB_ARGV_LOG"
 printf 'x' >> "$UV_STUB_COUNTER"
 attempts=$(($(wc -c < "$UV_STUB_COUNTER")))
 if [ "$attempts" -le "$UV_STUB_FAIL_TIMES" ]; then
-  echo "Server returned status code 500 Internal Server Error" >&2
+  echo "$UV_STUB_FAIL_MESSAGE" >&2
   exit 1
 fi
 echo "Uploaded ok"
 exit 0
 """
+
+# What upload.pypi.org actually emits when a request overruns its ~240s
+# server-side deadline -- the exact 0.46.8 failure.
+_UV_5XX_MESSAGE = (
+    "Failed to publish `dist/omnibase_core-0.46.8.tar.gz` to "
+    "https://upload.pypi.org/legacy/\n"
+    "  Caused by: Upload failed with status code 500 Internal Server Error."
+)
+# A deterministic, permanent rejection. Retrying this cannot help.
+_UV_4XX_MESSAGE = (
+    "Failed to publish `dist/omnibase_core-0.46.8.tar.gz` to "
+    "https://upload.pypi.org/legacy/\n"
+    "  Caused by: Upload failed with status code 403 Forbidden. "
+    "Invalid or non-existent authentication information."
+)
 
 _STUB_SLEEP = """#!/bin/bash
 printf '%s\\n' "$1" >> "$SLEEP_STUB_LOG"
@@ -134,7 +185,12 @@ class _PublishRun:
     sleep_seconds: list[int]
 
 
-def _run_publish_script(tmp_path: Path, *, fail_times: int) -> _PublishRun:
+def _run_publish_script(
+    tmp_path: Path,
+    *,
+    fail_times: int,
+    fail_message: str = _UV_5XX_MESSAGE,
+) -> _PublishRun:
     """Execute the committed publish shell with ``uv``/``sleep`` stubbed out."""
     script = _publish_script()
     # A GH expression would make the committed shell unexecutable here and the
@@ -172,6 +228,7 @@ def _run_publish_script(tmp_path: Path, *, fail_times: int) -> _PublishRun:
             "UV_STUB_ARGV_LOG": str(argv_log),
             "UV_STUB_COUNTER": str(counter),
             "UV_STUB_FAIL_TIMES": str(fail_times),
+            "UV_STUB_FAIL_MESSAGE": fail_message,
             "SLEEP_STUB_LOG": str(sleep_log),
             "UV_PUBLISH_TOKEN": "pypi-test-token",
         }
@@ -228,6 +285,9 @@ def _run_partial_state_script(
     dist_files: tuple[str, ...],
     index_files: tuple[str, ...] = (),
     curl_fails: bool = False,
+    release_result: str = "failure",
+    cascade_result: str = "skipped",
+    bind_env: bool = True,
 ) -> _PartialStateRun:
     """Execute the committed partial-state shell with ``curl`` stubbed out.
 
@@ -236,8 +296,14 @@ def _run_partial_state_script(
     exactly the shell most likely to ship a latent ``set -u`` / glob / errexit
     bug unnoticed. Asserting on the ``run:`` string cannot catch that; running
     it can.
+
+    ``bind_env=False`` removes ``RELEASE_TAG`` / ``RELEASE_RESULT`` /
+    ``CASCADE_RESULT`` from the child environment entirely, which is what makes
+    the ``${VAR:-}`` guards in the committed shell load-bearing rather than
+    decorative -- see
+    ``test_partial_release_state_survives_an_entirely_unbound_environment``.
     """
-    step = _step(_PARTIAL_STATE_STEP)
+    step = _partial_state_step()
     script = str(step["run"])
     # The tag must arrive via `env:`, not an inline expression -- otherwise the
     # committed shell is unexecutable here and this harness goes vacuous.
@@ -246,7 +312,11 @@ def _run_partial_state_script(
         "real shell can be executed under test"
     )
     step_env = _as_mapping(step["env"], f"{_PARTIAL_STATE_STEP} `env:`")
-    assert step_env["RELEASE_TAG"] == "${{ steps.tag.outputs.tag }}"
+    # The report is a separate job now, so the tag arrives off the `release`
+    # job's declared output, not off a sibling step in the same job.
+    assert step_env["RELEASE_TAG"] == "${{ needs.release.outputs.version }}"
+    assert step_env["RELEASE_RESULT"] == "${{ needs.release.result }}"
+    assert step_env["CASCADE_RESULT"] == "${{ needs['dependency-cascade'].result }}"
 
     script_path = tmp_path / "partial_state_step.sh"
     script_path.write_text(script)
@@ -279,9 +349,19 @@ def _run_partial_state_script(
             "CURL_STUB_ARGV_LOG": str(argv_log),
             "CURL_STUB_BODY": str(body),
             "CURL_STUB_FAIL": "1" if curl_fails else "0",
-            "RELEASE_TAG": release_tag,
         }
     )
+    if bind_env:
+        env.update(
+            {
+                "RELEASE_TAG": release_tag,
+                "RELEASE_RESULT": release_result,
+                "CASCADE_RESULT": cascade_result,
+            }
+        )
+    else:
+        for unbound in ("RELEASE_TAG", "RELEASE_RESULT", "CASCADE_RESULT"):
+            env.pop(unbound, None)
 
     proc = subprocess.run(
         ["bash", "-e", str(script_path)],
@@ -396,6 +476,48 @@ def test_publish_stops_retrying_once_it_succeeds(tmp_path: Path) -> None:
     assert run.sleep_seconds == [], run.sleep_seconds
 
 
+def test_publish_does_not_retry_a_non_retryable_failure(tmp_path: Path) -> None:
+    """AC3, exists-but-wrong guard: the retry must be *on 5xx*, not on any exit.
+
+    ``until uv publish; do ...; done`` retries every non-zero exit, so a
+    permanent 403 (bad token) or 400 (malformed metadata) burns the whole
+    15s + 45s backoff and is then reported with ``retrying`` -- the language of
+    a transient fault -- before failing anyway. AC3 as written says "on 5xx",
+    so the loop has to read the failure. A retry loop that cannot tell a 500
+    from a 403 satisfies the letter of "retries" and none of its intent.
+    """
+    run = _run_publish_script(tmp_path, fail_times=99, fail_message=_UV_4XX_MESSAGE)
+
+    assert run.returncode != 0, run.stdout
+    assert len(run.uv_invocations) == 1, (
+        "a 403 is deterministic; a second attempt cannot clear it: "
+        f"{run.uv_invocations}"
+    )
+    assert run.sleep_seconds == [], (
+        f"no backoff may be burned on a non-retryable failure: {run.sleep_seconds}"
+    )
+    assert "non-retryable" in run.stderr, run.stderr
+    assert "retrying in" not in run.stderr, (
+        "a permanent failure must not be reported in the language of a "
+        f"transient one: {run.stderr}"
+    )
+
+
+def test_publish_still_retries_the_real_pypi_deadline_5xx(tmp_path: Path) -> None:
+    """AC3 companion to the guard above: the 0.46.8 failure IS retryable.
+
+    Uses the verbatim shape uv emits when upload.pypi.org returns 500 after the
+    ~240s server-side deadline. A classifier tightened to the point where the
+    actual observed failure stops being retried would pass the negative test
+    above and silently un-fix the ticket.
+    """
+    run = _run_publish_script(tmp_path, fail_times=1, fail_message=_UV_5XX_MESSAGE)
+
+    assert run.returncode == 0, run.stderr
+    assert len(run.uv_invocations) == 2, run.uv_invocations
+    assert run.sleep_seconds == [15], run.sleep_seconds
+
+
 # --------------------------------------------------------------------------
 # AC2 -- runner egress
 # --------------------------------------------------------------------------
@@ -430,12 +552,64 @@ def test_dist_artifacts_are_preserved_before_publish() -> None:
     assert with_["if-no-files-found"] == "error"
 
 
-def test_partial_release_state_step_is_wired_to_the_failure_path() -> None:
-    """AC4 (shape): the report must fire on failure, after the release step."""
-    step = _step(_PARTIAL_STATE_STEP)
+def test_partial_release_state_job_also_covers_a_dependency_cascade_failure() -> None:
+    """AC4 (shape): the report has to be able to observe a cascade failure.
 
-    assert str(step["if"]).strip() == "failure()"
-    assert _step_index(_PARTIAL_STATE_STEP) > _step_index(_RELEASE_STEP)
+    AC4 names the Dependency Cascade among the things that must "either run, or
+    the run fails loudly naming which artifacts landed". While the report was a
+    step inside ``release`` it could not fire for a cascade failure at all --
+    ``release`` green + a red cascade matrix job produced a red run and total
+    silence about what had landed. It therefore has to be a job that needs
+    both.
+    """
+    job = _job(_PARTIAL_STATE_JOB)
+
+    needs = job["needs"]
+    assert isinstance(needs, list), needs
+    assert _RELEASE_JOB in needs, needs
+    assert _CASCADE_JOB in needs, needs
+
+    condition = str(job["if"])
+    assert "always()" in condition, condition
+    for upstream in (
+        "needs.release.result == 'failure'",
+        "needs['dependency-cascade'].result == 'failure'",
+    ):
+        assert upstream in condition, f"{upstream!r} missing from {condition!r}"
+
+
+def test_partial_release_state_does_not_fire_on_a_skipped_cascade() -> None:
+    """AC4 (shape, negative): an rc release is not a partial release.
+
+    ``dependency-cascade`` carries ``if: !contains(version, 'rc')``, so it is
+    ``skipped`` by design on every rc tag. A condition written as
+    ``result != 'success'`` -- the obvious way to write this -- would report a
+    perfectly good rc release as INCOMPLETE, every time.
+    """
+    condition = str(_job(_PARTIAL_STATE_JOB)["if"])
+
+    assert "!= 'success'" not in condition, condition
+    assert "'skipped'" not in condition, condition
+
+    cascade = _job(_CASCADE_JOB)
+    assert "rc" in str(cascade["if"]), (
+        "this test's premise is that the cascade is skipped on rc tags; if that "
+        f"stopped being true the assertions above are meaningless: {cascade['if']}"
+    )
+
+
+def test_partial_release_state_is_not_a_step_in_the_release_job() -> None:
+    """AC4 (shape, net-negative-surface): exactly one copy of this shell.
+
+    Keeping the old in-job step alongside the new job would leave two
+    independently-drifting copies of the only diagnostic a stranded release
+    emits.
+    """
+    release_step_names = [step.get("name") for step in _steps()]
+
+    assert _PARTIAL_STATE_STEP not in release_step_names, release_step_names
+    # ...and the release job still does the thing the report reports about.
+    assert _RELEASE_STEP in release_step_names, release_step_names
 
 
 def test_partial_release_state_names_landed_and_missing_artifacts(
@@ -512,6 +686,77 @@ def test_partial_release_state_reports_unknown_when_the_index_is_unreachable(
     assert "::error::UNKNOWN on PyPI: omnibase_core-0.46.8.tar.gz" in run.stdout
     assert "LANDED on PyPI" not in run.stdout
     assert "MISSING from PyPI" not in run.stdout
+
+
+def test_partial_release_state_names_a_failed_dependency_cascade(
+    tmp_path: Path,
+) -> None:
+    """AC4 (behaviour): the gap this remediation closes, executed.
+
+    ``release`` green, cascade red -- every artifact landed, but the downstream
+    bump PRs were never opened. Before this was a job, that combination
+    produced a red run and no census at all.
+    """
+    run = _run_partial_state_script(
+        tmp_path,
+        release_tag="v0.46.8",
+        dist_files=(
+            "omnibase_core-0.46.8-py3-none-any.whl",
+            "omnibase_core-0.46.8.tar.gz",
+        ),
+        index_files=(
+            "omnibase_core-0.46.8-py3-none-any.whl",
+            "omnibase_core-0.46.8.tar.gz",
+        ),
+        release_result="success",
+        cascade_result="failure",
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert "::error::RELEASE INCOMPLETE for v0.46.8" in run.stdout
+    assert "dependency cascade: failure" in run.stdout
+    assert "Dependency Cascade did NOT complete (failure)" in run.stdout
+    # The release job succeeded, so claiming it did not run would be false.
+    assert "GitHub Release and Dependency Cascade did NOT run." not in run.stdout
+    # Both artifacts are on the index -- the census must say so, not guess.
+    assert (
+        "::error::LANDED on PyPI: omnibase_core-0.46.8-py3-none-any.whl" in run.stdout
+    )
+    assert "::error::LANDED on PyPI: omnibase_core-0.46.8.tar.gz" in run.stdout
+    assert "MISSING from PyPI" not in run.stdout
+
+
+def test_partial_release_state_survives_an_entirely_unbound_environment(
+    tmp_path: Path,
+) -> None:
+    """AC4 (behaviour, negative): the ``${VAR:-}`` guards must be load-bearing.
+
+    Every other case in this file binds all three variables through the child
+    env, exactly as Actions does via the step's ``env:`` block -- which means
+    none of them would notice if the guards were deleted. This one removes the
+    variables outright. Under ``set -u`` an unguarded expansion aborts the
+    script, and the *only* diagnostic a stranded release emits disappears at
+    the moment it is needed.
+    """
+    run = _run_partial_state_script(
+        tmp_path,
+        release_tag="",
+        dist_files=("omnibase_core-0.46.8-py3-none-any.whl",),
+        index_files=(),
+        bind_env=False,
+    )
+
+    assert run.returncode == 0, (
+        f"the report must not abort on an unbound variable: {run.stderr!r}"
+    )
+    assert "::error::RELEASE INCOMPLETE for <tag unresolved>" in run.stdout
+    assert "release job: unknown" in run.stdout
+    assert "dependency cascade: unknown" in run.stdout
+    # The census still has to run: dist/ is readable regardless of the env.
+    assert "::error::MISSING from PyPI: omnibase_core-0.46.8-py3-none-any.whl" in (
+        run.stdout
+    )
+    assert "unbound variable" not in run.stderr, run.stderr
 
 
 def test_dependency_cascade_still_runs_off_the_release_output() -> None:


### PR DESCRIPTION
## OMN-15603 — resumable + retried PyPI publish, hosted release runner, loud partial state

Refs OMN-15603. **Deliberately not `Closes`** — see "Ticket disposition" at the bottom.

Evidence-Source: OCC#5853
Evidence-Ticket: OMN-15603

`omnibase_core` 0.46.8 shipped wheel-only. The single non-idempotent `Publish to PyPI` step
uploaded the 6.4 MiB wheel in 170–216s, then died on the 9.2 MiB sdist at **241.4s — identical
to the tenth of a second on two attempts** of run 30674223657 — with an HTTP 500 returned
*after* the full body transferred. That is upload.pypi.org's ~240s server-side request deadline
meeting the self-hosted `omnibase-ci` runner's measured 30–39 KiB/s egress. Not a flake. Every
downstream step was sequenced behind that one step, so checksums / tag / GitHub Release /
Dependency Cascade all skipped, the run preserved zero artifacts, and a re-run could not make
progress because it re-transferred the wheel it had already landed.

## Seam definition

Every field/key/flag this change reads or writes across a boundary:

| Seam | Dir | Shape / value | Consumer |
|---|---|---|---|
| `on.workflow_dispatch.inputs.tag` | in | `string`, `required: true`, `v`-prefixed (`v0.46.8`) | checkout `ref`, `Set release tag` |
| `actions/checkout@v7 .with.ref` | out | `workflow_dispatch ? inputs.tag : github.ref` | — |
| `steps.tag.outputs.tag` | out | `string`, **retains the `v` prefix** | `jobs.release.outputs.version`, artifact name |
| `jobs.release.outputs.version` | out | `${{ steps.tag.outputs.tag }}` | `dependency-cascade.with.version` (strips it via `VERSION="${VERSION#v}"` — verified, no double-`v`); **and now** `report-partial-state`'s download name + `RELEASE_TAG` |
| `needs.release.result` | in | `success\|failure\|cancelled\|skipped` | `report-partial-state.if`, `RELEASE_RESULT` |
| `needs['dependency-cascade'].result` | in | same enum; **bracket form is required** — `needs.dependency-cascade.result` parses as subtraction | `report-partial-state.if`, `CASCADE_RESULT` |
| `uv publish --check-url` | out | simple-index **ROOT** `https://pypi.org/simple/` | uv appends the package name itself; the package-scoped URL silently re-uploads |
| `UV_PUBLISH_TOKEN` ← `secrets.PYPI_TOKEN` | in | env | publish step |
| `actions/upload-artifact .with.name` | out | `dist-${{ steps.tag.outputs.tag }}` | consumed by `actions/download-artifact@v8` in `report-partial-state`, and cited verbatim in the recovery message |
| `RELEASE_TAG` / `RELEASE_RESULT` / `CASCADE_RESULT` | in | `string`, **all three may be empty or entirely unbound** when the run dies early | the report shell |
| `jobs.release.runs-on` | — | `ubuntu-latest` (was self-hosted `omnibase-ci`) | — |

The two shell steps (`Publish to PyPI`, `Report partial release state`) are **expression-free by
contract** — values arrive through `env:`. Both harnesses assert `"${{" not in script`, because an
inline expression would make the committed shell unrunnable under test and quietly turn the
behaviour tests into string matching.

## Acceptance criteria → proof

| AC | Proof |
|---|---|
| **AC1** resumable publish, wheel not re-transferred (<5s) | `test_publish_passes_check_url_so_already_landed_files_are_skipped`, `test_publish_uses_the_simple_index_root_not_the_package_page` — **plus live**: run 30690356517 log, `File omnibase_core-0.46.8-py3-none-any.whl already exists, skipping` at `07:45:40.708`, **0.13s** after the step started |
| **AC2** sdist transfer < 120s / egress ≥ 200 KiB/s | `test_release_job_runs_on_a_hosted_runner_with_pypi_egress` (structural) — **plus the measurement the AC demands**: `Uploading …tar.gz (9.2MiB)` `07:45:40.893` → `Uploaded …tar.gz` `07:45:43.404` = **2.51s for 9.2 MiB ≈ 3,750 KiB/s**, vs the 200 KiB/s floor and the 30–39 KiB/s that produced the deterministic 241.4s timeout. Whole publish step: **3s** |
| **AC3** ≥2 retries with backoff **on 5xx**, no-op for landed files | `test_publish_retries_at_least_twice_with_increasing_backoff`, `test_publish_recovers_when_a_transient_5xx_clears`, `test_publish_fails_closed_when_every_attempt_fails`, `test_publish_stops_retrying_once_it_succeeds`, and — new this round — `test_publish_does_not_retry_a_non_retryable_failure` + `test_publish_still_retries_the_real_pypi_deadline_5xx` |
| **AC4** post-publish work not silently lost; forced-failure dry run shows the partial-state message | Ordering: `test_checksums_and_release_tag_are_computed_before_publish`, `test_dist_artifacts_are_preserved_before_publish`, `test_dependency_cascade_still_runs_off_the_release_output`. Job wiring: `test_partial_release_state_job_also_covers_a_dependency_cascade_failure`, `test_partial_release_state_does_not_fire_on_a_skipped_cascade`, `test_partial_release_state_is_not_a_step_in_the_release_job`. **The forced-failure dry run is executed, not asserted about**: `…names_landed_and_missing_artifacts` (the exact 0.46.8 wreckage), `…names_a_failed_dependency_cascade`, `…survives_an_unresolved_tag_and_empty_dist`, `…survives_an_entirely_unbound_environment`, `…reports_unknown_when_the_index_is_unreachable` |
| **AC5** 0.46.8 repaired on all three surfaces | **Executed** — readback below |

## Remediation round (this push): three verifier findings

**1. AC3 retried on *any* non-zero exit, not on 5xx.** `until uv publish; do` cannot tell a
transient 500 from a permanent 403/400, so a bad token burned the full 15s + 45s backoff and was
then reported as `…failed; retrying in Ns` — the language of a transient fault. The loop now
captures the publish output and classifies it: only an upstream 5xx or a transport-level fault is
retried; anything else fails immediately. Two tests, deliberately paired so neither can be
satisfied alone:

* `test_publish_does_not_retry_a_non_retryable_failure` — a 403 yields **1 attempt, 0 backoff**,
  stderr says `non-retryable` and must *not* contain `retrying in`.
* `test_publish_still_retries_the_real_pypi_deadline_5xx` — the verbatim 0.46.8 failure string
  still retries and recovers. Without this, a classifier tightened into uselessness would pass
  the negative test and silently un-fix the ticket.

**2. AC4 could not observe a `dependency-cascade` failure.** `Report partial release state` was a
*step inside the `release` job*, so `release` green + a red cascade matrix job produced a red run
and total silence about what had landed — a real gap against AC4's wording, which names the
Dependency Cascade explicitly. It is now a **job**: `needs: [release, dependency-cascade]`,
`if: always() && (…result == 'failure' || …== 'cancelled')` for both upstreams, reading their
results through `env:`. One copy of the shell, not two (the old step is deleted, and
`test_partial_release_state_is_not_a_step_in_the_release_job` keeps it that way).
`skipped` is deliberately **not** a trigger: the cascade is skipped by design on rc tags, so the
obvious `!= 'success'` spelling would report every good rc release as INCOMPLETE —
`test_partial_release_state_does_not_fire_on_a_skipped_cascade` pins that.
The report reads `dist/` from the preserved artifact via `actions/download-artifact@v8` with
`continue-on-error: true`, so a release that died *before* `Upload dist artifacts` still emits.

**3. Correcting an overstated claim in the previous body.** The previous revision said the
mutation evidence covered the `RELEASE_TAG="${RELEASE_TAG:-}"` guard. **It did not, and the
verifier was right.** Injecting an unbound-var bug turned 3 tests red, but *deleting that specific
guard left all 15 green*, because every harness case bound `RELEASE_TAG` in the child env exactly
as Actions does — the guard was genuinely dead defence-in-depth whose removal no test would have
caught. Fixed rather than deleted: `_run_partial_state_script(bind_env=False)` now removes
`RELEASE_TAG` / `RELEASE_RESULT` / `CASCADE_RESULT` from the environment outright, and
`test_partial_release_state_survives_an_entirely_unbound_environment` asserts the report still
emits. Re-measured: deleting the guard now produces
`partial_state_step.sh: line 32: RELEASE_TAG: unbound variable`, exit 1, exactly 1 test red.

**RED-before for this round:** 9 of 21 tests fail against the pre-change workflow, including the
403 retried 3× with `sleep` calls `[15, 45]`.

## AC5: executed, with live readback

`gh workflow run release.yml --ref jonah/omn-15603-release-publish-resilience -f tag=v0.46.8`
→ [run 30690356517](https://github.com/OmniNode-ai/omnibase_core/actions/runs/30690356517), **success**, release job **30s wall clock**.

A tag-triggered run uses the workflow *at the tag*, so fixing `release.yml` on `dev` cannot repair
an already-cut tag. The repair therefore had to come through `workflow_dispatch` on the branch that
carries the fix, checking out the stranded tag's tree — which is what
`test_workflow_dispatch_recovery_checks_out_the_requested_tag` pins.

1. **sdist on PyPI** — `sdist omnibase_core-0.46.8.tar.gz` `upload_time 2026-08-01T07:45:41.330626Z`,
   present in the PEP 691 simple index. Downloaded and verified: **9,613,131 bytes**, sha256
   `2151f37eef3ea40c2d66205bc76357d375ecfdc7fb3ffbc7762640147bdb365b` matching PyPI's own digest,
   `PKG-INFO` → `Version: 0.46.8`. (The HTML simple index and the JSON API served a stale
   Fastly-cached body for several minutes after upload; cache-busted reads show it.)
2. **GitHub Release** — `gh release view v0.46.8` resolves, assets:
   `omnibase_core-0.46.8-py3-none-any.whl`, `omnibase_core-0.46.8.tar.gz`, `SHA256SUMS.txt`.
3. **Dependency Cascade** — ran, all 5 matrix jobs success. Bump PRs opened:
   omnimemory#422, omniclaude#1971, onex_change_control#5817. omniintelligence and omnibase_infra
   were no-ops (already at 0.46.8). **Not merged by this lane** — they belong to the merge sweep.
   Note this differs from the pre-run expectation of omniintelligence/omnimemory/omniclaude;
   the readback above is what actually happened.

Nothing was hand-uploaded and no Release was hand-created — the ticket's "deliberately not done"
constraint holds. Every artifact came out of a `release.yml` run.

## Also in this diff: the blocking red, root-caused

`Release Identity Validator` was red on this PR **and on pristine `dev` with a zero diff**.
`tests/scripts/test_check_release_identity.py::test_live_invocation_smoke` forced a synthetic
`v0.45.999999` tag into the **real** repo and asserted strict mode exited 0. But
`_latest_published_version` takes the **MAX over all tags**, so that fixture only decides the
comparison while it outranks every real tag. Once `v0.46.x` was cut it went inert, the real tag
became the maximum, and with `project.version` equal to the newest tag — the normal state of the
tree in the entire window between a release and the next bump — the gate correctly exited 1 and
the test failed on **every open PR**. The gate was right; the fixture was wrong.

Fixed by giving the smoke a throwaway repo whose tag set it owns (the script derives its root from
its own file location, so copying it + `pyproject.toml` into a tmp dir redirects every input),
plus a live negative for the not-ahead branch. This also drops the mutate-then-restore dance on the
developer's real checkout that OMN-14891 had to harden.

## Behaviour changes beyond the ACs (two, deliberate)

1. An unreachable PyPI index no longer reports `MISSING`. Absence of evidence is not evidence of
   absence on a public index, and the recovery decision differs, so it reports `UNKNOWN`.
   `test_partial_release_state_reports_unknown_when_the_index_is_unreachable` covers it.
2. The partial-state headline now names *which stage* failed
   (`release job: …, dependency cascade: …`) rather than unconditionally asserting "GitHub Release
   and Dependency Cascade did NOT run" — which is false when `release` succeeded and only the
   cascade died. `test_partial_release_state_names_a_failed_dependency_cascade` asserts the false
   sentence is absent in that case.

## Verification

- **Gates ran on `stickybeatz-studio`** (`.200`) via patch-transfer with **sha256 verification of
  both changed files on both hosts before any gate ran** (`9d217226…` release.yml, `74ba4759…`
  test file, matching byte-for-byte). `ruff format --check` clean (6075 files), `ruff check`
  clean, `mypy src/omnibase_core/` clean (**4207 files**), 31 focused tests green
  (`test_release_workflow_shape.py` 21 + `test_check_release_identity.py` 10).
- **The commit ran the full hook chain: 57 hooks Passed, 0 Failed.** No `--no-verify`, no
  `--no-gpg-sign`, no skip token, no allowlist widening.
- `pre-commit run --all-files` additionally reports pre-existing **dev-wide** failures
  (`yamlfmt`, ONEX String Version, Manual YAML Prevention, Error Raising Validation) in files this
  diff never touches. Proven exogenous: no hook output names either of my two files, and the 7
  files `yamlfmt` rewrote were reverted rather than smuggled into this PR.
- Capacity disclosure: `.200` swap sits at a standing ~96% (26-day uptime baseline, unchanged
  under load); load stayed ≤ 10.1. `PYTHONPATH` confirmed unset on the gate host.

### One gate could not run on `.200` — root-caused, ticketed, not bypassed

`reject-required-check-skip-vector` (OMN-14863) **crashes** on `.200` for any commit touching
`.github/workflows/`: `TypeError: zip() takes no keyword arguments`. The wrapper resolves
`PY="${PYTHON_BIN:-python3}"`, and `python3` on `.200` is **system 3.9.6**, while the validator
uses 3.10+ `zip(strict=)`. Proven exogenous and proven benign for this diff:

| Condition | Result |
|---|---|
| my change, `python3` (3.9.6) | `TypeError`, exit 1 |
| **HEAD, zero diff**, `python3` (3.9.6) | **`TypeError`, exit 1** ← not caused by this PR |
| my change, `python3.12` (what CI runs) | **`PASS: no required-check skip vectors found.`, exit 0** |

Resolved through the wrapper's own supported knob (`PYTHON_BIN=/opt/homebrew/bin/python3.12`), so
the gate **ran and passed** — it was not skipped. Filed as **OMN-15618** (High): a required-check
guard that is unrunnable on the host rule 11a makes the *default* gate target is exactly the
condition that pushes people toward `--no-verify`.

## OCC companion status — honest state

`Evidence-Source: OCC#5792` cites this PR's **merged** companion
(merge commit `518026119c99a284bc7735334f51ced0fae63fb3`, 2026-08-01T03:28:11Z). The line was lost
when a previous round of mine rewrote this body wholesale; restoring it is what clears
`occ-preflight / eligibility`, `verify / verify`, `Canonical Inference Gate`, `receipt-honesty`
and `CI Summary`.

The re-mint **OCC#5830 is red and cannot merge**, for reasons that are **not specific to this
lane and not fixable from this repo**:

* `OCC Append-Only Gate` — the producer emits the correct net-new `command.supersede.1536.yaml`
  files *and also* edits the merged base `command.yaml` receipts in place. Already tracked:
  **OMN-15485** (In Review), **OMN-14623** (In Progress), **OMN-15028** (In Progress).
* `Supersession Binding Ratchet` / `Pre-commit` / `tests+coverage (shadow)` / `reason-graph` —
  all three supersede files carry one byte-identical `replacement.check_value` across three
  distinct evidence items, which is the wrong-item rebind already tracked as **OMN-15459**
  (In Review).

**Cross-lane proof this is a producer defect, not this PR's doing:** OCC#5832 — a re-mint for
`omnimarket#1998`, an unrelated lane — fails `OCC Append-Only Gate` + `CI Summary` identically,
while first-mint companions (e.g. OCC#5845) merge fine. Nothing new was filed; all four tickets
already exist and dedupe says adopt, not duplicate.

Known limitation, stated rather than glossed: the companion-merged gate asserts *durability*
(the cited companion is MERGED), **not** exact-head binding — so citing OCC#5792 is the gate's
documented usage, and the fact that it binds an older head is the open gap tracked in
**OMN-15501**. I am not asserting the cited companion re-verifies this round's commit.

Per `feedback_no_self_authored_evidence`, I did not hand-author or hand-repair any companion
receipt for my own PR.

## Ticket disposition

This PR intentionally says `Refs`, not `Closes`. AC5's user-visible repair is **done and proven
above**, but it was executed by a `workflow_dispatch` from this branch, before merge — merging this
PR is not what makes AC5 true, and auto-closing the ticket on merge would assert a causal link that
does not exist. The verifier should read AC5 off the three live surfaces, not off this merge.

## Process disclosure

An earlier round had PR head `e614b11f` pushed by a peer Codex session onto this same branch — two
owners on one branch, which violates the one-exclusive-owner rule. Trees were identical
(`git diff e614b11f..b32408ef` empty), so no work was stranded. This round used a single worktree,
and the `.200` worktree at the same path was verified to be this lane's own (same branch, clean
tree, empty index) before reuse.

CodeRabbit's earlier threads are replied to and resolved; its second finding (route the gate
through `uv run --project <real repo>`) was declined with reasoning on the thread, because
`--project` pointed at the real repository would re-anchor the gate to the developer checkout —
restoring exactly the coupling this PR removes.



---

## Correction 2026-08-01T17:1xZ — OCC companion status (supersedes the "honest state" section above)

Recorded by lane `fable-drain-0801`, which did not implement this PR. Two claims in the
"OCC companion status" section above are **now false**, and are corrected here rather than
silently rewritten:

1. **"The re-mint OCC#5830 is red and cannot merge" — FALSE as of 2026-08-01T16:37:05Z.**
   OCC#5830 **merged** (merge commit `3e69aa5907dfcf4f0d851fcae4b77e4015aa22a5`). Its final merged
   diff is clean and append-only: 4 `added` files plus a 6+/0- append to `contracts/OMN-15603.yaml`,
   **zero** modified merged receipts, and three supersede records whose `replacement.check_value`s
   are **distinct** — not the byte-identical trio the section describes. Whatever the producer
   emitted first, what landed did not violate the Append-Only Gate or the OMN-15459 ratchet.

2. **`Evidence-Source` repointed `OCC#5792` → `OCC#5853`.** The section's closing sentence —
   "I am not asserting the cited companion re-verifies this round's commit" — was accurate and is
   now the defect worth naming: this PR's head commit `1687670106` was **pushed at 16:28:49Z**
   (corrected 2026-08-01T17:2xZ — see the Disclosure block below), and OCC#5830 merged **8m16s
   later** at 16:37:05Z still carrying receipts bound to the superseded head `48f1a694`. Three
   receipts merged on `onex_change_control@dev` therefore claim `status: PASS` for a probe that
   live-evaluates **`false`**:

   ```
   $ gh pr view 1536 --repo OmniNode-ai/omnibase_core --json number,state,headRefName,headRefOid \
       --jq '.number == 1536 and .state == "OPEN" and .headRefOid == "48f1a694e7c38bd8ca388eaa529e5b560bf52d75"'
   false
   ```

**Repair: `onex_change_control#5853`** (merged 2026-08-01T17:09:36Z, merge commit
`edbfe3c5040f61ecec0993d392f13d2869525486`) — a net-new, strictly append-only companion:
contract `28+/0-`, two `added` receipts, **0 supersede files, 0 modified merged receipts**. Its
probe is compound and discriminating, not the OMN-14443 vacuous `--json number,state` form the
autobind template wrote into all four prior entries:

```
bind="$(gh pr view 1536 --repo OmniNode-ai/omnibase_core --json headRefOid,baseRefName --jq '.headRefOid + " " + .baseRefName')" && test "$bind" = "1687670106e8e12b000168227b4241bc7148f1d5 dev"
```

Both merged #5853 receipts re-verify live-true against this PR's **current** head. Note the
binding is to head `1687670106`; **a further push to this branch invalidates it**, and a fresh
companion would be required.

No new ticket was filed — live Linear dedupe returned existing coverage for every component:
**OMN-15501** (exact-head binding as a merge precondition; this incident added as a live AC5
specimen), **OMN-15485 / OMN-14623 / OMN-15028 / OMN-13888** (producer mutating merged receipts),
**OMN-15459 / OMN-15477** (wrong-item / wrong-PR supersede rebind), **OMN-15247** (non-falsifiable
autobind evidence). Adopt, not duplicate.

---

## Disclosure 2026-08-01T17:2xZ — merge ordering: this PR was NOT merged on companion-backed evidence

Recorded by lane `fable-drain-0801` after an independent verifier flagged that the Correction
section above reads as though `OCC#5853` backed this PR's merge. It did not. The ordering, every
timestamp re-verified live via `gh api` at 2026-08-01T17:24Z:

| Event | Time (UTC) | Evidence |
|---|---|---|
| Head `1687670106` pushed | 2026-08-01T16:28:49Z | earliest `pull_request`-event workflow run at that head |
| Gating `occ-preflight / eligibility` runs completed | 2026-08-01T16:29:24Z – 16:29:49Z | `commits/1687670106…/check-runs` |
| **This PR merged** | **2026-08-01T17:02:25Z** | `merged_at`; merge commit `be324b80af9c455dab93d0a65cf7ef70870d5779`; `merged_by: jonahgabriel`; `auto_merge: null` (direct merge) |
| `OCC#5853` merged | 2026-08-01T17:09:36Z | **+7m11s after this PR merged** |
| This PR body repointed `Evidence-Source: OCC#5792` → `OCC#5853` | 2026-08-01T17:12:00Z | `updated_at`; **+9m35s after this PR merged** |

Stated plainly, without hedging:

- **This PR merged at 17:02:25Z, before `OCC#5853` existed as merged evidence.** `OCC#5853` did not
  gate this merge.
- **The eligibility runs that did gate the merge cited `OCC#5792`** — the stale-head chain bound to
  `48f1a694`, the exact binding this Correction section identifies as live-`false`. The merge was
  admitted on that chain.
- **`OCC#5853` (merged 17:09:36Z) and the `Evidence-Source` repoint (17:12:00Z) are post-merge
  evidence repairs.** They make the durable ticket record exact-head-correct going forward; they do
  not retroactively make the merge companion-backed. The `occ-preflight / eligibility` runs at
  17:12:07Z and later were triggered by the post-merge body edit and gate nothing.
- Nothing above is retracted on the merits — the repair is real and its probes re-verify live-true.
  Only the claim of *when* it applied is corrected. **This disclosure exists so the durable record
  does not overstate the gating.**

**Also retracted here: the push time and elapsed-gap figures.** An earlier revision of item 2 above
read "re-pushed to `1687670106` at 13:50:00Z … OCC#5830 merged **2h47m later**". `13:50:00Z` is that
commit's author/committer date (authored on `.200`), **not** its push time; the branch was pushed at
`16:28:49Z`. OCC#5830 merged at `16:37:05Z`, so the real gap is **8m16s**, not 2h47m. Item 2 is
corrected in place above. This is material, not bookkeeping: the incident is an ~8-minute race
between a re-push and an already-queued companion merge — not a stale binding sitting unnoticed for
~3 hours — which is a different failure mode with a different remediation shape for OMN-15501's AC5.
The same false figure is immutable in two merged `#5853` receipts (`occ-self-bind-pr-5853/command.yaml`
`actual_output` reads "three hours before") and in the OMN-15501 comment timeline; those merged
receipts are append-only and are **not** edited — this is the retraction of record. The receipts'
`check_value` probes are unaffected and remain live-true; the falsity was narrative `actual_output`
prose only.
