### PR TITLE
fix(OMN-16452): type the environment dependency convention with an enum member and env_var field

### DIFF
--- a/docs/architecture/CONTRACT_SYSTEM.md
+++ b/docs/architecture/CONTRACT_SYSTEM.md
@@ -188,6 +188,29 @@ validation_rules:
   max_input_size_bytes: 1048576
 ```
 
+### Dependency classification (`dependency_type` / `type`)
+
+A dependency entry is classified by `dependency_type`, whose values are the
+`EnumDependencyType` members: `protocol`, `service`, `module`, `external`,
+`environment`.
+
+Contracts in practice spell this key `type:`, so `type:` is accepted as an alias
+**only when its value names an `EnumDependencyType` member**. `type:` is otherwise
+freeform in the corpus (`handler`, `library`, `node`, class names, ...); those
+values are not classification and fall back to the `protocol` default rather than
+failing the contract load.
+
+Environment dependencies declare the variable that supplies them via `env_var`:
+
+```yaml
+dependencies:
+  - name: linear_api_key
+    type: environment
+    env_var: LINEAR_API_KEY
+    required: true
+    description: Linear API key for GraphQL mutations
+```
+
 ---
 
 ## Contract Models

--- a/docs/reference/API_DOCUMENTATION.md
+++ b/docs/reference/API_DOCUMENTATION.md
@@ -548,7 +548,7 @@ The enums package contains 100+ enum definitions. Key enums for the public API:
 |------|------|---------|
 | `EnumInjectionScope` | `enum_injection_scope.py` | `GLOBAL`, `TRANSIENT`, `SCOPED` |
 | `EnumServiceLifecycle` | `enum_service_lifecycle.py` | Service lifecycle states |
-| `EnumDependencyType` | `enum_dependency_type.py` | `REQUIRED`, `OPTIONAL`, `PREFERRED` |
+| `EnumDependencyType` | `enum_dependency_type.py` | `PROTOCOL`, `SERVICE`, `MODULE`, `EXTERNAL`, `ENVIRONMENT` |
 
 ### Execution Enums (exported from `omnibase_core.nodes`)
 

--- a/src/omnibase_core/enums/enum_dependency_type.py
+++ b/src/omnibase_core/enums/enum_dependency_type.py
@@ -20,3 +20,4 @@ class EnumDependencyType(UtilStrValueHelper, str, Enum):
     SERVICE = "service"
     MODULE = "module"
     EXTERNAL = "external"
+    ENVIRONMENT = "environment"

--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -72,6 +72,14 @@ from omnibase_core.types import (
     TypedDictPublishedEventEntry,
 )
 
+# Values that EnumDependencyType actually models. Derived from the enum so a new
+# member is picked up automatically. Used to decide whether a contract's freeform
+# ``type:`` key may be read as a ``dependency_type`` alias -- see
+# ``_batch_convert_dict_dependencies``.
+_DEPENDENCY_TYPE_MEMBER_VALUES: frozenset[str] = frozenset(
+    member.value for member in EnumDependencyType
+)
+
 
 class ModelContractBase(BaseModel, ABC):
     """
@@ -624,10 +632,26 @@ class ModelContractBase(BaseModel, ABC):
                     if item_dict.get("module") is not None
                     else None
                 )
-                dependency_type = item_dict.get(
-                    "dependency_type",
-                    EnumDependencyType.PROTOCOL,
-                )
+                # Contracts in the wild spell this key ``type:``, not
+                # ``dependency_type:``. ``type:`` is freeform, though: alongside
+                # real EnumDependencyType values ("protocol", "service",
+                # "environment") the corpus carries values the enum does not
+                # model ("handler", "library", "node", class names, ...).
+                # So ``type:`` is honoured ONLY when it names an enum member;
+                # every other value keeps the historical PROTOCOL default rather
+                # than turning ~180 committed dependency entries into hard
+                # contract-load failures.
+                if "dependency_type" in item_dict:
+                    dependency_type = item_dict["dependency_type"]
+                else:
+                    type_alias = item_dict.get("type")
+                    dependency_type = (
+                        type_alias
+                        if isinstance(type_alias, str)
+                        and type_alias in _DEPENDENCY_TYPE_MEMBER_VALUES
+                        else EnumDependencyType.PROTOCOL
+                    )
+
                 if isinstance(dependency_type, str):
                     dependency_type = EnumDependencyType(dependency_type)
                 elif not isinstance(dependency_type, EnumDependencyType):
@@ -644,6 +668,11 @@ class ModelContractBase(BaseModel, ABC):
                     if item_dict.get("description") is not None
                     else None
                 )
+                env_var = (
+                    str(item_dict["env_var"])
+                    if item_dict.get("env_var") is not None
+                    else None
+                )
 
                 result_deps.append(
                     ModelDependency(
@@ -653,6 +682,7 @@ class ModelContractBase(BaseModel, ABC):
                         version=version,
                         required=required,
                         description=description,
+                        env_var=env_var,
                     ),
                 )
             except (AttributeError, KeyError, TypeError, ValueError) as e:

--- a/src/omnibase_core/models/contracts/model_dependency.py
+++ b/src/omnibase_core/models/contracts/model_dependency.py
@@ -73,12 +73,21 @@ class ModelDependency(BaseModel):
         description="Human-readable dependency description",
     )
 
+    env_var: str | None = Field(
+        default=None,
+        description=(
+            "Environment variable name supplying this dependency "
+            "(e.g., 'LINEAR_API_KEY'); set on ENVIRONMENT dependencies"
+        ),
+    )
+
     # Type mapping for automatic classification
     _TYPE_PATTERNS: ClassVar[dict[str, EnumDependencyType]] = {
         "protocol": EnumDependencyType.PROTOCOL,
         "service": EnumDependencyType.SERVICE,
         "module": EnumDependencyType.MODULE,
         "external": EnumDependencyType.EXTERNAL,
+        "environment": EnumDependencyType.ENVIRONMENT,
     }
 
     # Compiled regex patterns for performance optimization (Phase 3L performance fix)

--- a/src/omnibase_core/validators/extra_forbid_waivers.yaml
+++ b/src/omnibase_core/validators/extra_forbid_waivers.yaml
@@ -31,11 +31,19 @@ waivers:
     pr: https://github.com/OmniNode-ai/omnibase_core/pull/1468
     expires_at: 2026-09-30
     reason: >-
-      S8 PR2 adds an additive optional `topic` field to this routing entry (the
-      PR2<->PR3 RuntimeDispatch seam). The model deliberately keeps extra="ignore"
-      to tolerate legacy handler_routing YAML fields (routing_key, handler_key,
-      priority, output_events, callable, lazy_import) still carried by live
-      contracts; the model docstring defers the extra="forbid" flip to a
-      dedicated migration PR once all consumers carry the live shape. Flipping
-      forbid here would break legacy contract loading and is out of scope for this
-      additive change. Time-boxed to the coordinated migration.
+      S8 PR2 adds an additive optional `topic` field to this routing entry (the PR2<->PR3 RuntimeDispatch
+      seam). The model deliberately keeps extra="ignore" to tolerate legacy handler_routing YAML fields
+      (routing_key, handler_key, priority, output_events, callable, lazy_import) still carried by live
+      contracts; the model docstring defers the extra="forbid" flip to a dedicated migration PR once all
+      consumers carry the live shape. Flipping forbid here would break legacy contract loading and is
+      out of scope for this additive change. Time-boxed to the coordinated migration. #magic___^_^___line
+  - fqn: omnibase_core.models.contracts.model_dependency:ModelDependency
+    ticket: OMN-16458
+    pr: https://github.com/OmniNode-ai/omnibase_core/pull/1583
+    expires_at: 2026-10-31
+    reason: >-
+      OMN-16452 adds an additive typed `env_var` field so the live `type: "environment"` contract convention
+      stops being silently dropped. Touching the model body trips this ratchet, but the extra="forbid"
+      flip is a separate, larger change: `ModelContractPatch.dependencies__add` coerces raw patch dicts
+      with no before-validator, and omnibase_core is an externally-consumed SDK, so the flip needs a consumer
+      sweep this additive PR cannot carry. Flip + baseline removal are tracked in OMN-16458.

--- a/tests/unit/contracts/test_model_contract_base.py
+++ b/tests/unit/contracts/test_model_contract_base.py
@@ -578,3 +578,181 @@ class TestModelContractBaseConfig:
         contract = SampleContractModel(**self.minimal_valid_data)
         assert isinstance(contract.config, ModelContractConfig)
         assert contract.config.model_extra == {}
+
+
+@pytest.mark.unit
+class TestEnvironmentDependencyConvention:
+    """Committed contracts declare env deps as `type: environment` (OMN-16452).
+
+    The dependency dicts exercised here are copied from live, committed
+    contracts so the test tracks the real corpus shape rather than an
+    invented one:
+
+    - ``omnibase_infra`` ``node_db_error_linear_effect/contract.yaml`` uses
+      ``type: "environment"`` + ``env_var: "LINEAR_API_KEY"``.
+    - ``omniclaude`` ``node_channel_slack_adapter/contract.yaml`` uses
+      ``type: environment`` + ``key: SLACK_BOT_TOKEN`` (no ``env_var``).
+    """
+
+    def setup_method(self):
+        self.minimal_valid_data = {
+            "name": "test_contract",
+            "contract_version": ModelSemVer(major=1, minor=0, patch=0),
+            "description": "Test contract",
+            "node_type": EnumNodeType.COMPUTE_GENERIC,
+            "input_model": "omnibase_core.models.test.TestInput",
+            "output_model": "omnibase_core.models.test.TestOutput",
+        }
+
+    # ---- enum member ------------------------------------------------
+
+    def test_enum_has_environment_member(self):
+        assert EnumDependencyType.ENVIRONMENT.value == "environment"
+
+    # ---- ModelDependency field --------------------------------------
+
+    def test_model_dependency_carries_env_var(self):
+        dependency = ModelDependency(
+            name="linear_api_key",
+            dependency_type=EnumDependencyType.ENVIRONMENT,
+            env_var="LINEAR_API_KEY",
+            required=True,
+            description="Linear API key for GraphQL mutations",
+        )
+        assert dependency.env_var == "LINEAR_API_KEY"
+
+    def test_env_var_defaults_to_none(self):
+        dependency = ModelDependency(
+            name="slack_bot_token",
+            dependency_type=EnumDependencyType.ENVIRONMENT,
+        )
+        assert dependency.env_var is None
+
+    def test_environment_dependency_matches_onex_patterns(self):
+        dependency = ModelDependency(
+            name="linear_api_key",
+            dependency_type=EnumDependencyType.ENVIRONMENT,
+            env_var="LINEAR_API_KEY",
+        )
+        assert dependency.matches_onex_patterns() is True
+
+    # ---- dict -> ModelDependency conversion --------------------------
+
+    def test_committed_env_var_shape_round_trips(self):
+        """The omnibase_infra `env_var` shape converts and validates."""
+        data = {
+            **self.minimal_valid_data,
+            "dependencies": [
+                {
+                    "name": "linear_api_key",
+                    "type": "environment",
+                    "env_var": "LINEAR_API_KEY",
+                    "description": "Linear API key for GraphQL mutations",
+                    "required": True,
+                },
+            ],
+        }
+
+        contract = SampleContractModel(**data)
+
+        dependency = contract.dependencies[0]
+        assert dependency.name == "linear_api_key"
+        assert dependency.dependency_type == EnumDependencyType.ENVIRONMENT
+        assert dependency.env_var == "LINEAR_API_KEY"
+        assert dependency.required is True
+        assert dependency.matches_onex_patterns() is True
+
+    def test_committed_key_shape_constructs_without_env_var(self):
+        """The omniclaude `key:` shape has no env_var but must still load."""
+        data = {
+            **self.minimal_valid_data,
+            "dependencies": [
+                {
+                    "name": "slack_bot_token",
+                    "type": "environment",
+                    "key": "SLACK_BOT_TOKEN",
+                    "required": True,
+                    "description": "Slack bot OAuth token",
+                },
+            ],
+        }
+
+        contract = SampleContractModel(**data)
+
+        dependency = contract.dependencies[0]
+        assert dependency.dependency_type == EnumDependencyType.ENVIRONMENT
+        assert dependency.env_var is None
+
+    def test_bare_environment_dependency_constructs(self):
+        """`type: environment` with neither env_var nor key must not raise."""
+        data = {
+            **self.minimal_valid_data,
+            "dependencies": [{"name": "some_env_dep", "type": "environment"}],
+        }
+
+        contract = SampleContractModel(**data)
+
+        assert contract.dependencies[0].dependency_type == (
+            EnumDependencyType.ENVIRONMENT
+        )
+        assert contract.dependencies[0].env_var is None
+
+    # ---- blast-radius guards ----------------------------------------
+
+    @pytest.mark.parametrize(
+        "freeform_type",
+        [
+            "handler",
+            "library",
+            "node",
+            "config",
+            "ModelONEXContainer",
+            "external_service",
+        ],
+    )
+    def test_non_member_type_values_keep_protocol_default(self, freeform_type):
+        """`type:` is freeform across the corpus.
+
+        Values that do not name an EnumDependencyType member must retain the
+        legacy EnumDependencyType.PROTOCOL default and must NOT raise -- ~180
+        committed dependency entries rely on that.
+        """
+        converted = SampleContractModel._batch_convert_dict_dependencies(
+            [(0, {"name": "some_dependency", "type": freeform_type})],
+        )
+
+        assert len(converted) == 1
+        assert converted[0].dependency_type == EnumDependencyType.PROTOCOL
+
+    def test_freeform_type_dependency_still_loads_in_contract(self):
+        """End-to-end guard for a non-member `type:` value."""
+        data = {
+            **self.minimal_valid_data,
+            "dependencies": [
+                {
+                    "name": "ProtocolEventBus",
+                    "module": "omnibase_core.protocol.protocol_event_bus",
+                    "type": "handler",
+                },
+            ],
+        }
+
+        contract = SampleContractModel(**data)
+
+        assert contract.dependencies[0].dependency_type == (EnumDependencyType.PROTOCOL)
+
+    def test_explicit_dependency_type_wins_over_type_alias(self):
+        converted = SampleContractModel._batch_convert_dict_dependencies(
+            [
+                (
+                    0,
+                    {
+                        "name": "some_service",
+                        "dependency_type": "service",
+                        "type": "environment",
+                    },
+                ),
+            ],
+        )
+
+        assert converted[0].dependency_type == EnumDependencyType.SERVICE


### PR DESCRIPTION
Evidence-Source: OCC#7005
Evidence-Ticket: OMN-16452

## Summary

Types the `dependencies[].type == "environment"` contract convention, which 18 committed contracts across 4 repos already use (40 entries) but the type system could not represent.

Ticket: **OMN-16452** — https://linear.app/omninode/issue/OMN-16452

### The defect

- `EnumDependencyType` had `PROTOCOL`, `SERVICE`, `MODULE`, `EXTERNAL` — **no** `ENVIRONMENT`.
- `ModelDependency` had no `env_var` field, and `model_config` is `extra="ignore"`, so an `env_var` kwarg was **silently dropped**.
- `ModelContractBase._batch_convert_dict_dependencies` read the dict key `dependency_type`. **No contract in the corpus uses `dependency_type` in YAML — they all use `type:`.** Every dependency everywhere therefore fell through to the `EnumDependencyType.PROTOCOL` default.

That default has teeth: `ModelDependency.matches_onex_patterns()` requires `"protocol"` in the name or module *only* when `dependency_type == PROTOCOL`. An env dependency named `linear_api_key` misclassified as PROTOCOL fails that check, and `_validate_protocol_dependencies` (called unconditionally from `model_post_init`) raises `ModelOnexError`.

### The change

1. `EnumDependencyType.ENVIRONMENT = "environment"`.
2. `ModelDependency.env_var: str | None` — typed field.
3. `_batch_convert_dict_dependencies` reads `env_var`, and accepts `type:` as an alias for `dependency_type` **only when `dependency_type` is absent AND the `type` value names an `EnumDependencyType` member**.

## Blast-radius reasoning for point 3

`type:` is **freeform** across the contract corpus. Measured over all committed contracts in omnibase_core, omnibase_infra, omniclaude and omnimarket (659 dict dependency entries):

| `type:` value | count | member? |
|---|---|---|
| *(absent)* | 216 | — |
| `handler` | 145 | no |
| `protocol` | 74 | yes |
| `environment` | 64 | yes (new) |
| `node` | 64 | no |
| `service` | 34 | yes |
| `library` | 22 | no |
| `ModelONEXContainer` | 18 | no |
| `config` | 12 | no |
| `container` / `path` / `mixin` / `external_service` | 10 | no |

271 entries carry a `type:` value the enum does not model. The pre-existing code path calls `EnumDependencyType(dependency_type)` on any string, which **raises `ValueError`** — and the whole loop body sits inside a `try/except (..., ValueError)` that collects into `conversion_errors` and then raises `ModelOnexError`. So routing an unrecognized `type:` into that call would turn ~271 committed dependency entries into hard contract-load failures.

The alias is therefore gated on membership: a non-member `type:` value keeps today's exact behavior (the `PROTOCOL` default) and never reaches the enum constructor. There is an explicit comment at the call site stating this constraint, since the code alone does not show why.

**Verified empirically.** A before/after sweep over all 659 committed dict dependency entries:

- conversion failures: **32 before, 32 after — identical set** (all pre-existing module-path security violations in omnimarket contracts, unrelated to this change)
- 64 entries now classify as `ENVIRONMENT` (were `PROTOCOL`)
- 34 entries now classify as `SERVICE` (were `PROTOCOL`)
- 30 `ENVIRONMENT` deps now carry a populated `env_var` (was 0 — silently dropped)

Nothing that passed before starts failing; this is strictly a loosening.

## Method

TDD. The failing tests were written first from the real committed contract shapes and confirmed to fail for the right reasons before any source change:

- `test_enum_has_environment_member` → `AttributeError: type object 'EnumDependencyType' has no attribute 'ENVIRONMENT'`
- `test_committed_env_var_shape_round_trips` → `ModelOnexError: [ONEX_CORE_006_VALIDATION_ERROR] Dependency does not follow ONEX patterns: linear_api_key`
- `test_committed_key_shape_constructs_without_env_var` → same error on `slack_bot_token`
- `test_bare_environment_dependency_constructs` → same error on `some_env_dep`

Fixtures are copied from live contracts, not invented: `omnibase_infra/.../node_db_error_linear_effect/contract.yaml` (the `env_var` shape) and `omniclaude/.../node_channel_slack_adapter/contract.yaml` (the `key:` shape). Regression guards cover the non-member `type:` values and explicit-`dependency_type`-wins precedence.

## Known debt: `ModelDependency` is `extra="ignore"`

`model_dependency.py` declares `extra="ignore"`, contradicting the repo-wide `extra="forbid"` rule. That is precisely why `env_var` was silently dropped before this PR.

Flipping it is **deliberately out of scope here** and is tracked in **OMN-16458**, held by a time-boxed entry in `extra_forbid_waivers.yaml` (the ratchet's own sanctioned mechanism — not a bypass). Evidence gathered while scoping it: the flip left 9224 tests green locally and no `ModelDependency(**dict)` / `model_validate` call site exists in `src/` of omnibase_infra, omniclaude, omnimarket or omniintelligence — but `ModelContractPatch.dependencies__add` coerces raw patch dicts with no before-validator, and omnibase_core is an externally-consumed SDK, so the flip needs a consumer sweep this additive PR cannot carry. Reviewers: the waiver's `expires_at` (2026-10-31) is a placeholder for approver adjustment.

## Verification

- Failing-test-first evidence above.
- `uv run mypy src/omnibase_core/ --strict`: 14 errors before, 14 after — **zero delta**, none in touched files (all pre-existing: missing optional `redis` / `omnibase_spi` stubs, redundant casts). The pre-push `mypy (strict)` hook passed.
- `pre-commit run --files <the 7 changed files>`: **exit 0, all hooks pass.** (`pre-commit run --all-files` has 20 pre-existing repo-wide failures in files outside this diff.)
- Governed impacted-test selector escalated to the full suite on push and passed: **44072 passed, 53 skipped, 3 xpassed, 0 failed** (1:44:45). No `PREPUSH_FULL_SUITE` / `ENABLE_SMART_TESTS` override was set.

## Docs

Fixed `docs/reference/API_DOCUMENTATION.md`, which documented `EnumDependencyType` as `REQUIRED, OPTIONAL, PREFERRED` — members it has never had. Added a short `CONTRACT_SYSTEM.md` section documenting the `type:` alias rule and the `env_var` shape.
