### PR TITLE
fix(OMN-16520): route validate-docs back to plain event-based selector

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -38,26 +38,11 @@ on:
 
 jobs:
   validate-docs:
-    # OMNI_RUNNER_SELECTOR_V1 (OMN-16413): `uv sync` here resolves packages from
-    # the internal-only PyPI mirror, which `ubuntu-latest` cannot reach (it is
-    # not on the tailnet). The prior selector routed ALL pull_request events to
-    # ubuntu-latest, so any PR that changed uv.lock (a GH Actions cache miss)
-    # failed deterministically with a DNS error, even for trusted same-repo PRs
-    # (e.g. onex_change_control#6850/#6823) — confirmed on 3 consecutive reruns.
-    # This mirrors the OMN-15699 fork-aware selector already used by
-    # deploy-gate-reusable.yml / main-target-guard.yml: only an ACTUAL fork PR
-    # (head repo != base repo) is routed to the public ubuntu-latest runner;
-    # every same-repo pull_request (including bot-authored dependency-bump
-    # branches, which are always same-repo, never forks) gets the
-    # tailnet-connected self-hosted omnibase-ci fleet, identical to push /
-    # merge_group / workflow_dispatch. This does NOT widen the trust boundary:
-    # untrusted fork code still never reaches the self-hosted fleet.
     runs-on: >-
       ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     env:
       CHECK_EXTERNAL: ${{ inputs.check-external }}


### PR DESCRIPTION
## What

Reverts the OMN-16413 fork-aware self-hosted repoint (PR #1579) for `validate-docs.yml`, restoring the pre-existing plain `runs-on: ubuntu-latest`.

## Why now

OMN-16413 routed this job onto the tailnet-connected self-hosted `omnibase-ci` fleet to work around a mirror-poisoning defect in `onex_change_control/uv.lock` (a stray `.201` Tailscale PyPI mirror baked into the committed lockfile, unreachable from GitHub-hosted `ubuntu-latest`). That routing moved load *toward* `.201` on the same day `.201` was already load-saturated, rather than fixing the actual defect.

The actual root cause is now permanently retired:
- **OMN-16516 (S1-1)**, merged `omnibase_infra#2897` — structural TOML-parsed lockfile registry-host allowlist CI gate + pre-commit hook, fail-closed backstop against any re-poisoned lock.
- **OMN-16517 (S1-2)**, merged `omnibase_core#1591` — sanitized `uv lock` generator environment (`omnibase_core/dependency-cascade.yml`); the `omnibase_infra` half was already fixed by OMN-16433.

With both landed, the mirror can no longer be baked into a committed lockfile undetected, so it is safe to move this job back to GitHub-hosted `ubuntu-latest`.

## Scope

Workflow-file-only. Exact inverse of PR #1579's `runs-on:` hunk in `.github/workflows/validate-docs.yml` — the explanatory comment block and the fork-aware conditional are removed, restoring the literal `runs-on: ubuntu-latest`. No other file touched.

## Ticket

OMN-16520 (S0-3 of docs/plans/2026-08-23-cloud-ci-offload-plan.md Stage 0c). Authorization: plan §5.1 (operator-approved 2026-08-25) + S1-1/S1-2 landed (both Done, merged 2026-08-25T22:16Z) — the ticket's own precondition for this revert. Companion revert `omnimarket#2149` (same ticket) merged 2026-08-26T09:46:24Z; `omninode_infra#1008` (same ticket) merged 2026-08-26T07:47:01Z — this is the third and final of the three OMN-16520 reverts.

## Verification

- YAML syntax validated.
- `pre-commit run --all-files` clean.
- Governed pre-push selector (OMN-13973) escalated to the full local unit suite (workflow-only diff, unnarrowable): 44144 passed, 53 skipped, 3 xpassed, 0 failed (10106.75s).
- Diff reviewed against `gh pr diff 1579` to confirm exact inverse, zero drift on `origin/dev` since the original 2026-08-23 merge.

Evidence-Ticket: OMN-16520
Evidence-Source: OCC#7173
