### PR TITLE
fix(OMN-16348): switch ci.yml pytest timeout method from thread to signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3187,7 +3187,7 @@ jobs:
             --group ${{ matrix.split }} \
             -n "$PYTEST_XDIST_WORKERS" \
             --timeout=60 \
-            --timeout-method=thread \
+            --timeout-method=signal \
             --tb=short \
             --junitxml=junit-${{ matrix.split }}.xml
 
@@ -3211,7 +3211,7 @@ jobs:
             --durations-path .test_durations \
             -n "$PYTEST_XDIST_WORKERS" \
             --timeout=60 \
-            --timeout-method=thread \
+            --timeout-method=signal \
             --tb=short \
             --junitxml=junit-${{ matrix.split }}.xml
 

--- a/tests/unit/validation/test_ci_workflow_shape.py
+++ b/tests/unit/validation/test_ci_workflow_shape.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -753,4 +754,79 @@ def test_ci_summary_is_hosted_no_needs_poller() -> None:
         "scripts/ci/ci_summary_gate.py" in str(step.get("run", ""))
         for step in job["steps"]
         if isinstance(step, dict)
+    )
+
+
+_TIMEOUT_METHOD_RE = re.compile(r"--timeout-method=(\S+)")
+
+
+def _has_pytest_token(run: str) -> bool:
+    """True when a non-comment line of the run script invokes pytest."""
+    return any(
+        token == "pytest" or token.endswith("/pytest")
+        for line in run.splitlines()
+        if not line.lstrip().startswith("#")
+        for token in line.split()
+    )
+
+
+def _all_workflow_run_commands() -> list[tuple[str, str, str]]:
+    """Every ``(workflow file, job, run script)`` triple in .github/workflows."""
+    commands: list[tuple[str, str, str]] = []
+    for path in sorted(WORKFLOW_PATH.parent.glob("*.yml")) + sorted(
+        WORKFLOW_PATH.parent.glob("*.yaml")
+    ):
+        data = yaml.safe_load(path.read_text())
+        if not isinstance(data, dict):
+            continue
+        jobs = data.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if isinstance(step, dict) and "run" in step:
+                    commands.append((path.name, str(job_name), str(step["run"])))
+    return commands
+
+
+def test_no_workflow_pytest_invocation_uses_thread_timeout_method() -> None:
+    """OMN-16348: every ``--timeout-method`` in any workflow must be ``signal``.
+
+    OMN-15977 banned pytest-timeout's ``thread`` method: its watcher thread
+    fires only when the GIL is released, so a CPU-bound pure-Python runaway
+    holds the GIL continuously and the declared ``--timeout`` ceiling silently
+    never fires (the config behind the 2026-08-12 46/53-minute pre-push
+    runaways that needed manual SIGKILL). The ban was originally enforced
+    per-file (``pyproject.toml`` addopts + the pre-push hook) and missed
+    ci.yml, whose explicit CLI flag overrides the addopts ``signal`` default.
+    This assertion is per-invocation-surface — the OMN-15977 guards were
+    per-file, which is exactly why a third surface stayed invisible — so it
+    scans every run step of every workflow file: none may pass
+    ``--timeout-method=`` with any value other than ``signal``.
+    """
+    commands = _all_workflow_run_commands()
+
+    # Positive control: the scanner must actually be seeing ci.yml's pytest
+    # steps — an empty scan would vacuously pass while enforcing nothing.
+    assert any(
+        source == WORKFLOW_PATH.name and _has_pytest_token(run)
+        for source, _, run in commands
+    )
+
+    violations = [
+        f"{source}::{job}: {line.strip()}"
+        for source, job, run in commands
+        for line in run.splitlines()
+        for method in _TIMEOUT_METHOD_RE.findall(line)
+        if method != "signal"
+    ]
+    assert violations == [], (
+        "workflow passes a non-signal --timeout-method (banned by OMN-15977; "
+        "the explicit CLI flag overrides the addopts signal default): "
+        f"{violations}"
     )


### PR DESCRIPTION
## Summary

OMN-15977 banned pytest-timeout's `thread` method (its watcher thread only
fires when the GIL is released, so a CPU-bound pure-Python runaway never
trips the declared `--timeout` ceiling -- the config behind the 2026-08-12
46/53-minute pre-push runaways that needed manual SIGKILL). The ban was
enforced per-file (`pyproject.toml` addopts + the pre-push hook) and missed
`.github/workflows/ci.yml`, whose explicit CLI flag overrides the addopts
`signal` default -- so every CI unit-test invocation still ran the banned
method and the declared `--timeout=60` ceiling silently could not fire.

- `ci.yml` "Run pytest (smart selection)" + "Run pytest (full suite)":
  `--timeout-method=thread` -> `signal`
- New per-invocation-surface guard test in
  `tests/unit/validation/test_ci_workflow_shape.py` that scans every `run`
  step of every workflow file for a non-`signal` `--timeout-method` value
  (mutation-proven red on flip, with a positive control against a vacuous
  pass).

## Test plan

- [x] `uv run pytest tests/unit/validation/test_ci_workflow_shape.py` -- 77 passed
- [x] Mutation proof: flipped `signal` back to `thread` locally, confirmed
      `test_no_workflow_pytest_invocation_uses_thread_timeout_method` goes red,
      reverted
- [x] `uv run ruff check tests/unit/validation/test_ci_workflow_shape.py` -- clean
- [x] Governed pre-push selector (`scripts/hooks/prepush_smart_tests.sh`) escalated
      to a full local run and passed

OMN-16348

Evidence-Ticket: OMN-16348
Evidence-Source: OCC#7044
