### PR TITLE
fix(OMN-16286): dependency-cascade base=dev, honest cascade evidence, provenance guard

### DIFF
--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -164,11 +164,47 @@ jobs:
       - name: Set branch and PR variables
         if: steps.token_check.outputs.has_token == 'true'
         id: vars
+        env:
+          # OMN-16286 (CodeRabbit finding, zizmor template-injection): these
+          # four inputs are threaded from release.yml's grep-extracted
+          # Evidence-Ticket/Evidence-Source pair, which is less trusted than
+          # a hardcoded workflow literal. Binding them through `env:` (a real
+          # process environment variable) instead of interpolating
+          # `${{ inputs.X }}` directly into this run body's bash text is the
+          # actual injection fix -- `env:` values are never template-expanded
+          # into the script, so they cannot terminate the shell context no
+          # matter what characters they contain. The explicit pattern
+          # validation below is defense-in-depth on top of that: only a
+          # value that already matches the documented safe shape for that
+          # field is allowed to flow into the branch name / PR title / PR
+          # body built in later steps.
+          RAW_VERSION: ${{ inputs.version }}
+          RAW_PACKAGE: ${{ inputs.package }}
+          RAW_TICKET: ${{ inputs.ticket }}
+          RAW_EVIDENCE_SOURCE: ${{ inputs.evidence_source }}
         run: |
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
-          PACKAGE="${{ inputs.package }}"
-          TICKET="${{ inputs.ticket }}"
+          VERSION="${RAW_VERSION#v}"
+          PACKAGE="$RAW_PACKAGE"
+          TICKET="$RAW_TICKET"
+          EVIDENCE_SOURCE="$RAW_EVIDENCE_SOURCE"
+
+          if ! [[ "$PACKAGE" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "::error::OMN-16286: inputs.package '${PACKAGE}' does not match the safe package-name pattern ^[A-Za-z0-9_-]+\$."
+            exit 1
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9.+-]*)?$ ]]; then
+            echo "::error::OMN-16286: inputs.version '${VERSION}' does not match the safe SemVer-ish pattern."
+            exit 1
+          fi
+          if ! [[ "$TICKET" =~ ^OMN-[0-9]+$ ]]; then
+            echo "::error::OMN-16286: inputs.ticket '${TICKET}' does not match the required ^OMN-[0-9]+\$ pattern."
+            exit 1
+          fi
+          if ! [[ "$EVIDENCE_SOURCE" =~ ^(OCC#[0-9]+|[0-9a-fA-F]{7,40})$ ]]; then
+            echo "::error::OMN-16286: inputs.evidence_source '${EVIDENCE_SOURCE}' does not match the required OCC#<n> or <hex-sha> pattern."
+            exit 1
+          fi
+
           # Use hyphenated package name for the branch (PyPI convention)
           PKG_HYPHEN="${PACKAGE//_/-}"
           # OMN-16286: the branch name must itself carry the ticket token --
@@ -180,6 +216,9 @@ jobs:
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "pkg_hyphen=$PKG_HYPHEN" >> $GITHUB_OUTPUT
+          echo "package=$PACKAGE" >> $GITHUB_OUTPUT
+          echo "ticket=$TICKET" >> $GITHUB_OUTPUT
+          echo "evidence_source=$EVIDENCE_SOURCE" >> $GITHUB_OUTPUT
 
       # OMN-16286 (ports omnibase_infra's own OMN-15604 AC4 guard verbatim --
       # single source of truth stays in omnibase_infra; this sparse-checks-out
@@ -195,58 +234,56 @@ jobs:
             scripts/check_dep_provenance.py
           sparse-checkout-cone-mode: false
 
-      - name: Create branch and upgrade lockfile
+      - name: Create branch
         if: steps.token_check.outputs.has_token == 'true'
+        env:
+          BRANCH: ${{ steps.vars.outputs.branch }}
         run: |
-          git checkout -b "${{ steps.vars.outputs.branch }}"
+          git checkout -b "$BRANCH"
 
-          # OMN-16286 / OMN-15604 AC4: `uv lock --upgrade-package` cannot move
-          # a [tool.uv.sources] git pin -- uv always prefers an explicit
-          # source override over registry resolution, so re-locking against
-          # the SAME override typically re-resolves to a byte-identical
-          # uv.lock. Left unchecked, the SKIP branch below would misreport
-          # that as "already on latest" when this repo is actually still
-          # stuck on the git pin (this is exactly what produced omniintelligence
-          # PR #827's untrustworthy ~54% full-file uv.lock rewrite). Fail loud
-          # and explicit BEFORE attempting the (guaranteed no-op / suspicious)
-          # lock, instead of after.
-          if ! python3 "${GITHUB_WORKSPACE}/_dep_provenance_gate/scripts/check_dep_provenance.py" \
+      # OMN-16286 / OMN-15604 AC4: `uv lock --upgrade-package` cannot move a
+      # [tool.uv.sources] git pin -- uv always prefers an explicit source
+      # override over registry resolution, so re-locking against the SAME
+      # override typically re-resolves to a byte-identical uv.lock. Left
+      # unchecked, the SKIP check below would misreport that as "already on
+      # latest" when this repo is actually still stuck on the git pin (this
+      # is exactly what produced omniintelligence PR #827's untrustworthy
+      # ~54% full-file uv.lock rewrite). Fail loud and explicit BEFORE
+      # attempting the (guaranteed no-op / suspicious) lock, instead of after.
+      - name: Check dependency is movable
+        if: steps.token_check.outputs.has_token == 'true'
+        env:
+          PKG_HYPHEN: ${{ steps.vars.outputs.pkg_hyphen }}
+          REPO_NAME: ${{ matrix.repo }}
+        run: |
+          if ! uv run python "${GITHUB_WORKSPACE}/_dep_provenance_gate/scripts/check_dep_provenance.py" \
             --pyproject pyproject.toml \
-            --check-movable "${{ steps.vars.outputs.pkg_hyphen }}"; then
-            echo "::error::Dependency cascade cannot move ${{ steps.vars.outputs.pkg_hyphen }} in ${{ matrix.repo }} -- it is pinned via a [tool.uv.sources] git override. 'uv lock --upgrade-package' will silently re-resolve against the SAME override and report no lockfile change, masking a no-op cascade (OMN-15604). Remove the [tool.uv.sources] override for ${{ steps.vars.outputs.pkg_hyphen }} in ${{ matrix.repo }}'s pyproject.toml first, then re-run this cascade."
+            --check-movable "$PKG_HYPHEN"; then
+            echo "::error::Dependency cascade cannot move ${PKG_HYPHEN} in ${REPO_NAME} -- it is pinned via a [tool.uv.sources] git override. 'uv lock --upgrade-package' will silently re-resolve against the SAME override and report no lockfile change, masking a no-op cascade (OMN-15604). Remove the [tool.uv.sources] override for ${PKG_HYPHEN} in ${REPO_NAME}'s pyproject.toml first, then re-run this cascade."
             exit 1
           fi
 
-          # Upgrade the package in the lockfile
-          uv lock --upgrade-package "${{ inputs.package }}"
-
-          # Check if anything changed
-          if git diff --quiet uv.lock; then
-            echo "SKIP=true" >> $GITHUB_ENV
-            echo "No lockfile changes -- ${{ matrix.repo }} already on latest ${{ inputs.package }}"
-          else
-            echo "SKIP=false" >> $GITHUB_ENV
-            echo "Lockfile updated with new ${{ inputs.package }} version"
-          fi
-
-      # OMN-16286: keep an exact pyproject.toml pin (`==X.Y.Z`) in sync with
-      # the lockfile the step above just bumped. A downstream repo that pins
-      # exactly (e.g. omnibase_infra's `omnibase-core==0.46.8`) otherwise ends
-      # up with a lockfile and a pin that silently disagree the moment this
-      # cascade lands (observed live on infra#2805). A repo with a
-      # range/no pin is untouched -- the regex only matches an exact pin for
-      # this package.
+      # OMN-16286 (CodeRabbit finding): keep an exact pyproject.toml pin
+      # (`==X.Y.Z`) in sync with the lockfile BEFORE running
+      # `uv lock --upgrade-package`, not after. `uv lock --upgrade-package`
+      # cannot select a version outside an exact `==` requirement in
+      # pyproject.toml -- if the pin stays stale, the lock step below
+      # silently re-resolves to the SAME old version and the SKIP check
+      # would misreport "already on latest" even though the repo is still
+      # pinned old. A downstream repo that pins exactly (e.g. omnibase_infra's
+      # `omnibase-core==0.46.8`) otherwise ends up with a lockfile and a pin
+      # that silently disagree the moment this cascade lands (observed live
+      # on infra#2805). A repo with a range/no pin is untouched -- the regex
+      # only matches an exact pin for this package.
       - name: Update pyproject.toml pin
-        if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
+        if: steps.token_check.outputs.has_token == 'true'
         env:
-          BUMP_PACKAGE: ${{ inputs.package }}
+          PKG_HYPHEN: ${{ steps.vars.outputs.pkg_hyphen }}
+          RESOLVED: ${{ steps.vars.outputs.version }}
         run: |
-          PKG_HYPHEN="${BUMP_PACKAGE//_/-}"
-          RESOLVED="${{ steps.vars.outputs.version }}"
-          export PKG_HYPHEN RESOLVED
           echo "Pinned version for ${PKG_HYPHEN}: ${RESOLVED}"
 
-          python3 - <<'PYEOF'
+          uv run python - <<'PYEOF'
           import re, os
           pkg = os.environ["PKG_HYPHEN"]
           version = os.environ["RESOLVED"]
@@ -259,46 +296,74 @@ jobs:
           open("pyproject.toml", "w").write(updated)
           PYEOF
 
+      - name: Upgrade lockfile
+        if: steps.token_check.outputs.has_token == 'true'
+        env:
+          BUMP_PACKAGE: ${{ steps.vars.outputs.package }}
+          REPO_NAME: ${{ matrix.repo }}
+        run: |
+          # Upgrade the package in the lockfile. pyproject.toml's exact pin
+          # (if any) was already brought forward by the previous step, so
+          # this can now actually resolve to the new version instead of
+          # being capped by a stale `==` requirement.
+          uv lock --upgrade-package "$BUMP_PACKAGE"
+
+          # Check if anything changed in either file -- a pin-only bump with
+          # no lockfile delta (or vice versa) is still a real change to land.
+          if git diff --quiet uv.lock pyproject.toml; then
+            echo "SKIP=true" >> $GITHUB_ENV
+            echo "No lockfile/pin changes -- ${REPO_NAME} already on latest ${BUMP_PACKAGE}"
+          else
+            echo "SKIP=false" >> $GITHUB_ENV
+            echo "Lockfile/pin updated with new ${BUMP_PACKAGE} version"
+          fi
+
       - name: Commit and push
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
+        env:
+          BUMP_PACKAGE: ${{ steps.vars.outputs.package }}
+          RESOLVED: ${{ steps.vars.outputs.version }}
+          BRANCH: ${{ steps.vars.outputs.branch }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add uv.lock pyproject.toml
-          git commit -m "chore(deps): bump ${{ inputs.package }} to ${{ steps.vars.outputs.version }}
+          git commit -m "chore(deps): bump ${BUMP_PACKAGE} to ${RESOLVED}
 
-          Automated dependency cascade from ${{ github.repository }} release ${{ inputs.version }}.
+          Automated dependency cascade from ${{ github.repository }} release ${RESOLVED}.
 
           Triggered-by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          git push origin "${{ steps.vars.outputs.branch }}"
+          git push origin "$BRANCH"
 
       - name: Open pull request
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
         env:
           GH_TOKEN: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+          REPO_NAME: ${{ matrix.repo }}
+          BRANCH: ${{ steps.vars.outputs.branch }}
         run: |
           # Check if a PR already exists for this branch
           EXISTING=$(gh pr list \
-            --repo "OmniNode-ai/${{ matrix.repo }}" \
-            --head "${{ steps.vars.outputs.branch }}" \
+            --repo "OmniNode-ai/${REPO_NAME}" \
+            --head "$BRANCH" \
             --state open \
             --json number \
             --jq 'length')
 
           if [ "$EXISTING" -gt 0 ]; then
-            echo "PR already exists for branch ${{ steps.vars.outputs.branch }} -- skipping"
+            echo "PR already exists for branch ${BRANCH} -- skipping"
             exit 0
           fi
 
           gh pr create \
-            --repo "OmniNode-ai/${{ matrix.repo }}" \
-            --title "chore(deps): bump ${{ steps.vars.outputs.pkg_hyphen }} to ${{ steps.vars.outputs.version }} (${{ inputs.ticket }})" \
+            --repo "OmniNode-ai/${REPO_NAME}" \
+            --title "chore(deps): bump ${{ steps.vars.outputs.pkg_hyphen }} to ${{ steps.vars.outputs.version }} (${{ steps.vars.outputs.ticket }})" \
             --body "$(cat <<'PREOF'
           ## Summary
 
-          Automated dependency bump triggered by a new release of `${{ inputs.package }}` (${{ inputs.version }}).
+          Automated dependency bump triggered by a new release of `${{ steps.vars.outputs.package }}` (${{ steps.vars.outputs.version }}).
 
-          - Updates `uv.lock` via `uv lock --upgrade-package ${{ inputs.package }}`
+          - Updates `uv.lock` via `uv lock --upgrade-package ${{ steps.vars.outputs.package }}`
           - Updates `pyproject.toml` exact pin (`==X.Y.Z`) to match, when this repo pins that exactly
           - No other source code changes
 
@@ -310,8 +375,8 @@ jobs:
           already proved the released package version -- reused honestly rather
           than fabricated or exempted:
 
-          - Source repo: `OmniNode-ai/${{ inputs.package }}`
-          - Released version: `${{ inputs.version }}`
+          - Source repo: `OmniNode-ai/${{ steps.vars.outputs.package }}`
+          - Released version: `${{ steps.vars.outputs.version }}`
 
           ## Triggered by
 
@@ -322,17 +387,20 @@ jobs:
           - [ ] CI passes (lockfile resolution is valid)
           - [ ] Downstream tests pass with the new dependency version
 
-          Evidence-Ticket: ${{ inputs.ticket }}
-          Evidence-Source: ${{ inputs.evidence_source }}
+          Evidence-Ticket: ${{ steps.vars.outputs.ticket }}
+          Evidence-Source: ${{ steps.vars.outputs.evidence_source }}
           PREOF
           )" \
-            --head "${{ steps.vars.outputs.branch }}" \
+            --head "$BRANCH" \
             --base dev
 
       - name: Skip summary
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'true'
+        env:
+          REPO_NAME: ${{ matrix.repo }}
+          BUMP_PACKAGE: ${{ steps.vars.outputs.package }}
         run: |
-          echo "### Skipped: ${{ matrix.repo }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Skipped: ${REPO_NAME}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "${{ matrix.repo }} already uses the latest version of ${{ inputs.package }}." >> $GITHUB_STEP_SUMMARY
+          echo "${REPO_NAME} already uses the latest version of ${BUMP_PACKAGE}." >> $GITHUB_STEP_SUMMARY
           echo "No lockfile changes needed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -31,6 +31,26 @@ on:
         description: 'Released version tag (e.g. v0.11.0)'
         required: true
         type: string
+      ticket:
+        description: >-
+          OMN ticket that closed the release being cascaded (OMN-16286).
+          Threaded verbatim into the PR title/branch/body of every downstream
+          bump PR this workflow opens so Receipt-Gate's identity binding
+          (title <-> branch <-> Evidence-Ticket) resolves honestly. Must be
+          the SAME ticket paired with `evidence_source` below.
+        required: true
+        type: string
+      evidence_source:
+        description: >-
+          Evidence-Source value (OCC#<n> or a merged OCC commit SHA) that
+          already proved the released package version (OMN-16286). Re-cited
+          verbatim as this PR's own `Evidence-Source:` line -- a cascade PR
+          carries no new testing of its own beyond this repo's CI against the
+          new lockfile, so it honestly reuses the evidence that proved the
+          release rather than fabricating new evidence or claiming an
+          exemption.
+        required: true
+        type: string
     secrets:
       cross-repo-pat:
         description: >-
@@ -47,6 +67,14 @@ on:
         type: string
       version:
         description: 'Released version tag (e.g. v0.11.0)'
+        required: true
+        type: string
+      ticket:
+        description: 'OMN ticket that closed the release being cascaded (OMN-16286), e.g. OMN-15449.'
+        required: true
+        type: string
+      evidence_source:
+        description: 'Evidence-Source that already proved the release (OMN-16286), e.g. OCC#6695.'
         required: true
         type: string
 
@@ -140,17 +168,54 @@ jobs:
           VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
           PACKAGE="${{ inputs.package }}"
+          TICKET="${{ inputs.ticket }}"
           # Use hyphenated package name for the branch (PyPI convention)
           PKG_HYPHEN="${PACKAGE//_/-}"
-          BRANCH="automation/bump-${PKG_HYPHEN}-${VERSION}"
+          # OMN-16286: the branch name must itself carry the ticket token --
+          # Receipt-Gate's identity binding checks title, branch, and
+          # Evidence-Ticket all reference the same OMN-<n> (case-insensitive,
+          # token-bounded match).
+          TICKET_SLUG="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"
+          BRANCH="automation/bump-${PKG_HYPHEN}-${VERSION}-${TICKET_SLUG}"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "pkg_hyphen=$PKG_HYPHEN" >> $GITHUB_OUTPUT
+
+      # OMN-16286 (ports omnibase_infra's own OMN-15604 AC4 guard verbatim --
+      # single source of truth stays in omnibase_infra; this sparse-checks-out
+      # only the one script into a side directory so it does not disturb the
+      # downstream repo's own checkout above).
+      - name: Checkout omnibase_infra dep-provenance script
+        if: steps.token_check.outputs.has_token == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: OmniNode-ai/omnibase_infra
+          path: _dep_provenance_gate
+          sparse-checkout: |
+            scripts/check_dep_provenance.py
+          sparse-checkout-cone-mode: false
 
       - name: Create branch and upgrade lockfile
         if: steps.token_check.outputs.has_token == 'true'
         run: |
           git checkout -b "${{ steps.vars.outputs.branch }}"
+
+          # OMN-16286 / OMN-15604 AC4: `uv lock --upgrade-package` cannot move
+          # a [tool.uv.sources] git pin -- uv always prefers an explicit
+          # source override over registry resolution, so re-locking against
+          # the SAME override typically re-resolves to a byte-identical
+          # uv.lock. Left unchecked, the SKIP branch below would misreport
+          # that as "already on latest" when this repo is actually still
+          # stuck on the git pin (this is exactly what produced omniintelligence
+          # PR #827's untrustworthy ~54% full-file uv.lock rewrite). Fail loud
+          # and explicit BEFORE attempting the (guaranteed no-op / suspicious)
+          # lock, instead of after.
+          if ! python3 "${GITHUB_WORKSPACE}/_dep_provenance_gate/scripts/check_dep_provenance.py" \
+            --pyproject pyproject.toml \
+            --check-movable "${{ steps.vars.outputs.pkg_hyphen }}"; then
+            echo "::error::Dependency cascade cannot move ${{ steps.vars.outputs.pkg_hyphen }} in ${{ matrix.repo }} -- it is pinned via a [tool.uv.sources] git override. 'uv lock --upgrade-package' will silently re-resolve against the SAME override and report no lockfile change, masking a no-op cascade (OMN-15604). Remove the [tool.uv.sources] override for ${{ steps.vars.outputs.pkg_hyphen }} in ${{ matrix.repo }}'s pyproject.toml first, then re-run this cascade."
+            exit 1
+          fi
 
           # Upgrade the package in the lockfile
           uv lock --upgrade-package "${{ inputs.package }}"
@@ -164,12 +229,42 @@ jobs:
             echo "Lockfile updated with new ${{ inputs.package }} version"
           fi
 
+      # OMN-16286: keep an exact pyproject.toml pin (`==X.Y.Z`) in sync with
+      # the lockfile the step above just bumped. A downstream repo that pins
+      # exactly (e.g. omnibase_infra's `omnibase-core==0.46.8`) otherwise ends
+      # up with a lockfile and a pin that silently disagree the moment this
+      # cascade lands (observed live on infra#2805). A repo with a
+      # range/no pin is untouched -- the regex only matches an exact pin for
+      # this package.
+      - name: Update pyproject.toml pin
+        if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
+        env:
+          BUMP_PACKAGE: ${{ inputs.package }}
+        run: |
+          PKG_HYPHEN="${BUMP_PACKAGE//_/-}"
+          RESOLVED="${{ steps.vars.outputs.version }}"
+          export PKG_HYPHEN RESOLVED
+          echo "Pinned version for ${PKG_HYPHEN}: ${RESOLVED}"
+
+          python3 - <<'PYEOF'
+          import re, os
+          pkg = os.environ["PKG_HYPHEN"]
+          version = os.environ["RESOLVED"]
+          content = open("pyproject.toml").read()
+          updated = re.sub(
+              r'"' + re.escape(pkg) + r'==[0-9]+\.[0-9]+\.[0-9]+"',
+              f'"{pkg}=={version}"',
+              content,
+          )
+          open("pyproject.toml", "w").write(updated)
+          PYEOF
+
       - name: Commit and push
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add uv.lock
+          git add uv.lock pyproject.toml
           git commit -m "chore(deps): bump ${{ inputs.package }} to ${{ steps.vars.outputs.version }}
 
           Automated dependency cascade from ${{ github.repository }} release ${{ inputs.version }}.
@@ -197,14 +292,26 @@ jobs:
 
           gh pr create \
             --repo "OmniNode-ai/${{ matrix.repo }}" \
-            --title "chore(deps): bump ${{ steps.vars.outputs.pkg_hyphen }} to ${{ steps.vars.outputs.version }}" \
+            --title "chore(deps): bump ${{ steps.vars.outputs.pkg_hyphen }} to ${{ steps.vars.outputs.version }} (${{ inputs.ticket }})" \
             --body "$(cat <<'PREOF'
           ## Summary
 
           Automated dependency bump triggered by a new release of `${{ inputs.package }}` (${{ inputs.version }}).
 
           - Updates `uv.lock` via `uv lock --upgrade-package ${{ inputs.package }}`
-          - No source code changes -- lockfile only
+          - Updates `pyproject.toml` exact pin (`==X.Y.Z`) to match, when this repo pins that exactly
+          - No other source code changes
+
+          ## Cascade provenance (OMN-16286)
+
+          This PR carries no dedicated testing of its own beyond this repo's own
+          CI running against the new lockfile. Its cited evidence below is the
+          upstream release's own Evidence-Ticket/Evidence-Source pair, which
+          already proved the released package version -- reused honestly rather
+          than fabricated or exempted:
+
+          - Source repo: `OmniNode-ai/${{ inputs.package }}`
+          - Released version: `${{ inputs.version }}`
 
           ## Triggered by
 
@@ -214,10 +321,13 @@ jobs:
 
           - [ ] CI passes (lockfile resolution is valid)
           - [ ] Downstream tests pass with the new dependency version
+
+          Evidence-Ticket: ${{ inputs.ticket }}
+          Evidence-Source: ${{ inputs.evidence_source }}
           PREOF
           )" \
             --head "${{ steps.vars.outputs.branch }}" \
-            --base main
+            --base dev
 
       - name: Skip summary
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,17 @@ jobs:
     # needs the self-hosted runner; it moves to a GitHub-hosted runner whose
     # egress clears the deadline (AC2).
     runs-on: ubuntu-latest
+    # OMN-16286: job-level override (job-level permissions REPLACE, not add
+    # to, the workflow-level block above) so this job can additionally read
+    # the release commit's merged PR + body via `gh` to resolve real cascade
+    # evidence below.
+    permissions:
+      contents: write
+      pull-requests: read
     outputs:
       version: ${{ steps.tag.outputs.tag }}
+      ticket: ${{ steps.release_evidence.outputs.ticket }}
+      evidence_source: ${{ steps.release_evidence.outputs.evidence_source }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -98,6 +107,45 @@ jobs:
           else
             echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
           fi
+
+      # OMN-16286: the Dependency Cascade job below opens a bump PR in every
+      # downstream repo. Those PRs previously carried no ticket and no
+      # Evidence-Source, so Receipt-Gate / occ-preflight hard-failed on every
+      # single one (no cascade PR could land anywhere without manual
+      # intervention). Rather than fabricate new evidence or add a bot
+      # exemption (both explicitly rejected -- OMN-16286), re-thread the SAME
+      # real Evidence-Ticket/Evidence-Source pair that already closed the
+      # release's own merged PR: that evidence is what actually proved this
+      # released code, and the cascade PRs are honestly downstream of it. Fail
+      # loud rather than open unlandable cascade PRs again when the tagged
+      # commit has no resolvable merged PR or evidence pair.
+      - name: Resolve release ticket + evidence (OMN-16286)
+        id: release_evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD)"
+
+          pr_number="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/pulls" --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -z "$pr_number" ]; then
+            echo "::error::OMN-16286: could not resolve a merged PR for release commit ${head_sha}. The dependency cascade requires a real Evidence-Ticket/Evidence-Source pair sourced from the release's own merged PR; a tag with no associated PR cannot cascade honestly."
+            exit 1
+          fi
+
+          pr_body="$(gh pr view "$pr_number" --repo "${{ github.repository }}" --json body --jq '.body' 2>/dev/null || true)"
+
+          ticket="$(printf '%s' "$pr_body" | grep -oiE '^Evidence-Ticket:[[:space:]]*OMN-[0-9]+' | head -1 | grep -oiE 'OMN-[0-9]+' | tr '[:lower:]' '[:upper:]' || true)"
+          evidence_source="$(printf '%s' "$pr_body" | grep -iE '^Evidence-Source:[[:space:]]+\S' | head -1 | sed -E 's/^Evidence-Source:[[:space:]]*//; s/[[:space:]]+$//' || true)"
+
+          if [ -z "$ticket" ] || [ -z "$evidence_source" ]; then
+            echo "::error::OMN-16286: release PR #${pr_number} (commit ${head_sha}) is missing a resolvable Evidence-Ticket/Evidence-Source pair (ticket='${ticket:-<none>}', evidence_source='${evidence_source:-<none>}'). Fix the release PR's evidence trailer, or release from a properly evidenced commit, before the dependency cascade can open honest downstream PRs."
+            exit 1
+          fi
+
+          echo "ticket=${ticket}" >> "$GITHUB_OUTPUT"
+          echo "evidence_source=${evidence_source}" >> "$GITHUB_OUTPUT"
+          echo "::notice::OMN-16286: resolved cascade evidence from PR #${pr_number} -- ticket=${ticket} evidence_source=${evidence_source}"
 
       # OMN-15603 (AC4): preserve the built artifacts BEFORE publishing. Run
       # 30674223657 ended with total_count=0 artifacts, so the only way to
@@ -203,6 +251,8 @@ jobs:
     with:
       package: omnibase_core
       version: ${{ needs.release.outputs.version }}
+      ticket: ${{ needs.release.outputs.ticket }}
+      evidence_source: ${{ needs.release.outputs.evidence_source }}
     secrets:
       cross-repo-pat: ${{ secrets.CROSS_REPO_PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,9 +127,24 @@ jobs:
           set -euo pipefail
           head_sha="$(git rev-parse HEAD)"
 
-          pr_number="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/pulls" --jq '.[0].number // empty' 2>/dev/null || true)"
+          # OMN-16286 (CodeRabbit finding): /commits/{sha}/pulls returns EVERY
+          # PR associated with this commit, not just the merged one -- GitHub
+          # includes open PRs too when the commit isn't yet on the default
+          # branch, and the endpoint documents no ordering guarantee. Selecting
+          # a bare .[0] risked propagating evidence from an open, unreviewed PR
+          # instead of the merged release PR that actually proved this code.
+          # Filter to state=="closed" && mergedAt != null explicitly and fail
+          # loud if none qualifies.
+          pr_number="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/pulls" \
+            --jq '[.[] | select(.state == "closed" and .merged_at != null)][0].number // empty' 2>/dev/null || true)"
           if [ -z "$pr_number" ]; then
-            echo "::error::OMN-16286: could not resolve a merged PR for release commit ${head_sha}. The dependency cascade requires a real Evidence-Ticket/Evidence-Source pair sourced from the release's own merged PR; a tag with no associated PR cannot cascade honestly."
+            echo "::error::OMN-16286: could not resolve a MERGED PR for release commit ${head_sha}. The dependency cascade requires a real Evidence-Ticket/Evidence-Source pair sourced from the release's own merged PR; a tag with no associated merged PR (only open/unmerged ones, or none at all) cannot cascade honestly."
+            exit 1
+          fi
+
+          pr_state="$(gh pr view "$pr_number" --repo "${{ github.repository }}" --json state --jq '.state' 2>/dev/null || true)"
+          if [ "$pr_state" != "MERGED" ]; then
+            echo "::error::OMN-16286: PR #${pr_number} (commit ${head_sha}) resolved to state='${pr_state:-<unknown>}', not MERGED. Refusing to propagate evidence from a non-merged PR."
             exit 1
           fi
 

--- a/tests/scripts/test_dependency_cascade_matrix.py
+++ b/tests/scripts/test_dependency_cascade_matrix.py
@@ -108,3 +108,151 @@ def test_omnibase_spi_and_infra_exclude_ccc() -> None:
     assert "onex_change_control" not in mapping.get("omnibase_infra", []), (
         "ccc does not depend on omnibase-infra; see onex_change_control/pyproject.toml"
     )
+
+
+# ---------------------------------------------------------------------------
+# OMN-16286: three confirmed bugs in the `open-bump-pr` job.
+#
+# 1. `--base main` was hardcoded, but every downstream repo's default branch
+#    (and the branch the job checks out) is `dev` -- the cascade PR diffed
+#    the entire dev-vs-main divergence and violated dev-only-promotion policy.
+# 2. Cascade PR titles/branches/bodies carried no OMN ticket and no
+#    Evidence-Source, so Receipt-Gate's identity-binding check (title <->
+#    branch <-> Evidence-Ticket, all four axes) hard-failed on every PR this
+#    workflow opened -- unlandable anywhere without manual intervention.
+# 3. No `check_dep_provenance.py --check-movable` guard (omnibase_infra's own
+#    copy has had one since OMN-15604), so `uv lock --upgrade-package`
+#    against a `[tool.uv.sources]` git-overridden pin silently produced a
+#    suspicious full-file uv.lock rewrite instead of failing loud.
+# ---------------------------------------------------------------------------
+
+
+def _job_body() -> dict[str, object]:
+    with WORKFLOW_PATH.open() as fh:
+        doc = yaml.safe_load(fh)
+    jobs = doc["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs["open-bump-pr"]
+    assert isinstance(job, dict)
+    return job
+
+
+def _step_run(step_name: str) -> str:
+    job = _job_body()
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            run = step.get("run", "")
+            assert isinstance(run, str)
+            return run
+    raise AssertionError(
+        f"open-bump-pr job has no step named {step_name!r}; steps present: "
+        f"{[s.get('name') for s in steps if isinstance(s, dict)]}"
+    )
+
+
+@pytest.mark.unit
+def test_open_pull_request_targets_dev_not_main() -> None:
+    """Bug 1: downstream branches are cut from dev, so the PR must target dev."""
+    script = _step_run("Open pull request")
+    assert "--base dev" in script, script
+    assert "--base main" not in script, (
+        "cascade PRs must never target main -- downstream repos' default "
+        f"branch is dev, and diffing dev-vs-main is the OMN-16286 bug: {script}"
+    )
+
+
+@pytest.mark.unit
+def test_workflow_call_requires_ticket_and_evidence_source() -> None:
+    """Bug 2: the caller (release.yml) must supply real, non-optional evidence."""
+    with WORKFLOW_PATH.open() as fh:
+        doc = yaml.safe_load(fh)
+    on_block = doc[True] if True in doc else doc["on"]
+    call_inputs = on_block["workflow_call"]["inputs"]
+    dispatch_inputs = on_block["workflow_dispatch"]["inputs"]
+
+    for inputs in (call_inputs, dispatch_inputs):
+        assert inputs["ticket"]["required"] is True, inputs["ticket"]
+        assert inputs["ticket"]["type"] == "string"
+        assert inputs["evidence_source"]["required"] is True, inputs["evidence_source"]
+        assert inputs["evidence_source"]["type"] == "string"
+
+
+@pytest.mark.unit
+def test_pr_title_branch_and_body_all_carry_the_same_ticket() -> None:
+    """Bug 2: Receipt-Gate's identity binding requires title, branch, and
+    Evidence-Ticket to all reference the same OMN-<n> (validator_receipt_gate
+    ``_verify_ticket_identity``, axes 1 + 2). A branch or title with no ticket
+    token can never satisfy that check, however honest the PR body is.
+    """
+    vars_script = _step_run("Set branch and PR variables")
+    assert "inputs.ticket" in vars_script, vars_script
+    assert 'BRANCH="automation/bump-${PKG_HYPHEN}-${VERSION}-${TICKET_SLUG}"' in (
+        vars_script
+    ), vars_script
+
+    open_pr_script = _step_run("Open pull request")
+    assert "(${{ inputs.ticket }})" in open_pr_script, open_pr_script
+
+
+@pytest.mark.unit
+def test_pr_body_cites_evidence_ticket_and_evidence_source() -> None:
+    """Bug 2: Receipt-Gate hard-requires an `Evidence-Source:` body line, and
+    (once present) a paired `Evidence-Ticket:` line -- both must resolve to
+    the real upstream release evidence, not be fabricated or omitted.
+    """
+    script = _step_run("Open pull request")
+    assert "Evidence-Ticket: ${{ inputs.ticket }}" in script, script
+    assert "Evidence-Source: ${{ inputs.evidence_source }}" in script, script
+
+
+@pytest.mark.unit
+def test_check_dep_provenance_movable_guard_runs_before_uv_lock() -> None:
+    """Bug 3: fail loud on a git-source-overridden pin instead of silently
+    re-resolving to a no-op (or, worse, a suspicious full-file rewrite --
+    see the omniintelligence#827 incident this guard exists to prevent).
+    """
+    job = _job_body()
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    names = [s.get("name") for s in steps if isinstance(s, dict)]
+    assert "Checkout omnibase_infra dep-provenance script" in names, names
+
+    checkout_idx = names.index("Checkout omnibase_infra dep-provenance script")
+    lockfile_idx = names.index("Create branch and upgrade lockfile")
+    assert checkout_idx < lockfile_idx, (
+        "the provenance script must be checked out before the step that "
+        f"invokes it: {names}"
+    )
+
+    lockfile_script = _step_run("Create branch and upgrade lockfile")
+    assert "check_dep_provenance.py" in lockfile_script, lockfile_script
+    assert "--check-movable" in lockfile_script, lockfile_script
+    guard_pos = lockfile_script.index("check_dep_provenance.py")
+    # The actual invocation, not the explanatory comment above it (which also
+    # contains this substring) -- anchor on the real command's argument.
+    lock_pos = lockfile_script.index(
+        'uv lock --upgrade-package "${{ inputs.package }}"'
+    )
+    assert guard_pos < lock_pos, (
+        "the movable guard must run BEFORE `uv lock --upgrade-package`, not "
+        f"after: {lockfile_script}"
+    )
+
+
+@pytest.mark.unit
+def test_pyproject_pin_kept_in_sync_with_lockfile_bump() -> None:
+    """Implied by the OMN-16286 remediation instructions: a downstream repo
+    that pins this package exactly (e.g. omnibase_infra's
+    `omnibase-core==0.46.8`) must not be left with a lockfile and a pin that
+    silently disagree (the live infra#2805 gap this closes).
+    """
+    job = _job_body()
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    names = [s.get("name") for s in steps if isinstance(s, dict)]
+    assert "Update pyproject.toml pin" in names, names
+
+    commit_script = _step_run("Commit and push")
+    assert "git add uv.lock pyproject.toml" in commit_script, commit_script

--- a/tests/scripts/test_dependency_cascade_matrix.py
+++ b/tests/scripts/test_dependency_cascade_matrix.py
@@ -179,6 +179,21 @@ def test_workflow_call_requires_ticket_and_evidence_source() -> None:
         assert inputs["evidence_source"]["type"] == "string"
 
 
+def _step_env(step_name: str) -> dict[str, object]:
+    job = _job_body()
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            env = step.get("env", {})
+            assert isinstance(env, dict)
+            return env
+    raise AssertionError(
+        f"open-bump-pr job has no step named {step_name!r}; steps present: "
+        f"{[s.get('name') for s in steps if isinstance(s, dict)]}"
+    )
+
+
 @pytest.mark.unit
 def test_pr_title_branch_and_body_all_carry_the_same_ticket() -> None:
     """Bug 2: Receipt-Gate's identity binding requires title, branch, and
@@ -186,14 +201,16 @@ def test_pr_title_branch_and_body_all_carry_the_same_ticket() -> None:
     ``_verify_ticket_identity``, axes 1 + 2). A branch or title with no ticket
     token can never satisfy that check, however honest the PR body is.
     """
+    vars_env = _step_env("Set branch and PR variables")
+    assert vars_env.get("RAW_TICKET") == "${{ inputs.ticket }}", vars_env
     vars_script = _step_run("Set branch and PR variables")
-    assert "inputs.ticket" in vars_script, vars_script
     assert 'BRANCH="automation/bump-${PKG_HYPHEN}-${VERSION}-${TICKET_SLUG}"' in (
         vars_script
     ), vars_script
+    assert 'echo "ticket=$TICKET" >> $GITHUB_OUTPUT' in vars_script, vars_script
 
     open_pr_script = _step_run("Open pull request")
-    assert "(${{ inputs.ticket }})" in open_pr_script, open_pr_script
+    assert "(${{ steps.vars.outputs.ticket }})" in open_pr_script, open_pr_script
 
 
 @pytest.mark.unit
@@ -203,8 +220,63 @@ def test_pr_body_cites_evidence_ticket_and_evidence_source() -> None:
     the real upstream release evidence, not be fabricated or omitted.
     """
     script = _step_run("Open pull request")
-    assert "Evidence-Ticket: ${{ inputs.ticket }}" in script, script
-    assert "Evidence-Source: ${{ inputs.evidence_source }}" in script, script
+    assert "Evidence-Ticket: ${{ steps.vars.outputs.ticket }}" in script, script
+    assert "Evidence-Source: ${{ steps.vars.outputs.evidence_source }}" in script, (
+        script
+    )
+
+
+@pytest.mark.unit
+def test_workflow_inputs_are_validated_before_use() -> None:
+    """CodeRabbit finding (template-injection, zizmor): `inputs.ticket` /
+    `inputs.evidence_source` / `inputs.package` / `inputs.version` are
+    threaded from release.yml's grep-extracted PR-body values, which are
+    less trusted than a hardcoded workflow literal. They must be bound
+    through `env:` (never template-expanded directly into a `run:` body)
+    and validated against a strict safe-charset pattern before any
+    downstream step reuses them in a branch name, PR title, or PR body.
+    """
+    vars_env = _step_env("Set branch and PR variables")
+    for key in ("RAW_VERSION", "RAW_PACKAGE", "RAW_TICKET", "RAW_EVIDENCE_SOURCE"):
+        assert key in vars_env, vars_env
+
+    vars_script = _step_run("Set branch and PR variables")
+    assert '"$PACKAGE" =~ ^[A-Za-z0-9_-]+$' in vars_script, vars_script
+    assert '"$TICKET" =~ ^OMN-[0-9]+$' in vars_script, vars_script
+    assert '"$EVIDENCE_SOURCE" =~ ^(OCC#[0-9]+|[0-9a-fA-F]{7,40})$' in vars_script, (
+        vars_script
+    )
+    # Every validation branch must fail loud, not warn-and-continue.
+    assert vars_script.count("exit 1") >= 4, vars_script
+
+    # No step in this job may template-expand a raw `inputs.*` value
+    # directly into a run body -- only the compute-matrix job's own
+    # closed-set `case` statement (never executed as a shell subcommand)
+    # is exempt.
+    job = _job_body()
+    job_steps = job["steps"]
+    assert isinstance(job_steps, list)
+    for step in job_steps:
+        if not isinstance(step, dict):
+            continue
+        run = step.get("run", "")
+        if isinstance(run, str):
+            assert "${{ inputs." not in run, (
+                step.get("name"),
+                run,
+            )
+
+
+@pytest.mark.unit
+def test_python_invocations_use_uv_run() -> None:
+    """Coding guideline: run all Python commands through `uv run`, never a
+    bare `python3` / `python` interpreter (CodeRabbit finding).
+    """
+    content = WORKFLOW_PATH.read_text()
+    assert re.search(r"(?<!uv run )\bpython3\b", content) is None, (
+        "bare `python3` invocation found; use `uv run python` instead"
+    )
+    assert "uv run python" in content
 
 
 @pytest.mark.unit
@@ -218,27 +290,23 @@ def test_check_dep_provenance_movable_guard_runs_before_uv_lock() -> None:
     assert isinstance(steps, list)
     names = [s.get("name") for s in steps if isinstance(s, dict)]
     assert "Checkout omnibase_infra dep-provenance script" in names, names
+    assert "Check dependency is movable" in names, names
+    assert "Upgrade lockfile" in names, names
 
     checkout_idx = names.index("Checkout omnibase_infra dep-provenance script")
-    lockfile_idx = names.index("Create branch and upgrade lockfile")
-    assert checkout_idx < lockfile_idx, (
-        "the provenance script must be checked out before the step that "
-        f"invokes it: {names}"
+    guard_idx = names.index("Check dependency is movable")
+    lockfile_idx = names.index("Upgrade lockfile")
+    assert checkout_idx < guard_idx < lockfile_idx, (
+        "the provenance script must be checked out, then the movable guard "
+        f"must run, then the lockfile upgrade: {names}"
     )
 
-    lockfile_script = _step_run("Create branch and upgrade lockfile")
-    assert "check_dep_provenance.py" in lockfile_script, lockfile_script
-    assert "--check-movable" in lockfile_script, lockfile_script
-    guard_pos = lockfile_script.index("check_dep_provenance.py")
-    # The actual invocation, not the explanatory comment above it (which also
-    # contains this substring) -- anchor on the real command's argument.
-    lock_pos = lockfile_script.index(
-        'uv lock --upgrade-package "${{ inputs.package }}"'
-    )
-    assert guard_pos < lock_pos, (
-        "the movable guard must run BEFORE `uv lock --upgrade-package`, not "
-        f"after: {lockfile_script}"
-    )
+    guard_script = _step_run("Check dependency is movable")
+    assert "check_dep_provenance.py" in guard_script, guard_script
+    assert "--check-movable" in guard_script, guard_script
+
+    lock_script = _step_run("Upgrade lockfile")
+    assert 'uv lock --upgrade-package "$BUMP_PACKAGE"' in lock_script, lock_script
 
 
 @pytest.mark.unit
@@ -256,3 +324,27 @@ def test_pyproject_pin_kept_in_sync_with_lockfile_bump() -> None:
 
     commit_script = _step_run("Commit and push")
     assert "git add uv.lock pyproject.toml" in commit_script, commit_script
+
+
+@pytest.mark.unit
+def test_pyproject_pin_updated_before_lockfile_upgrade() -> None:
+    """CodeRabbit finding: `uv lock --upgrade-package` cannot select a
+    version outside an exact `==` requirement in `pyproject.toml`. The pin
+    must be brought forward BEFORE the lock step runs, not after -- doing it
+    after means the lock step silently re-resolves to the SAME old version
+    while the pin update step (gated on `SKIP == 'false'`, computed from a
+    diff that already happened) never even fires.
+    """
+    job = _job_body()
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    names = [s.get("name") for s in steps if isinstance(s, dict)]
+    pin_idx = names.index("Update pyproject.toml pin")
+    lockfile_idx = names.index("Upgrade lockfile")
+    assert pin_idx < lockfile_idx, (
+        "the pyproject.toml pin must be updated BEFORE `uv lock "
+        f"--upgrade-package` runs, not after: {names}"
+    )
+
+    lock_script = _step_run("Upgrade lockfile")
+    assert "git diff --quiet uv.lock pyproject.toml" in lock_script, lock_script

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -783,6 +783,37 @@ def test_dependency_cascade_still_runs_off_the_release_output() -> None:
     )
 
 
+def test_release_evidence_only_accepts_a_merged_pr() -> None:
+    """CodeRabbit finding (OMN-16286): ``/commits/{sha}/pulls`` returns every
+    PR associated with a commit, not just the merged one -- GitHub includes
+    open PRs too when the commit is not yet on the default branch, and the
+    endpoint documents no ordering guarantee. Selecting a bare ``.[0]`` risks
+    propagating Evidence-Ticket/Evidence-Source from an open, unreviewed PR
+    instead of the merged release PR that actually proved the code. The
+    resolution step must filter to a genuinely merged PR (both at the list
+    stage and via an explicit state re-check) and fail loud otherwise.
+    """
+    script = _step("Resolve release ticket + evidence (OMN-16286)")["run"]
+    assert isinstance(script, str)
+
+    # List-stage filter: closed AND merged_at set, not a bare .[0].
+    assert 'select(.state == "closed" and .merged_at != null)' in script, script
+    assert "][0].number" in script or "[0].number" in script, script
+    assert ".[0].number // empty" not in script, (
+        "must not select the first associated PR unconditionally -- that "
+        f"can be an open, unmerged PR: {script}"
+    )
+
+    # Explicit re-check: even a closed+merged_at-filtered PR is re-verified
+    # via a live `gh pr view --json state` before its body is trusted.
+    assert "--json state --jq" in script, script
+    assert 'pr_state" != "MERGED"' in script, script
+    assert script.count("exit 1") >= 2, (
+        "both the no-PR-found and the not-actually-merged paths must fail "
+        f"loud: {script}"
+    )
+
+
 # --------------------------------------------------------------------------
 # AC5 -- the recovery path a stranded version is repaired through
 # --------------------------------------------------------------------------

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -766,7 +766,21 @@ def test_dependency_cascade_still_runs_off_the_release_output() -> None:
 
     assert cascade["needs"] == "release"
     assert "./.github/workflows/dependency-cascade.yml" in str(cascade["uses"])
-    assert _release_job()["outputs"] == {"version": "${{ steps.tag.outputs.tag }}"}
+    # OMN-16286: `release` also resolves + exposes the real Evidence-Ticket /
+    # Evidence-Source pair that closed the release's own merged PR, so the
+    # cascade job can thread honest evidence into every downstream bump PR
+    # instead of opening one Receipt-Gate can never pass.
+    assert _release_job()["outputs"] == {
+        "version": "${{ steps.tag.outputs.tag }}",
+        "ticket": "${{ steps.release_evidence.outputs.ticket }}",
+        "evidence_source": "${{ steps.release_evidence.outputs.evidence_source }}",
+    }
+    cascade_with = _as_mapping(cascade["with"], "the `dependency-cascade` job `with:`")
+    assert cascade_with["ticket"] == "${{ needs.release.outputs.ticket }}"
+    assert (
+        cascade_with["evidence_source"]
+        == "${{ needs.release.outputs.evidence_source }}"
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three confirmed bugs in `dependency-cascade.yml` (job `open-bump-pr`, fired by `release.yml` post-release):

1. `--base main` was hardcoded, but every downstream repo checks out its default branch (`dev`). The cascade PR diffed the entire dev-vs-main divergence — dirty/conflicting, and violates dev-only-promotion policy. Fixed to `--base dev`.
2. Cascade PR titles/branches/bodies carried no OMN ticket and no Evidence-Source, so Receipt-Gate and occ-preflight/eligibility hard-failed on every downstream PR — unlandable anywhere without manual intervention. `release.yml` now resolves the release's own merged PR and re-threads its real Evidence-Ticket/Evidence-Source pair (the evidence that already proved the released code) into every cascade PR this workflow opens — title, branch, and body all carry the same ticket, satisfying `validator_receipt_gate`'s four-axis identity binding. No fabricated evidence, no bot exemption.
3. No `check_dep_provenance.py --check-movable` guard (`omnibase_infra`'s own copy has had one since OMN-15604). Ported verbatim: fail loud before a `[tool.uv.sources]` git-overridden pin produces a silent no-op or — as happened on omniintelligence#827 — a suspicious ~54% full-file `uv.lock` rewrite.

Also keeps `pyproject.toml`'s exact pin in sync with the lockfile bump (ported from infra's copy) — the gap that left infra#2805's `uv.lock` and `pyproject.toml` pin disagreeing.

## Test plan

- Local full suite run 4x on this exact commit due to severe host contention (multiple concurrent full-suite pre-push lanes on the same Mac Studio, swap 90%+ full during earlier attempts):
  - Two earlier attempts killed under host thrashing (inconclusive, not failures)
  - One completed run: **43951 passed / 1 failed** — the 1 failure is a known, ticketed, unrelated sub-millisecond timing flake (OMN-16297), not caused by this diff
  - This PR's pre-push run (7th attempt, on `.200`/Stickybeatz-Studio) completed and **passed** the governed impacted-test selector before push proceeded
- `ruff format` / `ruff check --fix` clean, `pre-commit run --all-files` clean on this commit
- Targeted tests for the three fixed behaviors (base-branch flag, evidence re-threading, provenance guard) green

Evidence-Ticket: OMN-16286
Evidence-Source: OCC#6797