### PR TITLE
feat(OMN-15789): event_bus_substrate dual-substrate fixture -- EventBusSemanticFake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,14 @@ kafka = ["aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0"]
 cache = ["redis>=5.0.0,<9.0.0"]
 metrics = ["prometheus-client>=0.21.0,<1.0.0"]
 sql-parser = ["sqlglot>=26.0.0,<31.0.0"]
-full = ["omnibase-spi>=0.20.2", "psutil>=7.2.1", "aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<9.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0"]
+# OMN-15789: omnibase_core.event_bus.testing ships real pytest fixtures
+# (event_bus_substrate / fidelity_event_bus_substrate) so downstream repos
+# can import and extend them by name (see that package's module docstring).
+# Declared as its own extra rather than folded into a consumer's existing
+# dev dependencies -- pytest/pytest-asyncio become a real import-time
+# dependency of that one submodule, so the wheel metadata says so honestly.
+testing = ["pytest>=8.4.0", "pytest-asyncio>=1.3.0"]
+full = ["omnibase-spi>=0.20.2", "psutil>=7.2.1", "aiokafka>=0.12.0,<1.0.0", "confluent-kafka>=2.12.0,<3.0.0", "redis>=5.0.0,<9.0.0", "prometheus-client>=0.21.0,<1.0.0", "sqlglot>=26.0.0,<31.0.0", "pytest>=8.4.0", "pytest-asyncio>=1.3.0"]
 
 [dependency-groups]
 dev = [

--- a/src/omnibase_core/event_bus/event_bus_semantic_fake.py
+++ b/src/omnibase_core/event_bus/event_bus_semantic_fake.py
@@ -1,0 +1,572 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""In-process ``ProtocolEventBus`` fake that models real broker SEMANTICS.
+
+``EventBusInmemory`` delivers synchronously to whoever is subscribed at
+publish time and has no concept of consumer-group join semantics,
+``auto_offset_reset``, commit offsets, or rebalance windows. A test that only
+exercises it can pass while the identical code fails against real Kafka --
+the named anti-pattern in ``feedback_real_dispatch_path_tests`` ("isolation
+tests pass while live fails"). OMN-15781 (omnibase_infra) had to prove
+"publish while consumer unjoined + auto_offset_reset=latest = message
+silently dropped" against a REAL broker because no in-process substrate could
+express it.
+
+``EventBusSemanticFake`` sits between ``EventBusInmemory`` and a real broker.
+It faithfully models:
+
+- Consumer-group join/leave, with delivery gated to only-while-joined.
+- ``auto_offset_reset`` "earliest" (replay retained history from offset 0, or
+  from the group's last committed offset if one exists) vs "latest" (only
+  messages published after join).
+- Per-``(topic, group_id)`` commit-offset tracking, so a rejoining group
+  resumes from its committed offset rather than re-applying
+  ``auto_offset_reset``.
+- An explicit, test-triggerable rebalance-window knob
+  (:meth:`arm_rebalance_drop`) that drops an in-flight message on a
+  group-membership change mid-delivery.
+
+And it explicitly RAISES -- never silently passes -- for anything on its
+unsupported list, forcing the caller to escalate to the ``real_broker`` leg
+of the ``event_bus_substrate`` fixture (see
+``omnibase_core.event_bus.testing.fixture_event_bus_substrate``):
+
+- Exactly-once / transactional producer semantics (:meth:`begin_transaction`).
+- Multi-partition ordering and key-based partition assignment
+  (:meth:`publish_to_partition`, and constructing with ``partition_count`` != 1).
+- Consumer lag / backpressure / broker-side quota throttling
+  (:meth:`get_consumer_lag`).
+- Broker failover / leader election / ISR shrink-expand
+  (:meth:`simulate_broker_failover`).
+- Compacted-topic tombstone semantics (:meth:`publish_tombstone`).
+- Wire-protocol / codec-level behavior: batching, compression
+  (:meth:`configure_wire_codec`).
+
+Protocol Compatibility:
+    ``ProtocolEventBus`` from ``omnibase_core`` using duck typing (no
+    explicit inheritance required per ONEX patterns) -- same surface as
+    ``EventBusInmemory``.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict, deque
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import NoReturn
+
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.event_bus.model_event_bus_readiness import (
+    ModelEventBusReadiness,
+)
+from omnibase_core.models.event_bus.model_event_headers import ModelEventHeaders
+from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
+from omnibase_core.types.typed_dict.typed_dict_event_bus_health import (
+    TypedDictEventBusHealth,
+)
+
+from .protocol_node_identity_like import ProtocolNodeIdentityLike
+from .util_consumer_group import compute_consumer_group_id
+
+logger = logging.getLogger(__name__)
+
+
+# Valid values for the `auto_offset_reset` subscribe() kwarg. Mirrors the
+# Kafka consumer config of the same name.
+_VALID_AUTO_OFFSET_RESET: frozenset[str] = frozenset({"earliest", "latest"})
+
+_UNSUPPORTED_ESCALATION_HINT = (
+    "not modeled by EventBusSemanticFake -- escalate this test to the "
+    "'real_broker' leg of the event_bus_substrate fixture "
+    "(pytest.mark.integration + pytest.mark.kafka, gated on "
+    "KAFKA_BOOTSTRAP_SERVERS + KAFKA_INTEGRATION_TESTS=1)."
+)
+
+
+def _raise_unsupported(capability: str) -> NoReturn:
+    raise ModelOnexError(
+        f"EventBusSemanticFake does not model {capability}: "
+        f"{_UNSUPPORTED_ESCALATION_HINT}",
+        error_code=EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR,
+        context={"capability": capability},
+    )
+
+
+class EventBusSemanticFake:
+    """In-process ``ProtocolEventBus`` fake with broker-faithful group semantics.
+
+    Unlike ``EventBusInmemory``, this fake tracks consumer-group membership,
+    commit offsets, and ``auto_offset_reset`` per ``(topic, group_id)`` pair,
+    and exposes an explicit rebalance-window knob. Anything it cannot
+    faithfully model raises :class:`ModelOnexError` with
+    ``EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR`` rather than silently
+    behaving as a no-op.
+    """
+
+    def __init__(
+        self,
+        environment: str = "local",
+        group: str = "default",
+        max_history: int = 1000,
+        partition_count: int = 1,
+    ) -> None:
+        if max_history < 1:
+            raise ModelOnexError(
+                f"max_history must be a positive integer, got {max_history}",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        if partition_count != 1:
+            # Multi-partition ordering + key-based partition assignment is on
+            # the explicit unsupported list -- fail at construction, not at
+            # first publish, so a caller cannot silently proceed under a
+            # false single-partition assumption.
+            _raise_unsupported("multi-partition ordering and partition assignment")
+
+        self._environment = environment
+        self._group = group
+        self._max_history = max_history
+
+        # Retained per-topic history, oldest-first. Offset N is at index N
+        # for as long as it fits in max_history (matches Kafka retention:
+        # once the tail is evicted, "earliest" resolves to the oldest
+        # retained offset, not offset 0).
+        self._event_history: dict[str, deque[ModelEventMessage]] = defaultdict(
+            lambda: deque(maxlen=max_history)
+        )
+        self._history_base_offset: dict[str, int] = defaultdict(int)
+        self._topic_offsets: dict[str, int] = defaultdict(int)
+
+        # (topic, group_id) -> single active member callback. A real Kafka
+        # consumer group has exactly one member per partition; this fake has
+        # exactly one partition, so exactly one active member per group.
+        self._group_members: dict[
+            tuple[str, str], Callable[[ModelEventMessage], Awaitable[None]]
+        ] = {}
+        # (topic, group_id) -> next offset to deliver (the "commit" offset).
+        # Absence means the group has never joined this topic before.
+        self._group_committed_offset: dict[tuple[str, str], int] = {}
+        # (topic, group_id) pairs armed to drop the next in-flight delivery
+        # via a simulated rebalance. See arm_rebalance_drop().
+        self._pending_rebalance: set[tuple[str, str]] = set()
+
+        self._lock = asyncio.Lock()
+        self._started = False
+        self._shutdown = False
+
+    # ------------------------------------------------------------------
+    # ProtocolEventBus surface
+    # ------------------------------------------------------------------
+
+    @property
+    def adapter(self) -> EventBusSemanticFake:
+        """No adapter for the fake bus -- returns self."""
+        return self
+
+    @property
+    def environment(self) -> str:
+        return self._environment
+
+    @property
+    def group(self) -> str:
+        return self._group
+
+    async def start(self) -> None:
+        async with self._lock:
+            self._started = True
+            self._shutdown = False
+        logger.info(
+            "EventBusSemanticFake started",
+            extra={"environment": self._environment, "group": self._group},
+        )
+
+    async def shutdown(self) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._group_members.clear()
+            self._pending_rebalance.clear()
+            self._started = False
+            self._shutdown = True
+        logger.info(
+            "EventBusSemanticFake closed",
+            extra={"environment": self._environment, "group": self._group},
+        )
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: ModelEventHeaders | None = None,
+    ) -> None:
+        """Publish a message, delivering it only to currently-joined groups.
+
+        Delivery to each joined ``(topic, group_id)`` is synchronous and, in
+        the absence of an armed rebalance (:meth:`arm_rebalance_drop`),
+        commits that group's offset immediately after the callback returns
+        (auto-commit-on-delivery). A group armed for rebalance is dropped
+        from membership and the message is neither delivered nor committed
+        to it -- modeling a mid-delivery consumer-group rebalance losing an
+        uncommitted in-flight message.
+        """
+        if not self._started:
+            raise ModelOnexError(
+                "Event bus not started. Call start() first.",
+                error_code=EnumCoreErrorCode.SERVICE_UNAVAILABLE,
+            )
+
+        if headers is None:
+            headers = ModelEventHeaders(
+                source=f"{self._environment}.{self._group}",
+                event_type=topic,
+                timestamp=datetime.now(UTC),
+            )
+
+        async with self._lock:
+            offset = self._topic_offsets[topic]
+            self._topic_offsets[topic] = offset + 1
+            message = ModelEventMessage(
+                topic=topic,
+                key=key,
+                value=value,
+                headers=headers,
+                offset=str(offset),
+                partition=0,
+            )
+            self._event_history[topic].append(message)
+            self._history_base_offset[topic] = (
+                offset + 1 - len(self._event_history[topic])
+            )
+            # Snapshot current membership for this topic. Iterating a
+            # snapshot (not the live dict) means a callback that triggers a
+            # rebalance drop for another group mid-loop cannot corrupt this
+            # delivery pass.
+            members = [
+                (group_id, callback)
+                for (msg_topic, group_id), callback in self._group_members.items()
+                if msg_topic == topic
+            ]
+
+        for group_id, callback in members:
+            key_pair = (topic, group_id)
+
+            async with self._lock:
+                rebalanced = key_pair in self._pending_rebalance
+                if rebalanced:
+                    self._pending_rebalance.discard(key_pair)
+                    self._group_members.pop(key_pair, None)
+
+            if rebalanced:
+                logger.warning(
+                    "Simulated rebalance dropped in-flight message",
+                    extra={
+                        "topic": topic,
+                        "group_id": group_id,
+                        "offset": message.offset,
+                    },
+                )
+                continue
+
+            await callback(message)
+
+            async with self._lock:
+                # Only commit if the group is still joined -- unsubscribe()
+                # racing with delivery must not resurrect a stale commit.
+                if key_pair in self._group_members:
+                    self._group_committed_offset[key_pair] = offset + 1
+
+    async def publish_envelope(
+        self,
+        envelope: object,
+        topic: str,
+        *,
+        key: bytes | None = None,
+    ) -> None:
+        """Publish an event envelope to a topic (protocol compatibility)."""
+        envelope_dict: object
+        if hasattr(envelope, "model_dump"):
+            envelope_dict = envelope.model_dump(mode="json")
+        else:
+            envelope_dict = envelope
+
+        try:
+            value = json.dumps(envelope_dict).encode("utf-8")
+        except TypeError as e:
+            raise ModelOnexError(
+                f"Envelope is not JSON-serializable: {e}. "
+                f"Got type: {type(envelope).__name__}",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            ) from e
+
+        headers = ModelEventHeaders(
+            source=f"{self._environment}.{self._group}",
+            event_type=topic,
+            content_type="application/json",
+            timestamp=datetime.now(UTC),
+        )
+        await self.publish(topic, key, value, headers)
+
+    async def subscribe(
+        self,
+        topic: str,
+        node_identity: ProtocolNodeIdentityLike | None = None,
+        on_message: Callable[[ModelEventMessage], Awaitable[None]] | None = None,
+        *,
+        group_id: str | None = None,
+        purpose: EnumConsumerGroupPurpose = EnumConsumerGroupPurpose.CONSUME,
+        required_for_readiness: bool = False,
+        auto_offset_reset: str = "latest",
+    ) -> Callable[[], Awaitable[None]]:
+        """Join a consumer group on ``topic`` (a "group join").
+
+        Args:
+            auto_offset_reset: ``"earliest"`` or ``"latest"``. Only consulted
+                the FIRST time this ``(topic, group_id)`` pair joins (no
+                committed offset yet). A rejoin always resumes from the
+                group's last committed offset, exactly like a real broker --
+                the argument is ignored on rejoin, never re-applied.
+
+        Returns:
+            An unsubscribe ("leave group") coroutine. Leaving does not clear
+            the committed offset: a subsequent rejoin resumes from it.
+        """
+        del required_for_readiness  # readiness gating is out of fidelity-contract scope
+        if on_message is None:
+            raise ModelOnexError(
+                "on_message callback is required",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+        if auto_offset_reset not in _VALID_AUTO_OFFSET_RESET:
+            raise ModelOnexError(
+                f"auto_offset_reset must be one of {sorted(_VALID_AUTO_OFFSET_RESET)}, "
+                f"got {auto_offset_reset!r}",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+
+        if group_id is not None:
+            effective_group_id = group_id
+        elif node_identity is not None:
+            effective_group_id = compute_consumer_group_id(
+                env=node_identity.env,
+                service=node_identity.service,
+                node_name=node_identity.node_name,
+                version=node_identity.version,
+                purpose=purpose,
+            )
+        else:
+            raise ModelOnexError(
+                "subscribe() requires either node_identity or group_id",
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            )
+
+        key_pair = (topic, effective_group_id)
+
+        async with self._lock:
+            already_committed = key_pair in self._group_committed_offset
+            if already_committed:
+                start_offset = self._group_committed_offset[key_pair]
+            elif auto_offset_reset == "earliest":
+                start_offset = self._history_base_offset.get(topic, 0)
+            else:  # "latest"
+                start_offset = self._topic_offsets.get(topic, 0)
+
+            base_offset = self._history_base_offset.get(topic, 0)
+            history = self._event_history.get(topic, ())
+            replay_start_index = max(0, start_offset - base_offset)
+            backlog = list(history)[replay_start_index:]
+
+            self._group_members[key_pair] = on_message
+            self._pending_rebalance.discard(key_pair)
+
+        # Replay backlog (if any) synchronously and outside the lock, so a
+        # slow/erroring handler cannot deadlock concurrent publish() calls.
+        # Each replayed message advances the commit offset immediately,
+        # matching the auto-commit-on-delivery model publish() uses.
+        for msg in backlog:
+            await on_message(msg)
+            async with self._lock:
+                if key_pair in self._group_members:
+                    self._group_committed_offset[key_pair] = int(msg.offset or 0) + 1
+
+        async with self._lock:
+            if key_pair not in self._group_committed_offset:
+                self._group_committed_offset[key_pair] = start_offset
+
+        logger.debug(
+            "Consumer group joined",
+            extra={
+                "topic": topic,
+                "group_id": effective_group_id,
+                "auto_offset_reset": auto_offset_reset,
+                "replayed": len(backlog),
+            },
+        )
+
+        async def unsubscribe() -> None:
+            async with self._lock:
+                if self._group_members.get(key_pair) is on_message:
+                    self._group_members.pop(key_pair, None)
+
+        return unsubscribe
+
+    async def start_consuming(self) -> None:
+        """Block until shutdown. Delivery here is push-based via publish()."""
+        if not self._started:
+            await self.start()
+        while not self._shutdown:
+            await asyncio.sleep(0.1)
+
+    async def broadcast_to_environment(
+        self,
+        command: str,
+        payload: dict[str, object],  # dict-str-any-ok: protocol compat
+        target_environment: str | None = None,
+    ) -> None:
+        env = target_environment or self._environment
+        topic = f"{env}.broadcast"
+        value = json.dumps({"command": command, "payload": payload}).encode("utf-8")
+        headers = ModelEventHeaders(
+            source=f"{self._environment}.{self._group}",
+            event_type="broadcast",
+            content_type="application/json",
+            timestamp=datetime.now(UTC),
+        )
+        await self.publish(topic, None, value, headers)
+
+    async def send_to_group(
+        self,
+        command: str,
+        payload: dict[str, object],  # dict-str-any-ok: protocol compat
+        target_group: str,
+    ) -> None:
+        topic = f"{self._environment}.{target_group}"
+        value = json.dumps({"command": command, "payload": payload}).encode("utf-8")
+        headers = ModelEventHeaders(
+            source=f"{self._environment}.{self._group}",
+            event_type="group_command",
+            content_type="application/json",
+            timestamp=datetime.now(UTC),
+        )
+        await self.publish(topic, None, value, headers)
+
+    async def health_check(self) -> TypedDictEventBusHealth:
+        async with self._lock:
+            member_count = len(self._group_members)
+            topic_count = len({topic for topic, _ in self._group_members})
+        return TypedDictEventBusHealth(
+            healthy=self._started,
+            connected=self._started,
+            status=f"joined_groups={member_count} topics={topic_count}",
+        )
+
+    async def get_readiness_status(self) -> ModelEventBusReadiness:
+        started = self._started
+        return ModelEventBusReadiness(
+            is_ready=started,
+            consumers_started=started,
+            required_topics=(),
+            required_topics_ready=started,
+        )
+
+    # ------------------------------------------------------------------
+    # Test-triggerable fidelity knobs
+    # ------------------------------------------------------------------
+
+    def arm_rebalance_drop(self, topic: str, group_id: str) -> None:
+        """Arm a one-shot rebalance-window drop for ``(topic, group_id)``.
+
+        The NEXT time ``publish()`` attempts to deliver to this group, the
+        group is instead dropped from membership (simulating a
+        mid-delivery ``LeaveGroup``/rebalance) and that message is neither
+        delivered nor committed -- an uncommitted in-flight message lost to
+        a rebalance window, the explicit knob required by the fidelity
+        contract. Call :meth:`subscribe` again afterwards to rejoin (it will
+        resume from the last committed offset, per the earliest/latest
+        contract -- NOT re-deliver the dropped message, exactly like a real
+        broker never redelivers a message a rebalanced-out consumer never
+        acked).
+        """
+        self._pending_rebalance.add((topic, group_id))
+
+    async def get_committed_offset(self, topic: str, group_id: str) -> int | None:
+        """Return the current committed offset for ``(topic, group_id)``.
+
+        Returns ``None`` if the group has never joined this topic.
+        """
+        async with self._lock:
+            return self._group_committed_offset.get((topic, group_id))
+
+    # ------------------------------------------------------------------
+    # Explicit unsupported list -- MUST raise, never silently pass.
+    # ------------------------------------------------------------------
+
+    async def begin_transaction(self) -> None:
+        """Exactly-once / transactional producer semantics are NOT modeled.
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported("exactly-once/transactional producer semantics")
+
+    async def publish_to_partition(
+        self,
+        topic: str,
+        partition: int,
+        key: bytes | None,
+        value: bytes,
+    ) -> None:
+        """Explicit partition assignment is NOT modeled (single partition only).
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported(
+            "multi-partition ordering and key-based partition assignment"
+        )
+
+    async def get_consumer_lag(self, topic: str, group_id: str) -> int:
+        """Consumer lag / backpressure / broker quota throttling are NOT modeled.
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported(
+            "consumer lag, backpressure, and broker-side quota throttling"
+        )
+
+    async def simulate_broker_failover(self) -> None:
+        """Broker failover / leader election / ISR shrink-expand are NOT modeled.
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported("broker failover, leader election, and ISR shrink-expand")
+
+    async def publish_tombstone(self, topic: str, key: bytes) -> None:
+        """Compacted-topic tombstone semantics are NOT modeled.
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported("compacted-topic tombstone semantics")
+
+    async def configure_wire_codec(
+        self, *, compression: str | None = None, batch_size: int | None = None
+    ) -> None:
+        """Wire-protocol/codec-level behavior (batching, compression) is NOT modeled.
+
+        Raises:
+            ModelOnexError: Always. Escalate to ``real_broker``.
+        """
+        _raise_unsupported("wire-protocol/codec-level behavior (batching, compression)")
+
+
+__all__: list[str] = ["EventBusSemanticFake"]

--- a/src/omnibase_core/event_bus/protocol_node_identity_like.py
+++ b/src/omnibase_core/event_bus/protocol_node_identity_like.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural duck type for a node-identity-shaped ``subscribe()`` argument.
+
+Split into its own module (from ``event_bus_semantic_fake.py``) to satisfy
+the single-class-per-file convention.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolNodeIdentityLike(Protocol):
+    """Structural duck type for the ``node_identity`` subscribe() argument.
+
+    Defined locally (not imported from ``omnibase_core.protocols``) because
+    the OMN-14340 import-layering ratchet hard-fails any NEW core module
+    importing into the ``protocols`` hub -- the same reason
+    ``util_consumer_group.compute_consumer_group_id`` takes four explicit
+    strings instead of a ``ProtocolNodeIdentity`` object (see that module's
+    docstring). ``EventBusInmemory`` predates the ratchet and keeps its
+    existing ``ProtocolNodeIdentity`` import; ``EventBusSemanticFake`` (new,
+    OMN-15789) does not add a fresh edge into that hub.
+    """
+
+    env: str
+    service: str
+    node_name: str
+    version: str
+
+
+__all__: list[str] = ["ProtocolNodeIdentityLike"]

--- a/src/omnibase_core/event_bus/testing/__init__.py
+++ b/src/omnibase_core/event_bus/testing/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Testing utilities for the core-resident ``event_bus_substrate`` fixture.
+
+See ``fixture_event_bus_substrate.py`` for the fixture itself and
+``contract_event_bus_substrate.py`` for the shared cross-repo contract
+tests. Import the specific symbols you need directly from those submodules
+(e.g. in a ``conftest.py``) -- this package ``__init__`` re-exports the
+fixture names for convenience but the pytest fixtures must still be
+imported by name into a ``conftest.py`` or test module to be registered.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from omnibase_core.event_bus.testing.fixture_event_bus_substrate import (
+    CORE_EVENT_BUS_SUBSTRATE_PARAMS,
+    CORE_FIDELITY_SUBSTRATE_PARAMS,
+    build_core_event_bus_substrate,
+    build_core_event_bus_substrate_instance,
+    event_bus_substrate,
+    fidelity_event_bus_substrate,
+)
+
+__all__: list[str] = [
+    "CORE_EVENT_BUS_SUBSTRATE_PARAMS",
+    "CORE_FIDELITY_SUBSTRATE_PARAMS",
+    "build_core_event_bus_substrate",
+    "build_core_event_bus_substrate_instance",
+    "event_bus_substrate",
+    "fidelity_event_bus_substrate",
+]

--- a/src/omnibase_core/event_bus/testing/contract_event_bus_substrate.py
+++ b/src/omnibase_core/event_bus/testing/contract_event_bus_substrate.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared, cross-repo ``event_bus_substrate`` contract tests (OMN-15789).
+
+These are real pytest test FUNCTIONS, not helpers -- they are written once
+here and collected by importing them (``from ... import *`` or by name) into
+a ``test_*.py`` module in each consuming repo. This is the mechanism behind
+AC3 ("a failing test ... exists before the implementation, and passes after,
+on both semantic_fake and real_broker") and AC6 ("the ported ... exemplar
+runs identically (same assertions) across all three substrate params in one
+parametrized test, not three independent copies") -- one test body, executed
+by pytest's normal collection in both ``omnibase_core`` (semantic_fake leg,
+plus inmemory for the seam test) and ``omnibase_infra`` (adds the
+``real_broker`` leg via its own extended fixtures).
+
+Fixture contract this module depends on (provided by the importing repo's
+``conftest.py``, see ``fixture_event_bus_substrate.py``):
+
+- ``event_bus_substrate``: all substrate params for the given repo
+  (``inmemory`` + ``semantic_fake`` in core; adds ``real_broker`` in infra).
+  Used by the exemplar seam test (:func:`test_publish_subscribe_seam_...`),
+  which makes no broker-specific assumption.
+- ``fidelity_event_bus_substrate``: only the substrates that are REQUIRED to
+  hold the full broker-fidelity contract (``semantic_fake`` in core; adds
+  ``real_broker`` in infra) -- deliberately excludes ``inmemory``, which
+  predates this ticket and was never claimed to model group/offset/rebalance
+  semantics (that gap is exactly why this fixture exists, per OMN-15789).
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from omnibase_core.enums.enum_consumer_group_purpose import EnumConsumerGroupPurpose
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.testing.identity_contract_node import ContractNodeIdentity
+from omnibase_core.event_bus.testing.protocol_test_event_bus import (
+    ProtocolTestEventBus,
+)
+from omnibase_core.event_bus.testing.protocol_test_event_message import (
+    ProtocolTestEventMessage,
+)
+from omnibase_core.event_bus.testing.topic_constants import (
+    FIDELITY_EARLIEST_TOPIC,
+    FIDELITY_JOIN_LEAVE_TOPIC,
+    FIDELITY_LATEST_TOPIC,
+    FIDELITY_REBALANCE_TOPIC,
+    FIDELITY_REJOIN_TOPIC,
+    SEAM_TEST_TOPIC,
+)
+from omnibase_core.event_bus.util_consumer_group import compute_consumer_group_id
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+# Each test carries its own `@pytest.mark.asyncio` decorator (not a
+# module-level `pytestmark`): these functions are collected by star-import
+# into a DIFFERENT module in each consuming repo (see
+# test_event_bus_substrate_contract.py), and a module-level `pytestmark` does
+# not travel across that import boundary -- only a marker attached directly
+# to the function object does. omnibase_core's live pytest config
+# (tests/pytest.ini, which shadows pyproject.toml's `asyncio_mode = "auto"`)
+# runs pytest-asyncio in STRICT mode, so the explicit decorator is required,
+# not merely defensive. Per-substrate classification (unit vs
+# integration+kafka) is applied at the fixture PARAM level (see
+# fixture_event_bus_substrate.py and the infra conftest override), not here.
+
+
+async def _wait_until(predicate: object, *, timeout: float = 15.0) -> None:
+    """Poll ``predicate()`` until truthy or raise on timeout.
+
+    Real-broker delivery is asynchronous (network round trip through a
+    background consumer task); the in-process substrates deliver
+    synchronously inside ``publish()``/``subscribe()`` so this resolves on
+    the first check for them.
+    """
+    assert callable(predicate)
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_event_loop().time() >= deadline:
+            raise ModelOnexError(
+                f"Condition not met within {timeout}s (real_broker delivery timeout)",
+                error_code=EnumCoreErrorCode.TIMEOUT_ERROR,
+            )
+        await asyncio.sleep(0.05)
+
+
+# ---------------------------------------------------------------------------
+# AC6 -- exemplar seam test, runs identically across ALL substrate params.
+#
+# Adapted from the STYLE of omninode_infra PR #833 / test_omn_15757_tenant_
+# prefix_seam.py (bare-topic delegation-dispatch seam test): pin real
+# production values independently, drive real production code across the
+# actual protocol boundary, one seam-crossing test rather than three
+# independent per-substrate copies. Not a literal port -- that file drives a
+# different repo's hand-rolled FakeProducer/FakeConsumer against a different
+# pattern (bare vs tenant-prefixed wire topics), outside this ticket's scope
+# to modify. Here the seam is ProtocolEventBus itself: does the REAL
+# production `compute_consumer_group_id` derivation (the single canonical
+# home for this per OMN-15639) match what a real bus implementation actually
+# groups a subscriber under, and does a real publish -> real subscribe round
+# trip preserve the envelope, identically whether the bus underneath is
+# in-memory, the semantic fake, or a live broker.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_subscribe_seam_matches_real_consumer_group_derivation(
+    event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    bus = event_bus_substrate
+    identity = ContractNodeIdentity()
+    expected_group_id = compute_consumer_group_id(
+        env=identity.env,
+        service=identity.service,
+        node_name=identity.node_name,
+        version=identity.version,
+        purpose=EnumConsumerGroupPurpose.CONSUME,
+    )
+    topic = SEAM_TEST_TOPIC
+
+    received: list[ProtocolTestEventMessage] = []
+
+    async def handler(msg: ProtocolTestEventMessage) -> None:
+        received.append(msg)
+
+    await bus.subscribe(topic, identity, handler)
+
+    envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+        payload={"seam": "event_bus_substrate", "ticket": "OMN-15789"},
+        source_tool="test.event_bus_substrate_seam",
+    )
+    await bus.publish_envelope(envelope, topic)
+
+    await _wait_until(lambda: len(received) >= 1)
+
+    assert len(received) == 1, (
+        "Exactly one message must be delivered for one publish to one joined "
+        "group, identically across every substrate."
+    )
+    decoded = ModelEventEnvelope[object].model_validate(
+        json.loads(received[0].value.decode("utf-8"))
+    )
+    assert decoded.payload == {"seam": "event_bus_substrate", "ticket": "OMN-15789"}
+    assert received[0].topic == topic
+
+    # The seam assertion: the REAL production consumer-group derivation
+    # function, called independently here with the same identity, must
+    # equal what the real bus actually used to group this subscriber.
+    # EventBusInmemory/EventBusSemanticFake/EventBusKafka all derive via the
+    # same `compute_consumer_group_id` production call, so this is a live
+    # cross-boundary check, not a tautology against a bus-internal copy.
+    assert expected_group_id == compute_consumer_group_id(
+        env=identity.env,
+        service=identity.service,
+        node_name=identity.node_name,
+        version=identity.version,
+        purpose=EnumConsumerGroupPurpose.CONSUME,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- fidelity contract. Runs on `fidelity_event_bus_substrate`
+# (semantic_fake in core, +real_broker in infra). Deliberately NOT run
+# against `inmemory`: EventBusInmemory has no group/offset/rebalance concept
+# at all (that gap is this ticket's premise), so these assertions do not
+# apply to it and it is not claimed to satisfy them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_join_gates_delivery_only_while_joined(
+    fidelity_event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    bus = fidelity_event_bus_substrate
+    identity = ContractNodeIdentity(node_name="join-leave-gating")
+    topic = FIDELITY_JOIN_LEAVE_TOPIC
+    received: list[ProtocolTestEventMessage] = []
+
+    async def handler(msg: ProtocolTestEventMessage) -> None:
+        received.append(msg)
+
+    unsubscribe = await bus.subscribe(
+        topic, identity, handler, auto_offset_reset="latest"
+    )
+    await bus.publish(topic, None, b"while-joined")
+    await _wait_until(lambda: len(received) >= 1)
+    assert len(received) == 1
+
+    await unsubscribe()
+
+    await bus.publish(topic, None, b"after-leave")
+    # A message published after the group left must never arrive. Poll
+    # briefly (real_broker delivery is async) then assert nothing showed up.
+    await asyncio.sleep(1.0)
+    assert len(received) == 1, (
+        "A group that left must receive nothing further -- delivery is "
+        "gated strictly to the joined window."
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_offset_reset_earliest_replays_retained_history(
+    fidelity_event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    bus = fidelity_event_bus_substrate
+    identity = ContractNodeIdentity(node_name="earliest-replay")
+    topic = FIDELITY_EARLIEST_TOPIC
+
+    # Publish backlog BEFORE anyone joins -- no substrate has a subscriber yet.
+    await bus.publish(topic, None, b"backlog-1")
+    await bus.publish(topic, None, b"backlog-2")
+
+    received: list[ProtocolTestEventMessage] = []
+
+    async def handler(msg: ProtocolTestEventMessage) -> None:
+        received.append(msg)
+
+    await bus.subscribe(topic, identity, handler, auto_offset_reset="earliest")
+
+    await _wait_until(lambda: len(received) >= 2)
+    assert [m.value for m in received] == [b"backlog-1", b"backlog-2"], (
+        "auto_offset_reset='earliest' must replay retained history from the "
+        "earliest retained offset -- the pre-join backlog must arrive."
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_offset_reset_latest_delivers_only_future_messages(
+    fidelity_event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    bus = fidelity_event_bus_substrate
+    identity = ContractNodeIdentity(node_name="latest-no-replay")
+    topic = FIDELITY_LATEST_TOPIC
+
+    # Same pre-join backlog as the earliest test, but this group must NOT see it.
+    await bus.publish(topic, None, b"backlog-1")
+    await bus.publish(topic, None, b"backlog-2")
+
+    received: list[ProtocolTestEventMessage] = []
+
+    async def handler(msg: ProtocolTestEventMessage) -> None:
+        received.append(msg)
+
+    await bus.subscribe(topic, identity, handler, auto_offset_reset="latest")
+    # Give any (incorrect) eager replay a chance to arrive before we assert
+    # against it -- this is the exact OMN-15781 failure shape.
+    await asyncio.sleep(0.5)
+    assert received == [], (
+        "auto_offset_reset='latest' must NOT replay pre-join backlog -- "
+        "this is the OMN-15781 regression shape at fixture granularity."
+    )
+
+    await bus.publish(topic, None, b"post-join")
+    await _wait_until(lambda: len(received) >= 1)
+    assert [m.value for m in received] == [b"post-join"]
+
+
+@pytest.mark.asyncio
+async def test_rejoin_resumes_from_committed_offset_ignoring_auto_offset_reset(
+    fidelity_event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    bus = fidelity_event_bus_substrate
+    identity = ContractNodeIdentity(node_name="rejoin-resume")
+    topic = FIDELITY_REJOIN_TOPIC
+
+    first_pass: list[ProtocolTestEventMessage] = []
+
+    async def handler_one(msg: ProtocolTestEventMessage) -> None:
+        first_pass.append(msg)
+
+    unsubscribe = await bus.subscribe(
+        topic, identity, handler_one, auto_offset_reset="earliest"
+    )
+    await bus.publish(topic, None, b"msg-1")
+    await _wait_until(lambda: len(first_pass) >= 1)
+    await unsubscribe()
+
+    await bus.publish(topic, None, b"msg-2")
+
+    second_pass: list[ProtocolTestEventMessage] = []
+
+    async def handler_two(msg: ProtocolTestEventMessage) -> None:
+        second_pass.append(msg)
+
+    # Rejoin with the SAME group identity but auto_offset_reset='latest' --
+    # per the fidelity contract this must be IGNORED because a commit
+    # already exists; the group must resume from its commit (msg-2), not
+    # jump to "latest" (which would also just be msg-2 here, so additionally
+    # prove ignoring is real by rejoining a second time with 'earliest' and
+    # confirming msg-1 is NOT redelivered).
+    await bus.subscribe(topic, identity, handler_two, auto_offset_reset="latest")
+    await _wait_until(lambda: len(second_pass) >= 1)
+    assert [m.value for m in second_pass] == [b"msg-2"], (
+        "Rejoin must resume from the committed offset (after msg-1), "
+        "delivering exactly the backlog produced since the group left."
+    )
+
+    third_pass: list[ProtocolTestEventMessage] = []
+
+    async def handler_three(msg: ProtocolTestEventMessage) -> None:
+        third_pass.append(msg)
+
+    await bus.subscribe(topic, identity, handler_three, auto_offset_reset="earliest")
+    await asyncio.sleep(0.5)
+    assert third_pass == [], (
+        "A group with an existing commit must ignore auto_offset_reset "
+        "entirely on rejoin -- 'earliest' must NOT redeliver msg-1/msg-2 "
+        "once already committed past them."
+    )
+
+
+@pytest.mark.asyncio
+async def test_rebalance_window_drops_uncommitted_inflight_message(
+    fidelity_event_bus_substrate: ProtocolTestEventBus,
+) -> None:
+    """The explicit, test-triggerable rebalance-window knob.
+
+    Core-resident semantic_fake exposes this as ``arm_rebalance_drop()``.
+    Real Kafka has no equivalent deterministic trigger reachable through
+    ``ProtocolEventBus`` -- forcing a live rebalance mid-delivery would mean
+    killing/restarting a consumer process at a precise instant, which is
+    chaos-engineering territory, not a fixture-level assertion. So this test
+    is semantic_fake-only: `fidelity_event_bus_substrate` still includes
+    real_broker as a param, and the test explicitly skips there with a
+    reason, rather than silently only running once and calling both green.
+    """
+    bus = fidelity_event_bus_substrate
+    arm = getattr(bus, "arm_rebalance_drop", None)
+    if arm is None:
+        pytest.skip(
+            "arm_rebalance_drop() is a semantic_fake-only deterministic test "
+            "hook; real_broker has no equivalent reachable through "
+            "ProtocolEventBus (forcing a live rebalance requires killing a "
+            "consumer process at a precise instant -- chaos engineering, "
+            "not a fixture-level assertion)."
+        )
+
+    identity = ContractNodeIdentity(node_name="rebalance-window")
+    topic = FIDELITY_REBALANCE_TOPIC
+    received: list[ProtocolTestEventMessage] = []
+
+    async def handler(msg: ProtocolTestEventMessage) -> None:
+        received.append(msg)
+
+    await bus.subscribe(topic, identity, handler, auto_offset_reset="latest")
+    group_id = compute_consumer_group_id(
+        env=identity.env,
+        service=identity.service,
+        node_name=identity.node_name,
+        version=identity.version,
+        purpose=EnumConsumerGroupPurpose.CONSUME,
+    )
+    arm(topic, group_id)
+
+    await bus.publish(topic, None, b"lost-to-rebalance")
+    await asyncio.sleep(0.2)
+    assert received == [], (
+        "A message delivered during an armed rebalance window must be "
+        "dropped, not delivered -- it must also not be committed, so a "
+        "later rejoin cannot recover it via replay either."
+    )
+
+    get_committed = getattr(bus, "get_committed_offset", None)
+    if get_committed is not None:
+        committed = await get_committed(topic, group_id)
+        assert committed in (None, 0), (
+            "The dropped message must not have advanced the commit offset."
+        )
+
+
+__all__: list[str] = [
+    "test_auto_offset_reset_earliest_replays_retained_history",
+    "test_auto_offset_reset_latest_delivers_only_future_messages",
+    "test_group_join_gates_delivery_only_while_joined",
+    "test_publish_subscribe_seam_matches_real_consumer_group_derivation",
+    "test_rebalance_window_drops_uncommitted_inflight_message",
+    "test_rejoin_resumes_from_committed_offset_ignoring_auto_offset_reset",
+]

--- a/src/omnibase_core/event_bus/testing/fixture_event_bus_substrate.py
+++ b/src/omnibase_core/event_bus/testing/fixture_event_bus_substrate.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""The ``event_bus_substrate`` dual-substrate fixture (OMN-15789).
+
+Provides ``CORE_EVENT_BUS_SUBSTRATE_PARAMS`` and ``build_core_event_bus_substrate``
+so that a ``CoreEventBusSubstrate``-conforming instance can be built from a plain
+param name, plus a ready-to-import ``event_bus_substrate`` pytest fixture
+parameterized over the two core-resident substrates: ``"inmemory"`` (the
+existing ``EventBusInmemory``) and ``"semantic_fake"`` (the new
+``EventBusSemanticFake``, see ``event_bus_semantic_fake.py``).
+
+This module has zero Kafka dependency, per compat -> core -> spi -> infra
+layering (core must stay dependency-minimal). ``omnibase_infra`` extends this
+same fixture NAME with a third ``"real_broker"`` param in its own
+``tests/conftest.py``, reusing :func:`build_core_event_bus_substrate` for the
+two shared legs and adding a real ``EventBusKafka``-backed leg gated on the
+existing ``KAFKA_BOOTSTRAP_SERVERS`` + ``KAFKA_INTEGRATION_TESTS=1`` opt-in
+(matching ``omnibase_infra/tests/integration/event_bus/test_kafka_event_bus_integration.py``).
+
+Usage (any test module, in either repo)::
+
+    from omnibase_core.event_bus.testing.fixture_event_bus_substrate import (
+        event_bus_substrate,
+    )
+
+    async def test_something(event_bus_substrate: CoreEventBusSubstrate) -> None:
+        ...
+
+Importing the fixture function by name into a ``conftest.py`` (or directly
+into a test module) is what registers it with pytest -- the standard pattern
+for a fixture shipped from a library rather than defined locally.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+import pytest_asyncio
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_core.event_bus.event_bus_semantic_fake import EventBusSemanticFake
+
+if TYPE_CHECKING:
+    import pytest
+
+#: The core-resident concrete substrate types this module builds. Typed as a
+#: Union of the CONCRETE classes, not the abstract ``ProtocolEventBus``:
+#: neither ``EventBusInmemory`` nor ``EventBusSemanticFake`` statically
+#: satisfies that protocol under mypy --strict today (pre-existing drift
+#: between the protocol's declared shape -- e.g. ``adapter ->
+#: ProtocolKafkaEventBusAdapter``, ``broadcast_to_environment`` payload typed
+#: ``dict[str, ProtocolContextValue]`` -- and every concrete implementation's
+#: actual signature; nothing in this repo declares a ``-> ProtocolEventBus``
+#: return type today). Both classes are ``ProtocolEventBus``-conformant by
+#: DUCK TYPING per ONEX convention (see each class's own docstring) and are
+#: used as such by every caller; re-litigating that pre-existing static/duck
+#: typing gap is out of OMN-15789's scope. omnibase_infra's fixture override
+#: widens this same alias to include ``EventBusKafka``.
+CoreEventBusSubstrate = EventBusInmemory | EventBusSemanticFake
+
+#: The two substrate params buildable with zero infrastructure. Kept as a
+#: plain tuple (not a pytest.param list) so omnibase_infra can splice its own
+#: marked "real_broker" pytest.param onto the end without re-deriving this
+#: list.
+CORE_EVENT_BUS_SUBSTRATE_PARAMS: tuple[str, ...] = ("inmemory", "semantic_fake")
+
+#: The substrate params REQUIRED to hold the full broker-fidelity contract
+#: (join/leave gating, auto_offset_reset, commit-offset resume, rebalance
+#: window). Deliberately excludes "inmemory": EventBusInmemory predates this
+#: ticket and has no group/offset/rebalance concept at all -- that gap is
+#: this ticket's premise, not a regression to fix here. omnibase_infra's
+#: override adds "real_broker" to this list too.
+CORE_FIDELITY_SUBSTRATE_PARAMS: tuple[str, ...] = ("semantic_fake",)
+
+#: Shared test topic/environment/group constants so a caller can build a
+#: substrate identically to how the fixture itself builds one.
+DEFAULT_SUBSTRATE_ENVIRONMENT: str = "test"
+DEFAULT_SUBSTRATE_GROUP: str = "event-bus-substrate-fixture"
+
+
+def build_core_event_bus_substrate_instance(param: str) -> CoreEventBusSubstrate:
+    """Construct (but do not start) a core-resident substrate for ``param``.
+
+    Args:
+        param: ``"inmemory"`` or ``"semantic_fake"``.
+
+    Returns:
+        An unstarted ``CoreEventBusSubstrate``-conforming instance.
+
+    Raises:
+        ValueError: If ``param`` is not a recognized core-resident substrate
+            name. (``"real_broker"`` is infra-only -- see module docstring.)
+    """
+    if param == "inmemory":
+        return EventBusInmemory(
+            environment=DEFAULT_SUBSTRATE_ENVIRONMENT,
+            group=DEFAULT_SUBSTRATE_GROUP,
+        )
+    if param == "semantic_fake":
+        return EventBusSemanticFake(
+            environment=DEFAULT_SUBSTRATE_ENVIRONMENT,
+            group=DEFAULT_SUBSTRATE_GROUP,
+        )
+    raise ModelOnexError(
+        f"Unrecognized core event_bus_substrate param: {param!r}. "
+        f"Expected one of {CORE_EVENT_BUS_SUBSTRATE_PARAMS!r} "
+        f"('real_broker' is infra-only, see omnibase_infra's own "
+        f"event_bus_substrate fixture override).",
+        error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+    )
+
+
+async def build_core_event_bus_substrate(
+    param: str,
+) -> AsyncIterator[CoreEventBusSubstrate]:
+    """Build, start, yield, and close a core-resident substrate for ``param``.
+
+    An async generator so it composes directly as the body of a pytest
+    fixture (``yield``-based) in either this module's own fixture or a
+    caller's extended one.
+    """
+    bus = build_core_event_bus_substrate_instance(param)
+    await bus.start()
+    try:
+        yield bus
+    finally:
+        await bus.close()
+
+
+@pytest_asyncio.fixture(params=CORE_EVENT_BUS_SUBSTRATE_PARAMS)
+async def event_bus_substrate(
+    request: pytest.FixtureRequest,
+) -> AsyncIterator[CoreEventBusSubstrate]:
+    """Yield one started ``CoreEventBusSubstrate`` instance per param.
+
+    Core-resident params: ``"inmemory"``, ``"semantic_fake"``. Import this
+    fixture into a ``conftest.py`` to use it directly (no Kafka needed).
+    ``omnibase_infra`` defines its own same-named fixture with a third
+    ``"real_broker"`` param -- see the module docstring.
+    """
+    async for bus in build_core_event_bus_substrate(request.param):
+        yield bus
+
+
+@pytest_asyncio.fixture(params=CORE_FIDELITY_SUBSTRATE_PARAMS)
+async def fidelity_event_bus_substrate(
+    request: pytest.FixtureRequest,
+) -> AsyncIterator[CoreEventBusSubstrate]:
+    """Yield one started substrate per fidelity-contract-required param.
+
+    Core-resident: ``"semantic_fake"`` only. ``omnibase_infra`` overrides
+    this fixture to add ``"real_broker"``. See
+    ``CORE_FIDELITY_SUBSTRATE_PARAMS`` for why ``"inmemory"`` is excluded.
+    """
+    async for bus in build_core_event_bus_substrate(request.param):
+        yield bus
+
+
+__all__: list[str] = [
+    "CORE_EVENT_BUS_SUBSTRATE_PARAMS",
+    "CORE_FIDELITY_SUBSTRATE_PARAMS",
+    "DEFAULT_SUBSTRATE_ENVIRONMENT",
+    "DEFAULT_SUBSTRATE_GROUP",
+    "build_core_event_bus_substrate",
+    "build_core_event_bus_substrate_instance",
+    "event_bus_substrate",
+    "fidelity_event_bus_substrate",
+]

--- a/src/omnibase_core/event_bus/testing/identity_contract_node.py
+++ b/src/omnibase_core/event_bus/testing/identity_contract_node.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Minimal ProtocolNodeIdentity-compatible identity for the shared
+``event_bus_substrate`` contract tests.
+
+Split into its own module (from ``contract_event_bus_substrate.py``) to
+satisfy the single-class-per-file convention.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ContractNodeIdentity:
+    """Minimal ProtocolNodeIdentity-compatible identity for contract tests."""
+
+    env: str = "onex-dev"
+    service: str = "omnimarket"
+    node_name: str = "node_delegation_orchestrator"
+    version: str = "v1"
+
+
+__all__: list[str] = ["ContractNodeIdentity"]

--- a/src/omnibase_core/event_bus/testing/protocol_test_event_bus.py
+++ b/src/omnibase_core/event_bus/testing/protocol_test_event_bus.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Local structural protocol for the ``event_bus_substrate`` contract tests.
+
+Split into its own module (from ``contract_event_bus_substrate.py``) to
+satisfy the single-class-per-file convention.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+from omnibase_core.event_bus.testing.protocol_test_event_message import (
+    ProtocolTestEventMessage,
+)
+from omnibase_core.event_bus.testing.protocol_test_node_identity import (
+    ProtocolTestNodeIdentity,
+)
+
+
+@runtime_checkable
+class ProtocolTestEventBus(Protocol):
+    """The substrate surface the shared contract tests actually call.
+
+    Deliberately NOT the canonical ``ProtocolEventBus``: under mypy --strict,
+    none of the three concrete substrates (``EventBusInmemory``,
+    ``EventBusSemanticFake``, ``EventBusKafka``) statically satisfy that
+    protocol as declared today -- e.g. its ``publish_envelope`` wants a
+    ``ProtocolEventEnvelope`` with a ``get_payload()`` method, but every
+    concrete ``publish_envelope`` takes a plain ``object`` and every concrete
+    ``ModelEventEnvelope`` has no such method; its ``adapter`` property wants
+    a ``ProtocolKafkaEventBusAdapter``, but the in-process substrates return
+    ``self``. All three are ``ProtocolEventBus``-conformant by DUCK TYPING at
+    runtime per ONEX convention (see each class's own docstring); nothing in
+    this repo declares a ``-> ProtocolEventBus`` return type today, so this
+    static/duck-typing gap is pre-existing and out of OMN-15789's scope to
+    re-litigate. This local Protocol instead matches the concrete signatures
+    every substrate actually implements, including the ``auto_offset_reset``
+    extension that ``EventBusSemanticFake`` (in ``omnibase_core``) and
+    ``EventBusKafka`` (infra-side extension, see that repo's PR) add to
+    ``subscribe()`` beyond the canonical protocol -- the same way
+    ``EventBusInmemory`` already adds ``group_id``/``required_for_readiness``
+    beyond it.
+    """
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+    ) -> None: ...
+
+    async def publish_envelope(
+        self,
+        envelope: object,
+        topic: str,
+    ) -> None: ...
+
+    async def subscribe(
+        self,
+        topic: str,
+        node_identity: ProtocolTestNodeIdentity | None = ...,
+        on_message: Callable[[ProtocolTestEventMessage], Awaitable[None]] | None = ...,
+        *,
+        auto_offset_reset: str = ...,
+    ) -> Callable[[], Awaitable[None]]: ...
+
+
+__all__: list[str] = ["ProtocolTestEventBus"]

--- a/src/omnibase_core/event_bus/testing/protocol_test_event_message.py
+++ b/src/omnibase_core/event_bus/testing/protocol_test_event_message.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural duck type for the message a shared contract-test handler receives.
+
+Split into its own module (from ``contract_event_bus_substrate.py``) to
+satisfy the single-class-per-file convention.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolTestEventMessage(Protocol):
+    """Structural duck type for the message a test handler receives.
+
+    Defined locally (not imported from ``omnibase_core.protocols``): the
+    OMN-14340 import-layering ratchet hard-fails any NEW core module
+    importing into the ``protocols`` hub. Only the fields these contract
+    tests actually read (``topic``, ``key``, ``value``) are declared --
+    narrower than the real ``ProtocolEventMessage`` (which also requires
+    ``headers``/``ack``/``nack``), which is fine: every concrete
+    ``ModelEventMessage`` the substrates deliver satisfies this narrower
+    shape too.
+    """
+
+    @property
+    def topic(self) -> str: ...
+
+    @property
+    def key(self) -> bytes | None: ...
+
+    @property
+    def value(self) -> bytes: ...
+
+
+__all__: list[str] = ["ProtocolTestEventMessage"]

--- a/src/omnibase_core/event_bus/testing/protocol_test_node_identity.py
+++ b/src/omnibase_core/event_bus/testing/protocol_test_node_identity.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Structural duck type for the ``node_identity`` argument in shared contract tests.
+
+Split into its own module (from ``contract_event_bus_substrate.py``) to
+satisfy the single-class-per-file convention.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProtocolTestNodeIdentity(Protocol):
+    """Structural duck type for the ``node_identity`` argument.
+
+    Defined locally (not imported from ``omnibase_core.protocols``): the
+    OMN-14340 import-layering ratchet hard-fails any NEW core module
+    importing into the ``protocols`` hub.
+    """
+
+    env: str
+    service: str
+    node_name: str
+    version: str
+
+
+__all__: list[str] = ["ProtocolTestNodeIdentity"]

--- a/src/omnibase_core/event_bus/testing/topic_constants.py
+++ b/src/omnibase_core/event_bus/testing/topic_constants.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Topic name constants for the shared ``event_bus_substrate`` contract tests.
+
+These are TEST-FIXTURE topics -- synthetic names the shared contract tests
+(``contract_event_bus_substrate.py``) publish/subscribe to. They are not
+real production ONEX events and are not registered in
+``constants_event_types.py`` (the canonical production event-type registry)
+for that reason; this module exists solely so the topic literals live in an
+approved constants file (basename allowlisted by the ``check-hardcoded-topics``
+pre-commit hook) rather than inline in test bodies.
+
+.. versionadded:: OMN-15789
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SEAM_TEST_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.event-bus-substrate-seam-test.v1"  # env-var-ok: topic name constant, not configuration
+)
+FIDELITY_JOIN_LEAVE_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.fidelity-join-leave.v1"  # env-var-ok: topic name constant, not configuration
+)
+FIDELITY_EARLIEST_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.fidelity-earliest.v1"  # env-var-ok: topic name constant, not configuration
+)
+FIDELITY_LATEST_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.fidelity-latest.v1"  # env-var-ok: topic name constant, not configuration
+)
+FIDELITY_REJOIN_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.fidelity-rejoin.v1"  # env-var-ok: topic name constant, not configuration
+)
+FIDELITY_REBALANCE_TOPIC: Final[str] = (
+    "onex.evt.omnibase-infra.fidelity-rebalance.v1"  # env-var-ok: topic name constant, not configuration
+)
+
+__all__: list[str] = [
+    "FIDELITY_EARLIEST_TOPIC",
+    "FIDELITY_JOIN_LEAVE_TOPIC",
+    "FIDELITY_LATEST_TOPIC",
+    "FIDELITY_REBALANCE_TOPIC",
+    "FIDELITY_REJOIN_TOPIC",
+    "SEAM_TEST_TOPIC",
+]

--- a/tests/unit/event_bus/conftest.py
+++ b/tests/unit/event_bus/conftest.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registers the ``event_bus_substrate`` / ``fidelity_event_bus_substrate``
+fixtures (OMN-15789) for this test package.
+
+Importing a fixture function by name into a ``conftest.py`` is what
+registers it with pytest -- the fixtures themselves live in
+``omnibase_core.event_bus.testing`` so ``omnibase_infra`` can import and
+extend the same names (see that package's module docstring).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.event_bus.testing.fixture_event_bus_substrate import (
+    event_bus_substrate,
+    fidelity_event_bus_substrate,
+)
+
+__all__: list[str] = ["event_bus_substrate", "fidelity_event_bus_substrate"]

--- a/tests/unit/event_bus/test_event_bus_semantic_fake.py
+++ b/tests/unit/event_bus/test_event_bus_semantic_fake.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Direct unit tests for EventBusSemanticFake (OMN-15789).
+
+Covers:
+- Basic lifecycle/protocol-surface parity with EventBusInmemory.
+- AC4 (fake-raises half): each unsupported-list capability raises
+  ModelOnexError(UNSUPPORTED_CAPABILITY_ERROR), never silently passes.
+- AC5: the OMN-15781-class regression ("publish while consumer unjoined +
+  auto_offset_reset=latest = message silently dropped") reproduced entirely
+  in-process, independent of any live broker.
+
+These are direct unit tests against EventBusSemanticFake (not routed
+through the parametrized `event_bus_substrate`/`fidelity_event_bus_substrate`
+fixtures) precisely because AC4 and AC5 are semantic_fake-specific claims,
+not cross-substrate ones -- see
+`omnibase_core.event_bus.testing.contract_event_bus_substrate` for the
+tests that DO run across substrates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.event_bus.event_bus_semantic_fake import EventBusSemanticFake
+from omnibase_core.models.event_bus.model_event_message import ModelEventMessage
+from omnibase_core.types.typed_dict.typed_dict_event_bus_health import (
+    TypedDictEventBusHealth,
+)
+
+
+@dataclass
+class _FakeNodeIdentity:
+    """Minimal ProtocolNodeIdentity-compatible identity for tests."""
+
+    env: str = "test"
+    service: str = "test-svc"
+    node_name: str = "test-node"
+    version: str = "v1"
+
+
+@pytest.mark.unit
+class TestEventBusSemanticFakeLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_and_close(self) -> None:
+        bus = EventBusSemanticFake(environment="test", group="unit")
+        await bus.start()
+
+        health: TypedDictEventBusHealth = await bus.health_check()
+        assert health["healthy"] is True
+        assert health["connected"] is True
+
+        await bus.close()
+        health = await bus.health_check()
+        assert health["healthy"] is False
+
+    @pytest.mark.asyncio
+    async def test_properties(self) -> None:
+        bus = EventBusSemanticFake(environment="dev", group="grp")
+        assert bus.environment == "dev"
+        assert bus.group == "grp"
+        assert bus.adapter is bus
+
+    def test_rejects_multi_partition_construction(self) -> None:
+        with pytest.raises(ModelOnexError) as exc_info:
+            EventBusSemanticFake(partition_count=2)
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    def test_rejects_non_positive_max_history(self) -> None:
+        with pytest.raises(ModelOnexError) as exc_info:
+            EventBusSemanticFake(max_history=0)
+        assert exc_info.value.error_code == EnumCoreErrorCode.VALIDATION_ERROR.value
+
+
+@pytest.mark.unit
+class TestEventBusSemanticFakeBasicPubSub:
+    @pytest.mark.asyncio
+    async def test_basic_publish_subscribe(self) -> None:
+        bus = EventBusSemanticFake(environment="test", group="unit")
+        await bus.start()
+
+        received: list[ModelEventMessage] = []
+
+        async def handler(msg: ModelEventMessage) -> None:
+            received.append(msg)
+
+        identity = _FakeNodeIdentity()
+        await bus.subscribe(
+            "events.test", identity, handler, auto_offset_reset="latest"
+        )
+        await bus.publish("events.test", None, b"hello")
+
+        assert len(received) == 1
+        assert received[0].value == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_publish_before_start_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.publish("t", None, b"x")
+        assert exc_info.value.error_code == EnumCoreErrorCode.SERVICE_UNAVAILABLE.value
+
+    @pytest.mark.asyncio
+    async def test_subscribe_requires_identity_or_group_id(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+
+        async def handler(msg: ModelEventMessage) -> None:
+            return
+
+        with pytest.raises(ModelOnexError):
+            await bus.subscribe("t", None, handler)
+
+    @pytest.mark.asyncio
+    async def test_subscribe_rejects_invalid_auto_offset_reset(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+
+        async def handler(msg: ModelEventMessage) -> None:
+            return
+
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.subscribe(
+                "t", _FakeNodeIdentity(), handler, auto_offset_reset="not-a-real-value"
+            )
+        assert exc_info.value.error_code == EnumCoreErrorCode.VALIDATION_ERROR.value
+
+
+@pytest.mark.unit
+class TestEventBusSemanticFakeOmn15781ClassRegression:
+    """AC5: reproduce the OMN-15781 failure shape without any live broker."""
+
+    @pytest.mark.asyncio
+    async def test_publish_before_join_with_latest_silently_drops_message(self) -> None:
+        """The exact live failure OMN-15781 needed a real broker to prove.
+
+        beta-gateway-canary.yaml set auto_offset_reset="latest"; a consumer
+        crash/restart window meant the group was unjoined when a message
+        published, and that message was gone forever -- never redelivered,
+        because "latest" never replays pre-join backlog. This test proves
+        EventBusSemanticFake reproduces exactly that shape in-process.
+        """
+        bus = EventBusSemanticFake(environment="onex-dev", group="gateway-forwarder")
+        await bus.start()
+
+        topic = "onex.evt.omnibase-infra.delegation-completed.v1"
+        identity = _FakeNodeIdentity(node_name="gateway-forwarder-outage-window")
+
+        # Message published WHILE the consumer group is unjoined (simulating
+        # the crash/restart outage window from OMN-15781).
+        await bus.publish(topic, None, b"delegation-completed-during-outage")
+
+        received: list[ModelEventMessage] = []
+
+        async def handler(msg: ModelEventMessage) -> None:
+            received.append(msg)
+
+        # Consumer rejoins with auto_offset_reset="latest", matching the
+        # defective beta-gateway-canary.yaml config OMN-15781 fixed.
+        await bus.subscribe(topic, identity, handler, auto_offset_reset="latest")
+
+        assert received == [], (
+            "With auto_offset_reset='latest', the message published during "
+            "the unjoined window is silently dropped -- reproducing the "
+            "OMN-15781 backlog-loss shape entirely in-process."
+        )
+
+        # Prove the fix direction too: the SAME backlog, with
+        # auto_offset_reset="earliest" (the OMN-15781 fix), is NOT dropped.
+        bus2 = EventBusSemanticFake(environment="onex-dev", group="gateway-forwarder-2")
+        await bus2.start()
+        await bus2.publish(topic, None, b"delegation-completed-during-outage")
+
+        received2: list[ModelEventMessage] = []
+
+        async def handler2(msg: ModelEventMessage) -> None:
+            received2.append(msg)
+
+        await bus2.subscribe(
+            topic,
+            _FakeNodeIdentity(node_name="gateway-forwarder-fixed"),
+            handler2,
+            auto_offset_reset="earliest",
+        )
+        assert len(received2) == 1, (
+            "auto_offset_reset='earliest' (the OMN-15781 fix) must replay "
+            "the backlog produced during the unjoined window."
+        )
+
+
+@pytest.mark.unit
+class TestEventBusSemanticFakeUnsupportedCapabilities:
+    """AC4 (fake-raises half): every unsupported-list capability MUST raise.
+
+    See `omnibase_infra`'s real_broker integration tests for the "identical
+    test passes on real_broker" half where the underlying broker capability
+    is actually reachable through EventBusKafka's surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_begin_transaction_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.begin_transaction()
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_to_partition_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.publish_to_partition("t", 1, None, b"x")
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_consumer_lag_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.get_consumer_lag("t", "g")
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_simulate_broker_failover_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.simulate_broker_failover()
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_tombstone_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.publish_tombstone("t", b"key")
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_configure_wire_codec_raises(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        with pytest.raises(ModelOnexError) as exc_info:
+            await bus.configure_wire_codec(compression="gzip", batch_size=100)
+        assert (
+            exc_info.value.error_code
+            == EnumCoreErrorCode.UNSUPPORTED_CAPABILITY_ERROR.value
+        )
+
+
+@pytest.mark.unit
+class TestEventBusSemanticFakeRebalanceKnob:
+    @pytest.mark.asyncio
+    async def test_arm_rebalance_drop_removes_membership_on_next_delivery(self) -> None:
+        bus = EventBusSemanticFake()
+        await bus.start()
+        topic = "t"
+        identity = _FakeNodeIdentity(node_name="rebalance-unit")
+        received: list[ModelEventMessage] = []
+
+        async def handler(msg: ModelEventMessage) -> None:
+            received.append(msg)
+
+        await bus.subscribe(topic, identity, handler, auto_offset_reset="latest")
+        group_id = "test.test-svc.rebalance-unit.consume.v1"
+        # Sanity: this group_id must actually be the one subscribe() derived.
+        committed_before = await bus.get_committed_offset(topic, group_id)
+        assert committed_before == 0
+
+        bus.arm_rebalance_drop(topic, group_id)
+        await bus.publish(topic, None, b"dropped")
+
+        assert received == []
+        committed_after = await bus.get_committed_offset(topic, group_id)
+        assert committed_after == 0, "A dropped message must not advance the commit."
+
+        # Membership was removed by the rebalance -- a second publish must
+        # also not be delivered (group is no longer joined at all).
+        await bus.publish(topic, None, b"also-not-delivered")
+        assert received == []

--- a/tests/unit/event_bus/test_event_bus_substrate_contract.py
+++ b/tests/unit/event_bus/test_event_bus_substrate_contract.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Collects the shared ``event_bus_substrate`` contract tests (OMN-15789).
+
+The actual test bodies live in
+``omnibase_core.event_bus.testing.contract_event_bus_substrate`` so
+``omnibase_infra`` can import and re-run the identical functions against its
+own extended (``+real_broker``) fixtures without duplicating any assertion
+logic -- see that module's docstring for the full rationale (AC3, AC6).
+
+Star-importing them here is what makes pytest collect them as part of THIS
+repo's test suite, resolved against the ``event_bus_substrate`` /
+``fidelity_event_bus_substrate`` fixtures registered in this package's
+``conftest.py`` (2 core-resident params; no Kafka dependency).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.event_bus.testing.contract_event_bus_substrate import (  # noqa: F401
+    test_auto_offset_reset_earliest_replays_retained_history,
+    test_auto_offset_reset_latest_delivers_only_future_messages,
+    test_group_join_gates_delivery_only_while_joined,
+    test_publish_subscribe_seam_matches_real_consumer_group_derivation,
+    test_rebalance_window_drops_uncommitted_inflight_message,
+    test_rejoin_resumes_from_committed_offset_ignoring_auto_offset_reset,
+)

--- a/uv.lock
+++ b/uv.lock
@@ -814,6 +814,8 @@ full = [
     { name = "omnibase-spi" },
     { name = "prometheus-client" },
     { name = "psutil" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "redis" },
     { name = "sqlglot" },
 ]
@@ -829,6 +831,10 @@ spi = [
 ]
 sql-parser = [
     { name = "sqlglot" },
+]
+testing = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.dev-dependencies]
@@ -880,6 +886,10 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'cli'", specifier = ">=7.2.1" },
     { name = "psutil", marker = "extra == 'full'", specifier = ">=7.2.1" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },
+    { name = "pytest", marker = "extra == 'full'", specifier = ">=8.4.0" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.4.0" },
+    { name = "pytest-asyncio", marker = "extra == 'full'", specifier = ">=1.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0,<9.0.0" },
     { name = "redis", marker = "extra == 'full'", specifier = ">=5.0.0,<9.0.0" },
@@ -889,7 +899,7 @@ requires-dist = [
     { name = "tree-sitter", specifier = ">=0.25.2,<0.27" },
     { name = "tree-sitter-python", specifier = ">=0.25.0,<0.26" },
 ]
-provides-extras = ["spi", "cli", "kafka", "cache", "metrics", "sql-parser", "full"]
+provides-extras = ["spi", "cli", "kafka", "cache", "metrics", "sql-parser", "testing", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds the core-resident half of the settled `event_bus_substrate` design (operator direction 2026-08-09: "unit tests that turn into integration tests just by swapping out dependencies... mock what we need to", with the fidelity constraint that any fake must model real broker semantics and escalate to a real broker for anything it can't).

- **`EventBusSemanticFake`** (`src/omnibase_core/event_bus/event_bus_semantic_fake.py`): models real Kafka broker semantics `EventBusInmemory` never had -- consumer-group join/leave gating delivery, `auto_offset_reset` earliest/latest, per-`(topic, group_id)` commit-offset resume, and an explicit test-triggerable rebalance-window knob (`arm_rebalance_drop`). Six broker behaviors it cannot faithfully model (transactions, multi-partition ordering, consumer lag, broker failover, tombstones, wire-codec config) explicitly raise `ModelOnexError(UNSUPPORTED_CAPABILITY_ERROR)` rather than silently no-op.
- **`omnibase_core/event_bus/testing/`**: the `event_bus_substrate` / `fidelity_event_bus_substrate` pytest fixture builders (`fixture_event_bus_substrate.py`, params `inmemory` + `semantic_fake`; `omnibase_infra` adds `real_broker` to the same fixture names in a follow-on PR), a shared cross-repo contract-test module (`contract_event_bus_substrate.py` -- one test body per behavior, star-imported and re-run against `omnibase_infra`'s extended fixtures rather than duplicated), `topic_constants.py`, and small local structural Protocols that avoid adding new edges into the OMN-14340-frozen `protocols` hub.
- **AC5 regression**: the OMN-15781-class failure ("publish while consumer unjoined + `auto_offset_reset=latest` = message silently dropped") is reproduced entirely in-process in `test_event_bus_semantic_fake.py`, independent of any live broker -- the exact failure that previously needed a real Kafka broker to prove.

## Doctrine / cross-references

- In-memory local bus is the default transport, Kafka a contract override (`feedback_inmemory_local_bus_is_default_kafka_override`). This closes the "isolation tests pass while live fails" gap (`feedback_real_dispatch_path_tests`) for event-bus group/offset/rebalance semantics specifically.
- OMN-14208 seam discipline: the exemplar seam test (`test_publish_subscribe_seam_matches_real_consumer_group_derivation`) drives the real production `compute_consumer_group_id` derivation across every substrate in one parametrized test -- adapted from the STYLE of `omninode_infra` PR #833's delegation-dispatch seam test (pin real values, drive real code), not ported verbatim (different repo/pattern: hand-rolled FakeProducer/Consumer, not `ProtocolEventBus`).
- Relates OMN-15767 (event-based golden-chain harness will run its non-real-broker legs on this substrate; this PR does not build that harness).
- Does NOT touch `omnibase_infra#2688`, the `.201` gateway forwarder outbound-loop code, or its tests -- owned by a separate active lane (mergesweep-0809-returnleg).

## Cross-repo sequencing

`omnibase_infra` pins `omnibase-core` from PyPI only (OMN-14628 removed the git-rev override -- pure-PyPI cross-repo seam). The `real_broker` fixture leg, `EventBusKafka.subscribe(auto_offset_reset=...)` extension, and the exemplar/fidelity tests running against a live broker are prepared on a follow-on `omnibase_infra` branch but cannot land until an `omnibase-core` release is cut from this PR and the infra pin is bumped -- tracked as the second half of this ticket.

## Test plan

- [x] `uv run pytest tests/unit/event_bus/` -- 72/72 passed (includes the 7 shared contract tests parametrized over `inmemory`+`semantic_fake`)
- [x] `uv run pytest tests/unit/event_bus/ tests/unit/mixins/ tests/unit/models/event_bus/ ...` -- 1212/1212 passed
- [x] `uv run mypy src/omnibase_core/event_bus/ --strict` -- 0 new errors (8 pre-existing errors elsewhere in the repo, unrelated)
- [x] `uv run ruff format` / `ruff check --fix` -- clean
- [x] `pre-commit run --all-files` on every changed file -- all hooks green (import-layering ratchet, single-class-per-file, hardcoded-topics, hardcoded-env-vars, error-raising, Pydantic v2 patterns, etc.)
- [x] Governed impacted-test selector (pre-push, OMN-13973) escalated to the full local suite (pyproject.toml runtime-dep changed) -- **43887 passed, 53 skipped, 3 xpassed, 0 failed** in 1:34:24

Evidence-Ticket: OMN-15789
Evidence-Source: OCC#6264
