### PR TITLE
fix(OMN-15862): SKIP never aggregates into PASS in contract.verify.replay tier-2 verifier

### DIFF
--- a/src/omnibase_core/enums/enum_overall_status.py
+++ b/src/omnibase_core/enums/enum_overall_status.py
@@ -4,10 +4,17 @@
 """Overall status enum for contract.verify.replay verification reports.
 
 Represents the aggregated outcome of an entire verification run: pass
-(all required checks passed), fail (one or more checks failed), or error
-(the verification run itself encountered an unexpected exception).
+(every check ran and passed), fail (one or more checks failed), skip (no
+check failed, but at least one did not run), or error (the verification run
+itself encountered an unexpected exception).
+
+``SKIP`` exists because a skipped check is an *absence of evidence*, not
+evidence of correctness. Folding it into ``PASS`` makes an unverified package
+indistinguishable from a verified one (OMN-15862).
 
 .. versionadded:: 0.20.0
+.. versionchanged:: 0.20.1
+   Added :attr:`EnumOverallStatus.SKIP` (OMN-15862).
 """
 
 from enum import Enum
@@ -18,12 +25,20 @@ __all__ = ["EnumOverallStatus"]
 class EnumOverallStatus(str, Enum):
     """Aggregated outcome of a verification report.
 
+    Precedence when aggregating per-check results is FAIL > SKIP > PASS:
+    any failed check makes the run a FAIL; otherwise any skipped check makes
+    the run a SKIP; only a run in which every check executed and passed is a
+    PASS.
+
     Attributes:
-        PASS: All required checks passed.
+        PASS: Every check ran and passed. Nothing was skipped.
         FAIL: One or more checks failed.
+        SKIP: No check failed, but at least one check did not run, so the
+            package is *not* verified. Never treat SKIP as PASS.
         ERROR: The verification run itself raised an unexpected exception.
     """
 
     PASS = "pass"
     FAIL = "fail"
+    SKIP = "skip"
     ERROR = "error"

--- a/src/omnibase_core/models/contract_verify_replay/model_verify_replay_output.py
+++ b/src/omnibase_core/models/contract_verify_replay/model_verify_replay_output.py
@@ -40,9 +40,12 @@ class ModelVerifyReplayOutput(BaseModel):
         package_id: Package identifier from the bundle manifest.
         package_version: Package version from the bundle manifest.
         checks: Ordered list of per-check results.
-        overall_status: Aggregated outcome. ``"pass"`` iff all required checks
-            passed; ``"fail"`` if any check failed; ``"error"`` if the
-            verification run itself raised an unexpected exception.
+        overall_status: Aggregated outcome, with ``FAIL > SKIP > PASS``
+            precedence. ``"fail"`` if any check failed; else ``"skip"`` if any
+            check did not run; ``"pass"`` only when every check ran and passed;
+            ``"error"`` if the verification run itself raised an unexpected
+            exception. A ``"skip"`` report is NOT a verified package — never
+            treat it as a pass (OMN-15862).
         generated_at: UTC timestamp when the report was produced.
         report_digest: ``sha256:<hex>`` digest of the serialised report content
             (excluding this field and ``signature``). Used to verify the

--- a/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
+++ b/src/omnibase_core/nodes/node_contract_verify_replay_compute/handler.py
@@ -30,6 +30,14 @@ verification report.
 8. ``content_digest_integrity`` — if ``options.skip_digest_check`` is False,
    all content hashes in the manifest are verified.
 
+**Status aggregation (OMN-15862)**: per-check results aggregate with
+``FAIL > SKIP > PASS`` precedence. A skipped check is an absence of evidence and
+never contributes to a PASS verdict, so a run containing any skip reports
+``overall_status == "skip"``. Tier 2 (simulated replay) is still unimplemented:
+it reports SKIP for packages with no required replay artifacts, and fails CLOSED
+(FAIL) for packages whose manifest declares required scenarios or invariant
+suites, since those can only be discharged by tier 2.
+
 **Signing**: The report is serialised to canonical JSON, then its SHA-256 digest
 is computed. If ``~/.onex/verifier.key`` exists (ed25519 private key in PEM
 format) the digest is signed and the base64-encoded signature is embedded.
@@ -117,7 +125,9 @@ class NodeContractVerifyReplayCompute:
 
         Returns:
             A :class:`~omnibase_core.models.contract_verify_replay.model_verify_replay_output.ModelVerifyReplayOutput`
-            with ``overall_status`` set to ``"pass"``, ``"fail"``, or ``"error"``.
+            with ``overall_status`` set to ``"pass"``, ``"fail"``, ``"skip"``,
+            or ``"error"``. ``"skip"`` means no check failed but at least one
+            did not run — the package is NOT verified.
 
         Raises:
             ModelOnexError: If neither ``package_path`` nor ``package_bytes``
@@ -156,20 +166,12 @@ class NodeContractVerifyReplayCompute:
                 options=inp.options,
             )
         else:
-            # Tier 2 is deferred (OMN-2759 scope: tier1_static only).
-            checks = [
-                ModelVerifyCheckResult(
-                    check_name="tier2_simulated",
-                    status=EnumCheckStatus.SKIP,
-                    message="Tier 2 simulated replay is not implemented yet.",
-                )
-            ]
+            # Tier 2 executable replay is not implemented (OMN-2759 scope:
+            # tier1_static only). It reports SKIP — or FAIL when the package
+            # declares replay artifacts as required. See _tier2_result().
+            checks = [self._tier2_result(manifest)]
 
-        # Determine overall status.
-        if any(c.status == EnumCheckStatus.FAIL for c in checks):
-            overall = EnumOverallStatus.FAIL
-        else:
-            overall = EnumOverallStatus.PASS
+        overall = self._aggregate_overall_status(checks)
 
         # Build report (without digest/sig fields first so we can hash it).
         report_dict = self._build_report_dict(
@@ -199,6 +201,89 @@ class NodeContractVerifyReplayCompute:
             generated_at=datetime.now(tz=UTC),
             report_digest=report_digest,
             signature=signature,
+        )
+
+    # =========================================================================
+    # Status aggregation (OMN-15862)
+    # =========================================================================
+
+    @staticmethod
+    def _aggregate_overall_status(
+        checks: list[ModelVerifyCheckResult],
+    ) -> EnumOverallStatus:
+        """Aggregate per-check results with FAIL > SKIP > PASS precedence.
+
+        A SKIP is an absence of evidence, not evidence of correctness, so it
+        must never be aggregated into a PASS. Before OMN-15862 this method's
+        inline predecessor treated "no FAIL" as PASS, which reported a run
+        where nothing executed — including the hardcoded tier-2 skip — as a
+        verified package.
+
+        Args:
+            checks: All per-check results produced by this run.
+
+        Returns:
+            ``FAIL`` if any check failed; else ``SKIP`` if any check was
+            skipped; else ``PASS``.
+        """
+        if any(c.status == EnumCheckStatus.FAIL for c in checks):
+            return EnumOverallStatus.FAIL
+        if any(c.status == EnumCheckStatus.SKIP for c in checks):
+            return EnumOverallStatus.SKIP
+        return EnumOverallStatus.PASS
+
+    @staticmethod
+    def _declares_required_replay_artifacts(manifest: ModelOncpManifest) -> bool:
+        """Whether the package declares artifacts only tier 2 can discharge.
+
+        Scenarios and invariant suites are executed by tier-2 simulated replay.
+        A manifest entry marked ``required=True`` is the package asserting that
+        the artifact *must* pass for the package to be considered verified.
+
+        Args:
+            manifest: Parsed manifest from the bundle.
+
+        Returns:
+            True if any scenario or invariant entry is marked required.
+        """
+        return any(s.required for s in manifest.scenarios) or any(
+            i.required for i in manifest.invariants
+        )
+
+    def _tier2_result(self, manifest: ModelOncpManifest) -> ModelVerifyCheckResult:
+        """Build the tier-2 check result for the unimplemented replay tier.
+
+        Fails CLOSED when the package declares required scenarios/invariants:
+        such a package cannot be verified at the tier it itself declares as
+        required, and reporting that as a skip understates the gap. Packages
+        with no required replay artifacts report SKIP, which
+        :meth:`_aggregate_overall_status` keeps out of PASS.
+
+        Args:
+            manifest: Parsed manifest from the bundle.
+
+        Returns:
+            A FAIL result for packages requiring replay, else a SKIP result.
+        """
+        if self._declares_required_replay_artifacts(manifest):
+            return ModelVerifyCheckResult(
+                check_name="tier2_simulated",
+                status=EnumCheckStatus.FAIL,
+                message=(
+                    "Tier 2 simulated replay is not implemented, but this package "
+                    "declares required scenarios and/or invariant suites that only "
+                    "tier 2 can execute. Failing closed: the package cannot be "
+                    "verified at the tier it declares as required."
+                ),
+            )
+        return ModelVerifyCheckResult(
+            check_name="tier2_simulated",
+            status=EnumCheckStatus.SKIP,
+            message=(
+                "Tier 2 simulated replay is not implemented yet. This check did not "
+                "run, so it is an absence of evidence — it does not contribute to a "
+                "pass verdict."
+            ),
         )
 
     # =========================================================================

--- a/tests/unit/nodes/node_contract_verify_replay_compute/test_node_contract_verify_replay_compute.py
+++ b/tests/unit/nodes/node_contract_verify_replay_compute/test_node_contract_verify_replay_compute.py
@@ -12,7 +12,8 @@ Tests cover:
 - Incorrect content hash yields content_digest_integrity fail
 - No package provided raises ModelOnexError
 - Non-existent package_path raises ModelOnexError
-- Tier 2 yields a "skip" result (not implemented yet)
+- Tier 2 yields a "skip" check and overall_status "skip" — never "pass" (OMN-15862)
+- Tier 2 on a bundle declaring required scenarios/invariants fails CLOSED
 - Signed report: report_digest is always populated
 - package_bytes mode works without filesystem access
 
@@ -424,25 +425,74 @@ def test_missing_scenario_zip_entry_fails(
 
 
 # =============================================================================
-# Tier 2 — deferred
+# Tier 2 — deferred, and SKIP must never aggregate into PASS (OMN-15862)
 # =============================================================================
 
 
-def test_tier2_yields_skip(
+def test_tier2_skip_never_aggregates_into_pass(
     verifier: NodeContractVerifyReplayCompute,
     simple_bundle_bytes: bytes,
 ) -> None:
-    """Tier 2 is not implemented — all checks are 'skip'."""
+    """Tier 2 is not implemented — the skip surfaces as SKIP, never as PASS.
+
+    Inverted under OMN-15862. The prior assertion (``overall_status == "pass"``)
+    encoded the fail-open defect directly: an unimplemented verification tier
+    reported the package as *verified*. A skipped check is an absence of
+    evidence, not evidence of correctness, so it must never be aggregated into
+    a PASS verdict.
+    """
     inp = ModelVerifyReplayInput(
         package_bytes=simple_bundle_bytes,
         tier=EnumVerifyTier.TIER2_SIMULATED,
     )
     report = verifier.handle(inp)
+
     assert report.tier == EnumVerifyTier.TIER2_SIMULATED
-    # Tier 2 not implemented → all checks skipped → overall pass (no failures)
-    assert report.overall_status == "pass"
     for check in report.checks:
         assert check.status == "skip"
+    assert report.overall_status != "pass"
+    assert report.overall_status == "skip"
+
+
+def test_tier2_skip_fails_closed_when_bundle_requires_replay(
+    verifier: NodeContractVerifyReplayCompute,
+    scenario_file: Path,
+) -> None:
+    """A bundle declaring required replay artifacts fails CLOSED on a tier-2 skip.
+
+    ``OncpBuilder.add_scenario()`` marks the scenario ``required=True``; a
+    required scenario can only be discharged by tier-2 simulated replay. Because
+    that tier is unimplemented, the package cannot be verified at the tier it
+    declares as required — that is a FAIL, not a SKIP (OMN-15862).
+    """
+    bundle = _build_simple_package(add_scenario=True, scenario_path=scenario_file)
+    inp = ModelVerifyReplayInput(
+        package_bytes=bundle,
+        tier=EnumVerifyTier.TIER2_SIMULATED,
+    )
+    report = verifier.handle(inp)
+
+    tier2_check = next(c for c in report.checks if c.check_name == "tier2_simulated")
+    assert tier2_check.status == "fail"
+    assert tier2_check.message is not None
+    assert report.overall_status == "fail"
+
+
+def test_tier2_skip_fails_closed_when_bundle_requires_invariants(
+    verifier: NodeContractVerifyReplayCompute,
+    invariant_file: Path,
+) -> None:
+    """Required invariant suites are tier-2 artifacts too — same fail-closed rule."""
+    bundle = _build_simple_package(add_invariant=True, invariant_path=invariant_file)
+    inp = ModelVerifyReplayInput(
+        package_bytes=bundle,
+        tier=EnumVerifyTier.TIER2_SIMULATED,
+    )
+    report = verifier.handle(inp)
+
+    tier2_check = next(c for c in report.checks if c.check_name == "tier2_simulated")
+    assert tier2_check.status == "fail"
+    assert report.overall_status == "fail"
 
 
 # =============================================================================
@@ -454,7 +504,11 @@ def test_skip_digest_check_option(
     verifier: NodeContractVerifyReplayCompute,
     simple_bundle_bytes: bytes,
 ) -> None:
-    """skip_digest_check=True marks content_digest_integrity as skip."""
+    """skip_digest_check=True marks content_digest_integrity as skip.
+
+    The run is not a PASS: opting out of digest integrity means the bundle's
+    contents were never checked, so the report must say SKIP (OMN-15862).
+    """
     inp = ModelVerifyReplayInput(
         package_bytes=simple_bundle_bytes,
         options=ModelVerifyOptions(skip_digest_check=True),
@@ -464,3 +518,5 @@ def test_skip_digest_check_option(
         c for c in report.checks if c.check_name == "content_digest_integrity"
     )
     assert digest_check.status == "skip"
+    assert report.overall_status != "pass"
+    assert report.overall_status == "skip"


### PR DESCRIPTION
## OMN-15862 — SKIP never aggregates into PASS (narrow verification-honesty fix)

Ticket: OMN-15862 — https://linear.app/omninode/issue/OMN-15862

### The defect

`node_contract_verify_replay_compute` returned a **verified** verdict having verified nothing.

- The tier-2 branch (`handler.py` :159–165 on base) was a hardcoded `SKIP`.
- The aggregation immediately below (:168–172 on base) **failed open**:

```python
if any(c.status == EnumCheckStatus.FAIL for c in checks):
    overall = EnumOverallStatus.FAIL
else:
    overall = EnumOverallStatus.PASS      # <-- SKIP lands here
```

A `tier2_simulated` run therefore produced `overall_status == "pass"` with a single
skipped check. Absence of evidence was reported as evidence of correctness.

`test_tier2_yields_skip` (:430 on base) asserted that fail-open as correct:
`# Tier 2 not implemented → all checks skipped → overall pass (no failures)`.
Per the ticket it is **inverted, not deleted**.

### The fix (narrow — aggregation honesty only)

1. `EnumOverallStatus` gains `SKIP`. Aggregation precedence is now **FAIL > SKIP > PASS**
   (`_aggregate_overall_status`): any failed check → FAIL; else any skipped check → SKIP;
   `PASS` requires that **every** check ran and passed.
2. Tier 2 **fails CLOSED** when the package's manifest declares required scenarios or
   invariant suites (`_declares_required_replay_artifacts` / `_tier2_result`). Those
   artifacts can only be discharged by tier-2 simulated replay, so a package that requires
   them cannot be verified at all while that tier is unimplemented — that is FAIL, not SKIP.
   Packages with no required replay artifacts report SKIP, which no longer reaches PASS.
3. Same rule applies to the tier-1 `skip_digest_check=True` path: the run now reports
   `overall_status == "skip"`, because bundle contents were never checked.

**Explicitly out of scope:** the full tier-2 executable-replay program (replay executor,
capture manifests, session modes). That is separately scoped in
`resurrect-tier2-executable-replay-verification.md` and is not built here.

### RED-first proof

The four new/inverted assertions were run against the base commit `39cf6d9135` **before**
any source change (`uv run pytest tests/unit/nodes/node_contract_verify_replay_compute/ -n 0`):

```
FAILED ...::test_tier2_skip_never_aggregates_into_pass
  - AssertionError: assert <EnumOverallStatus.PASS: 'pass'> != 'pass'
FAILED ...::test_tier2_skip_fails_closed_when_bundle_requires_replay
  - AssertionError: assert <EnumCheckStatus.SKIP: 'skip'> == 'fail'
FAILED ...::test_tier2_skip_fails_closed_when_bundle_requires_invariants
  - AssertionError: assert <EnumCheckStatus.SKIP: 'skip'> == 'fail'
FAILED ...::test_skip_digest_check_option
  - AssertionError: assert <EnumOverallStatus.PASS: 'pass'> != 'pass'
4 failed, 12 passed
```

After the source change, on the same tests: **16 passed**.

The first failure line is the defect verbatim: the node reporting PASS for a tier-2 run in
which nothing executed.

### Consumer survey (requested before landing)

Surveyed every repo under `$OMNI_HOME` (`omnibase_core`, `omnibase_infra`, `omnibase_spi`,
`omnibase_compat`, `omnimarket`, `omniclaude`, `onex_change_control`, `omninode_infra`) for
readers of this node's verdict — `NodeContractVerifyReplayCompute`,
`ModelVerifyReplayOutput`, `EnumOverallStatus`, `EnumCheckStatus`, `contract.verify.replay`.

**No consumer anywhere reads `overall_status` from this node.** The only non-test references
are identity-level, and none is affected by a new enum member or a changed verdict:

| Reference | What it does |
|---|---|
| `pyproject.toml:159` (`onex.nodes` entry point) | registers the node module; never invokes it |
| `scripts/ci/rsd_provenance_stamp_baseline.py:24` | module-id string in a baseline list |
| `tests/unit/scripts/ci/test_canonical_handler_shape.py:205` | asserts handler *shape*, not status |
| `.yaml-validation-allowlist.yaml:235` | allowlist path entry |
| `docs/architecture/HANDLER_CLASSIFICATION_FILE_IO_SERVICES_3_4.md` | prose |

`EnumOverallStatus` is imported by exactly two modules — this handler and
`model_verify_replay_output.py`. The other repo-local `overall_status` occurrences
(`node_no_utcnow_check_compute`, `node_no_hardcoded_ip_check_compute`,
`node_no_raw_sqlite3_check_compute`, `node_no_env_fallbacks_check_compute`,
`mixin_health_check`) are **separate, unrelated status enums** with their own precedence
engines — they do not share this type. Nothing needed an in-PR fix, and nothing is left to
report as a follow-up.

Practical consequence: no runtime surface presents this node's verdict today, so this change
cannot regress a live consumer; it makes the verdict honest before any beta-facing surface
starts consuming it (per the ticket's beta-relevance note).

### Gates

Run on `.200` (`Stickybeatz-Studio`, 24-core Mac Studio) — this session's host **is** `.200`,
verified by `hostname` / `hw.model` / `SSH_CONNECTION` identity comparison, so no
edit-locality split existed between where files were written and where gates ran.

| Gate | Result |
|---|---|
| `uv run mypy src/omnibase_core/` (repo-canonical, `strict=true`) | Success: no issues found in 4239 source files |
| `uv run mypy --strict` on the 3 touched src files | Success: no issues found in 3 source files |
| `uv run ruff format` / `ruff check --fix src/ tests/` | All checks passed; no reformat of touched files |
| `pre-commit run --files <4 changed files>` | every hook Passed/Skipped, zero failures, zero file mutations |
| Governed selector (`scripts.ci.detect_test_paths`) | `is_full_suite: true`, `full_suite_reason: "shared_module"` — escalated, so the full suite is the required set |
| Full suite | see the run recorded in the evidence comment on this PR |

`uv run mypy src/ --strict` (CLI-strict, broader than the repo's own config) reports 9
pre-existing errors in 5 files — `contract_loader.py`, `validator_evidence_shape_cli.py`,
`cli_install.py`, `model_onex_container.py`. Verified identical on the base commit via
`git stash`: **0 delta from this PR**, none in a touched file. Not fixed here — out of scope
for a narrow verification-honesty fix.

### dod_evidence

- **Defect proven, not asserted:** RED run against base `39cf6d9135` shows
  `overall_status == PASS` for a tier-2 run with zero executed checks; GREEN run after the fix
  shows `skip` / `fail`. Both logs cited in the evidence comment on this PR.
- **Wrong assertion inverted, not deleted:** `test_tier2_yields_skip` →
  `test_tier2_skip_never_aggregates_into_pass`, now asserting `!= "pass"` and `== "skip"`.
- **Fail-closed path covered:** two new tests assert FAIL (not SKIP) for bundles declaring
  required scenarios / required invariant suites.
- **Consumer survey completed** before landing (table above); no consumer treats this node's
  PASS as verified, so nothing else required a change.
- **Full local gate set** run on `.200` (table above).


Evidence-Ticket: OMN-15862
Evidence-Source: OCC#6473
