### PR TITLE
fix(OMN-16373): migrate cross-repo CI reads/writes to onexbot-occ-writer App token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,11 +969,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # OMN-16373: CROSS_REPO_PAT retirement — mint a short-lived
+      # onexbot-occ-writer App installation token (org secrets
+      # ONEXBOT_OCC_APP_ID / ONEXBOT_OCC_PRIVATE_KEY), scoped to the one
+      # sibling repo this job reads.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+          repositories: onex_change_control
+
       - name: Checkout onex_change_control standards
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/onex_change_control
-          token: ${{ secrets.CROSS_REPO_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           path: onex_change_control
           sparse-checkout: |
             standards/
@@ -3316,9 +3329,21 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      # OMN-16373: CROSS_REPO_PAT retirement — mint a short-lived
+      # onexbot-occ-writer App installation token (org secrets
+      # ONEXBOT_OCC_APP_ID / ONEXBOT_OCC_PRIVATE_KEY) for the sibling-repo
+      # reads this test split may need.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+
       - name: Run integration tests (split ${{ matrix.split }}/4)
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           uv run pytest tests/integration/ \
             --splits 4 --group ${{ matrix.split }} \
@@ -3492,6 +3517,17 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v7
+      # OMN-16373: CROSS_REPO_PAT retirement — mint a short-lived
+      # onexbot-occ-writer App installation token, scoped to the one
+      # sibling repo this job reads.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+          repositories: onex_change_control
       - name: Checkout onex_change_control
         uses: actions/checkout@v7
         with:
@@ -3505,7 +3541,7 @@ jobs:
           # Re-pinned to OCC dev HEAD at the time of this change.
           ref: 91f5b69104366c2d86e4bb21de67c3c497702111
           path: onex_change_control
-          token: ${{ secrets.CROSS_REPO_PAT || github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -3608,7 +3644,6 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || github.token }}
       GH_REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
@@ -3619,6 +3654,20 @@ jobs:
     steps:
       - name: Checkout (gate script)
         uses: actions/checkout@v7
+      # OMN-16373: CROSS_REPO_PAT retirement. Mint a short-lived
+      # onexbot-occ-writer App token and export it as GH_TOKEN — job-level
+      # `env:` is resolved before any step runs, so it cannot reference a
+      # step output directly. `|| github.token` fallback kept for resilience.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+          repositories: onex_change_control
+      - name: Export GH_TOKEN
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token || github.token }}" >> "$GITHUB_ENV"
       - name: Require cited OCC evidence to be merged/durable before product merge
         run: python3 scripts/ci/check_occ_companion_merged.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,6 +981,7 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
           repositories: onex_change_control
+          permission-contents: write
 
       - name: Checkout onex_change_control standards
         uses: actions/checkout@v7
@@ -3340,6 +3341,7 @@ jobs:
           app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
+          permission-contents: write
 
       - name: Run integration tests (split ${{ matrix.split }}/4)
         env:
@@ -3528,6 +3530,7 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
           repositories: onex_change_control
+          permission-contents: write
       - name: Checkout onex_change_control
         uses: actions/checkout@v7
         with:
@@ -3666,6 +3669,7 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
           repositories: onex_change_control
+          permission-contents: write
       - name: Export GH_TOKEN
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token || github.token }}" >> "$GITHUB_ENV"
       - name: Require cited OCC evidence to be merged/durable before product merge

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -163,6 +163,8 @@ jobs:
           private-key: ${{ secrets.onexbot-occ-private-key }}
           owner: OmniNode-ai
           repositories: ${{ matrix.repo }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout downstream repo
         if: steps.token_check.outputs.has_token == 'true'

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -52,12 +52,16 @@ on:
         required: true
         type: string
     secrets:
-      cross-repo-pat:
-        description: >-
-          PAT with repo scope for cross-repo operations. Must be a classic PAT
-          with `repo` scope or a fine-grained PAT with Contents: read+write on
-          all downstream OmniNode-ai repos. When absent, checkout and PR
-          creation steps are skipped with a warning.
+      # OMN-16373: CROSS_REPO_PAT retired. The caller now passes through the
+      # onexbot-occ-writer GitHub App credentials (org secrets
+      # ONEXBOT_OCC_APP_ID / ONEXBOT_OCC_PRIVATE_KEY); this workflow mints a
+      # short-lived installation token per downstream repo instead of using
+      # a long-lived PAT.
+      onexbot-occ-app-id:
+        description: "onexbot-occ-writer GitHub App id (org secret ONEXBOT_OCC_APP_ID)"
+        required: false
+      onexbot-occ-private-key:
+        description: "onexbot-occ-writer GitHub App private key (org secret ONEXBOT_OCC_PRIVATE_KEY)"
         required: false
   workflow_dispatch:
     inputs:
@@ -134,25 +138,38 @@ jobs:
       matrix:
         repo: ${{ fromJson(needs.compute-matrix.outputs.repos) }}
     steps:
-      - name: Check CROSS_REPO_PAT is configured
+      - name: Check onexbot-occ-writer App credentials are configured
         id: token_check
         env:
-          CROSS_REPO_PAT: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+          APP_ID: ${{ secrets.onexbot-occ-app-id }}
+          APP_PRIVATE_KEY: ${{ secrets.onexbot-occ-private-key }}
         run: |
-          if [ -z "$CROSS_REPO_PAT" ]; then
-            echo "::warning::CROSS_REPO_PAT secret is not set. Skipping dependency bump for ${{ matrix.repo }}." \
-              "Set a PAT with 'repo' scope as the CROSS_REPO_PAT repository secret to enable automated dependency cascades."
+          if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "::warning::ONEXBOT_OCC_APP_ID / ONEXBOT_OCC_PRIVATE_KEY are not configured. Skipping dependency bump for ${{ matrix.repo }}." \
+              "Provision the onexbot-occ-writer App org secrets to enable automated dependency cascades."
             echo "has_token=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_token=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # OMN-16373: mint a short-lived onexbot-occ-writer App installation
+      # token, scoped to the one downstream repo this matrix leg touches.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        if: steps.token_check.outputs.has_token == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.onexbot-occ-app-id }}
+          private-key: ${{ secrets.onexbot-occ-private-key }}
+          owner: OmniNode-ai
+          repositories: ${{ matrix.repo }}
 
       - name: Checkout downstream repo
         if: steps.token_check.outputs.has_token == 'true'
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/${{ matrix.repo }}
-          token: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
 
       - name: Set up uv
@@ -338,7 +355,7 @@ jobs:
       - name: Open pull request
         if: steps.token_check.outputs.has_token == 'true' && env.SKIP == 'false'
         env:
-          GH_TOKEN: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO_NAME: ${{ matrix.repo }}
           BRANCH: ${{ steps.vars.outputs.branch }}
         run: |

--- a/.github/workflows/propagate-config.yml
+++ b/.github/workflows/propagate-config.yml
@@ -114,6 +114,8 @@ jobs:
           app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Run propagator
         env:

--- a/.github/workflows/propagate-config.yml
+++ b/.github/workflows/propagate-config.yml
@@ -8,7 +8,8 @@
 #
 # For each target declared in .github/propagation-targets.yaml under the
 # selected propagation name, the bot:
-#   1. Clones the target repo with CROSS_REPO_PAT.
+#   1. Clones the target repo with a minted onexbot-occ-writer App token
+#      (OMN-16373; CROSS_REPO_PAT retired).
 #   2. Appends the declared hook block to the target file (skips if already
 #      present — idempotent).
 #   3. Commits to a bot/propagate-<name>-<tag> branch and opens a PR.
@@ -102,9 +103,21 @@ jobs:
             echo "tag=manual-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # OMN-16373: CROSS_REPO_PAT retirement — mint a short-lived
+      # onexbot-occ-writer App installation token (org secrets
+      # ONEXBOT_OCC_APP_ID / ONEXBOT_OCC_PRIVATE_KEY) for the cross-repo
+      # clone + commit + PR-open this script performs on each target.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+
       - name: Run propagator
         env:
-          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PROPAGATION_NAME: ${{ steps.name.outputs.name }}
           PROPAGATION_RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: bash scripts/propagate-config.sh

--- a/.github/workflows/publish-downstream-pin-bump.yml
+++ b/.github/workflows/publish-downstream-pin-bump.yml
@@ -116,6 +116,8 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: OmniNode-ai
           repositories: ${{ matrix.repo }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout downstream (${{ matrix.repo }})
         uses: actions/checkout@v7

--- a/.github/workflows/publish-downstream-pin-bump.yml
+++ b/.github/workflows/publish-downstream-pin-bump.yml
@@ -7,7 +7,8 @@
 # sweep and any future on-demand replays).
 #
 # For each repo declared in docs/downstream-repos.yaml with pin_sites:
-#   1. Checkout the downstream repo with CROSS_REPO_PAT.
+#   1. Checkout the downstream repo with a minted onexbot-occ-writer App
+#      token (OMN-16373; CROSS_REPO_PAT retired).
 #   2. Run scripts/pin_bump.py to rewrite every pin_site to the new SHA.
 #   3. Commit + push a bot/bump-omnibase-core-pin-<shortsha> branch.
 #   4. Open a PR titled "chore(ci): bump omnibase_core pin to <shortsha> [bot]".
@@ -104,11 +105,23 @@ jobs:
         with:
           path: omnibase_core
 
+      # OMN-16373: CROSS_REPO_PAT retirement — mint a short-lived
+      # onexbot-occ-writer App installation token, reused for the checkout,
+      # push, and PR-open steps below.
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: OmniNode-ai
+          repositories: ${{ matrix.repo }}
+
       - name: Checkout downstream (${{ matrix.repo }})
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/${{ matrix.repo }}
-          token: ${{ secrets.CROSS_REPO_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           path: downstream
           fetch-depth: 0
 
@@ -144,7 +157,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         working-directory: downstream
         env:
-          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           SHORT="${NEW_SHA:0:12}"
           BRANCH="bot/bump-omnibase-core-pin-${SHORT}"
@@ -159,7 +172,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         working-directory: downstream
         env:
-          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           SHORT="${NEW_SHA:0:12}"
           BRANCH="bot/bump-omnibase-core-pin-${SHORT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,11 @@ jobs:
       ticket: ${{ needs.release.outputs.ticket }}
       evidence_source: ${{ needs.release.outputs.evidence_source }}
     secrets:
-      cross-repo-pat: ${{ secrets.CROSS_REPO_PAT }}
+      # OMN-16373: CROSS_REPO_PAT retired — pass the onexbot-occ-writer App
+      # credentials through so dependency-cascade.yml can mint its own
+      # per-repo installation token.
+      onexbot-occ-app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+      onexbot-occ-private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
 
   # ---------------------------------------------------------------------------
   # OMN-15603 (AC4): a failed release used to be silent about its own wreckage

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -97,7 +97,7 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "e52c18585e93fd68b8ea8e1db1689fb5bd255e352e176e362b359ede4f346d9b"  # pragma: allowlist secret
     ),
     "version-pin-check": (
-        "ade3ee77ab47c64b1cfc44f135116eec3d290c7505a30e54d8093c27a56f59bb"  # pragma: allowlist secret
+        "9bb546d8875e94cbd3454e42ffeaf1d330b687cd2f927f15274fe27a21ce5bd3"  # pragma: allowlist secret
     ),
     "sdk-boundary-check": (
         "6701fd3e6101f2107010ee2b6fc436acb2aaac73fb136e8ef237d41f0b7b70bb"  # pragma: allowlist secret

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -97,7 +97,7 @@ AUDITED_GUARD_JOB_EXECUTION_CONTRACTS = {
         "e52c18585e93fd68b8ea8e1db1689fb5bd255e352e176e362b359ede4f346d9b"  # pragma: allowlist secret
     ),
     "version-pin-check": (
-        "9bb546d8875e94cbd3454e42ffeaf1d330b687cd2f927f15274fe27a21ce5bd3"  # pragma: allowlist secret
+        "69ece7afcf893b932d5adb400a6fa7d84f12a2bfb1bb30715f54af920faf662c"  # pragma: allowlist secret
     ),
     "sdk-boundary-check": (
         "6701fd3e6101f2107010ee2b6fc436acb2aaac73fb136e8ef237d41f0b7b70bb"  # pragma: allowlist secret


### PR DESCRIPTION
## Summary
Retires `CROSS_REPO_PAT` in favor of a short-lived `onexbot-occ-writer` GitHub App installation token (org secrets `ONEXBOT_OCC_APP_ID` / `ONEXBOT_OCC_PRIVATE_KEY`), per OMN-16373's org-wide CROSS_REPO_PAT retirement inventory. Mirrors the already-merged pattern in `omnibase_infra#2831` / `omnibase_spi#273`.

- `ci.yml`: version-pin-check (OCC standards checkout), integration-tests split, contract-compliance (OCC checkout), OCC companion-merged gate — each job/matrix-leg mints its own App token via `actions/create-github-app-token` and uses `steps.app-token.outputs.token || github.token`.
- `release.yml`: dependency-cascade secrets pass-through (now `onexbot-occ-app-id`/`onexbot-occ-private-key` instead of a PAT).
- `dependency-cascade.yml` (reusable workflow): mints its own per-downstream-repo token instead of taking a PAT.
- `propagate-config.yml`, `publish-downstream-pin-bump.yml`: same pattern for their cross-repo clone/commit/PR-open steps.
- Every minted token declares explicit `permission-contents` (and `permission-pull-requests` where the step opens a PR) — least-privilege hardening matching a CodeRabbit finding on the sibling omnimemory PR.
- `tests/unit/validation/test_ci_workflow_shape.py` hash-locks `version-pin-check`'s exact step shape; updated the audited execution-contract digest to match the added mint step.

Ticket: OMN-16373

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all changed workflow files — valid YAML
- [x] `pre-commit run --files <changed files>` — all applicable hooks passed
- [x] Governed impacted-test selector (pre-push): 44001 passed, 53 skipped, 3 xpassed — full local suite (escalated by the selector; no narrowing was provable for a workflow-file diff), including the updated `test_ci_workflow_shape.py` digest assertions
- [ ] CI green (`gh pr checks --watch`)

Evidence-Ticket: OMN-16373
Evidence-Source: OCC#6862
