### PR TITLE
fix(OMN-15431): single-flight + pruned consumer graph so a cold worktree survives the xdist gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,11 @@ dist/
 build/
 *.egg-info/
 # === end onex-managed: python ===
+
+# Consumer-graph cache, its single-flight lock, and any interrupted temp file.
+# Derived build artifacts keyed to the local HEAD SHA -- never committed. Scoped
+# to these names, not all of .onex_state/, which holds tracked evidence
+# (OMN-15431).
+.onex_state/consumer-graph.json
+.onex_state/consumer-graph.lock
+.onex_state/consumer-graph.json.*.tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.8"
+version = "0.46.9"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -120,6 +120,21 @@ def _decode_blob(raw: bytes) -> str:
     )
 
 
+def _absent_response_length(out: bytes, pos: int, request: bytes) -> int | None:
+    """Length of the "not resolvable" response at ``pos``, or None if it is a blob.
+
+    ``git cat-file --batch`` answers an unresolvable name by echoing the request
+    back verbatim plus a status word. Matching that echo against the request we
+    actually sent is the only framing-independent way to consume the response:
+    the echo carries whatever bytes the path carried, newlines included, so
+    scanning for the next LF splits it and loses the FOLLOWING blob.
+    """
+    for status in (b" missing\n", b" ambiguous\n"):
+        if out.startswith(request + status, pos):
+            return len(request) + len(status)
+    return None
+
+
 def _git_files_at(
     repo_root: Path, requests: list[tuple[str, str]]
 ) -> dict[tuple[str, str], str]:
@@ -138,6 +153,16 @@ def _git_files_at(
     silently corrupting the content of unrelated files. The per-file ``git
     show`` shape this replaced had no such coupling, so ``-z`` is what keeps the
     batching behaviour-preserving.
+
+    ``-z`` frames stdin ONLY; git's stdout stays LF-framed on every git version
+    this repo supports (``-Z``, which also frames stdout, needs git >= 2.42 and
+    the fleet runs 2.39). So responses are NOT scanned for the next LF -- an
+    absent blob is answered by echoing the request VERBATIM followed by
+    " missing", which re-injects the embedded newline and would burn one
+    response slot per line. Each response is instead matched against the exact
+    request that produced it, which is framing-independent. This is not an
+    exotic case: :func:`_compute_report` asks for every changed path at BOTH
+    base and head, so every added or deleted file is a missing-blob request.
     """
     if not requests:
         return {}
@@ -151,18 +176,34 @@ def _git_files_at(
         check=False,
     )
     if result.returncode != 0:
+        # Degrade loudly. Every blob resolving to "" makes compute_diff report
+        # "no semantic changes" for the WHOLE diff, which reads identically to
+        # a genuinely clean diff; the per-file shape this replaced could only
+        # ever lose one file at a time.
+        print(  # noqa: T201
+            "warning: git cat-file failed; emitting empty advisory report for "
+            f"all {len(requests)} requested blobs: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}",
+            file=sys.stderr,
+        )
         return {}
 
     out = result.stdout
     sources: dict[tuple[str, str], str] = {}
     pos = 0
     for key in requests:
+        ref, rel = key
+        absent_len = _absent_response_length(out, pos, f"{ref}:{rel}".encode())
+        if absent_len is not None:
+            sources[key] = ""
+            pos += absent_len
+            continue
         end_of_header = out.find(b"\n", pos)
         if end_of_header == -1:
             break
         header = out[pos:end_of_header]
         pos = end_of_header + 1
-        # Success is "<oid> <type> <size>"; absence is "<request> missing".
+        # Success is "<oid> <type> <size>"; absence was handled above.
         fields = header.split(b" ")
         try:
             size = int(fields[2])

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -105,6 +105,21 @@ def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
     return [repo_root / line for line in result.stdout.splitlines() if line]
 
 
+def _decode_blob(raw: bytes) -> str:
+    """Decode one blob the way the previous per-file ``git show`` read did.
+
+    The old shape ran ``subprocess.run(..., text=True)``, i.e. universal
+    newlines, so a CRLF or CR source arrived LF-normalised. Reading raw bytes
+    out of the batch stream would silently drop that translation, so it is done
+    explicitly here and pinned by a test. Decoding with ``errors="replace"`` is
+    deliberately MORE forgiving than the old strict decode, which raised on a
+    non-UTF-8 blob and aborted an advisory report outright.
+    """
+    return (
+        raw.decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+    )
+
+
 def _git_files_at(
     repo_root: Path, requests: list[tuple[str, str]]
 ) -> dict[tuple[str, str], str]:
@@ -116,13 +131,20 @@ def _git_files_at(
     timeout. ``git cat-file --batch`` answers the whole set from a single
     process. Missing blobs yield "", matching the previous per-file behaviour.
     See OMN-15431.
+
+    Requests are NUL-delimited (``-z``), not newline-delimited: git permits a
+    newline inside a path, and a newline-framed request stream would split such
+    a path into two requests and desynchronise every response after it --
+    silently corrupting the content of unrelated files. The per-file ``git
+    show`` shape this replaced had no such coupling, so ``-z`` is what keeps the
+    batching behaviour-preserving.
     """
     if not requests:
         return {}
 
-    payload = "".join(f"{ref}:{rel}\n" for ref, rel in requests).encode()
+    payload = b"".join(f"{ref}:{rel}\0".encode() for ref, rel in requests)
     result = subprocess.run(
-        ["git", "cat-file", "--batch"],
+        ["git", "cat-file", "--batch", "-z"],
         cwd=repo_root,
         input=payload,
         capture_output=True,
@@ -147,7 +169,7 @@ def _git_files_at(
         except (IndexError, ValueError):
             sources[key] = ""
             continue
-        sources[key] = out[pos : pos + size].decode("utf-8", errors="replace")
+        sources[key] = _decode_blob(out[pos : pos + size])
         pos += size + 1  # blob payload plus its trailing newline
 
     return sources

--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -105,19 +105,52 @@ def _git_changed_py_files(base: str, head: str, repo_root: Path) -> list[Path]:
     return [repo_root / line for line in result.stdout.splitlines() if line]
 
 
-def _git_file_at(ref: str, rel_path: str, repo_root: Path) -> str:
-    """Return file content at given ref, empty string if not present."""
-    try:
-        result = subprocess.run(
-            ["git", "show", f"{ref}:{rel_path}"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout
-    except subprocess.CalledProcessError:
-        return ""
+def _git_files_at(
+    repo_root: Path, requests: list[tuple[str, str]]
+) -> dict[tuple[str, str], str]:
+    """Read every requested ``<ref>:<path>`` blob in ONE git process.
+
+    The previous shape spawned two ``git show`` processes per changed file, so a
+    1,000-file diff paid ~2,000 process spawns and that dominated CLI runtime --
+    enough, under the parallel test gate, to push the run past its per-test
+    timeout. ``git cat-file --batch`` answers the whole set from a single
+    process. Missing blobs yield "", matching the previous per-file behaviour.
+    See OMN-15431.
+    """
+    if not requests:
+        return {}
+
+    payload = "".join(f"{ref}:{rel}\n" for ref, rel in requests).encode()
+    result = subprocess.run(
+        ["git", "cat-file", "--batch"],
+        cwd=repo_root,
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {}
+
+    out = result.stdout
+    sources: dict[tuple[str, str], str] = {}
+    pos = 0
+    for key in requests:
+        end_of_header = out.find(b"\n", pos)
+        if end_of_header == -1:
+            break
+        header = out[pos:end_of_header]
+        pos = end_of_header + 1
+        # Success is "<oid> <type> <size>"; absence is "<request> missing".
+        fields = header.split(b" ")
+        try:
+            size = int(fields[2])
+        except (IndexError, ValueError):
+            sources[key] = ""
+            continue
+        sources[key] = out[pos : pos + size].decode("utf-8", errors="replace")
+        pos += size + 1  # blob payload plus its trailing newline
+
+    return sources
 
 
 def _compute_report(base: str, head: str, repo_root: Path) -> ModelSemanticDiffReport:
@@ -133,10 +166,17 @@ def _compute_report(base: str, head: str, repo_root: Path) -> ModelSemanticDiffR
     all_changes: list[ModelSymbolChange] = []
     total_consumers = 0
 
-    for file_path in changed_files:
-        rel = file_path.relative_to(repo_root).as_posix()
-        old_source = _git_file_at(base, rel, repo_root)
-        new_source = _git_file_at(head, rel, repo_root)
+    rel_paths = [
+        file_path.relative_to(repo_root).as_posix() for file_path in changed_files
+    ]
+    sources = _git_files_at(
+        repo_root,
+        [(ref, rel) for rel in rel_paths for ref in (base, head)],
+    )
+
+    for rel in rel_paths:
+        old_source = sources.get((base, rel), "")
+        new_source = sources.get((head, rel), "")
         consumers = consumer_graph.get(rel, 0)
         report = compute_diff(old_source, new_source, rel, consumers)
         all_changes.extend(report.changes)

--- a/src/omnibase_core/analysis/consumer_graph.py
+++ b/src/omnibase_core/analysis/consumer_graph.py
@@ -4,10 +4,25 @@
 """Consumer graph builder: counts how many files import each module."""
 
 import json
+import os
 import subprocess
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from pathlib import Path
 
 from omnibase_core.analysis.import_graph import build_import_graph
+
+try:  # pragma: no cover - POSIX always provides fcntl
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    _HAVE_FCNTL = False
+
+_LOCK_POLL_SECONDS = 0.05
+_LOCK_TIMEOUT_SECONDS = 300.0
 
 
 def build_consumer_graph(repo_root: Path) -> dict[str, int]:
@@ -15,29 +30,90 @@ def build_consumer_graph(repo_root: Path) -> dict[str, int]:
 
     Results are cached in .onex_state/consumer-graph.json keyed by the current
     git HEAD SHA. A SHA mismatch triggers a full recompute and cache overwrite.
+
+    Concurrent callers are single-flighted through an inter-process lock: when
+    several processes hit a cold cache at once, exactly one computes the graph
+    and the rest wait and then read its result. Without that, N concurrent test
+    workers each ran a full-repo build simultaneously and all of them blew the
+    per-test timeout (OMN-15431).
     """
     repo_root = repo_root.resolve()
-    cache_path = repo_root / ".onex_state" / "consumer-graph.json"
+    state_dir = repo_root / ".onex_state"
+    cache_path = state_dir / "consumer-graph.json"
     head_sha = _git_head_sha(repo_root)
 
-    if head_sha and cache_path.is_file():
-        try:
-            cached = json.loads(cache_path.read_text(encoding="utf-8"))
-            if isinstance(cached, dict) and cached.get("sha") == head_sha:
-                return {
-                    k: v
-                    for k, v in cached.items()
-                    if k != "sha" and isinstance(k, str) and isinstance(v, int)
-                }
-        except (json.JSONDecodeError, OSError):
-            # Cache reads are best-effort; invalid or unreadable cache forces recompute.
-            counts = _compute(repo_root)
-            _write_cache(cache_path, head_sha, counts)
-            return counts
+    cached = _read_cache(cache_path, head_sha)
+    if cached is not None:
+        return cached
 
-    counts = _compute(repo_root)
-    _write_cache(cache_path, head_sha, counts)
-    return counts
+    with _single_flight_lock(state_dir / "consumer-graph.lock") as holding_lock:
+        if holding_lock:
+            # Double-checked: whoever held the lock before us may have already
+            # built and published exactly the graph we are about to compute.
+            cached = _read_cache(cache_path, head_sha)
+            if cached is not None:
+                return cached
+        counts = _compute(repo_root)
+        _write_cache(cache_path, head_sha, counts)
+        return counts
+
+
+@contextmanager
+def _single_flight_lock(lock_path: Path) -> Iterator[bool]:
+    """Best-effort exclusive inter-process lock around a cold graph build.
+
+    Yields True while the lock is held and False when it could not be taken
+    (no fcntl, unwritable state dir, or timeout). The lock collapses a stampede
+    into one build; it is never a correctness barrier, so a False yield must
+    still let the caller compute its own result rather than wedge the build.
+    """
+    if not _HAVE_FCNTL:
+        yield False
+        return
+
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("w", encoding="utf-8")
+    except OSError:
+        yield False
+        return
+
+    acquired = False
+    deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+    try:
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_LOCK_POLL_SECONDS)
+        yield acquired
+    finally:
+        if acquired:
+            with suppress(OSError):
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def _read_cache(cache_path: Path, head_sha: str | None) -> dict[str, int] | None:
+    """Return cached counts for head_sha, or None if absent, stale, or unreadable."""
+    if not head_sha:
+        return None
+    try:
+        cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # Cache reads are best-effort; an invalid or unreadable cache forces recompute.
+        return None
+    if not isinstance(cached, dict) or cached.get("sha") != head_sha:
+        return None
+    return {
+        k: v
+        for k, v in cached.items()
+        if k != "sha" and isinstance(k, str) and isinstance(v, int)
+    }
 
 
 def _compute(repo_root: Path) -> dict[str, int]:
@@ -64,10 +140,32 @@ def _git_head_sha(repo_root: Path) -> str | None:
 
 
 def _write_cache(cache_path: Path, sha: str | None, counts: dict[str, int]) -> None:
+    """Publish the cache atomically (temp file + os.replace).
+
+    A plain write leaves the destination truncated mid-update, so a concurrent
+    reader can observe a torn, unparseable graph and fall back to a redundant
+    full rebuild. os.replace makes the swap atomic: readers see either the
+    previous graph or the new one, never a partial one.
+    """
+    payload: dict[str, object] = {"sha": sha, **counts}
+    tmp_path: Path | None = None
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        payload: dict[str, object] = {"sha": sha, **counts}
-        cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=cache_path.parent,
+            prefix=f"{cache_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            tmp_path = Path(handle.name)
+            json.dump(payload, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp_path.replace(cache_path)
     except OSError:
         # Cache writes are best-effort; callers already have the computed graph.
-        return
+        if tmp_path is not None:
+            with suppress(OSError):
+                tmp_path.unlink()

--- a/src/omnibase_core/analysis/consumer_graph.py
+++ b/src/omnibase_core/analysis/consumer_graph.py
@@ -22,7 +22,13 @@ except ImportError:  # pragma: no cover - non-POSIX fallback
     _HAVE_FCNTL = False
 
 _LOCK_POLL_SECONDS = 0.05
-_LOCK_TIMEOUT_SECONDS = 300.0
+
+# The canonical gate pins --timeout=60 (pyproject.toml [tool.pytest.ini_options]
+# addopts), so a waiter that blocks past 60s is killed by pytest-timeout anyway.
+# Waiting longer cannot rescue it -- it only keeps a doomed process holding an
+# xdist worker slot. The wait therefore never exceeds the tightest per-test
+# budget this lock is documented against (OMN-15431).
+_LOCK_TIMEOUT_SECONDS = 60.0
 
 
 def build_consumer_graph(repo_root: Path) -> dict[str, int]:
@@ -34,8 +40,15 @@ def build_consumer_graph(repo_root: Path) -> dict[str, int]:
     Concurrent callers are single-flighted through an inter-process lock: when
     several processes hit a cold cache at once, exactly one computes the graph
     and the rest wait and then read its result. Without that, N concurrent test
-    workers each ran a full-repo build simultaneously and all of them blew the
-    per-test timeout (OMN-15431).
+    workers each ran a full-repo build simultaneously (OMN-15431).
+
+    Read the division of labour precisely, because the lock alone is NOT a fix
+    for the timeout class: it collapses N concurrent builds into one, removing
+    the CPU/IO contention that made every one of them slower, but it converts
+    N-1 builders into N-1 waiters. What bounds the latency of the single
+    remaining build -- and so of everyone waiting on it -- is the pruned tree
+    walk in ``build_import_graph``. If that build ever regresses past the gate's
+    per-test budget again, the waiters die with it.
     """
     repo_root = repo_root.resolve()
     state_dir = repo_root / ".onex_state"

--- a/src/omnibase_core/analysis/import_graph.py
+++ b/src/omnibase_core/analysis/import_graph.py
@@ -4,11 +4,39 @@
 """Static import graph builder for Python and JavaScript/TypeScript files."""
 
 import ast
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
 _JS_EXTS = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
 _PY_EXTS = (".py",)
+
+# Directories that never contain first-party repo source. Descending into them
+# is both a correctness bug (vendored site-packages copies of a first-party
+# module shadow the real `src/` file when resolving a dotted import, so real
+# consumers get undercounted) and the dominant cost of a cold graph build:
+# an unpruned walk of a synced worktree AST-parses thousands of dependency
+# files. See OMN-15431.
+_PRUNED_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        "venv",
+        ".tox",
+        ".nox",
+        ".eggs",
+        "site-packages",
+        "node_modules",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".onex_state",
+        "htmlcov",
+    }
+)
 
 
 @dataclass
@@ -26,18 +54,8 @@ def build_import_graph(repo_root: Path) -> ImportGraph:
     """Build a static import graph for Python and JS/TS files under repo_root."""
     graph = ImportGraph()
     repo_root = repo_root.resolve()
-    python_search_roots = _python_search_roots(repo_root)
-
-    py_files: list[Path] = []
-    js_files: list[Path] = []
-
-    for path in repo_root.rglob("*"):
-        if not path.is_file():
-            continue
-        if path.suffix in _PY_EXTS:
-            py_files.append(path)
-        elif path.suffix in _JS_EXTS:
-            js_files.append(path)
+    py_files, js_files, src_dirs = _walk_source_tree(repo_root)
+    python_search_roots = [repo_root, *src_dirs]
 
     for path in py_files:
         rel = _to_repo_rel(path, repo_root)
@@ -91,11 +109,41 @@ def _parse_python_imports(
     return edges
 
 
-def _python_search_roots(repo_root: Path) -> list[Path]:
-    """Return module-resolution roots once per graph build."""
-    roots = [repo_root]
-    roots.extend(path for path in repo_root.rglob("src") if path.is_dir())
-    return roots
+def _is_pruned_dir(path: Path, repo_root: Path) -> bool:
+    """Return True for directories that hold no first-party repo source."""
+    name = path.name
+    if name in _PRUNED_DIR_NAMES or name.endswith(".egg-info"):
+        return True
+    # A nested checkout (submodule, sibling clone, or git worktree parked inside
+    # the tree) carries its own history and is not this repo's source.
+    return path != repo_root and (path / ".git").exists()
+
+
+def _walk_source_tree(repo_root: Path) -> tuple[list[Path], list[Path], list[Path]]:
+    """Walk repo_root once, returning (python files, JS/TS files, ``src`` dirs).
+
+    A single pruned walk replaces the previous pair of unpruned ``rglob`` passes.
+    Pruning happens in-place on ``os.walk``'s dirnames so excluded subtrees are
+    never descended into at all, rather than being enumerated and then filtered.
+    """
+    py_files: list[Path] = []
+    js_files: list[Path] = []
+    src_dirs: list[Path] = []
+
+    for dirpath, dirnames, filenames in os.walk(repo_root):
+        current = Path(dirpath)
+        dirnames[:] = [
+            name for name in dirnames if not _is_pruned_dir(current / name, repo_root)
+        ]
+        src_dirs.extend(current / name for name in dirnames if name == "src")
+        for name in filenames:
+            path = current / name
+            if path.suffix in _PY_EXTS:
+                py_files.append(path)
+            elif path.suffix in _JS_EXTS:
+                js_files.append(path)
+
+    return py_files, js_files, src_dirs
 
 
 def _relative_import_names(

--- a/tests/analysis/test_consumer_graph.py
+++ b/tests/analysis/test_consumer_graph.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -289,3 +290,29 @@ def test_build_still_completes_when_the_lock_cannot_be_taken(
 
     assert result["b.py"] == 1
     assert time.monotonic() - started < 60.0
+
+
+@pytest.mark.unit
+def test_lock_wait_never_outlasts_the_gate_per_test_timeout() -> None:
+    """A waiter must not block past the budget that will kill it anyway.
+
+    The single-flight lock turns N-1 concurrent cold builders into N-1 waiters.
+    pytest-timeout kills each of them at the ``--timeout=`` pinned in pyproject
+    addopts, so a wait longer than that budget cannot rescue a waiter -- it only
+    keeps an already-doomed process holding an xdist worker slot, which is the
+    exact OMN-15431 failure shape. This pins the lock wait against the real
+    gate value rather than a number copied into a comment.
+    """
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        addopts = tomllib.load(handle)["tool"]["pytest"]["ini_options"]["addopts"]
+
+    timeouts = [
+        float(opt.split("=", 1)[1]) for opt in addopts if opt.startswith("--timeout=")
+    ]
+    assert timeouts, f"no --timeout= in pyproject addopts: {addopts}"
+
+    assert min(timeouts) >= consumer_graph_module._LOCK_TIMEOUT_SECONDS, (
+        f"lock wait {consumer_graph_module._LOCK_TIMEOUT_SECONDS}s exceeds the "
+        f"gate per-test timeout {min(timeouts)}s; waiters would be killed mid-wait"
+    )

--- a/tests/analysis/test_consumer_graph.py
+++ b/tests/analysis/test_consumer_graph.py
@@ -2,11 +2,21 @@
 # SPDX-License-Identifier: MIT
 
 import json
+import os
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
 
+from omnibase_core.analysis import consumer_graph as consumer_graph_module
 from omnibase_core.analysis.consumer_graph import build_consumer_graph
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
+_REPO_SRC = str(Path(__file__).resolve().parents[2] / "src")
 
 
 @pytest.mark.unit
@@ -75,3 +85,207 @@ def test_build_consumer_graph_returns_dict_str_int(tmp_path: Path) -> None:
     for k, v in result.items():
         assert isinstance(k, str)
         assert isinstance(v, int)
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run one git command in repo with the location overrides scrubbed.
+
+    GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE are exported into every hook process
+    and override both cwd= and -C, so an unscrubbed call here would retarget the
+    real invoking worktree instead of repo (OMN-14891).
+    """
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        env={
+            **scrub_git_location_env(os.environ),
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    """Make path a real git repo so build_consumer_graph resolves a HEAD SHA.
+
+    The SHA is the cache key: without one the cache is never reused, so any
+    test about cache/lock behaviour must run against a genuine repo.
+    """
+    _git(path, "init", "-q")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+
+@pytest.mark.unit
+def test_vendored_dependency_dirs_are_not_counted_as_consumers(tmp_path: Path) -> None:
+    """Vendored trees must not be walked (OMN-15431).
+
+    Walking .venv both inflated cold-build cost into the per-test timeout and
+    corrupted the counts: a site-packages copy of a first-party module is a
+    different file than the real src/ one.
+    """
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+    vendored = tmp_path / ".venv" / "lib" / "python3.12" / "site-packages"
+    vendored.mkdir(parents=True)
+    (vendored / "vendor_consumer.py").write_text("import b\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    # Only the first-party importer counts; the vendored one is invisible.
+    assert result["b.py"] == 1
+    assert not any(key.startswith(".venv/") for key in result)
+
+
+@pytest.mark.unit
+def test_nested_checkout_is_not_counted_as_consumers(tmp_path: Path) -> None:
+    """A nested checkout (worktree/submodule) is not this repo's source."""
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+    nested = tmp_path / "nested_repo"
+    (nested / ".git").mkdir(parents=True)
+    (nested / "nested_consumer.py").write_text("import b\n", encoding="utf-8")
+
+    result = build_consumer_graph(tmp_path)
+
+    assert result["b.py"] == 1
+    assert not any(key.startswith("nested_repo/") for key in result)
+
+
+_CONCURRENT_BUILD_WORKER = """
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, "@SRC@")
+from omnibase_core.analysis import consumer_graph
+
+started_dir = Path("@STARTED@")
+computed_log = Path("@COMPUTED@")
+real_compute = consumer_graph._compute
+
+
+def instrumented(repo_root):
+    with computed_log.open("a", encoding="utf-8") as handle:
+        handle.write("build\\n")
+    time.sleep(@BUILD_SECONDS@)
+    return real_compute(repo_root)
+
+
+consumer_graph._compute = instrumented
+
+# Rendezvous: hold every worker until all of them are past interpreter startup.
+# Without this a fast first worker could finish and warm the cache before the
+# others even start, and the test would pass with no single-flight lock at all.
+(started_dir / str(os.getpid())).write_text("1", encoding="utf-8")
+deadline = time.monotonic() + 30.0
+while len(list(started_dir.iterdir())) < @WORKERS@ and time.monotonic() < deadline:
+    time.sleep(0.01)
+
+consumer_graph.build_consumer_graph(Path("@REPO@"))
+"""
+
+
+@pytest.mark.unit
+def test_concurrent_cold_builds_compute_the_graph_exactly_once(
+    tmp_path: Path,
+) -> None:
+    """Single-flight: N cold processes produce ONE build, not N (OMN-15431).
+
+    This is the defect that crashed the suite: four xdist workers each ran a
+    full-repo consumer-graph build at the same time, so every one of them
+    exceeded the 60s per-test timeout and xdist died with a scheduler KeyError.
+    """
+    workers = 4
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("import b\n", encoding="utf-8")
+    (repo / "b.py").write_text("", encoding="utf-8")
+    _init_git_repo(repo)
+
+    started_dir = tmp_path / "started"
+    started_dir.mkdir()
+    computed_log = tmp_path / "computed.log"
+
+    script = (
+        _CONCURRENT_BUILD_WORKER.replace("@SRC@", _REPO_SRC)
+        .replace("@REPO@", str(repo))
+        .replace("@STARTED@", str(started_dir))
+        .replace("@COMPUTED@", str(computed_log))
+        .replace("@BUILD_SECONDS@", "1.0")
+        .replace("@WORKERS@", str(workers))
+    )
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(workers)
+    ]
+    for proc in procs:
+        _, stderr = proc.communicate(timeout=120)
+        assert proc.returncode == 0, f"worker failed: {stderr}"
+
+    builds = computed_log.read_text(encoding="utf-8").split()
+    assert len(builds) == 1, f"expected exactly one build, got {len(builds)}"
+
+    # The published cache is intact and no temp file leaked from the atomic swap.
+    cache_path = repo / ".onex_state" / "consumer-graph.json"
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["b.py"] == 1
+    assert not list(cache_path.parent.glob("*.tmp"))
+
+
+@pytest.mark.unit
+def test_failed_cache_write_leaves_the_previous_cache_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Atomic publish: a write that dies mid-flight must not truncate the cache.
+
+    A plain write() truncates the destination first, so a reader concurrent with
+    a failing writer sees a torn file and falls back to a redundant full rebuild.
+    """
+    cache_path = tmp_path / ".onex_state" / "consumer-graph.json"
+    cache_path.parent.mkdir(parents=True)
+    previous = {"sha": "cafebabe" * 5, "kept.py": 7}
+    cache_path.write_text(json.dumps(previous), encoding="utf-8")
+
+    def explode(_fd: int) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(consumer_graph_module.os, "fsync", explode)
+
+    consumer_graph_module._write_cache(cache_path, "f" * 40, {"new.py": 1})
+
+    # Destination still holds the prior graph, byte for byte, and no temp leaked.
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == previous
+    assert not list(cache_path.parent.glob("*.tmp"))
+
+
+@pytest.mark.unit
+def test_build_still_completes_when_the_lock_cannot_be_taken(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lock is a stampede guard, never a correctness barrier.
+
+    If it cannot be acquired the build must still produce a correct graph rather
+    than wedge -- a lock that can hang is worse than the timeout it prevents.
+    """
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(consumer_graph_module, "_HAVE_FCNTL", False)
+
+    started = time.monotonic()
+    result = build_consumer_graph(tmp_path)
+
+    assert result["b.py"] == 1
+    assert time.monotonic() - started < 60.0

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -296,6 +296,11 @@ def test_git_files_at_survives_a_newline_inside_a_tracked_path(tmp_path: Path) -
     response after it is read against the wrong header and unrelated files come
     back corrupted or empty -- a regression the per-file ``git show`` shape this
     batching replaced could not have. The batch reader must be NUL-framed.
+
+    This covers the PRESENT-blob half only: ``-z`` frames stdin, which is what
+    this case needs. The absent-blob half re-injects the newline on git's
+    LF-framed STDOUT and is a separate defect, pinned by the sibling test
+    :func:`test_git_files_at_survives_a_newline_inside_a_missing_path`.
     """
     module = _load_cli_module()
 
@@ -315,6 +320,69 @@ def test_git_files_at_survives_a_newline_inside_a_tracked_path(tmp_path: Path) -
     assert sources[("HEAD", weird_rel)] == "WEIRD = 1\n"
     # The real regression: the blob AFTER the newline-bearing path.
     assert sources[("HEAD", "after.py")] == after
+
+
+@pytest.mark.unit
+def test_git_files_at_survives_a_newline_inside_a_missing_path(tmp_path: Path) -> None:
+    """A newline in an ABSENT path must not desync the blobs that follow it either.
+
+    ``-z`` frames stdin only; git's stdout stays LF-framed (``-Z`` needs git
+    >= 2.42, the fleet runs 2.39). git answers an unresolvable name by echoing
+    the request VERBATIM plus " missing", so a newline-bearing absent path puts
+    its own newline back into the response stream. Scanning for the next LF
+    splits that echo, burns an extra response slot, and silently loses the
+    FOLLOWING blob -- the response must be matched against the request instead.
+
+    Not exotic: ``_compute_report`` requests every changed path at both base and
+    head, so every added or deleted file is a missing-blob request.
+    """
+    module = _load_cli_module()
+
+    weird_rel = "we\nird.py"
+    after = "AFTER = 2\n"
+    # Only after.py is committed, so weird_rel is MISSING at HEAD.
+    (tmp_path / "after.py").write_text(after, encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+    sources = module._git_files_at(
+        tmp_path,
+        [("HEAD", weird_rel), ("HEAD", "after.py")],
+    )
+
+    assert sources[("HEAD", weird_rel)] == ""
+    # The regression: the blob after a MISSING newline-bearing path.
+    assert sources[("HEAD", "after.py")] == after
+
+
+@pytest.mark.unit
+def test_git_files_at_warns_instead_of_silently_emptying_the_whole_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed git process must say so, not masquerade as a clean diff.
+
+    One non-zero exit resolves EVERY blob to "", so ``compute_diff`` reports no
+    semantic changes for the whole diff -- byte-identical to a genuinely clean
+    result. The per-file ``git show`` shape this batching replaced could only
+    lose one file at a time, so batching made a silent failure global.
+    """
+    module = _load_cli_module()
+
+    # GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE are exported into hook processes and
+    # override cwd=, which would retarget this call at a REAL repo and make it
+    # succeed (OMN-14891).
+    for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+    # Not a git repository, so cat-file cannot start: a real process-level
+    # failure, not a simulated one.
+    sources = module._git_files_at(tmp_path, [("HEAD", "one.py")])
+
+    assert sources == {}
+    assert "git cat-file failed" in capsys.readouterr().err
 
 
 @pytest.mark.unit

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -15,8 +15,19 @@ from types import ModuleType
 
 import pytest
 
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI = REPO_ROOT / "scripts" / "analysis" / "semantic_diff.py"
+
+# Every test here shells out to the CLI, which builds the repo-wide consumer
+# graph. Pinning the module to one xdist group makes --dist=loadgroup run them
+# on a single worker, so the first pays the cold-cache build once and the rest
+# reuse it. Fanning them across workers is what drove four simultaneous cold
+# builds past the 60s per-test timeout and killed the run (OMN-15431).
+pytestmark = pytest.mark.xdist_group("semantic_diff_cli")
 
 # Ensure the worktree src takes precedence when running subprocess CLI calls.
 # The editable .pth install may resolve to the canonical clone if it appears
@@ -38,6 +49,27 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _git(repo: Path, *args: str) -> None:
+    """Run one git command in repo with the location overrides scrubbed.
+
+    GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE are exported into every hook process
+    and override both cwd= and -C, so an unscrubbed call here would retarget the
+    real invoking worktree instead of repo (OMN-14891).
+    """
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        env={
+            **scrub_git_location_env(os.environ),
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
 def _load_cli_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("semantic_diff_cli", CLI)
     assert spec is not None
@@ -47,24 +79,39 @@ def _load_cli_module() -> ModuleType:
     return module
 
 
+@pytest.fixture(scope="module")
+def cli_json_run() -> subprocess.CompletedProcess[str]:
+    """One real CLI run over the branch's real diff, shared by the assertions below.
+
+    Four tests previously issued this identical invocation, so the CLI analysed
+    the same (large) diff four times over. They assert different properties of
+    one run, not four different runs, so running it once is the same coverage at
+    a quarter of the cost -- and the run is still a real subprocess against the
+    real non-empty diff, so nothing here becomes a no-op (OMN-15431).
+    """
+    return _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
+
+
 @pytest.mark.unit
-def test_cli_exits_0_with_json_flag() -> None:
+def test_cli_exits_0_with_json_flag(
+    cli_json_run: subprocess.CompletedProcess[str],
+) -> None:
     """CLI exits 0 even when critical changes are detected (advisory mode)."""
-    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
-    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert cli_json_run.returncode == 0, f"stderr: {cli_json_run.stderr}"
 
 
 @pytest.mark.unit
-def test_cli_json_output_validates_against_model() -> None:
+def test_cli_json_output_validates_against_model(
+    cli_json_run: subprocess.CompletedProcess[str],
+) -> None:
     """JSON output validates against ModelSemanticDiffReport via a subprocess round-trip."""
     # Validate via subprocess so the worktree src path takes precedence cleanly.
     # In-process import resolves to the editable-installed canonical clone which
     # lacks not-yet-merged subpackages from stacked branches.
-    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
-    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert cli_json_run.returncode == 0, f"stderr: {cli_json_run.stderr}"
 
     with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
-        f.write(result.stdout)
+        f.write(cli_json_run.stdout)
         tmp_path = f.name
 
     validate_script = (
@@ -89,11 +136,12 @@ def test_cli_json_output_validates_against_model() -> None:
 
 
 @pytest.mark.unit
-def test_cli_json_has_required_fields() -> None:
+def test_cli_json_has_required_fields(
+    cli_json_run: subprocess.CompletedProcess[str],
+) -> None:
     """JSON output has changes list and total_consumers_affected."""
-    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
-    assert result.returncode == 0, f"stderr: {result.stderr}"
-    payload = json.loads(result.stdout)
+    assert cli_json_run.returncode == 0, f"stderr: {cli_json_run.stderr}"
+    payload = json.loads(cli_json_run.stdout)
     assert "changes" in payload
     assert "total_consumers_affected" in payload
     assert isinstance(payload["changes"], list)
@@ -144,14 +192,104 @@ def test_cli_unavailable_base_ref_emits_empty_advisory_report() -> None:
 
 
 @pytest.mark.unit
-def test_cli_json_change_fields() -> None:
+def test_cli_json_change_fields(
+    cli_json_run: subprocess.CompletedProcess[str],
+) -> None:
     """Each change entry has the required fields."""
-    result = _run_cli("--base", "origin/main", "--head", "HEAD", "--json")
-    assert result.returncode == 0
-    payload = json.loads(result.stdout)
+    assert cli_json_run.returncode == 0
+    payload = json.loads(cli_json_run.stdout)
     for change in payload["changes"]:
         assert "kind" in change
         assert "severity" in change
         assert "symbol_name" in change
         assert "file_path" in change
         assert "consumers_count" in change
+
+
+@pytest.mark.unit
+def test_compute_report_detects_changes_for_a_non_empty_python_diff(
+    tmp_path: Path,
+) -> None:
+    """A non-empty Python diff must still reach the consumer graph and report changes.
+
+    Counterpart to the empty-diff skip test above, and the guard that keeps this
+    suite fix-discriminating: the cold-cache crash (OMN-15431) would also "go
+    away" if the CLI stopped analysing real diffs or stopped building the graph,
+    so both must be asserted, not just that the run finished.
+    """
+    module = _load_cli_module()
+
+    target = tmp_path / "mod.py"
+    target.write_text(
+        "def kept() -> int:\n    return 1\n\n\ndef dropped() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer.py").write_text("import mod\n", encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base", "--no-gpg-sign")
+    _git(tmp_path, "branch", "-f", "base-ref")
+
+    target.write_text("def kept() -> int:\n    return 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "drop a function", "--no-gpg-sign")
+
+    graph_calls: list[Path] = []
+    real_build = module.build_consumer_graph
+
+    def recording_build(repo_root: Path) -> dict[str, int]:
+        graph_calls.append(repo_root)
+        return real_build(repo_root)
+
+    module.build_consumer_graph = recording_build
+
+    report = module._compute_report("base-ref", "HEAD", tmp_path)
+
+    # The expensive path is exercised, not short-circuited...
+    assert graph_calls == [tmp_path]
+    # ...and the deleted symbol is actually surfaced.
+    assert report.changes, "non-empty diff produced no changes"
+    assert "dropped" in {change.symbol_name for change in report.changes}
+    # consumer.py imports mod.py, so the affected-consumer count is real.
+    assert report.total_consumers_affected == 1
+
+
+@pytest.mark.unit
+def test_git_files_at_batches_reads_and_reports_missing_blobs(tmp_path: Path) -> None:
+    """One batched git process must return exactly what per-file reads returned.
+
+    Content has to survive the batch framing intact (header, payload, trailing
+    newline), and a path absent at a ref must still come back as "" rather than
+    shifting every later blob in the stream.
+    """
+    module = _load_cli_module()
+
+    first = "def one() -> int:\n    return 1\n"
+    second = "x = 'héllo'\n\n\ndef two() -> int:\n    return 2\n"
+    (tmp_path / "one.py").write_text(first, encoding="utf-8")
+    (tmp_path / "two.py").write_text(second, encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+    sources = module._git_files_at(
+        tmp_path,
+        [
+            ("HEAD", "one.py"),
+            ("HEAD", "absent.py"),
+            ("HEAD", "two.py"),
+        ],
+    )
+
+    assert sources[("HEAD", "one.py")] == first
+    # A missing blob must not desynchronise the blobs that follow it.
+    assert sources[("HEAD", "absent.py")] == ""
+    assert sources[("HEAD", "two.py")] == second
+
+
+@pytest.mark.unit
+def test_git_files_at_returns_empty_for_no_requests(tmp_path: Path) -> None:
+    """No requested blobs means no git process at all."""
+    module = _load_cli_module()
+
+    assert module._git_files_at(tmp_path, []) == {}

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -288,6 +288,66 @@ def test_git_files_at_batches_reads_and_reports_missing_blobs(tmp_path: Path) ->
 
 
 @pytest.mark.unit
+def test_git_files_at_survives_a_newline_inside_a_tracked_path(tmp_path: Path) -> None:
+    """A newline in a path must not split one request into two and desync the stream.
+
+    git permits a newline inside a path. A newline-framed ``git cat-file
+    --batch`` request stream turns such a path into two requests, so every
+    response after it is read against the wrong header and unrelated files come
+    back corrupted or empty -- a regression the per-file ``git show`` shape this
+    batching replaced could not have. The batch reader must be NUL-framed.
+    """
+    module = _load_cli_module()
+
+    weird_rel = "we\nird.py"
+    after = "AFTER = 2\n"
+    (tmp_path / weird_rel).write_text("WEIRD = 1\n", encoding="utf-8")
+    (tmp_path / "after.py").write_text(after, encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+    sources = module._git_files_at(
+        tmp_path,
+        [("HEAD", weird_rel), ("HEAD", "after.py")],
+    )
+
+    assert sources[("HEAD", weird_rel)] == "WEIRD = 1\n"
+    # The real regression: the blob AFTER the newline-bearing path.
+    assert sources[("HEAD", "after.py")] == after
+
+
+@pytest.mark.unit
+def test_git_files_at_normalises_newlines_like_the_previous_per_file_read(
+    tmp_path: Path,
+) -> None:
+    """CRLF/CR blobs must arrive LF-normalised, as universal-newline reads gave.
+
+    The replaced ``git show`` call used ``text=True``, so callers have always
+    seen LF. Reading raw bytes out of the batch stream would hand ``compute_diff``
+    CRLF instead; this pins the translation rather than leaving it incidental.
+    """
+    module = _load_cli_module()
+
+    (tmp_path / "crlf.py").write_bytes(b"a = 1\r\nb = 2\r\n")
+    (tmp_path / "cr.py").write_bytes(b"a = 1\rb = 2\r")
+    _git(tmp_path, "init", "-q")
+    # -A with core.autocrlf unset stores the bytes verbatim; pin it so a global
+    # ~/.gitconfig cannot normalise the fixture out from under the assertion.
+    _git(tmp_path, "config", "core.autocrlf", "false")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+    sources = module._git_files_at(
+        tmp_path,
+        [("HEAD", "crlf.py"), ("HEAD", "cr.py")],
+    )
+
+    assert sources[("HEAD", "crlf.py")] == "a = 1\nb = 2\n"
+    assert sources[("HEAD", "cr.py")] == "a = 1\nb = 2\n"
+
+
+@pytest.mark.unit
 def test_git_files_at_returns_empty_for_no_requests(tmp_path: Path) -> None:
     """No requested blobs means no git process at all."""
     module = _load_cli_module()

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.8"
+version = "0.46.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Fixes the OMN-15431 cold-cache regression that stopped a cold `omnibase_core`
worktree from completing the canonical non-integration pre-push suite.

**Ticket: OMN-15431** — *Regression: semantic-diff CLI cold cache crashes all
xdist workers on non-empty diffs* (High, Sprint 2026-07-20 → 2026-08-02).

Evidence-Source: 1f5a054da78721c0186030945129e44054a66c63
Evidence-Ticket: OMN-15431

## Root cause

On a non-empty Python diff the semantic-diff CLI builds the repo-wide consumer
graph. Under the canonical gate (`-n4 --dist=loadgroup --timeout=60`) four
`tests/scripts/test_semantic_diff_cli.py` subprocesses each launched a *full*
cold build simultaneously, every one blew the 60s per-test timeout, and xdist
died with an internal scheduler `KeyError`. Three independent defects stacked:

1. **`build_import_graph` walked the tree with an unpruned `rglob("*")`**,
   descending into `.venv`, `.git`, `node_modules` and caches. That was most of
   the cold build cost *and* a correctness bug: a `site-packages` copy of a
   first-party module shadows the real `src/` file during dotted-import
   resolution, so genuine consumers were undercounted.
2. **No cross-process serialisation**, so N cold callers each did the whole
   build. Now single-flighted behind a bounded `flock` with a double-checked
   cache read.
3. **The cache was published with a plain truncating write**, so a concurrent
   reader could observe a torn file. Now a temp sibling + `os.replace`.

Fixed at the seams that were actually slow — not by retrying, not by lowering
`-n`, not by prewarming.

The CLI's per-file blob reads (two `git show` processes per changed file, so
~2,048 spawns on this branch's own 1,024-file diff) were also collapsed into a
single `git cat-file --batch` process. The tests are pinned to one
`xdist_group` so `--dist=loadgroup` keeps them on one worker.

## Round-2 remediation (adversarial verifier findings)

Both findings were behaviour regressions in the new batched blob reader versus
the per-file `git show` shape it replaced. Both are fixed at the seam:

- **Request framing was newline-delimited.** git permits a newline inside a
  path; such a path split into two requests and desynchronised the response
  stream, silently corrupting the content of **every** blob after it. Requests
  are now NUL-delimited (`git cat-file --batch -z`). This is exactly the failure
  class the existing test claimed to cover ("A missing blob must not
  desynchronise the blobs that follow it") while only exercising the
  missing-blob case.
- **Newline translation was silently dropped.** The old reader used
  `text=True` (universal newlines), so CRLF/CR sources arrived LF-normalised;
  the batch reader decoded raw bytes and preserved CRLF. The translation is now
  explicit in `_decode_blob` and pinned by a test. `errors="replace"` is kept
  deliberately — it is strictly *more* forgiving than the old strict decode,
  which raised `UnicodeDecodeError` on a non-UTF-8 blob and aborted an advisory
  report outright.

## Round-3 remediation (adversarial verifier findings)

Four findings, all fixed on this branch. The first is a real correctness bug on
the common path, not an edge case.

**1. (MODERATE, correctness) The round-2 NUL-framing fix only closed the
present-blob half.** `-z` frames `git cat-file --batch` **stdin**; stdout stays
LF-framed, and `-Z` (which frames both) needs git >= 2.42 while the fleet runs
2.39.5. git answers an unresolvable name by echoing the request **verbatim**
plus `" missing"`, so a newline inside an **absent** path is re-injected into
the response stream. `out.find(b"\n", pos)` split that echo, burned an extra
response slot, and the **following blob was silently lost**. Reproduced against
the committed reader on `.200` — request `[(HEAD, "we\nird.py")` (absent)`,
(HEAD, "after.py")]` returned `''` for `after.py` instead of `'AFTER = 2\n'`.

This was **not exotic**: `_compute_report` requests every changed path at
**both** base and head, so every added or deleted file in any diff is a
missing-blob request. Fixed by matching each response against the exact request
that produced it (`_absent_response_length`), which is framing-independent.

**2. (test coverage) The round-2 test named the class but covered half of it.**
`test_git_files_at_survives_a_newline_inside_a_tracked_path` only ever requested
a newline-bearing path that **exists** — the residual above. That repeats, one
level down, exactly the defect round 2 called out about the test before it. Its
docstring now says which half it covers and points at the new sibling,
`test_git_files_at_survives_a_newline_inside_a_missing_path`, which drives the
absent case.

**3. (LOW) `_LOCK_TIMEOUT_SECONDS` was `300.0`, 5x the canonical `--timeout=60`.**
The single-flight lock converts N-1 concurrent cold builders into N-1 *waiters*;
if a cold build ever regresses past 60s again, pytest-timeout kills those
waiters mid-wait, exactly as before. A longer wait cannot rescue them — it only
holds an xdist worker slot in an already-doomed process. Now `60.0`, pinned by
`test_lock_wait_never_outlasts_the_gate_per_test_timeout`, which **reads
`--timeout=` out of pyproject `addopts`** rather than hardcoding the budget.
The verifier's substantive point is accepted and the docstrings now say it
outright: **what bounds the OMN-15431 failure is the pruning speedup, not the
lock.** The lock only collapses the stampede.

**4. (LOW) One process-level git failure produced a vacuous whole-diff report.**
Any non-zero exit from the single `git cat-file` process returned `{}`, so every
blob resolved to `''` and `compute_diff('', '', ...)` yielded "no semantic
changes" for the **entire** diff — indistinguishable from a genuinely clean
result. The per-file `git show` shape this batching replaced could only ever
degrade one file at a time. It now warns on stderr, matching the sibling git
failure paths in the same module. (`-z` itself is fine here: verified working on
git 2.39.5 on both hosts.)

**5. (BLOCKING, process) The `Evidence-Source:` line was missing from this body
— and this body blamed the wrong party for the resulting reds.** Five red
required contexts at `af389dd0` had **one** lane-owned cause: `occ-preflight`
exits at the body-parse step with `PR body is missing required
'Evidence-Source:' line`, and `verify / verify`, `receipt-honesty`,
`Canonical Inference Gate` and `call-reject-skip-token / occ-preflight /
eligibility` all cascade from it. The previous revision of this section asserted
those reds "stay red until that companion merges, which is the Codex merge
sweep's call, not this lane's." **That was false** — preflight never reaches
companion resolution, so no companion merge could have turned it green. The
false claim was also written into `docs/tracking/ROLLING_WORK_LEDGER.md`; a
correction entry has been appended there retracting it.

## Seam definition

Every field/key/type/flag this change reads or writes across a boundary.

**1. Consumer-graph cache — `.onex_state/consumer-graph.json`** (process to process)

| Key | Type | Meaning |
|---|---|---|
| `sha` | `str \| null` | git HEAD SHA the graph was built at |
| *(any other key)* | `str` -> `int` | repo-relative **POSIX** path -> count of files importing it |

Shape is **unchanged** by this PR — same writer (`_write_cache`) and reader
(`_read_cache`) contract, so no format version bump and no cross-version
incompatibility. Reader is fail-closed on shape: requires a `dict`, requires
`cached["sha"] == head_sha`, and keeps only entries where
`isinstance(k, str) and isinstance(v, int)`. A stale/torn/unparseable cache
returns `None` (recompute), never a partial graph.

**Write path (new):** temp sibling `consumer-graph.json.<rand>.tmp` in the same
directory, `flush()` + `os.fsync()`, then `Path.replace()` (atomic rename on the
same filesystem). Readers see the previous graph or the new one, never a
truncated one. A failed write unlinks the temp file and leaves the previous
cache intact.

**2. Single-flight lock — `.onex_state/consumer-graph.lock`** (process to process)

`fcntl.flock(LOCK_EX | LOCK_NB)`, polled every `_LOCK_POLL_SECONDS = 0.05`,
bounded by `_LOCK_TIMEOUT_SECONDS = 60.0` (round 3: was `300.0`; see below).
The context manager yields
`bool` — `True` = lock held (double-check the cache, then build), `False` =
could not take it (no `fcntl`, unwritable state dir, or timeout). **A `False`
yield still builds.** The lock is a stampede guard, never a correctness
barrier, so failing to take it degrades to a redundant build rather than ever
wedging the caller.

**3. `.gitignore`** — three literal paths added: `.onex_state/consumer-graph.json`,
`.onex_state/consumer-graph.lock`, `.onex_state/consumer-graph.json.*.tmp`.
Deliberately **scoped to these names, not all of `.onex_state/`**, which holds
tracked evidence.

**4. `git cat-file --batch -z` stdin/stdout** (process boundary)

- **stdin (CHANGED):** `f"{ref}:{rel}\0"` per request, UTF-8 bytes,
  **NUL-delimited** (was newline-delimited).
- **stdout (UNCHANGED framing):** per request either
  `<oid> SP <type> SP <size> LF <content> LF` or `<request> SP "missing" LF`.
  `-z` changes **only the input framing**. The flag that also NUL-frames output
  is `-Z`, which needs git >= 2.42 and is therefore **unusable on this fleet**
  (2.39.5 on both the authoring Mac and the `.200` gate host; CI runners are
  2.54.0). So the reader must not assume NUL-framed output.
- **Parser (CHANGED in round 3):** each response is first tested against the
  **exact request that produced it** — `out.startswith(request + b" missing\n")`
  (and `b" ambiguous\n"`) at the current offset, via `_absent_response_length`.
  Only if that does not match is the header read up to the next LF and parsed as
  `<oid> <type> <size>`, advancing `pos += size + 1`. Request-matching is
  framing-independent, which is what makes an absent path containing a newline
  safe. A header that still does not parse yields `""` and does **not** advance
  past a payload.
- **Decode:** `utf-8` with `errors="replace"`, then CRLF -> LF, CR -> LF.
- **Failure (CHANGED in round 3):** a non-zero exit still returns `{}`, but now
  emits `warning: git cat-file failed; ...` on **stderr** first.

**5. `_git_files_at(repo_root: Path, requests: list[tuple[str, str]]) -> dict[tuple[str, str], str]`**

Key is `(ref, repo-relative POSIX path)`. A blob missing at that ref maps to
`""` (matching prior per-file behaviour). Empty `requests` spawns no process.

**6. `build_import_graph(repo_root: Path) -> ImportGraph`**

Directory pruning is by **name** (`_PRUNED_DIR_NAMES`: `.git`, `.hg`, `.svn`,
`.venv`, `venv`, `.tox`, `.nox`, `.eggs`, `site-packages`, `node_modules`,
`__pycache__`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `.onex_state`,
`htmlcov`), by `*.egg-info` suffix, and by **nested checkout** (any dir other
than `repo_root` where `<dir>/.git` exists). Pruning is in-place on
`os.walk`'s `dirnames`, so excluded subtrees are never descended into.
`python_search_roots` is now `[repo_root, *src_dirs]` where `src_dirs` come from
that **same pruned walk** — previously an independent unpruned `rglob("src")`,
which is how vendored `src` roots entered module resolution.

**7. pytest grouping** — `pytestmark = pytest.mark.xdist_group("semantic_diff_cli")`
in `tests/scripts/test_semantic_diff_cli.py`, consumed by `--dist=loadgroup`.

## Acceptance criteria to proving test

| AC | Criterion | Proven by |
|---|---|---|
| **AC1** | Cold worktree passes `pytest tests/scripts/test_semantic_diff_cli.py -q -n4 --dist=loadgroup --timeout=60 --timeout-method=thread` without prewarming | Exact command, cache deleted first, on `.200`, re-run at round-3 head: **14 passed in 18.89s**. Same command at the pre-fix parent commit: **4 failed + xdist `INTERNALERROR KeyError <WorkerController gw7>` at `loadscope.py:275`, 66.11s, exit 3** |
| **AC2** | Concurrent tests do not independently rebuild or race-write the same graph | `tests/analysis/test_consumer_graph.py::test_concurrent_cold_builds_compute_the_graph_exactly_once` (single-flight: N cold processes yield **one** build), `::test_failed_cache_write_leaves_the_previous_cache_intact` (atomic publish), `::test_build_still_completes_when_the_lock_cannot_be_taken` (fail-open negative case) |
| **AC3** | Test remains fix-discriminating for a non-empty Python diff | `tests/scripts/test_semantic_diff_cli.py::test_compute_report_detects_changes_for_a_non_empty_python_diff` — asserts the consumer graph is actually built (`graph_calls == [tmp_path]`), the deleted symbol is surfaced, and the consumer count is real. **Mutation-proven:** replacing `build_consumer_graph` with `{}` makes it FAIL, so it is not vacuous |
| **AC4** | Canonical full non-integration pre-push suite passes from a cold worktree | See "Full-suite state" below — reported honestly, not asserted |
| **AC5** | Focused RED to GREEN evidence, full gates, OCC receipt | This body + the RED/GREEN blocks + gate results below |

Negative / fail-closed cases the criteria imply, also covered:
`test_vendored_dependency_dirs_are_not_counted_as_consumers`,
`test_nested_checkout_is_not_counted_as_consumers`,
`test_git_files_at_batches_reads_and_reports_missing_blobs`,
`test_git_files_at_survives_a_newline_inside_a_tracked_path` (present half),
`test_git_files_at_survives_a_newline_inside_a_missing_path` (absent half, new
in round 3), `test_git_files_at_warns_instead_of_silently_emptying_the_whole_report`
(new in round 3), `test_lock_wait_never_outlasts_the_gate_per_test_timeout`
(new in round 3), `test_git_files_at_normalises_newlines_like_the_previous_per_file_read`,
`test_git_files_at_returns_empty_for_no_requests`.

## RED to GREEN

All runs on the `.200` gate host (`stickybeatz-studio`), against the real
artifact — no mocks, no surrogates.

**Cold-cache xdist crash (AC1)** — exact canonical gate command:

```
RED   @ parent ac174387, cold : 4 failed, xdist INTERNALERROR
                                KeyError <WorkerController gw7> (loadscope.py:275)
                                66.11s, exit 3
GREEN @ this branch,     cold : 12 passed in 18.39s
```

Cold is now *faster* than the pre-fix **warm** run the ticket recorded (39.09s).

**Round-2 blob-reader regressions** — both new tests run against the
exists-but-wrong committed reader, then against the fix:

```
RED   (committed reader + new tests): 2 failed, 10 passed
  test_git_files_at_survives_a_newline_inside_a_tracked_path
    AssertionError: assert '' == 'WEIRD = 1\n'
    ...and the FOLLOWING blob (after.py) was lost too
  test_git_files_at_normalises_newlines_like_the_previous_per_file_read
    AssertionError: assert 'a = 1\r\nb = 2\r\n' == 'a = 1\nb = 2\n'

GREEN (fixed reader): 12 passed
```

**Round-3 findings** — all three new tests run against the exists-but-wrong
committed code first (`PYTHONPATH` scrubbed, because the ambient one on the
authoring Mac shadows worktree source with the canonical clone and would have
made the lock test fail as `AttributeError`, i.e. *absent*, not *wrong*):

```
RED (committed code + new tests), verbatim:
  test_git_files_at_survives_a_newline_inside_a_missing_path
    AssertionError: assert '' == 'AFTER = 2\n'
      -- the blob AFTER the absent newline-bearing path was silently lost
  test_lock_wait_never_outlasts_the_gate_per_test_timeout
    AssertionError: lock wait 300.0s exceeds the gate per-test timeout 60.0s;
                    waiters would be killed mid-wait
    assert 300.0 <= 60.0
  test_git_files_at_warns_instead_of_silently_emptying_the_whole_report
    AssertionError: assert 'git cat-file failed' in ''

GREEN (round-3 fix), on .200:
  tests/scripts/test_semantic_diff_cli.py  cold, canonical gate : 14 passed, 18.89s
  tests/analysis/                          cold, canonical gate : 74 passed,  4.46s
```

## Gates

Run on **`.200` / `stickybeatz-studio`**, via patch-transfer with `sha256`
parity verified on every changed file before gating (editor tool calls land on
the authoring Mac, so gating an unedited remote copy would be a vacuous green).

- `ruff format` — files left unchanged
- `ruff check` on every changed file — All checks passed
- `mypy` (strict) — Success: no issues found
- `pre-commit run --files <the 4 changed files>` — every hook Passed
- Pre-push chain (mypy strict, pyright, Evidence-Source shape, naming, file
  naming, protocol UUID, enum governance, node purity, governed impacted-test
  selector) — all Passed; the selector is the gate that admitted the push

**`pre-commit run --all-files` also run, and it has three failures — none from
this branch.** Reported rather than hidden: `yamlfmt` (reformats 7 YAML files
this diff never touches), `no-hardcoded-topics`
(`src/omnibase_core/utils/util_topic_suffix.py`,
`src/omnibase_core/runtime/harness/harness_topics.py`), and `no-untracked-todos`
(`src/omnibase_core/validation/todo_marker/*`). Provenance check, not assertion:
`git diff --name-only origin/dev...HEAD` over those paths returns **0 files** —
they are byte-identical to `dev`, so this is pre-existing repo drift, not
regression introduced here. The hook-modified YAML files were reverted rather
than swept into this commit. Fixing unrelated dev drift is out of scope for a
remediation round and would violate "do not rewrite unrelated code."

**Host note:** the `.200` gate host was under heavy memory pressure throughout
(`vm.swapusage` 46.3 GiB used of 47.1 GiB, load ~8-11). Per the operator
directive to bound shared-host usage, round 3 ran the **focused** cold-cache
gates rather than repeating the ~1h49m full-suite sweep; AC4's full-suite proof
is the round-2 run recorded below, and the round-3 diff is confined to the two
modules those focused gates cover plus their tests.

## Full-suite state (AC4) — honest reporting

**Pre-push gate (the enforced one), run on `.200` at HEAD `3e4526b1`:** the
governed selector emitted its own whole-tree "no narrowing achieved" sentinel —

```
[prepush-smart-tests] selection: is_full_suite=False reason=None paths=[ tests/unit/ ] (feature-flag=on)
[prepush-smart-tests] running impacted subset: uv run pytest tests/unit/ --ignore=tests/integration -n4 --dist=loadgroup --timeout=60 --timeout-method=thread
=== 42698 passed, 53 skipped, 3 xpassed, 179 warnings in 5754.95s (1:35:54) ===
[prepush-smart-tests] impacted tests passed; allowing push.
```

Zero failures. The push was **not** bypassed — the gate ran and went green. For
context, the previous attempt on this branch failed this same gate twice on one
unrelated, load-sensitive assertion
(`tests/unit/resolution/test_execution_resolver_performance.py::test_repeated_resolution_consistency`,
a wall-clock `std_dev < mean * 0.5` check on a ~0.45ms operation), filed as
**OMN-15609**. It passed on this run; OMN-15609 is a real latent gate flake and
stays open on its own merits.

**That run alone does NOT satisfy AC4, and I am not claiming it does.**
`tests/unit/` excludes `tests/scripts/` — which is exactly where the crashing
module (`test_semantic_diff_cli.py`) lives — so the enforced pre-push selection
does not exercise this regression at all. AC4 names the *full non-integration*
suite (`tests/ --ignore=tests/integration`), which is the run the ticket records
as dying at the semantic-diff group after ~7,550 passes.

**AC4 PROVEN — GREEN.** Run on `.200`, cold, at tree `3b3fef6d` (byte-identical
to this PR's head `af389dd0` — verified `git diff --stat` between them is empty,
so this evidence is not stale-by-one-commit):

```
COLD_CHECK: ls: .onex_state/consumer-graph.json: No such file or directory
[prepush-smart-tests] selection: is_full_suite=True reason=feature_flag_off paths=[ tests/ ]
[prepush-smart-tests] running FULL suite (fail-closed escalation):
  uv run pytest tests/ --ignore=tests/integration -n4 --dist=loadgroup --timeout=60 --timeout-method=thread

=== 43537 passed, 53 skipped, 3 xpassed, 179 warnings in 6534.03s (1:48:54) ===
[prepush-smart-tests] impacted tests passed; allowing push.
```

**Zero failures.** This is the criterion's actual target — `tests/` minus
integration, which *includes* `tests/scripts/` (the crashing module) and
`tests/analysis/`. It is 839 tests larger than the `tests/unit/` selection the
selector picks by default, and it is the shape the ticket records as previously
dying at the semantic-diff group after ~7,550 passes.

The full suite was forced with `PREPUSH_FULL_SUITE=1`, a knob the hook documents
explicitly ("Neither knob is a silent bypass -- forcing OFF runs MORE tests (the
whole suite), never fewer"). It was used to *widen* the enforced gate to the AC4
target, not to narrow anything, and it also let one run serve both the gate and
the proof instead of running two full suites on a shared, contended host.

Earlier, the *default* pre-push selection at HEAD `3e4526b1` also went green:
`is_full_suite=False paths=[ tests/unit/ ]`, **42,698 passed / 53 skipped /
3 xpassed / 0 failed in 1:35:54**. That run is reported for completeness but is
NOT the AC4 proof, because `tests/unit/` excludes `tests/scripts/`.

Note on **OMN-15609**: a previous attempt on this branch failed the pre-push gate
twice on one unrelated, load-sensitive assertion
(`tests/unit/resolution/test_execution_resolver_performance.py::test_repeated_resolution_consistency`,
a wall-clock `std_dev < mean * 0.5` check on a ~0.45ms operation). It passed on
both runs here. OMN-15609 is a real latent gate flake and stays open on its own
merits; nothing in this PR addresses or masks it.

## CI state (honest, at head `21f6ccda`)

**Retraction first.** The previous revision of this section claimed the reds at
`af389dd0` would "stay red until that companion merges, which is the Codex merge
sweep's call, not this lane's." **That was false, and it was this lane's own
misdiagnosis.** `occ-preflight` failed at the **body-parse** step —

```
##[error]OCC PREFLIGHT FAILED: PR body is missing required 'Evidence-Source:' line.
Add one of: 'Evidence-Source: OCC#<PR-number>' or 'Evidence-Source: <occ-sha>'
```

— and never reached companion resolution, so merging `OCC#5814` could not have
turned it green. All five reds (`occ-preflight / eligibility`, `verify / verify`,
`receipt-honesty`, `Canonical Inference Gate`, `call-reject-skip-token /
occ-preflight / eligibility`) had that single lane-owned cause: this body was
rewritten wholesale in an earlier round and the `Evidence-Source:` directive line
went with it. It is restored above. The same false claim was written into
`docs/tracking/ROLLING_WORK_LEDGER.md`; a correction entry has been appended
there retracting it, so the misdiagnosis does not persist in the durable ledger.

**Also carried forward honestly, and NOT fixed by the body edit:**

- `CI Summary` was terminal-**FAILURE** at `af389dd0` for two reasons, only one
  of which was the OCC cause: `default-deny sweep failures: OCC Companion Merged
  Gate (OMN-15214)` (companion still open) **and** `gates missing/pending: Tests
  Gate` at its poll deadline. `Tests Gate` subsequently completed `success` and
  all 38 `Tests (Split N/37)` runs were `success`, so that half was a
  poll-deadline race rather than a real red — but the umbrella is terminal and
  does not self-correct. The round-3 push mints a fresh run for both halves.
- `gate / CodeRabbit Thread Check` and `CodeQL / CodeQL Analysis (python)` never
  reported a check-run at `af389dd0` at all (verified via
  `commits/af389dd0.../check-runs`; CodeRabbit reported `Review rate limited`,
  `CodeQL` itself was `completed/skipped`). Both are required contexts, so an
  absent check-run blocks merge indefinitely. This is an infrastructure
  condition, not something a code change in this PR can clear; the new head
  gives both another chance to instantiate.
- `OCC Companion Merged Gate (OMN-15214)` is fail-closed on the cited evidence
  being **durable**. That one genuinely does wait on the companion merging, and
  that genuinely is the merge sweep's call — but it is one gate, not the five
  the previous revision blamed on it.

The terminal state at the round-3 head is reported in the lane's return value,
not asserted here.

**Why this lane had to write the `Evidence-Source:` line by hand.** The
born-admissible path (`call-occ-companion-effect.yml`) is what normally PATCHes
`Evidence-Source: OCC#<n>` onto a product PR body — but it is gated behind
`occ-preflight`, and `occ-preflight` fails on a body with no `Evidence-Source:`
line. Once the line was lost from this body, the automation could not restore
it: measured, not assumed — 9 minutes after the round-3 push at `21f6ccda`, no
new companion existed and the body still had no directive line. `OCC#5814` (the
machine-authored companion for this PR, still OPEN) is cited, which lets
preflight resolve and lets the companion machinery run again from a fresh head.

## Lane disclosure

The `0.46.8 -> 0.46.9` bump landed on this branch as `af389dd0` from a **peer
Codex lane** (`codex/omn-15431-release-identity-repair-200`, worktree
`omni_worktrees/OMN-15431/omnibase_core-release-identity-repair-200` on `.200`),
which independently diagnosed the same release-identity failure and pushed while
this lane's gate run was still going. This lane had prepared a **tree-identical**
commit; rather than force-push over a peer's work, that redundant commit was
dropped and both worktrees were reset to the pushed head. `git diff` between the
two commits is empty, so nothing was lost and the AC4 evidence above still
applies byte-for-byte to the current head.

## Not done here

- **No merge.** Merges belong to the Codex merge sweep.
- No `--no-verify`, no `--no-gpg-sign`, no `[skip-*]` token, no hand-typed
  `-k`/`-m` narrowing, no allowlist widening. The pre-push gate was run, not
  bypassed.

