### PR TITLE
feat(OMN-15651): align delegation task-class Literal to the 15-class Market authority

### DIFF
--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -136,6 +136,7 @@ class ModelDelegationRequest(BaseModel):
         "research",
         "code_generation",
         "code_review",
+        "documentation",
         "refactor",
         "reasoning",
         "complex_reasoning",
@@ -144,6 +145,7 @@ class ModelDelegationRequest(BaseModel):
         "summarization",
         "agent_delegation",
         "escalation",
+        "validator_generation",
     ] = Field(
         ...,
         description="Classification of the delegation task.",

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -46,6 +46,26 @@ from omnibase_core.models.delegation.wire import (
     validate_acceptance_criteria,
 )
 
+_CANONICAL_DELEGATION_TASK_TYPES = frozenset(
+    {
+        "agent_delegation",
+        "code_generation",
+        "code_review",
+        "complex_reasoning",
+        "document",
+        "documentation",
+        "escalation",
+        "planning",
+        "reasoning",
+        "refactor",
+        "research",
+        "review",
+        "summarization",
+        "test",
+        "validator_generation",
+    }
+)
+
 
 @pytest.mark.unit
 class TestModelBudget:
@@ -290,38 +310,32 @@ class TestModelDelegationRequest:
 
     @pytest.mark.parametrize(
         "task_type",
-        [
-            "test",
-            "document",
-            "research",
-            "code_generation",
-            "code_review",
-            "refactor",
-            "reasoning",
-            "complex_reasoning",
-            "planning",
-            "review",
-            "summarization",
-            "agent_delegation",
-            "escalation",
-        ],
+        sorted(_CANONICAL_DELEGATION_TASK_TYPES),
     )
-    def test_all_compat_task_types_accepted(self, task_type: str) -> None:
-        """All compat task_type values must be accepted (OMN-12663 parity fix).
+    def test_all_canonical_task_classes_accepted(self, task_type: str) -> None:
+        """Every Market-authoritative task class crosses the Core wire.
 
-        OMN-13541: ``code_review`` added — the consumer-facing delegation surface
-        (node_delegate_skill_orchestrator.allowed_task_types + the claude/codex
-        adapter) already accepts it, so the wire DTO must carry it or the bus
-        consumer rejects the command and emits no terminal event (Pattern-B
-        timeout, zero inference).
+        OMN-15651 keeps this consumer mechanically coherent with the Market-owned
+        15-class authority through cross-repository admission. Core intentionally
+        does not import Market at runtime.
         """
         r = self._make(task_type=task_type)
         assert r.task_type == task_type
 
+    def test_task_type_schema_is_exact_canonical_full_universe(self) -> None:
+        task_type_schema = ModelDelegationRequest.model_json_schema()["properties"][
+            "task_type"
+        ]
+
+        assert frozenset(task_type_schema["enum"]) == (_CANONICAL_DELEGATION_TASK_TYPES)
+
     def test_invalid_task_type_rejected(self) -> None:
-        """task_type values outside the compat set must be rejected (OMN-12663)."""
-        with pytest.raises(Exception):
+        """Unknown task classes fail closed at the Core wire boundary."""
+        with pytest.raises(ValidationError) as exc_info:
             self._make(task_type="invalid_task_type")
+
+        assert exc_info.value.errors()[0]["loc"] == ("task_type",)
+        assert exc_info.value.errors()[0]["type"] == "literal_error"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## OMN-15651: align delegation task-class Literal to the 15-class Market authority

Evidence-Source: OCC#6020
Evidence-Ticket: OMN-15651

This PR lands step **1b** of the OMN-15651 task-class-authority landing: it adds
the two missing classes (`documentation`, `validator_generation`) to
`ModelDelegationRequest.task_type`'s `Literal` in
`model_delegation_wire_request.py`, so the Core wire DTO admits the full
15-class Market-authoritative universe. Core intentionally does not import
Market at runtime — this Literal is the Core-side full-consumer copy, kept
mechanically coherent with the Market authority through cross-repository
admission, not a shared import.

Ticket: OMN-15651
proof_class: receipt-bound

### Seam declaration (OMN-14208)

- **Authority**: `omnimarket/src/omnimarket/configs/task_class_contracts.v1.yaml`,
  top-level key `task_classes`, exactly **15 classes**: `agent_delegation`,
  `code_generation`, `code_review`, `complex_reasoning`, `document`,
  `documentation`, `escalation`, `planning`, `reasoning`, `refactor`, `research`,
  `review`, `summarization`, `test`, `validator_generation`.
- **New field**: `gateway_exposure`, nested at `task_classes.<class>.gateway_exposure`,
  closed string enum `"public"|"internal"`, **required** on all 15 (no default,
  no inference) — owned by the Market authority (see companion PR
  `omnimarket#2012`, not part of this PR's diff).
  - `public` (11): `code_generation`, `code_review`, `complex_reasoning`,
    `document`, `planning`, `reasoning`, `refactor`, `research`, `review`,
    `summarization`, `test`.
  - `internal` (4): `agent_delegation`, `documentation`, `escalation`,
    `validator_generation`.
- **full_consumer copies** (each member set must equal the 15-class universe
  exactly): this PR's own file —
  `omnibase_core/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py`
  (`ModelDelegationRequest.task_type` Literal) — measured **before** this PR:
  13 members, missing `documentation` and `validator_generation`; **after**
  this PR: all 15 present (verified by the new
  `test_task_type_schema_is_exact_canonical_full_universe` test, which asserts
  `frozenset(schema["enum"]) == _CANONICAL_DELEGATION_TASK_TYPES` — the full
  15-class frozenset). The remaining full_consumer copies
  (`omnimarket` models/contracts, `node_delegate_skill_orchestrator`,
  `node_delegation_orchestrator`, `adapters/claude_code/delegate.py`,
  `node_task_execution_orchestrator`) are Market-owned and land in the
  companion `omnimarket#2012` PR, not this one.
- **public_consumer** (projection only, never authority):
  `omninode_infra/docker/onex-api/workflow-contracts.yaml` `task_type` regex —
  already admits exactly the 11 public classes; **no infra change required for
  this landing** (confirmed by the `omnimarket#2012` companion's live oracle
  run against the canonical `omninode_infra` clone).
- **No Core→Market runtime import**: confirmed live —
  `grep -rn "^import omnimarket\|^from omnimarket" src/` in the
  `omnibase_core` worktree returns **no matches**. (String/comment mentions of
  `omnimarket` in `topics.py` and `normalization/` are topic-name/doc
  references, not imports.)
- **Cross-boundary regression**: the oracle run below executes against the
  LIVE canonical `$OMNI_HOME` clones (`omnibase_core`, `omnimarket`,
  `omninode_infra`), not only frozen fixtures — see the omnimarket companion
  PR (`omnimarket#2012`) for the full multi-repo oracle output; this PR's own
  local evidence is the schema-exactness unit test plus the focused suite
  below.
- **Landing order (HARD)**: this is step **1b**, parallel and independent of
  step **1a** (`omnimarket#2012`). The `omninode_infra` follow-up PR is
  **explicitly deferred** until both 1a and 1b merge to `dev`, because its
  manifest pins commit/blob-oid/sha256 against merged SHAs — it cannot be
  authored against unmerged branches.

### Live oracle-run evidence (this session, 2026-08-03)

Before this change, the live canonical `omnibase_core` clone under `$OMNI_HOME`
showed exactly this gap against the Market authority (13 members vs the
15-class universe, missing `documentation` and `validator_generation`) — the
same gap independently confirmed by the `omnimarket#2012` companion's
cross-repo oracle run:

```
[core LIVE $OMNI_HOME/omnibase_core/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py]
  Literal members (13): ['agent_delegation', 'code_generation', 'code_review', 'complex_reasoning', 'document', 'escalation', 'planning', 'reasoning', 'refactor', 'research', 'review', 'summarization', 'test']
  missing vs market universe: ['documentation', 'validator_generation']
  extra vs market universe:   []
```

After this PR's diff, the Literal carries all 15 members, and the schema
constant `_CANONICAL_DELEGATION_TASK_TYPES` in
`tests/unit/models/delegation/wire/test_delegation_wire_models.py` — the same
15-class frozenset as the Market authority — is asserted equal to
`ModelDelegationRequest.model_json_schema()["properties"]["task_type"]["enum"]`
by `test_task_type_schema_is_exact_canonical_full_universe`.

### Gates run (this session, on `Stickybeatz-Studio` / `.200`, the canonical gate host)

- `uv run ruff format --check src/ tests/` — pass, 6083 files already formatted
- `uv run ruff check src/ tests/` — `All checks passed!` (one pre-existing
  invalid `# noqa` warning in `src/omnibase_core/utils/util_canonical_hash.py`
  is unrelated to this diff)
- `env -u PYTHONPATH uv run mypy src/ --strict` — clean of new errors after a
  venv repair (see below); 9 remaining errors are pre-existing, in files
  byte-identical to `origin/dev` (`model_adjacency_map.py`,
  `contract_loader.py`, `validator_evidence_shape_cli.py`, `cli_install.py`,
  `model_onex_container.py`), unrelated to this diff
- Focused tests: `env -u PYTHONPATH uv run pytest -q tests/unit/models/delegation/`
  — **222 passed**
- `env -u PYTHONPATH uv run pre-commit run --files <the 2 changed files>` —
  all applicable hooks **Passed** (the `--all-files` full-repo sweep surfaced
  only pre-existing, unrelated-to-this-diff repo-wide debt — confirmed
  byte-identical to `origin/dev` for every flagged file)
- Real `git push` pre-push hook chain (the actual enforcing gate): `trim
  trailing whitespace`, `fix end of files`, `check for added large files`,
  `mypy (type checking - strict)`, `pyright (type checking - basic)`,
  `Evidence-Source shape check`, `ONEX Naming Convention Validation`, `ONEX
  File Naming Convention Validation`, `Protocol UUID Enforcement Check`, `ONEX
  Enum Governance Validation`, `ONEX Node Purity Validation` — all **Passed**
- **Governed impacted-test selector (OMN-13973)** escalated to the **full
  suite** (`is_full_suite=True reason=shared_module`) per rule 4 —
  `uv run pytest tests/ --ignore=tests/integration -n4 --dist=loadgroup
  --timeout=60 --timeout-method=thread`: **43711 passed, 0 failed, 53
  skipped, 3 xpassed** in 5832.54s (1:37:12). (An ambient `POSTGRES_PASSWORD`
  / `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_USER` / `POSTGRES_DATABASE`
  set of env vars on this host inflated an earlier attempt's runtime well
  past the sibling `omnimarket#2012` PR's reference full-suite time; unset
  via `env -u` for the push so integration-DB tests skip as designed — no
  product code was touched to achieve this, matching the same gotcha the
  `omnimarket#2012` companion PR documented.)

### Landing

This PR lands via the normal Codex merge sweep. (An earlier revision of this
section carried a merge hold — that was the authoring lane's own stop-at-PR-open
constraint leaking into the body; it bound the build lane, never the sweep.
Hold lifted 2026-08-03 by fable-beta-0803; companion `omnimarket#2012` is
already merged, so landing order 1a+1b is satisfied.)
`omnimarket#2011`, `omnibase_infra#2632`, and `omnibase_core#1540` were a
separate Codex landing lane and are untouched by this PR.

