### PR TITLE
docs(OMN-16641): repoint README CI badge at PR-triggered ci.yml run

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 core models, validation tooling, and the canonical architecture vocabulary used
 by downstream OmniNode repos.
 
-[![CI](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml/badge.svg)](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml)
+[![CI](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml/badge.svg?event=pull_request&branch=dev)](https://github.com/OmniNode-ai/omnibase_core/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+> **Badge note:** this tracks the PR-triggered `ci.yml` run (`event=pull_request`), not the push-triggered run on `dev`. The push/schedule-triggered run is permanently red by design: its Contract Compliance Check job fails closed on every non-PR event because its DoD checks are PR-scoped and correctly refuse to vacuously pass outside PR context. That is an intentional, documented tradeoff, not a regression — see the `contract-compliance` job comment in `.github/workflows/ci.yml` for the rationale.
 
 ## Who Uses It
 


### PR DESCRIPTION
## Summary

- omnibase_core's push-triggered `ci.yml` run on `dev` has been permanently red since 2026-08-13: the `contract-compliance` job's Contract Compliance Check fails closed on every non-`pull_request` event because its DoD `check_values` are PR-scoped and correctly refuse to vacuously pass outside PR context (the OMN-14863 skip-vector guard). This is a deliberate, documented tradeoff — not a defect — but it left the README/status badge permanently red even though PR-triggered `ci.yml` runs on the same commits (the signal that actually gates merges) pass normally.
- Implements **option (b)** from OMN-16641: repoint the badge at the PR-triggered signal instead of building a push/merge_group-context DoD executor (option (a), out of scope here and left as the tracked long-term item).
- Repoints the README CI badge to `badge.svg?event=pull_request&branch=dev`. Verified by fetching all four `badge.svg` query-param variants directly and confirming the SVG `<title>` renders `CI - passing` only for the `event=pull_request` variants, vs `CI - failing` for the default push-scoped badge:
  - default (push): `CI - failing`
  - `?event=pull_request`: `CI - passing`
  - `?event=pull_request&branch=dev`: `CI - passing`
  - `?branch=dev` (push, no event filter): `CI - failing`
- Adds a short README footnote explaining the push-run red is intentional so it doesn't get re-investigated. The footnote points at the `contract-compliance` job's own comment block in `.github/workflows/ci.yml` rather than citing ticket ids directly — README.md is public and outside the `onex_change_control/`/`contracts/` exemption, so the repo's own doc-content-scan gate (OMN-13572) correctly rejects bare `OMN-<digits>` references there.
- No open fleet-brand-headers PR exists on this repo at time of writing (checked via `gh pr list`), so this ships as a standalone README-only PR rather than folded into another lane.

## Ticket

OMN-16641

## Test plan

- [x] Verified all four badge URL variants live via `curl` before committing (see above)
- [x] `pre-commit run --all-files` — full pass, including Doc-Content Scan Gate (OMN-13572)
- [x] Governed pre-push impacted-test selector — no impacted tests for a docs-only README change; push allowed
- [ ] `gh pr checks --watch` on this PR to confirm green before merge

Evidence-Ticket: OMN-16641
Evidence-Source: OCC#7201
