### PR TITLE
chore(OMN-16322): bump version 0.46.10 -> 0.46.11 to propagate the occ-preflight timeout fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.10"
+version = "0.46.11"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.10"
+version = "0.46.11"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

OMN-16322: #1573 raised the occ-preflight reusable workflow timeout from 10m to 15m so cold-runner runs stop landing as CANCELLED. Four downstream repos consume that workflow via `@main`, so **the fix only reaches them once `main` advances**.

Under the OMN-16289 release-synced-main policy, `main` advances by exactly one mechanism: `release.yml`'s Sync-main step fast-forwarding it to a release tag. Promotion PRs to main are retired. So cutting a release IS the propagation path for a CI-only change here, not unrelated ceremony.

`release.yml` validates that the tag matches `project.version`, and `dev` currently sits at 0.46.10 — the same version as the published v0.46.10 tag — so **v0.46.11 is not cuttable until this bump lands**.

## Why the release-identity gate didn't force this bump itself

Worth stating so it doesn't read as a gate miss: the OMN-13411 release-identity gate exempted #1573 because it changed only a workflow file, not packaged `src/**`. That is correct behaviour — the gate exists to stop two code states aliasing one *wheel* version, and a CI-only change doesn't alias a wheel. It just means a CI-only change leaves `dev` sitting on the published version, and a deliberate bump is needed to cut the next release.

## Verification

- **Release-identity gate passes:** `OK: version 0.46.11 is ahead of latest published 0.46.10` (run against `origin/dev`).
- **Fast-forward precondition checked:** `git merge-base --is-ancestor origin/main origin/dev` → TRUE, so the post-release Sync-main can actually succeed. This is deliberately *not* a three-dot `compare/main...tag` — that answers "is main the same as the tag", which is a different question and does not predict whether the sync will work. (An earlier release this session was stranded precisely because the three-dot form reported `identical` on a repo whose `main` was not an ancestor of `dev`.)
- **Governed pre-push selector: full escalated suite green** — `44003 passed, 53 skipped, 3 xpassed in 6344.64s (1:45:44)`, then `[prepush-smart-tests] impacted tests passed; allowing push`. The selector escalated to whole-suite-equivalent because `pyproject.toml` changed; it was run legitimately (waited for host load to drop below the threshold rather than setting `PREPUSH_ALLOW_LOCAL_FULL_SUITE=1`, which self-describes as degraded evidence).
- `uv.lock` regenerated in the same commit so the lock and `pyproject.toml` stay in sync.

## Test plan

- [x] Release-identity gate passes with the new version
- [x] `main` is an ancestor of `dev` (post-release FF can succeed)
- [x] Full local suite green (44003 passed)
- [x] `uv.lock` in sync
- [ ] `gh pr checks` green in CI (to be confirmed post-open)

## After this merges

Tag `v0.46.11` from `dev` → `release.yml` publishes and fast-forwards `main` → the four repos consuming core's reusable workflows `@main` pick up the occ-preflight timeout fix.

Note OMN-16322 itself stays **In Progress**, not Done: its DoD is the full timeout-vs-concurrency-preemption population investigation, and #1573 shipped only the timeout mitigation for omnibase_core. This PR is release mechanics for that mitigation, not closure of the ticket.

Evidence-Ticket: OMN-16322
Evidence-Source: OCC#6838
