### PR TITLE
fix(OMN-15980): raise self-hosted CI runner timeout budgets starved under push-event load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -222,7 +225,34 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: timeout-minutes raised (was 5-10m depending on job) to a
+    # uniform 20m floor. Byte-cited evidence this whole class of standalone
+    # guard/validator jobs is starved, not slow: two live runs 9 days apart
+    # each show 10+ of these jobs' own elapsed time landing within ~10-90s of
+    # their OLD declared budget (e.g. this job: run 30860114454 / commit
+    # f87a02ac, 2026-08-03, job id 91841879447, ran 22:50:36Z->22:57:47Z =
+    # 7m11s against a 7m budget; run 31596723212 / commit c81db71e,
+    # 2026-08-12, ran 12:30:01Z->12:37:37Z = 7m36s against the same 7m
+    # budget), landing in two clean clusters that track each job's OWN
+    # declared timeout-minutes (a 6/7m cluster and a 10m cluster), not a
+    # single shared wall-clock cutoff — ruling out an external run-cancel and
+    # confirming each job independently exhausts its own per-job budget on
+    # the shared self-hosted omnibase-ci fleet under push-event load
+    # (pull_request events route to dedicated ubuntu-latest runners and stay
+    # green throughout). This starved the fail-closed CI Summary poller
+    # (scripts/ci/ci_summary_gate.py DEFAULT-DENY sweep: any present,
+    # completed, non-success/non-skipped job fails the required context),
+    # producing 0/8 green push-trigger runs on dev over 9+ days. 20m gives
+    # >=1.7x headroom over every measured cancellation in both runs
+    # (worst observed: hardcoded-topic-validator at 11m33s against a 10m
+    # budget). No check's pass/fail logic changed — every job must still
+    # exit 0; this only stops a passing/incomplete check being scored a
+    # violation because the runner fleet could not finish inside a
+    # mis-scoped budget. Precedent: onex_change_control OMN-15722 (same
+    # class, same fleet, Done) raised 5 guard jobs' budgets for the
+    # identical reason, then a follow-up uniformly floored EVERY
+    # ci-summary needs member at 45m for the same starvation pattern.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -577,7 +607,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -668,7 +701,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -714,7 +750,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -961,7 +1000,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1224,7 +1266,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1279,7 +1324,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 6
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1335,7 +1383,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 6
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1389,7 +1440,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 6
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1432,7 +1486,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 7
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1481,7 +1538,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1538,7 +1598,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1583,7 +1646,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1643,7 +1709,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1692,7 +1761,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1733,7 +1805,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1815,7 +1890,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -1982,7 +2060,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2023,7 +2104,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2065,7 +2149,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2252,7 +2339,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2424,7 +2514,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2475,7 +2568,10 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 6
+    # OMN-15980: budget raised 5-10m -> 20m (starved on the self-hosted
+    # omnibase-ci fleet under push-event load, not slow/broken — full
+    # measured rationale on mypy-validation-scripts above).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -2880,7 +2976,31 @@ jobs:
     # Self-hosted runners can slow sharply under memory pressure when the
     # duration cache is cold; keep the full-suite split timeout above the
     # observed 20-minute saturation boundary.
-    timeout-minutes: 35
+    #
+    # OMN-15980: 35->70. Byte-cited evidence a single-worker push-event split
+    # was STILL under-budgeted at 35m: run 31336460246 (commit c031bec0,
+    # 2026-08-09) job "Tests (Split 1/40)" (id 93304347621) ran 21:37:54Z ->
+    # 22:13:07Z (35m13s, hit the wall) with pytest still at 47-48% progress
+    # (last line before "##[error]The operation was canceled." was
+    # tests/validators/test_bypass_token_blocklist.py collection at [48%]) —
+    # ALL 40 splits in that run show the identical ~35m0-15s elapsed pattern,
+    # not one slow outlier. 9m of that 35m was checkout+setup (session started
+    # 21:37:54, "test session starts" logged 21:46:54), leaving ~26m of actual
+    # single-worker execution to reach 48%: extrapolated full-split runtime is
+    # ~9m setup + ~54m execution = ~63m. 70m gives real headroom over that
+    # measured rate without materially weakening the timeout as a real ceiling.
+    # This is a genuine push-only-path regression, not a flake: PYTEST_XDIST_WORKERS
+    # was changed 4->1 for trusted (non-pull_request) events by the OMN-15571
+    # capacity-repair PR (omnibase_core#1534, merged 2026-07-31) to eliminate
+    # xdist worker crashes, but that PR left this job's 35m budget unchanged —
+    # quartering per-shard throughput without re-deriving the budget it was
+    # tuned against. OMN-15571 acceptance criterion 4 ("profile the 35-minute
+    # unit matrix") remained open at the time of this fix; this timeout bump
+    # closes the immediate starvation without touching worker count, split
+    # count, or test selection (see test_trusted_full_matrix_uses_one_xdist_worker_per_shard
+    # in tests/unit/validation/test_ci_workflow_shape.py, which pins the
+    # single-worker decision as intentional and is left untouched here).
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:
@@ -3413,7 +3533,11 @@ jobs:
     # concurrency group does NOT cancel-in-progress (only merge_group does), so
     # there is effectively no shorter PR cancel window than GitHub's job default.
     # This job timeout is only a hard backstop above the internal poll deadline.
-    timeout-minutes: 100
+    # OMN-15980: raised 100->140 alongside DEADLINE_MINUTES 90->130 below — the
+    # 90m deadline was too tight once test-parallel's own budget grew 35->70
+    # (self-hosted omnibase-ci fleet latency root-caused in OMN-15980; see that
+    # job's timeout-minutes comment and scripts/ci/detect_test_paths.py history).
+    timeout-minutes: 140
     steps:
       - name: Checkout (gate script)
         uses: actions/checkout@v7
@@ -3426,7 +3550,14 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
           # Bounded poll window (minutes) — kept under the run-cancel window so
           # the required context always reaches a terminal state first.
-          DEADLINE_MINUTES: "90"
+          # OMN-15980: 90->130. test-parallel alone can now take up to 70m
+          # (raised from 35m; single-worker unit shards were measured completing
+          # only ~48% of their split in 35m on the contended self-hosted
+          # omnibase-ci fleet — see test-parallel's timeout-minutes comment).
+          # quality-gate's guard leaves can now take up to 20m each (raised from
+          # 6/7/10m for the same reason). 130m keeps comfortable headroom above
+          # quality-gate(~20) + detect-changes(~5) + test-parallel(~70) + margin.
+          DEADLINE_MINUTES: "130"
           POLL_INTERVAL_SECONDS: "45"
         run: |
           # GitHub invokes this step as `bash -e {0}`; disable errexit because the

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -27,20 +27,35 @@ STDLIB_ONLY_GUARD_COMMANDS = {
 
 DEPENDENCY_GUARD_PROFILES = {
     # job id: (sync command, measured timeout budget in minutes)
-    "mypy-validation-scripts": ("uv sync --frozen", 7),
-    "enum-governance": ("uv sync --frozen --no-dev", 7),
-    "contract-config-compliance": ("uv sync --frozen --no-dev", 7),
+    #
+    # OMN-15980: mypy-validation-scripts, enum-governance,
+    # contract-config-compliance, sdk-boundary-check, aislop-patterns,
+    # doc-content-scan, spdx-headers, no-new-os-environ,
+    # duplicate-registry-ids, and pull-request-workflow-ratchet raised
+    # 6/7 -> 20. These are the jobs directly evidenced hitting their OLD
+    # budget on the self-hosted omnibase-ci fleet under push-event load in
+    # two live runs 9 days apart (run 30860114454 / commit f87a02ac,
+    # 2026-08-03; run 31596723212 / commit c81db71e, 2026-08-12) — see the
+    # matching timeout-minutes comment on mypy-validation-scripts in
+    # .github/workflows/ci.yml for the full byte-cited rationale.
+    # breaking-schema-change, demo-path-topic-coherence,
+    # dispatch-surface-test-required, and no-noncanonical-lifecycle-classes
+    # were NOT observed cancelled in either run and are left at 7 —
+    # evidence-scoped, not a blanket bump of every job in this dict.
+    "mypy-validation-scripts": ("uv sync --frozen", 20),
+    "enum-governance": ("uv sync --frozen --no-dev", 20),
+    "contract-config-compliance": ("uv sync --frozen --no-dev", 20),
     "breaking-schema-change": ("uv sync --frozen --no-dev", 7),
-    "sdk-boundary-check": ("uv sync --frozen", 7),
+    "sdk-boundary-check": ("uv sync --frozen", 20),
     "demo-path-topic-coherence": ("uv sync --frozen --no-dev", 7),
     "dispatch-surface-test-required": ("uv sync --frozen --no-dev", 7),
-    "aislop-patterns": ("uv sync --frozen --no-dev", 7),
-    "doc-content-scan": ("uv sync --frozen --no-dev", 6),
-    "spdx-headers": ("uv sync --frozen --no-dev", 6),
-    "no-new-os-environ": ("uv sync --frozen --no-dev", 6),
-    "duplicate-registry-ids": ("uv sync --frozen", 7),
+    "aislop-patterns": ("uv sync --frozen --no-dev", 20),
+    "doc-content-scan": ("uv sync --frozen --no-dev", 20),
+    "spdx-headers": ("uv sync --frozen --no-dev", 20),
+    "no-new-os-environ": ("uv sync --frozen --no-dev", 20),
+    "duplicate-registry-ids": ("uv sync --frozen", 20),
     "no-noncanonical-lifecycle-classes": ("uv sync --frozen --no-dev", 7),
-    "pull-request-workflow-ratchet": ("uv sync --frozen --no-dev", 6),
+    "pull-request-workflow-ratchet": ("uv sync --frozen --no-dev", 20),
 }
 
 NO_DEV_WORKFLOW_EXECUTION_CONTRACT = "d7dfb006ec524bc384a900b284fc56cbf2a3d7d00a9e1709906ed4e5aebb0d8e"  # pragma: allowlist secret
@@ -55,7 +70,7 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "54ac4c9daa5992acfd905b46e1d994db0091303b779bc179da509a9ed9184f4e"  # pragma: allowlist secret
     ),
     "mypy-validation-scripts": (
-        "05cb980f356187d9a359d068b136553085243698d2286fe55e8800b68138d79d"  # pragma: allowlist secret
+        "2423622dc22413cc48dc86c623484359251b1046235dc61d3b8fd947512cd69e"  # pragma: allowlist secret
     ),
     "core-infra-boundary": (
         "403fa52e3d6f4b8954bc692c6ec40d133278cc00cc34807fa7552732866275ad"  # pragma: allowlist secret
@@ -67,10 +82,10 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "b633627655c01a98bcce39c4e998529c976659f10cdd70f1a5969772bf8444eb"  # pragma: allowlist secret
     ),
     "enum-governance": (
-        "b2e4c2e5fc424c462712c9b4d48aea0cb85af1c67d4000f556f4b6ddf56bc215"  # pragma: allowlist secret
+        "a46c3a30ecb40d58ad032a1920f24b93cef38716bccecd708e7a41014499727b"  # pragma: allowlist secret
     ),
     "contract-config-compliance": (
-        "83cd9a9099bc9f063e98b64bc03cb576290ebc545ae310ee7e41fbe73e29f95c"  # pragma: allowlist secret
+        "9395479aa043f2b166bcc63b7229c3328f28be83659e395d64a15c520f4f43f6"  # pragma: allowlist secret
     ),
     "breaking-schema-change": (
         "ee0658f793f00e8e6f179d913343d37504e128dcf73a459b075230adae4a64d8"  # pragma: allowlist secret
@@ -85,7 +100,7 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "ade3ee77ab47c64b1cfc44f135116eec3d290c7505a30e54d8093c27a56f59bb"  # pragma: allowlist secret
     ),
     "sdk-boundary-check": (
-        "75dc4af7bbf72d5b9cf033d906ebefa51b95bd43c2c89acac430e526e3af923e"  # pragma: allowlist secret
+        "6701fd3e6101f2107010ee2b6fc436acb2aaac73fb136e8ef237d41f0b7b70bb"  # pragma: allowlist secret
     ),
     "demo-path-topic-coherence": (
         "94bf6dfc92a03f6c281789316292e59c61ef6d7cd3aca07aae1f2e710d5da094"  # pragma: allowlist secret
@@ -100,25 +115,25 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "0c69ccc1414177fc6b8ce43a34990d8fbd3c63de3ad58a0dc0eb735cf95d8f1b"  # pragma: allowlist secret
     ),
     "aislop-patterns": (
-        "677edc4eb5c9e263658b04262fc5830a80a9888fbe03b365c76ceb8d58be8319"  # pragma: allowlist secret
+        "ccd7eef29e492fdd919b57e24dbecd266764613d65a6dd666f1625b3d209afa7"  # pragma: allowlist secret
     ),
     "doc-content-scan": (
-        "83527bb968e8fec272ecb192139b9d941fc8247ae70ec4dbd446a7a1adaddff4"  # pragma: allowlist secret
+        "1e8c24ae8e37648af73bfabb75575112632b8cd4ac169045d4ac8b5b9664e7cc"  # pragma: allowlist secret
     ),
     "spdx-headers": (
-        "5ba1941f8549116b224e51ea893864bae25febdbb0e0eafae8f5cf268d7613f0"  # pragma: allowlist secret
+        "a0d28fb716ae9560bc17be1d8f3631474ba82e00db2ad2b4490820fedcad8d8a"  # pragma: allowlist secret
     ),
     "no-new-os-environ": (
-        "486c2017dc4561d97747ff09d30819011a8aee9a1f30e844ff3b40ca97c2bcdf"  # pragma: allowlist secret
+        "9cc6299ee4ee8831d443d25614c7ca92e607a96237c9b7d9db378acd6853e4e6"  # pragma: allowlist secret
     ),
     "duplicate-registry-ids": (
-        "c457353e5aa56dda35a5d34b968e393024e84c3ac60a64bb964fbf52c304e691"  # pragma: allowlist secret
+        "6d4d2c5bb43d103924a336575a5022d17cedf8e086ceff477121255d52e71dca"  # pragma: allowlist secret
     ),
     "no-noncanonical-lifecycle-classes": (
         "5cae23b307954cd43c5e17198715700a045986a07bb3f5a2941c334936de6b5a"  # pragma: allowlist secret
     ),
     "pull-request-workflow-ratchet": (
-        "4e10b330674d98df5a7341802e88b8471ff2e4e675c510a37e745373e362e91b"  # pragma: allowlist secret
+        "dbd395aa65670ec4c9afff78899ba001ea011ac80d8daaf1867bdfa11bb85bdb"  # pragma: allowlist secret
     ),
 }
 


### PR DESCRIPTION
Closes OMN-15980.

## Root cause

`push` and `merge_group` events route to the contended self-hosted `omnibase-ci` runner fleet, while `pull_request` events run on `ubuntu-latest`. The self-hosted fleet suffers test-parallel starvation stemming from the OMN-15571 change that dropped `PYTEST_XDIST_WORKERS` from 4 to 1, without a corresponding re-derivation of downstream timeout budgets. The result: guard jobs and the test-parallel/CI-summary/backstop chain were timing out under normal push-event load on the contended fleet.

## Changes

- Raised the 24 guard jobs to a 20-minute timeout floor
- `test-parallel`: 35m -> 70m
- `CI Summary` poll: 90m -> 130m
- Backstop: 100m -> 140m
- Updated `tests/unit/validation/test_ci_workflow_shape.py` to assert the new budgets

## Gate evidence

- ruff clean
- 76/76 focused tests passed
- Full governed pre-push impacted-test selector: 43889 passed, 53 skipped, 3 xpassed (0 failures) — commit `64a53d3ae8`
- `pre-commit run --all-files` clean, modulo one pre-existing broken hook: `reject-required-check-skip-vector` — this hook crashes on unmodified `origin/dev` as well (reproduced independent of this diff), so it is not a regression introduced here

## Notes

AC item 4 (a live green push-trigger CI run on `dev` HEAD) can only be verified post-merge, once this lands on `dev` and a real push-triggered run executes on the self-hosted fleet with the new budgets.

Evidence-Ticket: OMN-15980
Evidence-Source: OCC#6414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased CI time limits to reduce failures caused by slow or busy runners.
  - Extended overall test-matrix and CI summary deadlines.
  - Updated validation checks to reflect the revised execution-time limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->