### PR TITLE
feat(OMN-16451): declare the contract keys the runtime consumes; delete NodeCompute's dead metadata read

### DIFF
--- a/src/omnibase_core/models/contracts/model_contract_base.py
+++ b/src/omnibase_core/models/contracts/model_contract_base.py
@@ -53,6 +53,12 @@ from omnibase_core.models.contracts.model_contract_config import ModelContractCo
 from omnibase_core.models.contracts.model_contract_feature_flag import (
     ModelContractFeatureFlag,
 )
+from omnibase_core.models.contracts.model_contract_intent_consumption import (
+    ModelContractIntentConsumption,
+)
+from omnibase_core.models.contracts.model_contract_mcp_config import (
+    ModelContractMcpConfig,
+)
 from omnibase_core.models.contracts.model_dod_evidence import ModelDodEvidence
 from omnibase_core.models.contracts.model_lifecycle_config import ModelLifecycleConfig
 from omnibase_core.models.contracts.model_performance_requirements import (
@@ -61,6 +67,9 @@ from omnibase_core.models.contracts.model_performance_requirements import (
 from omnibase_core.models.contracts.model_validation_rules import ModelValidationRules
 from omnibase_core.models.contracts.subcontracts.model_contract_behavior_spec import (
     ModelContractBehaviorSpec,
+)
+from omnibase_core.models.contracts.subcontracts.model_event_bus_subcontract import (
+    ModelEventBusSubcontract,
 )
 from omnibase_core.models.contracts.subcontracts.model_protocol_dependency import (
     ModelProtocolDependency,
@@ -318,6 +327,28 @@ class ModelContractBase(BaseModel, ABC):
     # ONEX Infrastructure Extension Fields (OMN-1588)
     # These fields enable contract-level event routing and handler configuration
     # without requiring downstream repos to strip fields before validation.
+
+    # Top-level YAML sections the runtime reads from every node contract
+    # (OMN-16451). A section is declared here only when a runtime reader
+    # exists for it; sections nothing consumes are rejected by extra="forbid".
+    event_bus: ModelEventBusSubcontract | None = Field(
+        default=None,
+        description="Event-bus subscriptions, publications, and dead-letter topics. "
+        "Read by the runtime host to wire Kafka consumers and by auto-wiring "
+        "for DLQ routing.",
+    )
+
+    mcp: ModelContractMcpConfig | None = Field(
+        default=None,
+        description="MCP tool exposure. Read by the MCP adapter when scanning "
+        "contracts for AI-invocable tools.",
+    )
+
+    intent_consumption: ModelContractIntentConsumption | None = Field(
+        default=None,
+        description="Intent-type to effect-node routing. Read by the intent "
+        "routing loader when wiring intent executors.",
+    )
 
     handler_routing: "ModelHandlerRoutingSubcontract | None" = Field(
         default=None,

--- a/src/omnibase_core/models/contracts/model_contract_intent_consumption.py
+++ b/src/omnibase_core/models/contracts/model_contract_intent_consumption.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-declared intent consumption block.
+
+Schema for the top-level ``intent_consumption:`` section of a node
+``contract.yaml``. The intent routing loader reads ``intent_routing_table``
+to decide which effect node executes each intent type an orchestrator emits.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractIntentConsumption(BaseModel):
+    """Intent-to-effect routing declared in a contract YAML ``intent_consumption:`` block."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    intent_routing_table: dict[str, str] = Field(
+        ...,
+        min_length=1,
+        description="Map of intent_type (e.g. 'postgres.upsert_registration') to the "
+        "effect node name that executes it.",
+    )

--- a/src/omnibase_core/models/contracts/model_contract_mcp_config.py
+++ b/src/omnibase_core/models/contracts/model_contract_mcp_config.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Contract-declared MCP (Model Context Protocol) exposure block.
+
+Schema for the top-level ``mcp:`` section of a node ``contract.yaml``. The
+MCP adapter reads exactly these four keys when it decides whether, and how,
+to expose a node as an AI-invocable tool.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractMcpConfig(BaseModel):
+    """MCP tool exposure declared in a contract YAML ``mcp:`` block.
+
+    Every field is required: a contract that opts into MCP exposure must
+    say what the tool is called, what it does, and how long it may run.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    expose: bool = Field(
+        ...,
+        description="Whether the MCP adapter exposes this node as a tool.",
+    )
+
+    tool_name: str = Field(
+        ...,
+        min_length=1,
+        pattern=r"^[a-z][a-z0-9_]*$",
+        description="Snake-case MCP tool identifier presented to callers.",
+    )
+
+    description: str = Field(
+        ...,
+        min_length=1,
+        description="Tool description presented to the MCP client.",
+    )
+
+    timeout_seconds: int = Field(
+        ...,
+        gt=0,
+        description="Maximum wall-clock seconds a single tool invocation may take.",
+    )

--- a/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
+++ b/src/omnibase_core/models/contracts/subcontracts/model_event_bus_subcontract.py
@@ -220,6 +220,12 @@ class ModelEventBusSubcontract(BaseModel):
         description="Topic suffixes this node subscribes to. Format: onex.{kind}.{producer}.{event-name}.v{n}",
     )
 
+    dlq_topics: list[str] = Field(
+        default_factory=list,
+        description="Dead-letter topic suffixes for inbound messages that cannot be "
+        "routed to any handler. Read by the auto-wiring layer.",
+    )
+
     # Extension path for future schema_ref support
     publish_topic_metadata: dict[str, ModelTopicMeta] | None = Field(
         default=None,
@@ -237,7 +243,7 @@ class ModelEventBusSubcontract(BaseModel):
         description="Request-response pattern configuration for RPC-style Kafka communication",
     )
 
-    @field_validator("publish_topics", "subscribe_topics", mode="after")
+    @field_validator("publish_topics", "subscribe_topics", "dlq_topics", mode="after")
     @classmethod
     def validate_topic_suffixes(cls, topics: list[str]) -> list[str]:
         """Validate each topic suffix against ONEX naming convention."""

--- a/src/omnibase_core/nodes/node_compute.py
+++ b/src/omnibase_core/nodes/node_compute.py
@@ -519,33 +519,9 @@ class NodeCompute[T_Input, T_Output](NodeCoreBase, MixinHandlerRouting):
         # Extract computation_type directly from algorithm.algorithm_type.
         computation_type: str = contract.algorithm.algorithm_type
 
-        # Extract metadata (normalize None to empty dict)
-        # Type matches ModelComputeInput.metadata field
-        metadata = getattr(contract, "metadata", None) or {}
-
-        # Extract optional execution settings from metadata
-        cache_enabled = metadata.get("cache_enabled", True)
-        parallel_enabled = metadata.get("parallel_enabled", False)
-
-        # Log warning if parallel_enabled but data is not parallelizable
-        if parallel_enabled and not self._supports_parallel_execution(
-            ModelComputeInput(
-                data=input_data,
-                computation_type=computation_type,
-            )
-        ):
-            emit_log_event(
-                LogLevel.WARNING,
-                "Parallel execution requested but data is not parallelizable, using sequential execution",
-                {"node_id": str(self.node_id), "computation_type": computation_type},
-            )
-
         return ModelComputeInput(
             data=input_data,
             computation_type=computation_type,
-            metadata=metadata,
-            cache_enabled=cache_enabled,
-            parallel_enabled=parallel_enabled,
         )
 
     def register_computation(

--- a/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract_dlq_topics.py
+++ b/tests/unit/models/contracts/subcontracts/test_model_event_bus_subcontract_dlq_topics.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""``event_bus.dlq_topics`` is a declared subcontract field (OMN-16451).
+
+The auto-wiring layer reads ``event_bus.dlq_topics`` to route unroutable
+inbound messages; before this field existed, any contract declaring it
+failed to parse as ``ModelEventBusSubcontract`` (``extra="forbid"``).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.subcontracts.model_event_bus_subcontract import (
+    ModelEventBusSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+_VERSION = ModelSemVer(major=1, minor=0, patch=0)
+
+
+@pytest.mark.unit
+class TestEventBusSubcontractDlqTopics:
+    def test_defaults_to_empty(self) -> None:
+        sub = ModelEventBusSubcontract(version=_VERSION)
+        assert sub.dlq_topics == []
+
+    def test_accepts_declared_dlq_topics(self) -> None:
+        sub = ModelEventBusSubcontract(
+            version=_VERSION,
+            subscribe_topics=["onex.evt.platform.node-introspection.v1"],
+            dlq_topics=["onex.dlq.omnibase-infra.platform.v1"],
+        )
+        assert sub.dlq_topics == ["onex.dlq.omnibase-infra.platform.v1"]
+
+    def test_rejects_non_string_entries(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEventBusSubcontract(version=_VERSION, dlq_topics=[42])  # type: ignore[list-item]

--- a/tests/unit/models/contracts/test_contract_base_consumed_extension_keys.py
+++ b/tests/unit/models/contracts/test_contract_base_consumed_extension_keys.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelContractBase declares exactly the top-level keys the runtime consumes (OMN-16451).
+
+``event_bus``, ``mcp`` and ``intent_consumption`` are read from contract YAML
+by the runtime (subscription wiring, the MCP adapter, the intent routing
+loader) and must therefore be declared, typed fields. Keys with no runtime
+reader stay undeclared and are rejected by ``extra="forbid"``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums import EnumNodeType
+from omnibase_core.models.contracts import (
+    ModelAlgorithmConfig,
+    ModelAlgorithmFactorConfig,
+    ModelContractCompute,
+    ModelPerformanceRequirements,
+)
+from omnibase_core.models.contracts.model_contract_intent_consumption import (
+    ModelContractIntentConsumption,
+)
+from omnibase_core.models.contracts.model_contract_mcp_config import (
+    ModelContractMcpConfig,
+)
+from omnibase_core.models.contracts.subcontracts.model_event_bus_subcontract import (
+    ModelEventBusSubcontract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+
+def _create_minimal_compute(**overrides: object) -> ModelContractCompute:
+    defaults: dict[str, object] = {
+        "name": "test_node",
+        "contract_version": ModelSemVer(major=1, minor=0, patch=0),
+        "description": "Test compute contract",
+        "node_type": EnumNodeType.COMPUTE_GENERIC,
+        "input_model": "omnibase_core.models.ModelTestInput",
+        "output_model": "omnibase_core.models.ModelTestOutput",
+        "algorithm": ModelAlgorithmConfig(
+            algorithm_type="test",
+            factors={
+                "f1": ModelAlgorithmFactorConfig(
+                    weight=1.0,
+                    calculation_method="default",
+                ),
+            },
+        ),
+        "performance": ModelPerformanceRequirements(single_operation_max_ms=1000),
+    }
+    defaults.update(overrides)
+    return ModelContractCompute(**defaults)  # type: ignore[arg-type]
+
+
+_EVENT_BUS_YAML: dict[str, object] = {
+    "version": {"major": 1, "minor": 0, "patch": 0},
+    "subscribe_topics": ["onex.evt.platform.node-introspection.v1"],
+    "publish_topics": ["onex.evt.platform.node-registration-result.v1"],
+    "dlq_topics": ["onex.dlq.omnibase-infra.platform.v1"],
+}
+
+
+@pytest.mark.unit
+class TestContractBaseConsumedExtensionKeys:
+    def test_extension_keys_default_to_none(self) -> None:
+        contract = _create_minimal_compute()
+        assert contract.event_bus is None
+        assert contract.mcp is None
+        assert contract.intent_consumption is None
+
+    def test_event_bus_parses_as_subcontract_from_yaml_shape(self) -> None:
+        contract = _create_minimal_compute(event_bus=_EVENT_BUS_YAML)
+        assert isinstance(contract.event_bus, ModelEventBusSubcontract)
+        assert contract.event_bus.subscribe_topics == [
+            "onex.evt.platform.node-introspection.v1"
+        ]
+        assert contract.event_bus.dlq_topics == ["onex.dlq.omnibase-infra.platform.v1"]
+
+    def test_mcp_parses_as_typed_config(self) -> None:
+        contract = _create_minimal_compute(
+            mcp={
+                "expose": True,
+                "tool_name": "register_node",
+                "description": "Register a node.",
+                "timeout_seconds": 30,
+            }
+        )
+        assert isinstance(contract.mcp, ModelContractMcpConfig)
+        assert contract.mcp.tool_name == "register_node"
+
+    def test_intent_consumption_parses_as_typed_config(self) -> None:
+        contract = _create_minimal_compute(
+            intent_consumption={
+                "intent_routing_table": {
+                    "postgres.upsert_registration": "node_registry_effect"
+                }
+            }
+        )
+        assert isinstance(contract.intent_consumption, ModelContractIntentConsumption)
+        assert contract.intent_consumption.intent_routing_table == {
+            "postgres.upsert_registration": "node_registry_effect"
+        }
+
+    @pytest.mark.parametrize(
+        "undeclared_key",
+        [
+            "time_injection",
+            "projection_reader",
+            "error_handling",
+            "health_check",
+            "metadata",
+        ],
+    )
+    def test_keys_without_a_runtime_reader_stay_forbidden(
+        self, undeclared_key: str
+    ) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _create_minimal_compute(**{undeclared_key: {"enabled": True}})
+        assert any(
+            e["type"] == "extra_forbidden" and e["loc"] == (undeclared_key,)
+            for e in exc_info.value.errors()
+        )
+
+    def test_malformed_event_bus_is_rejected_not_dropped(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _create_minimal_compute(event_bus={**_EVENT_BUS_YAML, "not_a_field": True})
+        assert any(
+            e["type"] == "extra_forbidden" and e["loc"] == ("event_bus", "not_a_field")
+            for e in exc_info.value.errors()
+        )

--- a/tests/unit/models/contracts/test_model_contract_intent_consumption.py
+++ b/tests/unit/models/contracts/test_model_contract_intent_consumption.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelContractIntentConsumption (contract ``intent_consumption:`` block, OMN-16451)."""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.model_contract_intent_consumption import (
+    ModelContractIntentConsumption,
+)
+
+
+@pytest.mark.unit
+class TestModelContractIntentConsumption:
+    def test_parses_routing_table(self) -> None:
+        cfg = ModelContractIntentConsumption.model_validate(
+            {
+                "intent_routing_table": {
+                    "postgres.upsert_registration": "node_registry_effect",
+                    "postgres.update_registration": "node_registry_effect",
+                }
+            }
+        )
+        assert cfg.intent_routing_table["postgres.upsert_registration"] == (
+            "node_registry_effect"
+        )
+
+    def test_routing_table_is_required(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ModelContractIntentConsumption.model_validate({})
+        assert any(
+            e["loc"] == ("intent_routing_table",) for e in exc_info.value.errors()
+        )
+
+    def test_empty_routing_table_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelContractIntentConsumption.model_validate({"intent_routing_table": {}})
+
+    def test_rejects_unconsumed_subscribed_intents_key(self) -> None:
+        """``subscribed_intents`` has no runtime reader, so it is not part of the schema."""
+        with pytest.raises(ValidationError) as exc_info:
+            ModelContractIntentConsumption.model_validate(
+                {
+                    "subscribed_intents": ["postgres.upsert_registration"],
+                    "intent_routing_table": {
+                        "postgres.upsert_registration": "node_registry_effect"
+                    },
+                }
+            )
+        assert any(
+            e["type"] == "extra_forbidden" and e["loc"] == ("subscribed_intents",)
+            for e in exc_info.value.errors()
+        )

--- a/tests/unit/models/contracts/test_model_contract_mcp_config.py
+++ b/tests/unit/models/contracts/test_model_contract_mcp_config.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for ModelContractMcpConfig (contract ``mcp:`` block, OMN-16451)."""
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.contracts.model_contract_mcp_config import (
+    ModelContractMcpConfig,
+)
+
+_VALID: dict[str, object] = {
+    "expose": True,
+    "tool_name": "register_node",
+    "description": "Register a new ONEX node with the cluster.",
+    "timeout_seconds": 30,
+}
+
+
+@pytest.mark.unit
+class TestModelContractMcpConfig:
+    def test_parses_the_four_consumed_keys(self) -> None:
+        cfg = ModelContractMcpConfig.model_validate(_VALID)
+        assert cfg.expose is True
+        assert cfg.tool_name == "register_node"
+        assert cfg.description.startswith("Register")
+        assert cfg.timeout_seconds == 30
+
+    @pytest.mark.parametrize("missing", sorted(_VALID))
+    def test_every_field_is_required(self, missing: str) -> None:
+        data = {k: v for k, v in _VALID.items() if k != missing}
+        with pytest.raises(ValidationError) as exc_info:
+            ModelContractMcpConfig.model_validate(data)
+        assert any(e["loc"] == (missing,) for e in exc_info.value.errors())
+
+    def test_rejects_undeclared_key(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ModelContractMcpConfig.model_validate({**_VALID, "retries": 3})
+        assert any(e["type"] == "extra_forbidden" for e in exc_info.value.errors())
+
+    def test_rejects_non_positive_timeout(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelContractMcpConfig.model_validate({**_VALID, "timeout_seconds": 0})
+
+    def test_rejects_non_snake_case_tool_name(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelContractMcpConfig.model_validate(
+                {**_VALID, "tool_name": "Register-Node"}
+            )
+
+    def test_is_frozen(self) -> None:
+        cfg = ModelContractMcpConfig.model_validate(_VALID)
+        with pytest.raises(ValidationError):
+            cfg.expose = False  # type: ignore[misc]


### PR DESCRIPTION
## Declare the contract keys the runtime consumes; delete NodeCompute's dead metadata read

OMN-16451 (first of two PRs; the omnibase_infra companion adds the fail-fast strict loader on the `node_registration_orchestrator` load path and the contract cleanup, and lands after this ships in a core release + pin bump).

`ModelContractBase` sets `extra="forbid"`, but the runtime reads several top-level `contract.yaml` sections from the bare YAML dict — sections the model never declared. Under a strict parse those contracts fail; under the raw-dict path the policy has no enforcement point. This PR converges the model on the corpus for exactly the keys a production reader exists for (OMN-16451 verdict: model follows corpus for consumed keys; undeclared-and-unread keys get deleted, not typed).

### Added — typed optional fields on `ModelContractBase` (one per production reader)

| key | production reader (grep evidence, current trees) |
|-----|--------------------------------------------------|
| `event_bus: ModelEventBusSubcontract \| None` | `omnibase_infra/runtime/runtime_host_process.py:691,3703` (`contract.get("event_bus")`), `runtime/auto_wiring/discovery.py:415` (`raw.get("event_bus")`), plus ~25 more readers cited on the ticket |
| `mcp: ModelContractMcpConfig \| None` (new model) | `omnibase_infra/handlers/mcp/adapter_onex_to_mcp.py:305` (`raw.get("mcp")`) |
| `intent_consumption: ModelContractIntentConsumption \| None` (new model) | `omnibase_infra/runtime/service_intent_routing_loader.py:54+` (reads `intent_consumption.intent_routing_table`) |

### Added — `ModelEventBusSubcontract.dlq_topics: list[str]`

Auto-wiring consumes `event_bus.dlq_topics` (`omnibase_infra/runtime/auto_wiring/discovery.py:420`, `handler_wiring.py:2343 _read_dlq_topics`), but the subcontract model did not declare it — so **every contract that declared `dlq_topics` failed the subcontract parse**, a real latent bug since OMN-13852. `dlq_topics` entries now also run the same topic-suffix naming validator as `publish_topics`/`subscribe_topics`.

### Removed — `NodeCompute`'s dead `metadata` read

`node_compute.py:524` did `getattr(contract, "metadata", None) or {}`. Under `extra="forbid"` the attribute can never resolve, so `cache_enabled`/`parallel_enabled` always came out as the `ModelComputeInput` defaults and the "parallel requested but not parallelizable" warning was unreachable. The read, the derived settings, and the dead warning are deleted (ticket DoD item 5).

### Not in this PR (tracked)

- Nested strict parse of the orchestrator contract is blocked by four shape divergences inside the model (`published_events`/`consumed_events` discovery-typed, `input_model`/`output_model` str-vs-mapping) — split to OMN-16499.
- The infra-side fail-fast loader replacing `plugin.py`'s warn-and-`{}` fallback, the `service_node_introspection` `__dict__["event_bus"]` bypass removal, and the deletion of the six dead contract keys (`time_injection`, `projection_reader`, `error_handling`, `health_check`, `metadata`, `intent_consumption.subscribed_intents`) land in the omnibase_infra companion.

### dod_evidence

- New tests: `test_contract_base_consumed_extension_keys.py` (132 lines — declared keys parse strictly, undeclared keys still rejected), `test_model_event_bus_subcontract_dlq_topics.py`, `test_model_contract_mcp_config.py`, `test_model_contract_intent_consumption.py`.
- Local: `uv run mypy src/ --strict` → 0 errors on changed files; ruff format + check clean; pre-commit all hooks pass.
- Governed pre-push selector (OMN-13973 hook, no overrides) escalated to the full non-integration suite: **44119 passed, 53 skipped, 3 xpassed, 0 failed in 1:43:57** immediately before this push.

Evidence-Ticket: OMN-16451
Evidence-Source: OCC#7036
