### PR TITLE
fix(OMN-16288): remove redundant, permanently-broken OCC heads/main re-check in auto-merge.yml

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -155,66 +155,26 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Resolve OCC main SHA
-        id: occ_ref
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          sha="$(gh api repos/OmniNode-ai/onex_change_control/git/ref/heads/main --jq '.object.sha')"
-          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::could not resolve immutable onex_change_control/main SHA"
-            exit 1
-          fi
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-
-      - name: Check out OCC evidence snapshot
-        uses: actions/checkout@v7
-        with:
-          repository: OmniNode-ai/onex_change_control
-          path: .onex_change_control
-          ref: ${{ steps.occ_ref.outputs.sha }}
-          fetch-depth: 1
-
-      - name: OCC auto-merge preflight
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ needs.pre-check.outputs.pr }}
-        run: |
-          set -euo pipefail
-          pr_json="$(gh pr view "$PR" --repo "$GH_REPO" --json body,title,headRefName,commits)"
-          printf '%s' "$pr_json" | jq -r '.body // ""' > /tmp/pr_body.txt
-          PR_TITLE="$(printf '%s' "$pr_json" | jq -r '.title // ""')"
-          PR_BRANCH="$(printf '%s' "$pr_json" | jq -r '.headRefName // ""')"
-
-          commit_args=()
-          while IFS= read -r sha; do
-            [ -n "$sha" ] && commit_args+=(--pr-commit-sha "$sha")
-          done < <(printf '%s' "$pr_json" | jq -r '.commits[]?.oid // empty')
-          while IFS= read -r text; do
-            [ -n "$text" ] && commit_args+=(--pr-commit-text "$text")
-          done < <(printf '%s' "$pr_json" | jq -r '.commits[]? | ((.messageHeadline // "") + " " + (.messageBody // "" | gsub("\r?\n"; " ")))')
-
-          PYTHONPATH=src uv run python -m omnibase_core.validation.validator_occ_merge_eligibility \
-            --repo "${GH_REPO##*/}" \
-            --pr-number "$PR" \
-            --pr-title "$PR_TITLE" \
-            --pr-body-file /tmp/pr_body.txt \
-            --pr-branch "$PR_BRANCH" \
-            --occ-commit-sha "${{ steps.occ_ref.outputs.sha }}" \
-            --contracts-dir ".onex_change_control/contracts" \
-            --receipts-dir ".onex_change_control/drift/dod_receipts" \
-            "${commit_args[@]}" \
-            | tee /tmp/occ_auto_merge_preflight.json
+      # OMN-16288: this job previously re-resolved OCC eligibility here by
+      # fetching onex_change_control@heads/main and re-running
+      # validator_occ_merge_eligibility against that checkout. Nothing
+      # promotes OCC's own contracts dev->main (Tier-1 excluded from
+      # nightly-promote per OMN-15067), so OCC main is thousands of commits
+      # stale and that step failed permanently with eligible:false /
+      # missing_contract for every recently-minted ticket contract (e.g.
+      # OMN-16280, run 32359138410) -- it never once passed once main drifted
+      # this far, and it never gated arming: the `auto-merge` job here already
+      # requires `needs.occ-preflight.result == 'success'` (line 148 `if:`),
+      # and that occ-preflight job (line 69) calls the SAME reusable
+      # (occ-preflight.yml) that resolves OCC state from the PR body's
+      # Evidence-Source pin -- the pattern omnibase_infra and omnimarket's
+      # call-occ-preflight.yml already use, and the one context that is a
+      # required status check here ("occ-preflight / eligibility"). The
+      # heads/main re-check was a pure, broken duplicate of an
+      # already-required, already-passed check; this job now simply trusts
+      # that check's conclusion via the existing `needs:`/`if:` gate above
+      # instead of re-running its own resolution. The Python/uv setup steps
+      # that only existed to run that duplicate check are removed with it.
 
       - name: Enable auto-merge
         env:

--- a/tests/unit/validation/test_auto_merge_workflow_shape.py
+++ b/tests/unit/validation/test_auto_merge_workflow_shape.py
@@ -27,36 +27,45 @@ def _step(name: str) -> dict[str, object]:
     raise AssertionError(f"{name!r} step not found in auto-merge.yml")
 
 
-def test_auto_merge_uses_python_313() -> None:
-    step = _step("Set up Python 3.13")
-    assert step["with"]["python-version"] == "3.13"
+def _job() -> dict[str, object]:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    return data["jobs"]["auto-merge"]
 
 
-def test_auto_merge_pins_occ_before_preflight() -> None:
-    resolve_step = _step("Resolve OCC main SHA")
-    checkout_step = _step("Check out OCC evidence snapshot")
+def test_auto_merge_job_requires_occ_preflight_success() -> None:
+    # OMN-16288: the auto-merge job trusts the already-required
+    # "occ-preflight / eligibility" check's conclusion (resolved from the PR
+    # body's Evidence-Source pin by the shared occ-preflight.yml reusable --
+    # the same pattern omnibase_infra/omnimarket use) instead of re-resolving
+    # OCC eligibility itself. It must not run any step before that gate is
+    # satisfied.
+    job = _job()
 
-    assert "git/ref/heads/main" in resolve_step["run"]
-    assert checkout_step["with"]["ref"] == "${{ steps.occ_ref.outputs.sha }}"
+    assert "occ-preflight" in job["needs"]
+    assert "needs.occ-preflight.result == 'success'" in job["if"]
 
 
-def test_auto_merge_runs_occ_preflight_before_mutating_pr() -> None:
+def test_auto_merge_does_not_re_resolve_occ_against_heads_main() -> None:
+    # Regression guard for OMN-16288: this job previously re-resolved OCC
+    # eligibility by fetching onex_change_control@heads/main and re-running
+    # validator_occ_merge_eligibility against that checkout. Nothing promotes
+    # OCC's own contracts dev->main (OMN-15067), so OCC main is thousands of
+    # commits stale and that duplicate check failed permanently
+    # (eligible:false/missing_contract, e.g. OMN-16280 / run 32359138410) --
+    # it never gated arming (the job-level needs/if above already did), it
+    # only ever broke it. It must not come back.
     names = [step.get("name") for step in _steps()]
 
-    assert names.index("OCC auto-merge preflight") < names.index("Enable auto-merge")
-    assert names.index("OCC auto-merge preflight") < names.index(
-        "Enqueue armed PR and verify it entered the queue"
-    )
+    assert "Resolve OCC main SHA" not in names
+    assert "Check out OCC evidence snapshot" not in names
+    assert "OCC auto-merge preflight" not in names
+    assert "Set up Python 3.13" not in names
 
-
-def test_auto_merge_preflight_uses_single_pr_snapshot() -> None:
-    script = _step("OCC auto-merge preflight")["run"]
-
-    assert "gh pr view" in script
-    assert "--json body,title,headRefName,commits" in script
-    assert "omnibase_core.validation.validator_occ_merge_eligibility" in script
-    assert "--occ-commit-sha" in script
-    assert "--pr-body-file /tmp/pr_body.txt" in script
+    for step in _steps():
+        run = step.get("run", "")
+        if isinstance(run, str):
+            assert "onex_change_control/git/ref/heads/main" not in run
+            assert "validator_occ_merge_eligibility" not in run
 
 
 def test_enable_auto_merge_arms_bare_auto_not_squash() -> None:


### PR DESCRIPTION
## Summary

`auto-merge.yml`'s `occ-auto-merge-preflight` step re-resolved OCC eligibility by fetching `onex_change_control@heads/main` and re-running `validator_occ_merge_eligibility` against that checkout. Nothing promotes OCC's own ticket contracts `dev`->`main` (Tier-1 excluded from nightly-promote per OMN-15067), so OCC `main` is thousands of commits stale for ticket contracts and this step failed permanently with `eligible:false` / `missing_contract` for every recently-minted contract (live example: run 32359138410, OMN-16280).

This duplicate check never gated arming: the `auto-merge` job already requires `needs.occ-preflight.result == 'success'`, and that `occ-preflight` job calls the same `occ-preflight.yml` reusable that resolves OCC state from the PR body's Evidence-Source pin — the pattern `omnibase_infra` and `omnimarket` already use via `call-occ-preflight.yml`, and the one context that is actually a required status check here (`occ-preflight / eligibility`).

Fix: remove the redundant heads/main re-check (and the Python/uv setup steps that only existed to run it) and trust the already-required `occ-preflight` job's conclusion via the existing `needs:`/`if:` gate. Updated `tests/unit/validation/test_auto_merge_workflow_shape.py` assertions that referenced the removed steps.

**Scope boundary:** this is CI eligibility resolution only. It does not touch `grants/`, the prod-promotion `@main` grant-resolution anchor (`onex_change_control/grants/prod_promotion_grants.yaml`), or any prod-mutation gating — verified via diff review before push.

## Ticket

OMN-16288

dod_evidence: local gates green (ruff/mypy/pre-commit), full governed-selector local suite green (multiple runs across this lane), CI to be verified via `gh pr checks --watch` before merge.

## Test plan

- [x] `uv run ruff format` / `ruff check --fix` clean
- [x] `mypy --strict` clean
- [x] Updated workflow-shape unit tests (`tests/unit/validation/test_auto_merge_workflow_shape.py`) pass against the new step shape
- [x] Full local governed-selector suite green (multiple runs, most-advanced of concurrent lanes, see ledger)
- [ ] CI green via `gh pr checks --watch`
Evidence-Source: OCC#6793
Evidence-Ticket: OMN-16288