### PR TITLE
docs(OMN-16126): scrub live topology and personal paths from public docs — omnibase_core

### DIFF
--- a/.claude/architecture-handshake.md
+++ b/.claude/architecture-handshake.md
@@ -2,8 +2,8 @@
 source: omnibase_core/architecture-handshakes/repos/omnibase_core.md
 source_version: 0.16.0
 source_sha256: 3553cfd0922697c12358831f9ad7a2f0c032794772de0c2e88185b547c7fa52a
-installed_at: 2026-02-09T22:02:46Z
-installed_by: jonah
+installed_at: <install-timestamp>
+installed_by: <operator>
 -->
 
 # OmniNode Architecture – Constraint Map (omnibase_core)


### PR DESCRIPTION
## Summary

Wave 0 public-docs hygiene scrub for OMN-16126. `.claude/architecture-handshake.md` is committed to this public repo and carried real operator attribution + a real install timestamp:

- `installed_by: jonah` → `installed_by: <operator>`
- `installed_at: 2026-02-09T22:02:46Z` → `installed_at: <install-timestamp>`

Placeholder tokens follow the org convention already used correctly elsewhere (`<onex-host>` style, e.g. `omnibase_infra/docs/performance/LLM_ENDPOINT_SLO.md`).

Docs-only, zero behavior change: `architecture-handshakes/check-handshake.sh` verifies installed handshakes via `source_sha256` + the repo-name header only — it never reads `installed_by`/`installed_at` — so this edit cannot affect the handshake-staleness CI check.

**Out of scope (intentional):** the handshake's `source_version: 0.16.0` pin is stale vs the live repo version (0.46.9). That's a content/regeneration fix, not a hygiene leak, and is left untouched here per the plan.

## Verification

Repo-wide grep after the fix, for both leaked literals:

```
$ grep -rn "installed_by: jonah" --include="*.md" .
architecture-handshakes/README.md:208:installed_by: jonah

$ grep -rn "2026-02-09T22:02:46Z" .
(no results)
```

One residual occurrence remains, out of scope for this fix:
- `architecture-handshakes/README.md:208` — inside a fenced code block documenting the `HANDSHAKE_METADATA` block *format* for installers of this handshake in other repos (example username + example timestamp `2025-01-15T10:30:00Z`, not a real committed install record). Not named in the plan's H6 item, which targets only `.claude/architecture-handshake.md`; not this repo's own PII leak.

## Test plan

- [x] `pre-commit run --files .claude/architecture-handshake.md` — all hooks passed
- [x] `pre-commit run --all-files` equivalent gates ran again at commit time (full hook suite) — passed
- [x] Pre-push governed impacted-test selector — passed (no source/test change contributed a target)
- [x] Repo-wide grep confirms zero remaining occurrences of the two leaked literals outside the documented, out-of-scope example

Refs OMN-16126.

Evidence-Ticket: OMN-16126
Evidence-Source: OCC#6605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture handshake metadata to use installation timestamp and operator placeholders instead of specific values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->