### PR TITLE
fix(OMN-15639): single canonical consumer-group derivation in core + CI-enforced MSK IAM authorization gate

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -367,6 +367,18 @@ allowed_files:
     added: "2026-05-17"
     review: "2026-12-13"
 
+  - file: "src/omnibase_core/event_bus/util_consumer_group.py"
+    reason: >-
+      MSK IAM consumer-group pattern mirror loader (OMN-15639) — identical two-step pipeline to the aislop_rule_loader
+      entry above: yaml.safe_load() → ModelConsumerGroupIamPatterns.model_validate(). The raw mapping
+      is never used unvalidated, and the model is frozen/extra=forbid so a malformed mirror fails at load
+      rather than degrading into a silently-empty authorized-pattern set. Reading via omnibase_core.utils.util_safe_yaml_loader
+      was the first implementation and is the reason this entry exists rather than reusing that helper:
+      it adds a new importer to the `utils` hub, which the OMN-14340 import-layering ratchet tracks and
+      fails a test on, and this module has no other reason to depend on utils.
+    added: "2026-08-02"
+    review: "2027-02-02"
+
   - file: "src/omnibase_core/validators/breaking_schema_change.py"
     reason: >-
       Breaking-schema-change validator (OMN-12621) — must read adjacent *.topic-schema.yaml declarations

--- a/src/omnibase_core/cli/cli_run_node.py
+++ b/src/omnibase_core/cli/cli_run_node.py
@@ -20,9 +20,40 @@ import click
 from omnibase_core.cli.cli_node import _resolve_packaged_contract
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.core.model_generic_yaml import ModelGenericYaml
+from omnibase_core.models.event_bus.model_consumer_group_scope import (
+    ModelConsumerGroupScope,
+)
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+# Service and node tokens for the one-shot consumer this CLI creates.
+RUN_NODE_SERVICE = "omnibase_core"
+RUN_NODE_NAME = "cli_run_node"
+
+
+def derive_run_node_group_id(correlation_id: UUID) -> str:
+    """Derive the ephemeral consumer group ID for one ``onex run-node`` invocation.
+
+    This consumer is genuinely one-shot — a single request/response round trip — so it
+    needs a unique group per invocation. Before OMN-15639 the uniqueness was expressed
+    as the literal ``f"onex-run-node-{correlation_id}"``, which no MSK IAM pattern
+    authorized. The correlation ID is now carried as a declared scope discriminator
+    instead, so the environment token still leads and the name stays authorized while
+    remaining unique per run.
+
+    Args:
+        correlation_id: The invocation's correlation UUID.
+
+    Returns:
+        An environment-qualified, per-invocation consumer group ID.
+    """
+    return derive_service_group_id(
+        RUN_NODE_NAME,
+        service=RUN_NODE_SERVICE,
+        scope=ModelConsumerGroupScope(correlation_id=correlation_id),
+    )
 
 
 def load_workflow_contract(path: Path) -> dict[str, object]:
@@ -210,7 +241,7 @@ def publish_and_poll(
     consumer = Consumer(
         {
             "bootstrap.servers": bootstrap_servers,
-            "group.id": f"onex-run-node-{correlation_id}",
+            "group.id": derive_run_node_group_id(correlation_uuid),
             "auto.offset.reset": "latest",
             "enable.auto.commit": False,
         }

--- a/src/omnibase_core/contracts/consumer_group_iam_patterns.yaml
+++ b/src/omnibase_core/contracts/consumer_group_iam_patterns.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+#
+# Pinned mirror of the MSK IAM consumer-group authorization pattern set.
+#
+# THIS FILE IS A MIRROR, NOT THE SOURCE OF TRUTH. The authoritative value is the
+# terraform variable `managed_kafka_client_group_patterns` in the `source` block
+# below. It is mirrored here so that omnibase_core can assert, at CI time and
+# without AWS credentials, that every consumer-group name the runtime can mint is
+# matched by at least one authorized pattern (OMN-15639 AC3).
+#
+# Drift protection: `pattern_set_sha256` is the sha256 of the `authorized_patterns`
+# strings joined by "\n" with NO trailing newline. The AC3 gate recomputes it and
+# fails closed on mismatch, so an edit to `authorized_patterns` that does not also
+# update the digest is rejected. Refreshing this file requires re-reading the
+# terraform source and updating `source.file_sha256` /
+# `source.last_touch_commit` / `source.verified_at` together.
+#
+# Semantics reminder (this is the defect OMN-15639 was filed for): MSK IAM
+# resource patterns are whole-name glob matches, NOT substring matches. `onex.*`
+# authorizes a group whose name BEGINS `onex.` — it does not authorize
+# `runtime-local-HandlerDelegateSkill.__t.onex.cmd.omnimarket.delegate-skill.v1`
+# merely because `onex.` appears inside it. Any matcher implemented as a substring
+# test is a vacuous implementation of this contract.
+
+source:
+  repo: omninode_infra
+  path: aws/cluster-dev/managed-data-plane.auto.tfvars
+  variable: managed_kafka_client_group_patterns
+  consumed_by: aws/cluster-dev/msk_kafka.tf (AlterGroup/DescribeGroup resource ARNs)
+  file_sha256: 46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528
+  last_touch_commit: 39fcff2a8e0062a3d25d0beabef73926e49d09ca
+  verified_at: "2026-08-02"
+  ticket: OMN-15639
+
+pattern_set_sha256: e75f830b0a00d41c64900a05f3a7309997d83de3c23fbed2d4109af0e69b2616
+
+# Verbatim, in source order (managed-data-plane.auto.tfvars:33-42).
+authorized_patterns:
+  - "onex-dev.*"
+  - "local.runtime_config.*"
+  - "pattern-b-broker-*"
+  - "onex.*"
+  - "omninode.*"
+  - "phase5-msk-smoke-*"
+
+# Environments whose brokers are MSK and therefore subject to the IAM policy above.
+# Identity-derived group IDs lead with the environment token, so a managed
+# environment is authorized iff `"<env>."` is matched by some authorized pattern —
+# the AC3 gate asserts exactly that, so adding an environment here without IAM
+# coverage fails CI rather than failing at runtime with GroupAuthorizationFailedError.
+#
+# Environments NOT listed here (e.g. `local`, the `.201` Redpanda lanes) have no
+# MSK IAM policy in front of them; they are out of scope for the authorization
+# assertion, not silently exempted from it.
+managed_environments:
+  - "onex-dev"

--- a/src/omnibase_core/contracts/consumer_group_iam_patterns.yaml
+++ b/src/omnibase_core/contracts/consumer_group_iam_patterns.yaml
@@ -29,12 +29,12 @@ source:
   path: aws/cluster-dev/managed-data-plane.auto.tfvars
   variable: managed_kafka_client_group_patterns
   consumed_by: aws/cluster-dev/msk_kafka.tf (AlterGroup/DescribeGroup resource ARNs)
-  file_sha256: 46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528
-  last_touch_commit: 39fcff2a8e0062a3d25d0beabef73926e49d09ca
+  file_sha256: 46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528  # pragma: allowlist secret
+  last_touch_commit: 39fcff2a8e0062a3d25d0beabef73926e49d09ca  # pragma: allowlist secret
   verified_at: "2026-08-02"
   ticket: OMN-15639
 
-pattern_set_sha256: e75f830b0a00d41c64900a05f3a7309997d83de3c23fbed2d4109af0e69b2616
+pattern_set_sha256: e75f830b0a00d41c64900a05f3a7309997d83de3c23fbed2d4109af0e69b2616  # pragma: allowlist secret
 
 # Verbatim, in source order (managed-data-plane.auto.tfvars:33-42).
 authorized_patterns:

--- a/src/omnibase_core/contracts/contract_parser_event_bus.py
+++ b/src/omnibase_core/contracts/contract_parser_event_bus.py
@@ -38,6 +38,9 @@ from omnibase_core.models.contracts.model_event_bus_subscription import (
 
 _RECOGNIZED_KEYS: frozenset[str] = frozenset({"subscribe_topics", "subscribe"})
 
+# Keys allowed inside an `event_bus.subscribe[*]` mapping.
+_RECOGNIZED_SUBSCRIBE_KEYS: frozenset[str] = frozenset({"topic"})
+
 
 def parse_event_bus(contract: dict[str, object]) -> ModelEventBusParseResult:
     """Parse the ``event_bus`` block of a contract into normalized subscriptions.
@@ -108,6 +111,18 @@ def parse_event_bus(contract: dict[str, object]) -> ModelEventBusParseResult:
                     "(OMN-15639): consumer group IDs are derived from node identity "
                     "by omnibase_core.event_bus.util_consumer_group so that every minted "
                     "name is authorized by the MSK IAM pattern set. Remove the field.",
+                )
+            # Reject every other unknown key too. The model is built from `topic`
+            # alone, so an unrecognized key would be discarded here before
+            # ModelEventBusSubscription's extra="forbid" could ever see it — a silent
+            # subscription-shape drop, which is exactly what this parser exists to
+            # prevent. Mirrors the top-level _RECOGNIZED_KEYS check above.
+            unknown_entry_keys = sorted(set(entry) - _RECOGNIZED_SUBSCRIBE_KEYS)
+            if unknown_entry_keys:
+                raise EventBusContractShapeError(
+                    "event_bus.subscribe entries contain unrecognized keys; "
+                    f"got {unknown_entry_keys!r}, expected only "
+                    f"{sorted(_RECOGNIZED_SUBSCRIBE_KEYS)!r}",
                 )
             subscriptions.append(ModelEventBusSubscription(topic=topic))
 

--- a/src/omnibase_core/contracts/contract_parser_event_bus.py
+++ b/src/omnibase_core/contracts/contract_parser_event_bus.py
@@ -7,12 +7,21 @@ Parses the ``event_bus`` block of a node contract into a normalized list of
 subscriptions. Supports two shapes:
 
 1. **Classic** (``event_bus.subscribe_topics``): ``list[str]`` of topic suffixes.
-2. **Nested** (``event_bus.subscribe``): ``list[dict]`` with required ``topic``
-   and optional ``consumer_group``.
+2. **Nested** (``event_bus.subscribe``): ``list[dict]`` with a required ``topic``.
 
 Both shapes may coexist in a single contract; classic entries are emitted first.
 Unknown shapes (or a recognized shape missing required fields) raise
 :class:`EventBusContractShapeError` so silent subscription drops cannot occur.
+
+``consumer_group`` used to be accepted here as an optional per-subscription field.
+It was parsed into :class:`ModelEventBusSubscription` and then **never read by
+anything** — a contract could declare a consumer group and the runtime would silently
+ignore it. Under OMN-15639 consumer-group names are derived from node identity by
+``omnibase_core.event_bus.util_consumer_group`` so that every minted name is matched by the
+MSK IAM authorized pattern set; a contract-supplied override is exactly the ad-hoc
+naming surface that ruling removed. The key is now **rejected loudly** rather than
+accepted-and-ignored, per ``feedback_optional_input_means_the_check_does_not_exist``.
+No contract in any repo declared it, so nothing is broken by the removal.
 """
 
 from __future__ import annotations
@@ -93,17 +102,14 @@ def parse_event_bus(contract: dict[str, object]) -> ModelEventBusParseResult:
                 raise EventBusContractShapeError(
                     "event_bus.subscribe entries require a 'topic' string field",
                 )
-            consumer_group = entry.get("consumer_group")
-            if consumer_group is not None and not isinstance(consumer_group, str):
+            if "consumer_group" in entry:
                 raise EventBusContractShapeError(
-                    "event_bus.subscribe[*].consumer_group must be a string when present",
+                    "event_bus.subscribe[*].consumer_group is no longer supported "
+                    "(OMN-15639): consumer group IDs are derived from node identity "
+                    "by omnibase_core.event_bus.util_consumer_group so that every minted "
+                    "name is authorized by the MSK IAM pattern set. Remove the field.",
                 )
-            subscriptions.append(
-                ModelEventBusSubscription(
-                    topic=topic,
-                    consumer_group=consumer_group,
-                ),
-            )
+            subscriptions.append(ModelEventBusSubscription(topic=topic))
 
     return ModelEventBusParseResult(subscriptions=subscriptions)
 

--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -396,6 +396,7 @@ from .enum_registry_error_code import EnumRegistryErrorCode
 from .enum_registry_health_status import EnumRegistryHealthStatus
 from .enum_registry_type import EnumRegistryType
 from .enum_renderer_interaction_model import EnumRendererInteractionModel
+from .enum_reserved_group_prefix import EnumReservedGroupPrefix
 
 # Resolution tier enums (authenticated dependency resolution - OMN-2890)
 from .enum_resolution_failure_code import EnumResolutionFailureCode
@@ -785,6 +786,7 @@ __all__ = [
     "EnumComputationType",
     # Consumer group purpose domain (event bus subscription)
     "EnumConsumerGroupPurpose",
+    "EnumReservedGroupPrefix",
     # Contract-driven NodeCompute v1.0 domain
     "EnumCaseMode",
     "EnumComputeStepType",

--- a/src/omnibase_core/enums/enum_reserved_group_prefix.py
+++ b/src/omnibase_core/enums/enum_reserved_group_prefix.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Reserved consumer-group prefixes authorized by the MSK IAM policy.
+
+Most consumer groups are *identity-derived*: ``compute_consumer_group_id`` renders
+``{env}.{service}.{node_name}.{purpose}.{version}``, which is authorized because the
+leading environment token matches an entry in the pinned pattern set
+(``omnibase_core/contracts/consumer_group_iam_patterns.yaml``).
+
+A small number of lanes are not identity-derived — they own a reserved prefix in the
+IAM policy directly (pattern-B broker command dispatch, the phase-5 MSK smoke lane,
+the runtime-config ingress lane). Those lanes mint names through
+:func:`omnibase_core.event_bus.util_consumer_group.derive_prefixed_group_id` with a member
+of :class:`EnumReservedGroupPrefix`, so the prefix is a declared constant rather than
+an ad-hoc string literal.
+
+.. versionadded:: OMN-15639
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.enums.enum_str_enum_base import UtilStrValueHelper
+
+
+@unique
+class EnumReservedGroupPrefix(UtilStrValueHelper, str, Enum):
+    """Consumer-group prefixes reserved directly in the MSK IAM pattern set.
+
+    Each member's value is the prefix WITHOUT its trailing separator. The separator
+    is supplied by :meth:`separator` and is load-bearing: the IAM glob
+    ``pattern-b-broker-*`` requires the trailing ``-``, so the bare prefix
+    ``pattern-b-broker`` is NOT authorized. This is why
+    ``derive_prefixed_group_id`` refuses to render a scope-less name.
+
+    Attributes:
+        PATTERN_B_BROKER: Pattern-B broker command-dispatch groups
+            (IAM glob ``pattern-b-broker-*``).
+        PHASE5_MSK_SMOKE: Phase-5 MSK connectivity smoke lane
+            (IAM glob ``phase5-msk-smoke-*``).
+        LOCAL_RUNTIME_CONFIG: Runtime-config handler ingress lane
+            (IAM glob ``local.runtime_config.*``).
+    """
+
+    PATTERN_B_BROKER = "pattern-b-broker"
+    PHASE5_MSK_SMOKE = "phase5-msk-smoke"
+    LOCAL_RUNTIME_CONFIG = "local.runtime_config"
+
+    def separator(self) -> str:
+        """Return the separator the IAM glob requires between prefix and scope.
+
+        Returns:
+            ``"."`` for dotted prefixes, ``"-"`` for hyphenated prefixes.
+
+        Example:
+            >>> EnumReservedGroupPrefix.PATTERN_B_BROKER.separator()
+            '-'
+            >>> EnumReservedGroupPrefix.LOCAL_RUNTIME_CONFIG.separator()
+            '.'
+        """
+        return "." if self is EnumReservedGroupPrefix.LOCAL_RUNTIME_CONFIG else "-"
+
+    def authorized_glob(self) -> str:
+        """Return the IAM glob this prefix must be matched by.
+
+        Example:
+            >>> EnumReservedGroupPrefix.PATTERN_B_BROKER.authorized_glob()
+            'pattern-b-broker-*'
+        """
+        return f"{self.value}{self.separator()}*"
+
+
+__all__ = ["EnumReservedGroupPrefix"]

--- a/src/omnibase_core/errors/error_event_bus_contract_shape.py
+++ b/src/omnibase_core/errors/error_event_bus_contract_shape.py
@@ -17,10 +17,11 @@ class EventBusContractShapeError(ValueError):
 
     1. Classic: ``event_bus.subscribe_topics`` is a ``list[str]``.
     2. Nested: ``event_bus.subscribe`` is a ``list[dict]`` where each dict has
-       a required ``topic`` field and optional ``consumer_group``.
+       a required ``topic`` field.
 
-    Any other shape (or a recognized shape missing required fields) raises this
-    error so the contract author sees a loud failure instead of a silent skip.
+    Any other shape (a recognized shape missing required fields, or the removed
+    ``consumer_group`` key — see OMN-15639) raises this error so the contract author
+    sees a loud failure instead of a silent skip.
     """
 
 

--- a/src/omnibase_core/event_bus/event_bus_inmemory.py
+++ b/src/omnibase_core/event_bus/event_bus_inmemory.py
@@ -19,10 +19,8 @@ Protocol Compatibility:
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
-import re
 from collections import defaultdict, deque
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -40,67 +38,14 @@ from omnibase_core.types.typed_dict.typed_dict_event_bus_health import (
     TypedDictEventBusHealth,
 )
 
+from .util_consumer_group import compute_consumer_group_id
+
 if TYPE_CHECKING:
     from omnibase_core.protocols.event_bus.protocol_node_identity import (
         ProtocolNodeIdentity,
     )
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Consumer group ID helpers (inlined from omnibase_infra to avoid dep)
-# ---------------------------------------------------------------------------
-
-_INVALID_CHAR_PATTERN = re.compile(r"[^a-z0-9._-]")
-_CONSECUTIVE_SEPARATOR_PATTERN = re.compile(r"[._-]{2,}")
-_EDGE_SEPARATOR_PATTERN = re.compile(r"^[._-]+|[._-]+$")
-_KAFKA_CONSUMER_GROUP_MAX_LENGTH = 255
-
-
-def _normalize_kafka_identifier(value: str) -> str:
-    """Normalize a string for use as a consumer group ID component."""
-    if not value:
-        raise ValueError(  # error-ok: pure validation helper
-            "Consumer group component cannot be empty"
-        )
-    result = value.lower()
-    result = _INVALID_CHAR_PATTERN.sub("_", result)
-    result = _CONSECUTIVE_SEPARATOR_PATTERN.sub(lambda m: m.group(0)[0], result)
-    result = _EDGE_SEPARATOR_PATTERN.sub("", result)
-    if not result:
-        raise ValueError(  # error-ok: pure validation helper
-            f"Input {value!r} results in empty string after normalization"
-        )
-    if len(result) > _KAFKA_CONSUMER_GROUP_MAX_LENGTH:
-        hash_suffix = hashlib.sha256(value.encode()).hexdigest()[:8]
-        max_prefix = _KAFKA_CONSUMER_GROUP_MAX_LENGTH - 9
-        result = f"{result[:max_prefix]}_{hash_suffix}"
-    return result
-
-
-def _compute_consumer_group_id(
-    identity: ProtocolNodeIdentity,
-    purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
-) -> str:
-    """Compute canonical consumer group ID from node identity."""
-    parts = [
-        _normalize_kafka_identifier(identity.env),
-        _normalize_kafka_identifier(identity.service),
-        _normalize_kafka_identifier(identity.node_name),
-        _normalize_kafka_identifier(purpose.value),
-        _normalize_kafka_identifier(identity.version),
-    ]
-    group_id = ".".join(parts)
-    if len(group_id) > _KAFKA_CONSUMER_GROUP_MAX_LENGTH:
-        hash_input = (
-            f"{identity.env}|{identity.service}|{identity.node_name}|"
-            f"{purpose.value}|{identity.version}"
-        )
-        hash_suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
-        max_prefix = _KAFKA_CONSUMER_GROUP_MAX_LENGTH - 9
-        group_id = f"{group_id[:max_prefix]}_{hash_suffix}"
-    return group_id
-
 
 # ---------------------------------------------------------------------------
 # EventBusInmemory
@@ -249,7 +194,7 @@ class EventBusInmemory:
                 async with self._lock:
                     if failure_key in self._subscriber_failures:
                         del self._subscriber_failures[failure_key]
-            except Exception as e:
+            except Exception as e:  # fallback-ok: one subscriber's callback must not tear down the delivery loop for every other subscriber; the failure is counted per (topic, group) into _subscriber_failures, which drives the circuit breaker, and is logged with correlation_id. Pre-existing behaviour, annotated under OMN-15639 because that PR is the first to modify this file since the hook began flagging it.
                 async with self._lock:
                     self._subscriber_failures[failure_key] = (
                         self._subscriber_failures.get(failure_key, 0) + 1
@@ -324,7 +269,17 @@ class EventBusInmemory:
         if group_id is not None:
             effective_group_id = group_id
         elif node_identity is not None:
-            effective_group_id = _compute_consumer_group_id(node_identity, purpose)
+            # Components are unpacked here rather than passed as an identity
+            # object: util_consumer_group must not import the `protocols` hub
+            # (OMN-14340 ratchet), so the protocol-typed value is destructured at
+            # the call site that already depends on the protocol.
+            effective_group_id = compute_consumer_group_id(
+                env=node_identity.env,
+                service=node_identity.service,
+                node_name=node_identity.node_name,
+                version=node_identity.version,
+                purpose=purpose,
+            )
         else:
             raise ModelOnexError(
                 "subscribe() requires either node_identity or group_id",

--- a/src/omnibase_core/event_bus/event_bus_inmemory.py
+++ b/src/omnibase_core/event_bus/event_bus_inmemory.py
@@ -194,6 +194,8 @@ class EventBusInmemory:
                 async with self._lock:
                     if failure_key in self._subscriber_failures:
                         del self._subscriber_failures[failure_key]
+            except ModelOnexError:
+                raise
             except Exception as e:  # fallback-ok: one subscriber's callback must not tear down the delivery loop for every other subscriber; the failure is counted per (topic, group) into _subscriber_failures, which drives the circuit breaker, and is logged with correlation_id. Pre-existing behaviour, annotated under OMN-15639 because that PR is the first to modify this file since the hook began flagging it.
                 async with self._lock:
                     self._subscriber_failures[failure_key] = (

--- a/src/omnibase_core/event_bus/util_consumer_group.py
+++ b/src/omnibase_core/event_bus/util_consumer_group.py
@@ -487,14 +487,21 @@ def _compile_iam_glob(pattern: str) -> re.Pattern[str]:
     """Compile an IAM resource glob into an anchored regex.
 
     ``*`` matches any run of characters (including none); ``?`` matches exactly one.
-    Every other character — crucially ``.`` — is a literal. The result is anchored at
-    both ends, so matching is whole-name, never substring.
+    Every other character — crucially ``.`` — is a literal. The result is anchored with
+    ``^``/``\\Z``, so matching is whole-name, never substring, and never tolerates a
+    trailing newline the way ``$`` would.
     """
     compiled = "".join(
         ".*" if char == "*" else "." if char == "?" else re.escape(char)
         for char in pattern
     )
-    return re.compile(f"^{compiled}$")
+    # \Z, not $: in Python `$` also matches immediately BEFORE a trailing newline,
+    # so `^onex-dev\..*$` would authorize "onex-dev.svc\n". MSK matches the whole
+    # name with no such allowance. Derived names cannot contain a newline
+    # (normalize_kafka_identifier strips it), but is_authorized_group_name is also
+    # the gate's matcher for arbitrary caller-supplied names, so the anchor must be
+    # exact rather than rely on an upstream invariant.
+    return re.compile(f"^{compiled}\\Z")
 
 
 def is_authorized_group_name(group_name: str) -> bool:

--- a/src/omnibase_core/event_bus/util_consumer_group.py
+++ b/src/omnibase_core/event_bus/util_consumer_group.py
@@ -1,0 +1,555 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical Kafka consumer-group derivation and IAM authorization checking.
+
+This module is the **single** home for consumer-group name derivation across the
+platform (operator ruling 2026-08-02, option (c) on OMN-15639). ``omnibase_infra``
+imports from here; it does not keep its own copy, and neither does
+``event_bus_inmemory``. Three independent derivations previously existed and drifted:
+
+- ``omnibase_infra.utils.util_consumer_group`` (the original, OMN-1602),
+- ``omnibase_core.event_bus.event_bus_inmemory._compute_consumer_group_id`` (inlined
+  to avoid an infra dependency),
+- ad-hoc f-string literals at individual call sites.
+
+The third class is what caused OMN-15639: ``runtime_local.py`` minted
+``runtime-local-<handler>`` and ``cli_run_node.py`` minted
+``onex-run-node-<correlation_id>``, neither of which is matched by any pattern in the
+MSK IAM policy. Every ``onex delegate --bus kafka`` submission on onex-dev died with
+``GroupAuthorizationFailedError`` *before* publishing.
+
+Authorization model
+-------------------
+The MSK IAM policy authorizes ``AlterGroup``/``DescribeGroup`` on a fixed set of
+whole-name glob patterns, pinned in ``omnibase_core/contracts/consumer_group_iam_patterns.yaml``.
+Two derivation shapes are authorized by construction:
+
+1. **Identity-derived** — :func:`compute_consumer_group_id` renders
+   ``{env}.{service}.{node_name}.{purpose}.{version}``. Because the environment token
+   leads, the name is authorized whenever ``"<env>."`` is matched by some pattern
+   (``onex-dev.*`` for the managed environment).
+2. **Reserved-prefix** — :func:`derive_prefixed_group_id` renders
+   ``<reserved-prefix><sep><scope>`` for the handful of lanes that own an IAM prefix
+   outright (pattern-B broker, phase-5 smoke, runtime-config ingress).
+
+:func:`is_authorized_group_name` implements the glob semantics **exactly**: a pattern
+is anchored at both ends and ``*`` is the only metacharacter. A substring test would
+wrongly accept the OMN-15639 defect name (which *contains* ``onex.`` but does not
+*begin* with it) and is a vacuous implementation of this contract.
+
+.. versionadded:: OMN-15639
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from functools import lru_cache
+from importlib import resources
+from typing import Final
+
+import yaml
+
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_reserved_group_prefix import EnumReservedGroupPrefix
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.event_bus.model_consumer_group_iam_patterns import (
+    ModelConsumerGroupIamPatterns,
+)
+from omnibase_core.models.event_bus.model_consumer_group_scope import (
+    ModelConsumerGroupScope,
+)
+
+# Kafka's hard limit on consumer group ID length.
+KAFKA_CONSUMER_GROUP_MAX_LENGTH: Final[int] = (
+    255  # env-var-ok: Kafka wire-protocol limit, not configuration
+)
+
+# Infix markers. `.__t.` scopes a group to one topic; `.__i.` scopes it to one
+# instance/correlation. Both preserve the leading environment token.
+TOPIC_SCOPE_INFIX: Final[str] = ".__t."
+INSTANCE_SCOPE_INFIX: Final[str] = ".__i."
+
+# Environment variable naming the deployment environment. Allowlisted in
+# omnibase_core.validators.no_new_os_environ.
+ENVIRONMENT_ENV_VAR: Final[str] = "ENVIRONMENT"
+DEFAULT_ENVIRONMENT: Final[str] = "local"
+
+_IAM_PATTERNS_PACKAGE: Final[str] = "omnibase_core.contracts"
+_IAM_PATTERNS_RESOURCE: Final[str] = "consumer_group_iam_patterns.yaml"
+
+_INVALID_CHAR_PATTERN: Final[re.Pattern[str]] = re.compile(r"[^a-z0-9._-]")
+_CONSECUTIVE_SEPARATOR_PATTERN: Final[re.Pattern[str]] = re.compile(r"[._-]{2,}")
+_EDGE_SEPARATOR_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[._-]+|[._-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_kafka_identifier(value: str) -> str:
+    """Normalize a string for use as a Kafka consumer-group component.
+
+    Applies, in order: lowercase, replace characters outside ``[a-z0-9._-]`` with
+    ``_``, collapse runs of separators to the first separator in the run, strip
+    leading/trailing separators, then truncate to 255 with a deterministic 8-hex-char
+    suffix if still too long.
+
+    Args:
+        value: The raw component.
+
+    Returns:
+        A Kafka-safe identifier.
+
+    Raises:
+        ModelOnexError: ``VALIDATION_ERROR`` if ``value`` is empty or normalizes away
+            to the empty string.
+
+    Example:
+        >>> normalize_kafka_identifier("My Service!!")
+        'my_service'
+        >>> normalize_kafka_identifier("foo..bar__baz")
+        'foo.bar_baz'
+        >>> normalize_kafka_identifier("  UPPER_Case-Test  ")
+        'upper_case-test'
+    """
+    if not value:
+        raise ModelOnexError(
+            "Kafka consumer group component cannot be empty",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    result = value.lower()
+    result = _INVALID_CHAR_PATTERN.sub("_", result)
+    result = _CONSECUTIVE_SEPARATOR_PATTERN.sub(lambda m: m.group(0)[0], result)
+    result = _EDGE_SEPARATOR_PATTERN.sub("", result)
+
+    if not result:
+        raise ModelOnexError(
+            f"Input {value!r} results in empty string after normalization",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    return _truncate_with_hash(result, hash_input=value)
+
+
+def _truncate_with_hash(value: str, *, hash_input: str) -> str:
+    """Truncate to the Kafka limit, appending ``_<8 hex>`` derived from ``hash_input``.
+
+    The hash is taken over the *pre-normalization* input so that two distinct inputs
+    that normalize to the same 246-char prefix still produce distinct group IDs.
+    """
+    if len(value) <= KAFKA_CONSUMER_GROUP_MAX_LENGTH:
+        return value
+    suffix = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
+    return f"{value[: KAFKA_CONSUMER_GROUP_MAX_LENGTH - 9]}_{suffix}"
+
+
+def resolve_environment_token() -> str:
+    """Resolve the environment token that leads every identity-derived group ID.
+
+    Reads ``ENVIRONMENT`` and normalizes it. Falls back to ``"local"``, which is
+    deliberately NOT an MSK-managed environment: an unset ``ENVIRONMENT`` must not
+    silently masquerade as a managed one.
+
+    Returns:
+        The normalized environment token.
+    """
+    raw = os.environ.get(ENVIRONMENT_ENV_VAR, "").strip() or DEFAULT_ENVIRONMENT
+    return normalize_kafka_identifier(raw)
+
+
+# ---------------------------------------------------------------------------
+# Derivation
+# ---------------------------------------------------------------------------
+
+
+def compute_consumer_group_id(
+    *,
+    env: str,
+    service: str,
+    node_name: str,
+    version: str,
+    purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+) -> str:
+    """Compute the canonical identity-derived consumer group ID.
+
+    Format: ``{env}.{service}.{node_name}.{purpose}.{version}``, each component
+    normalized. The environment token leads, which is what makes the result
+    authorizable by an ``"<env>.*"`` IAM pattern.
+
+    Takes the four identity components explicitly rather than a
+    ``ProtocolNodeIdentity`` object. That is deliberate: the OMN-14340 import-layering
+    ratchet hard-fails any NEW core module that imports the ``protocols`` hub, and a
+    protocol-typed parameter would need exactly that import. Callers holding an
+    identity object (``ModelEmitterIdentity`` in core, ``ModelNodeIdentity`` in infra)
+    unpack it at the call site, which also keeps this module free of any model or
+    protocol coupling.
+
+    Args:
+        env: Environment token. Leads the group ID and decides IAM authorization.
+        service: Owning service name.
+        node_name: Node or handler name.
+        version: Identity version.
+        purpose: Consumer-group purpose. Defaults to ``CONSUME``.
+
+    Returns:
+        The canonical group ID, truncated with a deterministic hash suffix if it
+        would exceed 255 characters.
+
+    Example:
+        >>> compute_consumer_group_id(
+        ...     env="onex-dev",
+        ...     service="omnimarket",
+        ...     node_name="delegate_skill",
+        ...     version="v1",
+        ... )
+        'onex-dev.omnimarket.delegate_skill.consume.v1'
+    """
+    group_id = ".".join(
+        [
+            normalize_kafka_identifier(env),
+            normalize_kafka_identifier(service),
+            normalize_kafka_identifier(node_name),
+            normalize_kafka_identifier(purpose.value),
+            normalize_kafka_identifier(version),
+        ]
+    )
+    hash_input = f"{env}|{service}|{node_name}|{purpose.value}|{version}"
+    return _truncate_with_hash(group_id, hash_input=hash_input)
+
+
+def apply_topic_discriminator(group_id: str, topic: str | None) -> str:
+    """Append a ``.__t.<topic>`` scope infix, idempotently.
+
+    Args:
+        group_id: Base group ID.
+        topic: Topic name, or None/blank for no topic scoping.
+
+    Returns:
+        The topic-scoped group ID, or ``group_id`` unchanged when ``topic`` is empty.
+
+    Example:
+        >>> apply_topic_discriminator("onex-dev.svc.node.consume.v1", "example.evt.foo.v1")
+        'onex-dev.svc.node.consume.v1.__t.example.evt.foo.v1'
+        >>> apply_topic_discriminator("onex-dev.svc.node.consume.v1", None)
+        'onex-dev.svc.node.consume.v1'
+    """
+    return _apply_infix(group_id, TOPIC_SCOPE_INFIX, topic)
+
+
+def apply_instance_discriminator(group_id: str, instance_token: str | None) -> str:
+    """Append a ``.__i.<instance>`` scope infix, idempotently.
+
+    In multi-container environments, containers sharing an identity also share a
+    consumer group and split partitions. This infix gives each instance its own group.
+
+    Args:
+        group_id: Base group ID.
+        instance_token: Instance discriminator (typically ``KAFKA_INSTANCE_ID``), or
+            None/blank for no instance scoping.
+
+    Returns:
+        The instance-scoped group ID, or ``group_id`` unchanged when ``instance_token``
+        is empty.
+
+    Note:
+        ``instance_token`` is normalized before append, and the idempotency check uses
+        the normalized form. Callers must NOT pre-normalize.
+
+    Example:
+        >>> apply_instance_discriminator("onex-dev.svc.node.consume.v1", "pod-7")
+        'onex-dev.svc.node.consume.v1.__i.pod-7'
+        >>> apply_instance_discriminator(
+        ...     "onex-dev.svc.node.consume.v1.__i.pod-7", "pod-7"
+        ... )
+        'onex-dev.svc.node.consume.v1.__i.pod-7'
+    """
+    return _apply_infix(group_id, INSTANCE_SCOPE_INFIX, instance_token)
+
+
+def _apply_infix(group_id: str, infix: str, raw_value: str | None) -> str:
+    """Idempotently append ``<infix><normalized raw_value>`` within the length limit."""
+    if raw_value is None or not raw_value.strip():
+        return group_id
+    normalized = normalize_kafka_identifier(raw_value.strip())
+    suffix = f"{infix}{normalized}"
+    if group_id.endswith(suffix):
+        return group_id
+    return _truncate_with_hash(
+        f"{group_id}{suffix}", hash_input=f"{group_id}|{normalized}"
+    )
+
+
+def derive_consumer_group_id(
+    *,
+    env: str,
+    service: str,
+    node_name: str,
+    version: str,
+    purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+    scope: ModelConsumerGroupScope | None = None,
+) -> str:
+    """Derive the fully-scoped consumer group ID for an identity.
+
+    This is the call sites' entry point: identity + declared scope in, authorized
+    name out. Composition order is identity -> topic scope -> instance scope, so the
+    environment token always leads and IAM authorization is preserved.
+
+    Args:
+        env: Environment token.
+        service: Owning service name.
+        node_name: Node or handler name.
+        version: Identity version.
+        purpose: Consumer-group purpose. Defaults to ``CONSUME``.
+        scope: Optional declared scope. ``None`` means the shared, undiscriminated
+            group for this identity.
+
+    Returns:
+        The derived group ID.
+
+    Example:
+        >>> from uuid import UUID
+        >>> derive_consumer_group_id(
+        ...     env="onex-dev",
+        ...     service="omnibase_core",
+        ...     node_name="cli_run_node",
+        ...     version="v1",
+        ...     scope=ModelConsumerGroupScope(
+        ...         correlation_id=UUID("9f2c0000-0000-4000-8000-000000000000")
+        ...     ),
+        ... )
+        'onex-dev.omnibase_core.cli_run_node.consume.v1.__i.9f2c0000-0000-4000-8000-000000000000'
+    """
+    group_id = compute_consumer_group_id(
+        env=env,
+        service=service,
+        node_name=node_name,
+        version=version,
+        purpose=purpose,
+    )
+    if scope is None:
+        return group_id
+    group_id = apply_topic_discriminator(group_id, scope.topic)
+    tokens = scope.discriminator_tokens()
+    if tokens:
+        group_id = apply_instance_discriminator(group_id, "-".join(tokens))
+    return group_id
+
+
+def derive_service_group_id(
+    node_name: str,
+    *,
+    service: str,
+    version: str = "v1",
+    purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+    scope: ModelConsumerGroupScope | None = None,
+) -> str:
+    """Derive a group ID for a service-owned consumer, resolving env from the process.
+
+    Convenience wrapper over :func:`derive_consumer_group_id` for the common call-site
+    shape where the environment comes from :func:`resolve_environment_token` and the
+    remaining identity components are compile-time constants. Using this keeps call
+    sites free of group-name string literals, which is what the OMN-15639 AC3 gate
+    enforces statically.
+
+    Args:
+        node_name: Node or handler name.
+        service: Owning service (e.g. ``"omnibase_core"``).
+        version: Identity version. Defaults to ``"v1"``.
+        purpose: Consumer-group purpose. Defaults to ``CONSUME``.
+        scope: Optional declared scope.
+
+    Returns:
+        The derived, environment-qualified group ID.
+    """
+    return derive_consumer_group_id(
+        env=resolve_environment_token(),
+        service=service,
+        node_name=node_name,
+        version=version,
+        purpose=purpose,
+        scope=scope,
+    )
+
+
+def derive_prefixed_group_id(
+    prefix: EnumReservedGroupPrefix,
+    scope: ModelConsumerGroupScope,
+) -> str:
+    """Derive a consumer group ID under a reserved IAM prefix.
+
+    Args:
+        prefix: The reserved prefix this lane owns.
+        scope: Declared scope. Must carry at least one discriminator token.
+
+    Returns:
+        ``<prefix><separator><scope tokens joined by '-'>``, optionally topic-scoped.
+
+    Raises:
+        ModelOnexError: ``VALIDATION_ERROR`` when ``scope`` carries no discriminator
+            token. This is not defensive padding: the IAM glob is
+            ``pattern-b-broker-*``, so the bare prefix ``pattern-b-broker`` (no
+            trailing separator, no scope) is **unauthorized** and would fail at the
+            broker with ``GroupAuthorizationFailedError``. Failing here, at mint time,
+            is the fail-closed behaviour.
+
+    Example:
+        >>> from uuid import UUID
+        >>> derive_prefixed_group_id(
+        ...     EnumReservedGroupPrefix.PATTERN_B_BROKER,
+        ...     ModelConsumerGroupScope(
+        ...         ephemeral_tag="terminal",
+        ...         correlation_id=UUID("9f2c0000-0000-4000-8000-000000000000"),
+        ...     ),
+        ... )
+        'pattern-b-broker-terminal-9f2c0000-0000-4000-8000-000000000000'
+    """
+    tokens = scope.discriminator_tokens()
+    if not tokens:
+        raise ModelOnexError(
+            f"Reserved consumer-group prefix {prefix.value!r} requires a non-empty "
+            f"scope: the authorized IAM glob is {prefix.authorized_glob()!r}, which "
+            f"does not match the bare prefix.",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+    joined = normalize_kafka_identifier("-".join(tokens))
+    group_id = f"{prefix.value}{prefix.separator()}{joined}"
+    group_id = _truncate_with_hash(group_id, hash_input=f"{prefix.value}|{joined}")
+    return apply_topic_discriminator(group_id, scope.topic)
+
+
+# ---------------------------------------------------------------------------
+# IAM authorization
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def load_iam_pattern_document() -> ModelConsumerGroupIamPatterns:
+    """Load, validate, and digest-check the pinned MSK IAM pattern document.
+
+    Returns:
+        The validated document. Shape errors surface as Pydantic validation errors
+        (``extra="forbid"``, non-empty constraints) rather than as a silently-empty
+        authorized set.
+
+    Raises:
+        ModelOnexError: ``VALIDATION_ERROR`` when ``pattern_set_sha256`` does not
+            match the digest recomputed from ``authorized_patterns``. This is the
+            drift detector: it makes an un-receipted edit to the pattern list a hard
+            failure rather than a silent widening of what CI considers authorized.
+    """
+    # Two-step: yaml.safe_load() -> model_validate(). The raw mapping is never used
+    # unvalidated. Same shape as the sibling aislop_rule_loader / antipattern_registry_loader,
+    # and allowlisted alongside them in .yaml-validation-allowlist.yaml. Loading through
+    # omnibase_core.utils instead would add a new importer to the `utils` hub, which the
+    # OMN-14340 ratchet tracks and this module has no reason to deepen.
+    raw = (
+        resources.files(_IAM_PATTERNS_PACKAGE)
+        .joinpath(_IAM_PATTERNS_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+    document = ModelConsumerGroupIamPatterns.model_validate(yaml.safe_load(raw))
+
+    actual_digest = compute_pattern_set_digest(document.authorized_patterns)
+    if document.pattern_set_sha256 != actual_digest:
+        raise ModelOnexError(
+            f"{_IAM_PATTERNS_RESOURCE}: pattern_set_sha256 drift — declared "
+            f"{document.pattern_set_sha256!r}, recomputed {actual_digest!r}. "
+            f"Re-verify the terraform source before updating the digest.",
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    return document
+
+
+def compute_pattern_set_digest(patterns: tuple[str, ...]) -> str:
+    """Return the sha256 of ``patterns`` joined by ``\\n`` with no trailing newline."""
+    return hashlib.sha256("\n".join(patterns).encode()).hexdigest()
+
+
+def load_authorized_group_patterns() -> tuple[str, ...]:
+    """Return the pinned MSK IAM authorized consumer-group patterns, in source order."""
+    return load_iam_pattern_document().authorized_patterns
+
+
+def load_managed_environments() -> tuple[str, ...]:
+    """Return the environment tokens whose brokers are MSK (and thus IAM-gated)."""
+    return load_iam_pattern_document().managed_environments
+
+
+@lru_cache(maxsize=256)
+def _compile_iam_glob(pattern: str) -> re.Pattern[str]:
+    """Compile an IAM resource glob into an anchored regex.
+
+    ``*`` matches any run of characters (including none); ``?`` matches exactly one.
+    Every other character — crucially ``.`` — is a literal. The result is anchored at
+    both ends, so matching is whole-name, never substring.
+    """
+    compiled = "".join(
+        ".*" if char == "*" else "." if char == "?" else re.escape(char)
+        for char in pattern
+    )
+    return re.compile(f"^{compiled}$")
+
+
+def is_authorized_group_name(group_name: str) -> bool:
+    """Return True iff ``group_name`` is matched by at least one pinned IAM pattern.
+
+    Implements MSK IAM resource-pattern semantics: whole-name glob match, ``*`` as the
+    only wildcard, ``.`` literal.
+
+    Example:
+        >>> is_authorized_group_name("onex-dev.omnimarket.delegate.consume.v1")
+        True
+        >>> is_authorized_group_name("pattern-b-broker-terminal-9f2c")
+        True
+
+        The OMN-15639 defect name contains ``onex.`` but does not begin with it, so a
+        substring matcher would wrongly accept it:
+
+        >>> is_authorized_group_name(
+        ...     "runtime-local-HandlerDelegateSkill.__t."
+        ...     "onex.cmd.omnimarket.delegate-skill.v1"
+        ... )
+        False
+        >>> is_authorized_group_name("runtime-local-terminal")
+        False
+
+        The bare reserved prefix lacks the trailing separator the glob requires:
+
+        >>> is_authorized_group_name("pattern-b-broker")
+        False
+    """
+    if not group_name:
+        return False
+    return any(
+        _compile_iam_glob(pattern).match(group_name) is not None
+        for pattern in load_authorized_group_patterns()
+    )
+
+
+__all__: list[str] = [
+    "DEFAULT_ENVIRONMENT",
+    "ENVIRONMENT_ENV_VAR",
+    "INSTANCE_SCOPE_INFIX",
+    "KAFKA_CONSUMER_GROUP_MAX_LENGTH",
+    "TOPIC_SCOPE_INFIX",
+    "apply_instance_discriminator",
+    "apply_topic_discriminator",
+    "compute_consumer_group_id",
+    "compute_pattern_set_digest",
+    "derive_consumer_group_id",
+    "derive_prefixed_group_id",
+    "derive_service_group_id",
+    "is_authorized_group_name",
+    "load_authorized_group_patterns",
+    "load_iam_pattern_document",
+    "load_managed_environments",
+    "normalize_kafka_identifier",
+    "resolve_environment_token",
+]

--- a/src/omnibase_core/models/contracts/model_event_bus_subscription.py
+++ b/src/omnibase_core/models/contracts/model_event_bus_subscription.py
@@ -9,13 +9,15 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ModelEventBusSubscription(BaseModel):
-    """A single normalized subscription parsed from an event_bus contract block."""
+    """A single normalized subscription parsed from an event_bus contract block.
+
+    Carries only the topic. The former ``consumer_group`` field was parsed and never
+    read; consumer group IDs are now derived from node identity by
+    :mod:`omnibase_core.event_bus.util_consumer_group` so that every minted name is matched
+    by the MSK IAM authorized pattern set (OMN-15639).
+    """
 
     topic: str = Field(..., description="Topic suffix to subscribe to.")
-    consumer_group: str | None = Field(
-        default=None,
-        description="Optional consumer group; only present in the nested shape.",
-    )
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 

--- a/src/omnibase_core/models/event_bus/__init__.py
+++ b/src/omnibase_core/models/event_bus/__init__.py
@@ -3,6 +3,9 @@
 
 """Event bus models for ONEX message handling."""
 
+from .model_consumer_group_iam_patterns import ModelConsumerGroupIamPatterns
+from .model_consumer_group_iam_source import ModelConsumerGroupIamSource
+from .model_consumer_group_scope import ModelConsumerGroupScope
 from .model_delivery_result import ModelDeliveryResult
 from .model_event_bus_bootstrap_result import ModelEventBusBootstrapResult
 from .model_event_bus_input_output_state import ModelEventBusInputOutputState
@@ -17,6 +20,9 @@ from .model_producer_health_status import ModelProducerHealthStatus
 from .model_producer_message import ModelProducerMessage
 
 __all__ = [
+    "ModelConsumerGroupIamPatterns",
+    "ModelConsumerGroupIamSource",
+    "ModelConsumerGroupScope",
     "ModelDeliveryResult",
     "ModelEventBusBootstrapResult",
     "ModelEventBusInputOutputState",

--- a/src/omnibase_core/models/event_bus/model_consumer_group_iam_patterns.py
+++ b/src/omnibase_core/models/event_bus/model_consumer_group_iam_patterns.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed view of the pinned MSK IAM consumer-group pattern mirror.
+
+Backs ``omnibase_core/contracts/consumer_group_iam_patterns.yaml``. Modelling it
+rather than reading a raw mapping means a malformed or truncated mirror fails at load
+with a Pydantic error instead of degrading into a silently-empty authorized set — an
+empty set would make every authorization check fail open or closed by accident rather
+than by contract.
+
+.. versionadded:: OMN-15639
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.event_bus.model_consumer_group_iam_source import (
+    ModelConsumerGroupIamSource,
+)
+
+
+class ModelConsumerGroupIamPatterns(BaseModel):
+    """The pinned authorized-pattern set plus its provenance and drift digest."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    source: ModelConsumerGroupIamSource = Field(
+        ..., description="Provenance of the mirrored terraform variable."
+    )
+    pattern_set_sha256: str = Field(
+        ...,
+        min_length=64,
+        max_length=64,
+        description=(
+            "sha256 of authorized_patterns joined by newline with no trailing "
+            "newline; recomputed at load time and rejected on mismatch."
+        ),
+    )
+    authorized_patterns: tuple[str, ...] = Field(
+        ...,
+        min_length=1,
+        description="MSK IAM consumer-group globs, verbatim and in source order.",
+    )
+    managed_environments: tuple[str, ...] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Environment tokens whose brokers are MSK and therefore IAM-gated."
+        ),
+    )
+
+
+__all__ = ["ModelConsumerGroupIamPatterns"]

--- a/src/omnibase_core/models/event_bus/model_consumer_group_iam_source.py
+++ b/src/omnibase_core/models/event_bus/model_consumer_group_iam_source.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Provenance record for the pinned MSK IAM consumer-group pattern mirror.
+
+Split out of ``model_consumer_group_iam_patterns`` to satisfy the one-class-per-file
+rule (``onex-single-class-per-file``).
+
+.. versionadded:: OMN-15639
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelConsumerGroupIamSource(BaseModel):
+    """Provenance of the mirrored terraform variable.
+
+    Recorded so a reviewer can re-derive the mirror from the authoritative source
+    without guessing which file or commit it came from.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    repo: str = Field(..., min_length=1, description="Source repository name.")
+    path: str = Field(..., min_length=1, description="Path within the source repo.")
+    variable: str = Field(..., min_length=1, description="Terraform variable name.")
+    consumed_by: str = Field(
+        ..., min_length=1, description="Terraform resource that consumes the variable."
+    )
+    file_sha256: str = Field(
+        ..., min_length=64, max_length=64, description="sha256 of the source file."
+    )
+    last_touch_commit: str = Field(
+        ..., min_length=7, description="Commit that last modified the source file."
+    )
+    verified_at: str = Field(
+        ..., min_length=1, description="Date the pin was verified against the source."
+    )
+    ticket: str = Field(..., min_length=1, description="Owning ticket.")
+
+
+__all__ = ["ModelConsumerGroupIamSource"]

--- a/src/omnibase_core/models/event_bus/model_consumer_group_scope.py
+++ b/src/omnibase_core/models/event_bus/model_consumer_group_scope.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Declared scope discriminators for a derived consumer group ID.
+
+A consumer group's *identity* (env / service / node / purpose / version) says which
+logical consumer it is. Its *scope* says which slice of that consumer it is: a single
+process instance, a single one-shot correlation, or a single topic. Before OMN-15639
+each of those slices was expressed by hand-writing a group-name string literal at the
+call site (``f"runtime-local-{handler}"``, ``f"onex-run-node-{correlation_id}"``), which
+is exactly how names outside the MSK IAM authorized pattern set got minted.
+
+This model makes the scope a declared, typed input to the canonical derivation instead.
+
+.. versionadded:: OMN-15639
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelConsumerGroupScope(BaseModel):
+    """Optional discriminators applied on top of an identity-derived group ID.
+
+    All fields are optional; an all-empty scope is meaningful and means "the shared,
+    undiscriminated group for this identity". Rendering rules live in
+    :mod:`omnibase_core.event_bus.util_consumer_group`:
+
+    - ``topic`` is applied as a ``.__t.<topic>`` infix (topic-scoped subscription).
+    - ``ephemeral_tag`` / ``correlation_id`` / ``instance_token`` collapse into a single
+      ``.__i.<discriminator>`` infix, joined with ``-`` in declaration order.
+
+    Both infixes preserve the leading environment token, so a scoped name stays inside
+    whichever IAM pattern authorized the unscoped one.
+
+    Attributes:
+        ephemeral_tag: Short human-readable tag for a short-lived group
+            (e.g. ``"terminal"``).
+        correlation_id: Correlation UUID for a one-shot request/response consumer.
+        instance_token: Container/pod instance discriminator, typically the value of
+            ``KAFKA_INSTANCE_ID``. Named ``_token`` rather than ``_id`` because it is an
+            opaque string (pod name, container id), not a UUID.
+        topic: Topic name when the group is scoped to a single topic.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    ephemeral_tag: str | None = Field(
+        default=None,
+        description="Short tag identifying a short-lived consumer (e.g. 'terminal').",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Correlation UUID for a one-shot request/response consumer.",
+    )
+    instance_token: str | None = Field(
+        default=None,
+        description="Container/pod instance discriminator (e.g. KAFKA_INSTANCE_ID).",
+    )
+    topic: str | None = Field(
+        default=None,
+        description="Topic name when the consumer group is scoped to one topic.",
+    )
+
+    def discriminator_tokens(self) -> tuple[str, ...]:
+        """Return the non-empty instance-discriminator tokens in declaration order.
+
+        ``topic`` is deliberately excluded: it is rendered through a different infix
+        (``.__t.``) so that topic scoping and instance scoping stay distinguishable in
+        broker-side tooling.
+
+        Example:
+            >>> from uuid import UUID
+            >>> ModelConsumerGroupScope(
+            ...     ephemeral_tag="terminal",
+            ...     correlation_id=UUID("9f2c0000-0000-4000-8000-000000000000"),
+            ... ).discriminator_tokens()
+            ('terminal', '9f2c0000-0000-4000-8000-000000000000')
+        """
+        tokens: list[str] = []
+        for candidate in (
+            self.ephemeral_tag,
+            str(self.correlation_id) if self.correlation_id is not None else None,
+            self.instance_token,
+        ):
+            if candidate is not None and candidate.strip():
+                tokens.append(candidate.strip())
+        return tuple(tokens)
+
+    def is_empty(self) -> bool:
+        """Return True when the scope carries no discriminator at all.
+
+        Example:
+            >>> ModelConsumerGroupScope().is_empty()
+            True
+            >>> ModelConsumerGroupScope(topic="example.evt.foo.v1").is_empty()
+            False
+        """
+        return not self.discriminator_tokens() and not (
+            self.topic is not None and self.topic.strip()
+        )
+
+
+__all__ = ["ModelConsumerGroupScope"]

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -28,7 +28,7 @@ import uuid
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Final, cast
 
 import yaml
 from pydantic import BaseModel
@@ -37,6 +37,7 @@ from omnibase_core.enums.enum_cli_exit_code import EnumCLIExitCode
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
 from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
     ProtocolLocalRuntimeBus,
     UnsubscribeCallback,
@@ -52,6 +53,36 @@ from omnibase_core.protocols.runtime.protocol_local_runtime_payload_model import
 )
 
 logger = logging.getLogger(__name__)
+
+# Service token for consumer groups minted by this runtime.
+RUNTIME_LOCAL_SERVICE: Final[str] = "omnibase_core"
+
+# Node name for the subscription that watches the declared terminal event.
+TERMINAL_CONSUMER_NODE_NAME: Final[str] = "runtime_local_terminal"
+
+
+def derive_runtime_local_group_id(node_name: str) -> str:
+    """Derive the consumer group ID for a RuntimeLocal subscription.
+
+    RuntimeLocal is NOT local-only: ``_create_kafka_event_bus()`` loads ``EventBusKafka``
+    through the ``onex.backends`` entry point when ``--backend event_bus=kafka``, so the
+    names minted here reach MSK. Before OMN-15639 they were f-string literals
+    (``f"runtime-local-{handler}"``, ``"runtime-local-terminal"``) that no MSK IAM
+    pattern authorized, and every in-cluster ``onex delegate --bus kafka`` submission
+    died with ``GroupAuthorizationFailedError`` before publishing.
+
+    The environment token is resolved from ``ENVIRONMENT`` rather than hardcoded — the
+    adjacent ``EventBusInmemory(environment="local", ...)`` default is a local-bus
+    concern and must not leak into a name the broker sees.
+
+    Args:
+        node_name: Handler or subscription name.
+
+    Returns:
+        An environment-qualified, IAM-authorized consumer group ID.
+    """
+    return derive_service_group_id(node_name, service=RUNTIME_LOCAL_SERVICE)
+
 
 # Known backend protocol keys that --backend can override.
 # kafka_bootstrap is a Kafka-specific tuning knob: when ``event_bus=kafka`` is
@@ -560,7 +591,7 @@ class RuntimeLocal:
         await bus.subscribe(
             terminal_topic,
             on_message=_on_terminal_msg,
-            group_id="runtime-local-terminal",
+            group_id=derive_runtime_local_group_id(TERMINAL_CONSUMER_NODE_NAME),
         )
         logger.info("RuntimeLocal: subscribed to terminal topic '%s'", terminal_topic)
 
@@ -1177,7 +1208,7 @@ class RuntimeLocal:
             unsub = await bus.subscribe(
                 entry.input_topic,
                 on_message=adapter.on_message,
-                group_id=f"runtime-local-{entry.handler_name}",
+                group_id=derive_runtime_local_group_id(entry.handler_name),
             )
             unsubscribe_handles.append(unsub)
 
@@ -1192,7 +1223,7 @@ class RuntimeLocal:
         unsub = await bus.subscribe(
             terminal_topic,
             on_message=_on_terminal_msg,
-            group_id="runtime-local-terminal",
+            group_id=derive_runtime_local_group_id(TERMINAL_CONSUMER_NODE_NAME),
         )
         unsubscribe_handles.append(unsub)
 

--- a/src/omnibase_core/validation/doc_content_scan/runtime_doc_content_scan.py
+++ b/src/omnibase_core/validation/doc_content_scan/runtime_doc_content_scan.py
@@ -36,6 +36,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_DOC_CONTENT_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.doc_content_scan.handler import (
@@ -58,8 +59,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_DOC_CONTENT_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_DOC_CONTENT_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-doc-content-scan-runner"
-_HANDLER_GROUP: Final[str] = "validator-doc-content-scan-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_doc_content_scan_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_doc_content_scan_compute", service="omnibase_core"
+)
 
 # DOCUMENTATION extensions scanned — the EFFECT boundary that decides which files
 # are loaded at all. Docs only, per the OMN-13569 invariant.

--- a/src/omnibase_core/validation/hardcoded_topic/runtime_hardcoded_topic.py
+++ b/src/omnibase_core/validation/hardcoded_topic/runtime_hardcoded_topic.py
@@ -35,6 +35,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_HARDCODED_TOPIC_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.hardcoded_topic.handler import (
@@ -57,8 +58,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_HARDCODED_TOPIC_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_HARDCODED_TOPIC_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-hardcoded-topic-runner"
-_HANDLER_GROUP: Final[str] = "validator-hardcoded-topic-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_hardcoded_topic_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_hardcoded_topic_compute", service="omnibase_core"
+)
 
 # Text extensions scanned + directories pruned — the EFFECT boundary that decides
 # which files are loaded at all. Same sets as the local-paths / private-IP /

--- a/src/omnibase_core/validation/local_paths/runtime_local_paths.py
+++ b/src/omnibase_core/validation/local_paths/runtime_local_paths.py
@@ -40,6 +40,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_LOCAL_PATH_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.local_paths.handler import HandlerLocalPathsCompute
@@ -62,8 +63,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_LOCAL_PATH_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_LOCAL_PATH_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-local-paths-runner"
-_HANDLER_GROUP: Final[str] = "validator-local-paths-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_local_paths_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_local_paths_compute", service="omnibase_core"
+)
 
 # Text extensions scanned + directories pruned — same sets as the ground truth
 # (validator_local_paths). Kept here because this is the EFFECT boundary that

--- a/src/omnibase_core/validation/localhost_url/runtime_localhost_url.py
+++ b/src/omnibase_core/validation/localhost_url/runtime_localhost_url.py
@@ -35,6 +35,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_LOCALHOST_URL_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.localhost_url.handler import HandlerLocalhostUrlCompute
@@ -55,8 +56,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_LOCALHOST_URL_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_LOCALHOST_URL_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-localhost-url-runner"
-_HANDLER_GROUP: Final[str] = "validator-localhost-url-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_localhost_url_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_localhost_url_compute", service="omnibase_core"
+)
 
 # Text extensions scanned + directories pruned — the EFFECT boundary that decides
 # which files are loaded at all. Same sets as the private-IP / local-paths canaries.
@@ -151,7 +160,7 @@ class LocalhostUrlBusRunner:
             if scan_input.path not in self._results
         ]
         if missing:
-            raise RuntimeError(
+            raise RuntimeError(  # error-ok: bus-runner invariant breach (a dispatched input produced no result), not a domain validation outcome; surfaces as a non-zero CLI exit. Pre-existing, annotated under OMN-15639 as the first change to this file since the hook began flagging it.
                 "localhost-url validator did not receive results for "
                 f"{len(missing)} input(s): {', '.join(missing[:5])}"
             )
@@ -192,7 +201,7 @@ def _read_text(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:  # PermissionError is an OSError subclass
-        raise OSError(  # fail-closed: an unreadable file is not a clean file
+        raise OSError(  # error-ok: deliberately re-raises the OS-level failure so callers can distinguish an unreadable file from a clean one; fail-closed, see the docstring above. Pre-existing, annotated under OMN-15639.
             f"localhost-url validator could not read {path}: {exc}"
         ) from exc
 

--- a/src/omnibase_core/validation/no_faked_boundary/runtime_no_faked_boundary.py
+++ b/src/omnibase_core/validation/no_faked_boundary/runtime_no_faked_boundary.py
@@ -38,6 +38,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_NO_FAKED_BOUNDARY_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.no_faked_boundary.handler import (
@@ -60,8 +61,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_NO_FAKED_BOUNDARY_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_NO_FAKED_BOUNDARY_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-no-faked-boundary-runner"
-_HANDLER_GROUP: Final[str] = "validator-no-faked-boundary-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_no_faked_boundary_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_no_faked_boundary_compute", service="omnibase_core"
+)
 
 # Python source only — the EFFECT boundary that decides which files are loaded.
 _TEXT_EXTENSIONS: Final[frozenset[str]] = frozenset({".py"})

--- a/src/omnibase_core/validation/pin_hygiene/runtime_pin_hygiene.py
+++ b/src/omnibase_core/validation/pin_hygiene/runtime_pin_hygiene.py
@@ -52,6 +52,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_PIN_HYGIENE_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.pin_hygiene.handler import HandlerPinHygieneCompute
@@ -72,8 +73,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_PIN_HYGIENE_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_PIN_HYGIENE_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-pin-hygiene-runner"
-_HANDLER_GROUP: Final[str] = "validator-pin-hygiene-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_pin_hygiene_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_pin_hygiene_compute", service="omnibase_core"
+)
 
 # Only dependency-pin manifests carry sibling git pins.
 _PIN_FILENAMES: Final[frozenset[str]] = frozenset({"pyproject.toml", "uv.lock"})

--- a/src/omnibase_core/validation/private_ip/runtime_private_ip.py
+++ b/src/omnibase_core/validation/private_ip/runtime_private_ip.py
@@ -34,6 +34,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_PRIVATE_IP_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.private_ip.handler import HandlerPrivateIpCompute
@@ -54,8 +55,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_PRIVATE_IP_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_PRIVATE_IP_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-private-ip-runner"
-_HANDLER_GROUP: Final[str] = "validator-private-ip-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_private_ip_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_private_ip_compute", service="omnibase_core"
+)
 
 # Text extensions scanned + directories pruned — the EFFECT boundary that decides
 # which files are loaded at all. Same sets as the local-paths canary.

--- a/src/omnibase_core/validation/todo_marker/runtime_todo_marker.py
+++ b/src/omnibase_core/validation/todo_marker/runtime_todo_marker.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-# onex-allow-file-todo-marker OMN-13480 reason="this validator's docs/strings name the TODO/FIXME/HACK marker token as their SUBJECT; the tokens are not unfinished work"
+# onex-allow-file-todo-marker OMN-13480 reason="this validator's docs/strings name the marker tokens it scans for as their SUBJECT; they are not unfinished work. The token names are deliberately not spelled here: the file-level directive suppresses the rest of the file but not its own line, so spelling them made this very comment the sole reported violation (observed on OMN-15639)."
 """Two-transport runner for the TODO-marker COMPUTE validator (OMN-13480, §1A).
 
 The seam that makes the SAME ``HandlerTodoMarkerCompute`` run over a swappable bus
@@ -35,6 +35,7 @@ from omnibase_core.constants.constants_event_types import (
     TOPIC_VALIDATION_TODO_MARKER_SCAN_REQUESTED_CMD,
 )
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.util_consumer_group import derive_service_group_id
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_core.validation.todo_marker.handler import HandlerTodoMarkerCompute
@@ -55,8 +56,16 @@ __all__ = [
 COMMAND_TOPIC: Final[str] = TOPIC_VALIDATION_TODO_MARKER_SCAN_REQUESTED_CMD
 RESULT_TOPIC: Final[str] = TOPIC_VALIDATION_TODO_MARKER_SCAN_COMPLETED_EVENT
 
-_RUNNER_GROUP: Final[str] = "validator-todo-marker-runner"
-_HANDLER_GROUP: Final[str] = "validator-todo-marker-compute"
+# Consumer groups are derived, never literal: an ad-hoc literal is matched by no
+# MSK IAM pattern and fails at the broker with GroupAuthorizationFailedError
+# (OMN-15639). These runners are in-memory-bus only today, but they are held to
+# the same grammar so the AC3 gate can stay default-deny.
+_RUNNER_GROUP: Final[str] = derive_service_group_id(
+    "validator_todo_marker_runner", service="omnibase_core"
+)
+_HANDLER_GROUP: Final[str] = derive_service_group_id(
+    "validator_todo_marker_compute", service="omnibase_core"
+)
 
 # Text extensions scanned + directories pruned — the EFFECT boundary that decides
 # which files are loaded at all. Same sets as the local-paths / private-IP canaries.

--- a/tests/gates/__init__.py
+++ b/tests/gates/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pre-merge gate tests.
+
+Modules here are ordinary pytest tests collected by ``testpaths = ["tests"]`` in
+``pyproject.toml``, so they run inside the existing required CI job. They are kept in
+their own package because they assert cross-boundary invariants (source-tree shape,
+external policy conformance) rather than the behaviour of one unit.
+"""

--- a/tests/gates/test_consumer_group_name_authorization.py
+++ b/tests/gates/test_consumer_group_name_authorization.py
@@ -38,6 +38,7 @@ Structure
 from __future__ import annotations
 
 import ast
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from uuid import UUID
@@ -96,9 +97,53 @@ _MUST_BE_UNAUTHORIZED = (
     # Prefix-ish but not prefixed.
     "not-onex-dev.omnimarket.node.consume.v1",
     "",
+    # Trailing newline: Python's `$` matches immediately before it, so an anchor of
+    # `^...$` instead of `^...\\Z` would authorize this. MSK would not.
+    "onex-dev.omnimarket.node.consume.v1\n",
+    "onex-dev.omnimarket.node.consume.v1\n\n",
 )
 
 _SAMPLE_CORRELATION_ID = UUID("9f2c0000-0000-4000-8000-000000000000")
+
+# The eight validation runtimes bind their consumer groups at MODULE level, so the
+# env-parametrized tests below must reload them to observe a managed environment.
+_VALIDATOR_RUNTIME_SLUGS = (
+    "doc_content_scan",
+    "hardcoded_topic",
+    "local_paths",
+    "localhost_url",
+    "no_faked_boundary",
+    "pin_hygiene",
+    "private_ip",
+    "todo_marker",
+)
+
+
+def _validator_runtime_modules() -> tuple[str, ...]:
+    return tuple(
+        f"omnibase_core.validation.{slug}.runtime_{slug}"
+        for slug in _VALIDATOR_RUNTIME_SLUGS
+    )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_validator_module_state() -> Iterator[None]:
+    """Reload the validation runtimes after this module runs.
+
+    ``_real_producer_group_names`` reloads them under ``ENVIRONMENT=onex-dev`` to read
+    the names they actually mint. ``monkeypatch`` restores the env var, but NOT the
+    module-level ``_RUNNER_GROUP`` / ``_HANDLER_GROUP`` constants those reloads already
+    recomputed — so without this teardown a later test in the same worker would see
+    ``onex-dev.*`` groups instead of its own environment's, and the in-memory bus keys
+    subscriptions by group id. ``runtime_local`` and ``cli_run_node`` resolve the
+    environment lazily per call and need no cleanup.
+    """
+    import importlib
+
+    yield
+    for module_name in _validator_runtime_modules():
+        if module_name in sys.modules:
+            importlib.reload(sys.modules[module_name])
 
 
 # ---------------------------------------------------------------------------
@@ -223,20 +268,8 @@ def _real_producer_group_names(
 
     monkeypatch.setenv("ENVIRONMENT", env)
 
-    validator_modules = (
-        "doc_content_scan",
-        "hardcoded_topic",
-        "local_paths",
-        "localhost_url",
-        "no_faked_boundary",
-        "pin_hygiene",
-        "private_ip",
-        "todo_marker",
-    )
-
     names: dict[str, str] = {}
-    for slug in validator_modules:
-        module_name = f"omnibase_core.validation.{slug}.runtime_{slug}"
+    for module_name in _validator_runtime_modules():
         module = importlib.reload(importlib.import_module(module_name))
         names[f"{module_name}._RUNNER_GROUP"] = module._RUNNER_GROUP
         names[f"{module_name}._HANDLER_GROUP"] = module._HANDLER_GROUP
@@ -415,6 +448,19 @@ def test_wildcard_is_the_only_metacharacter() -> None:
     assert is_authorized_group_name("onex.anything")
     assert not is_authorized_group_name("onexZanything")
     assert not is_authorized_group_name("onex")
+
+
+@pytest.mark.unit
+def test_match_is_anchored_against_a_trailing_newline() -> None:
+    """Regression: the end anchor must be ``\\Z``, not ``$``.
+
+    Python's ``$`` matches immediately before a trailing newline, so ``^onex-dev\\..*$``
+    accepts ``"onex-dev.svc\\n"``. MSK matches the whole group name with no such
+    allowance, so a ``$`` anchor authorizes names the broker would refuse.
+    """
+    assert is_authorized_group_name("onex-dev.svc.node.consume.v1")
+    assert not is_authorized_group_name("onex-dev.svc.node.consume.v1\n")
+    assert not is_authorized_group_name("onex-dev.svc\nnot-authorized")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gates/test_consumer_group_name_authorization.py
+++ b/tests/gates/test_consumer_group_name_authorization.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-15639 AC3 — consumer-group names must be authorized by the MSK IAM policy.
+
+Why this gate exists
+--------------------
+``onex delegate --bus kafka`` died on onex-dev with ``GroupAuthorizationFailedError``
+*before publishing anything*, because ``runtime_local.py`` minted the ad-hoc group
+``runtime-local-HandlerDelegateSkill.__t.onex.cmd.omnimarket.delegate-skill.v1`` and the
+MSK IAM policy authorizes no ``runtime-local-`` prefix. Two individually-correct
+components, no field-by-field agreement, 100% runtime failure — the OMN-14208 seam
+class. A prose rule saying "keep these in sync" is not a mechanism
+(``feedback_a_rule_is_not_a_mechanism``), so this is a pre-merge gate.
+
+It is collected by ``testpaths = ["tests"]`` in ``pyproject.toml`` and therefore runs
+inside the existing required CI job. No new workflow and no new required status check
+were added — a standalone workflow would have to be wired into branch protection
+separately to gate anything.
+
+Structure
+---------
+- **A (static, default-deny):** no module under ``src/`` may bind a consumer-group
+  name from a string literal or f-string. This is the defect class itself, and it is
+  fail-closed: a newly-added literal fails without anyone remembering to update a list.
+- **B (real producers):** the group names the migrated call sites actually mint —
+  obtained by importing those modules, not by re-deriving a surrogate — are authorized
+  under every managed environment.
+- **C (reserved prefixes):** every reserved prefix yields an authorized name when
+  scoped, and refuses to render when unscoped (the bare prefix is unauthorized because
+  the IAM glob requires the trailing separator).
+- **D (matcher semantics):** the falsifier. The exact OMN-15639 defect names are
+  rejected. A substring matcher would accept them (they contain ``onex.``) and would
+  make this whole gate vacuous.
+- **E (pin integrity):** the pinned pattern set still matches its recorded digest.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+import omnibase_core
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.enums.enum_reserved_group_prefix import EnumReservedGroupPrefix
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.util_consumer_group import (
+    compute_consumer_group_id,
+    compute_pattern_set_digest,
+    derive_prefixed_group_id,
+    derive_service_group_id,
+    is_authorized_group_name,
+    load_authorized_group_patterns,
+    load_iam_pattern_document,
+    load_managed_environments,
+)
+from omnibase_core.models.event_bus.model_consumer_group_scope import (
+    ModelConsumerGroupScope,
+)
+
+SRC_ROOT = Path(omnibase_core.__file__).resolve().parent
+
+# Keyword arguments whose value names a Kafka consumer group.
+#
+# Deliberately excludes the bare keyword ``group``: ``EventBusInmemory(group="default")``
+# takes a source-header label, and ``runtime/transport/runtime_transport_conformance.py``
+# is a pytest conformance suite that lives under ``src/`` and passes ``group="g-order"``
+# and friends. Neither is a Kafka consumer group, and widening the keyword set to catch
+# them would only manufacture an exclusion list.
+_GROUP_KEYWORDS = frozenset({"group_id", "consumer_group", "kafka_group_id"})
+
+# Dict-literal keys that carry a consumer group. ``"group.id"`` is the librdkafka
+# config key: ``cli_run_node.py`` used ``Consumer({"group.id": f"onex-run-node-{...}"})``,
+# which a keyword-only scan would miss entirely — that call site is the seam's own
+# worked ephemeral example.
+_GROUP_DICT_KEYS = frozenset({"group.id", "group_id", "consumer_group"})
+
+# The exact names observed failing in the field, plus the bare reserved prefix.
+# Every one of these MUST be rejected; each is a distinct way a lazy matcher passes.
+_MUST_BE_UNAUTHORIZED = (
+    # Substring trap: contains "onex." but does not begin with it.
+    "runtime-local-HandlerDelegateSkill.__t.onex.cmd.omnimarket.delegate-skill.v1",
+    # The literal at runtime_local.py:563 / :1195 before OMN-15639.
+    "runtime-local-terminal",
+    # The literal at runtime_local.py:1180 before OMN-15639.
+    "runtime-local-HandlerDelegateSkill",
+    # The dict-literal value at cli_run_node.py:213 before OMN-15639.
+    "onex-run-node-9f2c0000-0000-4000-8000-000000000000",
+    # Reserved prefix without its trailing separator: "pattern-b-broker-*" needs the "-".
+    "pattern-b-broker",
+    "phase5-msk-smoke",
+    # Prefix-ish but not prefixed.
+    "not-onex-dev.omnimarket.node.consume.v1",
+    "",
+)
+
+_SAMPLE_CORRELATION_ID = UUID("9f2c0000-0000-4000-8000-000000000000")
+
+
+# ---------------------------------------------------------------------------
+# A — static default-deny scan
+# ---------------------------------------------------------------------------
+
+
+def _python_sources() -> Iterator[Path]:
+    yield from sorted(SRC_ROOT.rglob("*.py"))
+
+
+def _module_level_string_bindings(tree: ast.Module) -> dict[str, ast.expr]:
+    """Map module-level names bound to a string literal or f-string.
+
+    Without this, the eight validation runtimes escape the scan: they bind
+    ``_RUNNER_GROUP: Final[str] = "validator-x-runner"`` at module level and then pass
+    ``group_id=_RUNNER_GROUP``, so the keyword's value is a ``Name``, not a literal.
+    """
+    bindings: dict[str, ast.expr] = {}
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+            value = node.value
+        if value is None or not _is_string_valued(value):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                bindings[target.id] = value
+    return bindings
+
+
+def _is_string_valued(node: ast.expr) -> bool:
+    """True for a ``str`` constant or an f-string.
+
+    Scoped to string-valued expressions on purpose. ``model_event_bus_config.py:150``
+    passes ``group_id=uuid4()`` — a UUID field, not a Kafka group. A blanket
+    "the value must be a call to the canonical util" rule would force ``uuid4`` onto an
+    allowlist, which weakens the gate. Restricting to string values has zero false
+    positives here while still failing closed on any newly-added literal.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return True
+    return isinstance(node, ast.JoinedStr)
+
+
+def _literal_group_bindings(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, description)`` for every literal-valued group name in ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    module_strings = _module_level_string_bindings(tree)
+    findings: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg in _GROUP_KEYWORDS:
+            if _is_string_valued(node.value):
+                findings.append((node.value.lineno, f"{node.arg}=<string literal>"))
+            elif isinstance(node.value, ast.Name) and node.value.id in module_strings:
+                findings.append(
+                    (
+                        node.value.lineno,
+                        f"{node.arg}={node.value.id} "
+                        f"(module-level string constant at line "
+                        f"{module_strings[node.value.id].lineno})",
+                    )
+                )
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values, strict=True):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value in _GROUP_DICT_KEYS
+                    and _is_string_valued(value)
+                ):
+                    findings.append((value.lineno, f'"{key.value}": <string literal>'))
+    return findings
+
+
+@pytest.mark.unit
+def test_no_literal_consumer_group_names_in_src() -> None:
+    """Default-deny: consumer-group names are derived, never written as literals.
+
+    A literal group name is unauthorizable by construction — nothing forces it to lead
+    with an IAM-matched environment token. Derivation through
+    ``util_consumer_group`` is the only way the name is guaranteed to be authorized,
+    so the absence of literals is the enforceable form of AC3.
+    """
+    violations: list[str] = []
+    for path in _python_sources():
+        for lineno, description in _literal_group_bindings(path):
+            violations.append(
+                f"{path.relative_to(SRC_ROOT.parent)}:{lineno}: {description}"
+            )
+
+    assert not violations, (
+        "Consumer-group names must be derived via "
+        "omnibase_core.event_bus.util_consumer_group, never written as string literals "
+        "(OMN-15639: an ad-hoc literal is not matched by the MSK IAM pattern set and "
+        "fails at the broker with GroupAuthorizationFailedError before publishing).\n"
+        + "\n".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# B — real producers, real names
+# ---------------------------------------------------------------------------
+
+
+def _real_producer_group_names(
+    monkeypatch: pytest.MonkeyPatch, env: str
+) -> dict[str, str]:
+    """Import the migrated call sites under ``env`` and return the names they mint.
+
+    Modules are re-imported after the environment is set so that module-level
+    ``Final`` group constants are recomputed. These are the production symbols, not
+    re-derived copies — a surrogate here would make the gate vacuous
+    (``feedback_test_the_artifact_that_runs``).
+    """
+    import importlib
+
+    monkeypatch.setenv("ENVIRONMENT", env)
+
+    validator_modules = (
+        "doc_content_scan",
+        "hardcoded_topic",
+        "local_paths",
+        "localhost_url",
+        "no_faked_boundary",
+        "pin_hygiene",
+        "private_ip",
+        "todo_marker",
+    )
+
+    names: dict[str, str] = {}
+    for slug in validator_modules:
+        module_name = f"omnibase_core.validation.{slug}.runtime_{slug}"
+        module = importlib.reload(importlib.import_module(module_name))
+        names[f"{module_name}._RUNNER_GROUP"] = module._RUNNER_GROUP
+        names[f"{module_name}._HANDLER_GROUP"] = module._HANDLER_GROUP
+
+    runtime_local = importlib.reload(
+        importlib.import_module("omnibase_core.runtime.runtime_local")
+    )
+    names["runtime_local.terminal"] = runtime_local.derive_runtime_local_group_id(
+        runtime_local.TERMINAL_CONSUMER_NODE_NAME
+    )
+    names["runtime_local.handler"] = runtime_local.derive_runtime_local_group_id(
+        "HandlerDelegateSkill"
+    )
+
+    cli_run_node = importlib.reload(
+        importlib.import_module("omnibase_core.cli.cli_run_node")
+    )
+    names["cli_run_node.ephemeral"] = cli_run_node.derive_run_node_group_id(
+        _SAMPLE_CORRELATION_ID
+    )
+    return names
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env", load_managed_environments())
+def test_real_producer_group_names_are_authorized(
+    monkeypatch: pytest.MonkeyPatch, env: str
+) -> None:
+    """Every group name the migrated producers mint is IAM-authorized."""
+    names = _real_producer_group_names(monkeypatch, env)
+    assert names, "no producer names collected — the scan would be vacuous"
+
+    unauthorized = {
+        site: name for site, name in names.items() if not is_authorized_group_name(name)
+    }
+    assert not unauthorized, (
+        f"consumer-group names minted for managed environment {env!r} are not matched "
+        f"by any pattern in {list(load_authorized_group_patterns())}:\n"
+        + "\n".join(f"  {site}: {name}" for site, name in sorted(unauthorized.items()))
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env", load_managed_environments())
+def test_managed_environment_token_leads_and_is_authorized(env: str) -> None:
+    """Structural argument behind assertion B: authorization is decided by the env token.
+
+    Identity-derived names lead with ``"<env>."``. If that prefix is itself authorized,
+    every derived name under that environment is authorized regardless of service or
+    node name. Adding an environment to ``managed_environments`` without matching IAM
+    coverage therefore fails here at CI time, not at runtime.
+    """
+    derived = compute_consumer_group_id(
+        env=env,
+        service="omnimarket",
+        node_name="delegate_skill",
+        version="v1",
+        purpose=EnumConsumerGroupPurpose.CONSUME,
+    )
+    assert derived.startswith(f"{env}."), (
+        f"identity-derived group {derived!r} does not lead with the environment token"
+    )
+    assert is_authorized_group_name(derived), (
+        f"managed environment {env!r} has no IAM coverage: {derived!r} is matched by "
+        f"none of {list(load_authorized_group_patterns())}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env", load_managed_environments())
+@pytest.mark.parametrize("purpose", list(EnumConsumerGroupPurpose))
+def test_every_purpose_stays_authorized(
+    env: str, purpose: EnumConsumerGroupPurpose
+) -> None:
+    """Purpose is a group-ID component; no purpose value may break authorization."""
+    derived = compute_consumer_group_id(
+        env=env,
+        service="omnibase_core",
+        node_name="node",
+        version="v1",
+        purpose=purpose,
+    )
+    assert is_authorized_group_name(derived)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env", load_managed_environments())
+def test_scoped_names_stay_authorized(
+    monkeypatch: pytest.MonkeyPatch, env: str
+) -> None:
+    """Topic and instance scoping must not displace the leading environment token."""
+    monkeypatch.setenv("ENVIRONMENT", env)
+    scoped = derive_service_group_id(
+        "delegate_skill",
+        service="omnimarket",
+        scope=ModelConsumerGroupScope(
+            topic="onex.cmd.omnimarket.delegate-skill.v1",
+            ephemeral_tag="terminal",
+            correlation_id=_SAMPLE_CORRELATION_ID,
+        ),
+    )
+    assert is_authorized_group_name(scoped), scoped
+
+
+# ---------------------------------------------------------------------------
+# C — reserved prefixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", list(EnumReservedGroupPrefix))
+def test_reserved_prefix_with_scope_is_authorized(
+    prefix: EnumReservedGroupPrefix,
+) -> None:
+    """A scoped reserved-prefix name is authorized, and matches its declared glob."""
+    derived = derive_prefixed_group_id(
+        prefix,
+        ModelConsumerGroupScope(
+            ephemeral_tag="terminal", correlation_id=_SAMPLE_CORRELATION_ID
+        ),
+    )
+    assert derived.startswith(f"{prefix.value}{prefix.separator()}")
+    assert is_authorized_group_name(derived), derived
+    assert prefix.authorized_glob() in load_authorized_group_patterns(), (
+        f"reserved prefix {prefix.value!r} declares glob "
+        f"{prefix.authorized_glob()!r}, which is absent from the pinned IAM pattern set"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", list(EnumReservedGroupPrefix))
+def test_reserved_prefix_without_scope_refuses(
+    prefix: EnumReservedGroupPrefix,
+) -> None:
+    """Fail-closed: the bare prefix is unauthorized, so minting it must raise.
+
+    ``pattern-b-broker-*`` requires the trailing ``-``. Rendering the bare
+    ``pattern-b-broker`` would produce a name the broker refuses, so the derivation
+    refuses first rather than deferring the failure to runtime.
+    """
+    assert not is_authorized_group_name(prefix.value), (
+        f"bare prefix {prefix.value!r} is authorized — the trailing-separator "
+        f"requirement of {prefix.authorized_glob()!r} is not being enforced"
+    )
+    with pytest.raises(ModelOnexError, match="requires a non-empty scope"):
+        derive_prefixed_group_id(prefix, ModelConsumerGroupScope())
+
+
+# ---------------------------------------------------------------------------
+# D — matcher semantics (the falsifier)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("group_name", _MUST_BE_UNAUTHORIZED)
+def test_known_unauthorized_names_are_rejected(group_name: str) -> None:
+    """The matcher does whole-name glob matching, not substring matching.
+
+    ``runtime-local-HandlerDelegateSkill.__t.onex.cmd...`` contains ``onex.`` and would
+    pass a substring test while still failing at the broker. If this test ever passes
+    trivially, the gate above is vacuous.
+    """
+    assert not is_authorized_group_name(group_name), (
+        f"{group_name!r} must NOT be authorized — it is (or is shaped like) a name "
+        f"the MSK broker rejected with GroupAuthorizationFailedError"
+    )
+
+
+@pytest.mark.unit
+def test_wildcard_is_the_only_metacharacter() -> None:
+    """``.`` in a pattern is a literal, not a regex any-char.
+
+    ``onex.*`` must not match ``onexZfoo``; if it did, the matcher would be a regex
+    evaluator and the authorized surface would be far wider than the IAM policy's.
+    """
+    assert is_authorized_group_name("onex.anything")
+    assert not is_authorized_group_name("onexZanything")
+    assert not is_authorized_group_name("onex")
+
+
+# ---------------------------------------------------------------------------
+# E — pin integrity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pinned_pattern_set_matches_recorded_digest() -> None:
+    """The pinned mirror still matches its recorded digest and expected contents.
+
+    ``load_iam_pattern_document`` already fails closed on digest drift; this asserts it
+    explicitly and pins the exact six patterns, so silently widening the authorized
+    surface requires editing this test and is visible in review.
+    """
+    document = load_iam_pattern_document()
+    patterns = load_authorized_group_patterns()
+
+    assert patterns == (
+        "onex-dev.*",
+        "local.runtime_config.*",
+        "pattern-b-broker-*",
+        "onex.*",
+        "omninode.*",
+        "phase5-msk-smoke-*",
+    )
+    assert document.pattern_set_sha256 == compute_pattern_set_digest(patterns)
+    assert (
+        document.source.file_sha256
+        == "46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528"
+    )
+    assert document.source.path == ("aws/cluster-dev/managed-data-plane.auto.tfvars")
+
+
+@pytest.mark.unit
+def test_pinned_pattern_file_is_git_tracked_and_ships_in_the_wheel() -> None:
+    """The mirror must be tracked by git and inside a packaged directory.
+
+    Regression guard for a real miss on this ticket: the file was first placed at
+    ``src/omnibase_core/data/consumer_group_iam_patterns.yaml``, which
+    ``.gitignore:251`` (``data/``, for Docker runtime data dirs) silently excluded.
+    Every local run passed against the untracked working-tree copy while the file was
+    absent from the commit — the gate would have shipped green and then failed at
+    collection on any fresh checkout. Asserting git-trackedness here makes that
+    failure mode impossible to reintroduce.
+
+    ``[tool.hatch.build] artifacts`` globs ``src/omnibase_core/**/*.yaml``, so any
+    tracked YAML under the package ships in the wheel; being tracked is the whole
+    remaining condition.
+    """
+    import os
+    import subprocess
+
+    from omnibase_core.validators.no_unguarded_git_subprocess import (
+        scrub_git_location_env,
+    )
+
+    resource_path = SRC_ROOT / "contracts" / "consumer_group_iam_patterns.yaml"
+    assert resource_path.is_file(), resource_path
+
+    repo_root = SRC_ROOT.parent.parent
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", str(resource_path)],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        env=scrub_git_location_env(os.environ),
+    )
+    assert tracked.returncode == 0, (
+        f"{resource_path} is not tracked by git — it would be missing from a fresh "
+        f"checkout and from the wheel. stderr: {tracked.stderr.decode().strip()}"
+    )

--- a/tests/gates/test_consumer_group_name_authorization.py
+++ b/tests/gates/test_consumer_group_name_authorization.py
@@ -444,7 +444,7 @@ def test_pinned_pattern_set_matches_recorded_digest() -> None:
     assert document.pattern_set_sha256 == compute_pattern_set_digest(patterns)
     assert (
         document.source.file_sha256
-        == "46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528"
+        == "46b1742a195afffc5b6291d51d2be28b941ef355b79983e12a3c719cee5fd528"  # pragma: allowlist secret
     )
     assert document.source.path == ("aws/cluster-dev/managed-data-plane.auto.tfvars")
 

--- a/tests/unit/cli/test_cli_run_node_envelope.py
+++ b/tests/unit/cli/test_cli_run_node_envelope.py
@@ -26,6 +26,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from omnibase_core.event_bus.util_consumer_group import INSTANCE_SCOPE_INFIX
+
 pytestmark = pytest.mark.unit
 
 
@@ -238,8 +240,11 @@ class TestCliEnvelopeRoundTrip:
 
         def _make_consumer(config: dict[str, Any]) -> MagicMock:
             consumer = MagicMock()
+            # OMN-15639: the group ID is now identity-derived and carries the
+            # correlation UUID as a `.__i.` scope discriminator instead of the
+            # unauthorized `onex-run-node-<uuid>` literal.
             group_id = str(config.get("group.id", ""))
-            corr = group_id.removeprefix("onex-run-node-")
+            corr = group_id.rpartition(INSTANCE_SCOPE_INFIX)[2]
 
             topic_metadata = MagicMock()
             topic_metadata.partitions = {0: object()}

--- a/tests/unit/contracts/test_parser_event_bus_shapes.py
+++ b/tests/unit/contracts/test_parser_event_bus_shapes.py
@@ -75,6 +75,23 @@ def test_classic_and_nested_shapes_merge() -> None:
 
 
 @pytest.mark.unit
+def test_nested_subscribe_unknown_key_is_rejected() -> None:
+    """Regression: unknown nested keys were silently dropped.
+
+    The subscription model is built from ``topic`` alone, so an unrecognized key never
+    reached ``ModelEventBusSubscription``'s ``extra="forbid"`` — it was discarded here.
+    A silent subscription-shape drop is precisely what this parser exists to prevent.
+    """
+    contract = {
+        "event_bus": {
+            "subscribe": [{"topic": "onex.evt.bar.v1", "subscrbe_group": "typo"}],
+        },
+    }
+    with pytest.raises(EventBusContractShapeError, match="subscrbe_group"):
+        parse_event_bus(contract)
+
+
+@pytest.mark.unit
 def test_nested_shape_missing_topic_field_raises() -> None:
     contract = {"event_bus": {"subscribe": [{"not_a_topic": "x"}]}}
     with pytest.raises(EventBusContractShapeError, match="topic"):

--- a/tests/unit/contracts/test_parser_event_bus_shapes.py
+++ b/tests/unit/contracts/test_parser_event_bus_shapes.py
@@ -23,15 +23,27 @@ def test_classic_subscribe_topics_shape_parses() -> None:
 
 @pytest.mark.unit
 def test_nested_subscribe_topic_shape_parses() -> None:
+    contract = {"event_bus": {"subscribe": [{"topic": "onex.evt.bar.v1"}]}}
+    parsed = parse_event_bus(contract)
+    assert parsed.subscriptions == [
+        ModelEventBusSubscription(topic="onex.evt.bar.v1"),
+    ]
+
+
+@pytest.mark.unit
+def test_nested_subscribe_consumer_group_is_rejected() -> None:
+    """OMN-15639: the field was parsed and never read; it is now a loud failure.
+
+    Accepting it would restore the ad-hoc naming surface that let a contract mint a
+    consumer group no MSK IAM pattern authorizes.
+    """
     contract = {
         "event_bus": {
             "subscribe": [{"topic": "onex.evt.bar.v1", "consumer_group": "g1"}],
         },
     }
-    parsed = parse_event_bus(contract)
-    assert parsed.subscriptions == [
-        ModelEventBusSubscription(topic="onex.evt.bar.v1", consumer_group="g1"),
-    ]
+    with pytest.raises(EventBusContractShapeError, match="consumer_group"):
+        parse_event_bus(contract)
 
 
 @pytest.mark.unit
@@ -52,20 +64,20 @@ def test_classic_and_nested_shapes_merge() -> None:
     contract = {
         "event_bus": {
             "subscribe_topics": ["onex.evt.foo.v1"],
-            "subscribe": [{"topic": "onex.evt.bar.v1", "consumer_group": "g1"}],
+            "subscribe": [{"topic": "onex.evt.bar.v1"}],
         },
     }
     parsed = parse_event_bus(contract)
     assert parsed.subscriptions == [
         ModelEventBusSubscription(topic="onex.evt.foo.v1"),
-        ModelEventBusSubscription(topic="onex.evt.bar.v1", consumer_group="g1"),
+        ModelEventBusSubscription(topic="onex.evt.bar.v1"),
     ]
 
 
 @pytest.mark.unit
 def test_nested_shape_missing_topic_field_raises() -> None:
-    contract = {"event_bus": {"subscribe": [{"consumer_group": "g1"}]}}
-    with pytest.raises(EventBusContractShapeError):
+    contract = {"event_bus": {"subscribe": [{"not_a_topic": "x"}]}}
+    with pytest.raises(EventBusContractShapeError, match="topic"):
         parse_event_bus(contract)
 
 

--- a/tests/unit/event_bus/test_event_bus_inmemory.py
+++ b/tests/unit/event_bus/test_event_bus_inmemory.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
@@ -86,6 +87,26 @@ class TestEventBusInmemoryPubSub:
         await unsub()
         await bus.publish("events.test", b"key2", b"value2")
         assert len(received) == 1  # no new messages after unsubscribe
+
+        await bus.close()
+
+    @pytest.mark.asyncio
+    async def test_subscriber_model_onex_error_propagates(self) -> None:
+        bus = EventBusInmemory(environment="test", group="unit")
+        await bus.start()
+
+        async def handler(msg: ModelEventMessage) -> None:
+            raise ModelOnexError(
+                "subscriber domain failure",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+
+        await bus.subscribe("events.test", group_id="domain-errors", on_message=handler)
+
+        with pytest.raises(ModelOnexError, match="subscriber domain failure"):
+            await bus.publish("events.test", None, b"payload")
+
+        assert ("events.test", "domain-errors") not in bus._subscriber_failures
 
         await bus.close()
 

--- a/tests/unit/event_bus/test_util_consumer_group.py
+++ b/tests/unit/event_bus/test_util_consumer_group.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the canonical consumer-group derivation utility (OMN-15639).
+
+The authorization-conformance assertions live in
+``tests/gates/test_consumer_group_name_authorization.py``. This module covers the
+derivation mechanics themselves: normalization, truncation determinism, idempotent
+scope infixes, and byte-compatibility with the ``omnibase_infra`` implementation this
+module replaces as the single canonical home.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import UUID
+
+import pytest
+
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.enums.enum_reserved_group_prefix import EnumReservedGroupPrefix
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.util_consumer_group import (
+    DEFAULT_ENVIRONMENT,
+    KAFKA_CONSUMER_GROUP_MAX_LENGTH,
+    apply_instance_discriminator,
+    apply_topic_discriminator,
+    compute_consumer_group_id,
+    compute_pattern_set_digest,
+    derive_consumer_group_id,
+    derive_prefixed_group_id,
+    derive_service_group_id,
+    normalize_kafka_identifier,
+    resolve_environment_token,
+)
+from omnibase_core.models.event_bus.model_consumer_group_scope import (
+    ModelConsumerGroupScope,
+)
+
+_CORRELATION = UUID("9f2c0000-0000-4000-8000-000000000000")
+
+
+def _identity(**overrides: str) -> dict[str, str]:
+    """The four canonical identity components, as keyword arguments."""
+    fields = {
+        "env": "onex-dev",
+        "service": "omnimarket",
+        "node_name": "delegate_skill",
+        "version": "v1",
+    }
+    fields.update(overrides)
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# normalize_kafka_identifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("My Service!!", "my_service"),
+        ("foo..bar__baz", "foo.bar_baz"),
+        ("  UPPER_Case-Test  ", "upper_case-test"),
+        ("valid.consumer-group_id", "valid.consumer-group_id"),
+        ("---leading-and-trailing---", "leading-and-trailing"),
+    ],
+)
+def test_normalize_matches_documented_rules(raw: str, expected: str) -> None:
+    assert normalize_kafka_identifier(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw", ["", "@#$%^&*()", "..."])
+def test_normalize_rejects_empty_result(raw: str) -> None:
+    with pytest.raises(ModelOnexError):
+        normalize_kafka_identifier(raw)
+
+
+@pytest.mark.unit
+def test_normalize_truncation_is_deterministic_and_hashes_the_raw_input() -> None:
+    """Truncation hashes the PRE-normalization value.
+
+    Byte-compatible with the infra implementation this replaces. Hashing the
+    normalized form instead would collide two distinct inputs that normalize to the
+    same 246-char prefix.
+    """
+    raw = "A" * 300
+    result = normalize_kafka_identifier(raw)
+    assert len(result) == KAFKA_CONSUMER_GROUP_MAX_LENGTH
+    expected_suffix = hashlib.sha256(raw.encode()).hexdigest()[:8]
+    assert result == f"{'a' * 246}_{expected_suffix}"
+    assert normalize_kafka_identifier(raw) == result
+
+
+# ---------------------------------------------------------------------------
+# compute_consumer_group_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_canonical_format_and_component_order() -> None:
+    assert (
+        compute_consumer_group_id(**_identity())
+        == "onex-dev.omnimarket.delegate_skill.consume.v1"
+    )
+
+
+@pytest.mark.unit
+def test_purpose_is_a_component() -> None:
+    assert (
+        compute_consumer_group_id(
+            **_identity(), purpose=EnumConsumerGroupPurpose.INTROSPECTION
+        )
+        == "onex-dev.omnimarket.delegate_skill.introspection.v1"
+    )
+
+
+@pytest.mark.unit
+def test_components_are_normalized() -> None:
+    assert (
+        compute_consumer_group_id(
+            **_identity(env="DEV", service="Omni Intelligence", version="V1.0.0")
+        )
+        == "dev.omni_intelligence.delegate_skill.consume.v1.0.0"
+    )
+
+
+@pytest.mark.unit
+def test_long_identity_truncates_with_pipe_joined_hash() -> None:
+    """Truncation hash input is ``env|service|node|purpose|version``.
+
+    Pinned because ``omnibase_infra`` used exactly this input; a different join would
+    silently rename every over-long group when infra switches to this module.
+    """
+    identity = _identity(env="development", service="a" * 150, node_name="b" * 150)
+    result = compute_consumer_group_id(**identity)
+    assert len(result) == KAFKA_CONSUMER_GROUP_MAX_LENGTH
+    expected_suffix = hashlib.sha256(
+        f"development|{'a' * 150}|{'b' * 150}|consume|v1".encode()
+    ).hexdigest()[:8]
+    assert result.endswith(f"_{expected_suffix}")
+
+
+# ---------------------------------------------------------------------------
+# scope infixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_instance_discriminator_is_idempotent() -> None:
+    base = "onex-dev.svc.node.consume.v1"
+    once = apply_instance_discriminator(base, "pod-7")
+    assert once == f"{base}.__i.pod-7"
+    assert apply_instance_discriminator(once, "pod-7") == once
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_blank_discriminators_are_no_ops(blank: str | None) -> None:
+    base = "onex-dev.svc.node.consume.v1"
+    assert apply_instance_discriminator(base, blank) == base
+    assert apply_topic_discriminator(base, blank) == base
+
+
+@pytest.mark.unit
+def test_topic_and_instance_scopes_compose_in_a_fixed_order() -> None:
+    derived = derive_consumer_group_id(
+        **_identity(),
+        scope=ModelConsumerGroupScope(
+            topic="onex.cmd.omnimarket.delegate-skill.v1",
+            ephemeral_tag="terminal",
+            correlation_id=_CORRELATION,
+        ),
+    )
+    assert derived == (
+        "onex-dev.omnimarket.delegate_skill.consume.v1"
+        ".__t.onex.cmd.omnimarket.delegate-skill.v1"
+        f".__i.terminal-{_CORRELATION}"
+    )
+
+
+@pytest.mark.unit
+def test_scope_none_and_empty_scope_agree() -> None:
+    assert derive_consumer_group_id(**_identity()) == derive_consumer_group_id(
+        **_identity(), scope=ModelConsumerGroupScope()
+    )
+
+
+@pytest.mark.unit
+def test_discriminator_tokens_skip_blanks_and_keep_order() -> None:
+    scope = ModelConsumerGroupScope(
+        ephemeral_tag="  terminal  ",
+        correlation_id=_CORRELATION,
+        instance_token="",
+    )
+    assert scope.discriminator_tokens() == ("terminal", str(_CORRELATION))
+    assert not scope.is_empty()
+    assert ModelConsumerGroupScope().is_empty()
+
+
+# ---------------------------------------------------------------------------
+# reserved prefixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_reserved_prefix_reproduces_the_seam_example() -> None:
+    assert (
+        derive_prefixed_group_id(
+            EnumReservedGroupPrefix.PATTERN_B_BROKER,
+            ModelConsumerGroupScope(
+                ephemeral_tag="terminal", correlation_id=_CORRELATION
+            ),
+        )
+        == f"pattern-b-broker-terminal-{_CORRELATION}"
+    )
+
+
+@pytest.mark.unit
+def test_dotted_reserved_prefix_uses_a_dot_separator() -> None:
+    assert (
+        derive_prefixed_group_id(
+            EnumReservedGroupPrefix.LOCAL_RUNTIME_CONFIG,
+            ModelConsumerGroupScope(ephemeral_tag="ingress"),
+        )
+        == "local.runtime_config.ingress"
+    )
+
+
+@pytest.mark.unit
+def test_reserved_prefix_requires_scope() -> None:
+    with pytest.raises(ModelOnexError, match="requires a non-empty scope"):
+        derive_prefixed_group_id(
+            EnumReservedGroupPrefix.PHASE5_MSK_SMOKE, ModelConsumerGroupScope()
+        )
+
+
+# ---------------------------------------------------------------------------
+# environment resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_environment_defaults_to_local_when_unset_or_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset ENVIRONMENT must not masquerade as a managed environment."""
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    assert resolve_environment_token() == DEFAULT_ENVIRONMENT
+    monkeypatch.setenv("ENVIRONMENT", "   ")
+    assert resolve_environment_token() == DEFAULT_ENVIRONMENT
+
+
+@pytest.mark.unit
+def test_environment_is_read_and_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "ONEX-Dev")
+    assert resolve_environment_token() == "onex-dev"
+    assert derive_service_group_id("node", service="svc").startswith("onex-dev.")
+
+
+# ---------------------------------------------------------------------------
+# pin digest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pattern_set_digest_has_no_trailing_newline() -> None:
+    """Pinned because the digest is the drift detector for the IAM mirror."""
+    patterns = ("a", "b")
+    assert compute_pattern_set_digest(patterns) == (hashlib.sha256(b"a\nb").hexdigest())


### PR DESCRIPTION
Evidence-Ticket: OMN-15639
Evidence-Source: 13ce55e78e956d4a86a3c29f8256ee3d63eccd15

## OMN-15639 — consumer-group names the runtime mints are now authorized by construction, and a gate proves it

**Ticket:** OMN-15639 · **proof_class at merge: `code-only`** (see Residual proof leg — this PR does not and cannot close the ticket's live-readback AC).

### The defect

`onex delegate --bus kafka` — the canonical delegation path — died in-cluster on onex-dev with `GroupAuthorizationFailedError` on:

```
runtime-local-HandlerDelegateSkill.__t.onex.cmd.omnimarket.delegate-skill.v1
```

**before any publish.** Nothing reached the bus; `delegation_events` has 0 rows ever on onex-dev.

Both sides of the seam were confirmed in source:

| Side | Fact |
|---|---|
| A — who mints the name | `runtime_local.py:1180` minted `f"runtime-local-{handler_name}"`; `:563` / `:1195` minted `"runtime-local-terminal"`; `cli_run_node.py:213` minted `f"onex-run-node-{correlation_id}"` |
| B — what IAM authorizes | `omninode_infra aws/cluster-dev/managed-data-plane.auto.tfvars:33-42` → `onex-dev.*`, `local.runtime_config.*`, `pattern-b-broker-*`, `onex.*`, `omninode.*`, `phase5-msk-smoke-*` |

No pattern matches a `runtime-local-` prefix. `onex.*` does **not** rescue it: MSK IAM resource patterns are whole-name globs, and the failing name *contains* `onex.` without *beginning* with it. Textbook OMN-14208 seam mismatch — two individually-correct components, no field-by-field agreement, 100% runtime failure.

### What this implements

Operator ruling 2026-08-02, **option (c)** (ledger `docs/tracking/ROLLING_WORK_LEDGER.md:11694`): kill the explicit `group_id` overrides and route every producer through one canonical derivation. Explicitly **not** option (a) (IAM allowlist growth — rejected as allowlist-growth anti-pattern, and an AWS/IAM mutation outside the onex-dev deploy carve-out) and **not** option (b) (a third derivation copy).

**No terraform / IAM / AWS mutation in this PR.** The IAM pattern set is *mirrored read-only* and pinned by digest.

### Seam table

| Seam | Before | After | Matched by |
|---|---|---|---|
| Canonical util home | `omnibase_infra.utils.util_consumer_group` + an inlined copy in core's `event_bus_inmemory` + ad-hoc literals (3 derivations) | `omnibase_core.event_bus.util_consumer_group` (1) | infra imports it; lanes 3/4/5 |
| `compute_consumer_group_id` signature | `(identity: ModelNodeIdentity, purpose)` | `(*, env, service, node_name, version, purpose)` — keyword-only components | callers unpack their identity object |
| `apply_instance_discriminator` | `(group_id, instance_id)` | `(group_id, instance_token)` — rename only | positional callers unaffected |
| Group-ID grammar | ad-hoc | `{env}.{service}.{node}.{purpose}.{version}` + `.__t.<topic>` + `.__i.<discriminator>` | byte-compatible with infra's |
| Truncation hash input | `env\|service\|node\|purpose\|version` | unchanged | pinned by test |
| IAM pattern set | (none in core) | `src/omnibase_core/contracts/consumer_group_iam_patterns.yaml`, `pattern_set_sha256=e75f830b…` | pinned to tfvars sha256 `46b1742a…`, last-touch `39fcff2a`, verified live 2026-08-02 |
| Contract field | `event_bus.subscribe[*].consumer_group` parsed into `ModelEventBusSubscription`, never read | removed; now **rejected loudly** | zero contracts in any repo declared it |

**Why components, not a `ProtocolNodeIdentity` parameter:** the OMN-14340 import-layering ratchet hard-fails any *new* core module importing the `protocols` hub. A protocol-typed parameter requires that import. Unpacking at the call site keeps the util free of model *and* protocol coupling. `event_bus_inmemory.py` (already a baselined protocols importer) destructures there.

### Changes

- **New** `event_bus/util_consumer_group.py` — normalization, derivation, scope infixes, reserved IAM prefixes, `is_authorized_group_name`.
- **New** `enums/enum_reserved_group_prefix.py`, `models/event_bus/model_consumer_group_scope.py`, `model_consumer_group_iam_patterns.py`, `model_consumer_group_iam_source.py`.
- **New** `contracts/consumer_group_iam_patterns.yaml` — pinned mirror + provenance + drift digest.
- **Collapsed** the duplicate derivation inlined in `event_bus_inmemory.py`.
- **Migrated all 20 literal-minting sites**: `runtime_local` (3), `cli_run_node`'s `Consumer({"group.id": …})` dict literal (1), and the 16 `_RUNNER_GROUP`/`_HANDLER_GROUP` constants across 8 validation runtimes.
- **Removed** the dead contract field; 3 parser tests flipped from "parses" to "rejects".

### AC3 — the gate (`tests/gates/test_consumer_group_name_authorization.py`, 27 tests)

Wired as a pre-merge gate in the same PR per rule 5. **No new workflow and no new required status context** — `pyproject.toml testpaths = ["tests"]` means it is collected by the existing required job. A standalone workflow would have to be separately wired into branch protection to gate anything.

- **A — static default-deny.** No module under `src/` may bind a consumer-group name from a string literal, f-string, or a module-level constant holding one. Fail-closed: a newly-added literal fails without anyone updating a list.
- **B — real producers.** Imports the migrated modules and asserts the names *they actually mint* are authorized under every managed environment. Not a re-derived surrogate.
- **C — reserved prefixes.** Each yields an authorized name when scoped, and **raises** when unscoped (`pattern-b-broker-*` requires the trailing `-`, so the bare prefix is unauthorized — fail at mint time, not at the broker).
- **D — matcher semantics (the falsifier).** The exact field-observed names are rejected, including the substring trap. A substring matcher would accept them and make the whole gate vacuous.
- **E — pin integrity.** Digest drift on the mirror fails closed; the file must be git-tracked.

### RED → GREEN

**RED (before migration), gate named all 20 sites:**
```
FAILED test_no_literal_consumer_group_names_in_src
  omnibase_core/cli/cli_run_node.py:213: "group.id": <string literal>
  omnibase_core/runtime/runtime_local.py:563, :1180, :1195: group_id=<string literal>
  …16 × group_id=_HANDLER_GROUP/_RUNNER_GROUP (module-level string constant)
2 failed, 24 passed
```

**Non-vacuity, both legs proven independently** (re-verified on the final tree):
- Reverting the fix to return `"runtime-local-" + node_name` — a *non-literal* expression the static leg cannot see — still fails leg B: `runtime_local.handler: runtime-local-HandlerDelegateSkill`, `runtime_local.terminal: runtime-local-runtime_local_terminal`.
- Reintroducing the literals fails leg A. Neither leg is load-bearing alone.

**GREEN:** `27 passed`.

### Gates (all on `.200` / `stickybeatz-studio`, patch-transfer with `git write-tree` identity verified at every sync)

| Gate | Result |
|---|---|
| Full suite | **44281 passed**, 65 skipped, 12 xfailed, 43 xpassed, 0 failed (26:18, `-n16`) |
| Pre-push governed selector (escalated to full suite, `-n4`) | **43685 passed**, 0 failed (1:31:57) |
| mypy | `Success: no issues found in 4212 source files` |
| ruff check / format | clean |
| Import-layering ratchet | `protocols->models=65 (max 65)`, `hub_inbound={'utils': 127, …}` — **zero new** hub importers or edges |
| pre-commit (full chain, on commit) | green |

### Notes for review

1. **`.gitignore` near-miss the remote gate caught.** The pinned YAML was first placed at `src/omnibase_core/data/…`, which `.gitignore:251` (`data/`, for Docker runtime dirs) silently excluded. Local runs passed against an untracked working-tree copy while the file was absent from the commit. Relocated to `contracts/` (repo convention for packaged policy YAML), and gate test E now asserts git-trackedness so this cannot recur.
2. **Four pre-existing violations in files this PR had to touch**, each verified byte-identical on the untouched clone at the same base `be324b80`, each annotated with the hook's *documented* marker (no `[skip-*]` token, no `--no-verify`):
   - `event_bus_inmemory.py` deliberate subscriber-callback swallow → `# fallback-ok:` (it feeds the per-group circuit breaker; killing the loop for one bad subscriber would be worse).
   - `runtime_localhost_url.py` `raise RuntimeError` / `raise OSError` → `# error-ok:` (runner-invariant breach and fail-closed unreadable-file, both intentional).
   - `runtime_todo_marker.py:3` — the file's own `onex-allow-file-todo-marker` directive self-triggered because its `reason=` spelled the bare marker tokens; reworded, suppression preserved.
   These are collateral required to land, not scope creep — flagged explicitly so review can judge them.
3. **`.yaml-validation-allowlist.yaml` entry added** for the `safe_load → model_validate` two-step, matching the existing `aislop_rule_loader` / `antipattern_registry_loader` precedents. Routing through `utils.util_safe_yaml_loader` instead was tried first and rejected: it adds a `utils`-hub importer that the OMN-14340 ratchet test fails on.
4. **Offset reset** is the accepted one-time dev-class cost of the rename (operator ruling). The 16 validation-runtime groups are in-memory-bus only, migrated for grammar conformance so the gate can stay default-deny rather than acquire an exclusion list.

### Residual proof leg (this PR does NOT close the ticket)

The ticket's AC1 is **live-readback**: one in-cluster `onex delegate --bus kafka` on onex-dev reaching a truthful terminal **and** writing a durable `delegation_events` row. That requires merge → core `dev`→`main` promotion → **0.46.9** publish → downstream pin bump → redeploy (itself gated behind OMN-15628). Not attempted here. Do not mark OMN-15639 Done on this PR alone.

**Landing order** (infra consumes core from PyPI, not a git ref — `omnibase_infra/pyproject.toml:36,189` pins `omnibase-core==0.46.8` exactly): this PR → core `dev`→`main` → tag+publish 0.46.9 → pin bump → infra/market/memory lanes. Merging to core `dev` alone does **not** unblock them.

Refs OMN-15639



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consumer-group identifiers are now generated consistently from service, environment, topic, and invocation context.
  * Added support for validating authorized consumer-group naming patterns and scopes.
  * Added public models and enum support for consumer-group authorization and scope metadata.

* **Bug Fixes**
  * Nested event-bus subscriptions now reject unsupported consumer-group fields with clear validation errors.
  * Improved handling of long, invalid, or unauthorized consumer-group names.

* **Tests**
  * Expanded coverage for naming, authorization, scoping, parsing, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Carried forward from review — needs its own ticket (not introduced here)

CodeRabbit flagged a genuine **pre-existing** concurrency exposure in `RuntimeLocal` that this PR deliberately does not change:

> `derive_runtime_local_group_id` omits `ModelConsumerGroupScope`, so concurrent runs share handler and terminal consumer groups. `_on_terminal_event` accepts the first terminal payload without checking `correlation_id`. **A unique group alone is insufficient** — separate Kafka groups each receive all records on shared topics.

Before this PR the same sites used `f"runtime-local-{handler_name}"` and the literal `"runtime-local-terminal"` — equally shared, with the same unfiltered `_on_terminal_event`. This PR changes the *name* so MSK authorizes it and preserves the grouping semantics exactly; per-invocation isolation is a behavioural change to `RuntimeLocal` across every lane and was scoped out by the operator ruling.

Acceptance criteria for the follow-up, carried over verbatim so a future lane cannot ship a false fix (adding a scope and stopping there would not isolate anything):

1. Establish one correlation ID before subscribing; scope `runtime_local.py` lines 594, 1211, 1226 with it.
2. Filter **both** handler and terminal messages to that correlation ID.

No ticket ID is cited because this lane does not invent `OMN-XXXX` identifiers — flagged to the operator for filing.

### Review threads

All 7 CodeRabbit threads resolved with replies: 3 fixed in code with RED-proven regression tests (`\Z` anchor, unknown nested-key rejection, validator module-state teardown), 3 answered with live evidence disputing the premise (no `consumer_group` fixture or `event_bus.subscribe` doc exists; `# error-ok:` is documented for standard exceptions, not ValueError-only; re-raising from the in-memory bus callback would tear down delivery for all other subscribers), and this one carried forward above.
