### PR TITLE
fix(OMN-16266): cap ModelTicketContract list fields at _MAX_LIST_ITEMS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.9"
+version = "0.46.10"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/ticket/model_ticket_contract.py
+++ b/src/omnibase_core/models/ticket/model_ticket_contract.py
@@ -234,30 +234,47 @@ class ModelTicketContract(BaseModel):
 
     # Clarifying questions
     questions: list[ModelClarifyingQuestion] = Field(
-        default_factory=list, description="Clarifying questions for requirements"
+        default_factory=list,
+        description="Clarifying questions for requirements",
+        max_length=_MAX_LIST_ITEMS,
     )
 
     # Requirements specification
+    # OMN-16266: unbounded list on a contract that gets embedded wholesale
+    # (node_test_generator_compute copies a full JSON snapshot into its
+    # generated output's CONTRACT_MANIFEST plus per-requirement boilerplate,
+    # ~4x amplification) and published to Kafka, whose broker enforces a real
+    # message.max.bytes far below what client config implies (OMN-16267).
+    # Capped to match the DoS-prevention convention already applied to this
+    # model's sibling list fields (see _MAX_LIST_ITEMS above).
     requirements: list[ModelRequirement] = Field(
-        default_factory=list, description="Requirements derived from ticket"
+        default_factory=list,
+        description="Requirements derived from ticket",
+        max_length=_MAX_LIST_ITEMS,
     )
 
     # Verification and gates
     verification_steps: list[ModelVerificationStep] = Field(
-        default_factory=list, description="Verification steps to run"
+        default_factory=list,
+        description="Verification steps to run",
+        max_length=_MAX_LIST_ITEMS,
     )
     gates: list[ModelGate] = Field(
-        default_factory=list, description="Approval gates required"
+        default_factory=list,
+        description="Approval gates required",
+        max_length=_MAX_LIST_ITEMS,
     )
 
     # Interface contracts for parallel development
     interfaces_provided: list[ModelInterfaceProvided] = Field(
         default_factory=list,
         description="Interfaces this ticket provides to other tickets",
+        max_length=_MAX_LIST_ITEMS,
     )
     interfaces_consumed: list[ModelInterfaceConsumed] = Field(
         default_factory=list,
         description="Interfaces this ticket consumes (may be mocked)",
+        max_length=_MAX_LIST_ITEMS,
     )
 
     # Fingerprinting and timestamps

--- a/tests/unit/models/ticket/test_model_ticket_contract.py
+++ b/tests/unit/models/ticket/test_model_ticket_contract.py
@@ -26,12 +26,18 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from omnibase_core.enums.ticket.enum_definition_format import EnumDefinitionFormat
+from omnibase_core.enums.ticket.enum_interface_kind import EnumInterfaceKind
+from omnibase_core.enums.ticket.enum_interface_surface import EnumInterfaceSurface
+from omnibase_core.enums.ticket.enum_mock_strategy import EnumMockStrategy
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.ticket import (
     Action,
     ClarifyingQuestion,
     Gate,
     GateKind,
+    InterfaceConsumed,
+    InterfaceProvided,
     Phase,
     Requirement,
     Status,
@@ -39,6 +45,7 @@ from omnibase_core.models.ticket import (
     VerificationKind,
     VerificationStep,
 )
+from omnibase_core.models.ticket.model_ticket_contract import _MAX_LIST_ITEMS
 
 # =============================================================================
 # Fixtures
@@ -1169,6 +1176,148 @@ class TestEdgeCases:
 
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             TicketContract.model_validate(data)
+
+
+# =============================================================================
+# List-length caps (OMN-16266)
+# =============================================================================
+#
+# `requirements` had no `max_length` cap, unlike its sibling list fields
+# (`interfaces_touched`, `evidence_requirements`, `dod_evidence`) — a real
+# customer-exposure gap, not hygiene: node_test_generator_compute embeds a
+# full JSON copy of the contract plus per-requirement generated boilerplate
+# (~4x amplification) into its published result, and the Kafka broker's real
+# message.max.bytes is far below what client config implies (OMN-16267). An
+# unbounded `requirements` list can produce a result the broker rejects,
+# silently stranding the customer's workflow with no error surfaced to the
+# caller. Auditing this model while in here found FIVE further list fields
+# with the identical gap (`questions`, `verification_steps`, `gates`,
+# `interfaces_provided`, `interfaces_consumed`) — none carry any comment or
+# rationale suggesting deliberate unboundedness, so all six are capped here
+# to the same `_MAX_LIST_ITEMS` convention the sibling fields already use.
+
+
+def _requirement(n: int = 0) -> Requirement:
+    return Requirement(
+        id=f"r{n}",
+        statement="Implement feature X",
+        rationale="Business need",
+        acceptance=["Given/When/Then criteria"],
+    )
+
+
+def _clarifying_question(n: int = 0) -> ClarifyingQuestion:
+    return ClarifyingQuestion(id=f"q{n}", text="Q", category="scope")
+
+
+def _verification_step(n: int = 0) -> VerificationStep:
+    return VerificationStep(id=f"v{n}", kind=VerificationKind.UNIT_TESTS)
+
+
+def _gate(n: int = 0) -> Gate:
+    return Gate(
+        id=f"g{n}",
+        kind=GateKind.HUMAN_APPROVAL,
+        description="Approval",
+        required=True,
+        status=Status.PENDING,
+    )
+
+
+def _interface_provided(n: int = 0) -> InterfaceProvided:
+    return InterfaceProvided(
+        id=f"ip{n}",
+        name="ProtocolX",
+        kind=EnumInterfaceKind.PROTOCOL,
+        surface=EnumInterfaceSurface.PUBLIC_API,
+        definition_format=EnumDefinitionFormat.PYTHON,
+        definition="class ProtocolX: ...",
+    )
+
+
+def _interface_consumed(n: int = 0) -> InterfaceConsumed:
+    return InterfaceConsumed(
+        id=f"ic{n}",
+        name="ProtocolY",
+        kind=EnumInterfaceKind.PROTOCOL,
+        mock_strategy=EnumMockStrategy.PROTOCOL_STUB,
+    )
+
+
+@pytest.mark.unit
+class TestListLengthCaps:
+    """Every list field on TicketContract enforces max_length=_MAX_LIST_ITEMS."""
+
+    @pytest.mark.parametrize(
+        ("field_name", "item_factory"),
+        [
+            ("questions", _clarifying_question),
+            ("requirements", _requirement),
+            ("verification_steps", _verification_step),
+            ("gates", _gate),
+            ("interfaces_provided", _interface_provided),
+            ("interfaces_consumed", _interface_consumed),
+        ],
+    )
+    def test_at_cap_is_accepted(self, field_name, item_factory):
+        """Exactly _MAX_LIST_ITEMS items is valid — the cap is inclusive."""
+        items = [item_factory() for _ in range(_MAX_LIST_ITEMS)]
+        contract = TicketContract(
+            ticket_id="OMN-CAP",
+            title="At Cap",
+            **{field_name: items},
+        )
+        assert len(getattr(contract, field_name)) == _MAX_LIST_ITEMS
+
+    @pytest.mark.parametrize(
+        ("field_name", "item_factory"),
+        [
+            ("questions", _clarifying_question),
+            ("requirements", _requirement),
+            ("verification_steps", _verification_step),
+            ("gates", _gate),
+            ("interfaces_provided", _interface_provided),
+            ("interfaces_consumed", _interface_consumed),
+        ],
+    )
+    def test_over_cap_is_rejected(self, field_name, item_factory):
+        """_MAX_LIST_ITEMS + 1 items is rejected — this is the RED case that
+        proves the cap exists and is enforced, not merely declared."""
+        items = [item_factory() for _ in range(_MAX_LIST_ITEMS + 1)]
+        with pytest.raises(ValidationError, match="at most"):
+            TicketContract(
+                ticket_id="OMN-OVER-CAP",
+                title="Over Cap",
+                **{field_name: items},
+            )
+
+    def test_requirements_cap_matches_sibling_fields(self):
+        """OMN-16266: requirements uses the SAME constant as its already-capped
+        siblings, not an independently-chosen value that could drift."""
+        contract_fields = TicketContract.model_fields
+        capped_siblings = (
+            "interfaces_touched",
+            "evidence_requirements",
+            "dod_evidence",
+            "requirements",
+            "questions",
+            "verification_steps",
+            "gates",
+            "interfaces_provided",
+            "interfaces_consumed",
+        )
+        max_lengths = {
+            name: next(
+                (
+                    m.max_length
+                    for m in contract_fields[name].metadata
+                    if hasattr(m, "max_length")
+                ),
+                None,
+            )
+            for name in capped_siblings
+        }
+        assert all(v == _MAX_LIST_ITEMS for v in max_lengths.values()), max_lengths
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.9"
+version = "0.46.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

`ModelTicketContract.requirements: list[ModelRequirement]` had **no `max_length` cap**, unlike sibling list fields on the same model (`evidence_requirements`, `verification_steps`, etc.), which already enforce `_MAX_LIST_ITEMS=1000` as a documented DoS-prevention convention (`model_ticket_contract.py:76-77`).

## Real customer exposure (not hygiene)

Confirmed live during the OMN-14498 fault-injection probe: `node_test_generator_compute` embeds a full JSON copy of the ticket contract plus per-requirement generated pytest boilerplate (~4x amplification) into its published result. The Kafka broker's real `message.max.bytes` (~1,048,588 bytes, measured live — see OMN-16267) is well below what client-side config implies. An unbounded `requirements` list can produce a result payload the broker rejects.

Post-OMN-14498 this now safely DLQs the original command instead of losing data, but **the customer's workflow still silently never completes** — there is no error surfaced to the caller.

## Fix

Added `max_length=_MAX_LIST_ITEMS` (1000) to `requirements`, matching the existing sibling-field convention exactly.

**Audit finding:** while in this model, found five further list fields with the identical gap and no comment/rationale suggesting deliberate unboundedness: `questions`, `verification_steps`, `gates`, `interfaces_provided`, `interfaces_consumed`. All six capped in this PR to the same `_MAX_LIST_ITEMS` convention already applied to `interfaces_touched`, `evidence_requirements`, and `dod_evidence`.

## Tests (RED-then-GREEN)

- New `TestListLengthCaps` class in `tests/unit/models/ticket/test_model_ticket_contract.py`: parametrized over all six newly-capped fields, asserting `_MAX_LIST_ITEMS` items is accepted and `_MAX_LIST_ITEMS + 1` is rejected with `ValidationError`, plus a cross-check that all capped fields share the same constant (no independently-chosen values that could drift).
- Verified RED against the pre-fix model (7 failures: 6x "DID NOT RAISE ValidationError" + 1x cap-mismatch assertion) by stashing the model diff and re-running.
- Verified GREEN with the fix applied: 98/98 passed in the target test file.

## Cross-repo fixture check

Searched `omnibase_core` and `omnimarket` test suites for fixtures constructing `ModelTicketContract`/`TicketContract` with >1000 `requirements` (the OMN-14498 probe's 6000-item payload was against a *different* model/path — `node_test_generator_compute`'s `ModelTestGenerationRequest`, not `ModelTicketContract`). **None found in either repo** — no fixture fix needed, no cross-repo follow-up required.

## Gates

- `ruff format` / `ruff check --fix`: clean
- `mypy --strict` on touched module: clean
- `pre-commit run --all-files` (local, at commit time): all hooks passed, including the OMN-13411 release-identity gate (required `pyproject.toml` version bump 0.46.9 → 0.46.10, since a `uv.lock` line changed as a build side effect)
- Pre-push governed selector (OMN-13973) escalated to the full suite on `.200` (pyproject.toml/uv.lock touched a shared-config trigger): **43959 passed, 0 failed, 53 skipped, 3 xpassed** in 1:29:19 wall time (heavily contended host — see PR discussion if timing looks unusual)

OMN-16266

dod_evidence: RED-then-GREEN test evidence above; full local suite green on `.200` before push; PR gates to follow via CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation limits to ticket contract list fields, including requirements, questions, verification steps, gates, and interface lists.
  - Ticket contracts now reject entries beyond the supported maximum while continuing to accept lists at the limit.
  - Clarified requirements documentation around bounded lists.

- **Tests**
  - Added coverage confirming maximum-length lists are accepted and oversized lists produce validation errors.

- **Chores**
  - Updated the project version to 0.46.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-16266
Evidence-Source: OCC#6748
