### PR TITLE
fix(OMN-16347): make the semantic-diff batch read git-2.34-safe; make the OCC gate entrypoint tests hermetic

### DIFF
--- a/scripts/analysis/semantic_diff.py
+++ b/scripts/analysis/semantic_diff.py
@@ -120,99 +120,156 @@ def _decode_blob(raw: bytes) -> str:
     )
 
 
-def _absent_response_length(out: bytes, pos: int, request: bytes) -> int | None:
-    """Length of the "not resolvable" response at ``pos``, or None if it is a blob.
+def _warn_batch_read_failed(command: str, request_count: int, stderr: bytes) -> None:
+    """Degrade LOUDLY when a batch git process fails.
 
-    ``git cat-file --batch`` answers an unresolvable name by echoing the request
-    back verbatim plus a status word. Matching that echo against the request we
-    actually sent is the only framing-independent way to consume the response:
-    the echo carries whatever bytes the path carried, newlines included, so
-    scanning for the next LF splits it and loses the FOLLOWING blob.
+    Every blob resolving to "" makes compute_diff report "no semantic changes"
+    for the WHOLE diff, which reads identically to a genuinely clean diff; the
+    per-file ``git show`` shape the batching replaced could only ever lose one
+    file at a time.
     """
-    for status in (b" missing\n", b" ambiguous\n"):
-        if out.startswith(request + status, pos):
-            return len(request) + len(status)
-    return None
+    print(  # noqa: T201
+        f"warning: git {command} failed; emitting empty advisory report for "
+        f"all {request_count} requested blobs: "
+        f"{stderr.decode('utf-8', errors='replace').strip()}",
+        file=sys.stderr,
+    )
 
 
-def _git_files_at(
-    repo_root: Path, requests: list[tuple[str, str]]
-) -> dict[tuple[str, str], str]:
-    """Read every requested ``<ref>:<path>`` blob in ONE git process.
+def _git_blob_oids_at(repo_root: Path, ref: str) -> dict[str, str] | None:
+    """Map every blob path in ``ref``'s tree to its object id (None on failure).
 
-    The previous shape spawned two ``git show`` processes per changed file, so a
-    1,000-file diff paid ~2,000 process spawns and that dominated CLI runtime --
-    enough, under the parallel test gate, to push the run past its per-test
-    timeout. ``git cat-file --batch`` answers the whole set from a single
-    process. Missing blobs yield "", matching the previous per-file behaviour.
-    See OMN-15431.
-
-    Requests are NUL-delimited (``-z``), not newline-delimited: git permits a
-    newline inside a path, and a newline-framed request stream would split such
-    a path into two requests and desynchronise every response after it --
-    silently corrupting the content of unrelated files. The per-file ``git
-    show`` shape this replaced had no such coupling, so ``-z`` is what keeps the
-    batching behaviour-preserving.
-
-    ``-z`` frames stdin ONLY; git's stdout stays LF-framed on every git version
-    this repo supports (``-Z``, which also frames stdout, needs git >= 2.42 and
-    the fleet runs 2.39). So responses are NOT scanned for the next LF -- an
-    absent blob is answered by echoing the request VERBATIM followed by
-    " missing", which re-injects the embedded newline and would burn one
-    response slot per line. Each response is instead matched against the exact
-    request that produced it, which is framing-independent. This is not an
-    exotic case: :func:`_compute_report` asks for every changed path at BOTH
-    base and head, so every added or deleted file is a missing-blob request.
+    ``git ls-tree -r -z`` has framed its output with NUL since git 1.x, and a
+    NUL-framed listing carries a path VERBATIM -- newline included -- so this is
+    how a newline-bearing path is resolved without ever putting that path on a
+    newline-framed request stream (see :func:`_git_files_at`).
     """
-    if not requests:
-        return {}
-
-    payload = b"".join(f"{ref}:{rel}\0".encode() for ref, rel in requests)
     result = subprocess.run(
-        ["git", "cat-file", "--batch", "-z"],
+        ["git", "ls-tree", "-r", "-z", ref],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        _warn_batch_read_failed("ls-tree", 1, result.stderr)
+        return None
+
+    oids: dict[str, str] = {}
+    # Each entry is "<mode> <type> <oid>\t<path>" terminated by NUL.
+    for entry in result.stdout.split(b"\0"):
+        if not entry:
+            continue
+        meta, _, path = entry.partition(b"\t")
+        fields = meta.split(b" ")
+        if len(fields) != 3 or fields[1] != b"blob":
+            continue
+        oids[path.decode("utf-8", errors="surrogateescape")] = fields[2].decode("ascii")
+    return oids
+
+
+def _git_blobs(repo_root: Path, oids: list[str]) -> dict[str, str] | None:
+    """Read every listed blob in ONE ``git cat-file --batch`` process (None on failure).
+
+    Requests are object ids, so the newline-framed request stream that plain
+    ``--batch`` has accepted since git 1.5 is safe: an oid is 40 hex characters
+    and can never contain the framing byte. The response header for a resolved
+    object is ``<oid> <type> <size>`` on its own LF-terminated line, followed by
+    ``<size>`` payload bytes and one trailing LF.
+    """
+    payload = "".join(f"{oid}\n" for oid in oids).encode("ascii")
+    result = subprocess.run(
+        ["git", "cat-file", "--batch"],
         cwd=repo_root,
         input=payload,
         capture_output=True,
         check=False,
     )
     if result.returncode != 0:
-        # Degrade loudly. Every blob resolving to "" makes compute_diff report
-        # "no semantic changes" for the WHOLE diff, which reads identically to
-        # a genuinely clean diff; the per-file shape this replaced could only
-        # ever lose one file at a time.
-        print(  # noqa: T201
-            "warning: git cat-file failed; emitting empty advisory report for "
-            f"all {len(requests)} requested blobs: "
-            f"{result.stderr.decode('utf-8', errors='replace').strip()}",
-            file=sys.stderr,
-        )
-        return {}
+        _warn_batch_read_failed("cat-file", len(oids), result.stderr)
+        return None
 
     out = result.stdout
-    sources: dict[tuple[str, str], str] = {}
+    blobs: dict[str, str] = {}
     pos = 0
-    for key in requests:
-        ref, rel = key
-        absent_len = _absent_response_length(out, pos, f"{ref}:{rel}".encode())
-        if absent_len is not None:
-            sources[key] = ""
-            pos += absent_len
-            continue
+    for oid in oids:
         end_of_header = out.find(b"\n", pos)
         if end_of_header == -1:
             break
-        header = out[pos:end_of_header]
+        fields = out[pos:end_of_header].split(b" ")
         pos = end_of_header + 1
-        # Success is "<oid> <type> <size>"; absence was handled above.
-        fields = header.split(b" ")
-        try:
-            size = int(fields[2])
-        except (IndexError, ValueError):
-            sources[key] = ""
+        if len(fields) != 3 or not fields[2].isdigit():
+            # "<oid> missing" cannot happen for an oid ls-tree just listed, but
+            # it must never desynchronise the stream if it does.
+            blobs[oid] = ""
             continue
-        sources[key] = _decode_blob(out[pos : pos + size])
+        size = int(fields[2])
+        blobs[oid] = _decode_blob(out[pos : pos + size])
         pos += size + 1  # blob payload plus its trailing newline
 
+    unanswered = [oid for oid in oids if oid not in blobs]
+    if unanswered:
+        _warn_batch_read_failed(
+            "cat-file",
+            len(unanswered),
+            b"batch stream ended before every requested object was answered",
+        )
+        return None
+    return blobs
+
+
+def _git_files_at(
+    repo_root: Path, requests: list[tuple[str, str]]
+) -> dict[tuple[str, str], str]:
+    """Read every requested ``<ref>:<path>`` blob with a fixed number of git processes.
+
+    The original shape spawned two ``git show`` processes per changed file, so a
+    1,000-file diff paid ~2,000 process spawns and that dominated CLI runtime --
+    enough, under the parallel test gate, to push the run past its per-test
+    timeout (OMN-15431). This shape spends one ``git ls-tree`` per distinct ref
+    plus one ``git cat-file --batch`` for all blobs, regardless of file count.
+    Missing blobs yield "", matching the original per-file behaviour.
+
+    Why paths are resolved through ``ls-tree`` instead of being sent to
+    ``cat-file`` as ``<ref>:<path>`` requests: git permits a newline inside a
+    path, and a newline-framed request stream would split such a path into two
+    requests and desynchronise every response after it -- silently corrupting
+    the content of unrelated files. The NUL-framed request switches that would
+    avoid this (``cat-file -z`` / ``-Z``) do NOT exist on the git 2.34.1 that
+    the self-hosted runner fleet ships: the OMN-15431 batching used ``-z`` and
+    every ``cat-file`` call died there with ``error: unknown switch 'z'``,
+    which resolved EVERY blob to "" and made the CLI report "no semantic
+    changes" for genuinely non-empty diffs (OMN-16347). ``ls-tree -r -z`` and
+    plain ``cat-file --batch`` fed object ids are available on every git this
+    repo runs against, so nothing here depends on the runner's git version.
+    """
+    if not requests:
+        return {}
+
+    oids_by_ref: dict[str, dict[str, str]] = {}
+    for ref in dict.fromkeys(ref for ref, _ in requests):
+        listing = _git_blob_oids_at(repo_root, ref)
+        if listing is None:
+            return {}
+        oids_by_ref[ref] = listing
+
+    wanted: dict[tuple[str, str], str] = {}
+    for ref, rel in requests:
+        oid = oids_by_ref[ref].get(rel)
+        if oid is not None:
+            wanted[(ref, rel)] = oid
+
+    # A path absent at a ref is not an error: _compute_report asks for every
+    # changed path at BOTH base and head, so every added or deleted file is
+    # absent at one of them.
+    sources: dict[tuple[str, str], str] = dict.fromkeys(requests, "")
+    if not wanted:
+        return sources
+
+    blobs = _git_blobs(repo_root, list(dict.fromkeys(wanted.values())))
+    if blobs is None:
+        return {}
+    for key, oid in wanted.items():
+        sources[key] = blobs[oid]
     return sources
 
 

--- a/tests/scripts/test_semantic_diff_cli.py
+++ b/tests/scripts/test_semantic_diff_cli.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
 
@@ -377,12 +378,66 @@ def test_git_files_at_warns_instead_of_silently_emptying_the_whole_report(
     for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
         monkeypatch.delenv(var, raising=False)
 
-    # Not a git repository, so cat-file cannot start: a real process-level
-    # failure, not a simulated one.
+    # Not a git repository, so no git process can resolve anything: a real
+    # process-level failure, not a simulated one.
     sources = module._git_files_at(tmp_path, [("HEAD", "one.py")])
 
     assert sources == {}
-    assert "git cat-file failed" in capsys.readouterr().err
+    assert "failed; emitting empty advisory report" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_git_files_at_needs_no_cat_file_switch_newer_than_the_runner_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The batched read must work on the git 2.34.1 the self-hosted runners ship.
+
+    The OMN-15431 batching passed ``cat-file --batch -z`` to NUL-frame its
+    requests. That switch does not exist on git 2.34.1, so on every dev push
+    run ``cat-file`` exited 129 with ``error: unknown switch `z'``, every blob
+    resolved to "", and ``_compute_report`` reported "no semantic changes" for
+    genuinely non-empty diffs (OMN-16347: five failures in this module, one of
+    them a false negative in a change-analysis surface). Developer machines run
+    a newer git, so the plain suite cannot see this; the fake below refuses the
+    NUL-framing switches exactly as the runner's git does, and the read must
+    still succeed -- newline-bearing path included, since that path is the
+    whole reason ``-z`` was reached for.
+    """
+    module = _load_cli_module()
+
+    weird_rel = "we\nird.py"
+    after = "AFTER = 2\n"
+    (tmp_path / weird_rel).write_text("WEIRD = 1\n", encoding="utf-8")
+    (tmp_path / "after.py").write_text(after, encoding="utf-8")
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "seed", "--no-gpg-sign")
+
+    real_run = subprocess.run
+    cat_file_calls: list[list[str]] = []
+
+    def git_2_34_run(
+        argv: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[bytes]:
+        if argv[:2] == ["git", "cat-file"]:
+            cat_file_calls.append(argv)
+            if {"-z", "-Z", "--batch-command"} & set(argv):
+                return subprocess.CompletedProcess(
+                    argv, 129, b"", b"error: unknown switch `z'\n"
+                )
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(module.subprocess, "run", git_2_34_run)
+
+    sources = module._git_files_at(
+        tmp_path,
+        [("HEAD", weird_rel), ("HEAD", "absent.py"), ("HEAD", "after.py")],
+    )
+
+    assert cat_file_calls, "the batched read no longer reads blobs through cat-file"
+    assert sources[("HEAD", weird_rel)] == "WEIRD = 1\n"
+    assert sources[("HEAD", "absent.py")] == ""
+    assert sources[("HEAD", "after.py")] == after
 
 
 @pytest.mark.unit

--- a/tests/unit/scripts/ci/test_check_occ_companion_merged.py
+++ b/tests/unit/scripts/ci/test_check_occ_companion_merged.py
@@ -224,21 +224,51 @@ class TestBodyAndScopeVerdicts:
         assert verdict.code == EXIT_PASS
 
 
+# Every runner-provided default ``main`` reads. On a dev *push* run the suite
+# inherits GITHUB_EVENT_NAME=push, a non-gating event, so an entrypoint test
+# that leaves --event-name to the default evaluates to PASS (0) instead of the
+# PENDING/FAIL it asserts -- the OMN-16347 (omnibase_core) / OMN-16327
+# (omnibase_infra) dev-baseline failures. The verdict under test must not
+# depend on which CI event happens to be running the test suite.
+RUNNER_ENV_DEFAULTS: tuple[str, ...] = (
+    "GH_REPO",
+    "PR_NUMBER",
+    "GITHUB_EVENT_NAME",
+    "MERGE_GROUP_HEAD_REF",
+    "OCC_REPO",
+    "DEADLINE_SECONDS",
+    "POLL_INTERVAL_SECONDS",
+)
+
+
+def _open_companion_fetcher() -> FakeFetcher:
+    return FakeFetcher(
+        prs={
+            (PRODUCT_REPO, "77"): _product_pr("Evidence-Source: OCC#5032"),
+            (OCC_REPO, "5032"): {"state": "OPEN", "mergeCommit": None},
+        }
+    )
+
+
 class TestMainEntrypoint:
-    def test_once_mode_returns_pending_exit_code(self, monkeypatch) -> None:
+    @pytest.fixture(autouse=True)
+    def _hermetic_runner_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in RUNNER_ENV_DEFAULTS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_once_mode_returns_pending_exit_code(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # --once with an OPEN companion must surface PENDING (2), not PASS.
         import scripts.ci.check_occ_companion_merged as mod
 
-        fetcher = FakeFetcher(
-            prs={
-                (PRODUCT_REPO, "77"): _product_pr("Evidence-Source: OCC#5032"),
-                (OCC_REPO, "5032"): {"state": "OPEN", "mergeCommit": None},
-            }
-        )
+        fetcher = _open_companion_fetcher()
         monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
         rc = main(
             [
                 "--once",
+                "--event-name",
+                "pull_request",
                 "--repo",
                 PRODUCT_REPO,
                 "--pr-number",
@@ -249,18 +279,17 @@ class TestMainEntrypoint:
         )
         assert rc == EXIT_PENDING
 
-    def test_deadline_converts_pending_to_fail(self, monkeypatch) -> None:
+    def test_deadline_converts_pending_to_fail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import scripts.ci.check_occ_companion_merged as mod
 
-        fetcher = FakeFetcher(
-            prs={
-                (PRODUCT_REPO, "77"): _product_pr("Evidence-Source: OCC#5032"),
-                (OCC_REPO, "5032"): {"state": "OPEN", "mergeCommit": None},
-            }
-        )
+        fetcher = _open_companion_fetcher()
         monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
         rc = main(
             [
+                "--event-name",
+                "pull_request",
                 "--repo",
                 PRODUCT_REPO,
                 "--pr-number",
@@ -274,3 +303,53 @@ class TestMainEntrypoint:
             ]
         )
         assert rc == EXIT_FAIL
+
+    def test_explicit_event_name_wins_over_the_runner_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The exact ambient state of a dev push run: GITHUB_EVENT_NAME=push. An
+        # explicit --event-name must still evaluate the gate, not skip it.
+        import scripts.ci.check_occ_companion_merged as mod
+
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        fetcher = _open_companion_fetcher()
+        monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
+        rc = main(
+            [
+                "--once",
+                "--event-name",
+                "pull_request",
+                "--repo",
+                PRODUCT_REPO,
+                "--pr-number",
+                "77",
+                "--occ-repo",
+                OCC_REPO,
+            ]
+        )
+        assert rc == EXIT_PENDING
+
+    def test_event_name_defaults_from_the_runner_environment(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Pins the behaviour that produced the dev-baseline failures, so the
+        # env dependency is documented rather than rediscovered: with no
+        # --event-name the runner's GITHUB_EVENT_NAME decides applicability.
+        import scripts.ci.check_occ_companion_merged as mod
+
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+        fetcher = _open_companion_fetcher()
+        monkeypatch.setattr(mod, "GhFetcher", lambda: fetcher)
+        rc = main(
+            [
+                "--once",
+                "--repo",
+                PRODUCT_REPO,
+                "--pr-number",
+                "77",
+                "--occ-repo",
+                OCC_REPO,
+            ]
+        )
+        assert rc == EXIT_PASS
+        assert "not a merge-gating event" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fixes both real content clusters from OMN-16347's dev-baseline unit failures (run 32469349920):

**Cluster 1 — `tests/scripts/test_semantic_diff_cli.py` (5 failures).** The self-hosted runner's git is 2.34.1; the OMN-15431 batching used `git cat-file --batch -z`, which that git version refuses (`error: unknown switch 'z'`). `_git_files_at` silently returned `{}`, producing 4 `KeyError`s and a downstream false negative — `compute_report` reported zero changes for a genuinely non-empty diff. Fix: paths resolved via `git ls-tree -r -z <ref>` and blobs read via plain `git cat-file --batch` (both git-1.x-era, process count unchanged). A new regression test fakes git 2.34's refusal of `-z`/`-Z`/`--batch-command` and requires the read to still succeed (newline-bearing and missing paths included).

**Cluster 2 — `tests/unit/scripts/ci/test_check_occ_companion_merged.py` (2 failures).** `main()` defaulted `--event-name` from `GITHUB_EVENT_NAME`, which is `push` on a dev push — so both `TestMainEntrypoint` tests evaluated to PASS(0) instead of PENDING(2)/FAIL(1). Tests now scrub every runner-provided env default the entrypoint reads and pass `--event-name` explicitly; two new tests pin the env-default behavior and that the explicit flag wins over it. Same root cause as OMN-16327 (omnibase_infra, byte-identical test file except `PRODUCT_REPO`) — already fixed and merged there (infra#2872, squash 62abadbaa2).

## Proof

- Local, both files in full: 40 passed with ambient env, 40 passed with `GITHUB_EVENT_NAME=push`.
- `ruff format --check` / `ruff check`: clean.
- `mypy --strict` on `scripts/analysis/semantic_diff.py`: clean.
- Governed pre-push impacted-selector escalated to whole-suite-equivalent (`tests/unit/ tests/agents/ tests/analysis/ tests/ci/ tests/enums/ tests/gates/ tests/models/ tests/performance/ tests/scripts/ ...`); this Mac was over the 1.0x-core load threshold (heavy concurrent multi-lane session) and the `.201` gate-runner was independently over its own load gate at decision time, so the run used the hook's own documented `PREPUSH_ALLOW_LOCAL_FULL_SUITE=1` degraded-capacity override (not a selection bypass — the exact escalated selection ran, just flagged as weaker evidence due to host contention) rather than contending on an already-overloaded host. Result: **44129 passed, 0 failed, 53 skipped, 3 xpassed** in 6402.78s (1:46:42).

Evidence-Ticket: OMN-16347
Evidence-Source: OCC#7059
