### PR TITLE
fix(OMN-15661): always run the test paths the governed selector's closure cannot select

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import math
 import subprocess
 import sys
@@ -106,6 +107,93 @@ VOLUME_MAX_SPLITS = 40
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# --- Unnarrowable test paths (OMN-15661) -----------------------------------
+# The import-graph closure narrows WITHIN `tests/unit/`: that is the only tree
+# `compute_closure_selection` collects candidates from. `tests/integration/` is
+# excluded because it has its own unconditional CI job (ci.yml `tests-integration`,
+# and both pytest steps pass `--ignore=tests/integration`). EVERY OTHER test path
+# the full-suite step runs (`pytest tests/`) — `tests/gates/`, `tests/validation/`,
+# `tests/scripts/`, the loose `tests/test_*.py` files, and whatever lands
+# tomorrow — is outside the closure's candidate universe and can therefore never
+# appear in a narrowed selection, no matter what changed.
+#
+# That is fail-OPEN, and it was live: the OMN-15639 AC3 gate
+# (`tests/gates/test_consumer_group_name_authorization.py`) was collected ZERO
+# times on the everyday narrowed dev path, so a PR reintroducing the exact
+# consumer-group defect literal it guards would have passed narrowed CI
+# (OMN-15661). The closure cannot fix this by widening its candidate set either:
+# that gate's relationship to a source change is not an import edge at all — it
+# AST-scans every file under `src/` off disk, an edge no import graph models.
+#
+# So these paths are ALWAYS selected alongside the closure's answer whenever the
+# selection is narrowed and non-empty. The only exemption stays the docs-only
+# selection (step 5), which is positively proven to be able to affect nothing.
+#
+# The set is DERIVED from the tree, never hand-listed: a new `tests/<dir>/` is
+# covered the day it lands, with nobody having to remember a list — the same
+# default-deny posture the rest of this selector is built on.
+TESTS_DIR = "tests"
+
+# Roots deliberately NOT treated as unnarrowable, each for a proven reason.
+CLOSURE_NARROWABLE_TEST_ROOTS = frozenset({"unit"})  # the closure's own universe
+SEPARATELY_GATED_TEST_ROOTS = frozenset({"integration"})  # own unconditional job
+
+# Mirrors `[tool.pytest.ini_options] python_files` in pyproject.toml. Held equal
+# by tests/unit/scripts/ci/test_detect_test_paths.py, which reads that key — so
+# widening pytest's collection patterns without widening this fails a test rather
+# than silently dropping a newly-collectable family from the narrowed path.
+TEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
+
+
+def is_test_file_name(name: str) -> bool:
+    """True when pytest would collect a file with this name (``python_files``)."""
+    return any(fnmatch.fnmatch(name, pattern) for pattern in TEST_FILE_PATTERNS)
+
+
+def _contains_collectable_test(directory: Path) -> bool:
+    """True when ``directory`` holds at least one file pytest would collect.
+
+    Keeps genuinely test-free directories (``tests/fixtures/``, ``__pycache__``)
+    out of the always-run set on POSITIVE evidence — there is nothing in them to
+    run — rather than by naming them in an exclusion list that would rot.
+    """
+    return any(is_test_file_name(path.name) for path in directory.rglob("*.py"))
+
+
+def unnarrowable_test_paths(repo_root: Path) -> list[str]:
+    """Test paths the full suite runs that the closure cannot reason about.
+
+    Everything directly under ``tests/`` that holds collectable tests, minus the
+    closure's own universe (``tests/unit/``) and the separately-gated
+    ``tests/integration/``. See the block comment on
+    :data:`CLOSURE_NARROWABLE_TEST_ROOTS` for why these must always run.
+
+    Raises ``OSError`` when the tree cannot be enumerated — the caller escalates
+    to the full suite rather than emitting a selection it cannot prove covers
+    them.
+    """
+    tests_dir = repo_root / TESTS_DIR
+    if not tests_dir.is_dir():
+        # No tests/ tree at all (synthetic fixture roots): nothing is being
+        # dropped, so there is nothing to force. Distinct from "cannot read".
+        return []
+    paths: list[str] = []
+    for entry in sorted(tests_dir.iterdir()):
+        name = entry.name
+        if name in CLOSURE_NARROWABLE_TEST_ROOTS or name in SEPARATELY_GATED_TEST_ROOTS:
+            continue
+        if entry.is_dir():
+            if _contains_collectable_test(entry):
+                paths.append(f"{TESTS_DIR}/{name}/")
+        elif is_test_file_name(name):
+            paths.append(f"{TESTS_DIR}/{name}")
+    return paths
+
+
+def _with_unnarrowable(selected: list[str], unnarrowable: list[str]) -> list[str]:
+    """Union a narrowed selection with the always-run paths, order-stable."""
+    return [*selected, *[path for path in unnarrowable if path not in selected]]
+
 
 def compute_selection(
     changed_files: list[str],
@@ -196,18 +284,32 @@ def compute_selection(
             matrix=[1],
         )
 
+    # 5a. Always-run set (OMN-15661). Resolved once here, after the docs-only
+    # exemption (which stays empty — documentation is positively proven inert)
+    # and before every branch that emits a narrowed selection. Enumerating the
+    # tests/ tree is the same class of read this function already does through
+    # the closure; if it fails we cannot prove the narrowed selection covers the
+    # gates, so we fail closed. TEST_INFRASTRUCTURE is the honest reason: the
+    # tests/ tree IS the test infrastructure being enumerated.
+    try:
+        unnarrowable = unnarrowable_test_paths(closure_root)
+    except OSError:
+        return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
     # 5b. Required-check manifest changes are non-Python governance data with a
     # dedicated validator test. Without this positive mapping the import-graph
     # closure correctly treats the path as unresolved and selects tests/unit/,
     # which makes pre-push run the broad unit/import suite for manifest-only
     # reconciliations.
     if changed_files and set(changed_files) == {REQUIRED_CHECKS_MANIFEST_PATH}:
+        selected = _with_unnarrowable([REQUIRED_CHECKS_MANIFEST_TEST], unnarrowable)
+        split_count = _split_count_for(selected, repo_root=closure_root)
         return ModelTestSelection(
-            selected_paths=[REQUIRED_CHECKS_MANIFEST_TEST],
-            split_count=1,
+            selected_paths=selected,
+            split_count=split_count,
             is_full_suite=False,
             full_suite_reason=None,
-            matrix=[1],
+            matrix=list(range(1, split_count + 1)),
         )
 
     # 6. Smart selection (OMN-14921: file-grain import-graph closure, computed
@@ -217,7 +319,9 @@ def compute_selection(
     # empty result here means the closure positively proved zero test files
     # reference the change (stronger evidence than "no mapping found").
     closure = compute_closure_selection(changed_files, repo_root=closure_root)
-    selected = closure.selected_files
+    # The closure answers only for tests/unit/; the paths it structurally cannot
+    # see (OMN-15661) are unioned in so a narrowed run still covers them.
+    selected = _with_unnarrowable(closure.selected_files, unnarrowable)
     split_count = _split_count_for(selected, repo_root=closure_root)
 
     return ModelTestSelection(

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import math
+import os
 import subprocess
 import sys
 import tomllib
@@ -150,6 +151,10 @@ def is_test_file_name(name: str) -> bool:
     return any(fnmatch.fnmatch(name, pattern) for pattern in TEST_FILE_PATTERNS)
 
 
+def _raise_walk_error(error: OSError) -> None:
+    raise error
+
+
 def _contains_collectable_test(directory: Path) -> bool:
     """True when ``directory`` holds at least one file pytest would collect.
 
@@ -157,7 +162,10 @@ def _contains_collectable_test(directory: Path) -> bool:
     out of the always-run set on POSITIVE evidence — there is nothing in them to
     run — rather than by naming them in an exclusion list that would rot.
     """
-    return any(is_test_file_name(path.name) for path in directory.rglob("*.py"))
+    for _root, _dirs, files in os.walk(directory, onerror=_raise_walk_error):
+        if any(is_test_file_name(name) for name in files):
+            return True
+    return False
 
 
 def unnarrowable_test_paths(repo_root: Path) -> list[str]:

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -79,6 +79,10 @@ test_infrastructure_paths:
   - scripts/ci/test_selection_closure.py
   - scripts/ci/test_selection_adjacency.yaml
   - src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+  # OMN-15661: this EFFECT boundary now resolves the always-run test paths the
+  # closure cannot select (the mirror of the oracle's unnarrowable_test_paths),
+  # so it is selection-affecting surface on the same footing as selector_core.py.
+  - src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
   - tests/conftest.py
   - tests/fixtures/
   - tests/pytest.ini

--- a/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
+++ b/src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py
@@ -19,6 +19,10 @@ boundary (``runtime_test_selector.py``), never inside the handler:
   ``scripts.ci.test_selection_closure.compute_closure_selection`` (grimp graph
   build + test-file AST reads). ``None`` fails closed to the whole-tree
   fallback — see ``selector_core.compute_selection``.
+* ``unnarrowable_test_paths`` — the always-run test paths the closure cannot
+  select because they live outside ``tests/unit/`` (OMN-15661; a ``tests/``
+  directory walk). ``None`` fails closed to the FULL SUITE on the narrowed
+  path, because every narrower answer provably drops ``tests/gates/``.
 """
 
 from __future__ import annotations
@@ -45,3 +49,4 @@ class ModelTestSelectionRequest(BaseModel):
     pyproject_dependency_relevant: bool | None = None
     test_file_counts: dict[str, int] = Field(default_factory=dict)
     closure_selected_files: list[str] | None = None
+    unnarrowable_test_paths: list[str] | None = None

--- a/src/omnibase_core/nodes/node_test_selector_compute/handler.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/handler.py
@@ -58,4 +58,5 @@ class NodeTestSelectorCompute:
             pyproject_dependency_relevant=request.pyproject_dependency_relevant,
             test_file_counts=request.test_file_counts,
             closure_selected_files=request.closure_selected_files,
+            unnarrowable_test_paths=request.unnarrowable_test_paths,
         )

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -40,6 +40,7 @@ Exit code: always 0 on a successful computation (the selection JSON is the produ
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import sys
 from pathlib import Path
 
@@ -65,6 +66,12 @@ _DEFAULT_ADJACENCY_REL = "scripts/ci/test_selection_adjacency.yaml"
 # when pyproject.toml is in the diff.
 _PYPROJECT_RELEVANT: dict[str, bool] = {"on": True, "off": False}
 
+# OMN-15661 always-run set — mirrors the oracle's constants of the same names.
+_TESTS_DIR = "tests"
+_CLOSURE_NARROWABLE_TEST_ROOTS = frozenset({"unit"})
+_SEPARATELY_GATED_ROOTS = frozenset({"integration"})
+_TEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
+
 
 def _load_adjacency(path: Path) -> ModelAdjacencyMap:
     """YAML read boundary — parse the static adjacency map into its typed model.
@@ -82,6 +89,39 @@ def _count_test_files(rel_path: str, repo_root: Path) -> int:
     if not directory.is_dir():
         return 0
     return sum(1 for _ in directory.rglob("test_*.py"))
+
+
+def _is_test_file_name(name: str) -> bool:
+    """True when pytest would collect a file with this name (``python_files``)."""
+    return any(fnmatch.fnmatch(name, pattern) for pattern in _TEST_FILE_PATTERNS)
+
+
+def _unnarrowable_test_paths(repo_root: Path) -> list[str]:
+    """Always-run test paths the import-graph closure cannot select (OMN-15661).
+
+    Filesystem walk — this is the EFFECT boundary that owns it; the pure node
+    receives the resolved list. Mirrors
+    ``scripts.ci.detect_test_paths.unnarrowable_test_paths`` (the CI-governing
+    oracle), which this module is required to reproduce byte-for-byte; the
+    duplication is held honest by the CLI stdout parity battery in
+    ``tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py``,
+    which runs BOTH entrypoints over the real repo root — the same arrangement
+    already used for ``_count_test_files``.
+    """
+    tests_dir = repo_root / _TESTS_DIR
+    if not tests_dir.is_dir():
+        return []
+    paths: list[str] = []
+    for entry in sorted(tests_dir.iterdir()):
+        name = entry.name
+        if name in _CLOSURE_NARROWABLE_TEST_ROOTS or name in _SEPARATELY_GATED_ROOTS:
+            continue
+        if entry.is_dir():
+            if any(_is_test_file_name(p.name) for p in entry.rglob("*.py")):
+                paths.append(f"{_TESTS_DIR}/{name}/")
+        elif _is_test_file_name(name):
+            paths.append(f"{_TESTS_DIR}/{name}")
+    return paths
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -160,6 +200,16 @@ def main(argv: list[str] | None = None) -> int:
     # whole-tree fallback (never silently narrows on a missing closure) — this
     # entrypoint is not wired into CI (detect_test_paths.py is the governing
     # oracle), so the gap has no live-selection impact today.
+    # OMN-15661: the always-run paths ARE resolved here — a tests/ directory walk
+    # is read-only filesystem access this boundary already performs for
+    # test-file counts, so there is no reason to leave the node failing closed.
+    try:
+        unnarrowable: list[str] | None = _unnarrowable_test_paths(repo_root)
+    except OSError:  # boundary-ok: unreadable tests/ tree must fail closed
+        # None -> the pure node escalates to the full suite, matching the
+        # oracle's TEST_INFRASTRUCTURE escalation on the same failure.
+        unnarrowable = None
+
     def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
         return ModelTestSelectionRequest(
             changed_files=changed,
@@ -170,6 +220,7 @@ def main(argv: list[str] | None = None) -> int:
             pyproject_dependency_relevant=pyproject_dependency_relevant,
             test_file_counts=counts,
             closure_selected_files=None,
+            unnarrowable_test_paths=unnarrowable,
         )
 
     # Pass 1: selection (independent of test-file volume).

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import os
 import sys
 from pathlib import Path
 
@@ -96,6 +97,17 @@ def _is_test_file_name(name: str) -> bool:
     return any(fnmatch.fnmatch(name, pattern) for pattern in _TEST_FILE_PATTERNS)
 
 
+def _raise_walk_error(error: OSError) -> None:
+    raise error
+
+
+def _contains_collectable_test(directory: Path) -> bool:
+    for _root, _dirs, files in os.walk(directory, onerror=_raise_walk_error):
+        if any(_is_test_file_name(name) for name in files):
+            return True
+    return False
+
+
 def _unnarrowable_test_paths(repo_root: Path) -> list[str]:
     """Always-run test paths the import-graph closure cannot select (OMN-15661).
 
@@ -117,7 +129,7 @@ def _unnarrowable_test_paths(repo_root: Path) -> list[str]:
         if name in _CLOSURE_NARROWABLE_TEST_ROOTS or name in _SEPARATELY_GATED_ROOTS:
             continue
         if entry.is_dir():
-            if any(_is_test_file_name(p.name) for p in entry.rglob("*.py")):
+            if _contains_collectable_test(entry):
                 paths.append(f"{_TESTS_DIR}/{name}/")
         elif _is_test_file_name(name):
             paths.append(f"{_TESTS_DIR}/{name}")

--- a/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
@@ -228,17 +228,17 @@ def compute_selection(
             matrix=[1],
         )
 
-    # 6. Smart selection (OMN-14921: file-grain import-graph closure). The
-    # closure itself is I/O — computed at the caller/EFFECT boundary and
-    # injected here; this stays a pure lookup + the same whole-tree fallback
-    # used when no closure could be computed (mirrors the retired module-grain
-    # oracle's fallback for "no unit-test mapping found").
     # 5a. Always-run set (OMN-15661) — see the parameter's docstring entry. Not
     # supplied means not proven, and the fail-closed answer on this path is the
     # full suite (every conservative alternative still drops tests/gates/).
     if unnarrowable_test_paths is None:
         return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
 
+    # 6. Smart selection (OMN-14921: file-grain import-graph closure). The
+    # closure itself is I/O — computed at the caller/EFFECT boundary and
+    # injected here; this stays a pure lookup + the same whole-tree fallback
+    # used when no closure could be computed (mirrors the retired module-grain
+    # oracle's fallback for "no unit-test mapping found").
     selected = (
         list(closure_selected_files) if closure_selected_files is not None else None
     )

--- a/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/selector_core.py
@@ -130,6 +130,7 @@ def compute_selection(
     pyproject_dependency_relevant: bool | None = None,
     test_file_counts: dict[str, int] | None = None,
     closure_selected_files: list[str] | None = None,
+    unnarrowable_test_paths: list[str] | None = None,
 ) -> ModelTestSelection:
     """Resolve the test selection for a change set — pure, deterministic.
 
@@ -156,6 +157,18 @@ def compute_selection(
     The retired hand-curated ``adjacency`` reverse_deps map (module-grain,
     ``resolve_test_paths``) is deleted, not merely bypassed — 26/40 of its
     declarations were false against the real import graph.
+
+    ``unnarrowable_test_paths`` (OMN-15661) is the always-run set: the test paths
+    the full suite runs that the import-graph closure structurally cannot select,
+    because they live outside ``tests/unit/`` (its only candidate tree) — e.g.
+    ``tests/gates/``, whose AC3 consumer-group gate AST-scans ``src/`` off disk
+    rather than importing it. Enumerating them is a filesystem read, so it is
+    resolved at the caller/EFFECT boundary (``runtime_test_selector.py``) and
+    injected here, exactly like ``test_file_counts``. ``None`` means the caller
+    supplied nothing: the narrowed path then FAILS CLOSED to the full suite
+    rather than emitting a selection that provably drops those gates. Unlike the
+    ``closure_selected_files`` gap, no conservative in-between exists — the
+    whole-tree ``tests/unit/`` sentinel is itself a selection that misses them.
     """
     counts = test_file_counts or {}
 
@@ -220,11 +233,21 @@ def compute_selection(
     # injected here; this stays a pure lookup + the same whole-tree fallback
     # used when no closure could be computed (mirrors the retired module-grain
     # oracle's fallback for "no unit-test mapping found").
+    # 5a. Always-run set (OMN-15661) — see the parameter's docstring entry. Not
+    # supplied means not proven, and the fail-closed answer on this path is the
+    # full suite (every conservative alternative still drops tests/gates/).
+    if unnarrowable_test_paths is None:
+        return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
     selected = (
         list(closure_selected_files) if closure_selected_files is not None else None
     )
     if not selected:
         selected = ["tests/unit/"]
+    selected = [
+        *selected,
+        *[path for path in unnarrowable_test_paths if path not in selected],
+    ]
     total = sum(counts.get(path, 0) for path in selected)
     split_count = split_count_from_total(selected, total)
 

--- a/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
@@ -48,7 +48,11 @@ from omnibase_core.models.nodes.test_selector.model_test_selection_request impor
 from omnibase_core.nodes.node_test_selector_compute.handler import (
     NodeTestSelectorCompute,
 )
-from scripts.ci.detect_test_paths import _count_test_files, compute_selection
+from scripts.ci.detect_test_paths import (
+    _count_test_files,
+    compute_selection,
+    unnarrowable_test_paths,
+)
 from scripts.ci.test_selection_closure import compute_closure_selection
 from scripts.ci.test_selection_loader import load_adjacency_map
 
@@ -57,6 +61,16 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
 ADJ_MAP = load_adjacency_map(ADJ)
+
+# OMN-15661: a narrowed selection now also carries the always-run paths the
+# closure cannot select. Both surfaces produce them, so parity is unaffected —
+# only the literal expectations below grow.
+ALWAYS_RUN = unnarrowable_test_paths(REPO_ROOT)
+
+
+def _narrowed(*paths: str) -> list[str]:
+    """Expected narrowed selection: ``paths`` followed by the always-run set."""
+    return [*paths, *[p for p in ALWAYS_RUN if p not in paths]]
 
 
 def _node_selection(
@@ -77,6 +91,11 @@ def _node_selection(
     """
     node = NodeTestSelectorCompute()
     closure = compute_closure_selection(changed_files, repo_root=repo_root)
+    # OMN-15661: the always-run paths are the other I/O-derived input the pure
+    # node cannot compute. Resolved here with the oracle's own derivation, the
+    # same way the closure above is — a divergent copy would make the parity
+    # claim about this harness rather than about the node.
+    unnarrowable = unnarrowable_test_paths(repo_root)
 
     def _request(counts: dict[str, int]) -> ModelTestSelectionRequest:
         return ModelTestSelectionRequest(
@@ -85,6 +104,7 @@ def _node_selection(
             adjacency=ADJ_MAP,
             test_file_counts=counts,
             closure_selected_files=closure.selected_files,
+            unnarrowable_test_paths=unnarrowable,
             **kwargs,  # type: ignore[arg-type]
         )
 
@@ -145,7 +165,7 @@ def test_parity_single_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_parity_nonexistent_file_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     sel = _assert_parity(monkeypatch, ["src/omnibase_core/cli/foo.py"], "pr-branch")
     assert sel.is_full_suite is False
-    assert sel.selected_paths == ["tests/unit/"]
+    assert sel.selected_paths == _narrowed("tests/unit/")
 
 
 def test_parity_shared_module_change(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -185,7 +205,7 @@ def test_parity_multi_module_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_parity_empty_change_set(monkeypatch: pytest.MonkeyPatch) -> None:
     sel = _assert_parity(monkeypatch, [], "pr-branch")
     assert sel.is_full_suite is False
-    assert sel.selected_paths == ["tests/unit/"]
+    assert sel.selected_paths == _narrowed("tests/unit/")
 
 
 def test_parity_docs_only_selects_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -203,7 +223,7 @@ def test_parity_unrelated_scripts_ci_no_escalate(
     # identically in oracle and node.
     sel = _assert_parity(monkeypatch, ["scripts/ci/ci_summary_gate.py"], "pr-branch")
     assert sel.is_full_suite is False
-    assert sel.selected_paths == ["tests/unit/"]
+    assert sel.selected_paths == _narrowed("tests/unit/")
 
 
 def test_parity_selector_core_change_escalates(
@@ -277,7 +297,7 @@ def test_parity_integration_only_change(monkeypatch: pytest.MonkeyPatch) -> None
     sel = _assert_parity(
         monkeypatch, ["tests/integration/nodes/test_foo.py"], "pr-branch"
     )
-    assert sel.selected_paths == ["tests/unit/"]
+    assert sel.selected_paths == _narrowed("tests/unit/")
 
 
 def test_parity_protocols_reverse_dep_expansion(

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -29,8 +29,12 @@ from pathlib import Path
 import pytest
 
 from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+    _TEST_FILE_PATTERNS as RUNTIME_TEST_FILE_PATTERNS,
+)
+from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
     main as node_main,
 )
+from scripts.ci.detect_test_paths import TEST_FILE_PATTERNS as ORACLE_TEST_FILE_PATTERNS
 from scripts.ci.detect_test_paths import main as oracle_main
 from scripts.ci.detect_test_paths import unnarrowable_test_paths
 
@@ -76,6 +80,8 @@ def test_cli_stdout_parity(
     changed: list[str],
     extra: list[str],
 ) -> None:
+    assert RUNTIME_TEST_FILE_PATTERNS == ORACLE_TEST_FILE_PATTERNS
+
     changed_file = _changed_file(tmp_path, changed)
     common = [
         "--changed-files-from",

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -32,6 +32,7 @@ from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import
     main as node_main,
 )
 from scripts.ci.detect_test_paths import main as oracle_main
+from scripts.ci.detect_test_paths import unnarrowable_test_paths
 
 pytestmark = pytest.mark.unit
 
@@ -151,9 +152,17 @@ def test_cli_stdout_diverges_on_smart_selection_pending_closure_wiring(
     )
 
     # Node: fails closed to the whole-tree sentinel (documented gap, not silent
-    # under-selection — the fallback is conservative, never narrower).
+    # under-selection — the fallback is conservative, never narrower). The
+    # always-run paths (OMN-15661) are present on BOTH sides: unlike the
+    # closure, this EFFECT boundary does resolve them, so the divergence stays
+    # confined to the closure gap.
     assert node_payload["is_full_suite"] is False
-    assert node_payload["selected_paths"] == ["tests/unit/"]
+    assert node_payload["selected_paths"] == [
+        "tests/unit/",
+        *unnarrowable_test_paths(REPO_ROOT),
+    ]
+    for path in unnarrowable_test_paths(REPO_ROOT):
+        assert path in oracle_payload["selected_paths"]
 
     assert node_out != oracle_out
 
@@ -178,3 +187,22 @@ def test_cli_emits_single_trailing_newline(
     assert rc == 0
     assert out.endswith("\n")
     assert not out.rstrip("\n").endswith("\n")  # exactly one trailing newline
+
+
+def test_always_run_derivations_agree_between_the_two_surfaces() -> None:
+    """OMN-15661: the oracle and this EFFECT boundary derive the SAME set.
+
+    `runtime_test_selector.py` cannot import `scripts/ci/` (src must not depend
+    on the CI scripts tree), so the walk exists twice — the same arrangement
+    already used for `_count_test_files`. This asserts the two copies agree on
+    the real tree directly, rather than leaving it implied by the stdout parity
+    cases above, and it fails the moment one side learns a rule the other has
+    not.
+    """
+    from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+        _unnarrowable_test_paths,
+    )
+
+    derived = _unnarrowable_test_paths(REPO_ROOT)
+    assert derived == unnarrowable_test_paths(REPO_ROOT)
+    assert "tests/gates/" in derived

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -27,10 +27,23 @@ ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
 # Task 6: compute_selection escalation tests
 # ---------------------------------------------------------------------------
 
-from scripts.ci.detect_test_paths import compute_selection
+from scripts.ci.detect_test_paths import compute_selection, unnarrowable_test_paths
 from scripts.ci.test_selection_models import (
     EnumFullSuiteReason,
 )
+
+# OMN-15661: every narrowed, non-empty selection now also carries the test paths
+# the import-graph closure structurally cannot select (it only ever considers
+# tests/unit/). The literal expected set is pinned in
+# test_always_run_set_is_exactly_the_non_unit_test_tree below; this derived value
+# is used to build expected selections for the other cases so a single tree
+# change does not require rewriting every assertion in this file.
+ALWAYS_RUN = unnarrowable_test_paths(REPO_ROOT)
+
+
+def _narrowed(*paths: str) -> list[str]:
+    """Expected narrowed selection: ``paths`` followed by the always-run set."""
+    return [*paths, *[p for p in ALWAYS_RUN if p not in paths]]
 
 
 def test_shared_module_change_escalates_to_full_suite() -> None:
@@ -68,7 +81,7 @@ def test_workflow_only_change_no_longer_escalates() -> None:
     )
     assert selection.is_full_suite is False
     assert selection.full_suite_reason is None
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 def test_required_checks_manifest_uses_focused_guard_test() -> None:
@@ -80,11 +93,12 @@ def test_required_checks_manifest_uses_focused_guard_test() -> None:
 
     assert selection.is_full_suite is False
     assert selection.full_suite_reason is None
-    assert selection.selected_paths == [
+    # The focused guard test remains the only tests/unit/ entry; the always-run
+    # set (OMN-15661) rides along because this is still a narrowed selection.
+    assert selection.selected_paths == _narrowed(
         "tests/unit/validation/test_required_check_skip_guard.py"
-    ]
-    assert selection.split_count == 1
-    assert selection.matrix == [1]
+    )
+    assert selection.split_count == len(selection.matrix)
 
 
 def test_selector_change_escalates_to_distributed_full_suite() -> None:
@@ -260,7 +274,7 @@ def test_pyproject_version_bump_narrows_via_compute_selection() -> None:
     )
     assert selection.is_full_suite is False
     assert selection.full_suite_reason is None
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 def test_pyproject_dependency_change_escalates_via_compute_selection() -> None:
@@ -373,7 +387,7 @@ def test_nonexistent_source_file_fails_closed_to_whole_tree() -> None:
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +594,7 @@ def test_unrelated_scripts_ci_file_no_longer_escalates(unrelated_ci_file: str) -
     )
     assert selection.is_full_suite is False, f"{unrelated_ci_file} should not escalate"
     assert selection.full_suite_reason is None
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 # ---------------------------------------------------------------------------
@@ -711,7 +725,7 @@ def test_github_precommit_hooks_are_not_docs_exempt(non_doc_only: list[str]) -> 
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 def test_docs_only_does_not_suppress_shared_module_escalation() -> None:
@@ -741,7 +755,7 @@ def test_ambiguous_unclassified_diff_runs_fallback_not_empty() -> None:
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.selected_paths == ["tests/unit/"]
+    assert selection.selected_paths == _narrowed("tests/unit/")
     assert selection.selected_paths != []
 
 
@@ -976,7 +990,7 @@ def test_shadow_smart_path_fail_closed_on_unresolvable_file(
     )
     payload = _json.loads(out)
     assert payload["is_full_suite"] is False
-    assert payload["selected_paths"] == ["tests/unit/"]
+    assert payload["selected_paths"] == _narrowed("tests/unit/")
     report = _json.loads(shadow_path.read_text())
     assert report["narrowed"] is False
     assert report["fail_closed_reasons"]
@@ -1123,3 +1137,222 @@ adjacency:
             load_adjacency_map(Path(tmp_name))
     finally:
         Path(tmp_name).unlink()
+
+
+# ---------------------------------------------------------------------------
+# OMN-15661: test paths the import-graph closure structurally cannot select
+# must always run on the narrowed path.
+#
+# RED (dev @ dc35561c, live selector, ENABLE_SMART_TESTS=true):
+#   changed = ["src/omnibase_core/cli/cli_run_node.py"]
+#   -> {"selected_paths":["tests/unit/"],"is_full_suite":false}
+#   -> `pytest tests/unit/ --collect-only` collected 42,869 tests, of which
+#      tests/gates/ contributed ZERO.
+# The OMN-15639 AC3 consumer-group/MSK-IAM gate therefore did not gate the
+# everyday dev path at all: a PR reintroducing the exact defect literal that
+# gate guards would have merged green.
+# ---------------------------------------------------------------------------
+
+
+def test_always_run_set_is_exactly_the_non_unit_test_tree() -> None:
+    """Pin the derived always-run set against the real tree.
+
+    Deliberately an exact-equality pin, not a containment check: this set is
+    what a narrowed CI run adds on top of the closure's answer, so both a
+    silent DROP (a gate family stops running) and a silent ADD (a heavy tree
+    starts running on every PR) must surface in review rather than in a
+    surprise. Adding a `tests/<dir>/` therefore updates this list — which is
+    the point, since that directory is now always-run.
+    """
+    assert unnarrowable_test_paths(REPO_ROOT) == [
+        "tests/agents/",
+        "tests/analysis/",
+        "tests/ci/",
+        "tests/enums/",
+        "tests/gates/",
+        "tests/models/",
+        "tests/performance/",
+        "tests/scripts/",
+        "tests/test_db_ownership_subcontract.py",
+        "tests/test_direct_instantiation_danger.py",
+        "tests/test_doctor/",
+        "tests/test_json_serialization_crash.py",
+        "tests/utils/",
+        "tests/validation/",
+        "tests/validators/",
+    ]
+
+
+def test_always_run_set_excludes_the_closure_universe_and_integration() -> None:
+    """tests/unit/ is the closure's own tree; tests/integration/ has its own job.
+
+    Including either would be double-selection, not extra safety:
+    `tests/integration/` is run unconditionally by ci.yml's `tests-integration`
+    job and is explicitly `--ignore`d by both pytest steps in `test-parallel`.
+    """
+    always_run = unnarrowable_test_paths(REPO_ROOT)
+    assert "tests/unit/" not in always_run
+    assert "tests/integration/" not in always_run
+    # Directories with nothing pytest would collect stay out on positive
+    # evidence (there is nothing in them to run), not via an exclusion list.
+    assert "tests/fixtures/" not in always_run
+    assert not any("__pycache__" in path for path in always_run)
+
+
+def test_always_run_patterns_match_pytest_python_files() -> None:
+    """The file-name patterns must track pyproject's `python_files`.
+
+    If pytest is taught to collect a new file shape, the always-run derivation
+    has to learn it in the same commit — otherwise a newly-collectable family
+    silently stops being selected on the narrowed path, which is this ticket's
+    defect in a new costume.
+    """
+    import tomllib
+
+    from scripts.ci.detect_test_paths import TEST_FILE_PATTERNS
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    python_files = pyproject["tool"]["pytest"]["ini_options"]["python_files"]
+    assert list(TEST_FILE_PATTERNS) == list(python_files)
+
+
+def test_cli_run_node_only_diff_selects_the_ac3_gate() -> None:
+    """AC1/AC3: the exact RED change-set now reaches tests/gates/.
+
+    `cli_run_node.py` is one of the OMN-15639 migrated call sites — its
+    `derive_run_node_group_id` is imported and asserted on by the AC3 gate.
+    """
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/cli/cli_run_node.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert "tests/gates/" in selection.selected_paths
+    assert selection.selected_paths == _narrowed("tests/unit/")
+
+
+@pytest.mark.parametrize(
+    "producer_source",
+    [
+        # Every OMN-15639 migrated call site named by the AC3 gate's assertion B.
+        # `cli_run_node.py` (module `cli`) is the one that NARROWS — which is
+        # exactly why OMN-15661 named it. `runtime_local.py`, the consumer-group
+        # util, and the eight validation runtimes live under `runtime`,
+        # `event_bus`, and `validation`, all of which are `shared_modules` and
+        # therefore escalate. Both routes must reach the gate; asserting only
+        # "narrows and contains gates" would encode today's shared_modules list
+        # into this test, and a future demotion (the YAML explicitly allows one
+        # on shadow data) would then silently drop the gate instead of failing.
+        "src/omnibase_core/cli/cli_run_node.py",
+        "src/omnibase_core/runtime/runtime_local.py",
+        "src/omnibase_core/event_bus/util_consumer_group.py",
+        "src/omnibase_core/validation/todo_marker/runtime_todo_marker.py",
+        "src/omnibase_core/validation/pin_hygiene/runtime_pin_hygiene.py",
+        "src/omnibase_core/validation/private_ip/runtime_private_ip.py",
+        # A source with no relationship to consumer groups at all: the gate is
+        # reachable from ANY diff, because its static scan covers every file
+        # under src/ regardless of import edges.
+        "src/omnibase_core/cli/cli_bootstrap.py",
+    ],
+)
+def test_gate_is_reachable_from_every_producer_diff(producer_source: str) -> None:
+    """The AC3 gate runs for every migrated producer — narrowed or escalated."""
+    selection = compute_selection(
+        changed_files=[producer_source],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    if selection.is_full_suite:
+        # The full suite is `pytest tests/`, which collects tests/gates/.
+        assert selection.selected_paths == ["tests/"], producer_source
+    else:
+        assert "tests/gates/" in selection.selected_paths, producer_source
+
+
+def test_pinned_iam_pattern_file_change_reaches_the_gate() -> None:
+    """The gate's own pinned data file must also route to it.
+
+    `consumer_group_iam_patterns.yaml` is non-Python, so the import graph cannot
+    resolve it at all — it is exactly the "changed file the closure fails closed
+    on" case. Fail-closed is what saves it here, and the always-run set is what
+    makes that closure land on the gate rather than on tests/unit/ alone.
+    """
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/contracts/consumer_group_iam_patterns.yaml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    if selection.is_full_suite:
+        assert selection.selected_paths == ["tests/"]
+    else:
+        assert "tests/gates/" in selection.selected_paths
+
+
+def test_docs_only_selection_stays_empty() -> None:
+    """The one exemption: documentation is positively proven test-inert.
+
+    The always-run set must NOT resurrect tests here — that would undo the
+    OMN-14910 docs-only exemption and make every README edit run tests.
+    """
+    selection = compute_selection(
+        changed_files=["docs/x.md", "README.md"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is False
+    assert selection.selected_paths == []
+
+
+def test_full_suite_escalations_are_unchanged() -> None:
+    """No narrowing regression in the other direction: escalations still win.
+
+    The always-run union happens only on the narrowed path, so a shared-module
+    change still returns the plain `["tests/"]` 40-split shape rather than a
+    hybrid selection.
+    """
+    selection = compute_selection(
+        changed_files=["src/omnibase_core/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+    )
+    assert selection.is_full_suite is True
+    assert selection.selected_paths == ["tests/"]
+    assert selection.split_count == 40
+
+
+def test_unreadable_tests_tree_fails_closed_to_full_suite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail-closed: if the tests/ tree cannot be enumerated, escalate.
+
+    A narrowed selection is only honest if we can prove it covers the
+    unnarrowable paths. When the walk raises, we cannot — so the selector must
+    escalate rather than emit its best guess.
+    """
+    import scripts.ci.detect_test_paths as detect
+
+    (tmp_path / "tests").mkdir()
+
+    def _boom(_repo_root: Path) -> list[str]:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(detect, "unnarrowable_test_paths", _boom)
+    selection = detect.compute_selection(
+        changed_files=["src/omnibase_core/cli/cli_bootstrap.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=tmp_path,
+    )
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_synthetic_tree_without_tests_dir_adds_nothing(tmp_path: Path) -> None:
+    """A repo root with no tests/ tree yields an empty always-run set.
+
+    "No tests/ directory" is not the same failure as "cannot read tests/": the
+    former positively means nothing is being dropped.
+    """
+    assert unnarrowable_test_paths(tmp_path) == []

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -1217,6 +1217,29 @@ def test_always_run_patterns_match_pytest_python_files() -> None:
     assert list(TEST_FILE_PATTERNS) == list(python_files)
 
 
+def test_nested_always_run_scan_errors_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nested traversal errors must propagate to the caller's full-suite fallback."""
+    import scripts.ci.detect_test_paths as detect
+
+    target = tmp_path / "tests" / "gates"
+    target.mkdir(parents=True)
+
+    def _walk(
+        _directory: Path,
+        onerror: object | None = None,
+    ) -> object:
+        yield str(target), [], []
+        assert callable(onerror)
+        onerror(PermissionError("nested scan denied"))
+
+    monkeypatch.setattr(detect.os, "walk", _walk)
+
+    with pytest.raises(PermissionError, match="nested scan denied"):
+        detect.unnarrowable_test_paths(tmp_path)
+
+
 def test_cli_run_node_only_diff_selects_the_ac3_gate() -> None:
     """AC1/AC3: the exact RED change-set now reaches tests/gates/.
 


### PR DESCRIPTION
## Summary

The governed change-aware selector narrows **within `tests/unit/` only** — that is the sole tree `compute_closure_selection` collects candidates from. Every other test path the full-suite job runs was therefore unreachable on the narrowed dev path, `tests/gates/` included. The OMN-15639 AC3 consumer-group / MSK-IAM authorization gate was collected **zero times** on the everyday path it exists to guard, so a PR reintroducing the exact defect literal it rejects would have merged green.

This unions an always-run set — derived from the `tests/` tree, not hand-listed — into every narrowed, non-empty selection.

Evidence-Ticket: OMN-15661
Evidence-Source: OCC#5973

## RED (live selector, `dev` @ `dc35561c`, `ENABLE_SMART_TESTS=true`)

```
$ printf 'src/omnibase_core/cli/cli_run_node.py\n' > changed.txt
$ uv run python -m scripts.ci.detect_test_paths --changed-files-from changed.txt \
    --ref-name jonah/red-repro --event-name pull_request
{"selected_paths":["tests/unit/"],"split_count":37,"is_full_suite":false,"full_suite_reason":null,...}
```

Collecting exactly that selection (`-o addopts=""` so pytest prints ids as paths rather than the tree view):

```
$ uv run pytest tests/unit/ --collect-only -q -o addopts="" -p no:randomly
42886 tests collected
$ grep -c '^gates/' co_red.txt                            -> 0
$ grep -c 'consumer_group_name_authorization' co_red.txt  -> 0
```

Zero of the 30 AC3 gate tests are reachable. The gate only ever fired when something *else* forced a full-suite escalation.

## Mechanism, and why this one

The selector has two ways to reach a test: the import-graph closure, and full-suite escalation. Neither can be made to cover this by configuration:

- **An adjacency entry cannot fix it.** The hand-curated `adjacency:`/`reverse_deps` map is *retired* (OMN-14921 — 26 of 40 declarations were false against the real grimp graph), and `ModelAdjacencyMap.reject_adjacency_reintroduction` raises at load time if one is re-added. There is no mapping surface left to add a mapping to.
- **Widening the closure's candidate set cannot fix it either.** `tests/gates/`'s relationship to a source change is *not an import edge*: assertion A of that gate AST-scans every `*.py` under `src/` off disk. No import graph models that dependency, so no closure answer can select it for the diffs that matter. It would appear to work today only by accident — the file contains the string `importlib`, so `collect_direct_imports` returns `None` and the file is kept fail-closed. Delete that one import and it silently drops out again.

So this uses the selector's other governed idiom — an always-run set, the same class of fix as the `CHANGED_TEST_UNNARROWABLE` mechanism the ticket cites — and **derives** it rather than listing it:

`unnarrowable_test_paths(repo_root)` = everything directly under `tests/` holding a file pytest would collect, minus
- `tests/unit/` — the closure's own universe, already answered for, and
- `tests/integration/` — its own unconditional CI job (`tests-integration`), and `--ignore`d by both pytest steps in `test-parallel`.

Derivation rather than enumeration is the point: a new `tests/<dir>/` is covered the day it lands, with nobody remembering a list. Directories with nothing collectable (`tests/fixtures/`, `__pycache__`) stay out on positive evidence, not via an exclusion list that would rot.

**Fail-closed in both directions:**
- an unreadable `tests/` tree escalates (`TEST_INFRASTRUCTURE`) — never a selection we cannot prove covers the gates;
- the pure node twin (`selector_core.compute_selection`) escalates when the caller injects no set. Unlike the closure gap there is no conservative in-between, since the `tests/unit/` sentinel is itself a selection that misses the gates.

Nothing was weakened: escalation ordering, the docs-only exemption, the `pyproject.toml` content-aware classification and the closure's own fail-closed paths are untouched. No `-k`/`-m` narrowing anywhere; `ENABLE_SMART_TESTS` untouched.

## GREEN (same live selector, same diff)

```
{"selected_paths":["tests/unit/","tests/agents/","tests/analysis/","tests/ci/","tests/enums/",
 "tests/gates/","tests/models/","tests/performance/","tests/scripts/",
 "tests/test_db_ownership_subcontract.py","tests/test_direct_instantiation_danger.py",
 "tests/test_doctor/","tests/test_json_serialization_crash.py","tests/utils/",
 "tests/validation/","tests/validators/"],"split_count":39,"is_full_suite":false,...}

$ uv run pytest $PATHS --ignore=tests/integration --collect-only -q -o addopts=""
43759 tests collected
$ grep -c '^gates/' co_green.txt -> 30      (RED: 0)
```

The 30 AC3 gate tests pass, as does every other newly-always-run path:

```
$ uv run pytest tests/agents/ tests/analysis/ tests/ci/ tests/enums/ tests/gates/ \
    tests/models/ tests/performance/ tests/scripts/ tests/test_*.py tests/test_doctor/ \
    tests/utils/ tests/validation/ tests/validators/ -q
873 passed in 86.50s
```

**Measured cost:** +873 tests (+2.0% over the 42,886 the narrowed path already ran), 87s single-shot, spread across the split matrix. Split count moved 37 → 39.

## Spot-check across the other migrated call sites

Checked live through the selector, and worth stating precisely rather than as "the mapping covers them": **`cli_run_node.py` is the only OMN-15639 producer that narrows.** `runtime_local.py`, `event_bus/util_consumer_group.py` and the eight validation runtimes live under `runtime`, `event_bus` and `validation` — all `shared_modules` — so they escalate to the full suite, which runs `tests/` and therefore the gate. That is exactly why OMN-15661 named `cli_run_node.py` and no other file.

`test_gate_is_reachable_from_every_producer_diff` asserts the real property for all of them — *the gate runs*, via narrowed selection **or** via escalation — instead of encoding today's `shared_modules` list into the test. The adjacency YAML explicitly permits demoting a shared module on shadow data; had the test asserted "narrows and contains gates", such a demotion would silently drop the gate instead of failing.

The gate's own pinned data file (`contracts/consumer_group_iam_patterns.yaml`) is covered too — non-Python, so the closure fails closed on it.

## Seam

`scripts/ci/detect_test_paths.py` (CI-governing oracle) and `runtime_test_selector.py` (node EFFECT boundary) each own a copy of the walk, because `src/` must not import `scripts/ci/` — the same arrangement already in place for `_count_test_files`. The copies are held equal by the existing byte-for-byte CLI stdout parity battery over the real repo root, plus a new direct assertion that both derivations return the same list. `runtime_test_selector.py` is added to `test_infrastructure_paths`, since it is now selection-affecting surface on the same footing as `selector_core.py`.

`ModelTestSelectionRequest` gains `unnarrowable_test_paths`; the handler passes it through; the node parity harness injects it using the oracle's own derivation.

## Files

- `scripts/ci/detect_test_paths.py` — derivation, union into steps 5b/6, fail-closed escalation
- `scripts/ci/test_selection_adjacency.yaml` — `runtime_test_selector.py` added to `test_infrastructure_paths`
- `src/omnibase_core/nodes/node_test_selector_compute/{selector_core,runtime_test_selector,handler}.py`
- `src/omnibase_core/models/nodes/test_selector/model_test_selection_request.py`
- `tests/unit/scripts/ci/test_detect_test_paths.py`, `tests/unit/nodes/node_test_selector_compute/*`

## Residuals (not fixed here, not hidden)

1. The pure node lacks the oracle's step 5b (required-checks manifest) branch — a pre-existing oracle/node divergence, unrelated to this ticket and covered by no parity case. Not touched.
2. `runtime_test_selector.py` still does not compute/inject the closure (the documented OMN-14921 fast-follow). This PR wires the always-run input at that boundary, not the closure.

## Gates

Ran on `.200` (`stickybeatz-studio`) per rule 11a. Direct `jonah@192.168.86.200` still does not route from this Mac; the MagicDNS route was used, which is documented procedure. Edits were made locally and patch-transferred, with all 9 changed files verified byte-identical by `shasum -a 256` on both hosts at the same base commit before any gate ran. The pre-push hook escalated to the full suite (the diff touches selector surface, which is `test_infrastructure_paths` by design) and ran it on `.200`:

```
43707 passed, 53 skipped, 3 xpassed, 179 warnings in 5309.57s (1:28:29)
[prepush-smart-tests] impacted tests passed; allowing push.
```

Also green on `.200`: `ruff format --check` (13 files), `ruff check` on all 9 changed files, `mypy` on the 8 changed source files, the full pre-commit hook chain at commit time, and the selector/parity suites (`169 passed`).
