### PR TITLE
feat(OMN-16353): emit missing_occ_self_bind with exact remediation for the missing-self-bind-only OCC case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.12"
+version = "0.46.13"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/enums/enum_occ_eligibility_reason.py
+++ b/src/omnibase_core/enums/enum_occ_eligibility_reason.py
@@ -19,6 +19,11 @@ class EnumOccEligibilityReason(StrEnum):
     CONTRACT_HASH_MISMATCH = "contract_hash_mismatch"
     OCC_NOT_ON_MAIN = "occ_not_on_main"
     PR_TICKET_MISMATCH = "pr_ticket_mismatch"
+    # OMN-16353: the missing-self-bind-ONLY case on the OCC evidence repo —
+    # contracts resolve, receipts are PASS and hash-bound, but no receipt binds
+    # to the OCC PR itself (`occ-self-bind-pr-<N>` omitted). Split out of
+    # PR_TICKET_MISMATCH so the gate can name the exact remedy.
+    MISSING_OCC_SELF_BIND = "missing_occ_self_bind"
 
 
 __all__ = ["EnumOccEligibilityReason"]

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -44,6 +44,53 @@ EVIDENCE_TICKET_PATTERN = re.compile(
 )
 TICKET_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9])OMN-(\d+)(?![A-Z0-9])", re.IGNORECASE)
 
+# OMN-16353: the OCC evidence repo, where a PR under evaluation is itself the
+# companion carrying contracts/receipts and must self-bind via an
+# `occ-self-bind-pr-<N>` entry. Callers pass either the short repo name (the
+# CI workflows pass `REPO_SHORT`) or the org-qualified form.
+_OCC_REPO_NAME = "onex_change_control"
+
+
+def _is_occ_repo(repo: str) -> bool:
+    return repo.strip().rstrip("/").rsplit("/", maxsplit=1)[-1] == _OCC_REPO_NAME
+
+
+def _self_bind_remediation(ticket_id: str, pr_number: int) -> str:
+    """Exact remedy for an OCC companion missing its self-bind (OMN-16353).
+
+    Emitted only when everything else verifies: contracts resolve, receipts
+    are PASS and hash-bound — the sole defect is that no receipt carries
+    ``pr_number == <this OCC PR>``. Names the precise YAML entry and receipt
+    path so the convention is taught at the moment of failure instead of
+    costing a full CI round-trip of re-diagnosis.
+    """
+    entry_id = f"occ-self-bind-pr-{pr_number}"
+    return (
+        f"OCC evidence for {ticket_id} verifies (receipts PASS, hashes bound), "
+        f"but no receipt binds to this OCC PR (#{pr_number}). "
+        f"Add a self-bind entry to contracts/{ticket_id}.yaml:\n"
+        "\n"
+        f'  - id: "{entry_id}"\n'
+        "    description: >-\n"
+        f"      OCC self-binding receipt for PR #{pr_number}, the in-repo evidence PR\n"
+        f"      carrying this contract. Binds {ticket_id} to the OCC PR by pr_number\n"
+        "      so eligibility can resolve a PASS receipt for the evidence PR itself.\n"
+        '    source: "manual"\n'
+        '    status: "verified"\n'
+        "    checks:\n"
+        '      - check_type: "command"\n'
+        "        check_value: >-\n"
+        f"          gh pr view {pr_number} --repo OmniNode-ai/{_OCC_REPO_NAME} "
+        "--json number,state,headRefName\n"
+        "\n"
+        "then write a PASS receipt at "
+        f"drift/dod_receipts/{ticket_id}/{entry_id}/command.yaml with "
+        f"pr_number: {pr_number}. Recompute contract_sha256 on the EXISTING "
+        f"receipts for {ticket_id} — the whole-file hash moves when the contract "
+        "gains an entry; per-entry contract_entry_sha256 values do not "
+        "(OMN-13888)."
+    )
+
 
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
@@ -383,6 +430,26 @@ def validate_occ_merge_eligibility(
         if ticket_id not in tickets_with_pr_bound_receipt
     )
     if unbound_tickets:
+        if _is_occ_repo(snapshot.repo):
+            # OMN-16353: reaching this branch means every contract resolved and
+            # every required receipt is PASS and hash-bound — the ONLY defect is
+            # that no receipt binds to THIS PR. On the OCC repo itself that is
+            # the hand-authored-companion omission of the self-bind entry
+            # (three occurrences in one 2026-08-21 session: OCC#6819, #6820,
+            # #6675). The verdict is unchanged (ineligible either way);
+            # only the reason and remediation differ — advisory-to-actionable.
+            return ModelOccEligibilityResult(
+                eligible=False,
+                reason=EnumOccEligibilityReason.MISSING_OCC_SELF_BIND,
+                ticket_ids=ticket_ids,
+                occ_commit_sha=snapshot.occ_commit_sha,
+                contract_hashes=contract_hashes,
+                receipt_ids=tuple(sorted(receipt_ids)),
+                detail="\n\n".join(
+                    _self_bind_remediation(ticket_id, snapshot.pr_number)
+                    for ticket_id in unbound_tickets
+                ),
+            )
         return ModelOccEligibilityResult(
             eligible=False,
             reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -752,3 +752,303 @@ def test_checked_replacement_supersession_still_requires_its_own_receipt(
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
     assert result.missing_or_nonpass_receipts == (f"{TICKET}:dod-002-new:command",)
+
+
+# --- OMN-16353: missing-self-bind-only case emits an actionable reason ---------
+#
+# A hand-authored OCC companion that creates or extends a contract needs a
+# receipt binding the ticket to the OCC PR ITSELF (`occ-self-bind-pr-<N>`).
+# Omitting it used to surface as a generic `pr_ticket_mismatch` whose JSON
+# reported every receipt as found and valid — actively misleading (three
+# occurrences in one 2026-08-21 session: OCC#6819, #6820, #6675). When the
+# ONLY defect is the missing self-bind (contracts resolve, receipts PASS,
+# hashes valid, no receipt binds to THIS OCC-repo PR), the gate must emit
+# `missing_occ_self_bind` plus the exact YAML entry and receipt path to write.
+# The verdict itself is unchanged: ineligible before, ineligible after.
+
+
+def _occ_snapshot(
+    root: Path, *, repo: str = "onex_change_control"
+) -> ModelOccEligibilityInput:
+    """Snapshot for a PR on the OCC evidence repo itself."""
+    return ModelOccEligibilityInput(
+        repo=repo,
+        pr_number=123,
+        pr_title=f"docs({TICKET}): OCC evidence companion",
+        pr_body=f"Closes: {TICKET}",
+        pr_branch=f"jonah/{TICKET.lower()}-companion",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(f"docs({TICKET}): add contract + receipts",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=root / "contracts",
+        receipts_dir=root / "receipts",
+    )
+
+
+@pytest.mark.unit
+def test_missing_self_bind_only_emits_actionable_reason_on_occ_repo(
+    tmp_path: Path,
+) -> None:
+    """The missing-self-bind-only case gets its own reason + exact remedy.
+
+    Everything verifies (contract resolves, receipt is PASS and hash-bound);
+    the ONLY defect is that the receipt binds a foreign PR, not this OCC PR.
+    Pre-fix this returned the generic terminal ``pr_ticket_mismatch``.
+    """
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,  # the product PR, not this OCC PR
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
+    # the receipt is still reported as resolved — nothing is "missing"
+    assert result.receipt_ids == (f"{TICKET}:dod-001:command",)
+    assert result.missing_or_nonpass_receipts == ()
+    assert result.stale_receipt_bindings == ()
+    # remediation payload: exact entry id, contract file, receipt path,
+    # pr_number, and the OMN-13888 hash-recompute reminder
+    assert "occ-self-bind-pr-123" in result.detail
+    assert f"contracts/{TICKET}.yaml" in result.detail
+    assert (
+        f"drift/dod_receipts/{TICKET}/occ-self-bind-pr-123/command.yaml"
+        in result.detail
+    )
+    assert "pr_number: 123" in result.detail
+    assert "contract_sha256" in result.detail
+    assert "contract_entry_sha256" in result.detail
+    assert "OMN-13888" in result.detail
+
+
+@pytest.mark.unit
+def test_missing_self_bind_reason_accepts_org_qualified_occ_repo(
+    tmp_path: Path,
+) -> None:
+    """A caller passing the org-qualified repo name gets the same reason."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(
+        _occ_snapshot(tmp_path, repo="OmniNode-ai/onex_change_control")
+    )
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
+
+
+@pytest.mark.unit
+def test_unbound_receipt_on_product_repo_keeps_pr_ticket_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Product-repo behavior is byte-identical: the self-bind remedy is an
+    OCC-companion concept, so a product PR keeps the generic terminal reason."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+    assert "no PASS receipt for one or more tickets binds to PR #123" in result.detail
+    assert "occ-self-bind" not in result.detail
+
+
+@pytest.mark.unit
+def test_missing_self_bind_does_not_absorb_missing_receipt(tmp_path: Path) -> None:
+    """A genuinely missing receipt on the OCC repo stays MISSING_RECEIPT."""
+    _write_contract(tmp_path)
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
+
+
+@pytest.mark.unit
+def test_missing_self_bind_does_not_absorb_nonpass_receipt(tmp_path: Path) -> None:
+    """A FAIL receipt on the OCC repo stays NONPASS_RECEIPT."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path, status=EnumReceiptStatus.FAIL, contract_sha256=contract_hash
+    )
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.NONPASS_RECEIPT
+
+
+@pytest.mark.unit
+def test_missing_self_bind_does_not_absorb_stale_binding(tmp_path: Path) -> None:
+    """A stale contract hash on the OCC repo stays CONTRACT_HASH_MISMATCH."""
+    _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=STALE_HASH)
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+
+
+@pytest.mark.unit
+def test_missing_self_bind_does_not_absorb_missing_contract(tmp_path: Path) -> None:
+    """A missing contract on the OCC repo stays MISSING_CONTRACT."""
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_CONTRACT
+
+
+@pytest.mark.unit
+def test_missing_self_bind_does_not_absorb_unbound_ticket_text(
+    tmp_path: Path,
+) -> None:
+    """The EARLY pr_ticket_mismatch (ticket cited but not bound through PR
+    title/branch/commit/Evidence-Ticket) is a different defect and keeps its
+    reason even on the OCC repo."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, contract_sha256=contract_hash)
+    snapshot = ModelOccEligibilityInput(
+        repo="onex_change_control",
+        pr_number=123,
+        pr_title="docs: evidence companion without ticket token",
+        pr_body=f"Closes: {TICKET}",
+        pr_branch="jonah/no-ticket-here",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=("docs: unrelated commit",),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+    assert "cited but not bound" in result.detail
+
+
+@pytest.mark.unit
+def test_missing_self_bind_names_every_unbound_ticket(tmp_path: Path) -> None:
+    """With N unbound tickets, the remediation names each one (no serial
+    one-per-CI-round drip)."""
+    second_ticket = "OMN-10485"
+    first_hash = _write_contract(tmp_path)
+    second_hash = _write_contract(tmp_path, ticket_id=second_ticket)
+    _write_receipt(
+        tmp_path, pr_number=999, commit_sha="c" * 40, contract_sha256=first_hash
+    )
+    _write_receipt(
+        tmp_path,
+        ticket_id=second_ticket,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=second_hash,
+    )
+    snapshot = ModelOccEligibilityInput(
+        repo="onex_change_control",
+        pr_number=123,
+        pr_title=f"docs({TICKET}): companion",
+        pr_body=f"Closes: {TICKET}\nCloses: {second_ticket}",
+        pr_branch=f"jonah/{TICKET.lower()}-companion",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(
+            f"docs({TICKET}): contract",
+            f"docs({second_ticket}): contract",
+        ),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
+    assert f"contracts/{TICKET}.yaml" in result.detail
+    assert f"contracts/{second_ticket}.yaml" in result.detail
+    assert f"drift/dod_receipts/{second_ticket}/occ-self-bind-pr-123" in result.detail
+
+
+@pytest.mark.unit
+def test_missing_self_bind_only_names_the_unbound_ticket(tmp_path: Path) -> None:
+    """A ticket whose receipt DOES bind this PR is not named in the remedy."""
+    second_ticket = "OMN-10485"
+    first_hash = _write_contract(tmp_path)
+    second_hash = _write_contract(tmp_path, ticket_id=second_ticket)
+    # first ticket binds this PR; second binds only the foreign product PR
+    _write_receipt(tmp_path, pr_number=123, contract_sha256=first_hash)
+    _write_receipt(
+        tmp_path,
+        ticket_id=second_ticket,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=second_hash,
+    )
+    snapshot = ModelOccEligibilityInput(
+        repo="onex_change_control",
+        pr_number=123,
+        pr_title=f"docs({TICKET}): companion",
+        pr_body=f"Closes: {TICKET}\nCloses: {second_ticket}",
+        pr_branch=f"jonah/{TICKET.lower()}-companion",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(
+            f"docs({TICKET}): contract",
+            f"docs({second_ticket}): contract",
+        ),
+        occ_commit_sha="b" * 40,
+        contracts_dir=tmp_path / "contracts",
+        receipts_dir=tmp_path / "receipts",
+    )
+
+    result = validate_occ_merge_eligibility(snapshot)
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
+    assert f"drift/dod_receipts/{second_ticket}/occ-self-bind-pr-123" in result.detail
+    assert f"drift/dod_receipts/{TICKET}/" not in result.detail
+
+
+@pytest.mark.unit
+def test_occ_repo_with_self_bind_receipt_stays_eligible(tmp_path: Path) -> None:
+    """A properly self-bound OCC companion is eligible — verdicts unchanged."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(tmp_path, pr_number=123, contract_sha256=contract_hash)
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+
+
+@pytest.mark.unit
+def test_missing_self_bind_output_is_replay_stable(tmp_path: Path) -> None:
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    snapshot = _occ_snapshot(tmp_path)
+
+    first = validate_occ_merge_eligibility(snapshot)
+    second = validate_occ_merge_eligibility(snapshot)
+
+    assert first.to_json() == second.to_json()
+    assert '"reason":"missing_occ_self_bind"' in first.to_json()

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.12"
+version = "0.46.13"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Extends `validator_occ_merge_eligibility` so an OCC-repo companion PR whose
**only** eligibility defect is a missing self-bind (contracts resolve,
receipts PASS and hash-bound, but no receipt carries `pr_number == <this OCC
PR>`) emits `reason: missing_occ_self_bind` with the exact remedy instead of
the generic `pr_ticket_mismatch`, which reports every receipt as found and
valid — actively misleading.

The new branch names:
- the `occ-self-bind-pr-<N>` YAML entry to add to `contracts/<TICKET>.yaml`
- the receipt path at `drift/dod_receipts/<TICKET>/occ-self-bind-pr-<N>/command.yaml` with `pr_number`
- the OMN-13888 reminder: `contract_sha256` on pre-existing receipts must be
  recomputed when the contract gains an entry; `contract_entry_sha256`
  values do not move.

Advisory-to-actionable only — verdicts are unchanged (ineligible either way).
Product-repo behavior is byte-identical (kept `pr_ticket_mismatch`, proven by
test). 12 new unit tests cover the branch and prove it does not absorb
`MISSING_RECEIPT` / `NONPASS_RECEIPT` / `CONTRACT_HASH_MISMATCH` /
`MISSING_CONTRACT` / the early `pr_ticket_mismatch`, plus multi-ticket
remediation, per-ticket filtering, eligible-verdict stability, and
replay-stable JSON output.

## Evidence-Ticket: OMN-16353

Three prior occurrences (2026-08-21, one session): OCC#6819, #6820, #6675 —
each cost a full CI round-trip because the old diagnostic reported every
receipt as found and valid while giving no hint that a second, PR-scoped
receipt was needed.

## Test plan

- [x] `uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q` — 39/39 passed
- [x] `uv run mypy --strict` on both changed source files — 0 issues
- [x] `uv run ruff format --check` / `ruff check` — clean
- [x] Governed pre-push impacted-test selector (escalated to full local suite,
      shared_module class) — 44138 passed, 0 failed, 53 skipped, 3 xpassed
      (`5689.08s`)

Evidence-Ticket: OMN-16353
Evidence-Source: OCC#7050


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated validation result for OCC pull requests missing a receipt that binds to the pull request itself.
  * Added clear remediation guidance, including the required YAML updates and receipt path instructions.
* **Bug Fixes**
  * Improved eligibility reporting so OCC repository issues are distinguished from product repository ticket mismatches.
* **Tests**
  * Added coverage for missing self-bind receipts, multiple tickets, replay stability, and existing valid and invalid scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->