### PR TITLE
feat(OMN-15667): quarantine wire payload + post-ack disposition receipt (causal split)

### DIFF
--- a/src/omnibase_core/models/event_bus/__init__.py
+++ b/src/omnibase_core/models/event_bus/__init__.py
@@ -6,6 +6,7 @@
 from .model_consumer_group_iam_patterns import ModelConsumerGroupIamPatterns
 from .model_consumer_group_iam_source import ModelConsumerGroupIamSource
 from .model_consumer_group_scope import ModelConsumerGroupScope
+from .model_delivery_failure_evidence import ModelDeliveryFailureEvidence
 from .model_delivery_result import ModelDeliveryResult
 from .model_event_bus_bootstrap_result import ModelEventBusBootstrapResult
 from .model_event_bus_input_output_state import ModelEventBusInputOutputState
@@ -18,11 +19,13 @@ from .model_event_headers import ModelEventHeaders
 from .model_event_message import ModelEventMessage
 from .model_producer_health_status import ModelProducerHealthStatus
 from .model_producer_message import ModelProducerMessage
+from .model_quarantine_wire_payload import ModelQuarantineWirePayload
 
 __all__ = [
     "ModelConsumerGroupIamPatterns",
     "ModelConsumerGroupIamSource",
     "ModelConsumerGroupScope",
+    "ModelDeliveryFailureEvidence",
     "ModelDeliveryResult",
     "ModelEventBusBootstrapResult",
     "ModelEventBusInputOutputState",
@@ -35,4 +38,5 @@ __all__ = [
     "ModelEventMessage",
     "ModelProducerHealthStatus",
     "ModelProducerMessage",
+    "ModelQuarantineWirePayload",
 ]

--- a/src/omnibase_core/models/event_bus/model_delivery_failure_evidence.py
+++ b/src/omnibase_core/models/event_bus/model_delivery_failure_evidence.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed delivery-failure evidence for a failed transport publish.
+
+Canonical shared evidence type embedded in the pre-ack quarantine wire
+payload (``ModelQuarantineWirePayload``, OMN-15667) as ``source_failure``.
+Frozen public Core name/field-set authority: Linear comment
+cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb on OMN-15666 (2026-08-02T20:10:29Z).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelDeliveryFailureEvidence(BaseModel):
+    """Typed evidence describing why a transport publish attempt failed.
+
+    Replaces a bare ``str`` error message with a strict, structured record so
+    a quarantine consumer can classify the failure (stage, error type,
+    retryability) without parsing free text.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    stage: str = Field(
+        ...,
+        description=(
+            "Delivery stage that failed, e.g. 'primary_dlq_publish' or "
+            "'quarantine_publish'."
+        ),
+    )
+    error_type: str = Field(
+        ...,
+        description="Exception/error class name observed at the failing stage.",
+    )
+    error_message: str = Field(
+        ...,
+        description="Human-readable error message observed at the failing stage.",
+    )
+    retryable: bool = Field(
+        ...,
+        description="Whether the observed failure is considered retryable.",
+    )
+
+
+__all__ = ["ModelDeliveryFailureEvidence"]

--- a/src/omnibase_core/models/event_bus/model_quarantine_wire_payload.py
+++ b/src/omnibase_core/models/event_bus/model_quarantine_wire_payload.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical pre-ack quarantine Kafka wire payload (OMN-15667).
+
+Causal invariant: a Kafka record cannot contain the broker partition/offset
+assigned by publishing that same record. ``ModelQuarantineWirePayload`` is the
+PRE-ACK representation of a failed, unacknowledged primary-DLQ publish -- it
+carries the authoritative source identity, a lossless copy of the original
+record bytes, and typed evidence of why the primary-DLQ publish failed. It
+has NO quarantine-topic/partition/offset fields, by construction: those
+broker coordinates do not exist yet at the point this payload is built, and
+``extra="forbid"`` rejects any attempt to smuggle them in.
+
+Post-ack truth (the quarantine topic/partition/offset actually assigned by
+the broker once THIS payload has been published to the quarantine topic)
+lives exclusively in the separate ``ModelQuarantineDispositionReceipt``
+(``omnibase_core.models.runtime``), constructed only after that publish is
+acknowledged. The two models are never merged into one -- doing so would
+require this payload to contain a value that cannot exist until after the
+payload itself has already been serialized and accepted by the broker.
+
+Frozen public Core name/field-set authority: Linear comment
+cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb on OMN-15666 (2026-08-02T20:10:29Z),
+which reaffirms the accepted OMN-15667 shape from the causal-audit comment
+c54fcc0e-015c-431a-a095-68558eada2b5 (2026-08-02T18:41:06Z): "keeps every
+existing top-level source field and primary_dlq_error_* field and adds exact
+source_failure: ModelDeliveryFailureEvidence." Field set/names/types here are
+pinned verbatim by the R2 harness reference
+(tests/fixtures/omn_15663_r2/target_models.py in the READ-ONLY
+omni_worktrees/OMN-15663/omninode_infra-renewal worktree) so Family A of
+tests/gateway/test_omn_15663_r2_family_a_dlq_durability.py can turn green
+later without any test edit.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.event_bus.model_delivery_failure_evidence import (
+    ModelDeliveryFailureEvidence,
+)
+
+
+class ModelQuarantineWirePayload(BaseModel):
+    """Pre-ack quarantine Kafka wire payload for a failed primary-DLQ publish.
+
+    Idempotency identity is exactly the four-field authoritative source
+    tuple: ``(source_envelope_id, source_topic, source_partition,
+    source_offset)``. Replaying the identical tuple must be recognized as the
+    same logical quarantine event; a distinct ``source_offset`` is always a
+    distinct event.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    source_envelope_id: UUID = Field(
+        ...,
+        description="Envelope identifier of the original source record.",
+    )
+    source_topic: str = Field(
+        ...,
+        description="Topic the original source record was consumed from.",
+    )
+    source_partition: int = Field(
+        ...,
+        description="Partition the original source record was consumed from.",
+        ge=0,
+    )
+    source_offset: int = Field(
+        ...,
+        description="Offset of the original source record within its partition.",
+        ge=0,
+    )
+    source_key_b64: str = Field(
+        ...,
+        description="Standard-base64 encoding of the original record key bytes.",
+    )
+    source_value_b64: str = Field(
+        ...,
+        description="Standard-base64 encoding of the original record value bytes.",
+    )
+    source_headers_b64: tuple[tuple[str, str], ...] = Field(
+        ...,
+        description=(
+            "Ordered, duplicate-preserving sequence of (header name, "
+            "standard-base64 header value) pairs from the original record. "
+            "Never a mapping: a mapping would silently collapse repeated "
+            "header names and could reorder them."
+        ),
+    )
+    primary_dlq_error_type: str = Field(
+        ...,
+        description="Exception/error class name observed publishing to the primary DLQ.",
+    )
+    primary_dlq_error_message: str = Field(
+        ...,
+        description="Error message observed publishing to the primary DLQ.",
+    )
+    source_failure: ModelDeliveryFailureEvidence = Field(
+        ...,
+        description="Typed evidence of the failed primary-DLQ publish attempt.",
+    )
+
+
+__all__ = ["ModelQuarantineWirePayload"]

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -27,6 +27,9 @@ from omnibase_core.models.runtime.model_liveness_registry_entry import (
     ModelLivenessRegistryEntry,
 )
 from omnibase_core.models.runtime.model_output_join_spec import ModelOutputJoinSpec
+from omnibase_core.models.runtime.model_quarantine_disposition_receipt import (
+    ModelQuarantineDispositionReceipt,
+)
 from omnibase_core.models.runtime.model_runtime_address import ModelRuntimeAddress
 from omnibase_core.models.runtime.model_runtime_address_registry import (
     ModelRuntimeAddressRegistry,
@@ -95,6 +98,8 @@ __all__ = [
     "ModelLivenessRegistryEntry",
     "ModelOutputJoinSpec",
     "ModelSamplingPolicy",
+    # Canonical quarantine disposition receipt (OMN-15667)
+    "ModelQuarantineDispositionReceipt",
     # Directive payload types (re-exported for convenience)
     "ModelDirectivePayload",
     "ModelDirectivePayloadBase",

--- a/src/omnibase_core/models/runtime/model_quarantine_disposition_receipt.py
+++ b/src/omnibase_core/models/runtime/model_quarantine_disposition_receipt.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical post-ack quarantine disposition receipt (OMN-15667).
+
+``ModelQuarantineDispositionReceipt`` is the sole surface carrying quarantine
+broker coordinates (``quarantine_topic``/``quarantine_partition``/
+``quarantine_offset``). It exists only AFTER the broker has acknowledged the
+publish of a ``ModelQuarantineWirePayload`` to the quarantine topic -- it is
+never serialized as that same Kafka record, and it is a distinct model from
+the pre-ack payload for exactly the reason that payload cannot contain these
+coordinates: they are assigned by publishing the payload, so they cannot
+also be a field of it.
+
+Frozen public Core name/field-set authority: Linear comment
+cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb on OMN-15666 (2026-08-02T20:10:29Z):
+"Existing ModelQuarantineDispositionReceipt remains the exact validated
+quarantine payload plus broker-returned quarantine topic/partition/offset" --
+unchanged from OMN-15667's original acceptance (comment
+822ef49f-68df-4902-abad-f0764a1258e6). Field set/names/types are pinned
+verbatim by the R2 harness reference
+(tests/fixtures/omn_15663_r2/target_models.py in the READ-ONLY
+omni_worktrees/OMN-15663/omninode_infra-renewal worktree).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.event_bus.model_quarantine_wire_payload import (
+    ModelQuarantineWirePayload,
+)
+
+
+class ModelQuarantineDispositionReceipt(BaseModel):
+    """Post-ack quarantine disposition receipt.
+
+    Carries the exact validated pre-ack wire payload plus the broker
+    acknowledgement's quarantine topic/partition/offset. Constructed only
+    after that acknowledgement is observed.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    quarantine_payload: ModelQuarantineWirePayload = Field(
+        ...,
+        description="The exact validated pre-ack quarantine wire payload that was published.",
+    )
+    quarantine_topic: str = Field(
+        ...,
+        description="Quarantine topic the payload was published to.",
+    )
+    quarantine_partition: int = Field(
+        ...,
+        description="Partition assigned by the broker acknowledgement.",
+        ge=0,
+    )
+    quarantine_offset: int = Field(
+        ...,
+        description="Offset assigned by the broker acknowledgement.",
+        ge=0,
+    )
+
+
+__all__ = ["ModelQuarantineDispositionReceipt"]

--- a/tests/unit/models/event_bus/test_model_delivery_failure_evidence.py
+++ b/tests/unit/models/event_bus/test_model_delivery_failure_evidence.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelDeliveryFailureEvidence.
+
+Frozen r2 contract authority: Linear comment cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb
+on OMN-15666 (2026-08-02T20:10:29Z) -- strict, frozen, extra="forbid"; exact
+required field set (stage, error_type, error_message, retryable).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.event_bus.model_delivery_failure_evidence import (
+    ModelDeliveryFailureEvidence,
+)
+
+
+@pytest.mark.unit
+class TestModelDeliveryFailureEvidence:
+    """Test suite for ModelDeliveryFailureEvidence."""
+
+    def test_construction_with_required_fields(self) -> None:
+        evidence = ModelDeliveryFailureEvidence(
+            stage="primary_dlq_publish",
+            error_type="ConnectionError",
+            error_message="mock broker refused publish",
+            retryable=True,
+        )
+        assert evidence.stage == "primary_dlq_publish"
+        assert evidence.error_type == "ConnectionError"
+        assert evidence.error_message == "mock broker refused publish"
+        assert evidence.retryable is True
+
+    def test_is_frozen(self) -> None:
+        evidence = ModelDeliveryFailureEvidence(
+            stage="quarantine_publish",
+            error_type="TimeoutError",
+            error_message="broker did not ack",
+            retryable=False,
+        )
+        with pytest.raises(ValidationError):
+            evidence.stage = "primary_dlq_publish"  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDeliveryFailureEvidence(
+                stage="primary_dlq_publish",
+                error_type="ConnectionError",
+                error_message="mock broker refused publish",
+                retryable=True,
+                schema_version="1.0.0",  # type: ignore[call-arg]
+            )
+
+    def test_missing_required_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDeliveryFailureEvidence(  # type: ignore[call-arg]
+                stage="primary_dlq_publish",
+                error_type="ConnectionError",
+                retryable=True,
+            )
+
+    def test_exact_field_set(self) -> None:
+        assert set(ModelDeliveryFailureEvidence.model_fields) == {
+            "stage",
+            "error_type",
+            "error_message",
+            "retryable",
+        }

--- a/tests/unit/models/event_bus/test_model_quarantine_wire_payload.py
+++ b/tests/unit/models/event_bus/test_model_quarantine_wire_payload.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelQuarantineWirePayload -- the pre-ack Kafka quarantine wire
+shape (OMN-15667).
+
+Causal invariant under test: a record cannot contain the broker
+partition/offset assigned by publishing that same record. This model
+represents a FAILED, UNACKNOWLEDGED primary-DLQ publish -- quarantine broker
+coordinates must be ABSENT BY CONSTRUCTION (there is no
+``quarantine_topic``/``quarantine_partition``/``quarantine_offset`` field, and
+``extra="forbid"`` rejects any attempt to smuggle them in). Post-ack truth
+lives exclusively in the separate ``ModelQuarantineDispositionReceipt``.
+
+Frozen r2 contract authority: Linear comment cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb
+on OMN-15666 (2026-08-02T20:10:29Z), reconciled with the OMN-15667 causal-audit
+comment c54fcc0e-015c-431a-a095-68558eada2b5 (2026-08-02T18:41:06Z) and pinned
+verbatim by the R2 harness reference
+(tests/fixtures/omn_15663_r2/target_models.py in the
+omni_worktrees/OMN-15663/omninode_infra-renewal READ-ONLY worktree). Field set,
+names, and types here MUST match that pin exactly so Family A of
+tests/gateway/test_omn_15663_r2_family_a_dlq_durability.py can turn green
+later without any test edit.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.event_bus.model_delivery_failure_evidence import (
+    ModelDeliveryFailureEvidence,
+)
+from omnibase_core.models.event_bus.model_quarantine_wire_payload import (
+    ModelQuarantineWirePayload,
+)
+
+QUARANTINE_WIRE_PAYLOAD_REQUIRED_FIELDS: tuple[str, ...] = (
+    "source_envelope_id",
+    "source_topic",
+    "source_partition",
+    "source_offset",
+    "source_key_b64",
+    "source_value_b64",
+    "source_headers_b64",
+    "primary_dlq_error_type",
+    "primary_dlq_error_message",
+    "source_failure",
+)
+
+
+def _valid_failure_evidence() -> ModelDeliveryFailureEvidence:
+    return ModelDeliveryFailureEvidence(
+        stage="primary_dlq_publish",
+        error_type="ConnectionError",
+        error_message="mock broker refused publish",
+        retryable=True,
+    )
+
+
+def _valid_quarantine_kwargs() -> dict:
+    return {
+        "source_envelope_id": uuid.uuid4(),
+        "source_topic": "onex.cmd.omnibase-infra.delegation-request.v1",
+        "source_partition": 0,
+        "source_offset": 42,
+        "source_key_b64": "a2V5",
+        "source_value_b64": "dmFsdWU=",
+        "source_headers_b64": (("trace-id", "dHJhY2U="),),
+        "primary_dlq_error_type": "ConnectionError",
+        "primary_dlq_error_message": "mock broker refused publish",
+        "source_failure": _valid_failure_evidence(),
+    }
+
+
+@pytest.mark.unit
+class TestModelQuarantineWirePayloadConstruction:
+    """Basic construction and frozen/strict invariants."""
+
+    def test_construction_with_required_fields(self) -> None:
+        source_id = uuid.uuid4()
+        payload = ModelQuarantineWirePayload(
+            **{**_valid_quarantine_kwargs(), "source_envelope_id": source_id}
+        )
+        assert payload.source_envelope_id == source_id
+        assert payload.source_topic == "onex.cmd.omnibase-infra.delegation-request.v1"
+        assert payload.source_partition == 0
+        assert payload.source_offset == 42
+        assert payload.source_failure.error_type == "ConnectionError"
+
+    def test_exact_ten_required_fields(self) -> None:
+        assert set(ModelQuarantineWirePayload.model_fields) == set(
+            QUARANTINE_WIRE_PAYLOAD_REQUIRED_FIELDS
+        )
+        assert len(QUARANTINE_WIRE_PAYLOAD_REQUIRED_FIELDS) == 10
+
+    def test_is_frozen(self) -> None:
+        payload = ModelQuarantineWirePayload(**_valid_quarantine_kwargs())
+        with pytest.raises(ValidationError):
+            payload.source_offset = 999  # type: ignore[misc]
+
+    def test_missing_required_field_rejected(self) -> None:
+        kwargs = _valid_quarantine_kwargs()
+        del kwargs["source_failure"]
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+    @pytest.mark.parametrize("field", ["source_partition", "source_offset"])
+    def test_negative_coordinate_rejected(self, field: str) -> None:
+        kwargs = _valid_quarantine_kwargs()
+        kwargs[field] = -1
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+
+@pytest.mark.unit
+class TestModelQuarantineWirePayloadCausalInvariant:
+    """The causal invariant IS the ticket: this model cannot carry quarantine
+    broker coordinates, because those coordinates are assigned only by
+    publishing this exact record -- a record cannot contain its own
+    not-yet-assigned broker offset."""
+
+    def test_quarantine_coordinates_are_not_fields(self) -> None:
+        assert "quarantine_topic" not in ModelQuarantineWirePayload.model_fields
+        assert "quarantine_partition" not in ModelQuarantineWirePayload.model_fields
+        assert "quarantine_offset" not in ModelQuarantineWirePayload.model_fields
+
+    def test_construction_impossible_with_quarantine_topic(self) -> None:
+        kwargs = {
+            **_valid_quarantine_kwargs(),
+            "quarantine_topic": "onex.dlq.quarantine.v1",
+        }
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+    def test_construction_impossible_with_quarantine_partition_and_offset(self) -> None:
+        kwargs = {
+            **_valid_quarantine_kwargs(),
+            "quarantine_partition": 0,
+            "quarantine_offset": 7,
+        }
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+    def test_construction_impossible_with_any_quarantine_coordinate_alone(self) -> None:
+        for field, value in (
+            ("quarantine_topic", "onex.dlq.quarantine.v1"),
+            ("quarantine_partition", 0),
+            ("quarantine_offset", 7),
+        ):
+            kwargs = {**_valid_quarantine_kwargs(), field: value}
+            with pytest.raises(ValidationError):
+                ModelQuarantineWirePayload(**kwargs)
+
+
+@pytest.mark.unit
+class TestModelQuarantineWirePayloadSourceTupleVerbatim:
+    """Authoritative source tuple (source_topic, source_partition,
+    source_offset) must survive verbatim -- it is the idempotency identity."""
+
+    def test_source_tuple_round_trips_verbatim(self) -> None:
+        payload = ModelQuarantineWirePayload(
+            **{
+                **_valid_quarantine_kwargs(),
+                "source_topic": "onex.cmd.omnibase-infra.delegation-request.v1",
+                "source_partition": 3,
+                "source_offset": 99,
+            }
+        )
+        assert (
+            payload.source_topic,
+            payload.source_partition,
+            payload.source_offset,
+        ) == ("onex.cmd.omnibase-infra.delegation-request.v1", 3, 99)
+
+    def test_distinct_source_offset_yields_distinct_identity(self) -> None:
+        source_id = uuid.uuid4()
+        a = ModelQuarantineWirePayload(
+            **{
+                **_valid_quarantine_kwargs(),
+                "source_envelope_id": source_id,
+                "source_offset": 1,
+            }
+        )
+        b = ModelQuarantineWirePayload(
+            **{
+                **_valid_quarantine_kwargs(),
+                "source_envelope_id": source_id,
+                "source_offset": 2,
+            }
+        )
+        identity_a = (
+            a.source_envelope_id,
+            a.source_topic,
+            a.source_partition,
+            a.source_offset,
+        )
+        identity_b = (
+            b.source_envelope_id,
+            b.source_topic,
+            b.source_partition,
+            b.source_offset,
+        )
+        assert identity_a != identity_b
+
+
+@pytest.mark.unit
+class TestModelQuarantineWirePayloadHeadersRoundTrip:
+    """Kafka headers are an ordered, duplicate-preserving sequence of
+    (name, value) base64 pairs -- never a mapping, which would silently
+    collapse repeated header names and lose ordering."""
+
+    def test_headers_is_tuple_of_pairs(self) -> None:
+        payload = ModelQuarantineWirePayload(**_valid_quarantine_kwargs())
+        assert isinstance(payload.source_headers_b64, tuple)
+        assert payload.source_headers_b64 == (("trace-id", "dHJhY2U="),)
+
+    def test_duplicate_keys_and_order_preserved(self) -> None:
+        headers = (
+            ("trace-id", "dHJhY2U="),
+            ("trace-id", "ZHVw"),
+            ("span-id", "c3Bhbg=="),
+            ("trace-id", "dGhpcmQ="),
+        )
+        payload = ModelQuarantineWirePayload(
+            **{**_valid_quarantine_kwargs(), "source_headers_b64": headers}
+        )
+        assert payload.source_headers_b64 == headers
+        # Sanity check on the anti-pattern this model prevents: collapsing
+        # to a mapping silently drops duplicate keys and can reorder.
+        collapsed_as_dict = dict(payload.source_headers_b64)
+        assert len(collapsed_as_dict) == 2
+        assert len(payload.source_headers_b64) == 4
+
+    def test_empty_headers_allowed(self) -> None:
+        payload = ModelQuarantineWirePayload(
+            **{**_valid_quarantine_kwargs(), "source_headers_b64": ()}
+        )
+        assert payload.source_headers_b64 == ()
+
+    def test_headers_as_dict_rejected(self) -> None:
+        """A mapping must not be silently coerced into the pair-tuple shape."""
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(
+                **{
+                    **_valid_quarantine_kwargs(),
+                    "source_headers_b64": {"trace-id": "dHJhY2U="},
+                }
+            )
+
+
+@pytest.mark.unit
+class TestModelQuarantineWirePayloadR1RejectedMutations:
+    """Permanent standing control reproducing the r1-rejection findings
+    (Linear comment b1c09ed7): each named invented/renamed-field mutation
+    must independently fail strict validation -- forever, so no future edit
+    of this model can silently re-accept the rejected shape."""
+
+    def test_invented_schema_version_rejected(self) -> None:
+        kwargs = {**_valid_quarantine_kwargs(), "schema_version": "1.0.0"}
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+    def test_invented_primary_dlq_payload_rejected(self) -> None:
+        kwargs = {
+            **_valid_quarantine_kwargs(),
+            "primary_dlq_payload": {"nested": "wrong"},
+        }
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)
+
+    def test_renamed_nested_failure_key_rejected(self) -> None:
+        kwargs = _valid_quarantine_kwargs()
+        failure = kwargs.pop("source_failure")
+        kwargs["failure_evidence"] = failure
+        with pytest.raises(ValidationError):
+            ModelQuarantineWirePayload(**kwargs)

--- a/tests/unit/models/runtime/test_model_quarantine_disposition_receipt.py
+++ b/tests/unit/models/runtime/test_model_quarantine_disposition_receipt.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelQuarantineDispositionReceipt -- the post-ack quarantine
+disposition receipt (OMN-15667).
+
+This is the sole surface carrying quarantine broker coordinates
+(quarantine_topic/quarantine_partition/quarantine_offset), and it exists only
+AFTER the broker has acknowledged the quarantine publish. It is a distinct
+model from the pre-ack ``ModelQuarantineWirePayload`` -- the causal invariant
+under test in the sibling wire-payload suite is enforced here from the other
+side: this receipt is the ONLY place those coordinates may appear.
+
+Frozen r2 contract authority: Linear comment cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb
+on OMN-15666 ("Existing ModelQuarantineDispositionReceipt remains the exact
+validated quarantine payload plus broker-returned quarantine
+topic/partition/offset" -- unchanged from OMN-15667's original acceptance),
+pinned verbatim by the R2 harness reference
+(tests/fixtures/omn_15663_r2/target_models.py, READ-ONLY).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.event_bus.model_delivery_failure_evidence import (
+    ModelDeliveryFailureEvidence,
+)
+from omnibase_core.models.event_bus.model_quarantine_wire_payload import (
+    ModelQuarantineWirePayload,
+)
+from omnibase_core.models.runtime.model_quarantine_disposition_receipt import (
+    ModelQuarantineDispositionReceipt,
+)
+
+
+def _valid_wire_payload() -> ModelQuarantineWirePayload:
+    return ModelQuarantineWirePayload(
+        source_envelope_id=uuid.uuid4(),
+        source_topic="onex.cmd.omnibase-infra.delegation-request.v1",
+        source_partition=0,
+        source_offset=42,
+        source_key_b64="a2V5",
+        source_value_b64="dmFsdWU=",
+        source_headers_b64=(("trace-id", "dHJhY2U="),),
+        primary_dlq_error_type="ConnectionError",
+        primary_dlq_error_message="mock broker refused publish",
+        source_failure=ModelDeliveryFailureEvidence(
+            stage="primary_dlq_publish",
+            error_type="ConnectionError",
+            error_message="mock broker refused publish",
+            retryable=True,
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestModelQuarantineDispositionReceiptConstruction:
+    def test_construction_with_required_fields(self) -> None:
+        payload = _valid_wire_payload()
+        receipt = ModelQuarantineDispositionReceipt(
+            quarantine_payload=payload,
+            quarantine_topic="onex.dlq.quarantine.v1",
+            quarantine_partition=0,
+            quarantine_offset=7,
+        )
+        assert receipt.quarantine_payload == payload
+        assert receipt.quarantine_topic == "onex.dlq.quarantine.v1"
+        assert receipt.quarantine_partition == 0
+        assert receipt.quarantine_offset == 7
+
+    def test_exact_four_required_fields(self) -> None:
+        assert set(ModelQuarantineDispositionReceipt.model_fields) == {
+            "quarantine_payload",
+            "quarantine_topic",
+            "quarantine_partition",
+            "quarantine_offset",
+        }
+
+    def test_is_frozen(self) -> None:
+        receipt = ModelQuarantineDispositionReceipt(
+            quarantine_payload=_valid_wire_payload(),
+            quarantine_topic="onex.dlq.quarantine.v1",
+            quarantine_partition=0,
+            quarantine_offset=7,
+        )
+        with pytest.raises(ValidationError):
+            receipt.quarantine_offset = 8  # type: ignore[misc]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelQuarantineDispositionReceipt(
+                quarantine_payload=_valid_wire_payload(),
+                quarantine_topic="onex.dlq.quarantine.v1",
+                quarantine_partition=0,
+                quarantine_offset=7,
+                schema_version="1.0.0",  # type: ignore[call-arg]
+            )
+
+    @pytest.mark.parametrize("field", ["quarantine_partition", "quarantine_offset"])
+    def test_negative_coordinate_rejected(self, field: str) -> None:
+        kwargs = {
+            "quarantine_payload": _valid_wire_payload(),
+            "quarantine_topic": "onex.dlq.quarantine.v1",
+            "quarantine_partition": 0,
+            "quarantine_offset": 7,
+        }
+        kwargs[field] = -1
+        with pytest.raises(ValidationError):
+            ModelQuarantineDispositionReceipt(**kwargs)
+
+    def test_missing_quarantine_payload_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelQuarantineDispositionReceipt(  # type: ignore[call-arg]
+                quarantine_topic="onex.dlq.quarantine.v1",
+                quarantine_partition=0,
+                quarantine_offset=7,
+            )
+
+
+@pytest.mark.unit
+class TestModelQuarantineDispositionReceiptCausalInvariant:
+    """The receipt is the ONLY surface carrying quarantine broker
+    coordinates; the embedded wire payload must remain the exact pre-ack
+    model with no coordinate fields of its own."""
+
+    def test_embedded_payload_has_no_quarantine_coordinate_fields(self) -> None:
+        receipt = ModelQuarantineDispositionReceipt(
+            quarantine_payload=_valid_wire_payload(),
+            quarantine_topic="onex.dlq.quarantine.v1",
+            quarantine_partition=0,
+            quarantine_offset=7,
+        )
+        payload_fields = type(receipt.quarantine_payload).model_fields
+        assert "quarantine_topic" not in payload_fields
+        assert "quarantine_partition" not in payload_fields
+        assert "quarantine_offset" not in payload_fields
+
+    def test_replaying_identical_source_tuple_is_a_distinct_receipt_per_ack(
+        self,
+    ) -> None:
+        """Replaying the identical authoritative source tuple against two
+        separate acknowledgements (e.g. an idempotent retry that lands the
+        same publish twice) produces two receipts that are equal in payload
+        identity but may carry distinct broker coordinates -- the receipt
+        model itself does not collapse them; that collapsing is an
+        idempotency-layer concern (owned elsewhere), not a schema concern."""
+        payload = _valid_wire_payload()
+        first = ModelQuarantineDispositionReceipt(
+            quarantine_payload=payload,
+            quarantine_topic="onex.dlq.quarantine.v1",
+            quarantine_partition=0,
+            quarantine_offset=7,
+        )
+        second = ModelQuarantineDispositionReceipt(
+            quarantine_payload=payload,
+            quarantine_topic="onex.dlq.quarantine.v1",
+            quarantine_partition=0,
+            quarantine_offset=7,
+        )
+        assert first == second
+        assert (
+            first.quarantine_payload.source_envelope_id
+            == second.quarantine_payload.source_envelope_id
+        )


### PR DESCRIPTION
## OMN-15667: canonical quarantine schema — pre-ack wire payload vs post-ack disposition receipt

Adds two new, never-merged models plus a shared evidence type, encoding the causal invariant that is the ticket: **a Kafka record cannot contain the broker offset assigned by publishing that same record**, so a payload representing a failed, unacknowledged primary-DLQ publish cannot carry quarantine broker coordinates.

### Seam declaration (field-by-field)

**`omnibase_core.models.event_bus.ModelDeliveryFailureEvidence`** (new, shared) — strict/frozen/`extra="forbid"`:
| field | type |
|---|---|
| `stage` | `str` |
| `error_type` | `str` |
| `error_message` | `str` |
| `retryable` | `bool` |

**`omnibase_core.models.event_bus.ModelQuarantineWirePayload`** (new, PRE-ACK) — strict/frozen/`extra="forbid"`, exactly 10 fields, no more no fewer:
| field | type | note |
|---|---|---|
| `source_envelope_id` | `UUID` | authoritative source identity |
| `source_topic` | `str` | authoritative source identity |
| `source_partition` | `int` (`ge=0`) | authoritative source identity |
| `source_offset` | `int` (`ge=0`) | authoritative source identity |
| `source_key_b64` | `str` | lossless original record key |
| `source_value_b64` | `str` | lossless original record value |
| `source_headers_b64` | `tuple[tuple[str, str], ...]` | ordered, duplicate-preserving — **never** a mapping |
| `primary_dlq_error_type` | `str` | primary-DLQ publish failure evidence |
| `primary_dlq_error_message` | `str` | primary-DLQ publish failure evidence |
| `source_failure` | `ModelDeliveryFailureEvidence` | typed primary-DLQ failure evidence |

By construction there is **no** `quarantine_topic` / `quarantine_partition` / `quarantine_offset` field on this model, and `extra="forbid"` rejects any attempt to smuggle them in via kwargs — those coordinates do not exist yet at the point this payload is built.

**`omnibase_core.models.runtime.ModelQuarantineDispositionReceipt`** (new, POST-ACK, unchanged from the original OMN-15667 acceptance) — strict/frozen/`extra="forbid"`:
| field | type |
|---|---|
| `quarantine_payload` | `ModelQuarantineWirePayload` |
| `quarantine_topic` | `str` |
| `quarantine_partition` | `int` (`ge=0`) |
| `quarantine_offset` | `int` (`ge=0`) |

This is the **sole** surface carrying quarantine broker coordinates, constructed only after the broker acknowledges the publish of the wire payload above — it is never serialized as that same Kafka record.

### Authority reconciliation

Binding order followed: frozen comment > R2 harness pins > ruling prose.

1. **Frozen public Core names** — Linear comment [cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb](https://linear.app/omninode/issue/OMN-15666#comment-cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb) on OMN-15666 (2026-08-02T20:10:29Z): "the accepted OMN-15667 `ModelQuarantineWirePayload` keeps every existing top-level source field and `primary_dlq_error_*` field and adds exact `source_failure: ModelDeliveryFailureEvidence`" and "Existing `ModelQuarantineDispositionReceipt` remains the exact validated quarantine payload plus broker-returned quarantine topic/partition/offset." Both models here match that verbatim.
2. **R2 harness pins (READ-ONLY reference, not touched)** — `omni_worktrees/OMN-15663/omninode_infra-renewal/tests/fixtures/omn_15663_r2/target_models.py` pins the identical field set/names/types for `ModelDeliveryFailureEvidence`, `ModelQuarantineWirePayload`, and `ModelQuarantineDispositionReceipt`. This PR's models are field-for-field, type-for-type identical to that pin.
3. **OMN-15667's own body/comments** — the accepted r2 state ("lossless ordered duplicate Kafka headers and pre-ack-wire vs post-ack-receipt split now exact in both oracle and Linear," comment 850a432d / c54fcc0e) is treated as settled and not re-litigated; this PR implements exactly that settled shape.

Out of scope (belongs to OMN-15666, the dual-sink orchestration ticket): `ModelPrimaryDlqWirePayload`, `ModelTransportPublishAcknowledgement`, `ModelPrimaryDlqDispositionReceipt`, `ModelDeliveryContext`, `ProtocolTransportProducer`/`ProtocolTerminalDispositionAdapter`, `DualPublishFailureError`. This ticket owns only the quarantine-side payload/schema consumed at that boundary.

### Causal-invariant test evidence

33 new unit tests (`tests/unit/models/event_bus/test_model_delivery_failure_evidence.py`, `tests/unit/models/event_bus/test_model_quarantine_wire_payload.py`, `tests/unit/models/runtime/test_model_quarantine_disposition_receipt.py`), TDD (RED confirmed via `ModuleNotFoundError` before implementation, GREEN after):

- **No quarantine coords pre-ack**: `test_quarantine_coordinates_are_not_fields` (not in `model_fields`) + `test_construction_impossible_with_quarantine_topic` / `_and_offset` / `_any_quarantine_coordinate_alone` (each independently raises `ValidationError` under `extra="forbid"`).
- **Coords only post-ack**: `TestModelQuarantineDispositionReceiptCausalInvariant.test_embedded_payload_has_no_quarantine_coordinate_fields` — the receipt's own embedded payload still carries zero quarantine-coordinate fields; the receipt itself is the only place `quarantine_topic`/`quarantine_partition`/`quarantine_offset` can appear.
- **Lossless, ordered, duplicate-preserving headers**: `test_duplicate_keys_and_order_preserved` constructs four headers including three `trace-id` duplicates in a specific order, asserts the tuple round-trips byte-identical, and asserts collapsing to `dict()` would silently drop two of them (sanity check on the anti-pattern the tuple shape prevents). `test_headers_as_dict_rejected` proves a mapping input is not silently coerced.
- **Source tuple verbatim**: `TestModelQuarantineWirePayloadSourceTupleVerbatim` — `(source_topic, source_partition, source_offset)` round-trips unchanged; a distinct `source_offset` yields a distinct four-field identity tuple.
- **Standing r1-rejection controls**: `TestModelQuarantineWirePayloadR1RejectedMutations` reproduces the three mutations Linear comment b1c09ed7 rejected (`schema_version`, `primary_dlq_payload`, renamed `failure_evidence` key) — each independently raises `ValidationError` forever, mirroring the permanent control in the R2 harness.

Full suite (pre-push governed selector escalated to unconditional full run because shared `models/event_bus/__init__.py` + `models/runtime/__init__.py` exports were touched): **43,741 passed, 53 skipped, 3 xpassed, 0 failed** (1:41:31, `.200`/Stickybeatz-Studio). `mypy --strict`, `pyright`, `ruff format`/`check`, import-linter, and the naming-convention checker all pass clean on the touched files; `pre-commit` (staged-scope, commit-time) was clean.

### R2 Family A compatibility note

`tests/gateway/test_omn_15663_r2_family_a_dlq_durability.py` (READ-ONLY worktree, not touched) currently imports its reference models from `tests/fixtures/omn_15663_r2/target_models.py`, not from `omnibase_core`. This PR's `ModelDeliveryFailureEvidence` / `ModelQuarantineWirePayload` / `ModelQuarantineDispositionReceipt` are field-for-field, type-for-type identical to that pin (10 required fields on the wire payload, same names/types/nonnegative constraints, same tuple-of-pairs header shape) — Family A's RED assertions can turn GREEN later purely by re-pointing imports at these Core models, with **no test edit**.

### Landing order

Smaller diff than OMN-15665 (delivery-context rebuild) — suggest landing this PR first. Independent of OMN-15665 (no shared files touched: this PR only adds new `model_delivery_failure_evidence.py` / `model_quarantine_wire_payload.py` / `model_quarantine_disposition_receipt.py` files plus additive-only entries in the two pre-existing `__init__.py` export lists). Must land before OMN-15666 (dual-sink durability), which imports these models directly per the frozen r2 authority.

Ticket: OMN-15667

proof_class: code-only


Evidence-Ticket: OMN-15667
Evidence-Source: OCC#6028
promotion-receipt: OCC-6028
