### PR TITLE
feat(OMN-16882): theme instances + theme catalog — give a design-token value somewhere to live

### DIFF
--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -36,6 +36,10 @@ from omnibase_core.models.dashboard import (
     ModelRendererCapabilityContract,
     ModelRendererThemeContract,
     ModelReviewPacket,
+    ModelThemeActivation,
+    ModelThemeCatalog,
+    ModelThemeCatalogEntry,
+    ModelThemeInstance,
 )
 from omnibase_core.models.notifications import ModelStateTransitionNotification
 from omnibase_core.models.projectors import (
@@ -65,8 +69,13 @@ MODELS: dict[str, type[BaseModel]] = {
     "ModelPermissionContract": ModelPermissionContract,
     "ModelEvidenceRequirementContract": ModelEvidenceRequirementContract,
     "ModelRendererCapabilityContract": ModelRendererCapabilityContract,
-    # Versioned design-token contract (OMN-13389)
+    # Versioned design-token contract (OMN-13389) + the instance/catalog
+    # layer that gives a token VALUE somewhere to live (OMN-16882, Phase C1)
     "ModelRendererThemeContract": ModelRendererThemeContract,
+    "ModelThemeInstance": ModelThemeInstance,
+    "ModelThemeCatalogEntry": ModelThemeCatalogEntry,
+    "ModelThemeCatalog": ModelThemeCatalog,
+    "ModelThemeActivation": ModelThemeActivation,
     # Review Packet + OmniStudio Evidence Bundle (OMN-13387)
     "ModelReviewPacket": ModelReviewPacket,
     "ModelOmniStudioEvidenceBundle": ModelOmniStudioEvidenceBundle,

--- a/src/omnibase_core/contracts/themes/onex.theme.dark/1.0.0.yaml
+++ b/src/omnibase_core/contracts/themes/onex.theme.dark/1.0.0.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+theme_id: onex.theme.dark
+schema_version:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+instance_revision:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+summary: 'Default dark theme: deep slate surfaces, indigo accent. The theme the control-plane surfaces
+  render by default.'
+tokens:
+  theme_id: onex.theme.dark
+  contract_version:
+    major: 1
+    minor: 0
+    patch: 0
+    prerelease: null
+    build: null
+  color_background_primary: '#0f172a'
+  color_background_secondary: '#1e293b'
+  color_background_elevated: '#334155'
+  color_text_primary: '#f8fafc'
+  color_text_secondary: '#94a3b8'
+  color_text_disabled: '#475569'
+  color_accent_primary: '#6366f1'
+  color_accent_secondary: '#818cf8'
+  color_status_success: '#22c55e'
+  color_status_warning: '#f59e0b'
+  color_status_error: '#ef4444'
+  color_status_info: '#38bdf8'
+  color_border_default: '#334155'
+  color_border_strong: '#475569'
+  spacing_xs: 0.25rem
+  spacing_sm: 0.5rem
+  spacing_md: 1rem
+  spacing_lg: 1.5rem
+  spacing_xl: 2rem
+  font_family_base: '''Inter'', system-ui, sans-serif'
+  font_size_sm: 0.875rem
+  font_size_md: 1rem
+  font_size_lg: 1.125rem
+  font_weight_normal: '400'
+  font_weight_bold: '700'
+  border_radius_sm: 0.25rem
+  border_radius_md: 0.5rem
+  border_radius_lg: 1rem

--- a/src/omnibase_core/contracts/themes/onex.theme.light/1.0.0.yaml
+++ b/src/omnibase_core/contracts/themes/onex.theme.light/1.0.0.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+theme_id: onex.theme.light
+schema_version:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+instance_revision:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+summary: 'Default light theme: neutral slate surfaces, indigo accent, WCAG-AA contrast for body text on
+  every declared surface.'
+tokens:
+  theme_id: onex.theme.light
+  contract_version:
+    major: 1
+    minor: 0
+    patch: 0
+    prerelease: null
+    build: null
+  color_background_primary: '#ffffff'
+  color_background_secondary: '#f8fafc'
+  color_background_elevated: '#ffffff'
+  color_text_primary: '#0f172a'
+  color_text_secondary: '#475569'
+  color_text_disabled: '#94a3b8'
+  color_accent_primary: '#4f46e5'
+  color_accent_secondary: '#6366f1'
+  color_status_success: '#15803d'
+  color_status_warning: '#b45309'
+  color_status_error: '#b91c1c'
+  color_status_info: '#0369a1'
+  color_border_default: '#e2e8f0'
+  color_border_strong: '#cbd5e1'
+  spacing_xs: 0.25rem
+  spacing_sm: 0.5rem
+  spacing_md: 1rem
+  spacing_lg: 1.5rem
+  spacing_xl: 2rem
+  font_family_base: '''Inter'', system-ui, sans-serif'
+  font_size_sm: 0.875rem
+  font_size_md: 1rem
+  font_size_lg: 1.125rem
+  font_weight_normal: '400'
+  font_weight_bold: '700'
+  border_radius_sm: 0.25rem
+  border_radius_md: 0.5rem
+  border_radius_lg: 1rem

--- a/src/omnibase_core/contracts/themes/onex.theme.warm/1.0.0.yaml
+++ b/src/omnibase_core/contracts/themes/onex.theme.warm/1.0.0.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+theme_id: onex.theme.warm
+schema_version:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+instance_revision:
+  major: 1
+  minor: 0
+  patch: 0
+  prerelease: null
+  build: null
+summary: 'Warm dark theme: stone surfaces and an amber accent, for long-session operator consoles where
+  the indigo accent reads cold.'
+tokens:
+  theme_id: onex.theme.warm
+  contract_version:
+    major: 1
+    minor: 0
+    patch: 0
+    prerelease: null
+    build: null
+  color_background_primary: '#1c1917'
+  color_background_secondary: '#292524'
+  color_background_elevated: '#44403c'
+  color_text_primary: '#fafaf9'
+  color_text_secondary: '#d6d3d1'
+  color_text_disabled: '#78716c'
+  color_accent_primary: '#ea580c'
+  color_accent_secondary: '#fb923c'
+  color_status_success: '#84cc16'
+  color_status_warning: '#f59e0b'
+  color_status_error: '#ef4444'
+  color_status_info: '#22d3ee'
+  color_border_default: '#44403c'
+  color_border_strong: '#57534e'
+  spacing_xs: 0.25rem
+  spacing_sm: 0.5rem
+  spacing_md: 1rem
+  spacing_lg: 1.5rem
+  spacing_xl: 2rem
+  font_family_base: '''Inter'', system-ui, sans-serif'
+  font_size_sm: 0.875rem
+  font_size_md: 1rem
+  font_size_lg: 1.125rem
+  font_weight_normal: '400'
+  font_weight_bold: '700'
+  border_radius_sm: 0.25rem
+  border_radius_md: 0.5rem
+  border_radius_lg: 1rem

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -97,6 +97,12 @@ from omnibase_core.models.dashboard.model_status_item_config import (
 from omnibase_core.models.dashboard.model_table_column_config import (
     ModelTableColumnConfig,
 )
+from omnibase_core.models.dashboard.model_theme_activation import ModelThemeActivation
+from omnibase_core.models.dashboard.model_theme_catalog import ModelThemeCatalog
+from omnibase_core.models.dashboard.model_theme_catalog_entry import (
+    ModelThemeCatalogEntry,
+)
+from omnibase_core.models.dashboard.model_theme_instance import ModelThemeInstance
 from omnibase_core.models.dashboard.model_widget_config_chart import (
     ModelWidgetConfigChart,
 )
@@ -118,6 +124,11 @@ from omnibase_core.models.dashboard.model_widget_definition import (
 )
 
 __all__: tuple[str, ...] = (
+    # Theme contract, instances, and catalog (OMN-13389 / OMN-16882)
+    "ModelThemeActivation",
+    "ModelThemeCatalog",
+    "ModelThemeCatalogEntry",
+    "ModelThemeInstance",
     # Dashboard Configuration
     "ModelDashboardConfig",
     "ModelDashboardLayoutConfig",

--- a/src/omnibase_core/models/dashboard/model_theme_activation.py
+++ b/src/omnibase_core/models/dashboard/model_theme_activation.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ThemeActivation — a surface's active theme pointer (OMN-16882, Phase C1).
+
+Publish adds an immutable revision to the catalog and changes no pixels.
+**Activate** is the only step that changes what a surface renders, and it is a
+pointer move: this model *is* the pointer.
+
+Each activation carries the ``content_digest`` it resolved from the catalog, so
+a surface can report what it is actually rendering (gate G-U1's reporting half)
+and a rollback can be proven rather than asserted — the restored activation must
+carry the *same digest bytes* as the activation it restores, not merely the same
+revision number.
+
+``activation_sequence`` orders activations without a timestamp: ordering here is
+a fact about the pointer's history, and a monotonic integer is deterministic
+where a clock is not.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.dashboard.model_theme_catalog_entry import (
+    THEME_CONTENT_DIGEST_PATTERN,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelThemeActivation"]
+
+#: Reused so the pointer and the entry cannot disagree about digest shape.
+_DIGEST_PATTERN: re.Pattern[str] = THEME_CONTENT_DIGEST_PATTERN
+
+
+class ModelThemeActivation(BaseModel):
+    """Which published theme revision a surface is currently rendering."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    surface_id: str = Field(  # string-id-ok: semantic surface label, not a UUID
+        ...,
+        description="Surface whose active theme this pointer describes (e.g. 'omnidash')",
+        min_length=1,
+    )
+    theme_id: str = Field(  # string-id-ok: namespaced theme label, not a UUID
+        ...,
+        description="Namespaced theme identifier this surface renders",
+        min_length=1,
+    )
+    instance_revision: ModelSemVer = Field(
+        ...,
+        description="Exact published revision this surface renders",
+    )
+    content_digest: str = Field(
+        ...,
+        description=(
+            "Digest resolved from the catalog at activation time. Two surfaces "
+            "on one entry must report the same value (GC.2)."
+        ),
+    )
+    activation_sequence: int = Field(
+        ...,
+        ge=1,
+        description="Monotonic activation counter for this surface; first activation is 1",
+    )
+    superseded_revision: ModelSemVer | None = Field(
+        default=None,
+        description=(
+            "Revision this activation replaced, and therefore the revision a "
+            "rollback returns to. None on a surface's first activation."
+        ),
+    )
+
+    @field_validator("content_digest")
+    @classmethod
+    def validate_content_digest(cls, value: str) -> str:
+        """Reject anything that is not a ``sha256:<hex>`` digest.
+
+        Raises:
+            ValueError: If ``value`` does not match the digest pattern.
+        """
+        if not _DIGEST_PATTERN.match(value):
+            raise ValueError(
+                f"content_digest must match 'sha256:<64 hex chars>', got '{value}'"
+            )
+        return value

--- a/src/omnibase_core/models/dashboard/model_theme_catalog.py
+++ b/src/omnibase_core/models/dashboard/model_theme_catalog.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ThemeCatalog — the set of published theme revisions (OMN-16882, Phase C1).
+
+Resolution of open design item **OD-2** (plan §5.1), recorded here because the
+shape of this model *is* the answer:
+
+* **Published revisions are a compiled artifact shipped with the library.** They
+  are immutable, content-digested, and byte-reproducible offline, so two
+  surfaces can agree on a digest with no service in the path. A registry
+  projection cannot give that property to a build input.
+* **The active pointer is runtime state, not a catalog field.** Which surface
+  renders which revision is mutable, per-surface, and reported — that half is
+  ``ModelThemeActivation`` and is served the way every other read is served.
+
+Splitting them is what makes "rollback moves a pointer, and the digest proves
+the old bytes came back" mechanically true: the revisions cannot move, and the
+pointer carries the digest it resolved.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard.model_theme_catalog_entry import (
+    ModelThemeCatalogEntry,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelThemeCatalog"]
+
+
+class ModelThemeCatalog(BaseModel):
+    """Every published theme revision, indexed by (theme_id, instance_revision)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    catalog_version: ModelSemVer = Field(
+        ...,
+        description="Version of the catalog format itself (not of any theme)",
+    )
+    entries: tuple[ModelThemeCatalogEntry, ...] = Field(
+        ...,
+        description="Published, immutable theme revisions",
+    )
+
+    @model_validator(mode="after")
+    def validate_revisions_are_unique(self) -> Self:
+        """Reject a catalog that publishes one revision twice.
+
+        A duplicated (theme_id, instance_revision) makes ``entry_for`` ambiguous
+        and would let two digests claim the same revision — the exact drift the
+        digest axis exists to detect.
+
+        Raises:
+            ValueError: If any (theme_id, instance_revision) pair repeats.
+        """
+        seen: set[tuple[str, str]] = set()
+        for entry in self.entries:
+            key = (entry.theme_id, str(entry.instance_revision))
+            if key in seen:
+                raise ValueError(
+                    f"duplicate catalog entry for theme '{entry.theme_id}' "
+                    f"revision {entry.instance_revision}"
+                )
+            seen.add(key)
+        return self
+
+    def entry_for(
+        self, theme_id: str, instance_revision: ModelSemVer
+    ) -> ModelThemeCatalogEntry:
+        """Resolve one published revision, failing closed when it is absent.
+
+        Args:
+            theme_id: Namespaced theme identifier.
+            instance_revision: The exact revision to resolve. Consumers pin an
+                exact revision; there is deliberately no ``latest``.
+
+        Returns:
+            The matching catalog entry.
+
+        Raises:
+            ModelOnexError: If no entry matches.
+        """
+        for entry in self.entries:
+            if entry.theme_id == theme_id and entry.instance_revision == (
+                instance_revision
+            ):
+                return entry
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.RESOURCE_NOT_FOUND,
+            message=(
+                f"theme '{theme_id}' revision {instance_revision} is not published "
+                f"in this catalog"
+            ),
+        )

--- a/src/omnibase_core/models/dashboard/model_theme_catalog_entry.py
+++ b/src/omnibase_core/models/dashboard/model_theme_catalog_entry.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ThemeCatalogEntry — one published theme revision (OMN-16882, Phase C1).
+
+A catalog entry is the *published* record of one immutable theme instance
+revision: which theme, which revision, which schema version it validates
+against, the SHA-256 of its published bytes, and where those bytes live.
+
+The digest lives here rather than on ``ModelThemeInstance`` because an object
+cannot contain its own hash without the hash covering itself. It is the only
+one of the three version axes a machine can compare across two surfaces, which
+is exactly what gate GC.2 asks for.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelThemeCatalogEntry", "THEME_CONTENT_DIGEST_PATTERN"]
+
+#: Published-byte digests are ``sha256:<64 lowercase hex chars>``.
+THEME_CONTENT_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ModelThemeCatalogEntry(BaseModel):
+    """One immutable, digested theme revision in the catalog."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    theme_id: str = Field(  # string-id-ok: namespaced theme label, not a UUID
+        ...,
+        description="Namespaced theme identifier (e.g. 'onex.theme.dark')",
+        min_length=1,
+    )
+    schema_version: ModelSemVer = Field(
+        ...,
+        description="ModelRendererThemeContract version this revision validates against",
+    )
+    instance_revision: ModelSemVer = Field(
+        ...,
+        description="Revision of the theme instance document",
+    )
+    content_digest: str = Field(
+        ...,
+        description="SHA-256 over the published bytes, as 'sha256:<hex>'",
+    )
+    source_path: str = Field(
+        ...,
+        description="Catalog-root-relative path of the instance document",
+        min_length=1,
+    )
+
+    @field_validator("content_digest")
+    @classmethod
+    def validate_content_digest(cls, value: str) -> str:
+        """Reject anything that is not a ``sha256:<hex>`` digest.
+
+        Raises:
+            ValueError: If ``value`` does not match the digest pattern.
+        """
+        if not THEME_CONTENT_DIGEST_PATTERN.match(value):
+            raise ValueError(
+                f"content_digest must match 'sha256:<64 hex chars>', got '{value}'"
+            )
+        return value

--- a/src/omnibase_core/models/dashboard/model_theme_instance.py
+++ b/src/omnibase_core/models/dashboard/model_theme_instance.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ThemeInstance — a published set of design-token VALUES (OMN-16882, Phase C1).
+
+``ModelRendererThemeContract`` is a **schema**: every token field is required
+and the class holds no values. It answers *what a theme must contain*. It
+cannot answer *what this theme's accent colour is*, because there is nothing in
+the class to read.
+
+``ModelThemeInstance`` is the missing half — an instance document that carries a
+complete, schema-validated token set plus the header a lifecycle needs. Instance
+documents are **data**: serialized YAML under
+``omnibase_core/contracts/themes/<theme_id>/<instance_revision>.yaml``. Changing
+a token value edits a document; it never edits a Python class. A class edit is a
+*schema* change and moves a different version axis entirely.
+
+Three version axes, deliberately three fields:
+
+* ``schema_version`` — the ``ModelRendererThemeContract`` version this document
+  was authored against. Moves when a token *field* is added, removed, or
+  renamed.
+* ``instance_revision`` — this document's own revision. Moves when a token
+  *value* changes.
+* content digest — SHA-256 over the published bytes. Moves on any byte change
+  from either source above. Materialised on ``ModelThemeCatalogEntry``, never
+  stored inside the instance it digests.
+
+Conflating any two of them is how a stale artifact passes on a matching version
+number, so ``schema_version`` and ``theme_id`` are declared in the document
+header **and** cross-checked against the embedded token set: a document whose
+header disagrees with its body is rejected, not reconciled.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.dashboard.model_renderer_theme_contract import (
+    ModelRendererThemeContract,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelThemeInstance"]
+
+
+class ModelThemeInstance(BaseModel):
+    """A versioned, schema-validated set of design-token values.
+
+    The unit a surface activates and a catalog entry points at. Immutable:
+    a published revision is never edited in place, because rollback is only
+    meaningful if the bytes behind a revision cannot move.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    theme_id: str = Field(  # string-id-ok: namespaced theme label, not a UUID
+        ...,
+        description=(
+            "Stable, namespaced theme identifier (e.g. 'onex.theme.dark'). "
+            "Must equal the embedded token set's theme_id."
+        ),
+        min_length=1,
+    )
+    schema_version: ModelSemVer = Field(
+        ...,
+        description=(
+            "ModelRendererThemeContract version this document was authored "
+            "against. Must equal tokens.contract_version."
+        ),
+    )
+    instance_revision: ModelSemVer = Field(
+        ...,
+        description=(
+            "This document's own revision. Bump when a token VALUE changes; "
+            "distinct from schema_version, which tracks token FIELDS."
+        ),
+    )
+    summary: str = Field(
+        ...,
+        description="Human-readable description of what this theme revision is for",
+        min_length=1,
+    )
+    tokens: ModelRendererThemeContract = Field(
+        ...,
+        description="The complete, schema-validated token value set",
+    )
+
+    @model_validator(mode="after")
+    def validate_header_matches_tokens(self) -> Self:
+        """Fail closed when the document header disagrees with its token body.
+
+        The header exists so the three version axes are legible without parsing
+        the whole token set. A header that can drift from the body is worse than
+        no header at all, so a mismatch is an error rather than a reconciliation.
+
+        Raises:
+            ValueError: If ``theme_id`` or ``schema_version`` disagrees with the
+                embedded ``tokens``.
+        """
+        if self.theme_id != self.tokens.theme_id:
+            raise ValueError(
+                f"theme_id '{self.theme_id}' does not match tokens.theme_id "
+                f"'{self.tokens.theme_id}'"
+            )
+        if self.schema_version != self.tokens.contract_version:
+            raise ValueError(
+                f"schema_version '{self.schema_version}' does not match "
+                f"tokens.contract_version '{self.tokens.contract_version}'"
+            )
+        return self

--- a/src/omnibase_core/utils/util_theme_catalog.py
+++ b/src/omnibase_core/utils/util_theme_catalog.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Theme catalog loading, digesting, and the activate/rollback pointer moves.
+
+OMN-16882 (Phase C1). See ``ModelThemeCatalog`` for the OD-2 resolution this
+module implements: published revisions are packaged, immutable, digested data;
+the active pointer is separate, mutable, per-surface state.
+
+Catalog layout — ``<catalog root>/<theme_id>/<instance_revision>.yaml``. The
+filename carries the revision so a published revision is addressable without
+opening it, and ``build_theme_catalog`` fails closed when a document's declared
+revision disagrees with the filename it was published under.
+
+Digest — ``sha256`` over the RFC-8785-compatible canonical JSON of the instance
+(``compute_canonical_hash``), never over raw file bytes. Two surfaces that load
+one entry through different YAML writers must still agree (GC.2), and formatting
+churn must not read as a value change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard.model_theme_activation import ModelThemeActivation
+from omnibase_core.models.dashboard.model_theme_catalog import ModelThemeCatalog
+from omnibase_core.models.dashboard.model_theme_catalog_entry import (
+    ModelThemeCatalogEntry,
+)
+from omnibase_core.models.dashboard.model_theme_instance import ModelThemeInstance
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.utils.util_canonical_hash import compute_canonical_hash
+from omnibase_core.utils.util_safe_yaml_loader import load_and_validate_yaml_model
+
+__all__ = [
+    "THEME_CATALOG_ROOT",
+    "THEME_CATALOG_VERSION",
+    "activate_theme",
+    "build_theme_catalog",
+    "compute_theme_content_digest",
+    "load_packaged_theme_catalog",
+    "load_theme_instance",
+    "roll_back_theme",
+]
+
+#: Packaged instance documents. Data shipped with the library, not code.
+THEME_CATALOG_ROOT: Path = (
+    Path(__file__).resolve().parent.parent / "contracts" / "themes"
+)
+
+#: Version of the catalog *format* — not of any theme in it.
+THEME_CATALOG_VERSION: ModelSemVer = ModelSemVer(major=1, minor=0, patch=0)
+
+
+def compute_theme_content_digest(instance: ModelThemeInstance) -> str:
+    """Return the ``sha256:<hex>`` digest of a theme instance's published form.
+
+    Args:
+        instance: The theme instance to digest.
+
+    Returns:
+        The digest as ``sha256:<64 lowercase hex chars>``.
+    """
+    return f"sha256:{compute_canonical_hash(instance.model_dump(mode='json'))}"
+
+
+def load_theme_instance(path: Path) -> ModelThemeInstance:
+    """Load and schema-validate one theme instance document.
+
+    Args:
+        path: Path to a serialized ``ModelThemeInstance`` YAML document.
+
+    Returns:
+        The validated instance.
+
+    Raises:
+        ModelOnexError: If the file is missing, unparseable, or fails schema
+            validation.
+    """
+    return load_and_validate_yaml_model(path, ModelThemeInstance)
+
+
+def build_theme_catalog(root: Path) -> ModelThemeCatalog:
+    """Build a catalog from every instance document under ``root``.
+
+    Args:
+        root: Catalog root containing ``<theme_id>/<revision>.yaml`` documents.
+
+    Returns:
+        A catalog with one entry per published revision, ordered by
+        (theme_id, revision string) so the result is deterministic.
+
+    Raises:
+        ModelOnexError: If ``root`` is not a directory, or a document's declared
+            revision disagrees with the filename it is published under.
+    """
+    if not root.is_dir():
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.DIRECTORY_NOT_FOUND,
+            message=f"theme catalog root does not exist: {root}",
+        )
+
+    entries: list[ModelThemeCatalogEntry] = []
+    for document in sorted(root.rglob("*.yaml")):
+        instance = load_theme_instance(document)
+        declared_revision = str(instance.instance_revision)
+        if document.stem != declared_revision:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    f"theme instance {document} declares revision "
+                    f"{declared_revision} but is published as '{document.stem}'; "
+                    f"a published revision must be addressable by its filename"
+                ),
+            )
+        if document.parent.name != instance.theme_id:
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+                message=(
+                    f"theme instance {document} declares theme_id "
+                    f"'{instance.theme_id}' but is published under directory "
+                    f"'{document.parent.name}'"
+                ),
+            )
+        entries.append(
+            ModelThemeCatalogEntry(
+                theme_id=instance.theme_id,
+                schema_version=instance.schema_version,
+                instance_revision=instance.instance_revision,
+                content_digest=compute_theme_content_digest(instance),
+                source_path=document.relative_to(root).as_posix(),
+            )
+        )
+
+    return ModelThemeCatalog(
+        catalog_version=THEME_CATALOG_VERSION,
+        entries=tuple(entries),
+    )
+
+
+def load_packaged_theme_catalog() -> ModelThemeCatalog:
+    """Build the catalog from the instance documents shipped with omnibase_core.
+
+    Returns:
+        The packaged theme catalog.
+
+    Raises:
+        ModelOnexError: If the packaged catalog is missing or invalid.
+    """
+    return build_theme_catalog(THEME_CATALOG_ROOT)
+
+
+def activate_theme(
+    *,
+    catalog: ModelThemeCatalog,
+    surface_id: str,
+    theme_id: str,
+    instance_revision: ModelSemVer,
+    current: ModelThemeActivation | None = None,
+) -> ModelThemeActivation:
+    """Point ``surface_id`` at a published revision.
+
+    This is the only operation that changes rendered pixels. Publishing does
+    not; it only adds an immutable revision the pointer may later name.
+
+    Args:
+        catalog: Catalog the revision must already be published in.
+        surface_id: Surface whose pointer moves.
+        theme_id: Theme to activate.
+        instance_revision: Exact revision to activate.
+        current: The surface's existing activation, if any. Supplies the
+            sequence to increment and the revision a rollback returns to.
+
+    Returns:
+        The new activation pointer, carrying the digest resolved from the
+        catalog.
+
+    Raises:
+        ModelOnexError: If the revision is not published, or ``current``
+            belongs to a different surface.
+    """
+    if current is not None and current.surface_id != surface_id:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_PARAMETER,
+            message=(
+                f"current activation belongs to surface '{current.surface_id}', "
+                f"not '{surface_id}'"
+            ),
+        )
+
+    entry = catalog.entry_for(theme_id, instance_revision)
+    return ModelThemeActivation(
+        surface_id=surface_id,
+        theme_id=theme_id,
+        instance_revision=entry.instance_revision,
+        content_digest=entry.content_digest,
+        activation_sequence=1 if current is None else current.activation_sequence + 1,
+        superseded_revision=None if current is None else current.instance_revision,
+    )
+
+
+def roll_back_theme(
+    *,
+    catalog: ModelThemeCatalog,
+    current: ModelThemeActivation,
+) -> ModelThemeActivation:
+    """Move a surface's pointer back to the revision ``current`` superseded.
+
+    Rollback is a pointer move, not a rebuild: the returned activation carries
+    the digest read from the catalog entry for the superseded revision, so a
+    caller can prove the old bytes came back rather than a fresh compile that
+    happens to look similar.
+
+    Args:
+        catalog: Catalog holding the superseded revision.
+        current: The activation being rolled back.
+
+    Returns:
+        The restored activation pointer.
+
+    Raises:
+        ModelOnexError: If ``current`` has no superseded revision — a first
+            activation has nowhere to roll back to and must fail rather than
+            silently no-op.
+    """
+    if current.superseded_revision is None:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_STATE,
+            message=(
+                f"surface '{current.surface_id}' has no superseded revision for "
+                f"theme '{current.theme_id}'; there is nothing to roll back to"
+            ),
+        )
+
+    entry = catalog.entry_for(current.theme_id, current.superseded_revision)
+    return ModelThemeActivation(
+        surface_id=current.surface_id,
+        theme_id=current.theme_id,
+        instance_revision=entry.instance_revision,
+        content_digest=entry.content_digest,
+        activation_sequence=current.activation_sequence + 1,
+        superseded_revision=current.instance_revision,
+    )

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -38,6 +38,11 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     "ModelRendererCapabilityContract",
     # Versioned design-token contract (OMN-13389)
     "ModelRendererThemeContract",
+    # Theme instance + catalog layer (OMN-16882 — Phase C1)
+    "ModelThemeInstance",
+    "ModelThemeCatalogEntry",
+    "ModelThemeCatalog",
+    "ModelThemeActivation",
     # Review Packet + OmniStudio Evidence Bundle (OMN-13387)
     "ModelReviewPacket",
     "ModelOmniStudioEvidenceBundle",

--- a/tests/unit/models/dashboard/test_theme_catalog.py
+++ b/tests/unit/models/dashboard/test_theme_catalog.py
@@ -1,0 +1,504 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the theme instance + catalog layer (OMN-16882, Phase C1).
+
+`ModelRendererThemeContract` is a *schema*: every token field is required and
+the class holds no values. This module covers the instance layer that gives a
+token value somewhere to live, and the publish/activate/rollback lifecycle that
+makes changing one a data edit rather than a Python class edit.
+
+Gates under test:
+
+- **GC.1** — a theme instance's value can be changed, published, activated, and
+  rolled back without editing a Python class.
+- **GC.2** — two surfaces loading the same catalog entry report the same
+  content digest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard import (
+    ModelRendererThemeContract,
+    ModelThemeActivation,
+    ModelThemeCatalog,
+    ModelThemeCatalogEntry,
+    ModelThemeInstance,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.utils.util_safe_yaml_loader import serialize_data_to_yaml
+from omnibase_core.utils.util_theme_catalog import (
+    THEME_CATALOG_ROOT,
+    activate_theme,
+    build_theme_catalog,
+    compute_theme_content_digest,
+    load_packaged_theme_catalog,
+    load_theme_instance,
+    roll_back_theme,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+#: The three theme instances the catalog ships (plan §2.1: light/dark/warm are
+#: three catalog entries, not three hand-maintained stylesheets).
+_SHIPPED_THEME_IDS = ("onex.theme.light", "onex.theme.dark", "onex.theme.warm")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dark_tokens(*, accent: str = "#6366f1") -> ModelRendererThemeContract:
+    """A complete token set; ``accent`` is the value a test wants to vary."""
+    return ModelRendererThemeContract(
+        theme_id="onex.theme.dark",
+        contract_version=ModelSemVer(major=1, minor=0, patch=0),
+        color_background_primary="#0f172a",
+        color_background_secondary="#1e293b",
+        color_background_elevated="#334155",
+        color_text_primary="#f8fafc",
+        color_text_secondary="#94a3b8",
+        color_text_disabled="#475569",
+        color_accent_primary=accent,
+        color_accent_secondary="#818cf8",
+        color_status_success="#22c55e",
+        color_status_warning="#f59e0b",
+        color_status_error="#ef4444",
+        color_status_info="#38bdf8",
+        color_border_default="#334155",
+        color_border_strong="#475569",
+        spacing_xs="0.25rem",
+        spacing_sm="0.5rem",
+        spacing_md="1rem",
+        spacing_lg="1.5rem",
+        spacing_xl="2rem",
+        font_family_base="'Inter', system-ui, sans-serif",
+        font_size_sm="0.875rem",
+        font_size_md="1rem",
+        font_size_lg="1.125rem",
+        font_weight_normal="400",
+        font_weight_bold="700",
+        border_radius_sm="0.25rem",
+        border_radius_md="0.5rem",
+        border_radius_lg="1rem",
+    )
+
+
+def _dark_instance(
+    *, revision: ModelSemVer, accent: str = "#6366f1"
+) -> ModelThemeInstance:
+    return ModelThemeInstance(
+        theme_id="onex.theme.dark",
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
+        instance_revision=revision,
+        summary="Dark theme fixture",
+        tokens=_dark_tokens(accent=accent),
+    )
+
+
+def _write_instance(root: Path, instance: ModelThemeInstance) -> Path:
+    """Write ``instance`` into a catalog tree the way a publish would."""
+    target = root / instance.theme_id / f"{instance.instance_revision}.yaml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(serialize_data_to_yaml(instance.model_dump(mode="json")))
+    return target
+
+
+# ---------------------------------------------------------------------------
+# The shipped catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPackagedThemeCatalog:
+    """The instance documents that ship with omnibase_core."""
+
+    def test_catalog_root_is_packaged_data(self) -> None:
+        assert THEME_CATALOG_ROOT.is_dir()
+
+    def test_light_dark_warm_instances_exist_and_validate(self) -> None:
+        catalog = load_packaged_theme_catalog()
+        shipped = {entry.theme_id for entry in catalog.entries}
+        assert shipped == set(_SHIPPED_THEME_IDS)
+
+    def test_every_shipped_instance_document_validates_against_the_schema(
+        self,
+    ) -> None:
+        """This is the CI validation the ticket requires (C1a)."""
+        documents = sorted(THEME_CATALOG_ROOT.rglob("*.yaml"))
+        assert documents, "no theme instance documents found"
+        for document in documents:
+            instance = load_theme_instance(document)
+            assert isinstance(instance.tokens, ModelRendererThemeContract)
+
+    def test_shipped_entries_carry_a_digest_and_a_source_path(self) -> None:
+        catalog = load_packaged_theme_catalog()
+        for entry in catalog.entries:
+            assert entry.content_digest.startswith("sha256:")
+            assert (THEME_CATALOG_ROOT / entry.source_path).is_file()
+
+
+# ---------------------------------------------------------------------------
+# Three version axes (C1b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestThreeVersionAxes:
+    """schema version, instance revision, and content digest are distinct."""
+
+    def test_instance_declares_schema_version_and_instance_revision_separately(
+        self,
+    ) -> None:
+        instance = _dark_instance(revision=ModelSemVer(major=2, minor=3, patch=1))
+        assert instance.schema_version == ModelSemVer(major=1, minor=0, patch=0)
+        assert instance.instance_revision == ModelSemVer(major=2, minor=3, patch=1)
+        assert instance.schema_version != instance.instance_revision
+
+    def test_declared_schema_version_must_match_the_token_contract_version(
+        self,
+    ) -> None:
+        with pytest.raises(ValidationError):
+            ModelThemeInstance(
+                theme_id="onex.theme.dark",
+                schema_version=ModelSemVer(major=2, minor=0, patch=0),
+                instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+                summary="mismatched schema version",
+                tokens=_dark_tokens(),
+            )
+
+    def test_declared_theme_id_must_match_the_token_theme_id(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelThemeInstance(
+                theme_id="onex.theme.light",
+                schema_version=ModelSemVer(major=1, minor=0, patch=0),
+                instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+                summary="mismatched theme id",
+                tokens=_dark_tokens(),
+            )
+
+    def test_a_value_change_moves_the_digest_but_not_the_schema_version(self) -> None:
+        base = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        changed = _dark_instance(
+            revision=ModelSemVer(major=1, minor=1, patch=0), accent="#a855f7"
+        )
+        assert base.schema_version == changed.schema_version
+        assert compute_theme_content_digest(base) != compute_theme_content_digest(
+            changed
+        )
+
+
+# ---------------------------------------------------------------------------
+# GC.2 — digest determinism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContentDigest:
+    """GC.2: two surfaces loading one catalog entry report one digest."""
+
+    def test_digest_is_deterministic_across_independent_loads(self) -> None:
+        first = load_packaged_theme_catalog()
+        second = load_packaged_theme_catalog()
+        assert {(e.theme_id, e.content_digest) for e in first.entries} == {
+            (e.theme_id, e.content_digest) for e in second.entries
+        }
+
+    def test_digest_is_stable_across_a_serialize_reload_round_trip(
+        self, tmp_path: Path
+    ) -> None:
+        instance = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        path = _write_instance(tmp_path, instance)
+        reloaded = load_theme_instance(path)
+        assert compute_theme_content_digest(reloaded) == compute_theme_content_digest(
+            instance
+        )
+
+    def test_digest_is_prefixed_and_hex(self) -> None:
+        digest = compute_theme_content_digest(
+            _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        algorithm, _, hexdigest = digest.partition(":")
+        assert algorithm == "sha256"
+        assert len(hexdigest) == 64
+        assert set(hexdigest) <= set("0123456789abcdef")
+
+
+# ---------------------------------------------------------------------------
+# Catalog construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCatalogConstruction:
+    def test_catalog_indexes_every_published_revision(self, tmp_path: Path) -> None:
+        _write_instance(
+            tmp_path, _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        _write_instance(
+            tmp_path,
+            _dark_instance(
+                revision=ModelSemVer(major=1, minor=1, patch=0), accent="#a855f7"
+            ),
+        )
+        catalog = build_theme_catalog(tmp_path)
+        assert len(catalog.entries) == 2
+
+    def test_duplicate_theme_revision_is_rejected(self) -> None:
+        entry = ModelThemeCatalogEntry(
+            theme_id="onex.theme.dark",
+            schema_version=ModelSemVer(major=1, minor=0, patch=0),
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+            content_digest="sha256:" + "0" * 64,
+            source_path="onex.theme.dark/1.0.0.yaml",
+        )
+        with pytest.raises(ValidationError):
+            ModelThemeCatalog(
+                catalog_version=ModelSemVer(major=1, minor=0, patch=0),
+                entries=(entry, entry),
+            )
+
+    def test_entry_lookup_resolves_a_published_revision(self, tmp_path: Path) -> None:
+        instance = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        _write_instance(tmp_path, instance)
+        catalog = build_theme_catalog(tmp_path)
+        entry = catalog.entry_for(
+            "onex.theme.dark", ModelSemVer(major=1, minor=0, patch=0)
+        )
+        assert entry.content_digest == compute_theme_content_digest(instance)
+
+    def test_entry_lookup_fails_closed_on_an_unpublished_revision(
+        self, tmp_path: Path
+    ) -> None:
+        _write_instance(
+            tmp_path, _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        catalog = build_theme_catalog(tmp_path)
+        with pytest.raises(ModelOnexError):
+            catalog.entry_for("onex.theme.dark", ModelSemVer(major=9, minor=9, patch=9))
+
+    def test_a_document_whose_filename_disagrees_with_its_revision_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        instance = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        target = tmp_path / instance.theme_id / "9.9.9.yaml"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(serialize_data_to_yaml(instance.model_dump(mode="json")))
+        with pytest.raises(ModelOnexError):
+            build_theme_catalog(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# GC.1 — publish / activate / rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPublishActivateRollback:
+    """GC.1: a value change is a data edit, and rollback restores the bytes."""
+
+    def test_publishing_a_revision_does_not_change_what_is_activated(
+        self, tmp_path: Path
+    ) -> None:
+        _write_instance(
+            tmp_path, _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        catalog = build_theme_catalog(tmp_path)
+        activation = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+        )
+
+        # Publish a second revision — activation pointer must not move.
+        _write_instance(
+            tmp_path,
+            _dark_instance(
+                revision=ModelSemVer(major=1, minor=1, patch=0), accent="#a855f7"
+            ),
+        )
+        republished = build_theme_catalog(tmp_path)
+        assert len(republished.entries) == 2
+        assert activation.instance_revision == ModelSemVer(major=1, minor=0, patch=0)
+
+    def test_activation_carries_the_digest_of_the_revision_it_points_at(
+        self, tmp_path: Path
+    ) -> None:
+        instance = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        _write_instance(tmp_path, instance)
+        catalog = build_theme_catalog(tmp_path)
+        activation = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+        )
+        assert activation.content_digest == compute_theme_content_digest(instance)
+        assert activation.activation_sequence == 1
+        assert activation.superseded_revision is None
+
+    def test_a_token_value_changes_without_editing_a_python_class(
+        self, tmp_path: Path
+    ) -> None:
+        """GC.1 proper: publish v1, publish v1.1 with a new value, activate it."""
+        original = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        updated = _dark_instance(
+            revision=ModelSemVer(major=1, minor=1, patch=0), accent="#a855f7"
+        )
+        _write_instance(tmp_path, original)
+        _write_instance(tmp_path, updated)
+        catalog = build_theme_catalog(tmp_path)
+
+        first = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+        )
+        second = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=1, patch=0),
+            current=first,
+        )
+
+        assert second.activation_sequence == 2
+        assert second.superseded_revision == ModelSemVer(major=1, minor=0, patch=0)
+        assert second.content_digest != first.content_digest
+        assert (
+            load_theme_instance(
+                tmp_path
+                / (
+                    catalog.entry_for("onex.theme.dark", second.instance_revision)
+                ).source_path
+            ).tokens.color_accent_primary
+            == "#a855f7"
+        )
+
+    def test_rollback_moves_the_pointer_and_restores_the_original_digest(
+        self, tmp_path: Path
+    ) -> None:
+        original = _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        updated = _dark_instance(
+            revision=ModelSemVer(major=1, minor=1, patch=0), accent="#a855f7"
+        )
+        _write_instance(tmp_path, original)
+        _write_instance(tmp_path, updated)
+        catalog = build_theme_catalog(tmp_path)
+
+        first = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+        )
+        second = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=1, patch=0),
+            current=first,
+        )
+        rolled_back = roll_back_theme(catalog=catalog, current=second)
+
+        assert rolled_back.instance_revision == first.instance_revision
+        # The digest proves the OLD BYTES came back, not a lookalike recompile.
+        assert rolled_back.content_digest == first.content_digest
+        assert rolled_back.activation_sequence == 3
+        assert rolled_back.superseded_revision == ModelSemVer(major=1, minor=1, patch=0)
+
+    def test_rollback_fails_closed_when_there_is_nothing_to_roll_back_to(
+        self, tmp_path: Path
+    ) -> None:
+        _write_instance(
+            tmp_path, _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        catalog = build_theme_catalog(tmp_path)
+        first = activate_theme(
+            catalog=catalog,
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+        )
+        with pytest.raises(ModelOnexError):
+            roll_back_theme(catalog=catalog, current=first)
+
+    def test_activating_an_unpublished_revision_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        _write_instance(
+            tmp_path, _dark_instance(revision=ModelSemVer(major=1, minor=0, patch=0))
+        )
+        catalog = build_theme_catalog(tmp_path)
+        with pytest.raises(ModelOnexError):
+            activate_theme(
+                catalog=catalog,
+                surface_id="omnidash",
+                theme_id="onex.theme.dark",
+                instance_revision=ModelSemVer(major=7, minor=0, patch=0),
+            )
+
+    def test_activation_is_frozen(self) -> None:
+        activation = ModelThemeActivation(
+            surface_id="omnidash",
+            theme_id="onex.theme.dark",
+            instance_revision=ModelSemVer(major=1, minor=0, patch=0),
+            content_digest="sha256:" + "a" * 64,
+            activation_sequence=1,
+        )
+        with pytest.raises(ValidationError):
+            activation.surface_id = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# C1d — the TS mirror carries the schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTypeScriptMirrorRegistration:
+    """The emitter must carry the theme schema and the instance layer."""
+
+    @staticmethod
+    def _emitter_models() -> dict[str, object]:
+        path = _REPO_ROOT / "scripts" / "emit_ts_types.py"
+        spec = importlib.util.spec_from_file_location("_emit_ts_types_probe", path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+            return dict(module.MODELS)
+        finally:
+            sys.modules.pop(spec.name, None)
+
+    def test_emitter_registers_the_theme_schema_and_instance_layer(self) -> None:
+        models = self._emitter_models()
+        for name in (
+            "ModelRendererThemeContract",
+            "ModelThemeInstance",
+            "ModelThemeCatalogEntry",
+            "ModelThemeCatalog",
+            "ModelThemeActivation",
+        ):
+            assert name in models, f"{name} missing from emit_ts_types MODELS"
+
+    def test_instance_json_schema_embeds_the_token_schema(self) -> None:
+        schema = ModelThemeInstance.model_json_schema()
+        defs = schema.get("$defs", {})
+        assert "ModelRendererThemeContract" in defs
+        assert (
+            "color_accent_primary" in defs["ModelRendererThemeContract"]["properties"]
+        )


### PR DESCRIPTION
## Summary

Closes **OMN-16882** (Phase C1 of epic OMN-16879, per `omni_home/docs/plans/2026-08-27-omnidash-component-rework-plan.md` §1.4.1 / §2.1 / Phase C item C1).

`ModelRendererThemeContract` is a **schema**: every token field is `Field(...)`-required under `frozen=True, extra="forbid"`, and the class holds no values. `scripts/emit_ts_types.py` emits `model_json_schema()`. So the shipped pipeline had no way to carry a token **value** to a consumer, and "edit the Python class to change `color_accent_primary`" was never a workflow the code supported — there is no value in the class to edit.

This lands the instance layer the schema was always missing. It is purely additive; no existing model changes shape.

## What lands

| Object | Role |
|---|---|
| `ModelThemeInstance` | A schema-validated token value set plus the document header a lifecycle needs. `theme_id` / `schema_version` in the header are cross-checked against the embedded token set and **fail closed** on disagreement — a header that can drift from its body is worse than no header. |
| `ModelThemeCatalogEntry` | One published, immutable revision: theme, revision, schema version, `sha256:<hex>` content digest, source path. The digest lives here, not on the instance, because an object cannot contain a hash that covers itself. |
| `ModelThemeCatalog` | Every published revision, unique per `(theme_id, instance_revision)`, resolved by **exact** revision — there is deliberately no `latest`. |
| `ModelThemeActivation` | The active pointer: which surface renders which revision, carrying the digest it resolved and a monotonic `activation_sequence`. |
| `utils/util_theme_catalog.py` | `load` / `digest` / `build` / `activate` / `roll_back`. |
| `contracts/themes/<theme_id>/<revision>.yaml` | Instance documents for **light / dark / warm**, packaged data under the wheel's existing artifacts glob. |

## The three version axes are three fields

`schema_version` (token **fields**) · `instance_revision` (token **values**) · content digest (published **bytes**). Conflating any two is how a stale artifact passes on a matching version number, which is the precise failure §2.1 records. The digest is `sha256` over the instance's canonical JSON (`compute_canonical_hash`), not over raw file bytes, so two surfaces loading one entry through different YAML writers still agree and formatting churn cannot read as a value change.

## OD-2 resolved (plan §5.1)

**Published revisions are a compiled artifact shipped with the library; the active pointer is runtime state.** Revisions must be immutable, digested, and byte-reproducible offline so two surfaces agree on a digest with no service in the path — a registry projection cannot give that property to a build input. Which surface renders which revision is mutable, per-surface, and reported: that half is `ModelThemeActivation`. Splitting them is what makes "rollback moves a pointer and the digest proves the old bytes came back" mechanically true rather than asserted — revisions cannot move, so a restored pointer carrying the same digest bytes proves the old bytes returned rather than a fresh compile that happens to look similar.

## Gates

| Gate | Evidence |
|---|---|
| **GC.1** — a value change publishes, activates, and rolls back with **no Python class edit** | `test_a_token_value_changes_without_editing_a_python_class`, `test_rollback_moves_the_pointer_and_restores_the_original_digest` |
| **GC.2** — two loads of one entry report one digest | `test_digest_is_deterministic_across_independent_loads`, `test_digest_is_stable_across_a_serialize_reload_round_trip` |
| C1(a) instances exist for light/dark/warm, validated in CI | `test_light_dark_warm_instances_exist_and_validate`, `test_every_shipped_instance_document_validates_against_the_schema` |
| C1(b) three version axes are distinct fields | `test_instance_declares_schema_version_and_instance_revision_separately`, `test_a_value_change_moves_the_digest_but_not_the_schema_version` |
| C1(d) a fresh TS mirror carries the schema | `test_emitter_registers_the_theme_schema_and_instance_layer`, `test_instance_json_schema_embeds_the_token_schema` |

## dod_evidence

- `uv run pytest tests/unit/models/dashboard/ -q` → **327 passed** (26 new in `test_theme_catalog.py`).
- `uv run ruff format --check` clean; `uv run ruff check` clean on every changed file.
- `uv run mypy src/ --strict` → 14 errors, **all pre-existing** in unrelated files (`backend_cache_redis`, `service_protocol_auditor`, `model_onex_container`, …); zero in any file this PR touches.
- Additive only: no existing model, validator, or emitter symbol changes shape.

Phase C1 exit unblocks Phase 1B's theme binding; Phase 1A is unaffected and may run in parallel.

Evidence-Ticket: OMN-16882
Evidence-Source: OCC#7466
