### PR TITLE
fix(OMN-16552): skip OCC companion-gate app-token mint for dependency-bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3691,8 +3691,34 @@ jobs:
       # onexbot-occ-writer App token and export it as GH_TOKEN — job-level
       # `env:` is resolved before any step runs, so it cannot reference a
       # step output directly. `|| github.token` fallback kept for resilience.
+      #
+      # OMN-16552: GitHub Actions does not expose repository secrets to a
+      # pull_request run authored by Dependabot (secret-exfiltration
+      # protection), so on a Dependabot PR ONEXBOT_OCC_APP_ID/PRIVATE_KEY
+      # resolve empty and this mint hard-fails BEFORE the Python script's own
+      # DEPENDENCY_BOT_AUTHORS exemption ever runs — the job never reaches
+      # "Require cited OCC evidence...". Skip minting only when the author is
+      # a known dependency-bot login AND the title has a deps-bump prefix
+      # (both, not either, mirroring — but stricter than — the OR the
+      # pr-title-check-reusable.yml exemption uses, so a human cannot dress a
+      # PR as a bump to dodge evidence enforcement). The job itself stays
+      # unconditional (no job-level `if:`) so CI Summary's
+      # skip/cancel-fails-closed STRICT_SUCCESS_JOBS semantics hold; only
+      # this one step is skipped. "Export GH_TOKEN" already falls back to
+      # `github.token` when app-token has no output, and the script's author
+      # exemption needs only same-repo `gh pr view` access — no cross-repo
+      # onex_change_control read — so the default token is sufficient here.
       - name: Mint onexbot-occ-writer app token
         id: app-token
+        if: >-
+          !(
+            contains(fromJSON('["dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login) &&
+            (
+              startsWith(github.event.pull_request.title, 'chore(deps') ||
+              startsWith(github.event.pull_request.title, 'build(deps') ||
+              startsWith(github.event.pull_request.title, 'Bump ')
+            )
+          )
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}


### PR DESCRIPTION
## What

`occ-companion-merged`'s "Mint onexbot-occ-writer app token" step now carries a step-level `if:` that skips minting when the PR author is a known dependency-bot login (`dependabot[bot]`, `github-actions[bot]`) **AND** the title has a deps-bump prefix (`chore(deps`, `build(deps`, `Bump `) — both conditions required, mirroring but narrower than the OR the `pr-title-check-reusable.yml` exemption uses.

## Why

GitHub Actions does not expose repository secrets to `pull_request` runs authored by Dependabot (secret-exfiltration protection). `secrets.ONEXBOT_OCC_APP_ID`/`ONEXBOT_OCC_PRIVATE_KEY` resolve empty on those runs, so `actions/create-github-app-token` hard-fails ("The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string") and the job aborts before `scripts/ci/check_occ_companion_merged.py` ever runs — so its existing `DEPENDENCY_BOT_AUTHORS` author exemption never gets a chance to return PASS.

Identical pattern already landed and verified in the two sibling repos:
- omniclaude#2045 (merged 2026-08-25T20:45:01Z)
- omniintelligence#845 (merged 2026-08-25T20:36:05Z)

The job itself stays unconditional (no job-level `if:`) so `CI Summary`'s skip/cancel-fails-closed `STRICT_SUCCESS_JOBS` semantics hold — only the one step is skipped. "Export GH_TOKEN" already falls back to the default `github.token` when `app-token` has no output, and the script's author exemption only needs same-repo `gh pr view` access (no cross-repo `onex_change_control` read), so the default token is sufficient for the exempted path. Non-exempt PRs are unaffected — they still mint the token and run the full companion-merged check unchanged.

## Ticket

OMN-16552 (structural gap; related: OMN-15214 parent incident, OMN-13762 origin of the DEPENDENCY_BOT_AUTHORS exemption pattern).

## Verification

- `actionlint .github/workflows/ci.yml` — clean at the changed lines (pre-existing shellcheck info/style notices elsewhere in the file are unrelated to this diff).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses.
- Governed pre-push hook (`scripts/hooks/prepush_smart_tests.sh`) escalated to the full local suite (workflow-file diff) and ran it in full — no scope-narrowing, no `PREPUSH_FULL_SUITE`/`ENABLE_SMART_TESTS` overrides: `44143 passed, 53 skipped, 3 xpassed in 8664.20s (2:24:24)`, then `[prepush-smart-tests] impacted tests passed; allowing push.`
- Once merged, will rerun the finished (non-queued) `OCC Companion Merged Gate` runs on the originally-stuck bot PRs in this repo and confirm green.

Evidence-Ticket: OMN-16552
Evidence-Source: OCC#7139
