### PR TITLE
ci(OMN-16432): pin receipt-gate.yml's validator checkout to the OMN-16432 fix SHA

### DIFF
--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -459,13 +459,24 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      # OMN-16432: pinned to the exact omnibase_core merge SHA that fixed
+      # resolve_supersession() picking the numerically-highest .supersede
+      # suffix with no awareness of which downstream consumer PR a shared
+      # evidence_item_id's record targets (the OMN-16322 occ-self-bind-pr-6838
+      # collision). omnibase_core main is release-synced and does NOT carry
+      # this fix yet, so `ref: main` cannot be used until the next release
+      # cuts. Repoint to `main` once a release >= the tag containing
+      # 37bd85194b96 ships (same pattern as OMN-16413's docs-validate.yml
+      # pin, one layer deeper: this checkout supplies the validator SOURCE,
+      # not the calling workflow's own YAML, so pinning callers' `uses:` to a
+      # SHA alone would not have propagated a Python source-level fix).
       - name: Check out omnibase_core (for receipt-gate deps)
         if: "steps.bot_exempt.outputs.exempt != 'true' && ! hashFiles('./src/omnibase_core/__init__.py') && ! hashFiles('./omnibase_core/pyproject.toml')"
         uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
           path: .receipt-gate-deps/omnibase_core
-          ref: main
+          ref: 37bd85194b96c5a476ae2e2c0ef79235955fb748
           fetch-depth: 1
 
       - name: Install omnibase_core


### PR DESCRIPTION
## Summary

`occ-preflight / eligibility` (`occ-preflight.yml`) already reads its validator source via a `core-ref` input that defaults to `"dev"`, so it picked up the OMN-16432 `resolve_supersession()` fix automatically once #1580 merged. `Receipt Gate / verify` (`receipt-gate.yml`) has no such input — its internal "Check out omnibase_core (for receipt-gate deps)" step hardcodes `ref: main`, and `main` is release-synced, so it won't carry the fix until a release cuts.

Pins that internal checkout to the exact merge SHA of #1580 (`37bd85194b96c5a476ae2e2c0ef79235955fb748`) instead — same pattern as the OMN-16413 precedent in `onex_change_control/.github/workflows/docs-validate.yml`, one layer deeper: that precedent pinned a caller's `uses:` line (a workflow-YAML-level fix), while this fix lives in the validator's Python source, which this repo's own internal checkout resolves independently of whatever SHA a caller's `uses:` points at.

Repoint back to `ref: main` once a release ≥ the tag containing `37bd85194b96` ships.

## Test plan

- [x] Full governed pre-push suite: 44012 passed / 0 failed
- [x] Single-line workflow YAML change, no Python touched

Evidence-Ticket: OMN-16432
Evidence-Source: OCC#6979
