### PR TITLE
fix(OMN-16415): suppress pydantic schema field-shadow UserWarning at source

### DIFF
--- a/src/omnibase_core/models/contracts/subcontracts/model_db_table_declaration.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_db_table_declaration.py
@@ -3,11 +3,21 @@
 
 """DB table declaration model for contract-first projection nodes."""
 
+import warnings
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = ["ModelDbTableDeclaration"]
+
+# OMN-16415: see model_deployment_topology_database_migration_ledger.py for the
+# full rationale -- `schema` is the correct SQL-domain field name; the warning
+# is suppressed narrowly by message pattern, not renamed.
+warnings.filterwarnings(
+    "ignore",
+    message=r'Field name "schema" in ".*" shadows an attribute in parent "BaseModel"',
+    category=UserWarning,
+)
 
 
 class ModelDbTableDeclaration(BaseModel):

--- a/src/omnibase_core/models/core/model_deployment_topology_database_grant.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_grant.py
@@ -4,6 +4,7 @@
 """Explicit workload-principal grant in a deployment database topology."""
 
 import re
+import warnings
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -15,6 +16,15 @@ from omnibase_core.enums.enum_database_privilege import EnumDatabasePrivilege
 __all__ = ["ModelDeploymentTopologyDatabaseGrant"]
 
 _SQL_IDENTIFIER_PATTERN = r"^[a-z_][a-z0-9_]*$"
+
+# OMN-16415: see model_deployment_topology_database_migration_ledger.py for the
+# full rationale -- `schema` is the correct SQL-domain field name; the warning
+# is suppressed narrowly by message pattern, not renamed.
+warnings.filterwarnings(
+    "ignore",
+    message=r'Field name "schema" in ".*" shadows an attribute in parent "BaseModel"',
+    category=UserWarning,
+)
 _SQL_IDENTIFIER = re.compile(_SQL_IDENTIFIER_PATTERN)
 
 _ALLOWED_PRIVILEGES: dict[

--- a/src/omnibase_core/models/core/model_deployment_topology_database_migration_ledger.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_migration_ledger.py
@@ -3,11 +3,26 @@
 
 """Checksum-aware migration-ledger declaration for a deployment database."""
 
+import warnings
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = ["ModelDeploymentTopologyDatabaseMigrationLedger"]
 
 _SQL_IDENTIFIER_PATTERN = r"^[a-z_][a-z0-9_]*$"
+
+# OMN-16415: `schema` is the correct SQL-domain field name here (a database
+# schema reference); pydantic v2 still emits a UserWarning at class-definition
+# time because the name shadows BaseModel's deprecated `.schema()` classmethod.
+# Renaming would ripple into every deployment-topology YAML contract that
+# declares `schema:` across consuming repos for zero behavioral benefit, so the
+# warning is suppressed narrowly by message pattern at its emission point
+# (class definition) instead of a blanket ignore.
+warnings.filterwarnings(
+    "ignore",
+    message=r'Field name "schema" in ".*" shadows an attribute in parent "BaseModel"',
+    category=UserWarning,
+)
 
 
 class ModelDeploymentTopologyDatabaseMigrationLedger(BaseModel):

--- a/tests/unit/models/core/test_model_deployment_topology_database.py
+++ b/tests/unit/models/core/test_model_deployment_topology_database.py
@@ -3,6 +3,8 @@
 
 """Tests for typed application-database deployment topology contracts."""
 
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -296,3 +298,38 @@ def test_database_resource_is_frozen() -> None:
 
     with pytest.raises(ValidationError):
         topology.databases["application"].physical_name = "other"  # type: ignore[misc]
+
+
+def test_schema_field_shadow_warning_suppressed_on_fresh_import() -> None:
+    """OMN-16415: importing these three models must not emit the pydantic
+    ``schema`` field-shadow ``UserWarning`` -- that warning, printed to the
+    gateway-forwarder healthcheck's stdout on every invocation, was noise
+    surfacing on the container's Docker health log. A fresh subprocess is
+    required because the warning fires once at class-definition time, and the
+    pytest process has already imported (and cached) these modules by the time
+    this test runs.
+    """
+    script = (
+        "import warnings\n"
+        "with warnings.catch_warnings(record=True) as caught:\n"
+        "    warnings.simplefilter('always')\n"
+        "    from omnibase_core.models.core.model_deployment_topology_database_migration_ledger import (\n"
+        "        ModelDeploymentTopologyDatabaseMigrationLedger,\n"
+        "    )\n"
+        "    from omnibase_core.models.core.model_deployment_topology_database_grant import (\n"
+        "        ModelDeploymentTopologyDatabaseGrant,\n"
+        "    )\n"
+        "    from omnibase_core.models.contracts.subcontracts.model_db_table_declaration import (\n"
+        "        ModelDbTableDeclaration,\n"
+        "    )\n"
+        "shadow = [w for w in caught if 'shadows an attribute' in str(w.message)]\n"
+        "assert not shadow, [str(w.message) for w in shadow]\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

`model_deployment_topology_database_migration_ledger.py`,
`model_deployment_topology_database_grant.py`, and `model_db_table_declaration.py`
all declare a `schema` field, which pydantic v2 warns about at class-definition
time because it shadows `BaseModel`'s deprecated `.schema()` classmethod. The
warning printed on every gateway-forwarder healthcheck invocation, polluting
the Docker health log on `omninode-gateway-forwarder` (.201, FailingStreak=483
pre-fix).

`schema` is the correct SQL-domain field name (a database schema reference)
and is used across deployment-topology YAML contracts in consuming repos, so
renaming it was rejected as too invasive for zero behavioral benefit. Instead
the specific warning is suppressed narrowly by message pattern at each
model's import, verified via a subprocess-isolated regression test (the
warning fires once at class-definition time, so an in-process assertion
would pass vacuously after the first import in a test session).

Live re-verify after this change showed the gateway-forwarder healthcheck's
actual FAIL condition is unrelated to these warnings -- it is caused by an
unprovisioned canary topic (OMN-15810 / OMN-16420, fixed separately in
omnibase_infra). This PR still satisfies OMN-16415's acceptance criterion
("field shadow identified and fixed at the source") and removes real log
noise from every healthcheck tick across every consumer of these models.

## Verification

```
$ uv run pytest tests/unit/models/core/test_model_deployment_topology_database.py -v
20 passed in 2.02s
$ uv run mypy src/omnibase_core/models/contracts/subcontracts/model_db_table_declaration.py src/omnibase_core/models/core/model_deployment_topology_database_grant.py src/omnibase_core/models/core/model_deployment_topology_database_migration_ledger.py --strict
Success: no issues found in 3 source files
```

Governed pre-push full-suite escalation (`OMNI_RUNNER_SELECTOR_V1` shared-module
classification): **44010 passed, 53 skipped, 3 xpassed, 0 failed** in 1:32:11.

## Scope

Field-shadow suppression only. Does not touch the OMN-16420 canary-topic fix
(separate repo/PR) or attempt a field rename.

Evidence-Ticket: OMN-16415
Evidence-Source: OCC#6977
