### PR TITLE
fix(OMN-16297): replace the flaky sub-ms dispersion assertion with the file's own absolute budget idiom

### DIFF
--- a/tests/unit/resolution/test_execution_resolver_performance.py
+++ b/tests/unit/resolution/test_execution_resolver_performance.py
@@ -679,12 +679,22 @@ class TestExecutionResolverDeterminismPerformance:
         variance = sum((d - mean_duration) ** 2 for d in durations) / len(durations)
         std_dev = variance**0.5
 
-        # Verify performance consistency
-        # Allow for some variance due to system load
-        assert std_dev < mean_duration * 0.5, (
-            f"High variance in resolution times: mean={mean_duration * 1000:.2f}ms, "
-            f"std_dev={std_dev * 1000:.2f}ms"
-        )
+        # OMN-16297: this used to assert `std_dev < mean_duration * 0.5`. A
+        # dispersion RATIO over sub-millisecond durations (mean is ~0.4ms here)
+        # measures OS scheduler noise on the host, not the resolver, so it
+        # failed on a busy gate host while the resolver itself was fine -- most
+        # recently refusing an omnibase_core push whose other 44,115 tests all
+        # passed. The determinism this test is named for is already asserted
+        # unconditionally above (`results[i] == results[0]`), and is unaffected
+        # by host load. What remains worth pinning is an absolute upper bound
+        # that catches a real algorithmic regression, which is the same idiom
+        # every other perf test in this file uses (`assert duration < 1.0`).
+        for i, duration in enumerate(durations):
+            assert duration < 1.0, (
+                f"Resolution run {i} took {duration * 1000:.2f}ms, over the 1s "
+                f"budget (mean={mean_duration * 1000:.2f}ms, "
+                f"std_dev={std_dev * 1000:.2f}ms)"
+            )
 
         # Log performance metrics
         print(


### PR DESCRIPTION
## What

`tests/unit/resolution/test_execution_resolver_performance.py::TestExecutionResolverDeterminismPerformance::test_repeated_resolution_consistency` asserted

```python
assert std_dev < mean_duration * 0.5
```

over 10 resolutions whose mean duration is ~0.4 ms. This PR replaces that dispersion **ratio** with the absolute per-iteration budget every other perf test in the same file already uses (`assert duration < 1.0`). The determinism assertion the test is actually named for is untouched.

## Why

A dispersion ratio at sub-millisecond scale measures OS scheduler noise on the host, not the resolver. It fails when the gate host is busy while the resolver is behaving perfectly.

Measured cost — this is the third recorded recurrence, and OMN-15609 filed the identical assertion separately:

- **2026-08-27**, `.201` serialized push lane `OMN-16507`: `1 failed, 44115 passed, 55 skipped, 3 xpassed in 10910.70s (3:01:50)`, sole failure `AssertionError: High variance in resolution times: mean=0.42ms, std_dev=0.70ms`. The push was refused, so **three hours of gate-host CPU produced zero forward progress**.
- The same failure appears in the `OMN-16037` lane's own full-suite evidence, against a branch that does not touch `tests/unit/resolution/` at all.

The determinism this test exists to prove was never the flaky part — it is asserted unconditionally a few lines above and is host-load independent:

```python
for i in range(1, num_iterations):
    assert results[i] == results[0], f"Run {i} produced different results than run 0"
```

## What replaces it

An absolute 1s per-iteration ceiling, matching the six sibling perf tests in this file. It still catches a genuine algorithmic regression in resolution, and it cannot flake on scheduler jitter. `mean` and `std_dev` are retained in the failure message and in the existing metrics print, so the dispersion data stays visible when something does go wrong.

## Verification

- `uv run pytest tests/unit/resolution/test_execution_resolver_performance.py` → **7 passed**.
- `uv run ruff format` / `ruff check` clean on the touched file.
- Governed pre-push impacted-test selector (`scripts/hooks/prepush_smart_tests.sh`), run automatically on push, no bypass flags set (`PREPUSH_FULL_SUITE`, `ENABLE_SMART_TESTS`, `--no-verify` all unused): `is_full_suite=false`, **992 passed in 167.30s**, `[prepush-smart-tests] impacted tests passed; allowing push.`
- Full pre-commit hook set ran on commit and passed.

OMN-16297

Evidence-Ticket: OMN-16297
Evidence-Source: OCC#7274
