### PR TITLE
fix(OMN-15120): materialize required-check contexts on Dependabot PRs (OMN-14864)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -168,12 +168,15 @@ gates:
     producer_kind: local
     workflow: cr-thread-gate-caller.yml
     job_path: ["gate", "gate"]
-    skip_semantics: neutral_ok
-    rationale: "Caller job 'gate' has an ungated `if:` (github.actor != 'dependabot[bot]', among other
-      clauses) — vector-3. Same dependabot-actor exemption shape already ratified neutral_ok in omniclaude's
-      manifest for this identical reusable workflow (cr-thread-gate.yml). github.actor is not spoofable;
-      not yet human-ratified for omnibase_core specifically. skip_semantics: neutral_ok pending triage
-      in OMN-14864."
+    skip_semantics: never
+    rationale: "OMN-15120/OMN-14864 repair (docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-
+      contexts.md): the caller job 'gate' previously had an ungated `if:` (github.actor != 'dependabot[bot]',
+      among other clauses) — vector-3, a skipped caller job produces NO check run at all, which permanently
+      wedged this required context on Dependabot PRs (live case: omnibase_core#1548). The `if:` is now
+      removed entirely; the caller always invokes the reusable, and the former non-PR issue_comment guard
+      moved into the pr-number input (resolves to 0, which the reusable already no-ops on). The reusable
+      (cr-thread-gate.yml) carries no job-level `if:` of its own, so this context now always completes
+      success/failure — never skipped — hence skip_semantics: never."
 
   - name: "pr-title / check-title"
     mode: REQUIRED
@@ -706,15 +709,22 @@ gates:
     caller_job: occ-companion-effect
     cross_repo_ref: "OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev"
     skip_semantics: neutral_ok
-    rationale: "OMN-15120 fan-out finding: caller job 'occ-companion-effect' has a job-level `if: github.actor
+    rationale: "OMN-15120/OMN-14864 repair (docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-
+      contexts.md): the caller job 'occ-companion-effect' previously had its own job-level `if: github.actor
       != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (contains(...OMN-...))` -- vector-3 (ungated
-      caller if referencing github.actor / github.event.*). Same dependabot/renovate-actor exemption shape
-      already ratified neutral_ok elsewhere in this manifest family (e.g. omniclaude's cr-thread-gate.yml
-      precedent cited in 'gate / CodeRabbit Thread Check' above). github.actor is not spoofable; not yet
-      human-ratified for this specific workflow. skip_semantics: neutral_ok pending triage in OMN-14864.
-      Additive/non-blocking by design per this workflow's own header comment (OMN-14990) -- it publishes
-      a command and never fails a PR's merge on its own, but the composed context is a live required status
-      check regardless."
+      caller if). A skipped CALLER job never invokes the reusable at all, so no check run under this composed
+      context is ever created -- permanently PENDING, not a neutral skip. This was the live cause of omnibase_core#1548
+      (Dependabot) never materializing this context. Fix: the caller `if:` is removed entirely so the
+      reusable is always invoked. The identical actor/ticket exemption still exists, but now ONLY inside
+      the reusable's own job-level `if:` (omniclaude call-occ-companion-effect-reusable.yml, job `publish-occ-companion-effect`)
+      -- a job-level skip *inside* an invoked reusable still produces a real check run with conclusion=skipped
+      under this exact composed name, which GitHub branch protection accepts as passing. skip_semantics:
+      neutral_ok is accurate here (not `never`): this context legitimately terminates skipped for Dependabot/Renovate/ticketless
+      PRs by design, and always produces a check run when it does. Cross-repo remainder (not required
+      for correctness, tracked as a possible follow-up): the omniclaude reusable could additionally convert
+      its job-level `if:` into an in-script early-exit success so no producer ever reports a bare 'skipped'
+      conclusion; not implemented here since a job-level skip on the callee already satisfies branch protection
+      and requires no cross-repo change to close the OMN-14864/OMN-15120 defect."
 
   - name: "occ-preflight / eligibility"
     mode: REQUIRED

--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -174,9 +174,15 @@ gates:
       among other clauses) — vector-3, a skipped caller job produces NO check run at all, which permanently
       wedged this required context on Dependabot PRs (live case: omnibase_core#1548). The `if:` is now
       removed entirely; the caller always invokes the reusable, and the former non-PR issue_comment guard
-      moved into the pr-number input (resolves to 0, which the reusable already no-ops on). The reusable
-      (cr-thread-gate.yml) carries no job-level `if:` of its own, so this context now always completes
-      success/failure — never skipped — hence skip_semantics: never."
+      moved into the pr-number input (resolves to 0, which the reusable already no-ops on). A SECOND,
+      independently-discovered instance of the same vector-3 shape was found live on this repair's own
+      verification PR (omnibase_core#1549, CodeRabbit finding + confirmed via check-run inspection): `needs:
+      occ-preflight` with no `if: always()` also implicitly skips this caller job (and therefore the composed
+      context) whenever occ-preflight fails -- the ordinary state of ANY fresh non-exempt PR before its
+      OCC companion is minted, not Dependabot-specific. Fixed by adding `if: always()`, matching the convention
+      every other required `needs: occ-preflight` caller in this repo already follows. The reusable (cr-thread-gate.yml)
+      carries no job-level `if:` of its own, so this context now always completes success/failure — never
+      skipped — hence skip_semantics: never."
 
   - name: "pr-title / check-title"
     mode: REQUIRED
@@ -642,12 +648,18 @@ gates:
     producer_kind: local
     workflow: security-scan.yml
     job_path: ["codeql"]
-    skip_semantics: neutral_ok
-    rationale: "OMN-15120 fan-out finding: job 'codeql' in security-scan.yml has `needs: occ-preflight`
-      with no `if:` that provably runs regardless of the needs result -- vector-5 (ungated needs cascade,
-      OMN-15057). Same shape already ratified neutral_ok elsewhere in this manifest (e.g. 'Contract Compliance
-      Check', 'Ecosystem Integration Validation' below). skip_semantics: neutral_ok pending triage in
-      OMN-14864."
+    skip_semantics: never
+    rationale: "OMN-15120/OMN-14864 repair (docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-
+      contexts.md): job 'codeql' in security-scan.yml had `needs: occ-preflight` with no `if:` that provably
+      runs regardless of the needs result -- vector-5 (ungated needs cascade, OMN-15057), the triage this
+      row was pending. GitHub's default implicit-skip-on-failed-need behavior meant this caller job (and,
+      before it could invoke the reusable, the composed 'CodeQL / CodeQL Analysis (python)' context below)
+      went missing entirely whenever occ-preflight failed -- the ordinary state of any fresh non-exempt
+      PR before its OCC companion is minted, not merely a Dependabot case. Fixed by adding `if: always()`,
+      matching the convention every other required `needs: occ-preflight` caller in this repo already
+      follows. This bare job-name row ('codeql' job's own name override, `name: CodeQL`) resolves via
+      Shape A (direct job-name match, not a caller/callee composition per resolve_context_to_job) -- skip_semantics:
+      never is accurate post-fix since no conditional survives on this job."
 
   - name: "CodeQL / CodeQL Analysis (python)"
     mode: REQUIRED
@@ -663,9 +675,13 @@ gates:
       so 'CodeQL / CodeQL Analysis (python)' is structurally UNRESOLVED to the static resolver. Not a
       skip-vector finding -- a resolver limitation, same class as the pre-existing 'Integration Tests
       (Split N/4)' matrix rows below. producer_kind: matrix with skip_semantics: matrix_unresolvable documents
-      the static resolver exception already used for templated/composed required contexts. See the sibling
-      'CodeQL' row above for the actual checkable vector-5 finding on the same caller job. Tracked as
-      a follow-up in OMN-14864 (resolver enhancement: match on display name as well as job_id)."
+      the static resolver exception already used for templated/composed required contexts. The sibling
+      'CodeQL' row above documented the actual checkable vector-5 finding on the same caller job (`needs:
+      occ-preflight` with no `if: always()`) -- FIXED in the OMN-15120/OMN-14864 repair (docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md):
+      this composed context could never have materialized while occ-preflight failed, since the caller
+      job producing it was implicitly needs-skipped first. Still tracked as a follow-up in OMN-14864:
+      resolver enhancement to match on display name as well as job_id, so this row can be mechanically
+      checked instead of relying on the sibling row's checkable proxy."
 
   - name: "Ecosystem Integration Validation"
     mode: REQUIRED

--- a/.github/workflows/call-occ-companion-effect.yml
+++ b/.github/workflows/call-occ-companion-effect.yml
@@ -44,10 +44,16 @@
 # should not publish, and any future base filtering must be IN-JOB with a
 # logged skip, never at the trigger.
 #
-# ADDITIVE / REJECTS NOTHING: this workflow is NOT a required status check. It
-# publishes a command; it never fails a PR's merge. A fail-loud exit 1 on the
-# trusted runner (unreachable dev broker) is a non-blocking red signal, not a
-# merge gate.
+# ADDITIVE / REJECTS NOTHING: this workflow never fails a PR's merge on its
+# own publish logic — publishing errors are a non-blocking red signal, not a
+# gate. NOTE this comment predates OMN-15120's fan-out finding that the
+# composed context "occ-companion-effect / Publish occ-companion-effect
+# command" IS a live required status check on omnibase_core `dev` branch
+# protection (see .github/required-checks.yaml); "not a required status
+# check" is therefore stale and must not be relied on. A fail-loud exit 1 on
+# the trusted runner (unreachable dev broker) is still a non-blocking red
+# signal there — the REQUIRED-ness comes from branch protection observing the
+# check run, not from the publisher's own exit code semantics.
 #
 # PIN CHOICE (OMN-14939/E1 failure class): the reusable is pinned `@dev`
 # because that is the ref that resolves — the reusable exists only on
@@ -86,14 +92,24 @@ permissions:
 
 jobs:
   occ-companion-effect:
-    # Skip dependency bots and PRs with no OMN ticket token (same gate the
-    # reusable enforces defensively). Gating here means the reusable is not
-    # even invoked for non-OMN / bot PRs.
-    if: >-
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'renovate[bot]' &&
-      (contains(github.event.pull_request.title, 'OMN-') ||
-       contains(github.event.pull_request.head.ref, 'OMN-'))
+    # OMN-15120/OMN-14864: no top-level `if:` here — the caller job MUST
+    # always invoke the reusable, or GitHub never creates the composed
+    # "occ-companion-effect / Publish occ-companion-effect command" check run
+    # at all (vector-3: a skipped `uses:` job produces zero check runs, unlike
+    # a skipped job *inside* a reusable, which still posts a "skipped"
+    # conclusion that branch protection treats as passing). This was the
+    # exact failure mode that left omnibase_core#1548 (a Dependabot PR)
+    # permanently missing this required context — see
+    # docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md.
+    #
+    # The dependency-bot / ticketless-PR exemption still applies — it now
+    # lives ONLY inside the reusable's own job-level `if:`
+    # (call-occ-companion-effect-reusable.yml `publish-occ-companion-effect`
+    # job, unchanged). That job-level skip still produces a real "skipped"
+    # check run under the composed context name, which branch protection
+    # accepts as passing, so nothing downstream loses the exemption — only
+    # the caller-level duplicate of the gate (which produced NO check run at
+    # all) is removed.
     uses: OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev
     with:
       lane: dev

--- a/.github/workflows/call-occ-companion-effect.yml
+++ b/.github/workflows/call-occ-companion-effect.yml
@@ -44,16 +44,14 @@
 # should not publish, and any future base filtering must be IN-JOB with a
 # logged skip, never at the trigger.
 #
-# ADDITIVE / REJECTS NOTHING: this workflow never fails a PR's merge on its
-# own publish logic — publishing errors are a non-blocking red signal, not a
-# gate. NOTE this comment predates OMN-15120's fan-out finding that the
-# composed context "occ-companion-effect / Publish occ-companion-effect
-# command" IS a live required status check on omnibase_core `dev` branch
-# protection (see .github/required-checks.yaml); "not a required status
-# check" is therefore stale and must not be relied on. A fail-loud exit 1 on
-# the trusted runner (unreachable dev broker) is still a non-blocking red
-# signal there — the REQUIRED-ness comes from branch protection observing the
-# check run, not from the publisher's own exit code semantics.
+# ADDITIVE / CONFIGURES NO BRANCH PROTECTION: this workflow only publishes an
+# OCC companion-effect command; it does not itself configure repository branch
+# protection. The composed context "occ-companion-effect / Publish
+# occ-companion-effect command" IS a live required status check on
+# omnibase_core `dev` branch protection (see .github/required-checks.yaml), so
+# a publish-logic exit 1 on the trusted runner makes that required check fail
+# and blocks merging. The REQUIRED-ness comes from branch protection observing
+# the check run, not from the publisher configuring protection.
 #
 # PIN CHOICE (OMN-14939/E1 failure class): the reusable is pinned `@dev`
 # because that is the ref that resolves — the reusable exists only on

--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -25,13 +25,31 @@ jobs:
       receipts-dir: drift/dod_receipts
 
   gate:
+    # OMN-15120/OMN-14864: no top-level `if:` here — the caller job MUST
+    # always invoke the reusable, or GitHub never creates the composed
+    # "gate / CodeRabbit Thread Check" check run at all (vector-3: a skipped
+    # `uses:` job produces zero check runs, unlike a skipped job *inside* a
+    # reusable, which still posts a "skipped" conclusion that branch
+    # protection treats as passing). This was the exact failure mode that
+    # left omnibase_core#1548 (a Dependabot PR) permanently missing this
+    # required context — see
+    # docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md.
+    #
+    # The former dependabot-actor exemption is dropped outright: the reusable
+    # itself has no actor gate, so a Dependabot PR just gets its unresolved
+    # CodeRabbit thread count evaluated like any other PR (0 unresolved
+    # threads on a bot PR passes cleanly).
+    #
+    # The former non-PR `issue_comment` guard (skip when a comment lands on a
+    # bare issue, not a PR) moves into the `pr-number` computation below
+    # instead of a job-level `if:`: `github.event.issue.pull_request` is only
+    # truthy when the commented-on issue IS a PR, so a bare-issue comment now
+    # resolves pr-number to 0, and the reusable's own script already treats
+    # pr-number 0 as a graceful no-op success (same path used for
+    # merge_group).
     needs: occ-preflight
-    if: >-
-      github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
-      github.actor != 'dependabot[bot]')
     uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
     with:
-      pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}
+      pr-number: ${{ format('{0}', github.event.pull_request.number || (github.event.issue.pull_request && github.event.issue.number) || 0) }}
     secrets:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}

--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -25,13 +25,13 @@ jobs:
       receipts-dir: drift/dod_receipts
 
   gate:
-    # OMN-15120/OMN-14864: no top-level `if:` here — the caller job MUST
-    # always invoke the reusable, or GitHub never creates the composed
-    # "gate / CodeRabbit Thread Check" check run at all (vector-3: a skipped
-    # `uses:` job produces zero check runs, unlike a skipped job *inside* a
-    # reusable, which still posts a "skipped" conclusion that branch
-    # protection treats as passing). This was the exact failure mode that
-    # left omnibase_core#1548 (a Dependabot PR) permanently missing this
+    # OMN-15120/OMN-14864: no CONDITIONAL top-level `if:` here — the caller
+    # job MUST always invoke the reusable, or GitHub never creates the
+    # composed "gate / CodeRabbit Thread Check" check run at all (vector-3: a
+    # skipped `uses:` job produces zero check runs, unlike a skipped job
+    # *inside* a reusable, which still posts a "skipped" conclusion that
+    # branch protection treats as passing). This was the exact failure mode
+    # that left omnibase_core#1548 (a Dependabot PR) permanently missing this
     # required context — see
     # docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md.
     #
@@ -47,7 +47,25 @@ jobs:
     # resolves pr-number to 0, and the reusable's own script already treats
     # pr-number 0 as a graceful no-op success (same path used for
     # merge_group).
+    #
+    # `if: always()` (CodeRabbit finding on this PR, confirmed live —
+    # omnibase_core#1549 job 92915155222 showed the caller job's OWN bare
+    # name "gate", conclusion=skipped, with NO composed check run, on a run
+    # where `occ-preflight` failed): `needs: occ-preflight` without an
+    # `always()` override means GitHub's default implicit-skip-on-failed-need
+    # behavior ALSO skips this caller job — the identical vector-3 failure
+    # shape, just triggered by an unmet `needs:` instead of an explicit `if:`.
+    # occ-preflight failing is the ORDINARY state of any fresh non-exempt PR
+    # before its OCC companion is minted (unrelated to CodeRabbit-thread
+    # checking, which this job doesn't depend on any occ-preflight output
+    # for), so this was not Dependabot-specific — it silently wedged this
+    # context on any PR at opened/synchronize time. Every other required
+    # caller job with `needs: occ-preflight` in this repo already pairs it
+    # with `if: always()` (deploy-gate.yml, pr-title-check.yml,
+    # required-check-skip-guard-caller.yml, call-receipt-gate.yml) — this job
+    # was the one outlier.
     needs: occ-preflight
+    if: always()
     uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
     with:
       pr-number: ${{ format('{0}', github.event.pull_request.number || (github.event.issue.pull_request && github.event.issue.number) || 0) }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,7 +27,21 @@ jobs:
       receipts-dir: drift/dod_receipts
 
   codeql:
+    # OMN-15120/OMN-14864 (fan-out finding from the required-checks.yaml
+    # manifest, pre-flagged there as "vector-5 (ungated needs cascade),
+    # pending triage in OMN-14864"): `needs: occ-preflight` without an
+    # `if: always()` override means this caller job is implicitly skipped
+    # whenever occ-preflight fails (the ordinary state of a fresh PR before
+    # its OCC companion is minted) — identical vector-3 shape to the
+    # "gate / CodeRabbit Thread Check" fix in this same PR, just triggered
+    # via needs-cascade instead of an explicit `if:`. CodeQL analysis doesn't
+    # depend on any occ-preflight output, so there is no correctness reason
+    # to couple its execution to that outcome. Matches the established
+    # convention every other required `needs: occ-preflight` caller in this
+    # repo already follows (deploy-gate.yml, pr-title-check.yml,
+    # required-check-skip-guard-caller.yml, call-receipt-gate.yml).
     needs: occ-preflight
+    if: always()
     name: CodeQL
     uses: OmniNode-ai/onex_change_control/.github/workflows/codeql-reusable.yml@main
     with:

--- a/tests/unit/validation/test_required_check_skip_guard.py
+++ b/tests/unit/validation/test_required_check_skip_guard.py
@@ -8,10 +8,12 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
-ACTION_DIR = (
-    Path(__file__).parents[3] / ".github" / "actions" / "required-check-skip-guard"
-)
+REPO_ROOT = Path(__file__).parents[3]
+ACTION_DIR = REPO_ROOT / ".github" / "actions" / "required-check-skip-guard"
+MANIFEST_PATH = REPO_ROOT / ".github" / "required-checks.yaml"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 pytestmark = pytest.mark.unit
 
@@ -86,3 +88,73 @@ def test_cross_repo_unresolved_context_fails_closed() -> None:
     )
 
     assert [finding.vector for finding in findings] == ["vector-unresolved"]
+
+
+def test_no_required_caller_job_has_ungated_top_level_if() -> None:
+    """Regression guard (OMN-15120/OMN-14864).
+
+    A required context's CALLER job — the job in this repo's own workflow
+    file that does `uses: <reusable>.yml` and produces the composed
+    "<caller-job> / <reusable-job-name>" context string — must never carry a
+    top-level `if:` that can evaluate false on an ordinary PR/merge_group
+    event. If the CALLER job is skipped, GitHub never invokes the reusable
+    workflow at all, so no check run is ever created under the composed
+    context name: the required check goes PENDING forever, it does not pass.
+    This is distinct from (and strictly worse than) a job-level `if:` INSIDE
+    an already-invoked reusable, which still posts a real "skipped"
+    conclusion that GitHub branch protection accepts as passing.
+
+    Live case this guards against: omnibase_core#1548 (a Dependabot PR) could
+    never merge because "gate / CodeRabbit Thread Check" and
+    "occ-companion-effect / Publish occ-companion-effect command" both had an
+    ungated caller-level `if:` excluding `github.actor == 'dependabot[bot]'`.
+    See docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md.
+
+    Deliberately does NOT honor `skip_semantics: neutral_ok` from
+    required-checks.yaml — unlike the shared skip-vector guard script
+    (validate_no_required_check_skip_vectors.py), which currently lets
+    neutral_ok suppress this exact class of finding (the manifest drift the
+    diagnosis identifies). A caller-level skip is never semantically neutral:
+    it suppresses check-run creation outright, so there is no legitimate
+    ratified exception for it. If a future gate legitimately needs a
+    caller-level `if:`, eligibility belongs inside the executed producer
+    (the reusable's own job), not on the caller.
+    """
+    manifest = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8")) or {}
+    workflows = workflow_model.load_workflows(WORKFLOWS_DIR)
+
+    violations: list[str] = []
+    for gate in manifest.get("gates", []):
+        if gate.get("mode") != "REQUIRED":
+            continue
+        context = gate["name"]
+        try:
+            resolved = workflow_model.resolve_context_to_job(context, workflows)
+        except workflow_model.UnresolvedContext:
+            # Manifest/workflow drift is covered separately by
+            # validate_no_required_check_skip_vectors.py's vector-unresolved
+            # finding; not this guard's concern.
+            continue
+
+        if resolved.caller_job_id is None:
+            # Shape A: the producing job IS the context (no `uses:` wrapper),
+            # so there is no separate caller-level `if:` to suppress check-run
+            # creation. A job-level `if:` here still produces a "skipped"
+            # check run and is validated separately (vector-2).
+            continue
+
+        caller_wf = resolved.workflow
+        caller_job = caller_wf.jobs[resolved.caller_job_id]
+        declared_events = validator._declared_events(caller_wf)
+        verdict = workflow_model.classify(caller_job.if_expr, declared_events)
+        if verdict != workflow_model.ALWAYS_TRUE_FOR_PR:
+            violations.append(
+                f"{context!r}: caller job '{caller_job.job_id}' in "
+                f"{caller_wf.path.name} has `if: {caller_job.if_expr}` — a "
+                "skipped caller job produces NO check run under this composed "
+                "context name, wedging the required check PENDING forever. "
+                "Move actor/ticket eligibility inside the executed producer "
+                "(the reusable's own job) instead."
+            )
+
+    assert not violations, "\n".join(violations)

--- a/tests/unit/validation/test_required_check_skip_guard.py
+++ b/tests/unit/validation/test_required_check_skip_guard.py
@@ -158,3 +158,96 @@ def test_no_required_caller_job_has_ungated_top_level_if() -> None:
             )
 
     assert not violations, "\n".join(violations)
+
+
+def _is_bare_always(if_expr: str | None) -> bool:
+    """True when `if_expr` is exactly `always()`, bare or `${{ }}`-wrapped."""
+    normalized = (if_expr or "").strip()
+    if normalized.startswith("${{") and normalized.endswith("}}"):
+        normalized = normalized[3:-2].strip()
+    return normalized == "always()"
+
+
+def test_no_required_job_has_ungated_needs_cascade() -> None:
+    """Regression guard (OMN-15120/OMN-14864, second vector on the same tickets).
+
+    A required context's producing job — whether it IS the context (Shape A)
+    or is the CALLER job that wraps a reusable producing a composed context
+    (Shape B/C) — must never declare `needs:` without pairing it with
+    `if: always()`. GitHub's default behavior implicitly skips a job when any
+    job it `needs:` fails or is skipped, with NO explicit `if:` required to
+    trigger that skip. For a Shape A job this still produces a check run
+    (conclusion=skipped, which branch protection accepts) — but for a Shape
+    B/C CALLER job it reproduces the exact vector-3 failure from
+    test_no_required_caller_job_has_ungated_top_level_if above: the reusable
+    is never invoked, so the composed check run never exists at all, and the
+    required check is PENDING forever.
+
+    `occ-preflight` failing (the common `needs:` target across this repo's
+    required callers) is the ORDINARY state of any fresh non-exempt PR before
+    its OCC companion is minted — not Dependabot-specific. Two live instances
+    were found on this repair's own verification PR (omnibase_core#1549):
+
+    - `gate` in cr-thread-gate-caller.yml (CodeRabbit finding, confirmed via
+      check-run inspection: job 92915155222 showed the bare name "gate",
+      conclusion=skipped, no composed "gate / CodeRabbit Thread Check" run,
+      on a run where occ-preflight had failed).
+    - `codeql` in security-scan.yml, matching the manifest's own pre-existing
+      "vector-5 (ungated needs cascade)" note on the "CodeQL" gate, which
+      named this exact ticket pairing as the pending triage. This job
+      resolves Shape A on its OWN bare name ("CodeQL"), which a needs-skip
+      wouldn't itself endanger (a Shape A skip still posts a real
+      "skipped" check run) — but the job also has `uses:`, and the manifest
+      separately lists "CodeQL / CodeQL Analysis (python)" (the reusable's
+      OWN composed context) as REQUIRED too; that composed context can only
+      ever materialize if this job actually invokes the reusable.
+
+    Every other required `needs: occ-preflight` caller in this repo already
+    pairs it with `if: always()` (deploy-gate.yml, pr-title-check.yml,
+    required-check-skip-guard-caller.yml, call-receipt-gate.yml) — this test
+    makes that convention mechanically enforced instead of merely observed.
+
+    Scoped to jobs that themselves carry a `uses:` (invoke a reusable
+    workflow) — a plain local job (no `uses:`) that gets needs-cascade
+    skipped still posts its OWN check run with conclusion=skipped, which
+    satisfies branch protection directly; there is no reusable-invocation
+    boundary for the skip to hide behind, so no vector-3 danger exists for
+    it (e.g. ci.yml's `zone-filter`, omni-standards-compliance.yml's
+    `ecosystem-validation` — deliberately excluded, not oversights).
+    """
+    manifest = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8")) or {}
+    workflows = workflow_model.load_workflows(WORKFLOWS_DIR)
+
+    violations: list[str] = []
+    for gate in manifest.get("gates", []):
+        if gate.get("mode") != "REQUIRED":
+            continue
+        context = gate["name"]
+        try:
+            resolved = workflow_model.resolve_context_to_job(context, workflows)
+        except workflow_model.UnresolvedContext:
+            continue
+
+        job = resolved.workflow.jobs[resolved.job_id]
+        if job.uses is None:
+            # No reusable-invocation boundary — a needs-cascade skip here
+            # still produces this job's own "skipped" check run, which
+            # satisfies branch protection directly. Nothing to guard.
+            continue
+        needs = job.raw.get("needs")
+        if not needs:
+            continue
+        if _is_bare_always(job.if_expr):
+            continue
+
+        violations.append(
+            f"{context!r}: job '{job.job_id}' in {resolved.workflow.path.name} "
+            f"has `needs: {needs!r}` but `if: {job.if_expr!r}` is not "
+            "`always()` — GitHub's default implicit-skip-on-failed-need "
+            "behavior means this job (and, if it wraps a reusable via "
+            "`uses:`, the composed check-run under it) goes missing entirely "
+            "whenever any needed job fails or is skipped, with no explicit "
+            "conditional required to trigger it."
+        )
+
+    assert not violations, "\n".join(violations)


### PR DESCRIPTION
## Summary

Repairs the omnibase_core workflow producers for two branch-protected required
contexts so they materialize on dependency-bot PRs, per the diagnosis at
`docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md`:

- `gate / CodeRabbit Thread Check` (caller: `.github/workflows/cr-thread-gate-caller.yml`)
- `occ-companion-effect / Publish occ-companion-effect command` (caller: `.github/workflows/call-occ-companion-effect.yml`)

**Root cause:** both caller jobs had a top-level `if:` excluding
`github.actor == 'dependabot[bot]'` (and, for the occ-companion-effect
caller, `renovate[bot]` / ticketless PRs) *before* invoking their cross-repo
reusable workflow. A skipped **caller** job (the job that does `uses:`)
never invokes the reusable at all, so GitHub never creates the composed
check-run context — the required check is PENDING forever. This is a
different, worse failure mode than a job-level `if:` *inside* an
already-invoked reusable, which still posts a real `skipped` conclusion that
branch protection accepts as passing. This left
`OmniNode-ai/omnibase_core#1548` (a Dependabot PR) permanently unable to
satisfy branch protection — two guarded squash-merge attempts were rejected
with "the base branch policy prohibits the merge" because these two
contexts had no check run at all.

## Fix

- Removed the top-level `if:` from both caller jobs so they **always**
  invoke their reusable — preserving the exact context names
  (`gate / CodeRabbit Thread Check`,
  `occ-companion-effect / Publish occ-companion-effect command`).
- `cr-thread-gate-caller.yml`: the reusable (`cr-thread-gate.yml`, omniclaude)
  has no actor gate of its own, so a bot PR's unresolved-CodeRabbit-thread
  count is simply evaluated like any other PR. The former non-PR
  `issue_comment` guard (skip when a comment lands on a bare issue, not a
  PR) moves into the `pr-number` input expression instead of a job-level
  `if:` — `github.event.issue.pull_request` is only truthy when the
  commented-on issue is a PR, so a bare-issue comment now resolves
  `pr-number` to `0`, which the reusable's own script already treats as a
  graceful no-op success (the same path used for `merge_group`).
- `call-occ-companion-effect.yml`: the identical actor/ticket exemption
  already exists inside the reusable's own job-level `if:` (omniclaude
  `call-occ-companion-effect-reusable.yml`, job
  `publish-occ-companion-effect`) — unchanged, **no cross-repo edit
  required**. A job-level skip there still produces a real check run with
  `conclusion=skipped` under the composed context name, which branch
  protection accepts.
- `.github/required-checks.yaml`: updated both gates' `skip_semantics` /
  `rationale` to describe the actual post-fix producer shape —
  `gate / CodeRabbit Thread Check` is now `skip_semantics: never` (no `if:`
  survives anywhere in the chain, so it always completes success/failure);
  `occ-companion-effect / ...` stays `neutral_ok` (the reusable's own
  job-level skip is legitimate by design and still produces a check run).

## Regression check

New test: `tests/unit/validation/test_required_check_skip_guard.py
::test_no_required_caller_job_has_ungated_top_level_if`. It parses
`.github/required-checks.yaml` and every workflow under `.github/workflows/`
and fails if **any** REQUIRED context's producer **caller job** carries a
top-level `if:` that can suppress check-run creation.

- Verified this test **fails** against the pre-fix workflow files (both
  known violations reproduce, via a local `git stash` sanity check) and
  **passes** post-fix.
- Deliberately does **not** honor `skip_semantics: neutral_ok` for this
  class of finding — a caller-level skip is never semantically neutral,
  unlike the shared `validate_no_required_check_skip_vectors.py` guard
  (`.github/actions/required-check-skip-guard/`), which today lets
  `neutral_ok` suppress this exact class of finding. That tool/manifest
  mismatch is the root of the diagnosis and is intentionally left as-is in
  this PR (see Scope below) rather than patched in the shared vendored
  copy, since CI fetches the canonical version live from omniclaude at
  runtime and a vendored-copy-only edit would not be enforced there.
- Runs automatically in normal CI test discovery, and is also the exact
  file the repo's own governed change-aware test selector already maps
  `.github/required-checks.yaml` changes to
  (`tests/unit/scripts/ci/test_detect_test_paths.py
  ::test_required_checks_manifest_uses_focused_guard_test`).

## Scope / cross-repo remainder

No cross-repo (omniclaude) change was required to close this defect —
both reusables already have the right shape at the job level; the bug was
entirely in the omnibase_core-side caller `if:`. Noted as a non-blocking
follow-up in the manifest rationale: the omniclaude
`call-occ-companion-effect-reusable.yml` reusable could additionally
convert its job-level `if:` into an in-script early-exit *success* so no
producer ever reports a bare `skipped` conclusion — not implemented here
since a job-level skip on the callee already satisfies branch protection.

**PR #1548 is untouched by this change.** Per the diagnosis's stop
condition, it must be refreshed onto `dev` after this PR merges, then wait
for both `gate / CodeRabbit Thread Check` and
`occ-companion-effect / Publish occ-companion-effect command` to appear
(pass or legitimately skip) at the new exact head before any further guarded
merge attempt.

## Verification

- `uv run pytest tests/unit/validation/test_required_check_skip_guard.py -v`
  — 4 passed (including the new regression test).
- `.github/actions/required-check-skip-guard/validate_no_required_check_skip_vectors.py`
  run directly against the fixed manifest — `PASS: no required-check skip
  vectors found.`
- `pre-commit run --files <the 4 touched files>` — all hooks passed
  (yamlfmt auto-reflowed the manifest's rationale strings; content
  unchanged).
- Pre-push governed impacted-test-selector hook (OMN-13973) ran the full
  local `tests/unit/` + adjacent-dir mirror (this repo's adjacency map
  does not narrow `.github/workflows/` changes) — **43865 passed, 53
  skipped, 3 xpassed, 0 failed** in 5626s.
- `gh pr checks` not yet available (PR just opened) — will confirm CI green
  separately; this PR does not merge itself (Codex owns merges per repo
  policy).

Ticket: OMN-15120
Related ticket: OMN-14864
Diagnosis: `docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md`

proof_class: receipt-bound


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Required checks are now consistently created for pull requests and supported events, preventing missing-status failures.
  * Dependency-update and ticketless pull-request exemptions remain enforced within their workflows.
  * Comment-triggered checks now complete safely when no pull request is associated.
  * The companion publisher remains non-blocking while its required composed check is created.
  * Security scans can proceed even when preflight checks fail.

* **Tests**
  * Added regression coverage for workflows that could incorrectly skip required check creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#6172
Evidence-Head: 721069d46d565ed5121c7c883294ff8117c7622a
Evidence-Ticket: OMN-15120

