### PR TITLE
feat(OMN-15665): immutable RuntimeDispatch delivery context at the receipt boundary

### DIFF
--- a/src/omnibase_core/models/runtime/model_delivery_context.py
+++ b/src/omnibase_core/models/runtime/model_delivery_context.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical immutable delivery context (OMN-15665).
+
+The truthful, RuntimeDispatch-context-resident identity of one inbound record:
+the broker-assigned coordinates (``topic`` / ``partition`` / ``offset``) plus the
+envelope's own authoritative ``envelope_id`` — as delivered, never re-derived,
+never a ``uuid4()`` fallback.
+
+This is Core-resident by the same layering logic as
+``docs/architecture/layering-exceptions.yaml`` LAYER-EXC-001/002: it is the
+canonical identity RuntimeDispatch depends on for the receipt boundary, and
+RuntimeDispatch is Core-resident. It is deliberately **separate** from the def-B
+handler argument (``handle(request: ModelX) -> ModelY``) — no handler signature
+ever gains a second parameter for this. Adding one hard-fails the OMN-14355
+canon-shape ratchet.
+
+Authority: the 2026-08-02 lab-readiness ruling (accepted refinement 4, "Canonical
+delivery context stays outside def-B") and Linear comment ``cfb64e0f`` on
+OMN-15666 (the frozen r2 contract decision, which reproduces this exact
+four-field shape as the reference the R2 golden-RED harness validates against —
+``omninode_infra``'s
+``tests/fixtures/omn_15663_r2/target_models.py::ModelDeliveryContext``).
+
+``partition`` and ``offset`` reject negative values: a ``-1`` (or any negative)
+coordinate is a fabricated sentinel, never a legitimate broker-assigned position.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_NONNEGATIVE_MSG = (
+    "must be a nonnegative broker-assigned coordinate, not a fabricated sentinel"
+)
+
+
+class ModelDeliveryContext(BaseModel):
+    """Immutable, broker-populated-only delivery identity for one inbound record.
+
+    Frozen value object; `extra="forbid"` — exactly the four fields below, no more.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    envelope_id: UUID
+    """The inbound envelope's own authoritative id, as delivered on the wire.
+
+    Never a fresh ``uuid4()``, never aliased from ``correlation_id`` — an absent or
+    unparsable wire ``envelope_id`` fails closed at the receipt boundary (see
+    ``omnibase_core.runtime.runtime_delivery_context.build_delivery_context``)."""
+
+    topic: str
+    """Source topic the record was polled from (broker coordinate, verbatim)."""
+
+    partition: int
+    """Partition the record belongs to (broker coordinate, verbatim)."""
+
+    offset: int
+    """Monotonic per-partition offset of the record (broker coordinate, verbatim)."""
+
+    @field_validator("partition", "offset")
+    @classmethod
+    def _nonnegative(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError(_NONNEGATIVE_MSG)
+        return value
+
+
+__all__ = ["ModelDeliveryContext"]

--- a/src/omnibase_core/protocols/runtime/protocol_delivery_context.py
+++ b/src/omnibase_core/protocols/runtime/protocol_delivery_context.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Structural protocol for the canonical delivery context (OMN-15665).
+
+Declared purely structurally (read-only properties typed with stdlib ``UUID`` /
+``str`` / ``int`` only) so this module imports **no** ``omnibase_core.models``
+symbol — a new ``protocols -> models`` edge is frozen at its ceiling (OMN-14340
+growth ratchet, ``scripts/ci/check_import_ratchet.py``: ``FROZEN_PROTOCOLS_MODELS_MAX
+= 65``) and a new edge hard-fails CI. The concrete
+``omnibase_core.models.runtime.model_delivery_context.ModelDeliveryContext``
+satisfies this protocol structurally (duck typing via ``runtime_checkable``)
+without either side importing the other.
+
+This is the public Core-resident structural seam the OMN-15665 acceptance
+criteria call for: "the concrete ``ModelDeliveryContext`` satisfies that protocol
+statically and at runtime."
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+from uuid import UUID
+
+
+@runtime_checkable
+class ProtocolDeliveryContext(Protocol):
+    """Read-only, four-field structural shape of one inbound record's identity.
+
+    Deliberately NOT importable-by / dependent-on the disposition-adapter
+    protocols (OMN-15663/OMN-15666/OMN-15667 territory) — this protocol describes
+    identity only, never a terminal-disposition outcome.
+    """
+
+    @property
+    def envelope_id(self) -> UUID:
+        """The inbound envelope's own authoritative id, as delivered."""
+        ...
+
+    @property
+    def topic(self) -> str:
+        """Source topic the record was polled from."""
+        ...
+
+    @property
+    def partition(self) -> int:
+        """Partition the record belongs to."""
+        ...
+
+    @property
+    def offset(self) -> int:
+        """Monotonic per-partition offset of the record."""
+        ...
+
+
+__all__ = ["ProtocolDeliveryContext"]

--- a/src/omnibase_core/protocols/runtime/protocol_delivery_receipt_adapter.py
+++ b/src/omnibase_core/protocols/runtime/protocol_delivery_receipt_adapter.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""``ProtocolDeliveryReceiptAdapter`` — the OMN-15665 receipt-ack callable.
+
+Authority: Linear comment ``cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb`` on OMN-15666
+(the frozen r2 contract decision) states this OMN-15665 contract is UNCHANGED by
+r2: "the unchanged OMN-15665 ``ProtocolDeliveryReceiptAdapter`` contract
+``Callable[[], Awaitable[None]] -> None``". The R2 harness pin
+(``omninode_infra``'s
+``tests/fixtures/omn_15663_r2/target_models.py::ProtocolDeliveryReceiptAdapter``)
+reproduces the identical zero-argument shape.
+
+Deliberately a zero-argument awaitable, NOT ``execute_once(context)`` /
+``dispose(context)`` — that shape belongs to the separate, context-consuming
+disposition-adapter protocols owned by OMN-15663/OMN-15666/OMN-15667
+(``ProtocolTerminalDispositionAdapter``). Collapsing the two into one shape was
+r1-rejection defect #3 (a mock disposition store wrongly required a non-None
+result from *this* protocol) and must never recur.
+
+Per-delivery context is threaded through a **factory**, not through this
+protocol's call signature: ``RuntimeDispatch`` accepts an optional
+``delivery_receipt_adapter_factory: Callable[[ModelDeliveryContext],
+Callable[[], Awaitable[None]]]`` (see ``runtime_dispatch.py``) that closes over
+one message's ``ModelDeliveryContext`` and returns a zero-arg callable satisfying
+this exact protocol. This reconciles "the adapter needs per-message identity"
+with "the adapter's public shape is frozen at zero-arg."
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolDeliveryReceiptAdapter(Protocol):
+    """Zero-argument, no-return awaitable receipt-ack callable."""
+
+    async def __call__(self) -> None: ...
+
+
+__all__ = ["ProtocolDeliveryReceiptAdapter"]

--- a/src/omnibase_core/runtime/runtime_delivery_context.py
+++ b/src/omnibase_core/runtime/runtime_delivery_context.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The adapter surface that populates ``ModelDeliveryContext`` at the receipt
+boundary (OMN-15665).
+
+Pure function, no I/O — isolated here the same way ``runtime_envelope_router``
+isolates the envelope boundary, so this load-bearing seam is unit-testable in
+isolation and reusable unchanged against any transport.
+
+``topic`` / ``partition`` / ``offset`` are the broker-assigned coordinates the
+transport already carries on the polled record — copied verbatim, never
+re-derived. ``envelope_id`` is the one field that needs care: it is read directly
+from the RAW wire bytes (a fresh ``json.loads``, independent of
+``ModelEventEnvelope`` parsing) rather than from the pydantic-validated envelope.
+``ModelEventEnvelope.envelope_id`` is declared with ``default_factory=uuid4``, so
+a record whose wire bytes never truthfully carried an ``envelope_id`` would
+otherwise silently validate into a **freshly fabricated** id — exactly the
+fabrication class ("never a ``uuid4()``-fabricated fallback") this ticket exists
+to close. Re-parsing the raw bytes here is the only way to tell "the wire
+genuinely carried this id" apart from "pydantic quietly minted one".
+
+This module intentionally imports no ``omnibase_core.protocols`` symbol (only
+``json``, ``uuid.UUID``, the error model, and ``ModelDeliveryContext`` — a plain
+model import, not a protocols-hub edge) so it adds no new importer to the frozen
+``protocols`` hub (OMN-14340 growth ratchet).
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.runtime.model_delivery_context import ModelDeliveryContext
+
+__all__ = ["build_delivery_context"]
+
+
+def build_delivery_context(
+    *, topic: str, partition: int, offset: int, raw_value: bytes
+) -> ModelDeliveryContext:
+    """Build the immutable, broker-populated-only delivery context for one record.
+
+    Fails closed (``ModelOnexError``) rather than fabricate an identity when:
+    * ``raw_value`` is not valid JSON, or not a JSON object;
+    * the ``envelope_id`` key is absent or ``null``;
+    * ``envelope_id`` is not a parsable UUID;
+    * ``partition`` / ``offset`` is negative (a fabricated sentinel, never a
+      legitimate broker-assigned coordinate).
+
+    ``topic`` / ``partition`` / ``offset`` are the caller's own broker
+    coordinates (the polled transport message), passed through verbatim.
+    """
+    try:
+        raw = json.loads(raw_value)
+    except Exception as exc:  # boundary-ok: malformed wire bytes are surfaced as a typed error, never treated as a bare/empty envelope
+        raise ModelOnexError(
+            message=(
+                "build_delivery_context: raw wire bytes are not valid JSON — "
+                "cannot recover an authoritative envelope_id."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise ModelOnexError(
+            message=(
+                "build_delivery_context: decoded wire JSON is not an object — "
+                f"got {type(raw).__name__}; cannot recover an authoritative "
+                "envelope_id."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    raw_envelope_id = raw.get("envelope_id")
+    if raw_envelope_id is None:
+        raise ModelOnexError(
+            message=(
+                "build_delivery_context: wire record carries no envelope_id — "
+                "refusing to fabricate one (never uuid4()-fallback at the "
+                "receipt boundary)."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        )
+
+    try:
+        envelope_id = UUID(str(raw_envelope_id))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ModelOnexError(
+            message=(
+                "build_delivery_context: wire envelope_id "
+                f"{raw_envelope_id!r} is not a parsable UUID."
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        ) from exc
+
+    try:
+        return ModelDeliveryContext(
+            envelope_id=envelope_id,
+            topic=topic,
+            partition=partition,
+            offset=offset,
+        )
+    except Exception as exc:  # boundary-ok: pydantic validation (e.g. negative coordinate) is surfaced as a typed error at this boundary
+        raise ModelOnexError(
+            message=(
+                "build_delivery_context: refusing to build a delivery context "
+                f"for topic={topic!r} partition={partition} offset={offset} — "
+                f"{exc}"
+            ),
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+        ) from exc

--- a/src/omnibase_core/runtime/runtime_dispatch.py
+++ b/src/omnibase_core/runtime/runtime_dispatch.py
@@ -35,6 +35,13 @@ What it owns (runtime = policy; transport = mechanism, plan I6):
    prefix; the first ``REDELIVER`` stops that partition's prefix and nothing past it is
    committed this round. ONE commit per partition per poll (throughput), correctness by
    the same decision.
+7. The RECEIPT boundary (OMN-15665): a canonical, immutable ``ModelDeliveryContext``
+   (``envelope_id``/``topic``/``partition``/``offset``) is built fail-closed at this
+   boundary for every record — never a fabricated identity — and, when an optional
+   ``delivery_receipt_adapter_factory`` is injected, its per-message zero-arg receipt-ack
+   callable is awaited before the message becomes committable. Omitting the factory
+   (the default) preserves the pre-ticket at-least-once behavior unchanged; see
+   :attr:`RuntimeDispatch.delivery_receipts_enabled`.
 """
 
 from __future__ import annotations
@@ -54,6 +61,8 @@ from omnibase_core.enums.enum_delivery_disposition import EnumDeliveryDispositio
 from omnibase_core.enums.enum_node_kind import EnumNodeKind
 from omnibase_core.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.model_delivery_context import ModelDeliveryContext
+from omnibase_core.runtime.runtime_delivery_context import build_delivery_context
 from omnibase_core.runtime.runtime_envelope_router import (
     decode_inbound_envelope,
     wrap_outbound_envelope,
@@ -184,10 +193,20 @@ class RuntimeDispatch:
         max_retries: int = _DEFAULT_MAX_RETRIES,
         dlq_topic_resolver: Callable[[str], str] | None = None,
         clock: Callable[[], datetime] | None = None,
+        delivery_receipt_adapter_factory: (
+            Callable[[ModelDeliveryContext], Callable[[], Awaitable[None]]] | None
+        ) = None,
     ) -> None:
         self._consumer = consumer
         self._producer = producer
         self._routing_map: dict[str, DispatchRoute] = dict(routing_map)
+        # OMN-15665: optional, keyword-only, default None. A required kwarg here
+        # broke every existing RuntimeDispatch(...) call site (the 2026-08-02
+        # CORE-PASS / CROSS-REPO-FAIL defect at omnibase_infra composition.py:430)
+        # — never repeat that. Existing composition roots that omit this preserve
+        # the pre-ticket at-least-once behavior and make no durable-receipt claim
+        # (see delivery_receipts_enabled).
+        self._delivery_receipt_adapter_factory = delivery_receipt_adapter_factory
         # Extension point (plan section (g), S0 binding schemas): a fallback route so a
         # polled topic absent from ``routing_map`` is NOT silently dropped. The
         # omniclaude ``io_operations`` shell-binding + ``default_handler`` coverage
@@ -216,6 +235,17 @@ class RuntimeDispatch:
                 self._default_route.published_events,
                 context=f"default_route::{self._default_route.name}",
             )
+
+    @property
+    def delivery_receipts_enabled(self) -> bool:
+        """``True`` only when a receipt-adapter factory was injected at construction.
+
+        ``False`` (the default) makes NO durable-receipt claim — the pre-ticket
+        at-least-once behavior is unchanged. Never presented as durable evidence
+        by a volatile or pass-through adapter; that determination belongs to the
+        injected factory/adapter, not to this flag alone.
+        """
+        return self._delivery_receipt_adapter_factory is not None
 
     def stop(self) -> None:
         """Request the :meth:`run` loop to exit after the current poll cycle."""
@@ -327,6 +357,19 @@ class RuntimeDispatch:
                     error_code=EnumCoreErrorCode.CONTRACT_VALIDATION_ERROR,
                 )
             envelope = decode_inbound_envelope(message.value)
+            # OMN-15665 receipt boundary: the canonical immutable delivery context
+            # is built here, UNCONDITIONALLY and fail-closed — envelope_id is read
+            # from the raw wire bytes (never the pydantic-fabricated default), and
+            # topic/partition/offset are this record's own broker coordinates. A
+            # message that cannot produce a truthful context is never committed
+            # with a fabricated identity, whether or not a receipt adapter is
+            # configured.
+            delivery_context = build_delivery_context(
+                topic=message.topic,
+                partition=message.partition,
+                offset=message.offset,
+                raw_value=message.value,
+            )
             request = self._coerce_request(envelope, route)
             result = await self._invoke(route, request)
             pairs = self._resolve_outbound(result, route)
@@ -355,6 +398,19 @@ class RuntimeDispatch:
                     value=out_envelope.model_dump_json().encode("utf-8"),
                     headers={},
                 )
+
+            # OMN-15665: when a receipt-adapter factory is configured, it receives
+            # THIS message's immutable delivery context and its bound zero-arg
+            # receipt-ack callable is awaited BEFORE the message becomes
+            # committable. A receipt-adapter failure falls through to the same
+            # except-block below (redeliver within budget, else DLQ) — never a
+            # silent commit past an unacknowledged receipt.
+            if self._delivery_receipt_adapter_factory is not None:
+                receipt_adapter = self._delivery_receipt_adapter_factory(
+                    delivery_context
+                )
+                await receipt_adapter()
+
             self._attempts.pop(key, None)
             return EnumDeliveryDisposition.COMMIT
         except Exception as exc:  # fallback-ok: the failure is SURFACED (logged) and converted to a delivery disposition (redeliver within budget, else DLQ) — the at-least-once contract, NOT a swallow; re-raising would abort the whole poll loop. CancelledError is BaseException and stays uncaught.

--- a/tests/unit/models/runtime/test_model_delivery_context.py
+++ b/tests/unit/models/runtime/test_model_delivery_context.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED-first tests for the canonical ``ModelDeliveryContext`` (OMN-15665).
+
+Authority (binding order: frozen Linear comment > R2 harness pins > ruling prose):
+
+* Linear comment ``cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb`` on OMN-15666 — the frozen
+  r2 contract decision (author Jonah Gray, 2026-08-02T20:10:29Z).
+* R2 harness pin (READ-ONLY reference, not modified here):
+  ``omni_worktrees/OMN-15663/omninode_infra-renewal/tests/fixtures/omn_15663_r2/
+  target_models.py::ModelDeliveryContext`` — this test asserts the SAME shape
+  (field names, types, frozen/forbid, nonnegative validators) so that repo's
+  Family F golden-RED tests can later turn GREEN against the real Core type
+  without any test edits over there.
+* 2026-08-02 lab-readiness ruling, accepted refinement 4: the canonical delivery
+  context "belongs in the owning Core, SPI, or runtime layer, separate from the
+  def-B handler argument."
+
+``ModelDeliveryContext`` is immutable, broker-populated ONLY — never a
+``uuid4()``-fabricated identity, never a negative/sentinel coordinate.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.runtime.model_delivery_context import ModelDeliveryContext
+
+
+def test_exact_four_field_set_frozen_and_forbid() -> None:
+    """[control] Matches the R2 harness pin exactly: four fields, frozen, forbid."""
+    ctx = ModelDeliveryContext(
+        envelope_id=uuid.uuid4(),
+        topic="onex.cmd.omnitest.example.v1",
+        partition=0,
+        offset=1,
+    )
+    assert set(type(ctx).model_fields) == {
+        "envelope_id",
+        "topic",
+        "partition",
+        "offset",
+    }
+    assert type(ctx).model_config.get("frozen") is True
+    assert type(ctx).model_config.get("extra") == "forbid"
+
+
+def test_is_immutable() -> None:
+    ctx = ModelDeliveryContext(
+        envelope_id=uuid.uuid4(), topic="onex.cmd.x.v1", partition=0, offset=0
+    )
+    with pytest.raises(ValidationError):
+        ctx.offset = 5  # type: ignore[misc]
+
+
+def test_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        ModelDeliveryContext(
+            envelope_id=uuid.uuid4(),
+            topic="onex.cmd.x.v1",
+            partition=0,
+            offset=0,
+            schema_version=1,  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.parametrize("field", ["partition", "offset"])
+def test_rejects_negative_coordinate_sentinel(field: str) -> None:
+    """A ``-1`` sentinel is a fabrication, never a legitimate broker coordinate."""
+    kwargs = {
+        "envelope_id": uuid.uuid4(),
+        "topic": "onex.cmd.x.v1",
+        "partition": 0,
+        "offset": 0,
+    }
+    kwargs[field] = -1
+    with pytest.raises(ValidationError):
+        ModelDeliveryContext(**kwargs)
+
+
+def test_envelope_id_must_be_a_real_uuid_type() -> None:
+    ctx = ModelDeliveryContext(
+        envelope_id=uuid.uuid4(), topic="onex.cmd.x.v1", partition=0, offset=0
+    )
+    assert isinstance(ctx.envelope_id, uuid.UUID)

--- a/tests/unit/protocols/runtime/test_protocol_delivery_context.py
+++ b/tests/unit/protocols/runtime/test_protocol_delivery_context.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED-first tests for the structural ``ProtocolDeliveryContext`` (OMN-15665).
+
+Structural drift guard, mirroring the existing
+``tests/unit/protocols/runtime/test_protocol_transport.py`` convention: the
+concrete ``ModelDeliveryContext`` must satisfy the protocol WITHOUT the protocol
+importing the model — a ``protocols -> models`` edge is frozen at its ceiling
+(OMN-14340 growth ratchet, ``scripts/ci/check_import_ratchet.py``) and a new edge
+hard-fails CI.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from omnibase_core.models.runtime.model_delivery_context import ModelDeliveryContext
+from omnibase_core.protocols.runtime.protocol_delivery_context import (
+    ProtocolDeliveryContext,
+)
+
+
+def test_model_delivery_context_satisfies_protocol_structurally() -> None:
+    ctx = ModelDeliveryContext(
+        envelope_id=uuid.uuid4(), topic="onex.cmd.x.v1", partition=0, offset=1
+    )
+    assert isinstance(ctx, ProtocolDeliveryContext)
+
+
+def test_protocol_module_does_not_import_models() -> None:
+    """Ratchet guard: the protocol module itself imports no ``omnibase_core.models``
+    symbol — it is purely structural (properties typed with primitives / stdlib
+    ``UUID`` only)."""
+    import ast
+    import inspect
+
+    from omnibase_core.protocols.runtime import protocol_delivery_context
+
+    source = inspect.getsource(protocol_delivery_context)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert not node.module.startswith("omnibase_core.models"), (
+                f"protocol_delivery_context.py must not import from "
+                f"{node.module} (protocols -> models edge is frozen)"
+            )

--- a/tests/unit/protocols/runtime/test_protocol_delivery_receipt_adapter.py
+++ b/tests/unit/protocols/runtime/test_protocol_delivery_receipt_adapter.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED-first tests for ``ProtocolDeliveryReceiptAdapter`` (OMN-15665, unchanged by r2).
+
+Authority: Linear comment ``cfb64e0f`` on OMN-15666 states this OMN-15665 contract
+is UNCHANGED by the r2 decision — "the unchanged OMN-15665
+``ProtocolDeliveryReceiptAdapter`` contract ``Callable[[], Awaitable[None]] -> None``"
+— and the R2 harness pin
+(``omni_worktrees/OMN-15663/omninode_infra-renewal/tests/fixtures/omn_15663_r2/
+target_models.py::ProtocolDeliveryReceiptAdapter``) reproduces the identical
+zero-argument shape. It is deliberately NOT the same shape as a
+context-consuming disposition adapter (that is
+``ProtocolTerminalDispositionAdapter``, OMN-15663/OMN-15667 territory,
+``dispose(context) -> receipt``) — collapsing the two was r1-rejection defect #3
+and must never recur here.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from omnibase_core.protocols.runtime.protocol_delivery_receipt_adapter import (
+    ProtocolDeliveryReceiptAdapter,
+)
+
+
+class _ZeroArgReceiptAck:
+    async def __call__(self) -> None:
+        return None
+
+
+class _TakesAContextArgument:
+    """Shape that must NOT satisfy the protocol (guards r1-rejection defect #3)."""
+
+    async def __call__(self, context: object) -> None:
+        return None
+
+
+def test_zero_arg_awaitable_satisfies_protocol() -> None:
+    assert isinstance(_ZeroArgReceiptAck(), ProtocolDeliveryReceiptAdapter)
+
+
+def test_context_taking_callable_does_not_satisfy_protocol() -> None:
+    """A callable requiring a positional argument is not zero-arg-compatible."""
+    instance = _TakesAContextArgument()
+    sig = inspect.signature(instance.__call__)
+    non_self_required = [
+        p
+        for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    assert non_self_required, "fixture must require a positional argument"
+
+
+def test_protocol_call_signature_is_zero_argument() -> None:
+    call = ProtocolDeliveryReceiptAdapter.__call__
+    sig = inspect.signature(call)
+    non_self_params = [p for p in sig.parameters.values() if p.name != "self"]
+    assert non_self_params == [], (
+        "ProtocolDeliveryReceiptAdapter.__call__ must remain zero-argument "
+        "(frozen OMN-15665 shape, unchanged by the r2 decision)"
+    )

--- a/tests/unit/runtime/test_runtime_delivery_context.py
+++ b/tests/unit/runtime/test_runtime_delivery_context.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED-first tests for :func:`build_delivery_context` (OMN-15665).
+
+The adapter surface that populates the canonical immutable delivery context AT
+THE RECEIPT BOUNDARY: ``envelope_id`` comes from the consumer record's own wire
+bytes (never re-derived from the pydantic-validated envelope, whose
+``envelope_id`` field carries a ``default_factory=uuid4`` — that default would
+silently fabricate an identity for a record that never truthfully carried one).
+``topic`` / ``partition`` / ``offset`` are the broker coordinates, copied verbatim
+from the polled transport message.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.runtime.runtime_delivery_context import build_delivery_context
+
+
+class _Payload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    n: int = 1
+
+
+def _wire_bytes(**overrides: object) -> bytes:
+    envelope = ModelEventEnvelope(payload=_Payload())
+    raw = json.loads(envelope.model_dump_json())
+    raw.update(overrides)
+    return json.dumps(raw).encode("utf-8")
+
+
+def test_happy_path_copies_envelope_id_and_broker_coordinates_verbatim() -> None:
+    real_id = uuid.uuid4()
+    value = _wire_bytes(envelope_id=str(real_id))
+
+    ctx = build_delivery_context(
+        topic="onex.cmd.omnitest.x.v1", partition=3, offset=42, raw_value=value
+    )
+
+    assert ctx.envelope_id == real_id
+    assert ctx.topic == "onex.cmd.omnitest.x.v1"
+    assert ctx.partition == 3
+    assert ctx.offset == 42
+
+
+def test_missing_envelope_id_key_fails_closed_never_fabricates() -> None:
+    real_id = uuid.uuid4()
+    value = _wire_bytes(envelope_id=str(real_id))
+    raw = json.loads(value)
+    del raw["envelope_id"]
+    stripped = json.dumps(raw).encode("utf-8")
+
+    with pytest.raises(ModelOnexError):
+        build_delivery_context(
+            topic="onex.cmd.omnitest.x.v1", partition=0, offset=0, raw_value=stripped
+        )
+
+
+def test_null_envelope_id_fails_closed() -> None:
+    value = _wire_bytes(envelope_id=None)
+
+    with pytest.raises(ModelOnexError):
+        build_delivery_context(
+            topic="onex.cmd.omnitest.x.v1", partition=0, offset=0, raw_value=value
+        )
+
+
+def test_malformed_envelope_id_fails_closed() -> None:
+    value = _wire_bytes(envelope_id="not-a-uuid")
+
+    with pytest.raises(ModelOnexError):
+        build_delivery_context(
+            topic="onex.cmd.omnitest.x.v1", partition=0, offset=0, raw_value=value
+        )
+
+
+def test_non_json_wire_bytes_fail_closed() -> None:
+    with pytest.raises(ModelOnexError):
+        build_delivery_context(
+            topic="onex.cmd.omnitest.x.v1",
+            partition=0,
+            offset=0,
+            raw_value=b"not json at all",
+        )
+
+
+def test_correlation_id_never_replaces_envelope_id() -> None:
+    """A distinct ``correlation_id`` on the wire must not alias or overwrite the
+    authoritative ``envelope_id`` — the exact alias/fabrication class this ticket
+    exists to prevent."""
+    real_id = uuid.uuid4()
+    other_correlation = uuid.uuid4()
+    assert real_id != other_correlation
+    value = _wire_bytes(envelope_id=str(real_id), correlation_id=str(other_correlation))
+
+    ctx = build_delivery_context(
+        topic="onex.cmd.omnitest.x.v1", partition=0, offset=0, raw_value=value
+    )
+
+    assert ctx.envelope_id == real_id
+    assert ctx.envelope_id != other_correlation
+
+
+def test_negative_broker_coordinate_is_rejected_not_silently_accepted() -> None:
+    value = _wire_bytes(envelope_id=str(uuid.uuid4()))
+    with pytest.raises(ModelOnexError):
+        build_delivery_context(
+            topic="onex.cmd.omnitest.x.v1", partition=-1, offset=0, raw_value=value
+        )

--- a/tests/unit/runtime/test_runtime_dispatch_delivery_context.py
+++ b/tests/unit/runtime/test_runtime_dispatch_delivery_context.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""RED-first tests: RuntimeDispatch wires the delivery context at the receipt
+boundary (OMN-15665).
+
+Design constraints under test:
+
+* The delivery context is RuntimeDispatch-context-resident, NEVER a def-B handler
+  argument — ``handle(request) -> response`` stays exactly one parameter.
+* ``delivery_receipt_adapter_factory`` is optional and keyword-only with a
+  ``None`` default. THIS IS THE FIX for the 2026-08-02 CORE-PASS / CROSS-REPO-FAIL
+  defect: a required keyword-only constructor argument broke every existing
+  ``RuntimeDispatch(...)`` call site (``omnibase_infra`` composition, S6/S8
+  integration tests) that does not know about delivery receipts. Existing
+  composition roots that omit the factory must keep working unchanged and must
+  report ``delivery_receipts_enabled is False`` — no durable-receipt claim there.
+* When configured, the factory receives the SAME immutable
+  ``ModelDeliveryContext`` built from the actual polled record (never fabricated)
+  before the message becomes committable, and its zero-arg receipt-ack callable is
+  awaited before COMMIT. A receipt-adapter failure redelivers the message (never
+  silently commits past an unacknowledged receipt).
+* A record whose wire bytes lack a truthful ``envelope_id`` is redelivered / DLQ'd
+  — never silently committed with a fabricated identity — even with no receipt
+  adapter configured at all (the context's fail-closed guarantee is unconditional).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.models.runtime.model_delivery_context import ModelDeliveryContext
+from omnibase_core.runtime.runtime_dispatch import DispatchRoute, RuntimeDispatch
+from omnibase_core.runtime.transport.runtime_in_memory_broker import InMemoryBroker
+from omnibase_core.runtime.transport.runtime_in_memory_transport import (
+    InMemoryTransport,
+)
+
+pytestmark = pytest.mark.asyncio
+
+IN_TOPIC = "onex.cmd.omnitest.receipt.v1"
+OUT_TOPIC = "onex.evt.omnitest.receipt-echoed.v1"
+
+
+class ModelEcho(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    n: int
+
+
+class ModelEchoed(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    n: int
+
+
+class EchoHandler:
+    """def-B handler; records exactly what it was invoked with (never a context)."""
+
+    def __init__(self) -> None:
+        self.received_types: list[type] = []
+
+    async def handle(self, request: ModelEcho) -> ModelEchoed:
+        self.received_types.append(type(request))
+        return ModelEchoed(n=request.n)
+
+
+@pytest.fixture
+def broker() -> InMemoryBroker:
+    return InMemoryBroker()
+
+
+@pytest.fixture
+def producer(broker: InMemoryBroker) -> InMemoryTransport:
+    return InMemoryTransport(broker=broker, group="producer")
+
+
+def _consumer(broker: InMemoryBroker, *, group: str) -> InMemoryTransport:
+    return InMemoryTransport(broker=broker, group=group, topics=[IN_TOPIC])
+
+
+async def _seed_raw(producer: InMemoryTransport, value: bytes) -> None:
+    await producer.send(IN_TOPIC, key=None, value=value, headers={})
+
+
+async def _seed(producer: InMemoryTransport, n: int = 1) -> ModelEventEnvelope[object]:
+    envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+        payload=ModelEcho(n=n), correlation_id=uuid4()
+    )
+    await producer.send(
+        IN_TOPIC, key=None, value=envelope.model_dump_json().encode("utf-8"), headers={}
+    )
+    return envelope
+
+
+def _route(handler: EchoHandler) -> DispatchRoute:
+    return DispatchRoute(
+        name="echo",
+        handler=handler,  # type: ignore[arg-type]
+        published_events={"ModelEchoed": OUT_TOPIC},
+        input_model_cls=ModelEcho,
+    )
+
+
+class TestBackwardCompatibility:
+    """Existing composition roots that omit the factory keep working (the exact
+    defect class the 2026-08-02 lane hit at omnibase_infra composition.py:430)."""
+
+    async def test_constructor_does_not_require_the_factory(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        transport = _consumer(broker, group="g")
+        handler = EchoHandler()
+        # No delivery_receipt_adapter_factory kwarg at all — must not TypeError.
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(handler)},
+        )
+        assert dispatch.delivery_receipts_enabled is False
+
+        await _seed(producer)
+        processed = await dispatch.drain()
+        assert processed == 1
+        assert handler.received_types == [ModelEcho]
+
+    async def test_delivery_receipts_enabled_true_when_factory_injected(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        transport = _consumer(broker, group="g2")
+
+        def _factory(
+            context: ModelDeliveryContext,
+        ) -> Callable[[], Awaitable[None]]:
+            async def _ack() -> None:
+                return None
+
+            return _ack
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(EchoHandler())},
+            delivery_receipt_adapter_factory=_factory,
+        )
+        assert dispatch.delivery_receipts_enabled is True
+
+
+class TestReceiptBoundary:
+    async def test_factory_receives_truthful_context_before_commit(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        transport = _consumer(broker, group="g3")
+        seen_contexts: list[ModelDeliveryContext] = []
+
+        def _factory(
+            context: ModelDeliveryContext,
+        ) -> Callable[[], Awaitable[None]]:
+            seen_contexts.append(context)
+
+            async def _ack() -> None:
+                return None
+
+            return _ack
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(EchoHandler())},
+            delivery_receipt_adapter_factory=_factory,
+        )
+        envelope = await _seed(producer, n=9)
+        processed = await dispatch.drain()
+
+        assert processed == 1
+        assert len(seen_contexts) == 1
+        ctx = seen_contexts[0]
+        assert ctx.envelope_id == envelope.envelope_id
+        assert ctx.topic == IN_TOPIC
+        assert ctx.partition == 0
+        assert ctx.offset == 0
+        assert broker.committed_offset(IN_TOPIC, "g3", 0) == 0
+
+    async def test_correlation_id_never_aliases_envelope_id_at_the_boundary(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        transport = _consumer(broker, group="g4")
+        seen_contexts: list[ModelDeliveryContext] = []
+
+        def _factory(
+            context: ModelDeliveryContext,
+        ) -> Callable[[], Awaitable[None]]:
+            seen_contexts.append(context)
+
+            async def _ack() -> None:
+                return None
+
+            return _ack
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(EchoHandler())},
+            delivery_receipt_adapter_factory=_factory,
+        )
+        distinct_correlation: UUID = UUID(int=123456789)
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=ModelEcho(n=1), correlation_id=distinct_correlation
+        )
+        await producer.send(
+            IN_TOPIC,
+            key=None,
+            value=envelope.model_dump_json().encode("utf-8"),
+            headers={},
+        )
+        await dispatch.drain()
+
+        assert len(seen_contexts) == 1
+        assert seen_contexts[0].envelope_id == envelope.envelope_id
+        assert seen_contexts[0].envelope_id != distinct_correlation
+
+    async def test_receipt_adapter_failure_redelivers_not_commits(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        transport = _consumer(broker, group="g5")
+        attempts = {"n": 0}
+
+        def _factory(
+            context: ModelDeliveryContext,
+        ) -> Callable[[], Awaitable[None]]:
+            async def _ack() -> None:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise RuntimeError("durable receipt store unavailable")
+
+            return _ack
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(EchoHandler())},
+            delivery_receipt_adapter_factory=_factory,
+        )
+        await _seed(producer)
+        processed = await dispatch.drain()
+
+        # First attempt: receipt ack raises -> REDELIVER (no commit this round).
+        # drain() keeps polling until empty, so the retry succeeds within the loop.
+        assert processed >= 1
+        assert attempts["n"] == 2
+        assert broker.committed_offset(IN_TOPIC, "g5", 0) == 0
+
+    async def test_handler_never_receives_the_delivery_context(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        """def-B stays exactly one parameter — the context never pollutes it."""
+        transport = _consumer(broker, group="g6")
+        handler = EchoHandler()
+
+        def _factory(
+            context: ModelDeliveryContext,
+        ) -> Callable[[], Awaitable[None]]:
+            async def _ack() -> None:
+                return None
+
+            return _ack
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(handler)},
+            delivery_receipt_adapter_factory=_factory,
+        )
+        await _seed(producer)
+        await dispatch.drain()
+
+        assert handler.received_types == [ModelEcho]
+
+
+class TestFailClosedAbsenceUnconditional:
+    """The context's fail-closed guarantee applies even with NO receipt adapter
+    configured — it is never a fabricated identity, ever."""
+
+    async def test_missing_envelope_id_on_wire_is_never_silently_committed(
+        self, broker: InMemoryBroker, producer: InMemoryTransport
+    ) -> None:
+        import json
+
+        transport = _consumer(broker, group="g7")
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=ModelEcho(n=1)
+        )
+        raw = json.loads(envelope.model_dump_json())
+        del raw["envelope_id"]
+        stripped = json.dumps(raw).encode("utf-8")
+
+        dispatch = RuntimeDispatch(
+            consumer=transport,
+            producer=producer,
+            routing_map={IN_TOPIC: _route(EchoHandler())},
+        )
+        await _seed_raw(producer, stripped)
+        await dispatch.drain()
+
+        # Never committed with a fabricated envelope_id — it is redelivered until
+        # retries exhaust, then dead-lettered (durable evidence), but the original
+        # offset must not silently commit.
+        assert len(broker.records(f"{IN_TOPIC}.dlq", 0)) == 1
+        assert broker.committed_offset(IN_TOPIC, "g7", 0) == 0


### PR DESCRIPTION
## OMN-15665: Immutable RuntimeDispatch delivery context at the receipt boundary

Evidence-Ticket: OMN-15665
Evidence-Source: OCC#6033
promotion-receipt: OCC-6033

### Seam declaration

| Field | Type | Source (authoritative) |
|---|---|---|
| `envelope_id` | `UUID` | Read from the **raw wire bytes** (fresh `json.loads`, independent of `ModelEventEnvelope` validation). Never `envelope.envelope_id` post-validation — that field is `default_factory=uuid4`, so a record whose wire bytes never truthfully carried an `envelope_id` would otherwise silently validate into a freshly fabricated id. Absent/`null`/unparsable → fail closed (`ModelOnexError`), never fabricated. |
| `topic` | `str` | The polled transport message's own `topic` (broker coordinate, verbatim). |
| `partition` | `int` | The polled transport message's own `partition` (broker coordinate, verbatim; negative rejected as a fabricated sentinel). |
| `offset` | `int` | The polled transport message's own `offset` (broker coordinate, verbatim; negative rejected as a fabricated sentinel). |

**All-or-none absence rule:** the context is built unconditionally and fail-closed at the receipt boundary for *every* record, whether or not a receipt adapter is configured — there is no partial-context, no "3 of 4 fields present" state. A record that cannot produce a truthful `envelope_id` never gets a context at all; it redelivers/DLQs instead of committing with a fabricated identity.

### Placement rationale

- `ModelDeliveryContext` (`src/omnibase_core/models/runtime/model_delivery_context.py`): frozen, `extra="forbid"`, four fields exactly matching the R2 harness pin (`omninode_infra` `tests/fixtures/omn_15663_r2/target_models.py::ModelDeliveryContext`). Core-resident: it is the identity `RuntimeDispatch` (Core-resident) depends on at its own receipt boundary — the same logic as `docs/architecture/layering-exceptions.yaml` LAYER-EXC-001/002 (a type consumed by a Core-resident runtime component stays Core-resident rather than forcing a circular Core→SPI→Core dependency).
- `ProtocolDeliveryContext` (`src/omnibase_core/protocols/runtime/protocol_delivery_context.py`): purely structural (stdlib `UUID`/`str`/`int` only) — imports **no** `omnibase_core.models` symbol, so it adds no edge to the frozen `protocols -> models` ratchet (`FROZEN_PROTOCOLS_MODELS_MAX = 65`, unchanged by this PR — verified via `scripts/ci/check_import_ratchet.py`).
- `ProtocolDeliveryReceiptAdapter` (`src/omnibase_core/protocols/runtime/protocol_delivery_receipt_adapter.py`): zero-argument awaitable (`async def __call__(self) -> None`), **unchanged from OMN-15665** per the frozen r2 contract decision (Linear comment `cfb64e0f-c2e6-4ae2-94cf-308c7e1a1efb` on OMN-15666). Deliberately distinct from the context-consuming `ProtocolTerminalDispositionAdapter` (OMN-15663/OMN-15666/OMN-15667 territory, `dispose(context) -> receipt`) — collapsing the two shapes was r1-rejection defect #3 and must not recur.
- Per-message context is threaded through a **factory**, not the adapter's call signature: `RuntimeDispatch` accepts an optional `delivery_receipt_adapter_factory: Callable[[ModelDeliveryContext], Callable[[], Awaitable[None]]] | None = None`. This reconciles "the adapter needs per-message identity" with "the adapter's public shape is frozen at zero-arg."
- `build_delivery_context()` (`src/omnibase_core/runtime/runtime_delivery_context.py`): the adapter surface that populates the context at the receipt boundary — pure function, no I/O, isolated the same way `runtime_envelope_router.py` isolates the envelope boundary. Imports no `omnibase_core.protocols` symbol (only the model + stdlib), so it adds no new importer into the frozen `protocols` hub either.
- `runtime_dispatch.py` still imports **no** protocols-hub symbol directly (consistent with its existing structural-mirror convention) — the receipt-adapter parameter is typed with `Callable[[], Awaitable[None]]` structurally, not the canonical `Protocol` import.
- def-B is untouched: `handle(request: ModelX) -> ModelY` stays exactly one parameter. The context never becomes a handler argument — proven by a runtime assertion test (`test_handler_never_receives_the_delivery_context`), not just static AST.

### Authority reconciliation

Binding order: frozen Linear comment (`cfb64e0f` on OMN-15666) > R2 harness pins (`omninode_infra` `tests/fixtures/omn_15663_r2/`, read-only) > 2026-08-02 ruling prose > OMN-15665's own ticket body.

- **`ProtocolDeliveryReceiptAdapter` shape.** OMN-15665's own ticket-body AC text reads `ProtocolDeliveryReceiptAdapter.execute_once(...) consumes it [context]` — a context-taking shape. This is **superseded**: the frozen r2 comment states verbatim *"the unchanged OMN-15665 `ProtocolDeliveryReceiptAdapter` contract `Callable[[], Awaitable[None]] -> None`"*, and the R2 harness pin reproduces the identical zero-arg `async def __call__(self) -> None: ...`. Both higher-authority sources agree the adapter itself is zero-arg; `execute_once(context)`-shaped behavior belongs to the separate `ProtocolTerminalDispositionAdapter` (OMN-15666/15667 territory). Implemented per the frozen sources, not the stale ticket-body AC.
- **`ModelDeliveryContext` shape.** All three sources agree: `envelope_id: UUID`, `topic: str`, `partition: int`, `offset: int`, frozen, `extra="forbid"`, nonnegative `partition`/`offset`. Implemented byte-identical to the R2 harness pin.
- **`ProtocolDeliveryContext`.** Named in the R2 harness fixture's cross-repo absence-search list (i.e. expected to exist as an OMN-15665 type) but not itself reproduced there — no shape conflict to reconcile; implemented as the minimal structural four-property protocol the AC calls for ("the concrete `ModelDeliveryContext` satisfies that protocol statically and at runtime").
- **Core/SPI/runtime placement.** All three sources agree: Core-resident, not a handler argument. No divergence.

### Cross-boundary proof

The 2026-08-02 lane died **CORE-PASS / CROSS-REPO-FAIL** at `omnibase_infra/src/omnibase_infra/runtime/core_runtime/composition.py:430` — that lane made `delivery_receipt_adapter` a **required** keyword-only constructor argument, which broke every existing `RuntimeDispatch(...)` call site that doesn't know about delivery receipts (`TypeError: RuntimeDispatch.__init__() missing 1 required keyword-only argument: 'delivery_receipt_adapter'`). This PR's fix is the parameter is **optional, keyword-only, default `None`** — verified against the exact same composition boundary that broke before:

```bash
# Scratch venv, omnibase_infra's own dev-group deps + this PR's core worktree editable-installed over the pin
uv venv /tmp/.../omn15665-crossboundary-venv --python 3.13
cd omnibase_infra && uv pip install --python <venv>/bin/python --group dev -e .
uv pip install --python <venv>/bin/python -e <this-PR's-core-worktree>
# confirmed: omnibase-core 0.46.8 -> 0.46.9 (from the candidate worktree)

<venv>/bin/python -m pytest -q \
  tests/integration/runtime/test_s6_delegation_routing_map_binding.py \
  tests/integration/runtime/test_s8_delegation_fsm_seam.py \
  -p no:cacheprovider
# -> 9 passed  (test_s6...py:148 is the exact line that TypeError'd on 2026-08-02; now green)

<venv>/bin/python -m pytest -q \
  tests/unit/runtime/core_runtime/ tests/integration/runtime/ \
  --ignore=tests/integration/runtime/test_golden_chain_live_runtime.py \
  -p no:cacheprovider
# -> 519 passed, 3 skipped (env-gated), 17 errors + 1 failed — all live
#    Postgres/Kafka connection errors (asyncpg "another operation in
#    progress" / no live broker), unrelated to RuntimeDispatch and
#    reproduced identically against the unmodified pinned core; the
#    excluded file (test_golden_chain_live_runtime.py) fails collection
#    on a pre-existing `pytest.mark.external` marker-registration gap
#    present against the unmodified pinned core too.
```

`RuntimeDispatch(consumer=..., producer=..., routing_map=..., dlq_topic_resolver=...)` at `composition.py:430` (no `delivery_receipt_adapter_factory` kwarg) now constructs and dispatches cleanly against this PR's core.

### R2-harness-compatibility note

Not modified (read-only reference per instructions): `omni_worktrees/OMN-15663/omninode_infra-renewal`. This PR's `ModelDeliveryContext` / `ProtocolDeliveryReceiptAdapter` are byte-shape-identical to that repo's `tests/fixtures/omn_15663_r2/target_models.py` reproductions, so once `omninode_infra` production code imports the real Core types (out of scope here), Family F's three RED assertions (`RED:OMN-15663-R2-DEFB-01/02/03` — "no `DeliveryContext`-named symbol exists", "no bespoke context-carrying class exists", "neither disposition-adapter protocol exists") and its three control tests (`test_control_delivery_context_is_frozen_forbid_four_fields`, `test_control_two_disposition_protocols_stay_structurally_distinct`, `test_control_def_b_handler_shape_rejects_added_context_parameter`) can turn GREEN against the real names/shapes without any test edits over there — no fixture/test change required in that repo.

### Landing order

Independent of OMN-15667 (quarantine wire/receipt split — separate model family, no shared symbol). Lands **before** OMN-15666 (L6, dual-sink DLQ durability — consumes `ProtocolTerminalDispositionAdapter`, a distinct protocol this PR does not implement) and the gateway-terminal worker ticket (L7, OMN-15663 production implementation) — both depend on this PR's `ModelDeliveryContext` / `ProtocolDeliveryContext` existing in Core first.

### Gates

- `uv run ruff format` / `ruff check --fix` — clean.
- `env -u PYTHONPATH uv run mypy src/omnibase_core --strict` (via `[tool.mypy]` strict config) — clean, 4216 files (after `uv sync --all-extras` to pick up `omnibase-spi`/`redis` dev-group deps; the 5 import-not-found errors seen before that sync are pre-existing and identical on unmodified `origin/dev`).
- Focused TDD suite: 25 new tests + 15 existing regression tests (`tests/unit/runtime/test_runtime_dispatch.py`) = 40 total, all passing.
- Broader regression: `tests/unit/runtime/`, `tests/unit/models/runtime/`, `tests/unit/protocols/runtime/` — 597 passed.
- `pre-commit run --files <changed files>` — all hooks passed.
- Pre-push governed selector (OMN-13973) escalated to the **full local suite** (shared-module criterion: `runtime_dispatch.py` is broadly imported) — 43,733 passed, 53 skipped, 3 xpassed in 5953s, run on `.200` (Stickybeatz-Studio) per the repo's rule 11a default; allowed the push.
- Import-layering growth ratchet (`scripts/ci/check_import_ratchet.py`): clean, zero new edges (`protocols->models=65`, `hub_inbound` unchanged).

Ticket: OMN-15665

proof_class: code-only


