### PR TITLE
feat(OMN-15911): add proof_class field to ModelTicketContract

### DIFF
--- a/src/omnibase_core/enums/enum_proof_class.py
+++ b/src/omnibase_core/enums/enum_proof_class.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Proof-Class Enum (OMN-13977 doctrine, seam-completed by OMN-15911).
+
+Defines the closed set of "which surface proves this claim" values named by the
+root CLAUDE.md "Proof capacity" rule: every completion claim names its
+proof_class, and "Done" is invalid without naming and reading the surface that
+proves it.
+
+- CODE_ONLY: a merged PR only; no runtime meaning was observed.
+- RECEIPT_BOUND: an OCC receipt PASS on the correct (main) governance path,
+  with no product PR (e.g. a pure read-only audit/investigation).
+- DEPLOYED: an image was built and deployed to the target lane.
+- LIVE_READBACK: behavior was observed on a live surface (gh/Linear/ssh/
+  projection), independent of whether a PR exists.
+- REPLAY_PROVEN: proven via deterministic replay / golden chain.
+- PROD_PROVEN: proven on the prod lane specifically.
+
+Disambiguation: ``omnimarket.enums.enum_proof_class.EnumProofClass`` is a
+DIFFERENT, unrelated, narrower enum (``replay-proven`` /
+``runtime-observed-only``) scoped to LLM evidence-bundle token-count
+provenance for on-vs-off experiments (OMN-12794). It predates this doctrine
+enum, shares one member name by coincidence, and must not be confused with or
+imported in place of this one. This enum is the ticket/contract-level
+proof-class field consumed by
+``omnimarket.nodes.node_dod_verify.services.receipt_bound_evidence`` and
+``durable_evidence_gate``.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumProofClass(StrEnum):
+    """Which surface proves a ticket/contract completion claim.
+
+    Intended for use as the ``proof_class`` field on ``ModelTicketContract``
+    (OMN-15911). Values are lowercase-hyphenated strings to match the literal
+    vocabulary already used across CLAUDE.md doctrine text, Linear ticket
+    prose, and the ``omnimarket`` DurableEvidenceGate's receipt-bound
+    discriminator (``RECEIPT_BOUND_PROOF_CLASS = "receipt-bound"`` in
+    ``services/receipt_bound_evidence.py``, which reads this field verbatim
+    off a raw yaml-loaded contract dict).
+    """
+
+    CODE_ONLY = "code-only"
+    RECEIPT_BOUND = "receipt-bound"
+    DEPLOYED = "deployed"
+    LIVE_READBACK = "live-readback"
+    REPLAY_PROVEN = "replay-proven"
+    PROD_PROVEN = "prod-proven"
+
+
+__all__ = [
+    "EnumProofClass",
+]

--- a/src/omnibase_core/models/ticket/model_ticket_contract.py
+++ b/src/omnibase_core/models/ticket/model_ticket_contract.py
@@ -39,6 +39,7 @@ from pydantic import (
 
 from omnibase_core.enums.enum_contract_completeness import EnumContractCompleteness
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_proof_class import EnumProofClass
 from omnibase_core.enums.ticket import (
     PHASE_ALLOWED_ACTIONS,
     EnumTicketAction,
@@ -188,6 +189,25 @@ class ModelTicketContract(BaseModel):
     contract_completeness: EnumContractCompleteness = Field(
         default=EnumContractCompleteness.STUB,
         description="Completeness level of this contract",
+    )
+
+    # Proof class (OMN-15911, seam-completion of the OMN-13977 doctrine field).
+    # None default — additive, backward-compatible: every existing on-disk
+    # contract YAML that omits this key keeps loading unchanged. Mirrors the
+    # omnimarket DurableEvidenceGate consumer's seam exactly: that gate reads
+    # ``contract.get("proof_class")`` off a RAW yaml-loaded dict (never through
+    # this Pydantic model) and branches on the literal string "receipt-bound"
+    # (services/receipt_bound_evidence.py, RECEIPT_BOUND_PROOF_CLASS). This
+    # field accepts the same literal strings for the full six-value doctrine
+    # set rather than a bare ``str``, so a typo'd/invented proof class is
+    # rejected at authoring time instead of silently accepted.
+    proof_class: EnumProofClass | None = Field(
+        default=None,
+        description=(
+            "Which surface proves this ticket's completion claim: "
+            "code-only | receipt-bound | deployed | live-readback | "
+            "replay-proven | prod-proven. None when not yet declared."
+        ),
     )
 
     # =========================================================================

--- a/tests/unit/models/ticket/test_model_ticket_contract_merged.py
+++ b/tests/unit/models/ticket/test_model_ticket_contract_merged.py
@@ -406,3 +406,123 @@ def test_on_disk_yaml_sample_loads() -> None:
     assert contract.emergency_bypass.enabled is False
     assert len(contract.dod_evidence) == 5
     assert contract.dod_evidence[0].id == "dod-001"
+
+
+# ============================================================================
+# T7 — proof_class field (OMN-15911, seam-completion of OMN-13977 doctrine)
+# ============================================================================
+#
+# omnimarket's node_dod_verify DurableEvidenceGate (services/receipt_bound_evidence.py,
+# `is_receipt_bound_contract`) already reads a top-level `proof_class` key off the
+# RAW yaml-loaded contract dict and branches Check 2 of the gate on the literal
+# string "receipt-bound" — but ModelTicketContract (extra="forbid") has never
+# declared the field, so authoring a contract that uses it fails schema
+# validation (`validate-yaml`, wired as both a pre-commit hook and a CI job in
+# onex_change_control) before it can ever reach the gate. This is the schema-side
+# half of the seam the consumer already implements; see OMN-15911 DoD item 1.
+
+
+@pytest.mark.unit
+def test_proof_class_field_accepted() -> None:
+    """ModelTicketContract accepts proof_class as a declared field, not an extra.
+
+    Mirrors the consumer's seam exactly (omnimarket
+    services/receipt_bound_evidence.py, RECEIPT_BOUND_PROOF_CLASS =
+    "receipt-bound"): the field must accept the plain string "receipt-bound"
+    and round-trip it losslessly, since the gate reads
+    ``contract.get("proof_class")`` off a raw yaml.safe_load dict, never through
+    this Pydantic model. None (unset) must remain the default so every existing
+    on-disk contract YAML that omits the field keeps loading unchanged.
+    """
+    from omnibase_core.enums.enum_proof_class import EnumProofClass
+
+    contract = ModelTicketContract(
+        ticket_id="OMN-15911",
+        title="proof_class field test",
+        proof_class="receipt-bound",
+    )
+
+    declared_fields = ModelTicketContract.model_fields
+    assert "proof_class" in declared_fields, (
+        "proof_class must be a declared field, not stored in model_extra"
+    )
+    assert isinstance(contract.proof_class, EnumProofClass), (
+        f"proof_class must coerce to EnumProofClass, got {type(contract.proof_class)}"
+    )
+    assert contract.proof_class == EnumProofClass.RECEIPT_BOUND
+    # The exact literal string the consumer compares against (RECEIPT_BOUND_PROOF_CLASS).
+    assert contract.proof_class.value == "receipt-bound"
+
+    # Default is None — existing contracts that omit proof_class keep loading.
+    default_contract = ModelTicketContract(ticket_id="OMN-TEST", title="no proof_class")
+    assert default_contract.proof_class is None
+
+
+@pytest.mark.unit
+def test_proof_class_rejects_value_outside_doctrine_set() -> None:
+    """proof_class rejects any string outside the OMN-13977 six-value doctrine.
+
+    Team-lead ruling (OMN-15956 session): "if the consumer compares against
+    specific strings, prefer that constrained set over bare str." The doctrine
+    vocabulary (root CLAUDE.md "Proof capacity" rule) is the full accepted set,
+    not just the one value ("receipt-bound") the gate currently branches on —
+    a bare `str` field would silently accept typos/invented classes.
+    """
+    with pytest.raises(ValidationError):
+        ModelTicketContract(
+            ticket_id="OMN-TEST",
+            title="invalid proof_class",
+            proof_class="not-a-real-proof-class",
+        )
+
+
+@pytest.mark.unit
+def test_proof_class_accepts_full_doctrine_set() -> None:
+    """Every one of the six OMN-13977 doctrine values round-trips cleanly."""
+    from omnibase_core.enums.enum_proof_class import EnumProofClass
+
+    doctrine_values = [
+        "code-only",
+        "receipt-bound",
+        "deployed",
+        "live-readback",
+        "replay-proven",
+        "prod-proven",
+    ]
+    for value in doctrine_values:
+        contract = ModelTicketContract(
+            ticket_id="OMN-TEST", title="doctrine sweep", proof_class=value
+        )
+        assert contract.proof_class == EnumProofClass(value)
+        assert contract.proof_class.value == value
+
+
+@pytest.mark.unit
+def test_proof_class_yaml_round_trip_matches_gate_consumer_shape() -> None:
+    """YAML round-trip: parsed proof_class equals the raw-dict shape the gate reads.
+
+    This is the cross-boundary half, in-process: `from_yaml` (Pydantic path,
+    what `validate-yaml` runs) and a plain `yaml.safe_load` (the raw-dict path
+    `omnimarket.node_dod_verify.services.evidence_collector.collect()` and
+    `receipt_bound_evidence.is_receipt_bound_contract()` actually use) must
+    agree on the exact string value for the same YAML bytes — no far-side mock,
+    both are the real parsers.
+    """
+    import yaml
+
+    contract_yaml = textwrap.dedent(
+        """
+        ticket_id: "OMN-15911"
+        title: "proof_class round-trip"
+        proof_class: "receipt-bound"
+        """
+    )
+
+    # Path 1: the raw dict the gate's is_receipt_bound_contract() consumes.
+    raw = yaml.safe_load(contract_yaml)
+    assert raw.get("proof_class") == "receipt-bound"
+
+    # Path 2: the strict Pydantic model validate-yaml enforces.
+    contract = ModelTicketContract.from_yaml(contract_yaml)
+    assert contract.proof_class is not None
+    assert contract.proof_class.value == raw.get("proof_class")


### PR DESCRIPTION
## Summary

Seam-completion of the OMN-13977 doctrine field. omnimarket's `DurableEvidenceGate` (`services/receipt_bound_evidence.py`) already reads a top-level `proof_class` key off the raw yaml-loaded contract dict and branches on the literal string `"receipt-bound"`, but `ModelTicketContract` (`extra="forbid"`) never declared the field, so authoring a contract that uses it failed `validate-yaml` before it could ever reach the gate.

- Adds `EnumProofClass` (`omnibase_core.enums.enum_proof_class`) covering the full six-value doctrine set: `code-only | receipt-bound | deployed | live-readback | replay-proven | prod-proven`.
- Adds a `proof_class: EnumProofClass | None` field (default `None`) on `ModelTicketContract` — additive and backward-compatible with every existing on-disk contract that omits the key.

## Verification

- RED-before/GREEN-after proof: 3 new tests fail on current `dev` (module not found / `extra_forbidden`), pass after the fix.
- A fourth test proves the exact seam a real consumer needs — `yaml.safe_load` raw-dict shape (what the gate reads) agrees with the Pydantic `from_yaml` shape (what `validate-yaml` enforces) for the same bytes.
- Full suite (277 tests in `tests/unit/models/ticket/` + `contracts/`), `mypy --strict`, and `ruff` all clean.
- Cross-boundary verified live (not just unit-tested) against the actual `onex_change_control` OMN-15956.yaml contract and the actual `is_receipt_bound_contract()` consumer, via a temporary editable install in the OCC worktree's venv — reverted after verification, not committed.

## Test plan
- [x] Full local suite green (models/ticket + contracts, 277 tests)
- [x] mypy --strict clean
- [x] ruff clean
- [x] Pre-push hook suite green
- [ ] CI green on this PR

Evidence-Ticket: OMN-15911
Evidence-Source: OCC#6619
