### PR TITLE
fix(OMN-16709): restore sys.modules in the scaffold fixture so the unrestored-del ratchet passes

### DIFF
--- a/tests/unit/cli/test_cli_new_scaffold_runnable.py
+++ b/tests/unit/cli/test_cli_new_scaffold_runnable.py
@@ -43,11 +43,18 @@ def importable_src() -> Iterator[list[str]]:
     """
     added: list[str] = []
     original_path = list(sys.path)
-    original_modules = set(sys.modules)
+    original_modules = dict(sys.modules)
     yield added
     sys.path[:] = original_path
-    for name in set(sys.modules) - original_modules:
+    for name in set(sys.modules) - set(original_modules):
         del sys.modules[name]
+    # Put the pre-existing entries back verbatim. The purge above only removes
+    # names the scaffold run itself introduced, so this restore is a no-op in
+    # the common case -- but it makes the fixture provably incapable of leaking
+    # an OMN-14944-class eviction even if a scaffold import displaces an
+    # already-cached module, and it is the explicit restore the OMN-14985
+    # ratchet (test_no_unrestored_del_sys_modules_in_tests) requires to see.
+    sys.modules.update(original_modules)
 
 
 def _scaffold(


### PR DESCRIPTION
## OMN-16709 — unblocks every omnibase_core PR on `dev`

`CI Summary` is a **required** status check on `omnibase_core` `dev` and fail-closes behind
`Tests Gate`. `Tests Gate` has been red on **every** branch cut from `dev` since #1598
(OMN-16679) merged at 2026-08-27T00:00:29Z (`240ca9f205c35274094dff7ca133f576b1ef17db`),
because the failing test is a static AST scan of the whole `tests/` tree — it does not care
what the PR under test changed.

```
tests/unit/test_omn_14944_sys_modules_purge_regression.py::test_no_unrestored_del_sys_modules_in_tests
AssertionError: Unrestored `del sys.modules[...]` found (OMN-14944 contaminator class -- see OMN-14985).
assert not ['tests/unit/cli/test_cli_new_scaffold_runnable.py:50']
```

Net effect: no omnibase_core PR could merge to `dev`, regardless of content. Observed live on
the docs-only #1600 (OMN-16581), reproduced byte-identically across jobs 98394415201 and
98400912799 — deterministic, not flaky.

### Root cause

The `importable_src` fixture added by #1598 ends with a bare `del sys.modules[name]` loop. The
OMN-14985 ratchet (`_function_restores_sys_modules`) only accepts a `del sys.modules[...]` when
the enclosing function also contains a `with isolated_sys_modules(...)` block, a
`sys.modules[key] = ...` assignment, or a `sys.modules.update(...)` call. The fixture has none
of the three.

### This was a false positive — and the obvious fix is the wrong one

The OMN-14944 leak class is: evict **pre-existing** `omnibase_core.*` entries and never restore
them. This fixture does the opposite — it deletes only `set(sys.modules) - original_modules`,
i.e. entries that did **not** exist before the test. That is cleanup of the scaffolded temp
package, which genuinely must not leak across xdist-shared workers.

`isolated_sys_modules` was deliberately **not** used: it has different semantics (it evicts
pre-existing entries and restores them on exit, while explicitly *leaving in place* entries
newly imported inside the block). Swapping it in would have satisfied the guard while silently
deleting the scaffold-package purge this fixture exists to perform, reintroducing the very
cross-worker leak #1598 was guarding against.

### Fix

Snapshot `sys.modules` as a dict, keep the newly-added-name purge exactly as-is, then restore
the pre-existing entries explicitly:

```python
original_modules = dict(sys.modules)
...
for name in set(sys.modules) - set(original_modules):
    del sys.modules[name]
sys.modules.update(original_modules)
```

Strictly stronger than before: the purge is unchanged, and any pre-existing entry a scaffold
import displaced is now also restored. It satisfies the ratchet through the
`sys.modules.update(...)` branch as an honest restore, not a guard-appeasement no-op.

One file, +9/-2, tests only. No source change.

### dod_evidence

- `tests/unit/test_omn_14944_sys_modules_purge_regression.py` — **3 passed**; repo-wide
  violations list empty.
- `tests/unit/cli/test_cli_new_scaffold_runnable.py` — **8 passed** (the OMN-16679 acceptance
  tests still pass, so the fixture's purge behavior is unchanged).
- Combined local run on the pushing host: `11 passed in 5.53s`.
- Governed pre-push selector ran the impacted subset with **no** overrides — verified
  `is_full_suite=False`, `full_suite_reason=None`, 44 selected paths, and no bare `tests/` or
  `tests/unit/` entry (so the OMN-15408 whole-suite-equivalent guard correctly did not fire).
  `env | grep -Ei 'PREPUSH|ENABLE_SMART_TESTS'` → none present. No `--no-verify`, no
  `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS`, no `PREPUSH_ALLOW_*`.
- Final proof is this PR's own green `Tests Gate` + `CI Summary`, plus previously-blocked #1600
  (OMN-16581) going green on a re-run with no change to its own diff.

Fixes OMN-16709

Evidence-Ticket: OMN-16709
Evidence-Source: OCC#7260
