### PR TITLE
fix(OMN-16680): make a freshly scaffolded ONEX project pass `onex validate`

### DIFF
--- a/src/omnibase_core/cli/cli_commands.py
+++ b/src/omnibase_core/cli/cli_commands.py
@@ -185,12 +185,20 @@ def validate(
             },
         )
 
+    # OMN-16680: declared OUTSIDE the try because `ctx.exit()` must be called
+    # outside it. `ctx.exit()` signals completion by raising
+    # `click.exceptions.Exit`, which subclasses RuntimeError and was therefore
+    # caught by the `except Exception` catch-all below and re-raised as
+    # `ClickException("Unexpected error: EnumCLIExitCode.SUCCESS")`. That made
+    # exit code 1 the only reachable outcome of `onex validate` on ANY input,
+    # including a fully clean tree.
+    overall_success = True
+
     try:
         # Import validation suite lazily to avoid circular imports
         from omnibase_core.validation.validator_cli import ServiceValidationSuite
 
         suite = ServiceValidationSuite()
-        overall_success = True
 
         for directory in directories:
             if not quiet:
@@ -214,8 +222,6 @@ def validate(
             else:
                 click.echo(click.style("Validation failures detected.", fg="red"))
 
-        ctx.exit(EnumCLIExitCode.SUCCESS if overall_success else EnumCLIExitCode.ERROR)
-
     except ModelOnexError as e:
         emit_log_event_sync(
             EnumLogLevel.ERROR,
@@ -236,6 +242,8 @@ def validate(
             {"error": str(e), "type": type(e).__name__},
         )
         raise click.ClickException(f"Unexpected error: {e}") from e
+
+    ctx.exit(EnumCLIExitCode.SUCCESS if overall_success else EnumCLIExitCode.ERROR)
 
 
 def _display_validation_result(

--- a/src/omnibase_core/cli/cli_new.py
+++ b/src/omnibase_core/cli/cli_new.py
@@ -20,14 +20,33 @@ NODE_TYPES = ("compute", "effect", "reducer", "orchestrator")
 # ``_VERSION_LINE`` in ``cli_init.py``.
 _TODO = "TO" + "DO"
 
+# OMN-16680 — two fields here are shaped by what `onex validate` actually
+# accepts, and both were wrong before:
+#
+#   node_type  is resolved through EnumNodeType by
+#              ModelYamlContract.validate_node_type, which matches by NAME OR
+#              VALUE *case-insensitively* (it upper-cases the input first). So
+#              the bare archetype word fails in EITHER case — neither "compute"
+#              nor "COMPUTE" is a member. The generic archetype members are
+#              <ARCHETYPE>_GENERIC. The readable archetype still travels in
+#              descriptor.node_archetype.
+#   *_version  are ModelSemVer, which takes only the structured mapping form;
+#              its docstring calls string literals like "1.0.0" deprecated and
+#              ModelYamlContract rejects one outright. Every in-repo contract
+#              already uses the mapping form.
 CONTRACT_TEMPLATE = Template(
     """\
 name: ${node_name}
-node_type: ${node_type_upper}
-contract_version: "1.0.0"
-node_version: "0.1.0"
-input_model: ${package}.nodes.${node_name}.models.models_${node_name}.${input_class}
-output_model: ${package}.nodes.${node_name}.models.models_${node_name}.${output_class}
+
+# Archetype as EnumNodeType names it. The friendly name is descriptor.node_archetype.
+node_type: ${node_type_enum}
+
+# Versions are structured semver, not strings.
+contract_version: {major: 1, minor: 0, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+
+input_model: ${package}.nodes.${node_name}.models.model_${node_name}_input.${input_class}
+output_model: ${package}.nodes.${node_name}.models.model_${node_name}_output.${output_class}
 
 # Handler binding. RuntimeLocal reads BOTH of these:
 #   - handler.module / handler.class / handler.input_model build the initial
@@ -37,7 +56,7 @@ output_model: ${package}.nodes.${node_name}.models.models_${node_name}.${output_
 handler:
   module: ${handler_module}
   class: ${handler_class}
-  input_model: ${package}.nodes.${node_name}.models.models_${node_name}.${input_class}
+  input_model: ${package}.nodes.${node_name}.models.model_${node_name}_input.${input_class}
 
 handler_routing:
   default_handler: ${handler_module}:${handler_class}
@@ -80,12 +99,15 @@ class ${node_class}:
     ${todo}(OMN-XXXX): Implement node logic.
     \"\"\"
 
-    def process(self, input_data: object) -> object:
-        \"\"\"Process input and return output.
+    def ${node_method}(self, input_data: object) -> object:
+        \"\"\"Run the ${node_type} step for ${node_name_display}.
+
+        Named for the archetype rather than a bare ``process``: ``onex validate``
+        rejects ``process``/``run``/``execute`` as generic terminology.
 
         ${todo}(OMN-XXXX): Implement ${node_type} logic for ${node_name_display}.
         \"\"\"
-        raise NotImplementedError("${node_class}.process not yet implemented")
+        raise NotImplementedError("${node_class}.${node_method} not yet implemented")
 """
 )
 
@@ -97,8 +119,10 @@ HANDLER_TEMPLATE = Template(
 
 from __future__ import annotations
 
-from ${package}.nodes.${node_name}.models.models_${node_name} import (
+from ${package}.nodes.${node_name}.models.model_${node_name}_input import (
     ${input_class},
+)
+from ${package}.nodes.${node_name}.models.model_${node_name}_output import (
     ${output_class},
 )
 
@@ -129,15 +153,22 @@ ${data_provenance_guidance}        \"\"\"
 """
 )
 
-MODELS_TEMPLATE = Template(
+# OMN-16680: input and output live in SEPARATE modules. ONEX is a
+# one-model-per-file architecture and `onex validate`'s `architecture`
+# validator hard-fails two BaseModel subclasses in one file. The enclosing
+# DIRECTORY (`models/`) is unchanged, which is the granularity
+# omnibase_core/CLAUDE.md -> External SDK Surface pins as stable.
+MODEL_INPUT_TEMPLATE = Template(
     """\
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-\"\"\"Models for ${node_name_display}.\"\"\"
+\"\"\"Input model for ${node_name_display}.\"\"\"
 
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
+
+__all__ = ["${input_class}"]
 
 
 class ${input_class}(BaseModel):
@@ -149,10 +180,28 @@ class ${input_class}(BaseModel):
     \"\"\"
 
     model_config = ConfigDict(extra="forbid")
+"""
+)
+
+MODEL_OUTPUT_TEMPLATE = Template(
+    """\
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+\"\"\"Output model for ${node_name_display}.\"\"\"
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["${output_class}"]
 
 
 class ${output_class}(BaseModel):
-    \"\"\"Output model for ${node_name_display}.\"\"\"
+    \"\"\"Output model for ${node_name_display}.
+
+    ``extra="forbid"`` for the same reason as the input model: an unknown field
+    on a response is a contract mismatch, not something to drop silently.
+    \"\"\"
 
     model_config = ConfigDict(extra="forbid")
 """
@@ -262,8 +311,13 @@ def new_node(node_name: str, node_type: str, project_root: Path | None) -> None:
 
     snake = _to_snake(node_name)
     cls = _to_class(node_name)
-    input_class = f"{cls}Input"
-    output_class = f"{cls}Output"
+    # OMN-16680: the `Model` prefix is the ONEX naming convention for Pydantic
+    # BaseModel classes (omnibase_core/CLAUDE.md), it is what OMN-16679's
+    # AC2 already specified for the generated handler signature
+    # (`handle(request: ModelXInput) -> ModelXOutput`), and the `patterns`
+    # validator enforces it.
+    input_class = f"Model{cls}Input"
+    output_class = f"Model{cls}Output"
 
     node_dir = project_root / "src" / package / "nodes" / snake
     if node_dir.exists():
@@ -299,12 +353,24 @@ def new_node(node_name: str, node_type: str, project_root: Path | None) -> None:
         "effect": "side effects belong here, and nowhere else.",
         "orchestrator": "job is to coordinate, not to hold business logic.",
     }
+    # The node shell's entry-point method, per archetype. A bare `process`
+    # (and `run`, `execute`, ...) is rejected by the `patterns` validator as
+    # generic terminology; these read as the archetype's own verb (OMN-16680).
+    _node_method_map = {
+        "compute": "compute",
+        "reducer": "reduce_state",
+        "effect": "apply_effect",
+        "orchestrator": "orchestrate",
+    }
     ctx = {
         "todo": _TODO,
         "node_name": snake,
         "node_type": node_type,
-        "node_type_upper": node_type.upper(),
+        # EnumNodeType's generic archetype members (OMN-16680); see the comment
+        # on CONTRACT_TEMPLATE's node_type field.
+        "node_type_enum": f"{node_type.upper()}_GENERIC",
         "node_type_title": node_type.title(),
+        "node_method": _node_method_map[node_type],
         "node_class": f"Node{cls}",
         "node_name_display": node_name,
         "package": package,
@@ -353,10 +419,16 @@ def new_node(node_name: str, node_type: str, project_root: Path | None) -> None:
     models_dir = node_dir / "models"
     models_dir.mkdir()
     (models_dir / "__init__.py").write_text("")
-    (models_dir / f"models_{snake}.py").write_text(MODELS_TEMPLATE.substitute(ctx))
+    (models_dir / f"model_{snake}_input.py").write_text(
+        MODEL_INPUT_TEMPLATE.substitute(ctx)
+    )
+    (models_dir / f"model_{snake}_output.py").write_text(
+        MODEL_OUTPUT_TEMPLATE.substitute(ctx)
+    )
 
     click.echo(f"Created {node_type} node '{node_name}' at {node_dir}")
     click.echo("  contract.yaml")
     click.echo(f"  node_{snake}_{node_type}.py")
     click.echo(f"  handlers/handler_{snake}.py")
-    click.echo(f"  models/models_{snake}.py")
+    click.echo(f"  models/model_{snake}_input.py")
+    click.echo(f"  models/model_{snake}_output.py")

--- a/src/omnibase_core/validation/checker_generic_pattern.py
+++ b/src/omnibase_core/validation/checker_generic_pattern.py
@@ -28,10 +28,19 @@ class GenericPatternChecker(ast.NodeVisitor):
         """Check function patterns."""
         func_name = node.name
 
-        # Check for overly generic function names
+        # Check for overly generic function names.
+        #
+        # OMN-16680: `handle` is deliberately NOT on this list. It is not a
+        # lazily-named function — it is the canonical ONEX definition-B handler
+        # entry point, `handle(request: ModelX) -> ModelY`, mandated by the
+        # canonical architecture and mechanically enforced by the OMN-14355
+        # canon-shape ratchet. Every conforming ONEX handler is required to be
+        # called `handle`, in this repo (see
+        # `nodes/node_test_selector_compute/handler.py`) and in every consumer
+        # project the `onex new node` scaffold generates. Flagging it told users
+        # to rename the one method they are contractually forbidden to rename.
         generic_names = [
             "process",
-            "handle",
             "execute",
             "run",
             "do",

--- a/tests/unit/cli/test_cli_new.py
+++ b/tests/unit/cli/test_cli_new.py
@@ -59,7 +59,8 @@ def test_onex_new_node_creates_structure(tmp_path: Path) -> None:
     assert (node_dir / "contract.yaml").exists()
     assert (node_dir / "node_my_crawler_effect.py").exists()
     assert (node_dir / "handlers" / "handler_my_crawler.py").exists()
-    assert (node_dir / "models" / "models_my_crawler.py").exists()
+    assert (node_dir / "models" / "model_my_crawler_input.py").exists()
+    assert (node_dir / "models" / "model_my_crawler_output.py").exists()
     assert (node_dir / "__init__.py").exists()
     assert (node_dir / "handlers" / "__init__.py").exists()
     assert (node_dir / "models" / "__init__.py").exists()
@@ -143,10 +144,17 @@ def test_onex_new_node_contract_content(tmp_path: Path) -> None:
         project / "src" / "pkg" / "nodes" / "data_parser" / "contract.yaml"
     ).read_text()
     assert "name: data_parser" in contract
-    assert "node_type: COMPUTE" in contract
-    assert "pkg.nodes.data_parser.models.models_data_parser.DataParserInput" in contract
+    # OMN-16680: EnumNodeType's archetype members are <ARCHETYPE>_GENERIC.
+    # The bare word fails ModelYamlContract.validate_node_type in EITHER
+    # case, because that lookup upper-cases the input before matching.
+    assert "node_type: COMPUTE_GENERIC" in contract
     assert (
-        "pkg.nodes.data_parser.models.models_data_parser.DataParserOutput" in contract
+        "pkg.nodes.data_parser.models.model_data_parser_input.ModelDataParserInput"
+        in contract
+    )
+    assert (
+        "pkg.nodes.data_parser.models.model_data_parser_output.ModelDataParserOutput"
+        in contract
     )
     assert "pkg.nodes.data_parser.handlers.handler_data_parser" in contract
 
@@ -291,8 +299,11 @@ def test_onex_new_node_stubs_have_descriptive_errors(tmp_path: Path) -> None:
 
     # Node file should have descriptive NotImplementedError
     node_content = (node_dir / "node_my_widget_effect.py").read_text()
+    # OMN-16680: the node shell's method is named for its archetype
+    # ("apply_effect" here); a bare `process` is rejected by the `patterns`
+    # validator as generic terminology.
     assert (
-        'NotImplementedError("NodeMyWidget.process not yet implemented")'
+        'NotImplementedError("NodeMyWidget.apply_effect not yet implemented")'
         in node_content
     )
     assert "TODO(OMN-XXXX)" in node_content
@@ -303,10 +314,16 @@ def test_onex_new_node_stubs_have_descriptive_errors(tmp_path: Path) -> None:
     handler_content = (node_dir / "handlers" / "handler_my_widget.py").read_text()
     assert "NotImplementedError" not in handler_content
     assert "TODO(OMN-XXXX)" in handler_content
-    assert "return MyWidgetOutput()" in handler_content
+    assert "return ModelMyWidgetOutput()" in handler_content
 
     # Models should be clean (no NotImplementedError)
-    models_content = (node_dir / "models" / "models_my_widget.py").read_text()
-    assert "NotImplementedError" not in models_content
-    assert "MyWidgetInput" in models_content
-    assert "MyWidgetOutput" in models_content
+    input_content = (node_dir / "models" / "model_my_widget_input.py").read_text()
+    output_content = (node_dir / "models" / "model_my_widget_output.py").read_text()
+    assert "NotImplementedError" not in input_content
+    assert "NotImplementedError" not in output_content
+    assert "ModelMyWidgetInput" in input_content
+    assert "ModelMyWidgetOutput" in output_content
+    # OMN-16680: one model per file — the input module must not also carry the
+    # output model, which is what the `architecture` validator hard-failed on.
+    assert "ModelMyWidgetOutput" not in input_content
+    assert "ModelMyWidgetInput" not in output_content

--- a/tests/unit/cli/test_cli_new_scaffold_runnable.py
+++ b/tests/unit/cli/test_cli_new_scaffold_runnable.py
@@ -166,7 +166,7 @@ def test_scaffolded_contract_binds_handler_in_module_ref_class_form(
     assert handler_block["class"] == class_name
     assert (
         handler_block["input_model"]
-        == "binding_proj.nodes.parser_node.models.models_parser_node.ParserNodeInput"
+        == "binding_proj.nodes.parser_node.models.model_parser_node_input.ModelParserNodeInput"
     ), "the runtime builds its initial payload from handler.input_model"
 
 
@@ -181,7 +181,10 @@ def test_scaffolded_handler_is_canonical_definition_b(tmp_path: Path) -> None:
     handler = (contract.parent / "handlers" / "handler_widget_node.py").read_text()
 
     assert "class HandlerWidgetNode:" in handler
-    assert "def handle(self, request: WidgetNodeInput) -> WidgetNodeOutput:" in handler
+    assert (
+        "def handle(self, request: ModelWidgetNodeInput) -> ModelWidgetNodeOutput:"
+        in handler
+    )
     assert "ModelEventEnvelope" not in handler
     assert "ModelHandlerOutput" not in handler
     assert "NotImplementedError" not in handler, (
@@ -206,7 +209,9 @@ def test_scaffolded_node_payload_is_the_typed_input_model(
 
     from importlib import import_module
 
-    models = import_module("payload_proj.nodes.typed_node.models.models_typed_node")
+    models = import_module(
+        "payload_proj.nodes.typed_node.models.model_typed_node_input"
+    )
     handler_mod = import_module(
         "payload_proj.nodes.typed_node.handlers.handler_typed_node"
     )
@@ -226,4 +231,4 @@ def test_scaffolded_node_payload_is_the_typed_input_model(
         handler_mod.HandlerTypedNode.handle = original_handle  # type: ignore[method-assign]
 
     assert len(seen) == 1
-    assert isinstance(seen[0], models.TypedNodeInput)
+    assert isinstance(seen[0], models.ModelTypedNodeInput)

--- a/tests/unit/cli/test_cli_scaffold_validates_clean.py
+++ b/tests/unit/cli/test_cli_scaffold_validates_clean.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-16680: a freshly scaffolded ONEX project must pass `onex validate`.
+
+`onex init` -> `onex new node` -> `onex validate` is the documented
+getting-started flow and every one of those three commands is a stable
+external SDK surface (``omnibase_core/CLAUDE.md`` -> External SDK Surface).
+A new user's first ``onex validate`` therefore runs against code they did not
+write, and it must come back clean.
+
+These tests are the AC2 anti-drift guard: the scaffold templates in
+``cli_new.py`` and the validators in ``omnibase_core.validation`` cannot drift
+apart again without one of them going red.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from omnibase_core.cli.cli_commands import cli
+
+NODE_TYPES = ("compute", "effect", "reducer", "orchestrator")
+
+
+def _scaffold_project(runner: CliRunner, workdir: Path) -> Path:
+    """Run `onex init` + `onex new node` for all four archetypes.
+
+    Args:
+        runner: Click test runner.
+        workdir: Directory to create the project inside.
+
+    Returns:
+        Path to the generated project root.
+    """
+    result = runner.invoke(cli, ["init", "demo_pkg", "--path", str(workdir)])
+    assert result.exit_code == 0, f"onex init failed: {result.output}"
+
+    project = workdir / "demo_pkg"
+    for node_type in NODE_TYPES:
+        result = runner.invoke(
+            cli,
+            [
+                "new",
+                "node",
+                f"n-{node_type}",
+                "--type",
+                node_type,
+                "--project-root",
+                str(project),
+            ],
+        )
+        assert result.exit_code == 0, (
+            f"onex new node {node_type} failed: {result.output}"
+        )
+    return project
+
+
+@pytest.mark.unit
+def test_onex_validate_exits_zero_on_a_clean_tree(tmp_path: Path) -> None:
+    """`onex validate` must exit 0 when nothing is wrong.
+
+    Regression guard for the swallowed-``ctx.exit`` defect: ``ctx.exit()``
+    raises ``click.exceptions.Exit``, which subclasses ``RuntimeError`` and was
+    therefore caught by the command's broad ``except Exception`` handler and
+    re-raised as ``ClickException("Unexpected error: EnumCLIExitCode.SUCCESS")``.
+    That made exit code 1 the ONLY reachable outcome of `onex validate`, on any
+    input, so AC1 was unreachable no matter what the scaffold emitted.
+    """
+    src = tmp_path / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", str(tmp_path / "src")])
+
+    assert result.exit_code == 0, f"clean tree did not exit 0: {result.output}"
+    assert "Unexpected error" not in result.output
+
+
+@pytest.mark.unit
+def test_scaffolded_project_passes_onex_validate(tmp_path: Path) -> None:
+    """AC1: init -> new node (all four archetypes) -> validate exits 0."""
+    runner = CliRunner()
+    project = _scaffold_project(runner, tmp_path)
+
+    result = runner.invoke(cli, ["validate", str(project / "src")])
+
+    assert result.exit_code == 0, f"onex validate failed:\n{result.output}"
+    assert "[FAIL]" not in result.output
+
+
+@pytest.mark.unit
+def test_scaffolded_project_has_zero_validation_issues(tmp_path: Path) -> None:
+    """AC1 (strict): every validator reports zero issues, not merely `is_valid`.
+
+    The `patterns` validator only flips ``is_valid`` under ``--strict``, so a
+    plain exit-0 assertion would let pattern drift accumulate silently. This
+    asserts the stronger, drift-proof property directly against the suite.
+    """
+    from omnibase_core.services.service_validation_suite import ServiceValidationSuite
+
+    runner = CliRunner()
+    project = _scaffold_project(runner, tmp_path)
+
+    results = ServiceValidationSuite().run_all_validations(project / "src", strict=True)
+    offenders = {
+        name: result.errors for name, result in results.items() if result.errors
+    }
+    assert offenders == {}, f"scaffold trips validators: {offenders}"
+
+
+@pytest.mark.unit
+def test_scaffolded_contract_node_type_is_a_real_enum_member(tmp_path: Path) -> None:
+    """Drift 1: `node_type` must name an actual `EnumNodeType` member.
+
+    ``ModelYamlContract.validate_node_type`` matches the YAML string against
+    ``EnumNodeType`` by name or value **case-insensitively** (it upper-cases the
+    input first). So the scaffold's ``COMPUTE`` and the lowercase ``compute``
+    used by several in-repo contracts fail identically — neither is a member.
+    The generic archetype members are ``<ARCHETYPE>_GENERIC``, so that is the
+    only spelling that resolves.
+    """
+    from omnibase_core.enums.enum_node_type import EnumNodeType
+    from omnibase_core.models.contracts.model_yaml_contract import ModelYamlContract
+
+    runner = CliRunner()
+    project = _scaffold_project(runner, tmp_path)
+
+    for node_type in NODE_TYPES:
+        expected = f"{node_type.upper()}_GENERIC"
+        contract = (
+            project / "src" / "demo_pkg" / "nodes" / f"n_{node_type}" / "contract.yaml"
+        ).read_text()
+        assert f"node_type: {expected}" in contract
+        # The value the scaffold writes must round-trip through the same
+        # validator `onex validate` uses, not merely look plausible.
+        assert ModelYamlContract.validate_node_type(expected) is EnumNodeType[expected]

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -652,10 +652,17 @@ class TestCliEdgeCases:
 
         runner = CliRunner()
 
-        # Mock the validation suite to raise a ModelOnexError
-        # Note: ServiceValidationSuite is imported lazily inside the validate function
+        # Mock the validation suite to raise a ModelOnexError.
+        # OMN-16680: patch the name `validate` actually imports
+        # (`validator_cli.ServiceValidationSuite`), NOT the defining module.
+        # `validator_cli` re-exports the class by value at import time, so
+        # patching `service_validation_suite.ServiceValidationSuite` rebinds a
+        # name nothing reads and the mock never takes effect. That made this
+        # test pass for the wrong reason: the real suite ran clean, and the exit
+        # code was non-zero only because `ctx.exit()`'s `click.exceptions.Exit`
+        # was being swallowed by the command's catch-all. It asserted the bug.
         with patch(
-            "omnibase_core.services.service_validation_suite.ServiceValidationSuite"
+            "omnibase_core.validation.validator_cli.ServiceValidationSuite"
         ) as mock_suite_class:
             mock_suite = MagicMock()
             mock_suite.run_all_validations.side_effect = ModelOnexError(
@@ -677,10 +684,11 @@ class TestCliEdgeCases:
         """Test that unexpected errors are properly handled in validate."""
         runner = CliRunner()
 
-        # Mock the validation suite to raise an unexpected error
-        # Note: ServiceValidationSuite is imported lazily inside the validate function
+        # Mock the validation suite to raise an unexpected error.
+        # OMN-16680: see test_validate_with_onex_error — patch the re-exported
+        # name in `validator_cli`, which is what `validate` imports.
         with patch(
-            "omnibase_core.services.service_validation_suite.ServiceValidationSuite"
+            "omnibase_core.validation.validator_cli.ServiceValidationSuite"
         ) as mock_suite_class:
             mock_suite = MagicMock()
             mock_suite.run_all_validations.side_effect = RuntimeError(

--- a/tests/unit/validation/test_patterns.py
+++ b/tests/unit/validation/test_patterns.py
@@ -389,18 +389,25 @@ def process(data):
         assert len(checker.issues) > 0
         assert any("too generic" in issue for issue in checker.issues)
 
-    def test_generic_function_name_handle(self):
-        """Test detection of generic function name 'handle'."""
+    def test_handle_is_exempt_as_the_canonical_handler_entry_point(self):
+        """OMN-16680: `handle` must NOT be reported as a generic name.
+
+        `handle(request: ModelX) -> ModelY` is the canonical ONEX definition-B
+        handler signature, mandated by the canonical architecture and enforced
+        by the OMN-14355 canon-shape ratchet. Every conforming handler — in this
+        repo and in every project `onex new node` scaffolds — is required to name
+        that method `handle`, so flagging it told users to rename the one method
+        they are contractually forbidden to rename.
+        """
         code = """
-def handle(event):
+def handle(request):
     pass
 """
         tree = ast.parse(code)
         checker = GenericPatternChecker("test.py")
         checker.visit(tree)
 
-        assert len(checker.issues) > 0
-        assert any("too generic" in issue for issue in checker.issues)
+        assert checker.issues == []
 
     def test_generic_function_name_execute(self):
         """Test detection of generic function name 'execute'."""

--- a/tests/unit/validation/test_patterns_extended.py
+++ b/tests/unit/validation/test_patterns_extended.py
@@ -519,8 +519,14 @@ def action():
         checker = GenericPatternChecker("test.py")
         checker.visit(tree)
 
-        # Should detect all generic function names
-        assert len(checker.issues) >= 11
+        # Should detect all generic function names. `handle` is in this
+        # sample but is deliberately exempt (OMN-16680): it is the canonical
+        # ONEX definition-B handler entry point, not a lazily-named function.
+        flagged = {
+            issue.split("'")[1] for issue in checker.issues if "too generic" in issue
+        }
+        assert "handle" not in flagged
+        assert len(checker.issues) >= 10
         assert all("too generic" in issue.lower() for issue in checker.issues)
 
     def test_checker_detects_functions_with_too_many_parameters(self) -> None:


### PR DESCRIPTION
## Summary

Fixes OMN-16680. `onex init` → `onex new node` → `onex validate` is the documented getting-started flow, and all three are stable external SDK surfaces. A new user's very first `onex validate` failed on code they did not write.

```
onex init demo_pkg
onex new node n-compute --type compute --project-root demo_pkg
onex validate demo_pkg/src
#   [FAIL] architecture  (4 issues)
#   [FAIL] contracts     (1 issue, "Files processed: 0")
#   Error: Unexpected error: EnumCLIExitCode.ERROR
```

## Two corrections to the ticket, verified before writing code

**1. The ticket's proposed fix for drift 1 is wrong.** Both the ticket and the triage note say the fix is to lowercase `node_type: COMPUTE` → `compute`. It is not. `ModelYamlContract.validate_node_type` (`model_yaml_contract.py:118-126`) upper-cases the input and *then* matches `EnumNodeType` by name or value, so `compute` and `COMPUTE` fail **identically** — neither is a member:

```
validate_node_type('COMPUTE')         -> VALIDATION_ERROR
validate_node_type('compute')         -> VALIDATION_ERROR   # same error
validate_node_type('COMPUTE_GENERIC') -> EnumNodeType.COMPUTE_GENERIC
```

The ticket's supporting evidence ("every in-repo contract uses lowercase") is real — 12 occurrences — but those contracts are not proof the value is valid; they carry the same drift. The generic archetype members are `<ARCHETYPE>_GENERIC`, which is also what this repo's own contract-loader tests already use.

**2. There are six drifts, not four.** Two were invisible from the ticket's vantage point.

## The six drifts

| # | Validator | Defect | Fix |
|---|-----------|--------|-----|
| 1 | contracts (hard fail) | `node_type: COMPUTE` is not an `EnumNodeType` member in either case | emit `<ARCHETYPE>_GENERIC` |
| 2 | architecture (hard fail) | both models in one `models_<node>.py` | split into `model_<node>_input.py` / `model_<node>_output.py` |
| 3 | patterns | models lack the `Model` prefix | `Model<Node>Input` / `Model<Node>Output` |
| 4 | patterns | node shell's `def process(...)` | archetype verb: `compute` / `apply_effect` / `reduce_state` / `orchestrate` |
| **5** | **— (NEW)** | **`onex validate` can never exit 0, on any input** | move `ctx.exit()` out of the `try` |
| **6** | **contracts (NEW)** | **`contract_version: "1.0.0"` is a string where `ModelSemVer` takes only the mapping form** | emit `{major: 1, minor: 0, patch: 0}` |

**Drift 5** is a hard blocker on AC1 that is independent of the scaffold. `ctx.exit()` signals completion by raising `click.exceptions.Exit`, which subclasses `RuntimeError`; it was called inside the command's `try`, so the `except Exception` catch-all converted it into `ClickException("Unexpected error: EnumCLIExitCode.SUCCESS")`. A tree with nothing wrong printed `All validations passed!` and then exited 1. No scaffold change could have satisfied AC1 while this stood.

**Drift 6** was hidden behind drift 1: the contracts validator raises on the first bad contract and aborts the whole run, which is why it reported `Files processed: 0`. Fixing drift 1 exposed it.

## The (a)/(b) decision the ticket asks for

Decided per-rule on the merits rather than wholesale, and documented here rather than escalated:

- **(a) scaffold conforms** for drifts 1, 2, 3, 4-`process`, 6. One-model-per-file and the `Model` prefix are real ONEX conventions, not incidental house style — and `Model<Node>Input` / `Model<Node>Output` is literally the shape **OMN-16679's own AC2 specified** (`handle(request: ModelXInput) -> ModelXOutput`) but did not ship. The enclosing `models/` **directory** is unchanged, which is the granularity `omnibase_core/CLAUDE.md` → External SDK Surface pins as stable ("Directory structure from `onex init` / `onex new node`").
- **(b) validator is wrong** for exactly one rule: `handle`.

### Why `handle` had to be fixed on the validator side

The ticket's drift 4 names only `process`, but `handle` sits on the same generic-name list and fired **once per scaffolded node**. It cannot be renamed: `handle(request: ModelX) -> ModelY` is the canonical ONEX definition-B handler entry point, mandated by the canonical architecture and mechanically enforced by the OMN-14355 canon-shape ratchet. Every conforming handler — in this repo (`nodes/node_test_selector_compute/handler.py`) and in every project the scaffold generates — is *required* to name that method `handle`. The rule was telling users to rename the one method they are contractually forbidden to rename. Removed from the list; removing an entry only ever reduces findings, so no existing report can regress.

All four archetypes, real CLI, after the change:

```
$ onex --verbose validate demo_pkg/src
  [PASS] architecture   Files processed: 16
  [PASS] union-usage    Files processed: 30
  [PASS] contracts      Files processed: 4      # was 0 — it aborted at the first contract
  [PASS] patterns       Files processed: 30
All validations passed!
EXIT=0

$ onex validate --strict demo_pkg/src
STRICT_EXIT=0
```

- **AC1** — satisfied, and satisfied under `--strict` too (the `patterns` validator only flips `is_valid` under `--strict`, so plain exit-0 alone would let pattern drift re-accumulate silently).
- **AC2** — `tests/unit/cli/test_cli_scaffold_validates_clean.py` scaffolds a real project through the CLI and runs the real validators, asserting **zero issues** from every validator, plus a dedicated regression test for the drift-5 exit code.

OMN-16679's executable runtime tests still pass unchanged in substance — the generated node still runs end-to-end through `RuntimeLocal` with zero hand edits.

Local: `mypy --strict` clean, `pre-commit` clean on every changed file, and the governed pre-push selector escalated to the **full suite** (validator change = broad blast radius) and passed: **44207 passed, 53 skipped, 3 xpassed, 0 failed**.

### Two pre-existing defects found and NOT absorbed here

- `tests/unit/cli/test_commands.py::test_validate_with_{onex,unexpected}_error` were passing for the wrong reason — they patch `service_validation_suite.ServiceValidationSuite` while the command imports the re-exported `validator_cli.ServiceValidationSuite`, so the mock never took effect and the assertion `exit_code != 0` was satisfied only by drift 5 itself. **Fixed here** (in scope: they are the tests for the code being changed).
- `src/omnibase_core/contracts/antipattern_registry.yaml:20` carries `version: "1.0.0"` and fails the `validate-string-versions` hook on `--all-files` — confirmed pre-existing on a clean `origin/dev` worktree with this branch stashed. **Not fixed here:** `ModelAntipatternRegistry.version` is declared `str`, so correcting it is a registry schema change plus loader plus tests, unrelated to this ticket. Filed as a residual rather than absorbed as a drive-by.

## Test plan

- `uv run pytest tests/ --ignore=tests/integration` — full suite, green (see above).
- Manual: `onex init` → 4× `onex new node` → `onex validate` and `onex validate --strict`, both exit 0.

Evidence-Ticket: OMN-16680
Evidence-Source: OCC#7424
