### PR TITLE
fix(OMN-16323): stop interpolating the release tag into shell source in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,11 @@ jobs:
           test -z "$(git ls-files --others --exclude-standard)"
 
       - name: Validate tag matches pyproject.toml version
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+            TAG="$RELEASE_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
@@ -101,9 +103,19 @@ jobs:
 
       - name: Set release tag
         id: tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            # A newline in the dispatch input would forge extra GITHUB_OUTPUT
+            # entries, so constrain it to the tag charset before writing it.
+            case "$RELEASE_TAG" in
+              ''|*[!A-Za-z0-9.+_-]*)
+                echo "::error::release tag contains unsupported characters"
+                exit 1
+                ;;
+            esac
+            echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           else
             echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
           fi
@@ -264,9 +276,11 @@ jobs:
       # authenticates this push.
       - name: Sync main to release tag
         if: ${{ !contains(steps.tag.outputs.tag, 'rc') }}
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
+          TAG="$RELEASE_TAG"
           TAG_SHA=$(git rev-list -n 1 "$TAG")
           echo "Resolved tag $TAG -> commit $TAG_SHA"
           git push origin "${TAG_SHA}:refs/heads/main"


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml` interpolated the caller-supplied `workflow_dispatch` input `tag` directly into shell source inside three `run:` blocks, and the tainted value reached the step that writes `main`.

Taint chain, verified against this repo rather than inferred:

1. `on.workflow_dispatch.inputs.tag` — required, free text, no format constraint.
2. `Validate tag matches pyproject.toml version` ran `TAG="${{ inputs.tag }}"`.
3. `Set release tag` ran `echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT` — a shell sink *and* a `GITHUB_OUTPUT` forging vector in its own right.
4. `Sync main to release tag` ran `TAG="${{ steps.tag.outputs.tag }}"` — the value from (3), interpolated into shell again.
5. That same step runs `git push origin "${TAG_SHA}:refs/heads/main"` under `permissions: contents: write`.

So a crafted tag executed arbitrary shell **in the step that writes `main`**.

## Fix

The tag now travels through an `env:` block and is read as `$RELEASE_TAG` at all three `run:` sites. Verified by walking the parsed workflow rather than grepping: zero `${{ inputs.tag }}` / `${{ steps.tag.outputs.tag }}` expressions remain inside any `run:` block.

The set-tag step additionally rejects anything outside the tag charset before writing to `$GITHUB_OUTPUT`. The `env:` change alone does not stop a newline in the dispatch input from forging extra step outputs, so that vector would have survived the fix as usually described. Behaviour-checked against real tag shapes: `v0.46.9`, `v1.0.0-rc1`, `v1.2.3.post1`, `v1.0.0+build.5` all accepted; empty, newline-bearing, `"; curl … | sh; #`, and `$(whoami)` all rejected. Every release tag in this repo is a plain `vX.Y.Z`, so nothing legitimate is refused.

Interpolations in YAML-expression contexts — `ref:`, `tag_name:`, `if:`, the artifact `name:`, and the job `outputs.version` — are deliberately unchanged. They are not shell-injection sinks and churning them would only add review surface.

## Severity — calibrated

Not an anonymous RCE: triggering `workflow_dispatch` requires repo write access. It is a **privilege-escalation / supply-chain-integrity** issue — any write-access identity, or a compromised contributor or bot token, gets code execution in a `contents: write` job and can write arbitrary content to `main`.

Corroborated independently by zizmor (`template-injection`) and CodeRabbit (Security & Privacy / Major) on the sibling omnibase_spi#271.

## Why this matters now

OMN-16289 step 2 empties `main`'s required-status-context set and restricts `main` pushes to the release automation — making this workflow the sole authorized writer to `main` while removing the CI gate in front of it. Step 2 was stopped on exactly this finding; landing this is what unblocks it.

The same fix is landing across all six release repos under OMN-16323.

## Verification

- Parsed-workflow checker: `run-block tag interpolations: NONE`, exit 0.
- Guard behaviour tested against real and hostile tag values (above).
- `pre-commit run --files .github/workflows/release.yml`: zero failures.
- Pre-push impacted-test suite passed; pushed with hooks enabled, no bypass flag.

## Ticket

OMN-16323 (parent context: OMN-16289).

Evidence-Ticket: OMN-16323
Evidence-Source: OCC#6816
