### PR TITLE
fix(OMN-16353): match the OCC repo exactly, not by suffix (CodeRabbit follow-up)

### DIFF
--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -49,10 +49,22 @@ TICKET_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9])OMN-(\d+)(?![A-Z0-9])", re.IGNO
 # `occ-self-bind-pr-<N>` entry. Callers pass either the short repo name (the
 # CI workflows pass `REPO_SHORT`) or the org-qualified form.
 _OCC_REPO_NAME = "onex_change_control"
+_OCC_REPO_ORG = "OmniNode-ai"
+_OCC_REPO_QUALIFIED = f"{_OCC_REPO_ORG}/{_OCC_REPO_NAME}"
 
 
 def _is_occ_repo(repo: str) -> bool:
-    return repo.strip().rstrip("/").rsplit("/", maxsplit=1)[-1] == _OCC_REPO_NAME
+    """True only for the canonical OCC repo — bare name or exact org/name.
+
+    Matches the short name (``onex_change_control``, what CI passes as
+    ``REPO_SHORT``) or the exact canonical org-qualified name
+    (``OmniNode-ai/onex_change_control``). Deliberately NOT a bare suffix
+    match: a differently-owned repo that merely shares the short name (e.g.
+    a fork under another org) must not be classified as the OCC evidence
+    repo (CodeRabbit finding on OMN-16353's initial diff).
+    """
+    normalized = repo.strip().rstrip("/")
+    return normalized in (_OCC_REPO_NAME, _OCC_REPO_QUALIFIED)
 
 
 def _self_bind_remediation(ticket_id: str, pr_number: int) -> str:
@@ -80,7 +92,7 @@ def _self_bind_remediation(ticket_id: str, pr_number: int) -> str:
         "    checks:\n"
         '      - check_type: "command"\n'
         "        check_value: >-\n"
-        f"          gh pr view {pr_number} --repo OmniNode-ai/{_OCC_REPO_NAME} "
+        f"          gh pr view {pr_number} --repo {_OCC_REPO_QUALIFIED} "
         "--json number,state,headRefName\n"
         "\n"
         "then write a PASS receipt at "

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -847,6 +847,36 @@ def test_missing_self_bind_reason_accepts_org_qualified_occ_repo(
 
 
 @pytest.mark.unit
+def test_missing_self_bind_reason_rejects_same_name_other_org_repo(
+    tmp_path: Path,
+) -> None:
+    """A repo that merely shares the short name under a DIFFERENT org is not
+    the canonical OCC repo — it must NOT get OCC self-bind remediation.
+
+    CodeRabbit finding on OMN-16353's initial diff: matching on the bare
+    suffix (``rsplit("/")[-1] == "onex_change_control"``) would misclassify
+    ``other-org/onex_change_control`` as the OCC evidence repo. Only the bare
+    short name or the exact canonical ``OmniNode-ai/onex_change_control`` may
+    resolve to MISSING_OCC_SELF_BIND.
+    """
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(
+        _occ_snapshot(tmp_path, repo="other-org/onex_change_control")
+    )
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+    assert "occ-self-bind" not in result.detail
+
+
+@pytest.mark.unit
 def test_unbound_receipt_on_product_repo_keeps_pr_ticket_mismatch(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1587 (OMN-16353): fixes a correctness bug CodeRabbit flagged on
that PR's diff that landed before the fix could be pushed (auto-merge fired
on the pre-fix commit — see detail below).

`_is_occ_repo` matched any repo whose short name ended in `onex_change_control`
(`rsplit("/")[-1]`), which would misclassify a same-named repo under a
**different** org (e.g. `other-org/onex_change_control`) as the canonical OCC
evidence repo and hand it OCC self-bind remediation it has no business
receiving. Restricts the match to the bare short name or the exact canonical
`OmniNode-ai/onex_change_control`, and adds a regression test proving a
same-name-other-org repo keeps the generic `pr_ticket_mismatch` reason.

**Why this is a separate PR:** #1587 auto-merged on commit `32b430459c` (the
version-bump commit) before this fix (`dcb73a701d`, now rebased as
`e34909c13e`) was pushed — resolving the CodeRabbit review threads via the
API while the fix sat only in a local commit let the required CodeRabbit
thread-check re-poll green on the unfixed code, and auto-merge landed in the
gap. `dev`'s `_is_occ_repo` still has the bare-suffix bug; this PR carries
the actual fix.

Evidence-Ticket: OMN-16353
Evidence-Source: OCC#7114

## Test plan

- [x] `uv run pytest tests/unit/validation/test_occ_merge_eligibility.py -q` — 40/40 passed
- [x] `uv run mypy --strict` on the changed source file — 0 issues
- [x] `uv run ruff format --check` / `ruff check` — clean
- [x] Governed pre-push impacted-test selector (escalated to full local
      suite, shared_module class) — 44143 passed, 0 failed, 53 skipped,
      3 xpassed (`1:59:50`)