### PR TITLE
fix(OMN-16432): resolve_supersession() target-aware resolution for shared supersede chains

### DIFF
--- a/.yaml-validation-allowlist.yaml
+++ b/.yaml-validation-allowlist.yaml
@@ -426,6 +426,18 @@ allowed_files:
     added: "2026-08-12"
     review: "2026-12-13"
 
+  - file: "src/omnibase_core/validation/validator_receipt_supersession.py"
+    reason: >-
+      DoD receipt supersession-chain resolver (OMN-13888 scope 3 / OMN-16432). _load_supersede_record
+      reads one drift/dod_receipts/<TICKET>/<ITEM>/<CHECK>.supersede.<SUFFIX>.yaml record on disk and
+      must tolerate files that are not valid YAML (yaml.safe_load wrapped in try/except (yaml.YAMLError,
+      OSError), returning an error string rather than raising) before immediately handing the parsed dict
+      to ModelReceiptSupersession.model_validate(raw) for the actual typed validation a few lines later
+      — the exact YAML-parse-before-Pydantic-validate pipeline shape this allowlist exists for, same pattern
+      as validator_receipt_honesty.py above.
+    added: "2026-08-23"
+    review: "2026-12-13"
+
 # Specific filenames that are allowed (matched by basename)
 # Allows the same utility to be used across different module paths (e.g., copied utilities)
 allowed_filenames:

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -209,8 +209,15 @@ def validate_occ_merge_eligibility(
             # OMN-13888 (scope 3): resolve the supersession chain first. A
             # tombstone invalidates the key (no active receipt); a replacement
             # re-binds it to a net-new receipt without editing the base file.
+            # OMN-16432: current_pr_number scopes resolution to the record
+            # that explicitly targets this consumer when a shared key is
+            # bound to several downstream PRs.
             supersession = resolve_supersession(
-                snapshot.receipts_dir, ticket_id, evidence_item_id, check_type
+                snapshot.receipts_dir,
+                ticket_id,
+                evidence_item_id,
+                check_type,
+                current_pr_number=snapshot.pr_number,
             )
             if supersession is not None:
                 if supersession.error is not None:

--- a/src/omnibase_core/validation/validator_receipt_gate.py
+++ b/src/omnibase_core/validation/validator_receipt_gate.py
@@ -980,8 +980,15 @@ def _check_one_receipt(
     # OMN-13888 (scope 3): resolve the supersession chain before loading the
     # base file. A tombstone means the key has no active receipt (fail as
     # missing); a replacement re-binds the key without editing the base file.
+    # OMN-16432: current_pr_number scopes resolution to the record that
+    # explicitly targets this consumer when a shared key is bound to several
+    # downstream PRs (see validator_receipt_supersession module docstring).
     supersession = resolve_supersession(
-        receipts_dir, ticket_id, evidence_item_id, check_type
+        receipts_dir,
+        ticket_id,
+        evidence_item_id,
+        check_type,
+        current_pr_number=current_pr_number,
     )
     receipt: ModelDodReceipt
     if supersession is not None:

--- a/src/omnibase_core/validation/validator_receipt_supersession.py
+++ b/src/omnibase_core/validation/validator_receipt_supersession.py
@@ -9,22 +9,43 @@ A receipt key ``(<TICKET>, <EVIDENCE_ITEM>, <CHECK_TYPE>)`` maps to a base file:
 
 plus an append-only chain of net-new correction records::
 
-    drift/dod_receipts/<TICKET>/<EVIDENCE_ITEM>/<CHECK_TYPE>.supersede.<NNNN>.yaml
+    drift/dod_receipts/<TICKET>/<EVIDENCE_ITEM>/<CHECK_TYPE>.supersede.<SUFFIX>.yaml
 
-The record with the highest zero-padded ``NNNN`` is authoritative. A tombstone
-record (``tombstone: true``, no replacement) invalidates the key; a replacement
-record re-binds the key to a new receipt embedded in the record. When no
-supersession file exists, the key resolves to its base receipt file. No merged
-file is ever edited — corrections are always net-new higher-numbered files.
+A tombstone record (``tombstone: true``, no replacement) invalidates the key; a
+replacement record re-binds the key to a new receipt embedded in the record.
+When no supersession file exists, the key resolves to its base receipt file.
+No merged file is ever edited — corrections are always net-new files.
+
+Two resolution tiers (OMN-16432):
+
+1. **Target-aware.** When the caller supplies ``current_pr_number``, a single
+   shared ``evidence_item_id`` may legitimately be re-bound to *several*
+   different downstream consumer PRs by separate supersession records (e.g.
+   an ``occ-self-bind-pr-<N>`` anchor rebound once per consumer). The record
+   whose ``replacement.pr_number`` matches ``current_pr_number`` — or a
+   tombstone, which invalidates the key for everyone — wins, using the
+   chronologically latest (``created_at``) applicable record. This makes
+   resolution correct regardless of what convention a record's filename
+   suffix follows.
+2. **Legacy fallback.** Untouched from the original OMN-13888 design: the
+   record with the numerically highest ``NNNN`` filename suffix is
+   authoritative. This is the sole path when no candidate explicitly targets
+   ``current_pr_number`` (including when the caller passes no PR context at
+   all), so existing single-consumer chains — the overwhelming majority, and
+   the only shape that predates per-target binding — resolve exactly as
+   before. Non-numeric suffixes never participate in this tiebreak, matching
+   pre-OMN-16432 behavior.
 
 This module keeps the path-local O(1) glob the receipt tree was built for; it
-does not scan a global supersessions directory.
+does not scan a global supersessions directory, and chain length for a single
+key is always small (this is not a global scan).
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 import yaml
@@ -35,7 +56,11 @@ from omnibase_core.models.contracts.ticket.model_receipt_supersession import (
     ModelReceiptSupersession,
 )
 
-_SUPERSEDE_NNNN_RE = re.compile(r"\.supersede\.(\d+)\.yaml$")
+# Suffix is everything between ".supersede." and ".yaml" — deliberately not
+# digit-only. A prior digit-only pattern silently dropped non-numeric-suffix
+# files (e.g. "command.supersede.2010-head.yaml") from consideration with no
+# error; widening this keeps every real record visible to resolution below.
+_SUPERSEDE_SUFFIX_RE = re.compile(r"\.supersede\.([^./]+)\.yaml$")
 
 
 @dataclass(frozen=True)
@@ -47,8 +72,8 @@ class SupersessionResolution:
     - ``receipt`` set → the key is re-bound to this replacement receipt.
     - ``tombstoned`` True → the key is deliberately invalidated (no active
       receipt); the caller must treat it as MISSING / non-satisfied.
-    - ``error`` set → the latest supersession record is unreadable/invalid; the
-      caller must fail closed.
+    - ``error`` set → the authoritative supersession record is
+      unreadable/invalid; the caller must fail closed.
 
     ``source_path`` names the record used, for operator-facing messages.
     """
@@ -59,13 +84,68 @@ class SupersessionResolution:
     source_path: Path
 
 
+def _load_supersede_record(
+    path: Path,
+    ticket_id: str,
+    evidence_item_id: str,
+    check_type: str,
+) -> tuple[ModelReceiptSupersession | None, str | None]:
+    """Load, parse, and key-validate one supersession record.
+
+    Returns ``(record, None)`` on success or ``(None, error_message)`` on any
+    read/parse/key-mismatch failure.
+    """
+    try:
+        with path.open(encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+    except (yaml.YAMLError, OSError) as exc:
+        return None, f"supersession record {path} is unreadable: {exc}"
+
+    try:
+        record = ModelReceiptSupersession.model_validate(raw)
+    except ValidationError as exc:
+        return None, f"supersession record {path} is invalid: {exc}"
+
+    if (record.ticket_id, record.evidence_item_id, record.check_type) != (
+        ticket_id,
+        evidence_item_id,
+        check_type,
+    ):
+        return None, (
+            f"supersession record {path} declares key "
+            f"({record.ticket_id}, {record.evidence_item_id}, "
+            f"{record.check_type}) but is filed under "
+            f"({ticket_id}, {evidence_item_id}, {check_type})"
+        )
+    return record, None
+
+
+def _resolution_from_record(
+    record: ModelReceiptSupersession, path: Path
+) -> SupersessionResolution:
+    if record.tombstone:
+        return SupersessionResolution(
+            receipt=None, tombstoned=True, error=None, source_path=path
+        )
+    return SupersessionResolution(
+        receipt=record.replacement, tombstoned=False, error=None, source_path=path
+    )
+
+
 def resolve_supersession(
     receipts_dir: Path,
     ticket_id: str,
     evidence_item_id: str,
     check_type: str,
+    current_pr_number: int | None = None,
 ) -> SupersessionResolution | None:
     """Resolve the active receipt for a key from its supersession chain.
+
+    ``current_pr_number``, when supplied, scopes resolution to the record
+    that explicitly targets that consumer PR (see module docstring, tier 1).
+    Omitting it reproduces the original numeric-highest-suffix behavior
+    exactly (tier 2) — every existing call site that has not been updated to
+    pass PR context keeps behaving as it always has.
 
     Returns ``None`` when no supersession file exists for the key — the caller
     then proceeds with the base receipt file exactly as before (backward
@@ -76,69 +156,70 @@ def resolve_supersession(
     if not key_dir.is_dir():
         return None
 
-    numbered: list[tuple[int, Path]] = []
+    candidates: list[tuple[str, Path]] = []
     for candidate in key_dir.glob(f"{check_type}.supersede.*.yaml"):
-        match = _SUPERSEDE_NNNN_RE.search(candidate.name)
+        match = _SUPERSEDE_SUFFIX_RE.search(candidate.name)
         if match is not None:
-            numbered.append((int(match.group(1)), candidate))
-    if not numbered:
+            candidates.append((match.group(1), candidate))
+    if not candidates:
         return None
 
-    numbered.sort(key=lambda item: item[0])
-    _, latest_path = numbered[-1]
-
-    try:
-        with latest_path.open(encoding="utf-8") as handle:
-            raw = yaml.safe_load(handle)
-    except (yaml.YAMLError, OSError) as exc:
-        return SupersessionResolution(
-            receipt=None,
-            tombstoned=False,
-            error=f"supersession record {latest_path} is unreadable: {exc}",
-            source_path=latest_path,
+    # Load every candidate up front. This chain is already scoped to a single
+    # receipt key (never a global scan) so it stays bounded by chain length —
+    # in practice 1-5 files even for a heavily-corrected key.
+    loaded: list[tuple[str, Path, ModelReceiptSupersession | None, str | None]] = []
+    for suffix, path in candidates:
+        record, err = _load_supersede_record(
+            path, ticket_id, evidence_item_id, check_type
         )
+        loaded.append((suffix, path, record, err))
 
-    try:
-        record = ModelReceiptSupersession.model_validate(raw)
-    except ValidationError as exc:
-        return SupersessionResolution(
-            receipt=None,
-            tombstoned=False,
-            error=f"supersession record {latest_path} is invalid: {exc}",
-            source_path=latest_path,
-        )
-
-    if (record.ticket_id, record.evidence_item_id, record.check_type) != (
-        ticket_id,
-        evidence_item_id,
-        check_type,
-    ):
-        return SupersessionResolution(
-            receipt=None,
-            tombstoned=False,
-            error=(
-                f"supersession record {latest_path} declares key "
-                f"({record.ticket_id}, {record.evidence_item_id}, "
-                f"{record.check_type}) but is filed under "
-                f"({ticket_id}, {evidence_item_id}, {check_type})"
-            ),
-            source_path=latest_path,
-        )
-
-    if record.tombstone:
-        return SupersessionResolution(
-            receipt=None,
-            tombstoned=True,
-            error=None,
-            source_path=latest_path,
-        )
-
-    return SupersessionResolution(
-        receipt=record.replacement,
-        tombstoned=False,
-        error=None,
-        source_path=latest_path,
+    numeric = sorted(
+        (item for item in loaded if item[0].isdigit()),
+        key=lambda item: int(item[0]),
     )
+
+    def _legacy_winner() -> SupersessionResolution | None:
+        """Tier 2: numerically-highest suffix wins (pre-OMN-16432 behavior)."""
+        if not numeric:
+            return None
+        _, path, record, err = numeric[-1]
+        if record is None:
+            return SupersessionResolution(
+                receipt=None, tombstoned=False, error=err, source_path=path
+            )
+        return _resolution_from_record(record, path)
+
+    if current_pr_number is None:
+        return _legacy_winner()
+
+    # Tier 1: records that explicitly apply to this consumer — a tombstone
+    # (key-wide invalidation, applies to every consumer) or a rebind whose
+    # replacement targets current_pr_number exactly. Latest created_at wins;
+    # numeric suffix is only a same-timestamp tiebreak.
+    applicable: list[tuple[datetime, str, Path, ModelReceiptSupersession]] = []
+    for suffix, path, record, _err in loaded:
+        if record is None:
+            continue
+        if record.tombstone:
+            applicable.append((record.created_at, suffix, path, record))
+            continue
+        if (
+            record.replacement is not None
+            and record.replacement.pr_number == current_pr_number
+        ):
+            applicable.append((record.created_at, suffix, path, record))
+
+    if applicable:
+        applicable.sort(
+            key=lambda item: (item[0], int(item[1]) if item[1].isdigit() else -1)
+        )
+        _, _, winner_path, winner_record = applicable[-1]
+        return _resolution_from_record(winner_record, winner_path)
+
+    # No record targets this consumer specifically — behave exactly as a
+    # caller with no PR context would (legacy / untargeted chain).
+    return _legacy_winner()
 
 
 __all__ = ["SupersessionResolution", "resolve_supersession"]

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -131,6 +131,16 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
     env["PREPUSH_FULL_SUITE"] = "1"
     env["PREPUSH_BASE_REF"] = "HEAD"
     env["PREPUSH_200_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
+    # OMN-16425: PREPUSH_ALLOW_LOCAL_FULL_SUITE leaking in from the outer
+    # process's ambient env (e.g. an operator's own degraded-host `git push`
+    # override) defeats this test's own assertion -- the hook takes the
+    # "DEGRADED-HOST OVERRIDE IN EFFECT" branch instead of refusing, and
+    # actually runs the real full suite as a subprocess of this already-
+    # running one (observed live: recursive full-suite spawns roughly every
+    # 1-2 minutes until the machine starved). Same stripping already used by
+    # _run_hook_forcing_full_suite below; this call site builds its own env
+    # inline and had been missed.
+    env.pop("PREPUSH_ALLOW_LOCAL_FULL_SUITE", None)
     result = subprocess.run(
         ["bash", str(HOOK_SCRIPT)],
         cwd=REPO_ROOT,

--- a/tests/unit/validation/test_occ_per_entry_hashing.py
+++ b/tests/unit/validation/test_occ_per_entry_hashing.py
@@ -356,7 +356,11 @@ def test_both_bindings_absent_hard_fails(tmp_path: Path) -> None:
 
 
 def _supersession_dict(
-    *, item_id: str, tombstone: bool, replacement: dict | None
+    *,
+    item_id: str,
+    tombstone: bool,
+    replacement: dict | None,
+    created_at: datetime | None = None,
 ) -> dict:
     data = {
         "schema_version": "1.0.0",
@@ -366,7 +370,7 @@ def _supersession_dict(
         "supersedes": f"drift/dod_receipts/{TICKET}/{item_id}/command.yaml",
         "reason": "rebind to the actually-merged PR",
         "superseder": "closeout-agent",
-        "created_at": datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        "created_at": created_at or datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
         "tombstone": tombstone,
     }
     if replacement is not None:
@@ -475,6 +479,205 @@ def test_highest_nnnn_untombstones(tmp_path: Path) -> None:
     assert resolution.tombstoned is False
     assert resolution.receipt is not None
     assert resolution.receipt.pr_number == 303
+
+
+# --------------------------------------------------------------------------- #
+# OMN-16432 — target-aware resolution (shared evidence_item_id, multiple
+# consumers, two competing suffix-numbering conventions)
+# --------------------------------------------------------------------------- #
+
+
+def _write_shared_key_base(
+    tmp_path: Path, item_id: str = "occ-self-bind-pr-6838"
+) -> Path:
+    key_dir = tmp_path / "receipts" / TICKET / item_id
+    key_dir.mkdir(parents=True, exist_ok=True)
+    (key_dir / "command.yaml").write_text("placeholder: true\n", encoding="utf-8")
+    return key_dir
+
+
+def _write_shared_supersede(
+    key_dir: Path,
+    *,
+    suffix: str,
+    item_id: str,
+    pr_number: int,
+    created_at: datetime,
+) -> None:
+    replacement = _receipt_dict(
+        item_id=item_id,
+        pr_number=pr_number,
+        commit_sha=f"{pr_number:040x}"[:40],
+        contract_entry_sha256="sha256:" + "0" * 64,
+    )
+    (key_dir / f"command.supersede.{suffix}.yaml").write_text(
+        yaml.safe_dump(
+            _supersession_dict(
+                item_id=item_id,
+                tombstone=False,
+                replacement=replacement,
+                created_at=created_at,
+            ),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.unit
+def test_target_aware_resolution_reproduces_omn_16322_collision(
+    tmp_path: Path,
+) -> None:
+    """Reproduces the live OMN-16322 occ-self-bind-pr-6838 collision: one
+    shared evidence_item_id superseded by two competing numbering
+    conventions (downstream-consumer-PR-number vs OCC-repair-PR-own-number).
+    The numerically-highest suffix (6940, the repair PR's own number) must
+    NOT shadow the records that explicitly target the two product consumers.
+    """
+    item_id = "occ-self-bind-pr-6838"
+    key_dir = _write_shared_key_base(tmp_path, item_id)
+    # Consumer PR #2010 (omniclaude), numbered by its own PR number.
+    _write_shared_supersede(
+        key_dir,
+        suffix="2010",
+        item_id=item_id,
+        pr_number=2010,
+        created_at=datetime(2026, 8, 23, 20, 11, 25, tzinfo=UTC),
+    )
+    # Consumer PR #2836 (omnibase_infra), same convention.
+    _write_shared_supersede(
+        key_dir,
+        suffix="2836",
+        item_id=item_id,
+        pr_number=2836,
+        created_at=datetime(2026, 8, 23, 20, 11, 25, tzinfo=UTC),
+    )
+    # OCC repair PR #6934 rebinds the anchor to itself, numbered by ITS OWN
+    # PR number — a different, competing convention.
+    _write_shared_supersede(
+        key_dir,
+        suffix="6934",
+        item_id=item_id,
+        pr_number=6934,
+        created_at=datetime(2026, 8, 23, 20, 20, 0, tzinfo=UTC),
+    )
+    # OCC repair PR #6940 does the same, numerically highest of all five.
+    _write_shared_supersede(
+        key_dir,
+        suffix="6940",
+        item_id=item_id,
+        pr_number=6940,
+        created_at=datetime(2026, 8, 23, 23, 18, 0, tzinfo=UTC),
+    )
+
+    # Each consumer resolves to ITS OWN record, not the numerically-highest
+    # (6940) one that shadowed everything pre-fix.
+    for consumer_pr in (2010, 2836, 6934, 6940):
+        resolution = resolve_supersession(
+            tmp_path / "receipts",
+            TICKET,
+            item_id,
+            "command",
+            current_pr_number=consumer_pr,
+        )
+        assert resolution is not None
+        assert resolution.error is None, resolution.error
+        assert resolution.receipt is not None
+        assert resolution.receipt.pr_number == consumer_pr, (
+            f"consumer #{consumer_pr} resolved to pr_number="
+            f"{resolution.receipt.pr_number} instead of itself"
+        )
+
+    # A caller with NO PR context (the pre-OMN-16432 call shape) keeps the
+    # exact legacy behavior: numerically-highest suffix wins.
+    legacy = resolve_supersession(tmp_path / "receipts", TICKET, item_id, "command")
+    assert legacy is not None
+    assert legacy.receipt is not None
+    assert legacy.receipt.pr_number == 6940
+
+
+@pytest.mark.unit
+def test_target_aware_resolution_honors_non_numeric_suffix_correction(
+    tmp_path: Path,
+) -> None:
+    """The live collision also included a non-numeric-suffix correction
+    (command.supersede.2010-head.yaml) that the old digit-only regex silently
+    dropped from consideration. It must now be visible and, being the latest
+    record targeting PR #2010, must win over the earlier same-PR record.
+    """
+    item_id = "occ-self-bind-pr-6838"
+    key_dir = _write_shared_key_base(tmp_path, item_id)
+    _write_shared_supersede(
+        key_dir,
+        suffix="2010",
+        item_id=item_id,
+        pr_number=2010,
+        created_at=datetime(2026, 8, 23, 20, 11, 25, tzinfo=UTC),
+    )
+    # Non-numeric suffix, same consumer, LATER correction.
+    refreshed = _receipt_dict(
+        item_id=item_id,
+        pr_number=2010,
+        commit_sha="f" * 40,
+        contract_entry_sha256="sha256:" + "0" * 64,
+    )
+    (key_dir / "command.supersede.2010-head.yaml").write_text(
+        yaml.safe_dump(
+            _supersession_dict(
+                item_id=item_id,
+                tombstone=False,
+                replacement=refreshed,
+                created_at=datetime(2026, 8, 23, 22, 38, 0, tzinfo=UTC),
+            ),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    resolution = resolve_supersession(
+        tmp_path / "receipts", TICKET, item_id, "command", current_pr_number=2010
+    )
+    assert resolution is not None
+    assert resolution.error is None, resolution.error
+    assert resolution.receipt is not None
+    assert resolution.receipt.commit_sha == "f" * 40
+
+
+@pytest.mark.unit
+def test_target_aware_resolution_tombstone_applies_to_every_consumer(
+    tmp_path: Path,
+) -> None:
+    """A tombstone on a shared key invalidates it for every consumer, not
+    just the one that happened to file it — key-wide invalidation semantics
+    are preserved by the new per-target resolution tier.
+    """
+    item_id = "occ-self-bind-pr-6838"
+    key_dir = _write_shared_key_base(tmp_path, item_id)
+    _write_shared_supersede(
+        key_dir,
+        suffix="2010",
+        item_id=item_id,
+        pr_number=2010,
+        created_at=datetime(2026, 8, 23, 20, 11, 25, tzinfo=UTC),
+    )
+    (key_dir / "command.supersede.9999.yaml").write_text(
+        yaml.safe_dump(
+            _supersession_dict(
+                item_id=item_id,
+                tombstone=True,
+                replacement=None,
+                created_at=datetime(2026, 8, 23, 21, 0, 0, tzinfo=UTC),
+            ),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    resolution = resolve_supersession(
+        tmp_path / "receipts", TICKET, item_id, "command", current_pr_number=2010
+    )
+    assert resolution is not None
+    assert resolution.tombstoned is True
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`resolve_supersession()` picked the numerically-highest `.supersede.NNNN.yaml` suffix unconditionally, with no awareness of what `NNNN` means or who the record targets. Two numbering conventions coexist in practice (downstream-consumer-PR-number vs. an OCC-repair-PR's own number), so on a shared `evidence_item_id` rebound to multiple consumers, the repair PR's own self-referential record always shadowed the real consumer's record.

Live on OMN-16322's `occ-self-bind-pr-6838`: OCC#6940's self-bind shadowed both omniclaude#2010 and omnibase_infra#2836, burning two repair attempts (OCC#6934, #6940) before diagnosis.

- `resolve_supersession()` gains an optional `current_pr_number` parameter, threaded from `validator_receipt_gate._check_one_receipt` and `validator_occ_merge_eligibility.validate_occ_merge_eligibility` (both already had PR context available). When supplied, the record whose `replacement.pr_number == current_pr_number` (or a tombstone, which is key-wide) wins, using the chronologically latest (`created_at`) applicable record — regardless of suffix numbering.
- Every call site without PR context keeps the exact legacy numeric-highest-suffix behavior unchanged.
- Fixes a second bug: a non-numeric suffix (e.g. `2010-head`) was silently invisible to the old digit-only regex, so a corrected record could vanish from the chain with no error.
- Bonus fix (OMN-16425): `test_guard_refuses_full_suite_escalation_on_non_200_host` leaked `PREPUSH_ALLOW_LOCAL_FULL_SUITE` from the ambient env into its subprocess, causing the pre-push hook it spawns to recursively launch another full-suite pytest run instead of refusing — reproduced live 3x while landing this PR (every attempt with the degraded-host override set hit this). Fixed by stripping the leaky var, matching two sibling call sites in the same file that already do this.

## Verification

- 3 new tests reproduce the exact live OMN-16322 collision (5 files, 2 numbering conventions, non-numeric suffix, tombstone-applies-to-all semantics). 24/24 pass in-file, 401/401 pass across `tests/unit/validation/`.
- mypy --strict clean, ruff clean.
- Full-repo suite run locally 4 times under `PREPUSH_ALLOW_LOCAL_FULL_SUITE=1` (**degraded-evidence override** — both designated hosts, this machine and the .201 gate-runner, were over the governed pre-push hook's load threshold from ~6 concurrent agent lanes' full-suite runs sharing this Mac tonight; team-lead pre-approved this escape hatch for this ticket). Final run (after the OMN-16425 fix): **44012 passed / 53 skipped / 3 xpassed / 0 failed**, 1h41m.
- Live dry-run against real `onex_change_control@dev` data (not synthetic): the resolver now correctly selects `occ-self-bind-pr-6838/command.supersede.2010-head.yaml` for consumer omniclaude#2010 instead of OCC#6940's self-bind. That specific merged supersede file has its own separate, pre-existing content-authoring defect (stale `contract_entry_sha256`) — flagged on OMN-16322 as a follow-up, not fixed here (append-only; likely moot given the #2010 sub-lane's own net-new dod entry).

## Propagation

`occ-preflight / eligibility` (`occ-preflight.yml`, `core-ref` input defaults to `"dev"`) picks this fix up automatically on merge — no release needed. `Receipt Gate / verify` (`receipt-gate.yml`) hardcodes its internal validator checkout to `ref: main` with no override input, so it needs a small follow-up PR (per the OMN-16413 precedent in `onex_change_control/.github/workflows/docs-validate.yml`) repointing that checkout to this PR's merge SHA, then repointing each consumer's `call-receipt-gate.yml` `uses:` line to that follow-up's SHA — tracked on OMN-16432, not cutting a release for this.

Closes: OMN-16432, OMN-16425

## Test plan

- [x] `uv run pytest tests/unit/validation/ -q` — 401 passed
- [x] `uv run pytest tests/scripts/test_prepush_hook_host_identity_guard.py -q` — 30 passed
- [x] `uv run mypy src/omnibase_core/validation/validator_receipt_supersession.py src/omnibase_core/validation/validator_receipt_gate.py src/omnibase_core/validation/validator_occ_merge_eligibility.py --strict` — clean
- [x] Full governed pre-push suite — 44012 passed / 0 failed
- [x] Live dry-run against real `onex_change_control@dev` receipts confirming the fix

Evidence-Ticket: OMN-16432
Evidence-Source: OCC#6973
