### PR TITLE
feat(OMN-16289): sync main to release tag SHA on successful release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,25 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
 
+      # OMN-16289: main = the last release. Once a release publishes
+      # successfully, fast-forward main to the released tag's commit SHA.
+      # This is a non-force push of an already-proven dev SHA (release
+      # tags are cut from dev; dev CI + this job already validated it).
+      # Promotion PRs to main are retired -- main protection now empties
+      # required_status_checks on main and restricts pushes to this job's
+      # automation identity, so no separate token/secret is needed: the
+      # same GITHUB_TOKEN persisted by actions/checkout@v7 above already
+      # authenticates this push.
+      - name: Sync main to release tag
+        if: ${{ !contains(steps.tag.outputs.tag, 'rc') }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          echo "Resolved tag $TAG -> commit $TAG_SHA"
+          git push origin "${TAG_SHA}:refs/heads/main"
+          echo "main fast-forwarded to $TAG_SHA ($TAG)"
+
   # ---------------------------------------------------------------------------
   # Post-release: open dependency bump PRs in downstream repos (OMN-5109)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a `Sync main to release tag` step to `release.yml`, run after `Create GitHub Release` succeeds (skipped on `rc` prereleases). Resolves the just-published tag to its commit SHA and non-force-pushes that SHA to `refs/heads/main`, using the same `GITHUB_TOKEN` identity the job's checkout already persists -- no new secret class introduced.

## Why (OMN-16289)

Operator-confirmed policy: **main = the last release.** Promotion PRs to main are retired -- main's meaning becomes "the exact source state of the last published artifact." See omnimarket#2112 / omnibase_spi#271 / omnibase_infra#2813 (other wave-1 repos landing in the same pass).

## Scope

This PR only adds the sync step. It does not change main branch protection -- that is a separate, live, per-repo mutation applied and readback-verified after this merges, with before/after JSON posted as an OMN-16289 ticket comment.

OMN-16289


Evidence-Source: OCC#6790
Evidence-Ticket: OMN-16289