### PR TITLE
ci(OMN-16281): migrate validator-no-unguarded-git-subprocess.yml into ci.yml, permanently close the pull-request-workflow-budget waiver

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -61,7 +61,9 @@
 # check-skip-vectors`) are confirmed now live-REQUIRED on dev and flipped to
 # `mode: REQUIRED` (+ `branch: dev`) accordingly, per this file's own
 # schema-v3 ordering rule (mode change lands with the branch-protection
-# observation, same PR).
+# observation, same PR). `no-unguarded-git-subprocess`'s `workflow:` was later
+# repointed to `ci.yml` by OMN-16281 (see note below) -- the row and its
+# `mode: REQUIRED` stay unchanged, only the producing workflow file moved.
 #
 # Post-reconcile verification: see PR body for reconcile_manifest_vs_live.py
 # and validate_no_required_check_skip_vectors.py output for both branches.
@@ -73,6 +75,21 @@
 # `job_path` len 1 = Shape A (direct job); len 2 = Shape B/C
 # ([caller_job_id, reusable_job_id]) per the design spec's context->job
 # resolution algorithm (OMN-14854 ticket, spec section 1).
+#
+# 2026-08-20 (OMN-16281): the "no-unguarded-git-subprocess" REQUIRED row's
+# `workflow:` was repointed from the retired standalone file
+# (validator-no-unguarded-git-subprocess.yml, now workflow_dispatch-only) to
+# `ci.yml`, whose new unconditional job keeps the IDENTICAL job id/context
+# string "no-unguarded-git-subprocess". Unlike the OMN-14877 batch (all
+# confirmed decorative, no row here at all), this context IS a live dev
+# branch-protection required_status_checks entry, so the row is kept -- not
+# deleted -- deliberately to avoid any live branch-protection mutation: the
+# same context name now simply gets produced by ci.yml instead of the retired
+# workflow, so branch protection needs zero edits (no-agent-mutates-live-
+# branch-protection stays satisfied; see
+# tests/unit/scripts/ci/fixtures/required_status_checks_snapshot.json's _meta).
+# This matches the `workflow: ci.yml` shape already used by other direct-job
+# required rows in this file (e.g. "CI Summary", "Zone Filter").
 
 schema_version: 3
 classification: toolchain
@@ -632,15 +649,18 @@ gates:
     mode: REQUIRED
     branch: dev
     producer_kind: local
-    workflow: validator-no-unguarded-git-subprocess.yml
+    workflow: ci.yml
     job_path: ["no-unguarded-git-subprocess"]
     skip_semantics: never
     rationale: "OMN-14891: blocks reintroduction of git shell-outs in tests/ that inherit GIT_DIR / GIT_WORK_TREE
       / GIT_INDEX_FILE / GIT_COMMON_DIR from a git hook (those OVERRIDE cwd= and -C, so a tmp_path fixture
       under the pre-push hook mutates the REAL invoking worktree -- observed twice, incl. 6707 phantom
-      staged deletions on the shared canonical clone). Runs unconditionally on every PR but is NOT YET
-      in required_status_checks; per the schema-v3 ordering rule the branch-protection flip and the mode
-      change to REQUIRED land together in a follow-up, after 2 independent green runs on dev."
+      staged deletions on the shared canonical clone). OMN-16281 (permanent closure of the OMN-16280 waiver
+      renewal): migrated from its own standalone workflow (validator-no-unguarded-git-subprocess.yml,
+      now workflow_dispatch-only) into an unconditional job in ci.yml with the IDENTICAL job id, so the
+      required context keeps firing under the same name from a different, already-allowlisted producer
+      workflow -- zero live branch-protection mutation needed (no-agent-mutates-live-branch-protection
+      stays satisfied)."
 
   - name: "CodeQL"
     mode: REQUIRED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2597,6 +2597,91 @@ jobs:
         run: |
           .venv/bin/python -m omnibase_core.validation.validator_pull_request_workflow_ratchet --repo-root .
 
+  # Migrated from validator-no-unguarded-git-subprocess.yml (OMN-16281, permanent
+  # closure of the OMN-16280 waiver — do not renew a third time). Same OMN-14877
+  # migration shape: unconditional job under the required "CI Summary" default-deny
+  # sweep, no `needs:` (a cross-job dependency can skip the gate on an unrelated
+  # failure — OMN-14666/14668 lesson), standalone workflow retired to
+  # workflow_dispatch-only. Unlike the OMN-14877 batch, this validator's context
+  # ("no-unguarded-git-subprocess") IS a directly-required dev branch-protection
+  # context — preserved (not dropped) by keeping the job's `name:` byte-identical
+  # to the retired workflow's job name, so the same required context now fires
+  # from ci.yml instead. This intentionally avoids any live branch-protection
+  # mutation (no agent may mutate live branch protection — see
+  # tests/unit/scripts/ci/fixtures/required_status_checks_snapshot.json's _meta);
+  # .github/required-checks.yaml's row for this context was repointed to
+  # `workflow: ci.yml` rather than removed, same pattern as its other direct-job
+  # rows (e.g. "CI Summary", "Zone Filter").
+  #
+  # THE DEFECT THIS GATES (OMN-14891): git exports GIT_DIR / GIT_WORK_TREE /
+  # GIT_INDEX_FILE / GIT_COMMON_DIR into the environment of every hook it runs,
+  # and those variables OVERRIDE both `cwd=` and `git -C`. So when pytest runs as
+  # a subprocess of the repo's own pre-push hook, a fixture doing
+  # `subprocess.run(["git", "init"], cwd=tmp_path)` re-initialises the REAL
+  # invoking worktree instead of tmp_path. Observed twice, log-proven (2026-07-20
+  # OMN-14891, 2026-07-21 OMN-14863) — corrupted the shared canonical clone's
+  # .git/config and index across concurrent sessions.
+  no-unguarded-git-subprocess:
+    # name deliberately matches the job id EXACTLY (not a display-friendly
+    # Title Case, unlike the decorative OMN-14877 migrations above/below) --
+    # this context is a live dev branch-protection required_status_checks
+    # entry, and GitHub resolves a required-check context to a job's `name:`
+    # (falling back to job id when unset). Keeping the string byte-identical
+    # to the retired standalone workflow's job name is what lets ci.yml
+    # satisfy the SAME required context without any branch-protection edit
+    # (see .github/required-checks.yaml's "no-unguarded-git-subprocess" row).
+    name: no-unguarded-git-subprocess
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # The regression test shells out to git, so CI needs an identity for the
+      # decoy repos it creates in tmp_path.
+      - name: Configure git identity for fixture repos
+        run: |
+          git config --global user.email "ci@omninode.ai"
+          git config --global user.name "OmniNode CI"
+
+      - name: Run no-unguarded-git-subprocess unit tests
+        run: |
+          uv run pytest \
+            tests/unit/validators/test_no_unguarded_git_subprocess.py \
+            -v
+
+      - name: Run git-environment isolation regression
+        run: |
+          uv run pytest \
+            tests/unit/test_git_env_isolation.py \
+            -v
+
+      - name: Self-scan omnibase_core tests/
+        run: uv run python -m omnibase_core.validators.no_unguarded_git_subprocess tests/
+
   # ---------------------------------------------------------------------------
   # Phase 1.5 - Quality Gate (aggregates all Phase 1 quality checks)
   # ---------------------------------------------------------------------------

--- a/.github/workflows/validator-no-unguarded-git-subprocess.yml
+++ b/.github/workflows/validator-no-unguarded-git-subprocess.yml
@@ -3,15 +3,18 @@
 ---
 # No Unguarded Git Subprocess — test git-environment isolation gate [OMN-14891]
 #
-# Canonical CI gate for `omnibase_core.validators.no_unguarded_git_subprocess`.
-# Required status check context (once flipped): "no-unguarded-git-subprocess".
-#
-# The job id/name is deliberately unique ("no-unguarded-git-subprocess"), NOT the
-# shared "validate" used by some of core's other validator workflows. GitHub
-# surfaces the check-run context as the bare job name, so a shared name collides
-# across unrelated workflows and cannot be made a required status check without
-# forcing all of them. This mirrors validator-no-plugin-daemon-classes.yml
-# (OMN-13309 / OMN-13284).
+# MIGRATED INTO ci.yml (OMN-16281, permanent closure of the OMN-16280 waiver
+# renewal): this workflow used to trigger on push/pull_request, giving it its
+# OWN github.run_id and putting it inside the pull-request-workflow-budget
+# allowlist (the thing that needed a waiver). Its validate steps now run
+# UNCONDITIONALLY inside ci.yml — an already-allowlisted workflow, so no
+# waiver or new budget slot is needed — and its embedded occ-preflight caller
+# no longer fires on PRs. The ci.yml job keeps the job name byte-identical
+# ("no-unguarded-git-subprocess"), so the SAME directly-required dev
+# branch-protection context now fires from ci.yml instead: no live
+# branch-protection mutation was made or needed (see
+# .github/required-checks.yaml's row for this context, `workflow: ci.yml`).
+# This file is retained workflow_dispatch-only for manual/ad-hoc invocation.
 #
 # THE DEFECT THIS GATES
 # ---------------------
@@ -34,25 +37,16 @@
 # Rationale (Operating Rule #5, "enforcement not detection"): OMN-14744 fixed one
 # file in omnibase_infra by hand and the class recurred in a different repo across
 # five different files. The systemic remedy is the session-level os.environ scrub
-# in tests/conftest.py; this workflow is what stops the shape being reintroduced.
-# A pre-commit-only check is advisory — it does not block a PR that bypassed local
-# hooks.
+# in tests/conftest.py; this gate is what stops the shape being reintroduced.
 #
 # Related: OMN-14892 (index corruption under the same full-suite run),
-#          OMN-14744 (the per-file precedent that did not hold).
-#
-# This workflow runs:
-#   1. unit pytest for the validator (incl. its live self-scan of tests/)
-#   2. pytest for the git-environment isolation regression (the RED-proven pair)
-#   3. a standalone self-scan of the tests/ tree; must exit 0
+#          OMN-14744 (the per-file precedent that did not hold),
+#          OMN-16280 (the waiver renewal this migration permanently closes).
 
 name: No Unguarded Git Subprocess
 
 on:
-  push:
-    branches: [main, develop, dev, "hotfix/**"]
-  pull_request:
-    branches: [main, develop, dev]
+  workflow_dispatch: {}
 
 env:
   PYTHON_VERSION: "3.12"
@@ -63,31 +57,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
-    permissions:
-      contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
-
-  no-unguarded-git-subprocess:
-    needs: occ-preflight
-    if: always()
-    name: no-unguarded-git-subprocess
-    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+  # Job id/name deliberately NOT "no-unguarded-git-subprocess" (CodeRabbit
+  # finding on this migration PR): that exact name now belongs to ci.yml's
+  # job, and per GitHub's own branch-protection guidance, identical job
+  # names across workflow files make a required-status-check context
+  # ambiguous. This workflow is workflow_dispatch-only (never fires on
+  # pull_request, so it structurally cannot race ci.yml's job on a live PR
+  # check-run today), but a distinct name removes even the manual-dispatch
+  # edge case at zero cost.
+  manual-no-unguarded-git-subprocess:
+    name: manual-no-unguarded-git-subprocess
     runs-on: >-
       ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout omnibase_core
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -95,29 +95,19 @@ allowlisted_workflows:
 # net-negative rule). A past-expiry waiver fails the gate. Empty at baseline —
 # the sanctioned default is retire-one, not waive.
 waivers:
-  - workflow_file: validator-no-unguarded-git-subprocess.yml
-    ticket: OMN-16280
-    expires: "2026-08-27"
-    justification: >-
-      RENEWAL (OMN-16280) of the original OMN-14891 waiver, which expired 2026-08-19T00:00Z and fail-closed
-      every PR into dev (WAIVER_EXPIRED -> Pull-Request Workflow Ratchet -> CI Summary, a directly required
-      dev context) until this fix. Verified live at renewal time that the "take a freed OMN-14877 slot"
-      path this waiver originally pointed to does NOT hold: budget=31 == len(allowlisted_workflows)=31,
-      zero slack, zero STALE/NOT_PR_TRIGGERED entries (confirmed by running validator_pull_request_workflow_ratchet
-      directly) -- OMN-14877's drain dropped budget 49->31 exactly matching its 18 retired files, consuming
-      its own freed capacity rather than reserving a slot here. Opening a slot requires actively retiring
-      or migrating an existing allowlisted workflow in the same PR, comparable-or-greater effort to migrating
-      this workflow itself -- too large for tonight's urgent unblock during runner congestion (controller
-      ruling, OMN-16280). The underlying gate remains load-bearing and unchanged: git-environment-isolation
-      blocking the twice-observed (2026-07-20 OMN-14891, 2026-07-21 OMN-14863) repo-corruption class (hook-exported
-      GIT_DIR/GIT_WORK_TREE/ GIT_INDEX_FILE override cwd=/-C in test subprocesses, mutating the real shared
-      canonical clone). Short 7-day expiry (not another month) deliberately forces real closure rather
-      than silent drift: OMN-16281 tracks the permanent fix (migrate into ci.yml, or retire-and-swap a
-      freed slot) and this waiver MUST NOT be renewed a third time -- a still-open OMN-16281 close to
-      2026-08-27 needs an explicit operator call, not an auto-renew.
-    retires: >-
-      The recurring manual post-incident .git/config + index forensics-and-repair step for hook-context
-      test corruption, and the per-file hand-fix pattern of OMN-14744 that demonstrably did not hold.
+  # validator-no-unguarded-git-subprocess.yml waiver (OMN-14891 original,
+  # OMN-16280 renewal) PERMANENTLY CLOSED by OMN-16281: the workflow was
+  # migrated into ci.yml as the `no-unguarded-git-subprocess` job (Option 1,
+  # the OMN-14877 migration pattern). Budget stays flat at 31 -- ci.yml was
+  # already an allowlisted_workflows entry, so no new slot was needed. The
+  # standalone file is retired to workflow_dispatch-only. The
+  # "no-unguarded-git-subprocess" required-context row stays in
+  # .github/required-checks.yaml, repointed to `workflow: ci.yml` -- the
+  # ci.yml job keeps the byte-identical job name, so the same directly-
+  # required dev branch-protection context fires from ci.yml instead, with
+  # zero branch-protection mutation. See
+  # architecture-handshakes/standalone-validator-debt.yaml
+  # (migrated_into_ci_yml).
   - workflow_file: call-occ-companion-effect.yml
     ticket: OMN-14990
     expires: "2026-08-23"

--- a/architecture-handshakes/standalone-validator-debt.yaml
+++ b/architecture-handshakes/standalone-validator-debt.yaml
@@ -104,6 +104,16 @@ migrated_into_ci_yml:
     ci_job_key: release-identity-validator
   - workflow_file: validator-todo-marker.yml
     ci_job_key: todo-marker-validator
+  # OMN-16281 (permanent closure of the OMN-16280 waiver renewal): unlike the
+  # 18 OMN-14877 entries above (all confirmed decorative), this context
+  # ("no-unguarded-git-subprocess") IS a live dev branch-protection
+  # required_status_checks context. It stays a directly-required context after
+  # this migration -- the ci.yml job keeps the identical job name, so the same
+  # required context now fires from ci.yml instead of the retired standalone
+  # workflow. No branch-protection mutation was made or needed (see
+  # .github/required-checks.yaml's row for this context, `workflow: ci.yml`).
+  - workflow_file: validator-no-unguarded-git-subprocess.yml
+    ci_job_key: no-unguarded-git-subprocess
 
 # TRACKED DEBT (OMN-14430 fast-follow, ticket OMN-14430): confirmed decorative
 # — no merge gate blocks on any of these today; pre-commit (if installed, if not
@@ -112,17 +122,13 @@ migrated_into_ci_yml:
 # gate count this ticket asked to be reported.
 #
 # EMPTIED 2026-07-21 (OMN-14877): all 18 remaining decorative validators were
-# batch-migrated into ci.yml (see migrated_into_ci_yml above). The only
-# remaining advisory entry is the OMN-14891 git-env-isolation gate from current
-# dev, which has a unique context and is not yet a required_status_checks
-# context.
-decorative_debt:
-  # OMN-14891 git-env-isolation gate: unique context, ADVISORY today (NOT in
-  # required_status_checks — verified 2026-07-22 via the gh api command above).
-  # Moves to natively_required_contexts when the required flip tracked in
-  # .github/required-checks.yaml lands (after 2 independent green dev runs).
-  - workflow_file: validator-no-unguarded-git-subprocess.yml
-    context: no-unguarded-git-subprocess
+# batch-migrated into ci.yml (see migrated_into_ci_yml above).
+#
+# EMPTIED AGAIN 2026-08-20 (OMN-16281): the one remaining entry (OMN-14891
+# git-env-isolation gate) was migrated into ci.yml too — see migrated_into_ci_yml
+# above. This bucket is intentionally empty; it is not dead code, the next
+# decorative standalone validator discovered lands here.
+decorative_debt: []
 
 metadata:
   generated_by: "OMN-14430 audit, 2026-07-20"

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -645,9 +645,6 @@ DIRECT_REQUIRED_JOB_CONTEXTS: dict[tuple[str, str], tuple[str, ...]] = {
     ("validator-no-plugin-daemon-classes.yml", "no-plugin-daemon-classes"): (
         "no-plugin-daemon-classes",
     ),
-    ("validator-no-unguarded-git-subprocess.yml", "no-unguarded-git-subprocess"): (
-        "no-unguarded-git-subprocess",
-    ),
     ("validator-runtime-profiles.yml", "runtime-profiles"): ("runtime-profiles",),
     ("check-handshake.yml", "check-handshake"): ("Check architecture handshake",),
     ("canonical-inference-gate.yml", "canonical-inference-gate"): (

--- a/tests/validation/test_standalone_validator_workflow_registry.py
+++ b/tests/validation/test_standalone_validator_workflow_registry.py
@@ -53,10 +53,12 @@ def test_decorative_debt_is_the_reported_count(tmp_path: Path) -> None:
     this number — update the constant in the same PR as the migration."""
     manifest = yaml.safe_load(DEBT_MANIFEST_PATH.read_text(encoding="utf-8"))
     # OMN-14877 (2026-07-21): the 18 remaining decorative validators were
-    # batch-migrated into ci.yml and reclassified to migrated_into_ci_yml. The
-    # one remaining advisory entry is OMN-14891's git-env-isolation validator
-    # from current dev.
-    assert len(manifest["decorative_debt"]) == 1
+    # batch-migrated into ci.yml and reclassified to migrated_into_ci_yml.
+    # OMN-16281 (2026-08-20): the last remaining entry, OMN-14891's
+    # git-env-isolation validator, was migrated into ci.yml too. This bucket
+    # is now empty; a future decorative standalone validator raises this back
+    # above zero and is expected to update this constant in the same PR.
+    assert len(manifest["decorative_debt"]) == 0
 
 
 def test_planted_undeclared_standalone_validator_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Permanently closes the `pull-request-workflow-budget.yaml` waiver for
`validator-no-unguarded-git-subprocess.yml` (ticket 14891 original, ticket 16280
renewal, expires 2026-08-27, "do not renew a third time"). Option 1 from the
ticket: migrate the validator's job into `ci.yml` (same shape as the
ticket 14877 batch migration), retire the standalone workflow to
`workflow_dispatch`-only, delete the waiver entry. Budget stays flat at 31 —
`ci.yml` was already an `allowlisted_workflows` entry, so no new slot is
needed.

## The branch-protection wrinkle, and how this PR avoids it

Unlike the 18 ticket 14877 validators (all confirmed decorative — gated
nothing), `no-unguarded-git-subprocess` **is a live, directly-required `dev`
branch-protection context** — confirmed via
`gh api repos/OmniNode-ai/omnibase_core/branches/dev/protection/required_status_checks`
(37 contexts, includes both `no-unguarded-git-subprocess` and `CI Summary`).
A naive migration that just deletes the workflow's `pull_request` trigger
would mean nothing ever produces that context again, wedging every future
core PR on a required check that never fires — the exact class of outage
ticket 16280 just fixed, self-reproduced. Per this repo's own
`required_status_checks_snapshot.json` fixture note, no agent may mutate
live branch protection, so that isn't an available fix either.

**This PR avoids the problem instead of requiring a branch-protection edit**:
the new `ci.yml` job keeps the job `name:` byte-identical
(`no-unguarded-git-subprocess`) to the retired standalone workflow's job
name. GitHub resolves a required-status-check context to a job's `name:`
regardless of which workflow file produced it, so the *same* required
context now simply fires from `ci.yml` instead — zero branch-protection
mutation made or needed. `.github/required-checks.yaml`'s row for this
context is repointed to `workflow: ci.yml` (same shape already used by its
other direct-job rows, e.g. `CI Summary`, `Zone Filter`) rather than
deleted.

## Changes

- `.github/workflows/ci.yml`: new `no-unguarded-git-subprocess` job,
  unconditional (no `needs`/`if`), job `name:` byte-identical to the retired
  workflow's job name so the required context keeps firing.
- `.github/workflows/validator-no-unguarded-git-subprocess.yml`: retired to
  `on: workflow_dispatch: {}` only; embedded `occ-preflight` caller dropped
  (dead once it no longer fires on PRs).
- `.github/required-checks.yaml`: the `no-unguarded-git-subprocess` row's
  `workflow:` repointed from the retired file to `ci.yml`; row and
  `mode: REQUIRED` unchanged.
- `architecture-handshakes/pull-request-workflow-budget.yaml`: waiver entry
  deleted.
- `architecture-handshakes/standalone-validator-debt.yaml`: entry moved from
  `decorative_debt` to `migrated_into_ci_yml`. `decorative_debt` is now
  empty.
- `tests/validation/test_standalone_validator_workflow_registry.py`:
  decorative count 1 → 0.
- `tests/unit/scripts/ci/test_ci_summary_gate.py`: removed the
  `DIRECT_REQUIRED_JOB_CONTEXTS` entry keyed to the retired workflow file
  (ci.yml jobs are covered by the in-run default-deny sweep, not this dict —
  confirmed by the dict's own module docstring).

## Verification

- `uv run python -m omnibase_core.validation.validator_pull_request_workflow_ratchet --repo-root .` — exit 0, zero gaps, `budget=31 == len(allowlisted_workflows)=31`.
- `verify_standalone_validator_registry` — zero gaps.
- `.github/actions/required-check-skip-guard/validate_no_required_check_skip_vectors.py` — PASS, no skip vectors.
- Targeted suite (114 tests: `test_pull_request_workflow_ratchet.py`, `test_standalone_validator_workflow_registry.py`, `test_ci_summary_gate.py`, `test_no_unguarded_git_subprocess.py`, `test_git_env_isolation.py`) — 114 passed.
- Full local unit suite (governed selector escalated to full suite — `tests/validation` is a `shared_modules` entry): run twice, once on `.201` (headroom host, this Mac was oversubscribed at load 30/24 from 3 concurrent full-suite pre-push lanes — see PR body process note below) and once on this Mac at the actual `git push` (load had since dropped to ~15/24): **43982 passed, 53 skipped, 3 xpassed, 0 failed** both times, identical result.
- yaml syntax of all touched workflow/handshake files parses clean.

## Process note

This Mac (`.200`/stickybeatz-studio) was running 3 concurrent full-suite
pre-push jobs (load 30/24, 1.25x oversubscribed) when this PR's governed
selector first escalated to the full suite. Per CLAUDE.md's
serialize-heavy-prepush rule, ran the full suite once on `.201`
(headroom host, load ~11/32) via patch-transfer + sha256/diff verification
first, confirming green before the real `git push` (which reran it locally
once load had subsided, per the ticket 15059 host guard — that guard isn't
load-aware yet, only identity-aware; ticket 16295 adds load-awareness but is
still open).

Evidence-Ticket: OMN-16281
Related: ticket 16280, ticket 14891, ticket 14877, ticket 14907, ticket 14430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Consolidated the unguarded Git subprocess validation into the main CI workflow.
  - Preserved the existing required check status and validation behavior.
  - Added Git-environment isolation checks and scans for unsafe subprocess usage.

- **Maintenance**
  - Retired the standalone validator workflow, leaving it available only for manual runs.
  - Removed the completed workflow migration waiver and updated validation records.
  - Updated CI summary and registry checks to reflect the completed migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#6801

