### PR TITLE
ci(OMN-16589): pilot-wire the org-wide KB doc gate into omnibase_core (transition mode)

### DIFF
--- a/.github/workflows/kb-doc-gate.yml
+++ b/.github/workflows/kb-doc-gate.yml
@@ -17,6 +17,12 @@ on:
 
 jobs:
   kb-doc-gate:
-    uses: OmniNode-ai/omniclaude/.github/workflows/kb-doc-gate-reusable.yml@main
+    # Pinned by immutable SHA, not @main: the reusable workflow file exists
+    # only on omniclaude dev (this is dev's 2026-08-26 merge commit that
+    # introduced it, OMN-16589 #2047); main is release-synced and does not
+    # carry it yet (promotion deferred by policy), so @main fails with
+    # "reusable workflow not found" on every PR. Advance this pin via a
+    # normal PR when the gate is updated or main promotion lands.
+    uses: OmniNode-ai/omniclaude/.github/workflows/kb-doc-gate-reusable.yml@82a3394c1af183d8aed36fdb7b0fee011d39372a
     with:
       mode: transition

--- a/.github/workflows/kb-doc-gate.yml
+++ b/.github/workflows/kb-doc-gate.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# KB Doc Gate — thin caller. OMN-16589.
+# Blocks new/regrown non-KB markdown docs, evaluated against the PR diff.
+# Validator lives in omniclaude (mirrors deploy-gate.yml's thin-caller pattern).
+#
+# Pilot wiring (P1): transition mode, NOT a required status check yet. The
+# required-check flip is explicit follow-up scope once this repo and
+# omnimarket both run green on real PRs — see OMN-16589 AC.
+
+name: KB Doc Gate
+
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  kb-doc-gate:
+    uses: OmniNode-ai/omniclaude/.github/workflows/kb-doc-gate-reusable.yml@main
+    with:
+      mode: transition

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1789,11 +1789,10 @@ repos:
         stages: [pre-commit]
 
   # KB doc gate (OMN-16589) — blocks new/regrown non-KB markdown docs.
-  # Pinned to the omniclaude feature-branch commit that ships the exported
-  # hook; re-pin to the merged dev/main SHA once OmniNode-ai/omniclaude#2047
-  # lands.
+  # Pinned to the omniclaude dev commit that merged the exported hook
+  # (OmniNode-ai/omniclaude#2047, merged 2026-08-26).
   - repo: https://github.com/OmniNode-ai/omniclaude
-    rev: 796c7e97b283c974b55051d4fd9916e06bb7672f  # pragma: allowlist secret
+    rev: 82a3394c1af183d8aed36fdb7b0fee011d39372a  # pragma: allowlist secret
     hooks:
       - id: kb-doc-gate
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1788,6 +1788,15 @@ repos:
       - id: no-untracked-todos
         stages: [pre-commit]
 
+  # KB doc gate (OMN-16589) — blocks new/regrown non-KB markdown docs.
+  # Pinned to the omniclaude feature-branch commit that ships the exported
+  # hook; re-pin to the merged dev/main SHA once OmniNode-ai/omniclaude#2047
+  # lands.
+  - repo: https://github.com/OmniNode-ai/omniclaude
+    rev: 796c7e97b283c974b55051d4fd9916e06bb7672f  # pragma: allowlist secret
+    hooks:
+      - id: kb-doc-gate
+
   # Demo-path topic coherence gate (OMN-12777)
   # Scoped to demo-path contracts (metadata.demo_path: true).
   # Fails on: orphan producers/consumers, publish/subscribe byte-mismatch,

--- a/architecture-handshakes/pull-request-workflow-budget.yaml
+++ b/architecture-handshakes/pull-request-workflow-budget.yaml
@@ -157,6 +157,23 @@ waivers:
       The manual, implementer-adjacent OCC evidence-companion authoring step for every omnibase_core PR
       (Codex hand-authoring every companion because the born path could never fire -- no call-occ-autobind.yml
       or call-occ-companion-effect.yml existed in this repo before this ticket). #magic___^_^___line
+  - workflow_file: kb-doc-gate.yml
+    ticket: OMN-16589
+    expires: "2026-09-25"
+    justification: >-
+      Pilot wiring (P1) of the org-wide KB doc gate per operator direction (2026-08-26): a hook that stops
+      new markdown docs from being created in non-KB repos, plus a stub-size cap on edits to existing
+      pointer stubs (strict mode). Thin `uses:` caller of an omniclaude-hosted reusable (kb-doc-gate-reusable.yml)
+      -- own concurrency, no interaction with ci.yml's job graph. NOT a required status check yet: this
+      is the transition-mode pilot (omnibase_core + omnimarket) proving green on real PRs before any required-check
+      flip, per OMN-16589's AC. Waived rather than budget-bumped so the count lock stays flat; once the
+      pilot is proven and the gate is adopted fleet-wide, the natural closure is folding this caller into
+      ci.yml as a job (OMN-16281 pattern), the same structural migration already proven for the call-occ-companion-effect.yml
+      waiver above.
+    retires: >-
+      The status quo where a new or regrown non-KB-canonical markdown doc in this repo had zero mechanical
+      prevention -- human code review was the only backstop against re-growing content that the Wave-1/Wave-2
+      KB migration already moved to the knowledge-base repo.
 metadata:
   generated_by: "C7 / OMN-14907, 2026-07-21"
   baseline_ref: "origin/dev@d09128fc"
@@ -169,3 +186,4 @@ metadata:
     - OMN-16281  # permanent closure follow-through for that waiver -- do not renew a third time
     - OMN-14990  # origin ticket for the call-occ-companion-effect.yml waiver
     - OMN-16359  # bounded renewal + structural-closure ticket for the call-occ-companion-effect.yml waiver -- do not renew a third time
+    - OMN-16589  # kb-doc-gate.yml waiver -- P1 pilot wiring of the org-wide KB doc gate

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -689,6 +689,15 @@ EXPLICIT_EXEMPT_JOBS: dict[tuple[str, str], str] = {
         "audit, structurally cannot be a merge gate (same class as "
         "auto-tag-on-merge)."
     ),
+    ("kb-doc-gate.yml", "kb-doc-gate"): (
+        "thin uses: caller of omniclaude's kb-doc-gate-reusable.yml (OMN-16589 "
+        "pilot, transition mode) -- self-declared non-required per the "
+        "pull-request-workflow-budget.yaml waiver on this same workflow file; "
+        "NOT added to EXPECTED_EXTERNAL_CONTEXTS, since that would make this "
+        "poller treat it as de facto required, contradicting the pilot's "
+        "explicit not-required-yet scope. The fleet-wide required-check flip "
+        "is tracked separately once the pilot proves green."
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

Pilot-wires the org-wide KB doc gate into `omnibase_core` (OMN-16589 AC2, second of the two pilot repos — omnimarket's half landed as omnimarket#2151 + the SHA-pin fix omnimarket#2153, merged 2026-08-26T19:59:23Z).

Four commits:

1. **`ci: pilot-wire the KB doc gate (transition mode)`** — adds `.github/workflows/kb-doc-gate.yml`, a thin `uses:` caller of omniclaude's `kb-doc-gate-reusable.yml` (mirrors the existing `deploy-gate.yml` thin-caller pattern), plus the `kb-doc-gate` pre-commit hook entry. Mode is `transition` (new-file block only, no stub-size cap) because this repo has not been stripped by Wave 4.
2. **`ci: re-pin kb-doc-gate hook rev to the merged omniclaude SHA`** — the pre-commit `rev:` points at the omniclaude dev merge commit that actually carries the exported hook (`82a3394c1af183d8aed36fdb7b0fee011d39372a`, OmniNode-ai/omniclaude#2047).
3. **`fix: classify kb-doc-gate.yml job in CI Summary poller`** — registers the job in `EXPLICIT_EXEMPT_JOBS` rather than `EXPECTED_EXTERNAL_CONTEXTS`. Adding it to the latter would make the poller treat the gate as de facto required, which contradicts the pilot's explicit not-required-yet scope.
4. **`fix: pin kb-doc-gate.yml reusable workflow by immutable SHA`** — same defect and same fix as omnimarket#2153: `@main` resolves to nothing because the reusable file exists only on omniclaude `dev` (main is release-synced and does not carry it; promotion is deferred by policy), so `@main` fails `reusable workflow not found` with zero jobs on every run. Pinned to the immutable 40-char SHA instead of the mutable `@dev`.

**This gate is deliberately NOT a required status check.** Per the ticket's AC3, the pilots run green on real PRs first; the fleet-wide rollout and the required-check flip are tracked as explicit follow-up scope. The `pull-request-workflow-budget.yaml` waiver on this workflow file records the same.

Ticket: OMN-16589

## Test plan

- [x] Governed pre-push impacted-test selector (`scripts/hooks/prepush_smart_tests.sh`), run on the .201 gate host through the serialized push queue: **44112 passed, 55 skipped, 3 xpassed, 0 failed** in 13327.95s (3:42:07), then `[prepush-smart-tests] impacted tests passed; allowing push`. No `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no `--no-verify`, no `PREPUSH_ALLOW_*` override — the selector's own escalation decided the scope.
- [x] Local pre-commit hooks green
- [ ] CI on this PR — this PR is itself the AC3 pilot exercise: the `KB Doc Gate` job running green here is the evidence the ticket needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated documentation validation for pull requests targeting the development branch.
  * Added a pre-commit check to help identify documentation updates that may be required.

* **Chores**
  * Documented the validation pilot, including its temporary transition-mode status and expiration.
  * Updated CI classification and testing to account for the non-blocking validation job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-16589
Evidence-Source: OCC#7232
