### PR TITLE
ci(OMN-16322): raise occ-preflight reusable timeout 10m -> 15m so cold-runner runs stop landing as CANCELLED

### DIFF
--- a/.github/workflows/occ-preflight.yml
+++ b/.github/workflows/occ-preflight.yml
@@ -59,7 +59,19 @@ jobs:
         && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
-    timeout-minutes: 10
+    # OMN-16322: was 10. A cold self-hosted runner spends ~2m38s in "Set up job"
+    # (image pull) and ~4m05s checking out omnibase_compat before the eligibility
+    # check even starts, so the job lands at ~9-10m wall and trips the timeout
+    # DURING results upload -- after every step, including "Complete job", has
+    # already succeeded. GitHub stamps a timed-out job `cancelled`, and both
+    # CI Summary and GitHub's own required-check semantics fail closed on
+    # `cancelled`, so a job that logged "OCC eligibility: PASS" still blocks the
+    # PR. Measured on the sibling inlined copy (onex_change_control#6714):
+    # attempt 1 = 10m35s cancelled, attempt 2 = 10m25s cancelled (cancel arrived
+    # at exactly T+600s), attempt 3 on a warm runner = 1m44s success. 15m covers
+    # the observed 647-840s cold tail with headroom; it does not mask a hang,
+    # because the work itself completes in ~104s warm.
+    timeout-minutes: 15
     # I2: Disable GHA cache so merge_group re-fires fully.
     # A stale PASS from a prior PR-open run cannot satisfy the gate on a new merge_group event.
     env:


### PR DESCRIPTION
## Summary

Raise the `occ-preflight / eligibility` job timeout from **10m to 15m** in the reusable workflow, so a cold-runner execution stops tripping the timeout and landing as `CANCELLED`.

This is the sibling of onex_change_control#6805 (merged), which fixed OCC's own **inlined** copy. This file is the **reusable** consumed via `uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main` by **omnibase_core, omniclaude, omnidash and omnimarket**.

## Why

The job passes and is still recorded as cancelled. On a cold trusted-CI runner it spends ~2m38s in `Set up job` (image pull) and ~4m05s checking out `omnibase_compat` before the eligibility check even starts, putting it at ~10m wall. The 10m timeout then fires **during results upload** — after every step, including `Complete job`, has already succeeded. GitHub stamps a timed-out job `cancelled`, and both CI Summary and GitHub's own required-check semantics fail closed on `cancelled`, so a PR is blocked by a job whose log reads `OCC eligibility: PASS`.

## Evidence

Measured on the sibling inlined copy, onex_change_control#6714 (run [32322408466](https://github.com/OmniNode-ai/onex_change_control/actions/runs/32322408466)):

| Attempt | Runner | Duration | Conclusion |
|---|---|---|---|
| 1 | omninode-runner-64 | 10m35s | cancelled |
| 2 | omninode-runner-38 | 10m25s | cancelled |
| 3 | omninode-runner-84 | **1m44s** | **success** |

Attempt 2's job `started_at` is 23:37:03Z and the cancellation arrived at **23:47:03Z — exactly T+600s**, matching `timeout-minutes: 10` precisely. Host forensics on runner-38 confirm the cancel came from GitHub's Actions backend down the Listener long-poll, not from the runner or host.

Across a 60-run sample of the OCC copy, 28 runs were cancelled on their FIRST attempt, and the cancelled-duration distribution is bimodal — roughly 20 under 570s (a separate `cancel-in-progress` preemption class, deliberately **not** addressed here) and roughly 9 at 647-840s, which is this timeout class.

## Why 15m and not more

15m covers the observed 647-840s cold tail with headroom. It does not mask a hang: the work itself completes in ~104s on a warm runner, so a genuinely stuck job still trips well before the new bound.

## Propagation note

Callers pin this reusable at `@main`, so this change reaches omniclaude, omnidash and omnimarket only after an omnibase_core release moves `main` (OMN-16289 release-synced-main). Merging to `dev` alone does not propagate it.

## Test plan
- [x] Full governed pre-push suite passed locally (ruff, mypy, pyright, bandit, ONEX validators, node purity, and the impacted-test selector's full unit run)
- [ ] `gh pr checks` green on this PR

Refs: OMN-16322, onex_change_control#6805 (sibling fix, merged), OMN-16236 (the CI Summary latest-per-name fix, which does **not** help this class — a rerun replaces the check-run row rather than adding one, so latest-per-name has no fresher row to prefer).

Evidence-Source: OCC#6814
Evidence-Ticket: OMN-16322

