### PR TITLE
fix(OMN-15449): stamp run_id into workflow_result.json for caller identity join

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -257,6 +257,9 @@ class RuntimeLocal:
         state_root: Root directory for disk state (default ``.onex_state``).
         backend_overrides: Optional backend key-value overrides.
         timeout: Maximum execution time in seconds (default 300).
+        run_id: Identity anchor stamped into ``workflow_result.json`` (OMN-15449).
+            Defaults to a freshly minted UUID when the caller has no run_id of
+            its own to propagate.
     """
 
     def __init__(
@@ -267,12 +270,20 @@ class RuntimeLocal:
         backend_overrides: dict[str, str] | None = None,
         input_path: Path | None = None,
         timeout: int = 300,
+        run_id: uuid.UUID | None = None,
     ) -> None:
         self.workflow_path = workflow_path
         self.state_root = state_root
         self.backend_overrides = backend_overrides or {}
         self.input_path = input_path
         self.timeout = timeout
+        # OMN-15449: identity anchor stamped into workflow_result.json so a
+        # caller reading that FIXED, non-run-scoped path back can verify the
+        # content it sees is THIS run's own output rather than a different
+        # (concurrent, or leftover-from-a-skipped-write) run's. Callers that
+        # need the join (e.g. receipt_mode.py) pass their own run_id; callers
+        # that don't care mint one so the field is always present.
+        self.run_id: uuid.UUID = run_id if run_id is not None else uuid.uuid4()
 
         self._contract: RawWorkflowMap = {}
         self._result: EnumWorkflowResult = EnumWorkflowResult.TIMEOUT
@@ -1708,7 +1719,15 @@ class RuntimeLocal:
                     "and no handler spec found (need handler_routing.default_handler "
                     "or handler.module/class)."
                 )
-                return EnumWorkflowResult.FAILED
+                self._result = EnumWorkflowResult.FAILED
+                # OMN-15449: this path used to return without writing state,
+                # leaving whatever a PREVIOUS run against the same state_root
+                # had written in place for the next reader to find. Writing
+                # this run's own (failed) state — including its run_id — means
+                # a caller reading workflow_result.json back sees THIS run's
+                # outcome, never a leftover one.
+                self._write_state()
+                return self._result
 
         terminal_topic_name = str(terminal_topic)
         logger.info(
@@ -1962,6 +1981,14 @@ class RuntimeLocal:
             "result": self._result.value,
             "exit_code": self.exit_code,
             "workflow": str(self.workflow_path),
+            # OMN-15449: identity anchor. workflow_result.json is a FIXED path
+            # shared by every RuntimeLocal invocation against the same
+            # state_root — a concurrent invocation (or a stale leftover from a
+            # run whose write path was skipped) can otherwise be read back as
+            # if it were this run's own output. run_id lets a caller (e.g.
+            # receipt_mode.py) verify the file it reads actually belongs to
+            # the run it just executed before trusting its content.
+            "run_id": str(self.run_id),
         }
         if self._terminal_payload is not None:
             data["terminal_payload"] = self._terminal_payload

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -1198,3 +1198,142 @@ def test_classify_result_plain_object_without_failure_markers_is_completed() -> 
         value: int = 1
 
     assert RuntimeLocal._classify_result(_Ok()) == EnumWorkflowResult.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# OMN-15449: workflow_result.json identity anchor.
+#
+# ``workflow_result.json`` lives at a FIXED path shared by every RuntimeLocal
+# invocation against the same ``state_root``. A caller (receipt_mode.py in
+# omnibase_infra) that reads it back after ``run()`` returns has no way to
+# tell whether the content it sees is THIS run's own output or a different
+# run's (a concurrent invocation against the same state_root, or a leftover
+# from a run whose write path was skipped) — that ambiguity is the mechanism
+# behind a reported class of false-Done receipt (a green, fully-verified
+# table that belongs to a different ticket than the one requested, while the
+# run's own capture log correctly names what it actually resolved).
+#
+# These two tests cover the WRITER side of the fix: (1) the stamped
+# ``run_id`` a caller can join against, and (2) the one ``run_async`` exit
+# path that used to return without writing state at all, leaving a stale
+# predecessor file in place for the next reader to (mis)trust.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_write_state_stamps_run_id_for_caller_identity_join(
+    tmp_path: Path,
+) -> None:
+    """``workflow_result.json`` carries this run's own ``run_id`` (OMN-15449).
+
+    A caller that passes its own ``run_id`` into the constructor must see
+    that SAME value echoed back in the written file — the join key a reader
+    needs to verify the file it is about to trust actually belongs to the
+    run it just executed, not a concurrent or leftover one.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_compute_handler_contract(contract_path, "_InitExecuteLifecycleHandler")
+    caller_run_id = _uuid_module.uuid4()
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+        run_id=caller_run_id,
+    )
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.COMPLETED
+    assert runtime.run_id == caller_run_id
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    assert workflow_data["run_id"] == str(caller_run_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_write_state_mints_run_id_when_caller_supplies_none(
+    tmp_path: Path,
+) -> None:
+    """A caller with no run_id of its own still gets a stamped, valid UUID."""
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_compute_handler_contract(contract_path, "_InitExecuteLifecycleHandler")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+    )
+    await runtime.run_async()
+
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    # Raises ValueError if not a valid UUID string — the assertion IS the parse.
+    assert _uuid_module.UUID(str(workflow_data["run_id"])) == runtime.run_id
+
+
+def _write_no_terminal_event_no_handler_contract(target: Path) -> None:
+    """A contract with neither ``terminal_event`` nor any handler spec.
+
+    Hits the one ``run_async`` exit branch that returns FAILED without any
+    dispatch at all — the specific gap this ticket closes.
+    """
+    target.write_text(
+        yaml.safe_dump({"workflow_id": "omn-15449-no-handler-no-terminal"}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_terminal_event_no_handler_spec_still_writes_state(
+    tmp_path: Path,
+) -> None:
+    """The 'nothing to dispatch' exit path must not leave a stale file in place.
+
+    BEFORE OMN-15449: this branch returned ``FAILED`` without calling
+    ``_write_state()`` at all. If a PREVIOUS run against the same
+    ``state_root`` had left a workflow_result.json behind, a caller reading
+    the file back after THIS run would see that unrelated previous run's
+    content with no signal that it does not belong to this run — the reader
+    could not tell "no write happened" from "a stale file is sitting here"
+    without this fix. Writing this run's own (failed) state, including its
+    own run_id, closes that gap directly, independent of the reader-side
+    identity check in omnibase_infra.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_no_terminal_event_no_handler_contract(contract_path)
+
+    # Seed a stale file from a "previous run" with a DIFFERENT run_id, exactly
+    # the shape a caller must never mistake for this run's own output.
+    state_root.mkdir(parents=True)
+    stale_run_id = _uuid_module.uuid4()
+    (state_root / "workflow_result.json").write_text(
+        json.dumps(
+            {
+                "result": "completed",
+                "exit_code": 0,
+                "workflow": "unrelated-previous-run",
+                "run_id": str(stale_run_id),
+                "handler_result": {"ticket_id": "OMN-UNRELATED"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=5,
+    )
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.FAILED
+    assert runtime.exit_code != 0
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    assert workflow_data["run_id"] == str(runtime.run_id)
+    assert workflow_data["run_id"] != str(stale_run_id)
+    assert workflow_data["result"] == EnumWorkflowResult.FAILED.value
+    assert "handler_result" not in workflow_data


### PR DESCRIPTION
## Summary

`workflow_result.json` is a FIXED path shared by every `RuntimeLocal` invocation
against the same `state_root`. A caller reading it back after `run()` returns
has no way to verify the content it sees belongs to its own run rather than a
different one — a concurrent invocation against the same `state_root`, or a
run whose write path was skipped entirely.

This is the writer half of the OMN-15449 fix (cross-ticket contamination in
`dod_verify`'s Done-flip receipts): `RuntimeLocal` now accepts an optional
`run_id` (keyword-only, minted when the caller supplies none) and stamps it
into every `workflow_result.json` write. The reader half — a fail-closed join
in `omnibase_infra/cli/receipt_mode.py` that refuses to trust the file's
content unless its `run_id` matches the current invocation — lands as a
**separate, dependent PR** once this one is merged and released. **Landing
order is load-bearing**: this PR (the writer) must merge and be released
before the infra PR (a fail-closed reader) can be un-drafted, or the reader
would refuse every single run against the currently-published core version.

## Seam (writer side)

- Field: `run_id` (new, keyword-only constructor arg on `RuntimeLocal`)
- Type: `uuid.UUID | None`, defaults to a freshly minted `uuid.uuid4()`
- Where stamped: `RuntimeLocal._write_state()` → `workflow_result.json["run_id"] = str(self.run_id)`
- Consumer (separate PR): `omnibase_infra/cli/receipt_mode.py::_verify_workflow_data_identity` compares this against the `run_id` it generates for `onex node`/`onex skill` dispatch and refuses (non-zero exit, `status=ERROR`) on any mismatch or absence.

## Also closed

The one `run_async` exit path that returned `FAILED` without calling
`_write_state()` at all (contract has neither `terminal_event` nor a
resolvable `handler_routing.default_handler`/`handler.module+class`) now
writes its own (failed) state first. Previously this left whatever a
PREVIOUS run against the same `state_root` had written in place,
uncontradicted — every other exit path already called `_write_state()` in a
`finally` block; this was the one gap.

## Root-cause note (OMN-15449 AC1)

The exact live trigger for the ~17% reported reproduction rate was not
pinned within the investigation timebox — the fixed-path handoff with no
identity verification is the mechanism CLASS; the concrete write-skip path
above is one proven instance, and a concurrent `onex` invocation against the
same `state_root` (the ordinary state of this fleet — many parallel agent
sessions routinely touch the same canonical clones) is the other plausible
instance, reproduced here via fault injection rather than genuine live
concurrency (see the paired infra PR's test). The run_id join makes the
whole class structurally impossible regardless of which trigger actually
fired historically.

## Tests

`tests/unit/runtime/test_runtime_local.py`:
- `test_write_state_stamps_run_id_for_caller_identity_join` — a caller-supplied `run_id` round-trips into the written file.
- `test_write_state_mints_run_id_when_caller_supplies_none` — a valid UUID is always present.
- `test_no_terminal_event_no_handler_spec_still_writes_state` — the write-skip gap: seeds a stale file with a DIFFERENT run_id, asserts the fixed exit path now overwrites it with its own.

Confirmed RED against pre-fix `runtime_local.py` (`git stash` the source, same tests): `TypeError: unexpected keyword argument 'run_id'` / `KeyError: 'run_id'` / `AttributeError: no attribute 'run_id'`. Restored, GREEN.

Full `tests/unit/runtime/` (365 tests): passed. `mypy --strict` on the changed file: clean. `pre-commit run --files <changed>`: clean (all hooks passed).

## Evidence-Source

OMN-15449

dod_evidence:
_none — this PR alone does not close OMN-15449; the fail-closed reader in the paired omnibase_infra PR is what makes the anchor-join enforceable. This PR is receipt-bound on its own tests above; the ticket closes once both PRs are merged and the infra PR's dependency on this release is satisfied._


Evidence-Source: OCC#6695

Evidence-Ticket: OMN-15449
