### PR TITLE
fix(OMN-16413): validate-docs routes same-repo PRs to self-hosted runner

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -38,11 +38,26 @@ on:
 
 jobs:
   validate-docs:
+    # OMNI_RUNNER_SELECTOR_V1 (OMN-16413): `uv sync` here resolves packages from
+    # the internal-only PyPI mirror, which `ubuntu-latest` cannot reach (it is
+    # not on the tailnet). The prior selector routed ALL pull_request events to
+    # ubuntu-latest, so any PR that changed uv.lock (a GH Actions cache miss)
+    # failed deterministically with a DNS error, even for trusted same-repo PRs
+    # (e.g. onex_change_control#6850/#6823) — confirmed on 3 consecutive reruns.
+    # This mirrors the OMN-15699 fork-aware selector already used by
+    # deploy-gate-reusable.yml / main-target-guard.yml: only an ACTUAL fork PR
+    # (head repo != base repo) is routed to the public ubuntu-latest runner;
+    # every same-repo pull_request (including bot-authored dependency-bump
+    # branches, which are always same-repo, never forks) gets the
+    # tailnet-connected self-hosted omnibase-ci fleet, identical to push /
+    # merge_group / workflow_dispatch. This does NOT widen the trust boundary:
+    # untrusted fork code still never reaches the self-hosted fleet.
     runs-on: >-
       ${{
-        github.event_name != 'pull_request'
-        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     env:
       CHECK_EXTERNAL: ${{ inputs.check-external }}


### PR DESCRIPTION
## Summary

`validate-docs.yml`'s `uv sync` resolves packages from OCC's internal-only PyPI mirror, which `ubuntu-latest` cannot reach (not on the tailnet). The prior runner selector routed **all** `pull_request` events to `ubuntu-latest`, so any PR that changed `uv.lock` (a GH Actions cache miss) failed deterministically with a DNS error — confirmed on `onex_change_control#6850` (3 consecutive reruns, each failing a different newly-resolved package) and identically on its sibling `#6823`, both same-repo dependency-bump PRs, never forks.

Adopts the existing `OMNI_RUNNER_SELECTOR_V1` fork-aware idiom already used by `deploy-gate-reusable.yml` / `main-target-guard.yml`: only an actual fork PR (`head.repo.full_name != github.repository`) routes to the public `ubuntu-latest` runner. Every same-repo `pull_request` routes to the tailnet-connected self-hosted `omnibase-ci` fleet, identical to `push` / `merge_group` / `workflow_dispatch`.

This does **not** widen the trust boundary — untrusted fork code still never reaches the self-hosted fleet. It only stops penalizing trusted same-repo PRs with an unreachable-mirror failure.

## Evidence

Full diagnosis, reproduction, and evidence trail in OMN-16413. Local pre-push escalated to the near-full unit suite (workflow-YAML-only diff, no Python impact to narrow against) per the governed selector (OMN-13973) — 44,009 passed, 53 skipped, 3 xpassed, 0 failed.

Evidence-Ticket: OMN-16413
Evidence-Source: OCC#6910

## Test plan

- [x] `actionlint` clean on the changed file (pre-existing shellcheck notes in an unrelated step, confirmed present on `dev` before this change too)
- [x] Local pre-commit green
- [x] Governed pre-push selector escalated to near-full suite, 44,009 passed / 0 failed
- [ ] CI green on this PR
