### PR TITLE
feat(OMN-16295): load-based host selection for the pre-push guard (.201 gate-runner)

### DIFF
--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -63,8 +63,111 @@ die() {
 # "harden" this into a hard block later -- the failure mode this guard exists
 # to prevent is a stalled/contended local machine, not an untrusted push.
 PREPUSH_200_HOSTNAME="${PREPUSH_200_HOSTNAME:-stickybeatz-studio}"
+
+# =============================================================================
+# Live-load host selection (OMN-16295)
+# =============================================================================
+# Extends the host-IDENTITY guard below with a CAPACITY dimension: `.200`
+# being the right host by IDENTITY does not mean it has headroom. Measured
+# 2026-08-20: `.200` load average 32-34 against 24 cores (and, live during
+# this same investigation, 56/24 -- 2.3x oversubscribed) driving an 89-93
+# minute full-suite run with orphaned pytest processes left behind. Same
+# failure class as the 2026-07-24 incident described below, recurring under
+# concurrent-session load. OMN-16295 adds a second execution target -- a
+# hard-capped gate-runner container on `.201`
+# (docker/docker-compose.gate-runner.yml in omnibase_infra), selected ONLY
+# when `.200` is over threshold, never the default.
+#
+# FAIL-CLOSED, unlike the host-IDENTITY guard's fail-open posture below --
+# deliberately different, not inconsistent. An unresolvable HOSTNAME is
+# ambiguous evidence about WHERE we are (fail open: don't lock a developer out
+# of their own repo on a shaky read). An unresolvable LOAD reading is a
+# failure to prove EITHER candidate host has capacity, and proceeding anyway
+# on that silence is exactly how the 2026-07-24 / 2026-08-20 incidents
+# happened -- assumed headroom that was not there. "Neither host reachable"
+# refuses; it does not skip the check.
+PREPUSH_201_GATE_RUNNER_HOSTNAME="${PREPUSH_201_GATE_RUNNER_HOSTNAME:-gate-runner-201}"
+PREPUSH_200_SSH_TARGET="${PREPUSH_200_SSH_TARGET:-jonah@stickybeatz-studio.tail75df5e.ts.net}"  # onex-allow-internal-ip OMN-16295 reason="pre-push guard needs the real host target to probe live load"
+PREPUSH_201_SSH_TARGET="${PREPUSH_201_SSH_TARGET:-jonah@192.168.86.201}"  # onex-allow-internal-ip OMN-16295 reason="pre-push guard needs the real host target to probe live load" # fallback-ok: real .201 host target, not a dev/local placeholder
+# load1/cores at or under this ratio counts as "fit". 1.0 == "not
+# oversubscribed" (a standard load-average heuristic); correctly reads the
+# observed-fit `.201` snapshot (~0.4x, 2026-08-20) as fit and both observed
+# `.200` snapshots above (1.33x and 2.3x) as over threshold.
+PREPUSH_LOAD_THRESHOLD="${PREPUSH_LOAD_THRESHOLD:-1.0}"
+
+# Cross-platform (Linux `.201` / macOS `.200`) load probe: os.getloadavg()[0]
+# and os.cpu_count() are both POSIX-portable via the stdlib, which sidesteps
+# needing separate /proc/loadavg-vs-sysctl branches (and their escaping) in
+# both the local AND the remote-via-ssh cases below. No quote characters
+# appear in this snippet -- it is embedded inside a single-quoted remote
+# command string in the ssh branch, so it must stay that way.
+_PREPUSH_LOAD_PROBE_PY='import os,sys
+n=os.cpu_count() or 0
+sys.exit(1) if n<=0 else print(os.getloadavg()[0], n)'
+
+# Prefer GNU coreutils timeout(1); fall back to gtimeout(1) (Homebrew name on
+# macOS); fall back to no wrapper at all (ssh -o ConnectTimeout already bounds
+# the connection phase, and the remote command is a single fast python3 -c).
+_prepush_timeout_cmd() {
+  if command -v timeout > /dev/null 2>&1; then
+    printf 'timeout'
+  elif command -v gtimeout > /dev/null 2>&1; then
+    printf 'gtimeout'
+  fi
+}
+
+# host_load_ratio TARGET -- prints "<load1> <nproc> <ratio>" and returns 0, or
+# prints nothing and returns 1 on any read/parse/timeout failure. TARGET is
+# empty for "read this host directly" or an ssh(1) target string for a
+# bounded remote read. Deterministic, network-free overrides for tests (each a
+# "<load1> <nproc>" pair -- the ratio is still computed from it, never
+# hardcoded):
+#   PREPUSH_LOAD_OVERRIDE_LOCAL   overrides the direct (TARGET="") read
+#   PREPUSH_LOAD_OVERRIDE_REMOTE  overrides every ssh-target read
+host_load_ratio() {
+  local target="$1" raw load1 ncpu timeout_cmd
+  if [ -z "$target" ]; then
+    if [ -n "${PREPUSH_LOAD_OVERRIDE_LOCAL:-}" ]; then
+      raw="$PREPUSH_LOAD_OVERRIDE_LOCAL"
+    else
+      raw="$(python3 -c "$_PREPUSH_LOAD_PROBE_PY" 2> /dev/null)" || return 1
+    fi
+  else
+    if [ -n "${PREPUSH_LOAD_OVERRIDE_REMOTE:-}" ]; then
+      raw="$PREPUSH_LOAD_OVERRIDE_REMOTE"
+    else
+      timeout_cmd="$(_prepush_timeout_cmd)"
+      if [ -n "$timeout_cmd" ]; then
+        raw="$("$timeout_cmd" 6 ssh -o ConnectTimeout=3 -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+          "$target" "python3 -c '${_PREPUSH_LOAD_PROBE_PY}'" 2> /dev/null)" || return 1
+      else
+        raw="$(ssh -o ConnectTimeout=3 -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+          "$target" "python3 -c '${_PREPUSH_LOAD_PROBE_PY}'" 2> /dev/null)" || return 1
+      fi
+    fi
+  fi
+  [ -n "$raw" ] || return 1
+  # shellcheck disable=SC2086
+  set -- $raw
+  load1="${1:-}"
+  ncpu="${2:-}"
+  [ -n "$load1" ] && [ -n "$ncpu" ] && [ "$ncpu" != "0" ] || return 1
+  awk -v l="$load1" -v n="$ncpu" 'BEGIN { if (n + 0 <= 0) exit 1; printf "%s %s %.3f\n", l, n, (l / n) }'
+}
+
+# host_is_fit TARGET -- 0 if measured load1/nproc is at/under
+# PREPUSH_LOAD_THRESHOLD, 1 if over threshold, 2 if the read itself failed
+# (unreachable/unresolvable). Callers must not conflate 1 and 2 anywhere the
+# difference is user-visible ("over capacity" vs "could not check").
+host_is_fit() {
+  local target="$1" ratio
+  ratio="$(host_load_ratio "$target" | awk '{print $3}')" || return 2
+  [ -n "$ratio" ] || return 2
+  awk -v r="$ratio" -v thr="$PREPUSH_LOAD_THRESHOLD" 'BEGIN { exit !(r <= thr + 0) }'
+}
+
 guard_full_suite_host() {
-  local host lc_host lc_target heavy_what
+  local host lc_host lc_target lc_201 heavy_what
   # OMN-15408: the caller names WHICH heavyweight run is being guarded, so the
   # refusal names the real cause. Default preserves the OMN-15059 wording for
   # the flag-driven escalation call sites, which pass no argument.
@@ -76,8 +179,34 @@ guard_full_suite_host() {
   fi
   lc_host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
   lc_target="$(printf '%s' "$PREPUSH_200_HOSTNAME" | tr '[:upper:]' '[:lower:]')"
-  if [ "$lc_host" = "$lc_target" ]; then
-    return 0
+  lc_201="$(printf '%s' "$PREPUSH_201_GATE_RUNNER_HOSTNAME" | tr '[:upper:]' '[:lower:]')"
+  if [ "$lc_host" = "$lc_target" ] || [ "$lc_host" = "$lc_201" ]; then
+    # OMN-16295: identity alone is not enough -- this known-good host must
+    # also have capacity right now.
+    if host_is_fit ""; then
+      return 0
+    fi
+    if [ -n "${PREPUSH_ALLOW_LOCAL_FULL_SUITE:-}" ]; then
+      log "WARNING: DEGRADED-CAPACITY OVERRIDE IN EFFECT (PREPUSH_ALLOW_LOCAL_FULL_SUITE set) -- running ${heavy_what} on '${host}' at/over the ${PREPUSH_LOAD_THRESHOLD}x-core load threshold. Treat any evidence from this run as WEAKER than a fit-host-run gate."
+      return 0
+    fi
+    local other_target other_label other_rc other_note
+    if [ "$lc_host" = "$lc_target" ]; then
+      other_target="$PREPUSH_201_SSH_TARGET"
+      other_label="the .201 gate-runner (${PREPUSH_201_GATE_RUNNER_HOSTNAME})"
+    else
+      other_target="$PREPUSH_200_SSH_TARGET"
+      other_label=".200 (${PREPUSH_200_HOSTNAME})"
+    fi
+    other_rc=0
+    host_is_fit "$other_target" || other_rc=$?
+    case "$other_rc" in
+      0) other_note="${other_label} currently HAS capacity -- route there instead" ;;
+      2) other_note="${other_label} could not be reached to check capacity" ;;
+      *) other_note="${other_label} is ALSO at/over the load threshold" ;;
+    esac
+    die "${heavy_what} triggered on '${host}' (the designated host by identity), but its load is at/over the ${PREPUSH_LOAD_THRESHOLD}x-core threshold" \
+        "${other_note}. See docs/runbooks/200-build-lane-execution-pattern.md for the .201 gate-runner recipe, or set PREPUSH_ALLOW_LOCAL_FULL_SUITE=1 to run here anyway (degraded evidence -- do not use as a routine bypass)"
   fi
   if [ -n "${PREPUSH_ALLOW_LOCAL_FULL_SUITE:-}" ]; then
     log "WARNING: DEGRADED-HOST OVERRIDE IN EFFECT (PREPUSH_ALLOW_LOCAL_FULL_SUITE set) -- running ${heavy_what} on '${host}', NOT the designated .200 host ('${PREPUSH_200_HOSTNAME}'). This host has weaker isolation/headroom than .200; treat any evidence from this run as WEAKER than a .200-run gate. See docs/runbooks/200-build-lane-execution-pattern.md."

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -52,7 +52,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 from scripts.ci.test_selection_closure import TEST_UNIT_PREFIX
@@ -632,3 +634,265 @@ def test_guard_allows_a_genuinely_narrow_selection_on_a_local_host(
         "expected the narrow selection's own path to be handed to pytest; "
         f"stdout: {result.stdout!r}"
     )
+
+
+# =============================================================================
+# OMN-16295: live-load host selection
+# =============================================================================
+# The guard above answers "is this host the right one by IDENTITY". OMN-16295
+# adds a second question -- "does the right host have CAPACITY right now" --
+# answered by `host_load_ratio()` / `host_is_fit()` and consulted inside
+# `guard_full_suite_host()` before it returns 0 for a known-good host. See
+# docs/runbooks/200-build-lane-execution-pattern.md and
+# omnibase_infra/docker/docker-compose.gate-runner.yml for the second
+# execution target this selects between.
+
+_LOAD_HELPERS_RE = re.compile(
+    r"^_prepush_timeout_cmd\(\) \{.*?^host_is_fit\(\) \{.*?^\}",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def _extract_load_helpers_source() -> str:
+    """Extract-and-execute the real `PREPUSH_LOAD_THRESHOLD` default,
+    `host_load_ratio` / `host_is_fit` / `_prepush_timeout_cmd` bash functions,
+    and their shared `_PREPUSH_LOAD_PROBE_PY` constant from the shipped hook
+    -- never a Python re-implementation, for the same reason
+    `_extract_predicate_source` above extracts `selection_is_whole_suite`
+    rather than re-implementing it. The threshold default must travel with
+    the functions: `host_is_fit` reads `$PREPUSH_LOAD_THRESHOLD` directly, and
+    an unset value silently awk-coerces to 0 (every positive ratio reads as
+    "over threshold"), which would falsely fail the fit-path tests below."""
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    threshold_match = re.search(
+        r'^PREPUSH_LOAD_THRESHOLD="\$\{PREPUSH_LOAD_THRESHOLD:-[^}]*\}"$',
+        script_text,
+        re.MULTILINE,
+    )
+    assert threshold_match is not None, (
+        f"expected a PREPUSH_LOAD_THRESHOLD default assignment in {HOOK_SCRIPT}"
+    )
+    py_match = re.search(
+        r"^_PREPUSH_LOAD_PROBE_PY='.*?'$", script_text, re.DOTALL | re.MULTILINE
+    )
+    assert py_match is not None, f"expected _PREPUSH_LOAD_PROBE_PY in {HOOK_SCRIPT}"
+    fn_match = _LOAD_HELPERS_RE.search(script_text)
+    assert fn_match is not None, (
+        f"expected _prepush_timeout_cmd/host_load_ratio/host_is_fit in {HOOK_SCRIPT}"
+    )
+    return f"{threshold_match.group(0)}\n{py_match.group(0)}\n{fn_match.group(0)}\n"
+
+
+def test_host_load_helpers_are_defined() -> None:
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    for name in ("host_load_ratio()", "host_is_fit()", "_prepush_timeout_cmd()"):
+        assert name in script_text, f"expected {name} defined in {HOOK_SCRIPT}"
+
+
+def _run_load_helper(
+    *args: str, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    script = f'{_extract_load_helpers_source()}\n"$@"\n'
+    env = dict(os.environ)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", "-c", script, "load-helper-test", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env=env,
+    )
+
+
+def test_host_is_fit_true_under_threshold() -> None:
+    result = _run_load_helper(
+        "host_is_fit", "", env_extra={"PREPUSH_LOAD_OVERRIDE_LOCAL": "5 24"}
+    )
+    assert result.returncode == 0, f"expected fit (rc=0): {result!r}"
+
+
+def test_host_is_fit_false_over_threshold() -> None:
+    result = _run_load_helper(
+        "host_is_fit", "", env_extra={"PREPUSH_LOAD_OVERRIDE_LOCAL": "50 24"}
+    )
+    assert result.returncode == 1, f"expected over-threshold (rc=1): {result!r}"
+
+
+def test_host_is_fit_distinguishes_unreachable_from_over_threshold() -> None:
+    """rc=2 (could not check) must never collapse into rc=1 (measured, over
+    threshold) -- callers give a different remediation message for each."""
+    result = _run_load_helper(
+        "host_is_fit",
+        "definitely-unroutable.invalid",
+        env_extra={"PREPUSH_LOAD_OVERRIDE_LOCAL": ""},
+    )
+    assert result.returncode == 2, (
+        f"expected unreachable (rc=2) for an unresolvable remote target with "
+        f"no override and no real network dependency assumed: {result!r}"
+    )
+
+
+def test_host_load_ratio_computes_from_the_override_not_a_hardcoded_value() -> None:
+    """Anti-vacuous-test pin: two different override pairs must produce two
+    different measured ratios, proving the arithmetic actually runs against
+    the input rather than returning a constant."""
+    low = _run_load_helper(
+        "host_load_ratio", "", env_extra={"PREPUSH_LOAD_OVERRIDE_LOCAL": "2 24"}
+    )
+    high = _run_load_helper(
+        "host_load_ratio", "", env_extra={"PREPUSH_LOAD_OVERRIDE_LOCAL": "48 24"}
+    )
+    assert low.returncode == 0 and high.returncode == 0, (low, high)
+    assert low.stdout.strip() != high.stdout.strip()
+    assert low.stdout.split()[-1] == "0.083"
+    assert high.stdout.split()[-1] == "2.000"
+
+
+def _run_hook_forcing_full_suite(
+    *, env_extra: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run the REAL hook with the full-suite escalation forced
+    (`PREPUSH_FULL_SUITE=1`) and the REAL governed selector (a fast, real `uv
+    run` invocation) -- but with a stub `uv` that intercepts only the eventual
+    `pytest` invocation, so the (potentially minutes-long) real test run never
+    happens while every decision up to and including `guard_full_suite_host`
+    is exercised for real."""
+    real_uv = shutil.which("uv")
+    assert real_uv is not None, "expected uv on PATH to run this test"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        stub_bin = Path(tmp) / "stub-bin"
+        stub_bin.mkdir(parents=True, exist_ok=True)
+        uv_stub = stub_bin / "uv"
+        uv_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            'case "$*" in\n'
+            "  *pytest*)\n"
+            '    echo "STUB-PYTEST-INVOKED $*"\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            f'exec "{real_uv}" "$@"\n',
+            encoding="utf-8",
+        )
+        uv_stub.chmod(0o755)
+
+        env = dict(os.environ)
+        env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+        env["PREPUSH_FULL_SUITE"] = "1"
+        env["PREPUSH_BASE_REF"] = "HEAD"
+        for leaky in ("PREPUSH_ALLOW_LOCAL_FULL_SUITE",):
+            env.pop(leaky, None)
+        env.update(env_extra)
+
+        return subprocess.run(
+            ["bash", str(HOOK_SCRIPT)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+
+def test_guard_refuses_known_good_host_that_is_over_the_load_threshold() -> None:
+    """The core OMN-16295 behavior: identity match is no longer sufficient.
+
+    PREPUSH_LOAD_OVERRIDE_REMOTE is set (to an arbitrary fit value) so the
+    "other host" probe never makes a real network call -- this test is only
+    about the SELF-host refusal, not about which remediation phrasing the
+    other-host probe produces (that's covered by the two tests below)."""
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_200_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "50 24",
+            "PREPUSH_LOAD_OVERRIDE_REMOTE": "3 32",
+        },
+    )
+    assert result.returncode != 0, (
+        f"expected refusal on an over-threshold known-good host: {result!r}"
+    )
+    assert "at/over the" in result.stderr and "x-core threshold" in result.stderr, (
+        f"expected the capacity-refusal message, got stderr={result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" not in result.stdout, (
+        "the guard must refuse BEFORE pytest is ever invoked"
+    )
+
+
+def test_guard_allows_known_good_host_that_is_under_the_load_threshold() -> None:
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_200_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "2 24",
+        },
+    )
+    assert result.returncode == 0, f"expected success on a fit known host: {result!r}"
+    assert "STUB-PYTEST-INVOKED" in result.stdout, (
+        f"expected the run to reach pytest: {result!r}"
+    )
+
+
+def test_guard_allows_the_201_gate_runner_identity_when_fit() -> None:
+    """The .201 gate-runner is a valid execution host by identity, not just
+    `.200` -- this is the routing half of OMN-16295."""
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_201_GATE_RUNNER_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_200_HOSTNAME": "definitely-not-this-host",
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "2 24",
+        },
+    )
+    assert result.returncode == 0, (
+        f"expected success when this host matches the .201 gate-runner "
+        f"identity and is fit: {result!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" in result.stdout, result
+
+
+def test_guard_override_still_works_under_load() -> None:
+    """PREPUSH_ALLOW_LOCAL_FULL_SUITE must still force through the NEW
+    capacity check, exactly as it already does for the identity check --
+    same escape hatch, same visible degraded-evidence warning."""
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_200_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "50 24",
+            "PREPUSH_ALLOW_LOCAL_FULL_SUITE": "1",
+        },
+    )
+    assert result.returncode == 0, result
+    assert "DEGRADED-CAPACITY OVERRIDE" in result.stderr, result.stderr
+    assert "STUB-PYTEST-INVOKED" in result.stdout, result
+
+
+def test_guard_refusal_names_a_fit_alternate_host() -> None:
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_200_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "50 24",
+            "PREPUSH_LOAD_OVERRIDE_REMOTE": "3 32",
+        },
+    )
+    assert result.returncode != 0, result
+    assert "HAS capacity -- route there instead" in result.stderr, result.stderr
+
+
+def test_guard_refusal_names_both_hosts_saturated() -> None:
+    result = _run_hook_forcing_full_suite(
+        env_extra={
+            "PREPUSH_200_HOSTNAME": _real_short_hostname(),
+            "PREPUSH_LOAD_OVERRIDE_LOCAL": "50 24",
+            "PREPUSH_LOAD_OVERRIDE_REMOTE": "40 32",
+        },
+    )
+    assert result.returncode != 0, result
+    assert "is ALSO at/over the load threshold" in result.stderr, result.stderr
+
+
+def _real_short_hostname() -> str:
+    return subprocess.run(
+        ["hostname", "-s"], capture_output=True, text=True, check=True
+    ).stdout.strip()


### PR DESCRIPTION
## Summary

Extends the OMN-15059 pre-push host-identity guard (`guard_full_suite_host()` in `scripts/hooks/prepush_smart_tests.sh`) with a live-load CAPACITY dimension. Companion PRs: omnibase_infra (adds the `.201` gate-runner container this routes to) and omnimarket (same guard extension).

## Why

`.200` being the right host by IDENTITY does not mean it has headroom. Measured 2026-08-20: `.200` load average 32-34 against 24 cores, an 89-93 minute full-suite run, orphaned pytest processes left behind. Live during this same investigation, `.200` hit **56/24 (2.3x oversubscribed)** — corroborated by 5 concurrent full-suite pytest processes from unrelated sessions observed live on the host at that moment. Same failure class as the 2026-07-24 incident the existing guard's own comments describe, recurring under concurrent-session load.

## What changed

- `host_load_ratio()` / `host_is_fit()`: cross-platform (Linux `.201` / macOS `.200`) live-load probes via `os.getloadavg()`/`os.cpu_count()` (POSIX-portable stdlib, no separate `/proc/loadavg`-vs-`sysctl` branching needed). Local read or a bounded-timeout (`ConnectTimeout=3` + `timeout 6`) ssh read. Deterministic, network-free env-var overrides (`PREPUSH_LOAD_OVERRIDE_LOCAL` / `PREPUSH_LOAD_OVERRIDE_REMOTE`) for tests.
- `guard_full_suite_host()` now recognizes a second known-good host by identity — the `.201` gate-runner (`PREPUSH_201_GATE_RUNNER_HOSTNAME`, default `gate-runner-201`) — and requires the matched host to also be **fit** (load1/nproc ≤ `PREPUSH_LOAD_THRESHOLD`, default 1.0) before proceeding. Refuses with a remediation message naming the other host's measured status (fit / over-threshold / unreachable) when the matched host is over threshold.
- **FAIL-CLOSED**, unlike the existing identity check's fail-open posture — a deliberate difference, documented inline: an unresolvable hostname is ambiguous evidence about *where* we are (fail open); an unresolvable load reading is a failure to prove *either* candidate host has capacity, and proceeding anyway on that silence is exactly how the 2026-07-24 / 2026-08-20 incidents happened.
- `PREPUSH_ALLOW_LOCAL_FULL_SUITE` still works as the visible, degraded-evidence override for the new capacity dimension, same as it already does for the identity dimension.

## Tests

10 new regression tests (all green): fit/unfit/unreachable classification (`host_is_fit`), ratio computed from the actual override input rather than a hardcoded constant, refusal message shape, `.201` identity accepted when fit, override still forces through under load, remediation names a fit vs. saturated alternate host. Existing OMN-15059 (host-identity) and OMN-15408 (heavyweight-selection) coverage — 20 tests — unchanged and green.

```
30 passed, 3 warnings in 26s  (tests/scripts/test_prepush_hook_host_identity_guard.py)
```

Also verified: shellcheck clean on the modified hook script; the pre-existing `test_guard_refuses_full_suite_escalation_on_non_200_host` regression (unknown-host refusal) still passes unmodified.

## Coordination note

`OMN-15977` (PR #1554) merged to `dev` moments before this PR was opened, touching the same file (a different region — `PREPUSH_TIMEOUT_FLAGS`'s `--timeout-method`). Verified both changes coexist correctly (non-overlapping line ranges, clean `git apply`, both behaviors present and passing post-merge).

OMN-16295

Evidence-Ticket: OMN-16295
Evidence-Source: OCC#6784
