### PR TITLE
docs(OMN-16541): Wave-3 correctness fixes — P4 rename sweep, compat extra, dead pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 core models, validation tooling, and the canonical architecture vocabulary used
 by downstream OmniNode repos.
 
-[![CI](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/test.yml/badge.svg)](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/test.yml)
+[![CI](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml/badge.svg)](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -53,7 +53,7 @@ Install optional surfaces only when needed:
 
 ```bash
 uv add "omnibase_core[spi]"
-uv add "omnibase_core[compat]"
+uv add "omnibase_core[kafka]"
 uv add "omnibase_core[full]"
 ```
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -335,6 +335,7 @@ src/omnibase_core/
 ├── errors/                 # Error handling (ModelOnexError)
 ├── event_bus/              # In-memory event bus (registered in onex.backends)
 ├── factories/              # Contract and profile factories
+├── feature_flags/          # Feature-flag catalog + registry
 ├── gate/                   # OmniGate config loader, diff hash, receipt canonical
 ├── infrastructure/         # Base node classes
 ├── integrations/           # External integrations

--- a/docs/architecture/CONTRACT_STABILITY_SPEC.md
+++ b/docs/architecture/CONTRACT_STABILITY_SPEC.md
@@ -222,7 +222,7 @@ Fingerprints appear in:
 
 ### Location
 
-`src/omnibase_core/contracts/hash_registry.py`
+`src/omnibase_core/contracts/contract_hash_registry.py`
 
 ### API
 

--- a/docs/architecture/MIXIN_ARCHITECTURE.md
+++ b/docs/architecture/MIXIN_ARCHITECTURE.md
@@ -524,8 +524,6 @@ MRO principle for wrappers: `ModelService* → MixinNodeService → Node<Type> �
 
 Use wrappers unless you need a specialized composition; if so, inherit directly from `Node<Type>` and add mixins, keeping node type first and mixins ordered by dependency.
 
-> See also: `src/omnibase_core/models/nodes/node_services/README.md` for end-to-end examples and migration guidance.
-
 ---
 
 **Next Steps**:

--- a/docs/architecture/NODE_PURITY_GUARANTEES.md
+++ b/docs/architecture/NODE_PURITY_GUARANTEES.md
@@ -228,7 +228,7 @@ uv run python scripts/check_node_purity.py --file src/omnibase_core/nodes/node_c
 
 ### CI Integration
 
-Add to `.github/workflows/test.yml`:
+Add to `.github/workflows/ci.yml`:
 
 ```yaml
 - name: Check Node Purity

--- a/docs/ci/CI_MONITORING_GUIDE.md
+++ b/docs/ci/CI_MONITORING_GUIDE.md
@@ -187,7 +187,7 @@ Trigger alerts when:
 gh run view <run-id>
 
 # List all runs for comparison
-gh run list --workflow=test.yml --limit 10
+gh run list --workflow=ci.yml --limit 10
 ```
 
 **Questions to Answer**:
@@ -295,7 +295,7 @@ slowest durations:
 **Command**:
 ```
 # List recent runs with durations
-gh run list --workflow=test.yml --json databaseId,conclusion,createdAt,updatedAt --limit 20
+gh run list --workflow=ci.yml --json databaseId,conclusion,createdAt,updatedAt --limit 20
 
 # View specific run
 gh run view <run-id> --log | grep "split-12"
@@ -391,7 +391,7 @@ uv run pytest tests/ --splits=20 --group=12 --durations=20
 curl https://www.githubstatus.com/api/v2/status.json
 
 # Compare multiple recent runs
-gh run list --workflow=test.yml --limit 5
+gh run list --workflow=ci.yml --limit 5
 ```
 
 **Resolution**:
@@ -525,7 +525,7 @@ brew install gh  # macOS
 gh auth login
 
 # View latest CI run
-gh run list --workflow=test.yml --limit 1
+gh run list --workflow=ci.yml --limit 1
 
 # View specific run details
 gh run view <run-id>
@@ -577,7 +577,7 @@ The following is an example monitoring script you can create locally. It is not 
 RUNS=10
 echo "Analyzing last $RUNS CI runs..."
 
-gh run list --workflow=test.yml --limit $RUNS --json databaseId,createdAt,conclusion | \
+gh run list --workflow=ci.yml --limit $RUNS --json databaseId,createdAt,conclusion | \
   jq -r '.[] | "\(.databaseId) \(.createdAt) \(.conclusion)"' | \
   while read run_id created_at conclusion; do
     echo "Run: $run_id ($conclusion) - $created_at"
@@ -639,7 +639,7 @@ if __name__ == "__main__":
 1. **Export Data**:
    ```bash
    # Export last 30 runs to CSV
-   gh run list --workflow=test.yml --limit 30 --json databaseId,createdAt,updatedAt,conclusion > ci_history.json
+   gh run list --workflow=ci.yml --limit 30 --json databaseId,createdAt,updatedAt,conclusion > ci_history.json
    ```
 
 2. **Calculate Metrics**:
@@ -724,7 +724,7 @@ if __name__ == "__main__":
 - [ ] Check test distribution: `pytest --collect-only --splits=20 --group=X`
 - [ ] Profile slow tests: `pytest --durations=20 --splits=20 --group=X`
 - [ ] Review resource usage in GitHub Actions logs
-- [ ] Compare with historical data: `gh run list --workflow=test.yml --limit 10`
+- [ ] Compare with historical data: `gh run list --workflow=ci.yml --limit 10`
 - [ ] Document root cause and resolution
 - [ ] Update baselines if needed
 
@@ -732,7 +732,7 @@ if __name__ == "__main__":
 
 ```
 # View latest CI run
-gh run view $(gh run list --workflow=test.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view $(gh run list --workflow=ci.yml --limit 1 --json databaseId --jq '.[0].databaseId')
 
 # Run slow split locally with profiling
 uv run pytest tests/ --splits=20 --group=12 --durations=20
@@ -748,7 +748,7 @@ gh run watch
 - **[CLAUDE.md](../../CLAUDE.md)** - Development standards and CI configuration
 - **[PARALLEL_TESTING.md](../testing/PARALLEL_TESTING.md)** - Parallel testing configuration
 - **[DEPRECATION_WARNINGS.md](DEPRECATION_WARNINGS.md)** - Deprecation warning configuration (historical, v0.5.0 migration completed)
-- **GitHub Actions Workflow**: [`.github/workflows/test.yml`](../../.github/workflows/ci.yml)
+- **GitHub Actions Workflow**: [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
 - **GitHub CLI Docs**: https://cli.github.com/manual/
 
 ---

--- a/docs/ci/CORE_PURITY_FAILURE.md
+++ b/docs/ci/CORE_PURITY_FAILURE.md
@@ -339,7 +339,7 @@ uv run python scripts/check_node_purity.py --json
 
 ## CI Configuration
 
-The purity check runs as part of CI in GitHub Actions (see `.github/workflows/test.yml`):
+The purity check runs as part of CI in GitHub Actions (see `.github/workflows/ci.yml`):
 
 ```yaml
 node-purity-check:

--- a/docs/ci/PERFORMANCE_BENCHMARK_CI_INTEGRATION.md
+++ b/docs/ci/PERFORMANCE_BENCHMARK_CI_INTEGRATION.md
@@ -2,6 +2,12 @@
 
 # Performance Benchmark CI Integration Guide
 
+**Status**: ⚠️ Proposal — NOT YET IMPLEMENTED. `tests/performance/` exists and its
+tests run as part of the ordinary `test-parallel` job in `.github/workflows/ci.yml`,
+but there is no dedicated `performance-benchmarks` job, threshold-enforcement gate,
+regression-detection step, or historical tracking dashboard in live CI. Everything
+below describing those as active is aspirational design, not current behavior.
+
 **Purpose**: Comprehensive guide for integrating performance benchmarks into CI pipeline with threshold enforcement and regression detection
 
 **Last Updated**: 2026-02-14
@@ -67,7 +73,7 @@ tests/
 
 ### CI Configuration
 
-**Current Configuration** (.github/workflows/test.yml):
+**Current Configuration** (.github/workflows/ci.yml):
 
 ```yaml
 # Performance benchmarks run as part of test-parallel job
@@ -146,7 +152,7 @@ class TestModelReducerOutputPerformance:
 **Configuration**:
 
 ```yaml
-# Add to .github/workflows/test.yml after test-parallel job
+# Add to .github/workflows/ci.yml after test-parallel job
 performance-benchmarks:
   name: Performance Benchmarks
   needs: [lint, pyright, exports-validation]  # Phase 1 dependencies
@@ -587,7 +593,7 @@ addopts = [
 **Configuration**:
 
 ```yaml
-# Add to .github/workflows/test.yml performance-benchmarks job
+# Add to .github/workflows/ci.yml performance-benchmarks job
 - name: Extract performance metrics
   if: always()
   run: |
@@ -903,7 +909,7 @@ def test_memory_usage(self) -> None:
 **Status**: Not yet implemented (originally proposed Q4 2025)
 
 **Deliverables**:
-- Dedicated `performance-benchmarks` job in test.yml
+- Dedicated `performance-benchmarks` job in ci.yml
 - Separate artifact upload for performance results
 - Performance summary in GitHub Actions summary
 

--- a/docs/conventions/CAPABILITY_NAMING.md
+++ b/docs/conventions/CAPABILITY_NAMING.md
@@ -348,7 +348,7 @@ dep = ModelCapabilityDependency(
 
 - **Naming Conventions**: `docs/conventions/NAMING_CONVENTIONS.md` - General ONEX naming patterns
 - **ModelCapabilityDependency**: `src/omnibase_core/models/capabilities/model_capability_dependency.py` - Implementation reference
-- **ModelRequirementSet**: `src/omnibase_core/models/capabilities/model_requirement_set.py` - Requirement constraints
+- **ModelRequirementSet**: `src/omnibase_core/models/capabilities/model_capability_requirement_set.py` - Requirement constraints
 - **Pydantic Best Practices**: `docs/conventions/PYDANTIC_BEST_PRACTICES.md`
 
 ---

--- a/docs/guides/DECLARATIVE_NODE_IMPORT_RULES.md
+++ b/docs/guides/DECLARATIVE_NODE_IMPORT_RULES.md
@@ -494,7 +494,7 @@ The purity linter runs automatically on every pre-push. The script internally di
 The linter runs in CI via GitHub Actions:
 
 ```yaml
-# .github/workflows/test.yml (excerpt)
+# .github/workflows/ci.yml (excerpt)
 - name: Run purity linter
   run: uv run python scripts/check_node_purity.py --verbose
 ```

--- a/docs/guides/MIGRATING_FROM_DICT_ANY.md
+++ b/docs/guides/MIGRATING_FROM_DICT_ANY.md
@@ -717,7 +717,7 @@ error = ModelErrorDetails.from_dict(original.copy())
 
 ## Additional Resources
 
-- **ModelErrorDetails**: `src/omnibase_core/models/services/model_error_details.py`
+- **ModelErrorDetails**: `src/omnibase_core/models/core/model_error_details.py`
 - **ModelEffectOperationConfig**: `src/omnibase_core/models/operations/model_effect_operation_config.py`
 - **ModelSchemaValue**: `src/omnibase_core/models/common/model_schema_value.py`
 - **Error Handling Guide**: `docs/conventions/ERROR_HANDLING_BEST_PRACTICES.md`

--- a/docs/guides/PROTOCOL_UUID_MIGRATION.md
+++ b/docs/guides/PROTOCOL_UUID_MIGRATION.md
@@ -349,7 +349,7 @@ def upgrade():
 
 The following method signatures have changed to use UUID types:
 
-#### ServiceRegistry (`container/service_registry.py`)
+#### ServiceRegistry (`container/container_service_registry.py`)
 
 | Method | Parameter | Before | After |
 |--------|-----------|--------|-------|

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -863,7 +863,7 @@ open htmlcov/index.html
 
 #### GitHub Actions Configuration
 
-See `.github/workflows/test.yml` for complete configuration. Key features:
+See `.github/workflows/ci.yml` for complete configuration. Key features:
 
 - **Poetry 2.2.1**: Latest stable Poetry version
 - **Python 3.12**: Minimum supported version

--- a/docs/reference/api/nodes.md
+++ b/docs/reference/api/nodes.md
@@ -176,8 +176,6 @@ class WorkflowOrchestratorNode(NodeOrchestrator):
 
 ## Service Wrapper Classes
 
-> Tip: For comprehensive guidance and examples, see `src/omnibase_core/models/nodes/node_services/README.md`.
-
 ### ModelServiceCompute
 
 **Location**: `omnibase_core.nodes.node_service_compute`

--- a/docs/testing/COVERAGE.md
+++ b/docs/testing/COVERAGE.md
@@ -317,7 +317,7 @@ While this script is designed for local development, it can be integrated into C
 
 - **[PARALLEL_TESTING.md](PARALLEL_TESTING.md)** - Detailed parallel testing architecture, resource management, and troubleshooting
 - Project root `CLAUDE.md` - Poetry usage requirements
-- `.github/workflows/test.yml` - CI test configuration and matrix strategy
+- `.github/workflows/ci.yml` - CI test configuration and matrix strategy
 - `scripts/run-coverage-parallel.sh` - Parallel coverage script implementation
 
 ## Maintenance

--- a/docs/testing/INTEGRATION_TESTING.md
+++ b/docs/testing/INTEGRATION_TESTING.md
@@ -733,7 +733,7 @@ Integration tests are included in the standard CI pipeline alongside unit tests:
 
 ### CI Configuration
 
-From `.github/workflows/test.yml`:
+From `.github/workflows/ci.yml`:
 
 ```yaml
 - name: Run Tests (Split ${{ matrix.split }})

--- a/docs/testing/PARALLEL_TESTING.md
+++ b/docs/testing/PARALLEL_TESTING.md
@@ -168,7 +168,7 @@ The script automatically detects CPU count and warns if configuration is too agg
 ### CI Execution Model (Horizontal Scaling)
 
 ```
-# .github/workflows/test.yml
+# .github/workflows/ci.yml
 strategy:
   matrix:
     split: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
@@ -526,7 +526,7 @@ done
 ## Related Documentation
 
 - [COVERAGE.md](COVERAGE.md) - Coverage testing overview and usage
-- `.github/workflows/test.yml` - CI test configuration
+- `.github/workflows/ci.yml` - CI test configuration
 - `scripts/run-coverage-parallel.sh` - Parallel coverage script
 
 ## Summary

--- a/docs/testing/PERFORMANCE_TESTING_GUIDE.md
+++ b/docs/testing/PERFORMANCE_TESTING_GUIDE.md
@@ -1011,7 +1011,7 @@ class TestPerformanceRegression:
 ### CI Configuration
 
 ```yaml
-# .github/workflows/test.yml
+# .github/workflows/ci.yml
 - name: Run Performance Tests
   run: |
     uv run pytest tests/performance/ \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -280,7 +280,7 @@ Add to `.pre-commit-config.yaml`:
 ## Related Documentation
 
 - **Contract Stability Spec**: `docs/architecture/CONTRACT_STABILITY_SPEC.md`
-- **Hash Registry**: `src/omnibase_core/contracts/hash_registry.py`
+- **Hash Registry**: `src/omnibase_core/contracts/contract_hash_registry.py`
 - **Security Validators**: `scripts/validation/README.md`
 - **ONEX Architecture**: `docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md`
 


### PR DESCRIPTION
## Summary

Wave-3 doc-correctness pass for OMN-16541 (child of epic OMN-16304), scoped to
the residual items from the 2026-08-17 doc-audit catalog
(`docs/plans/2026-08-17-public-docs-kb-consolidation-plan.md` §8b) after
`OMN-16305`'s Wave-2 migration already fixed the fabricated-terminology items
listed in the ticket as pre-resolved. Every claim below was re-verified live
against `origin/dev` before touching anything — several catalog rows were
already stale.

**Fixed (verified genuinely still wrong):**

- `test.yml` → `ci.yml` (renamed 2026-03-24, OMN-6212): README CI badge (both
  the image URL and the link target) + 10 docs. `CI_MONITORING_GUIDE.md` alone
  had 7 stale `gh run --workflow=test.yml` invocations plus a markdown link
  whose display text (`test.yml`) didn't match its already-correct URL
  (`ci.yml`).
- Post-rename source-path sweep — **5 docs, not the 9 the catalog claimed**
  (4 were already correct live, see below): `hash_registry.py` →
  `contract_hash_registry.py` (`CONTRACT_STABILITY_SPEC.md`, `scripts/README.md`),
  `service_registry.py` → `container_service_registry.py`
  (`PROTOCOL_UUID_MIGRATION.md`), `model_requirement_set.py` →
  `model_capability_requirement_set.py` (`CAPABILITY_NAMING.md`),
  `model_error_details.py` — wrong subpackage, `models/services/` →
  `models/core/` (`MIGRATING_FROM_DICT_ANY.md`).
- README `uv add "omnibase_core[compat]"` — no `compat` extra exists in
  `pyproject.toml` (`spi, cli, kafka, cache, metrics, sql-parser, testing,
  full`). Swapped for the real `kafka` extra.
- Removed 2 dead pointers to `src/omnibase_core/models/nodes/node_services/README.md`
  (`MIXIN_ARCHITECTURE.md`, `docs/reference/api/nodes.md`) — that directory was
  deleted in `b1ff7e0be5`, well before the doc-audit catalog was written. The
  models it described (`ModelServiceCompute` etc.) now live directly as
  `node_service_*.py` under `src/omnibase_core/nodes/`, and both surviving docs
  already document that location inline right next to the dead pointer, so
  there's nothing left to point to.
- Labeled `docs/ci/PERFORMANCE_BENCHMARK_CI_INTEGRATION.md` a proposal: no
  `performance-benchmarks` CI job, threshold-enforcement gate, or
  regression-detection step exists in `.github/workflows/ci.yml`.
  `tests/performance/` does exist and its tests do run, but only as ordinary
  members of the `test-parallel` job — not the dedicated pipeline the doc
  describes as current.
- Added the missing `feature_flags/` row to `docs/INDEX.md`'s package
  structure tree (confirmed the only omission — diffed live `src/omnibase_core/`
  top-level dirs against the doc's tree, one miss).

**Catalog claim proven stale, not touched (already fixed upstream):**

- **ADR-006 collision.** The catalog's "index says 8 ADRs; dir has 12, two
  claim ADR-006, 3 unindexed" is now moot. `OMN-16305`'s Wave-2 migration
  turned `docs/decisions/*` into KB pointer stubs — `docs/decisions/README.md`
  no longer indexes ADRs by number at all (just points at the KB), and the two
  former `ADR-006-*.md` files are each now a 4-line stub carrying a distinct,
  non-colliding KB number (`ADR-0028`, `ADR-0035`). There is no in-repo
  renumbering decision left to flag — the collision was resolved by giving
  each decision a unique canonical id in the new home, not by renumbering the
  old one. Any future correction to the *content* of those ADRs belongs in
  `knowledge-base`, not here.
- `event_types.py` → `constants_event_types.py` and the hooks-path rename: the
  catalog listed these as still-drifted; live grep across the repo (incl.
  `docs/conventions/NAMING_CONVENTIONS.md`, the naming-convention source of
  truth) found zero remaining references to the old names. Already correct.

**Not in scope for this repo (per KB pointer-stub convention):** nothing in
this diff touches `docs/decisions/`, `docs/standards/`, or `docs/troubleshooting/`
— those are Wave-2 pointer stubs; the onex_terminology.md and
ASYNC_HANG_DEBUGGING.md items the ticket flags as "already resolved, verify
don't re-fix" were confirmed exactly that (fixed in `knowledge-base#33` /
`omnibase_core#1589`, cited in the ticket itself) and are untouched here.

## Test plan

- [x] Every fix verified against live `origin/dev` code (paths, extras,
      workflow filenames, CI job list) before writing the doc change — no
      claim taken on the catalog's word.
- [x] `pre-commit run --all-files` — all applicable hooks passed (docs-only
      diff; most repo hooks reported "no files to check").
- [x] Governed pre-push selector (`scripts/hooks/prepush_smart_tests.sh`,
      OMN-13973): correctly narrowed to zero impacted tests for a docs-only
      change, not bypassed.
- [x] `git diff --name-only` confirmed zero touched files under
      `docs/decisions/`, `docs/standards/`, `docs/troubleshooting/` (the
      Wave-2 pointer-stub subtrees).

OMN-16541

Evidence-Ticket: OMN-16541
Evidence-Source: OCC#7157
