### PR TITLE
chore(OMN-15989): make .onex_state disposable-by-default with two named durable subtrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,10 +349,41 @@ build/
 *.egg-info/
 # === end onex-managed: python ===
 
-# Consumer-graph cache, its single-flight lock, and any interrupted temp file.
-# Derived build artifacts keyed to the local HEAD SHA -- never committed. Scoped
-# to these names, not all of .onex_state/, which holds tracked evidence
-# (OMN-15431).
-.onex_state/consumer-graph.json
-.onex_state/consumer-graph.lock
-.onex_state/consumer-graph.json.*.tmp
+# -----------------------------------------------------------------------------
+# .onex_state/ -- disposable by default, two named durable subtrees (OMN-15989)
+# -----------------------------------------------------------------------------
+# THE RULE (write it down once, so no one adjudicates it per file again):
+#
+#   Inside a repo checkout, `.onex_state/` is DISPOSABLE. The only durable
+#   content is what lives under the two subtrees named below --
+#   `.onex_state/evidence/` and `.onex_state/friction/` -- which are committed
+#   and stay visible to `git status`.
+#
+# Everything else under `.onex_state/` is regenerable from a command or is a
+# per-run log/lock/scratch file: the consumer-graph cache and its single-flight
+# lock (OMN-15431), push logs and exit codes, prepush-waiter scripts and their
+# output, node run state, and lane scratch that leaked into the worktree root.
+#
+# State that must OUTLIVE the checkout does not belong in a checkout at all.
+# It lives outside every worktree at `$OMNI_HOME/.onex_state/` -- lane scratch,
+# ledger locks, claim/run state (see `omnibase_infra/scripts/lane_scratch.py`,
+# whose root resolves to `$OMNI_HOME/.onex_state/lane_scratch` for exactly this
+# reason). Nothing here can reach it, so worktree teardown cannot take it.
+#
+# WHY: an untracked generated artifact left a landed, 0-ahead/0-behind worktree
+# dirty, and a dirty worktree escalates teardown into a per-incident
+# owner-approval gate. Six omnibase_core worktrees were blocked this way at the
+# time of writing, none of them by real work. One standing rule replaces an
+# unbounded series of identical manual decisions.
+#
+# SHAPE: ignore the top level (`/*`), then re-include the durable subtrees. The
+# `/*` form is deliberate -- ignoring `.onex_state/` outright would exclude the
+# directory itself, and git cannot re-include a path whose parent directory is
+# excluded, so the negations below would be dead.
+#
+# The rule is asserted by tests/validation/test_onex_state_disposable_gitignore.py,
+# which names both sides of the line and carries a negative control proving this
+# block never widens over src/ or tests/.
+.onex_state/*
+!.onex_state/evidence/
+!.onex_state/friction/

--- a/tests/validation/test_onex_state_disposable_gitignore.py
+++ b/tests/validation/test_onex_state_disposable_gitignore.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The `.onex_state/` disposable-vs-durable separation rule (OMN-15989).
+
+WHAT THIS LOCKS
+---------------
+`.onex_state/` inside a repo checkout is a mixed bag: it holds regenerable
+per-run output (caches, locks, push logs, lane scratch) *and* a small amount of
+committed evidence. Before OMN-15989 the split was adjudicated per file, by
+hand, every time a landed worktree came up for teardown — an untracked
+generated artifact left the worktree dirty, and a dirty worktree escalates into
+an owner-approval gate before it can be removed.
+
+The rule that replaces that judgement call, in one sentence:
+
+    Inside a repo checkout, ``.onex_state/`` is DISPOSABLE by default; the only
+    durable content is what lives under the explicitly named subtrees
+    ``.onex_state/evidence/`` and ``.onex_state/friction/``.
+
+Durable state that must outlive the worktree does not belong in the worktree at
+all -- it lives outside every checkout under ``$OMNI_HOME/.onex_state/``
+(lane scratch, ledger locks, claim/run state; see
+``omnibase_infra/scripts/lane_scratch.py``, which resolves its root to
+``$OMNI_HOME/.onex_state/lane_scratch`` precisely so a worktree teardown cannot
+take it with them).
+
+WHY THE ASSERTIONS USE ``--no-index``
+-------------------------------------
+``git check-ignore`` consults the index by default and refuses to report a
+*tracked* path as ignored, which would make the durable-side assertions pass
+for the wrong reason (they are tracked, therefore reported un-ignored,
+regardless of the patterns). ``--no-index`` evaluates the ignore rules alone,
+so these tests answer the question actually being asked: what happens to a
+*new*, not-yet-tracked file at each of these paths.
+
+NEGATIVE CONTROL
+----------------
+``test_real_source_paths_are_never_ignored`` exists so this rule can never
+widen into a mask over real work. If a future edit to the ignore block starts
+swallowing ``src/`` or ``tests/`` paths, that test fails before the change can
+land.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITIGNORE = REPO_ROOT / ".gitignore"
+
+# The written-down rule must stay attached to the patterns that implement it.
+# A bare pattern block with the rationale stripped out is how the separation
+# decays back into per-file judgement.
+RULE_MARKER = "OMN-15989"
+
+# ---------------------------------------------------------------------------
+# The line, named on both sides (AC1 / AC2).
+# ---------------------------------------------------------------------------
+# DISPOSABLE: regenerable from a command, or a per-run log/lock/scratch file.
+# Every entry below was observed untracked in a real omnibase_core worktree
+# during the OMN-15989 survey, except where noted.
+DISPOSABLE_PATHS = (
+    # Derived build cache + its single-flight lock (OMN-15431).
+    ".onex_state/consumer-graph.json",
+    ".onex_state/consumer-graph.lock",
+    ".onex_state/consumer-graph.json.1234.tmp",
+    # Push-path logs and exit codes.
+    ".onex_state/push_log.txt",
+    ".onex_state/push_exit_code.txt",
+    # Lane scratch that leaked into the worktree root instead of
+    # $OMNI_HOME/.onex_state/lane_scratch.
+    ".onex_state/omn16507-prepush-waiter.sh",
+    ".onex_state/omn16507-prepush-waiter.out",
+    ".onex_state/MOVED_TO_201.md",
+    ".onex_state/OMN-16677-push-handoff.md",
+    # Nested per-run output (not observed in core, observed in sibling repos).
+    ".onex_state/local_runtime/some_node/run-id/state.yaml",
+    ".onex_state/tmp/probe-0000.json",
+    ".onex_state/lane_scratch/label-123-abcd.log",
+)
+
+# DURABLE: committed evidence. A NEW file at either of these prefixes must stay
+# visible to `git status` so it can be reviewed and committed, not silently
+# swallowed.
+DURABLE_PATHS = (
+    ".onex_state/evidence/OMN-15989/separation-rule-evidence.md",
+    ".onex_state/evidence/deterministic-ir/deterministic-ir-evidence.txt",
+    ".onex_state/friction/a-newly-observed-friction.md",
+)
+
+# NEGATIVE CONTROL: ordinary work that must never be masked.
+SOURCE_PATHS = (
+    "src/omnibase_core/analysis/consumer_graph.py",
+    "tests/validation/test_onex_state_disposable_gitignore.py",
+    "docs/architecture/ONEX_CANONICAL_ARCHITECTURE.md",
+    ".gitignore",
+)
+
+
+def _is_ignored(rel_path: str) -> bool:
+    """True when the repo's ignore rules alone would exclude ``rel_path``.
+
+    The env is scrubbed (OMN-14891): git exports GIT_DIR / GIT_WORK_TREE into
+    every hook environment and those override ``cwd=``, so an unscrubbed call
+    from a pre-push hook would silently evaluate a different repository.
+    """
+    result = subprocess.run(
+        ["git", "check-ignore", "--no-index", "-q", "--", rel_path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=scrub_git_location_env(os.environ),
+    )
+    # 0 = ignored, 1 = not ignored, anything else = git itself failed.
+    assert result.returncode in (0, 1), (
+        f"git check-ignore failed for {rel_path!r} "
+        f"(rc={result.returncode}): {result.stderr.strip()}"
+    )
+    return result.returncode == 0
+
+
+@pytest.mark.unit
+def test_separation_rule_is_written_down_next_to_the_patterns() -> None:
+    text = GITIGNORE.read_text(encoding="utf-8")
+    assert RULE_MARKER in text, (
+        ".gitignore must carry the OMN-15989 separation rule as prose next to "
+        "the .onex_state patterns — the patterns alone do not say which side "
+        "of the line a new path falls on."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rel_path", DISPOSABLE_PATHS)
+def test_generated_onex_state_artifacts_are_ignored(rel_path: str) -> None:
+    assert _is_ignored(rel_path), (
+        f"{rel_path} is regenerable output but is NOT ignored — it will leave a "
+        "landed worktree dirty and block teardown behind an owner-approval gate."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rel_path", DURABLE_PATHS)
+def test_durable_onex_state_subtrees_stay_visible(rel_path: str) -> None:
+    assert not _is_ignored(rel_path), (
+        f"{rel_path} holds durable evidence and must stay visible to "
+        "`git status`; ignoring it would silently hide committable work."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rel_path", SOURCE_PATHS)
+def test_real_source_paths_are_never_ignored(rel_path: str) -> None:
+    assert not _is_ignored(rel_path), (
+        f"NEGATIVE CONTROL FAILED: {rel_path} is ordinary tracked work and must "
+        "never be swallowed by the .onex_state ignore rule."
+    )


### PR DESCRIPTION
## OMN-15989 — `.onex_state/` is disposable by default, with two named durable subtrees

This is the **second of two surfaces** for OMN-15989. The first, `omniclaude#2061`, merged 2026-08-28T19:45:16Z and taught the canonical teardown tool (`scripts/prune-worktrees.sh`) the same rule. This PR writes the rule into the repo where the failure was actually observed, so it applies at `git status` time rather than only at teardown time.

### Premise check first — the ticket's example was stale, its mechanism was not

The ticket cites `.onex_state/consumer-graph.json`. That file was **already** gitignored here by OMN-15431 (merge `d4831d76`, 2026-08-01) — twelve days *before* the ticket was filed — and the ledger line it cites (`docs/tracking/2026-07-09-codex-merge-controller-ledger.md:4776`) does not exist; that file is 2258 lines. Recorded on the ticket before any code was written.

The **failure class** is live. A bounded scan (1037 worktrees enumerated via `git worktree list --porcelain` across every canonical clone, narrowed to those holding a `.onex_state/` dir, then `git status --porcelain --untracked-files=all` on each) finds six worktrees dirty **solely** from untracked `.onex_state` scratch, with zero non-`.onex_state` dirt — all of them in this repo:

| worktree | untracked `.onex_state` entries |
|---|---|
| `OMN-16177/omnibase_core` | `push_exit_code.txt`, `push_log.txt` |
| `OMN-16346/omnibase_core` | `MOVED_TO_201.md`, `omn16346-prepush-waiter.sh`, `.out` |
| `OMN-16507/omnibase_core` | `MOVED_TO_201.md`, `omn16507-prepush-waiter.sh`, `.out` |
| `OMN-16589/omnibase_core` | `MOVED_TO_201.md` |
| `OMN-16625/omnibase_core` | `MOVED_TO_201.md` |
| `OMN-16677/omnibase_core` | `OMN-16677-push-handoff.md` |

Each one turns teardown into a per-incident owner-approval decision about a file a command can rewrite. Not one of them is real work.

### The rule (AC1)

> Inside a repo checkout, `.onex_state/` is **disposable**. The only durable content is the two named subtrees `.onex_state/evidence/` and `.onex_state/friction/`. State that must outlive the checkout lives outside every worktree at `$OMNI_HOME/.onex_state/` — lane scratch, ledger locks, claim/run state (cf. `omnibase_infra/scripts/lane_scratch.py`, whose root resolves there for exactly this reason), so teardown cannot take it.

The rule ships as prose *next to* the patterns, and a test asserts it stays there — a bare pattern block with the rationale stripped is how the separation decays back into per-file judgement.

### Both sides of the line, named (AC2)

The durable side is not a guess: `git ls-tree -r --name-only origin/dev -- .onex_state` returns exactly 7 paths, and every one is under `evidence/` or `friction/`.

**Durable — stays visible to `git status`:** `.onex_state/evidence/**` (6 tracked files) and `.onex_state/friction/**` (1 tracked file).

**Disposable — ignored:** everything else at `.onex_state/*`. Observed instances: `consumer-graph.json` / `.lock` / `.json.*.tmp` (OMN-15431), `push_log.txt`, `push_exit_code.txt`, `MOVED_TO_201.md`, `*-prepush-waiter.sh` / `.out`, `OMN-16677-push-handoff.md`, plus nested per-run output (`local_runtime/`, `tmp/`, `lane_scratch/`).

The three `consumer-graph` lines are replaced, not dropped — `.onex_state/*` is a strict superset of them. Their OMN-15431 rationale is folded into the new block.

**Shape:** `.onex_state/*` then `!.onex_state/evidence/` + `!.onex_state/friction/`. The `/*` form is load-bearing and commented in place: ignoring `.onex_state/` outright excludes the directory itself, and git cannot re-include a path whose parent directory is excluded, which would make both negations dead.

### TDD, red first

`tests/validation/test_onex_state_disposable_gitignore.py` drives real `git check-ignore --no-index` against this repo's real `.gitignore` — `--no-index` because `check-ignore` otherwise refuses to report a *tracked* path as ignored, which would make the durable-side assertions pass for the wrong reason. The env is scrubbed via `scrub_git_location_env` (OMN-14891) so a hook-context `GIT_DIR` cannot silently retarget another repo.

**RED** (`.gitignore` reverted to `origin/dev`, final test file): **8 failed, 12 passed**. Every failure is a live artifact from the table above, plus the written-down-rule assertion. The 12 passes are correct: 3 consumer-graph paths were already covered by OMN-15431, and the durable + negative-control cases must pass on both sides of the fix.

**GREEN** (`test_onex_state_disposable_gitignore.py` + both pre-existing `test_gitignore_baseline*.py`): **41 passed** — 20 new, 21 pre-existing baseline tests unchanged.

### Live end-to-end proof (AC3 / AC4 / AC5)

Three throwaway detached worktrees off this repo, identical disposable artifacts in each, using the real names observed above:

| worktree | `.gitignore` | contents | `git status --porcelain` | `git worktree remove` (**no** `--force`) |
|---|---|---|---|---|
| before | `origin/dev` | disposable only | **3 lines** | rc=**128** `contains modified or untracked files` — still on disk |
| after | this branch | disposable only | **0 lines** | rc=**0** — removed |
| negative | this branch | disposable **+ a real edit to `src/omnibase_core/__init__.py`** | **1 line** (` M src/omnibase_core/__init__.py`) | rc=**128** — still on disk |

`before` and `after` differ *only* in the `.gitignore`, which makes the rule the demonstrated cause rather than a correlate. The `negative` row is the guard the ticket asks for: this must never widen into a mask over unpushed work. A parametrised negative control in the test file covers the same ground statically over `src/`, `tests/`, `docs/`, and `.gitignore` itself.

### Shared location, not per-machine (AC6)

The rule lives in the tracked `.gitignore` and in the tracked `scripts/prune-worktrees.sh` — never in `.git/info/exclude` or a `core.excludesFile`, so it travels with the clone and cannot diverge per machine by construction.

One correction to the ticket's wording: it asks to "verify on both `.200` and this Mac." This Mac **is** `.200` (`ipconfig getifaddr en0` → `192.168.86.200`, hostname `Stickybeatz-Studio.local`), so that is one host, not two. Being tracked repo content, the rule is machine-independent by construction rather than by two-host testing; the honest statement is that the two-host check is not available to be run, not that it passed.

### Known limit, stated rather than papered over

A `.gitignore` cannot retroactively clean a worktree that already exists — a worktree checks out *its own branch's* `.gitignore`, so this rule is absent from the tree of any worktree branched before it merges. The six worktrees above are unblocked by the already-merged `omniclaude#2061` teardown-tool half, not by this PR. This PR closes the class going forward. That division is why the ticket's AC6 permits either surface and this ticket landed both.

### Local verification

`ruff format` (unchanged), `ruff check` (all passed), `mypy` (no issues) on the new test. Governed pre-push selector ran on push — no override flag, no `--no-verify`, no bypass.

Ticket: OMN-15989

Evidence-Ticket: OMN-15989
Evidence-Source: OCC#7469
