### PR TITLE
fix(OMN-16489): prepush hook S0 defect patch — recursion guard, override env sanitization, fail-closed empty-hostname

### DIFF
--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -44,6 +44,27 @@ die() {
 }
 
 # =============================================================================
+# Recursion guard (OMN-16489, F-01)
+# =============================================================================
+# This hook spawns pytest, and the spawned suite contains tests that exec THIS
+# script again (tests/scripts/test_prepush_hook_host_identity_guard.py and
+# siblings). OMN-16425 proved one leaked override var turns that re-entry into
+# a recursive full-suite launcher (~9h03m lost across 5 failed ~1h45m runs;
+# friction report F-01) — and its fix covered the test sites, not the hook.
+# The env scrub at the pytest invocations below closes the override-
+# inheritance vector; this sentinel closes the re-entry class itself: a nested
+# invocation refuses fail-closed before the selector resolves or any pytest
+# spawns. The sentinel deliberately survives the override scrub — children
+# must inherit it for this guard to hold. A test that intends to exercise this
+# script's FIRST-entry behavior must strip ONEX_PREPUSH_HOOK_ACTIVE from the
+# subprocess env it constructs.
+if [ -n "${ONEX_PREPUSH_HOOK_ACTIVE:-}" ]; then
+  die "nested invocation refused: this hook is already active in an ancestor process (ONEX_PREPUSH_HOOK_ACTIVE=${ONEX_PREPUSH_HOOK_ACTIVE}, this pid $$)" \
+      "a pre-push hook run must never be spawned from inside another pre-push hook run (OMN-16425 recursion class). If a test means to exercise first-entry behavior, construct the subprocess env explicitly and strip ONEX_PREPUSH_HOOK_ACTIVE"
+fi
+export ONEX_PREPUSH_HOOK_ACTIVE="$$"
+
+# =============================================================================
 # .200-default host guard for the heavy (full-suite) escalation (OMN-15059)
 # =============================================================================
 # CLAUDE.md documents that pushes / heavy gate runs default to the `.200`
@@ -57,11 +78,14 @@ die() {
 # escalation), never on the fast impacted-subset path -- gating every push
 # would get this hook disabled within a week, which is worse than no guard.
 #
-# This is a ROUTING OPTIMIZATION, not a security control: if host identity
-# cannot be determined, FAIL OPEN (let the push proceed on this host) rather
-# than lock a developer out of their own repo on an ambiguous read. Do not
-# "harden" this into a hard block later -- the failure mode this guard exists
-# to prevent is a stalled/contended local machine, not an untrusted push.
+# An UNRESOLVABLE hostname fails CLOSED (OMN-16489 defect 3, redesign plan
+# 2026-08-24 §4 S0 item 3 / C2 — supersedes the earlier fail-open note here).
+# Heavy runs are routed BY host identity; a host that cannot be identified
+# cannot be routed, and proceeding on that silence is the same assumed-
+# headroom failure class as the load-probe incidents below. The refusal is
+# cheap (<1s, before any pytest) and names its remediation, consistent with
+# this hook's fail-loud doctrine: a gate that cannot run must be
+# indistinguishable from a failing gate.
 PREPUSH_200_HOSTNAME="${PREPUSH_200_HOSTNAME:-stickybeatz-studio}"
 
 # =============================================================================
@@ -174,8 +198,9 @@ guard_full_suite_host() {
   heavy_what="${1:-heavy fail-closed full-suite escalation}"
   host="$(hostname -s 2>/dev/null || true)"
   if [ -z "$host" ]; then
-    log "WARNING: could not determine local hostname -- unable to verify this is the .200 build host; proceeding locally (fail-open: this guard is a routing optimization, not a security gate)."
-    return 0
+    # Fail CLOSED (OMN-16489): see the routing note above PREPUSH_200_HOSTNAME.
+    die "could not determine the local hostname while deciding where ${heavy_what} may run" \
+        "heavy gate runs are routed by host identity (OMN-15059) and an unidentifiable host cannot be routed. Fix 'hostname -s' (macOS: 'sudo scutil --set HostName <name>'; Linux: 'hostnamectl set-hostname <name>'), or run the push from a designated gate host (.200 '${PREPUSH_200_HOSTNAME}' or the .201 gate-runner '${PREPUSH_201_GATE_RUNNER_HOSTNAME}')"
   fi
   lc_host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
   lc_target="$(printf '%s' "$PREPUSH_200_HOSTNAME" | tr '[:upper:]' '[:lower:]')"
@@ -444,11 +469,39 @@ SELECTOR_WHOLE_TREE_SENTINEL="tests/unit/"
 # what each one is.
 HEAVY_SELECTION_TARGETS="${FULL_SUITE_TARGET} ${SELECTOR_WHOLE_TREE_SENTINEL}"
 
+# =============================================================================
+# Override-inheritance sanitization (OMN-16489, F-04)
+# =============================================================================
+# PREPUSH_* overrides (and ENABLE_SMART_TESTS) are honored at THIS hook's
+# entry only. They must never inherit into the pytest subprocess tree: a test
+# down there that re-invokes this script would receive the OUTER push's bypass
+# grants -- the exact mechanism that turned one sanctioned override into a
+# recursive 44k-test full-suite launcher (friction report F-01/F-04, ~9h03m).
+# Called inside the subshell wrapping each pytest invocation, after the
+# command's own knobs have been captured into non-PREPUSH names, so the parent
+# hook's variables are untouched. Only EXPORTED names can inherit, so only
+# those are scrubbed. ONEX_PREPUSH_HOOK_ACTIVE deliberately survives -- the
+# recursion guard above depends on children inheriting it. This stops
+# inheritance ONLY; override semantics at hook entry are unchanged (the
+# override-mechanism redesign is OMN-16480, review-gated).
+scrub_prepush_override_env() {
+  local v
+  for v in $(compgen -A export PREPUSH_ || true); do
+    unset "$v" || true
+  done
+  unset ENABLE_SMART_TESTS || true
+}
+
 if [ "$IS_FULL" = "True" ] || [ "$IS_FULL" = "true" ]; then
   guard_full_suite_host
   log "running FULL suite (fail-closed escalation): uv run pytest ${FULL_SUITE_TARGET} --ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
-  # shellcheck disable=SC2086
-  uv run pytest "${FULL_SUITE_TARGET}" --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?
+  (
+    _pytest_timeout_flags="${PREPUSH_TIMEOUT_FLAGS}"
+    _pytest_extra_args="${PREPUSH_PYTEST_ARGS:-}"
+    scrub_prepush_override_env
+    # shellcheck disable=SC2086
+    exec uv run pytest "${FULL_SUITE_TARGET}" --ignore=tests/integration --tb=short ${_pytest_timeout_flags} ${_pytest_extra_args}
+  ) || RC=$?
 elif [ "${#PATHS[@]}" -gt 0 ]; then
   # OMN-15408: guard on the SELECTED WORK, not the is_full_suite flag. A
   # selection that covers a whole heavy target is the heavy run under another
@@ -457,8 +510,13 @@ elif [ "${#PATHS[@]}" -gt 0 ]; then
     guard_full_suite_host "whole-suite-equivalent impacted selection (is_full_suite=${IS_FULL}, selected paths [ ${PATHS_STR}] cover an entire heavyweight target [ ${HEAVY_SELECTION_TARGETS} ])"
   fi
   log "running impacted subset: uv run pytest ${PATHS_STR}--ignore=tests/integration ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-}"
-  # shellcheck disable=SC2086
-  uv run pytest "${PATHS[@]}" --ignore=tests/integration --tb=short ${PREPUSH_TIMEOUT_FLAGS} ${PREPUSH_PYTEST_ARGS:-} || RC=$?
+  (
+    _pytest_timeout_flags="${PREPUSH_TIMEOUT_FLAGS}"
+    _pytest_extra_args="${PREPUSH_PYTEST_ARGS:-}"
+    scrub_prepush_override_env
+    # shellcheck disable=SC2086
+    exec uv run pytest "${PATHS[@]}" --ignore=tests/integration --tb=short ${_pytest_timeout_flags} ${_pytest_extra_args}
+  ) || RC=$?
 else
   log "no impacted unit tests mapped for this push (no source/test change contributed a target); nothing to run."
 fi

--- a/tests/scripts/test_prepush_hook_has_bounded_timeout.py
+++ b/tests/scripts/test_prepush_hook_has_bounded_timeout.py
@@ -33,12 +33,14 @@ _HOOK_SCRIPT = (
 
 def _pytest_invocation_lines(script_text: str) -> list[str]:
     """Return only the lines that actually EXECUTE pytest -- i.e. start with
-    ``uv run pytest`` -- excluding ``log "... uv run pytest ..."`` lines that
-    merely mention the invocation for human-readable output."""
+    ``uv run pytest`` or ``exec uv run pytest`` (OMN-16489 wraps each
+    invocation in a scrubbed subshell that ``exec``s pytest) -- excluding
+    ``log "... uv run pytest ..."`` lines that merely mention the invocation
+    for human-readable output."""
     return [
         line
         for line in script_text.splitlines()
-        if line.strip().startswith("uv run pytest")
+        if line.strip().startswith(("uv run pytest", "exec uv run pytest"))
     ]
 
 
@@ -75,10 +77,18 @@ def test_every_pytest_invocation_has_bounded_timeout_and_parallelism() -> None:
         f"found {len(invocation_lines)}: {invocation_lines!r}"
     )
 
+    timeout_flags = _resolve_shell_var(script_text, "PREPUSH_TIMEOUT_FLAGS")
+    # OMN-16489: each invocation runs inside a scrubbed subshell that captures
+    # the flags into a non-PREPUSH name BEFORE the scrub, so the executed line
+    # references ${_pytest_timeout_flags}. Pin that capture so the resolution
+    # below stays honest -- if the capture disappears, the flags are gone too.
+    assert '_pytest_timeout_flags="${PREPUSH_TIMEOUT_FLAGS}"' in script_text, (
+        "expected each pytest subshell to capture PREPUSH_TIMEOUT_FLAGS into "
+        "_pytest_timeout_flags before scrub_prepush_override_env (OMN-16489)"
+    )
     resolved_vars = {
-        "PREPUSH_TIMEOUT_FLAGS": _resolve_shell_var(
-            script_text, "PREPUSH_TIMEOUT_FLAGS"
-        )
+        "PREPUSH_TIMEOUT_FLAGS": timeout_flags,
+        "_pytest_timeout_flags": timeout_flags,
     }
 
     for line in invocation_lines:

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -100,14 +100,21 @@ def test_guard_is_called_before_every_full_suite_pytest_invocation() -> None:
         )
 
 
-def test_guard_fails_open_when_hostname_cannot_be_determined() -> None:
+def test_guard_fails_closed_when_hostname_cannot_be_determined() -> None:
+    """OMN-16489 defect 3 inverted this pin: the empty-hostname branch used to
+    WARN and return 0 (fail-open), letting the heavy escalation proceed on a
+    host that could not be identified. It now refuses with remediation. The
+    behavioral proof lives in test_prepush_hook_recursion_and_env_guard.py."""
     script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
     assert 'if [ -z "$host" ]; then' in script_text, (
         "expected the guard to check for an unresolvable hostname"
     )
-    assert "this guard is a routing optimization, not a security gate" in script_text, (
-        "expected the fail-open comment explaining why an unresolvable host "
-        "must not block the push"
+    assert "could not determine the local hostname" in script_text, (
+        "expected the empty-hostname branch to die with a remediation message "
+        "(fail-closed, OMN-16489)"
+    )
+    assert "proceeding locally (fail-open" not in script_text, (
+        "the empty-hostname branch must not fail open (OMN-16489)"
     )
 
 
@@ -141,6 +148,9 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
     # _run_hook_forcing_full_suite below; this call site builds its own env
     # inline and had been missed.
     env.pop("PREPUSH_ALLOW_LOCAL_FULL_SUITE", None)
+    # OMN-16489: this test deliberately exercises FIRST-entry behavior, so the
+    # recursion sentinel an outer hook run exports must not leak in.
+    env.pop("ONEX_PREPUSH_HOOK_ACTIVE", None)
     result = subprocess.run(
         ["bash", str(HOOK_SCRIPT)],
         cwd=REPO_ROOT,
@@ -316,6 +326,9 @@ def _run_hook_with_stubbed_selection(
         "ENABLE_SMART_TESTS",
         "PREPUSH_ADJACENCY",
         "PREPUSH_PYTEST_ARGS",
+        # OMN-16489: this harness exercises FIRST-entry behavior, so the
+        # recursion sentinel an outer hook run exports must not leak in.
+        "ONEX_PREPUSH_HOOK_ACTIVE",
     ):
         env.pop(leaky, None)
 
@@ -792,7 +805,12 @@ def _run_hook_forcing_full_suite(
         env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
         env["PREPUSH_FULL_SUITE"] = "1"
         env["PREPUSH_BASE_REF"] = "HEAD"
-        for leaky in ("PREPUSH_ALLOW_LOCAL_FULL_SUITE",):
+        for leaky in (
+            "PREPUSH_ALLOW_LOCAL_FULL_SUITE",
+            # OMN-16489: this harness exercises FIRST-entry behavior, so the
+            # recursion sentinel an outer hook run exports must not leak in.
+            "ONEX_PREPUSH_HOOK_ACTIVE",
+        ):
             env.pop(leaky, None)
         env.update(env_extra)
 

--- a/tests/scripts/test_prepush_hook_recursion_and_env_guard.py
+++ b/tests/scripts/test_prepush_hook_recursion_and_env_guard.py
@@ -78,12 +78,12 @@ SENTINEL=${ONEX_PREPUSH_HOOK_ACTIVE:-UNSET}"
     exit 0
     ;;
 esac
-shift
-if [ "$1" = "python" ]; then
-  shift
-  exec python3 "$@"
-fi
-exec "$@"
+# The hook makes exactly two kinds of `uv` calls (the selector and pytest),
+# both modeled above. Anything else reaching this stub is a harness gap, not
+# something to run for real -- refuse loudly instead of delegating to whatever
+# interpreter happens to be on PATH.
+echo "STUB-UV-UNMODELED-INVOCATION $args" >&2
+exit 97
 """
 
 

--- a/tests/scripts/test_prepush_hook_recursion_and_env_guard.py
+++ b/tests/scripts/test_prepush_hook_recursion_and_env_guard.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""S0 tactical defect patch for the pre-push hook (OMN-16489).
+
+Three defects, each proven live in the 2026-08-23/24 window
+(`docs/tracking/2026-08-24-system-friction-report.md` F-01/F-04, plan
+`docs/plans/2026-08-24-blocker-decoupling-redesign-plan.md` §4 S0 items 1-3):
+
+1. NO recursion guard — this hook spawns pytest, and the spawned suite
+   contains tests that exec this same hook script. A re-entering child can
+   launch nested full suites: the OMN-16425 class cost ~9h03m across 5 failed
+   ~1h45m runs. OMN-16425's fix scrubbed the *test sites*; the hook itself
+   still accepted re-entry. Fix: an exported `ONEX_PREPUSH_HOOK_ACTIVE=<pid>`
+   sentinel; a nested invocation refuses fail-closed before any selector or
+   pytest work.
+
+2. Override env vars inherit downward — the hook handed its FULL environment
+   (including `PREPUSH_ALLOW_LOCAL_FULL_SUITE` and every `PREPUSH_*` override)
+   to the pytest subprocess tree, so a bypass granted to the outer push was
+   silently honored by every descendant (F-04: "permission to bypass once"
+   became "permission for every descendant process, forever"). Fix: the hook
+   strips exported `PREPUSH_*` (+`ENABLE_SMART_TESTS`) from the spawned
+   pytest env. Entry semantics are deliberately UNCHANGED — the override
+   redesign is OMN-16480, review-gated.
+
+3. Empty-hostname fail-open — `guard_full_suite_host()` warned and
+   `return 0`ed when `hostname -s` produced nothing, so the heavy escalation
+   proceeded on a host that could not be identified, contradicting the hook's
+   own fail-loud doctrine ("a gate that cannot run must be indistinguishable
+   from a failing gate"). Fix: fail CLOSED with a remediation message.
+
+All behavioral tests below run THE real hook script end-to-end with the same
+stubbed-`uv` harness `tests/scripts/test_prepush_hook_host_identity_guard.py`
+established for OMN-15408, never a Python re-implementation of it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh"
+
+# Matches the guaranteed-non-matching override used by the OMN-15059 tests, so
+# host-identity never accidentally matches while these tests run on .200 itself.
+_NON_MATCHING_HOSTNAME = "definitely-not-the-200-host-omn16489"
+_NARROW_SELECTION = "tests/scripts/"
+
+# Every env var the hook honors at entry that must NOT leak into its pytest
+# children. Mirrors the leaky-var scrub list in the OMN-15408 harness plus the
+# recursion sentinel this ticket introduces.
+_LEAKY_VARS = (
+    "PREPUSH_FULL_SUITE",
+    "PREPUSH_ALLOW_LOCAL_FULL_SUITE",
+    "ENABLE_SMART_TESTS",
+    "PREPUSH_ADJACENCY",
+    "PREPUSH_PYTEST_ARGS",
+    "ONEX_PREPUSH_HOOK_ACTIVE",
+)
+
+_UV_STUB = """#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *detect_test_paths*)
+    cat "$PREPUSH_TEST_SELECTION_JSON"
+    exit 0
+    ;;
+  *pytest*)
+    echo "STUB-PYTEST-INVOKED $args"
+    echo "STUB-PYTEST-ENV ALLOW=${PREPUSH_ALLOW_LOCAL_FULL_SUITE:-UNSET} \
+CANARY=${PREPUSH_CANARY_LEAK_PROBE:-UNSET} \
+SMART=${ENABLE_SMART_TESTS:-UNSET} \
+SENTINEL=${ONEX_PREPUSH_HOOK_ACTIVE:-UNSET}"
+    exit 0
+    ;;
+esac
+shift
+if [ "$1" = "python" ]; then
+  shift
+  exec python3 "$@"
+fi
+exec "$@"
+"""
+
+
+def _run_hook(
+    tmp_path: Path,
+    *,
+    is_full_suite: bool,
+    selected_paths: list[str],
+    extra_env: dict[str, str] | None = None,
+    empty_hostname: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run the REAL hook with a stubbed selector + observable stubbed pytest.
+
+    The pytest stub echoes the override vars it received, so assertions can
+    see exactly what the hook's subprocess env carried. `empty_hostname=True`
+    additionally shadows `hostname` with a stub that produces nothing, driving
+    the guard's unresolvable-hostname branch deterministically on any host.
+    """
+    selection_file = tmp_path / "selection.json"
+    selection_file.write_text(
+        json.dumps(
+            {
+                "is_full_suite": is_full_suite,
+                "full_suite_reason": None,
+                "selected_paths": selected_paths,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    stub_bin = tmp_path / "stub-bin"
+    stub_bin.mkdir(parents=True, exist_ok=True)
+    uv_stub = stub_bin / "uv"
+    uv_stub.write_text(_UV_STUB, encoding="utf-8")
+    uv_stub.chmod(0o755)
+    if empty_hostname:
+        hostname_stub = stub_bin / "hostname"
+        hostname_stub.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+        hostname_stub.chmod(0o755)
+
+    env = dict(os.environ)
+    for leaky in _LEAKY_VARS:
+        env.pop(leaky, None)
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["PREPUSH_TEST_SELECTION_JSON"] = str(selection_file)
+    env["PREPUSH_BASE_REF"] = "HEAD"
+    env["PREPUSH_200_HOSTNAME"] = _NON_MATCHING_HOSTNAME
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        ["bash", str(HOOK_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+def _stub_pytest_env(stdout: str) -> dict[str, str]:
+    for line in stdout.splitlines():
+        if line.startswith("STUB-PYTEST-ENV "):
+            return dict(pair.split("=", 1) for pair in line.split(" ", 1)[1].split())
+    raise AssertionError(f"no STUB-PYTEST-ENV line in stdout: {stdout!r}")
+
+
+# =============================================================================
+# Defect 1 — nested invocation must refuse
+# =============================================================================
+
+
+def test_recursion_sentinel_is_exported() -> None:
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    assert 'export ONEX_PREPUSH_HOOK_ACTIVE="$$"' in script_text, (
+        "expected the hook to export the ONEX_PREPUSH_HOOK_ACTIVE=<pid> "
+        "recursion sentinel at entry (OMN-16489 defect 1)"
+    )
+
+
+def test_nested_invocation_refuses(tmp_path: Path) -> None:
+    """A hook invoked while an ancestor hook is active must refuse fail-closed.
+
+    RED against the pre-fix hook (it proceeded all the way to pytest, exit 0).
+    """
+    result = _run_hook(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_NARROW_SELECTION],
+        extra_env={"ONEX_PREPUSH_HOOK_ACTIVE": "99999"},
+    )
+    assert result.returncode != 0, (
+        "expected a nested hook invocation to refuse; got exit "
+        f"{result.returncode}. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "nested invocation refused" in result.stderr, (
+        f"expected the nested-invocation refusal in stderr: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" not in result.stdout, (
+        "a nested invocation must refuse BEFORE any pytest is spawned; "
+        f"stdout: {result.stdout!r}"
+    )
+
+
+def test_nested_full_suite_escalation_refuses(tmp_path: Path) -> None:
+    """The exact OMN-16425 shape: a nested invocation that would escalate to
+    the full suite (leaked override included) must still refuse at entry —
+    even the degraded-host override cannot arm a nested run."""
+    result = _run_hook(
+        tmp_path,
+        is_full_suite=True,
+        selected_paths=[],
+        extra_env={
+            "ONEX_PREPUSH_HOOK_ACTIVE": "99999",
+            "PREPUSH_FULL_SUITE": "1",
+            "PREPUSH_ALLOW_LOCAL_FULL_SUITE": "1",
+        },
+    )
+    assert result.returncode != 0, (
+        "expected the nested escalation to refuse; got exit "
+        f"{result.returncode}. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "nested invocation refused" in result.stderr
+    assert "STUB-PYTEST-INVOKED" not in result.stdout
+
+
+# =============================================================================
+# Defect 2 — overrides must not inherit into the pytest subprocess
+# =============================================================================
+
+
+def test_scrub_helper_is_defined_and_called_before_every_pytest() -> None:
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    assert "scrub_prepush_override_env()" in script_text, (
+        "expected a scrub_prepush_override_env helper stripping PREPUSH_* "
+        "overrides from the pytest subprocess env (OMN-16489 defect 2)"
+    )
+    pytest_invocations = script_text.count("uv run pytest")
+    scrub_calls = script_text.count("scrub_prepush_override_env\n")
+    assert scrub_calls >= 2, (
+        "expected scrub_prepush_override_env to be invoked ahead of both "
+        f"pytest invocation sites; found {scrub_calls} call(s) for "
+        f"{pytest_invocations} documented invocation(s)"
+    )
+
+
+def test_overrides_do_not_inherit_into_pytest_child(tmp_path: Path) -> None:
+    """The F-04 mechanism: an override honored by THIS hook run must be
+    invisible to the pytest tree it spawns, while the recursion sentinel must
+    inherit (children need it for the recursion guard to hold).
+
+    RED against the pre-fix hook (ALLOW=1 leaked straight through).
+    """
+    result = _run_hook(
+        tmp_path,
+        is_full_suite=False,
+        selected_paths=[_NARROW_SELECTION],
+        extra_env={
+            "PREPUSH_ALLOW_LOCAL_FULL_SUITE": "1",
+            "PREPUSH_CANARY_LEAK_PROBE": "leaked",
+            # Deliberately a value the hook's FLAG parsing ignores, so the
+            # selection stays the narrow subset; only inheritance is probed.
+            "ENABLE_SMART_TESTS": "true",
+        },
+    )
+    assert result.returncode == 0, (
+        "narrow selection must still run; got exit "
+        f"{result.returncode}. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    child_env = _stub_pytest_env(result.stdout)
+    assert child_env["ALLOW"] == "UNSET", (
+        "PREPUSH_ALLOW_LOCAL_FULL_SUITE leaked into the pytest child env — "
+        f"the exact F-01/F-04 recursion fuel: {child_env!r}"
+    )
+    assert child_env["CANARY"] == "UNSET", (
+        f"a generic PREPUSH_* var leaked into the pytest child env: {child_env!r}"
+    )
+    assert child_env["SMART"] == "UNSET", (
+        f"ENABLE_SMART_TESTS leaked into the pytest child env: {child_env!r}"
+    )
+    assert child_env["SENTINEL"] != "UNSET", (
+        "the ONEX_PREPUSH_HOOK_ACTIVE sentinel must inherit into the pytest "
+        f"tree (the recursion guard depends on it): {child_env!r}"
+    )
+    assert child_env["SENTINEL"].isdigit(), (
+        f"the sentinel must carry the exporting hook's pid: {child_env!r}"
+    )
+
+
+# =============================================================================
+# Defect 3 — unresolvable hostname must fail CLOSED
+# =============================================================================
+
+
+def test_empty_hostname_refuses_heavy_escalation(tmp_path: Path) -> None:
+    """A host that cannot be identified cannot be routed; the heavy escalation
+    must refuse with remediation, never proceed on silence.
+
+    RED against the pre-fix hook (it warned, returned 0, and ran pytest).
+    """
+    result = _run_hook(
+        tmp_path,
+        is_full_suite=True,
+        selected_paths=[],
+        empty_hostname=True,
+    )
+    assert result.returncode != 0, (
+        "expected the guard to refuse the heavy escalation when the hostname "
+        f"cannot be determined; got exit {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "could not determine the local hostname" in result.stderr, (
+        f"expected the fail-closed refusal in stderr: {result.stderr!r}"
+    )
+    assert "REMEDIATION" in result.stderr, (
+        f"a fail-closed refusal must name its remediation: {result.stderr!r}"
+    )
+    assert "STUB-PYTEST-INVOKED" not in result.stdout, (
+        f"the guard must refuse BEFORE pytest is spawned; stdout: {result.stdout!r}"
+    )
+
+
+def test_fail_open_hostname_branch_is_gone() -> None:
+    """The old branch logged a WARNING and returned 0; neither the log line
+    nor the fail-open rationale string may survive."""
+    script_text = HOOK_SCRIPT.read_text(encoding="utf-8")
+    assert "proceeding locally (fail-open" not in script_text, (
+        "the empty-hostname fail-open branch must be gone (OMN-16489 defect 3)"
+    )
+    assert "this guard is a routing optimization, not a security gate" not in (
+        script_text
+    ), (
+        "the fail-open rationale is superseded by the S0 fail-closed ruling "
+        "(plan §4 S0 item 3); remove it so it cannot be cited to re-open "
+        "the branch"
+    )


### PR DESCRIPTION
## Summary

S0 tactical defect patch on `scripts/hooks/prepush_smart_tests.sh` per the 2026-08-24 blocker-decoupling redesign plan §4 S0 items 1-3 (friction report F-01/F-04; OMN-16425 sibling). Ticket: OMN-16489. Third and final repo copy — omnibase_infra#2870 and omnimarket#2135 are merged.

1. **Recursion guard** — `ONEX_PREPUSH_HOOK_ACTIVE=<pid>` exported at entry; a nested invocation (hook re-entered from its own spawned pytest tree, the OMN-16425 class that cost ~9h03m) refuses fail-closed before any selector or pytest work.
2. **Override-inheritance sanitization** — exported `PREPUSH_*` overrides and `ENABLE_SMART_TESTS` are stripped from the spawned pytest env (subshell + scrub + exec) at both pytest invocation sites, so a bypass granted to the outer push is invisible to every descendant. The recursion sentinel deliberately survives the scrub. Entry semantics unchanged in this repo — the OMN-16480 grant-token entry redesign landed in omnibase_infra; the port to this copy is tracked as OMN-16491.
3. **Empty-hostname fail-closed** — the heavy-escalation host guard's empty-hostname branch flipped fail-open → fail-closed with remediation, consistent with the hook's fail-loud doctrine.

## TDD evidence

- `tests/scripts/test_prepush_hook_recursion_and_env_guard.py` — 7 tests RED against the pre-fix hook, incl. the verbatim OMN-16425 nested-escalation shape, run against the REAL hook via the stubbed-uv harness.
- Existing fail-open hostname pin in `test_prepush_hook_host_identity_guard.py` inverted to fail-closed; recursion sentinel stripped at the first-entry env-construction sites in that file and in `test_prepush_hook_has_bounded_timeout.py` (its `_run_hook_forcing_full_suite` harness had 6 tests red under an ambient sentinel; the OMN-14967 bounded-timeout guard taught the exec-in-scrubbed-subshell shape).
- Local: the three touched test files 41 passed — both plain AND with `ONEX_PREPUSH_HOOK_ACTIVE` ambient (simulating execution inside a real pre-push pytest child); `tests/scripts/` 138 passed both ways on the predecessor lane.
- `bash -n` clean; ruff format/check clean; pre-commit on changed files exit 0. Governed pre-push selector ran on push (no `PREPUSH_*`/`ENABLE_SMART_TESTS` overrides; the hook's own capacity guard was waited out, not bypassed).

Sibling PRs: omnibase_infra#2870 (merged `eee839f7517da664cc68ba38c272028f533678f9`), omnimarket#2135 (merged `072bf14c3ace5964c6e22d2a053193b67f0d8e88`).

Evidence-Ticket: OMN-16489
Evidence-Source: OCC#7022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented nested pre-push checks from running recursively.
  - Ensured test configuration overrides do not unintentionally carry into pytest runs.
  - Added safer handling when the local hostname cannot be determined, preventing inappropriate heavy test-suite escalation.
  - Improved failure messages to clarify when pre-push validation is refused.

- **Tests**
  - Added regression coverage for recursion protection, environment isolation, hostname validation, timeout handling, and both supported pytest invocation styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->