### PR TITLE
feat(OMN-16883): one versioned widget envelope — the unit Plane 1 distributes

### DIFF
--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -36,6 +36,8 @@ from omnibase_core.models.dashboard import (
     ModelRendererCapabilityContract,
     ModelRendererThemeContract,
     ModelReviewPacket,
+    ModelWidgetEnvelope,
+    ModelWidgetProvenance,
 )
 from omnibase_core.models.notifications import ModelStateTransitionNotification
 from omnibase_core.models.projectors import (
@@ -67,6 +69,10 @@ MODELS: dict[str, type[BaseModel]] = {
     "ModelRendererCapabilityContract": ModelRendererCapabilityContract,
     # Versioned design-token contract (OMN-13389)
     "ModelRendererThemeContract": ModelRendererThemeContract,
+    # One versioned widget envelope — the unit Plane 1 distributes; carries the
+    # config half ModelComponentContract never had (OMN-16883, Phase C2)
+    "ModelWidgetEnvelope": ModelWidgetEnvelope,
+    "ModelWidgetProvenance": ModelWidgetProvenance,
     # Review Packet + OmniStudio Evidence Bundle (OMN-13387)
     "ModelReviewPacket": ModelReviewPacket,
     "ModelOmniStudioEvidenceBundle": ModelOmniStudioEvidenceBundle,

--- a/scripts/emit_ts_types.py
+++ b/scripts/emit_ts_types.py
@@ -88,6 +88,26 @@ MODELS: dict[str, type[BaseModel]] = {
 }
 
 
+def _combined_defs() -> dict[str, object]:
+    """Build root-level definitions so nested ``#/$defs/...`` refs resolve."""
+    defs: dict[str, object] = {}
+    for name, model in MODELS.items():
+        schema = model.model_json_schema()
+        nested_defs = schema.pop("$defs", {})
+        if not isinstance(nested_defs, dict):
+            raise TypeError(f"{name} emitted non-object $defs")
+        for nested_name, nested_schema in nested_defs.items():
+            existing = defs.get(nested_name)
+            if existing is not None and existing != nested_schema:
+                raise ValueError(f"conflicting nested schema for {nested_name}")
+            defs[nested_name] = nested_schema
+        existing = defs.get(name)
+        if existing is not None and existing != schema:
+            raise ValueError(f"conflicting schema for {name}")
+        defs[name] = schema
+    return defs
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         print("usage: emit_ts_types.py <output_json_path>", file=sys.stderr)
@@ -95,7 +115,7 @@ def main() -> int:
     output = Path(sys.argv[1])
     combined = {
         "$id": "https://omninode.ai/schemas/omnidash-v2.json",
-        "$defs": {name: model.model_json_schema() for name, model in MODELS.items()},
+        "$defs": _combined_defs(),
     }
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(combined, indent=2))

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -116,6 +116,10 @@ from omnibase_core.models.dashboard.model_widget_definition import (
     ModelWidgetConfig,
     ModelWidgetDefinition,
 )
+from omnibase_core.models.dashboard.model_widget_envelope import ModelWidgetEnvelope
+from omnibase_core.models.dashboard.model_widget_provenance import (
+    ModelWidgetProvenance,
+)
 
 __all__: tuple[str, ...] = (
     # Dashboard Configuration
@@ -154,6 +158,10 @@ __all__: tuple[str, ...] = (
     "ModelRendererCapabilityContract",
     # Versioned design-token contract (OMN-13389)
     "ModelRendererThemeContract",
+    # One versioned widget envelope — the unit Plane 1 distributes
+    # (OMN-16883, Phase C2)
+    "ModelWidgetEnvelope",
+    "ModelWidgetProvenance",
     # Review Packet + OmniStudio Evidence Bundle (OMN-13387)
     "ModelReviewPacket",
     "ModelOmniStudioEvidenceBundle",

--- a/src/omnibase_core/models/dashboard/model_widget_envelope.py
+++ b/src/omnibase_core/models/dashboard/model_widget_envelope.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""WidgetEnvelope — one object that is a whole widget (OMN-16883, Phase C2).
+
+Two shipped contracts each held half a widget and neither held the other half
+(plan §1.4.2):
+
+* ``ModelComponentContract`` — identity, kind, contract version, bindings,
+  actions, permission, evidence, empty-state reasons. **No config.**
+* ``ModelWidgetDefinition`` — config and grid placement. **No bindings, no
+  actions, no component-contract version, no provenance, no hash.**
+
+So "a pack ships a widget contract" named no object, and half a widget had to
+travel out-of-band. ``ModelWidgetEnvelope`` is the missing whole: the unit
+Plane 1 distributes.
+
+**What it deliberately does not carry: grid placement.** Row/column/span are a
+*dashboard's* facts about where it put a widget, not the widget's own facts, and
+D9 assigns layout to the frame. ``ModelWidgetDefinition`` therefore keeps its
+placement role and is neither subsumed nor shimmed here; what moves into the
+envelope is the *contract* half — config, bindings, actions, versions, origin.
+
+**The seal.** ``content_digest`` covers every other field, so a consumer can
+decide whether a discovered widget is the bytes its publisher sealed without
+trusting the publisher to say so. It is computed over the envelope's canonical
+JSON with ``content_digest`` excluded — a hash cannot cover itself. Use
+``omnibase_core.utils.util_widget_envelope.seal_widget_envelope`` to build one
+and ``verify_widget_envelope`` to check one; a mismatch is an error, never a
+recomputation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.models.dashboard.model_widget_definition import ModelWidgetConfig
+from omnibase_core.models.dashboard.model_widget_provenance import ModelWidgetProvenance
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelWidgetEnvelope", "WIDGET_ENVELOPE_DIGEST_PATTERN"]
+
+#: Seals are ``sha256:<64 lowercase hex chars>``.
+WIDGET_ENVELOPE_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ModelWidgetEnvelope(BaseModel):
+    """A complete, versioned, sealed widget contract.
+
+    Three versions live here and they answer different questions:
+    ``envelope_version`` is the version of *this format*, ``widget_version`` is
+    the version of *this widget as published*, and
+    ``component.contract_version`` is the version of the *component contract*
+    the widget binds. A consumer that must reject an envelope it cannot parse
+    reads the first; a consumer choosing between two published widgets reads the
+    second; a renderer deciding whether it can render at all reads the third.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    envelope_version: ModelSemVer = Field(
+        ...,
+        description="Version of the envelope format itself, not of any widget",
+    )
+    widget_id: str = Field(  # string-id-ok: namespaced widget label, not a UUID
+        ...,
+        description="Stable, namespaced widget identifier (e.g. 'onex.widget.system_health')",
+        min_length=1,
+    )
+    widget_version: ModelSemVer = Field(
+        ...,
+        description="Version of this widget as published by its pack",
+    )
+    component: ModelComponentContract = Field(
+        ...,
+        description=(
+            "Component contract half: identity, kind, bindings, actions, "
+            "permission, evidence requirements, empty-state reasons"
+        ),
+    )
+    config: ModelWidgetConfig = Field(
+        ...,
+        description="Discriminated widget configuration, keyed by config_kind",
+    )
+    provenance: ModelWidgetProvenance = Field(
+        ...,
+        description="Which pack published this widget, at which source revision",
+    )
+    content_digest: str = Field(
+        ...,
+        description=(
+            "SHA-256 over this envelope's canonical JSON excluding this field, "
+            "as 'sha256:<hex>'. Lets a consumer validate a discovered widget "
+            "without trusting the publisher."
+        ),
+    )
+
+    @field_validator("content_digest")
+    @classmethod
+    def validate_content_digest(cls, value: str) -> str:
+        """Reject anything that is not a ``sha256:<hex>`` seal.
+
+        Raises:
+            ValueError: If ``value`` does not match the digest pattern.
+        """
+        if not WIDGET_ENVELOPE_DIGEST_PATTERN.match(value):
+            raise ValueError(
+                f"content_digest must match 'sha256:<64 hex chars>', got '{value}'"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def validate_component_kind_matches_config(self) -> Self:
+        """Fail closed when the declared kind and the config disagree.
+
+        The component kind is what a renderer gates on; the config discriminator
+        is what a parser keys on. An envelope where they disagree renders one
+        thing and validates as another, which is precisely the out-of-band
+        half-widget this model exists to end.
+
+        Raises:
+            ValueError: If ``component.component_kind`` does not equal the
+                config's ``config_kind``.
+        """
+        if self.component.component_kind.value != self.config.config_kind:
+            raise ValueError(
+                f"component_kind '{self.component.component_kind.value}' does not "
+                f"match config_kind '{self.config.config_kind}'"
+            )
+        return self

--- a/src/omnibase_core/models/dashboard/model_widget_provenance.py
+++ b/src/omnibase_core/models/dashboard/model_widget_provenance.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""WidgetProvenance — who published a widget, and from which bytes (OMN-16883).
+
+A widget envelope crosses Plane 1 — the contract plane a marketplace
+distributes. A consumer that cannot say *which pack published this and from
+which source revision* is trusting the publisher, which is the failure
+distributing contracts rather than code exists to avoid.
+
+The source revision is a **full** 40-character git object id on purpose. An
+abbreviated revision is ambiguous by construction — it names a prefix, not a
+commit — and provenance that cannot be resolved back to exact bytes is
+decoration.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelWidgetProvenance", "WIDGET_SOURCE_REVISION_PATTERN"]
+
+#: A full, unabbreviated git object id.
+WIDGET_SOURCE_REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ModelWidgetProvenance(BaseModel):
+    """Publishing origin of a widget envelope."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    pack_namespace: str = Field(  # string-id-ok: namespaced pack label, not a UUID
+        ...,
+        description="Namespace that published this widget (e.g. 'onex.packs.platform')",
+        min_length=1,
+    )
+    pack_name: str = Field(  # string-id-ok: semantic pack label, not a UUID
+        ...,
+        description="Name of the publishing pack within its namespace",
+        min_length=1,
+    )
+    pack_version: ModelSemVer = Field(
+        ...,
+        description="Version of the publishing pack this widget shipped in",
+    )
+    source_revision: str = Field(
+        ...,
+        description=(
+            "Full 40-character git object id of the source the pack was built "
+            "from. Abbreviated revisions are rejected: they name a prefix, not "
+            "a commit."
+        ),
+    )
+
+    @field_validator("source_revision")
+    @classmethod
+    def validate_source_revision(cls, value: str) -> str:
+        """Reject anything that is not a full git object id.
+
+        Raises:
+            ValueError: If ``value`` is not 40 lowercase hex characters.
+        """
+        if not WIDGET_SOURCE_REVISION_PATTERN.match(value):
+            raise ValueError(
+                f"source_revision must be a full 40-character lowercase git "
+                f"object id, got '{value}'"
+            )
+        return value

--- a/src/omnibase_core/models/dashboard/model_widget_provenance.py
+++ b/src/omnibase_core/models/dashboard/model_widget_provenance.py
@@ -54,6 +54,9 @@ class ModelWidgetProvenance(BaseModel):
             "from. Abbreviated revisions are rejected: they name a prefix, not "
             "a commit."
         ),
+        min_length=40,
+        max_length=40,
+        pattern=WIDGET_SOURCE_REVISION_PATTERN.pattern,
     )
 
     @field_validator("source_revision")
@@ -64,7 +67,7 @@ class ModelWidgetProvenance(BaseModel):
         Raises:
             ValueError: If ``value`` is not 40 lowercase hex characters.
         """
-        if not WIDGET_SOURCE_REVISION_PATTERN.match(value):
+        if not WIDGET_SOURCE_REVISION_PATTERN.fullmatch(value):
             raise ValueError(
                 f"source_revision must be a full 40-character lowercase git "
                 f"object id, got '{value}'"

--- a/src/omnibase_core/utils/util_widget_envelope.py
+++ b/src/omnibase_core/utils/util_widget_envelope.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Sealing and verifying widget envelopes (OMN-16883, Phase C2).
+
+The seal is what makes a discovered widget judgeable without trusting whoever
+published it: a consumer recomputes the digest over the bytes it received and
+compares. A mismatch is an error — never a silent re-seal, because re-sealing
+tampered bytes is exactly how a supply chain launders an edit.
+
+Digest — ``sha256`` over the RFC-8785-compatible canonical JSON of the envelope
+with ``content_digest`` excluded (``compute_canonical_hash``), never over raw
+transport bytes. Two consumers that received the same envelope through different
+JSON writers must agree, and formatting churn must not read as an edit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.models.dashboard.model_widget_definition import ModelWidgetConfig
+from omnibase_core.models.dashboard.model_widget_envelope import ModelWidgetEnvelope
+from omnibase_core.models.dashboard.model_widget_provenance import ModelWidgetProvenance
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.utils.util_canonical_hash import compute_canonical_hash
+
+__all__ = [
+    "WIDGET_ENVELOPE_FORMAT_VERSION",
+    "compute_widget_envelope_digest",
+    "seal_widget_envelope",
+    "verify_widget_envelope",
+]
+
+#: Version of the envelope FORMAT — bumped when envelope fields change, never
+#: when a widget's own content does.
+WIDGET_ENVELOPE_FORMAT_VERSION: ModelSemVer = ModelSemVer(major=1, minor=0, patch=0)
+
+#: The seal cannot cover itself.
+_UNSEALED_FIELDS: set[str] = {"content_digest"}
+
+#: Placeholder used only to build the pre-seal draft; excluded from the digest.
+_PLACEHOLDER_DIGEST = f"sha256:{'0' * 64}"
+
+
+def _digest_payload(payload: Mapping[str, object]) -> str:
+    """Return the ``sha256:<hex>`` digest of an unsealed envelope payload."""
+    return f"sha256:{compute_canonical_hash(payload)}"
+
+
+def compute_widget_envelope_digest(envelope: ModelWidgetEnvelope) -> str:
+    """Return the seal an envelope's content implies.
+
+    Args:
+        envelope: The envelope to digest. Its own ``content_digest`` is excluded
+            from the computation.
+
+    Returns:
+        The digest as ``sha256:<64 lowercase hex chars>``.
+    """
+    return _digest_payload(envelope.model_dump(mode="json", exclude=_UNSEALED_FIELDS))
+
+
+def seal_widget_envelope(
+    *,
+    widget_id: str,
+    widget_version: ModelSemVer,
+    component: ModelComponentContract,
+    config: ModelWidgetConfig,
+    provenance: ModelWidgetProvenance,
+    envelope_version: ModelSemVer = WIDGET_ENVELOPE_FORMAT_VERSION,
+) -> ModelWidgetEnvelope:
+    """Build a sealed envelope from a widget's parts.
+
+    Every cross-field rule (kind/config agreement, provenance shape) is enforced
+    on the draft before the seal is computed, so a sealed envelope is never a
+    sealed contradiction.
+
+    Args:
+        widget_id: Stable, namespaced widget identifier.
+        widget_version: Version of this widget as published.
+        component: The component contract half — bindings, actions, permission.
+        config: Discriminated widget configuration.
+        provenance: Publishing pack and source revision.
+        envelope_version: Envelope format version; defaults to the current one.
+
+    Returns:
+        The sealed envelope.
+
+    Raises:
+        pydantic.ValidationError: If the parts do not form a valid widget.
+    """
+    draft = ModelWidgetEnvelope(
+        envelope_version=envelope_version,
+        widget_id=widget_id,
+        widget_version=widget_version,
+        component=component,
+        config=config,
+        provenance=provenance,
+        content_digest=_PLACEHOLDER_DIGEST,
+    )
+    payload = draft.model_dump(mode="json", exclude=_UNSEALED_FIELDS)
+    return ModelWidgetEnvelope.model_validate(
+        {**payload, "content_digest": _digest_payload(payload)}
+    )
+
+
+def verify_widget_envelope(envelope: ModelWidgetEnvelope) -> None:
+    """Check that an envelope's content still matches its seal.
+
+    Args:
+        envelope: The envelope to verify.
+
+    Raises:
+        ModelOnexError: If the recomputed digest differs from the declared one —
+            the envelope was edited after it was sealed.
+    """
+    recomputed = compute_widget_envelope_digest(envelope)
+    if recomputed != envelope.content_digest:
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.VALIDATION_ERROR,
+            message=(
+                f"widget '{envelope.widget_id}' fails its seal: declared "
+                f"content_digest {envelope.content_digest} but its content "
+                f"digests to {recomputed}; the envelope was edited after sealing"
+            ),
+        )

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -38,6 +38,9 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     "ModelRendererCapabilityContract",
     # Versioned design-token contract (OMN-13389)
     "ModelRendererThemeContract",
+    # One versioned widget envelope (OMN-16883 — Phase C2)
+    "ModelWidgetEnvelope",
+    "ModelWidgetProvenance",
     # Review Packet + OmniStudio Evidence Bundle (OMN-13387)
     "ModelReviewPacket",
     "ModelOmniStudioEvidenceBundle",

--- a/tests/unit/models/dashboard/test_widget_envelope.py
+++ b/tests/unit/models/dashboard/test_widget_envelope.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""One versioned widget envelope — the unit Plane 1 distributes (OMN-16883, Phase C2).
+
+Two shipped contracts each hold half a widget: ``ModelComponentContract`` has
+bindings and actions but no config; ``ModelWidgetDefinition`` has config and grid
+placement but no bindings, no actions, no component version, no provenance, and
+no hash. Nothing held a whole one, so "a pack ships a widget contract" named no
+object.
+
+These tests pin the envelope that does, and gate **GC.3**: the envelope
+round-trips Python → JSON Schema → a validated discovered widget, with the seal
+proving the bytes were not edited in transit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_empty_state_reason import EnumEmptyStateReason
+from omnibase_core.enums.enum_widget_type import EnumWidgetType
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard.model_component_contract import (
+    ModelComponentContract,
+)
+from omnibase_core.models.dashboard.model_data_binding_contract import (
+    ModelDataBindingContract,
+)
+from omnibase_core.models.dashboard.model_widget_config_metric_card import (
+    ModelWidgetConfigMetricCard,
+)
+from omnibase_core.models.dashboard.model_widget_config_table import (
+    ModelWidgetConfigTable,
+)
+from omnibase_core.models.dashboard.model_widget_envelope import ModelWidgetEnvelope
+from omnibase_core.models.dashboard.model_widget_provenance import ModelWidgetProvenance
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.utils.util_widget_envelope import (
+    compute_widget_envelope_digest,
+    seal_widget_envelope,
+    verify_widget_envelope,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SOURCE_REVISION = "b7d3f0a1c9e24a6f8b1d5c3e7a9f2b4d6c8e0a13"
+
+
+def _component(
+    kind: EnumWidgetType = EnumWidgetType.TABLE,
+) -> ModelComponentContract:
+    """A component contract with bindings, actions, and empty-state reasons."""
+    return ModelComponentContract(
+        component_id="onex.component.system_health",
+        component_kind=kind,
+        title="System Health",
+        contract_version=ModelSemVer(major=1, minor=2, patch=0),
+        data_bindings=(
+            ModelDataBindingContract(
+                binding_id="consumer_flow",
+                projection_topic="onex.projection.consumer_flow",
+                ordering_authority_field="observed_at",
+                required_fields=("consumer_group", "classification"),
+            ),
+        ),
+        supported_empty_state_reasons=(EnumEmptyStateReason.NO_DATA,),
+    )
+
+
+def _provenance() -> ModelWidgetProvenance:
+    return ModelWidgetProvenance(
+        pack_namespace="onex.packs.platform",
+        pack_name="system-health",
+        pack_version=ModelSemVer(major=0, minor=4, patch=1),
+        source_revision=_SOURCE_REVISION,
+    )
+
+
+def _config(kind: EnumWidgetType) -> Any:
+    """A config of the requested kind.
+
+    ``STATUS_GRID`` is deliberately absent: ``ModelWidgetConfigStatusGrid``
+    cannot be JSON-serialised at all today, because ``status_colors`` defaults
+    to a ``MappingProxyType`` of raw hex that Pydantic refuses in ``mode="json"``
+    (`PydanticSerializationError: Unable to serialize unknown type:
+    mappingproxy`). OMN-16884 (Phase C3) removes that default; until it lands, a
+    status-grid widget cannot cross the wire an envelope exists to cross.
+    """
+    if kind is EnumWidgetType.TABLE:
+        return ModelWidgetConfigTable()
+    return ModelWidgetConfigMetricCard(metric_key="queue_depth", label="Queue depth")
+
+
+def _envelope(kind: EnumWidgetType = EnumWidgetType.TABLE) -> ModelWidgetEnvelope:
+    """A sealed envelope for one published widget."""
+    config: Any = _config(kind)
+    return seal_widget_envelope(
+        widget_id="onex.widget.system_health",
+        widget_version=ModelSemVer(major=1, minor=0, patch=0),
+        component=_component(kind),
+        config=config,
+        provenance=_provenance(),
+    )
+
+
+@pytest.mark.unit
+class TestEnvelopeIsAWholeWidget:
+    """One object carries every half a widget was previously split across."""
+
+    def test_envelope_carries_identity_kind_config_bindings_and_provenance(
+        self,
+    ) -> None:
+        envelope = _envelope()
+
+        assert envelope.widget_id == "onex.widget.system_health"
+        assert envelope.widget_version == ModelSemVer(major=1, minor=0, patch=0)
+        assert envelope.component.component_kind is EnumWidgetType.TABLE
+        # The half ModelComponentContract never had:
+        assert envelope.config.config_kind == "table"
+        # The half ModelWidgetDefinition never had:
+        assert envelope.component.data_bindings[0].binding_id == "consumer_flow"
+        assert envelope.component.contract_version == ModelSemVer(
+            major=1, minor=2, patch=0
+        )
+        assert envelope.provenance.pack_namespace == "onex.packs.platform"
+        assert envelope.provenance.source_revision == _SOURCE_REVISION
+        assert envelope.content_digest.startswith("sha256:")
+
+    def test_config_is_the_discriminated_union_not_an_untyped_blob(self) -> None:
+        """A metric-card envelope deserializes to the metric-card config, by discriminator."""
+        payload = _envelope(EnumWidgetType.METRIC_CARD).model_dump(mode="json")
+
+        restored = ModelWidgetEnvelope.model_validate(payload)
+
+        assert isinstance(restored.config, ModelWidgetConfigMetricCard)
+
+    def test_envelope_is_frozen(self) -> None:
+        envelope = _envelope()
+
+        with pytest.raises(ValidationError):
+            envelope.widget_id = "other"  # type: ignore[misc]
+
+    def test_component_kind_must_agree_with_the_config_kind(self) -> None:
+        """A table component carrying a metric-card config is not a widget."""
+        with pytest.raises(ValidationError, match="component_kind"):
+            seal_widget_envelope(
+                widget_id="onex.widget.mismatch",
+                widget_version=ModelSemVer(major=1, minor=0, patch=0),
+                component=_component(EnumWidgetType.TABLE),
+                config=_config(EnumWidgetType.METRIC_CARD),
+                provenance=_provenance(),
+            )
+
+
+@pytest.mark.unit
+class TestProvenanceIsVerifiable:
+    """Provenance names a pack and an exact source revision, or it is refused."""
+
+    def test_abbreviated_source_revision_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="source_revision"):
+            ModelWidgetProvenance(
+                pack_namespace="onex.packs.platform",
+                pack_name="system-health",
+                pack_version=ModelSemVer(major=0, minor=4, patch=1),
+                source_revision=_SOURCE_REVISION[:7],
+            )
+
+    def test_provenance_is_required_on_the_envelope(self) -> None:
+        payload = _envelope().model_dump(mode="json")
+        del payload["provenance"]
+
+        with pytest.raises(ValidationError, match="provenance"):
+            ModelWidgetEnvelope.model_validate(payload)
+
+
+@pytest.mark.unit
+class TestSealDetectsTampering:
+    """The hash is what lets a consumer skip trusting the publisher."""
+
+    def test_seal_is_deterministic_across_independent_seals(self) -> None:
+        assert _envelope().content_digest == _envelope().content_digest
+
+    def test_seal_survives_a_serialize_reload_round_trip(self) -> None:
+        envelope = _envelope()
+
+        restored = ModelWidgetEnvelope.model_validate(
+            json.loads(envelope.model_dump_json())
+        )
+
+        assert restored.content_digest == envelope.content_digest
+        verify_widget_envelope(restored)
+
+    def test_seal_does_not_cover_itself(self) -> None:
+        """The digest is computed over every field except the digest."""
+        envelope = _envelope()
+
+        assert compute_widget_envelope_digest(envelope) == envelope.content_digest
+
+    def test_an_edited_config_fails_verification(self) -> None:
+        """A publisher-side edit after sealing is caught by the consumer."""
+        payload = _envelope().model_dump(mode="json")
+        payload["config"]["page_size"] = 100
+
+        tampered = ModelWidgetEnvelope.model_validate(payload)
+
+        with pytest.raises(ModelOnexError, match="content_digest"):
+            verify_widget_envelope(tampered)
+
+    def test_an_edited_binding_fails_verification(self) -> None:
+        """Repointing a binding at another projection is a tamper, not a config tweak."""
+        payload = _envelope().model_dump(mode="json")
+        payload["component"]["data_bindings"][0]["projection_topic"] = (
+            "onex.projection.other"
+        )
+
+        tampered = ModelWidgetEnvelope.model_validate(payload)
+
+        with pytest.raises(ModelOnexError, match="content_digest"):
+            verify_widget_envelope(tampered)
+
+    def test_a_malformed_digest_is_rejected_at_construction(self) -> None:
+        payload = _envelope().model_dump(mode="json")
+        payload["content_digest"] = "deadbeef"
+
+        with pytest.raises(ValidationError, match="content_digest"):
+            ModelWidgetEnvelope.model_validate(payload)
+
+
+@pytest.mark.unit
+class TestGateGC3:
+    """GC.3 — Python → JSON Schema → a validated discovered widget."""
+
+    @staticmethod
+    def _emitter_models() -> dict[str, type[BaseModel]]:
+        path = _REPO_ROOT / "scripts" / "emit_ts_types.py"
+        spec = importlib.util.spec_from_file_location("_emit_ts_probe_envelope", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        models: dict[str, type[BaseModel]] = dict(module.MODELS)
+        return models
+
+    def test_emitter_registers_the_envelope_and_its_provenance(self) -> None:
+        models = self._emitter_models()
+
+        assert "ModelWidgetEnvelope" in models
+        assert "ModelWidgetProvenance" in models
+
+    def test_emitted_schema_validates_a_discovered_widget(self, tmp_path: Path) -> None:
+        """The full pipeline: run the emitter, validate a widget against its output.
+
+        This is the consumer's position — a JSON document arrives, and the only
+        thing available to judge it is the emitted schema plus the seal. No
+        publisher is trusted at any step.
+        """
+        output = tmp_path / "onex-models.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_REPO_ROOT / "scripts" / "emit_ts_types.py"),
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+        combined = json.loads(output.read_text())
+        envelope_schema = combined["$defs"]["ModelWidgetEnvelope"]
+        discovered: dict[str, Any] = json.loads(_envelope().model_dump_json())
+
+        jsonschema.validate(instance=discovered, schema=envelope_schema)
+
+        # …and the consumer can then parse it into typed objects and check the seal.
+        parsed = ModelWidgetEnvelope.model_validate(discovered)
+        verify_widget_envelope(parsed)
+        assert isinstance(parsed.config, ModelWidgetConfigTable)
+
+    def test_emitted_schema_rejects_a_widget_whose_config_kind_is_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        """A config kind outside the union is not silently accepted as extra data."""
+        output = tmp_path / "onex-models.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(_REPO_ROOT / "scripts" / "emit_ts_types.py"),
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        combined = json.loads(output.read_text())
+        envelope_schema = combined["$defs"]["ModelWidgetEnvelope"]
+        discovered: dict[str, Any] = json.loads(_envelope().model_dump_json())
+        discovered["config"]["config_kind"] = "sparkline"
+
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=discovered, schema=envelope_schema)

--- a/tests/unit/models/dashboard/test_widget_envelope.py
+++ b/tests/unit/models/dashboard/test_widget_envelope.py
@@ -174,6 +174,23 @@ class TestProvenanceIsVerifiable:
                 source_revision=_SOURCE_REVISION[:7],
             )
 
+    def test_source_revision_with_trailing_newline_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="source_revision"):
+            ModelWidgetProvenance(
+                pack_namespace="onex.packs.platform",
+                pack_name="system-health",
+                pack_version=ModelSemVer(major=0, minor=4, patch=1),
+                source_revision=f"{_SOURCE_REVISION}\n",
+            )
+
+    def test_source_revision_schema_exposes_exact_hex_constraints(self) -> None:
+        schema = ModelWidgetProvenance.model_json_schema()
+        source_revision = schema["properties"]["source_revision"]
+
+        assert source_revision["minLength"] == 40
+        assert source_revision["maxLength"] == 40
+        assert source_revision["pattern"] == r"^[0-9a-f]{40}$"
+
     def test_provenance_is_required_on_the_envelope(self) -> None:
         payload = _envelope().model_dump(mode="json")
         del payload["provenance"]
@@ -276,10 +293,15 @@ class TestGateGC3:
         assert result.returncode == 0, result.stderr
 
         combined = json.loads(output.read_text())
-        envelope_schema = combined["$defs"]["ModelWidgetEnvelope"]
+        envelope_schema = {**combined, "$ref": "#/$defs/ModelWidgetEnvelope"}
+        provenance_schema = {**combined, "$ref": "#/$defs/ModelWidgetProvenance"}
         discovered: dict[str, Any] = json.loads(_envelope().model_dump_json())
 
         jsonschema.validate(instance=discovered, schema=envelope_schema)
+        jsonschema.validate(
+            instance=discovered["provenance"],
+            schema=provenance_schema,
+        )
 
         # …and the consumer can then parse it into typed objects and check the seal.
         parsed = ModelWidgetEnvelope.model_validate(discovered)
@@ -302,7 +324,7 @@ class TestGateGC3:
             check=True,
         )
         combined = json.loads(output.read_text())
-        envelope_schema = combined["$defs"]["ModelWidgetEnvelope"]
+        envelope_schema = {**combined, "$ref": "#/$defs/ModelWidgetEnvelope"}
         discovered: dict[str, Any] = json.loads(_envelope().model_dump_json())
         discovered["config"]["config_kind"] = "sparkline"
 

--- a/tests/unit/models/dashboard/test_widget_envelope.py
+++ b/tests/unit/models/dashboard/test_widget_envelope.py
@@ -52,7 +52,8 @@ from omnibase_core.utils.util_widget_envelope import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-_SOURCE_REVISION = "b7d3f0a1c9e24a6f8b1d5c3e7a9f2b4d6c8e0a13"
+# A synthetic 40-hex git object id used as provenance test data, not a credential.
+_SOURCE_REVISION = "0" * 40
 
 
 def _component(


### PR DESCRIPTION
## Summary

Closes **OMN-16883** (Phase C2 of epic OMN-16879, plan `omni_home/docs/plans/2026-08-27-omnidash-component-rework-plan.md` §1.4.2 / Phase C item C2).

Two shipped contracts each held **half a widget**, and nothing held a whole one:

| Model | Has | Lacks |
|---|---|---|
| `ModelComponentContract` | identity, kind, contract version, bindings, actions, permission, evidence, empty-state reasons | **no config** |
| `ModelWidgetDefinition` | config, grid placement, untyped `data_source: str \| None` | **no bindings, no actions, no component version, no provenance, no hash** |

So "a pack ships a widget contract" named no object, and half a widget had to travel out-of-band — the reachability failure of §1.7 wearing a new label. `ModelWidgetEnvelope` is the whole: the unit Plane 1 distributes.

## What lands

| Object | Role |
|---|---|
| `ModelWidgetEnvelope` | identity, three distinct versions (envelope format / widget / component contract), the component-contract half, the **discriminated** `ModelWidgetConfig` union, provenance, and a content seal. `component_kind` and `config_kind` must agree or the envelope is refused — one that renders as one kind and parses as another is the same out-of-band half-widget in one object's clothing. |
| `ModelWidgetProvenance` | publishing namespace, pack, pack version, and a **full 40-character** git object id. Abbreviated revisions are rejected: they name a prefix, not a commit, and provenance that cannot resolve to exact bytes is decoration. |
| `utils/util_widget_envelope.py` | `seal_widget_envelope` / `compute_widget_envelope_digest` / `verify_widget_envelope`. |
| `scripts/emit_ts_types.py` | registers `ModelWidgetEnvelope` + `ModelWidgetProvenance`. |

## The seal

`sha256` over the envelope's canonical JSON **excluding `content_digest`** — a hash cannot cover itself — so two consumers that received the same envelope through different JSON writers agree, and formatting churn does not read as an edit. A mismatch **raises**; it is never silently re-sealed, because re-sealing tampered bytes is exactly how a supply chain launders an edit. Cross-field rules are enforced on the draft *before* the seal is computed, so a sealed envelope is never a sealed contradiction.

## Two scope decisions, made and documented rather than escalated

**1. Grid placement is deliberately not in the envelope.** Row/column/span are a *dashboard's* facts about where it put a widget, and D9 assigns layout to the frame ("omnidash owns the shell, layout, dashboard CRUD…"). `ModelWidgetDefinition` therefore keeps its placement role: it is **not** subsumed, so nothing is deleted and no re-export shim is added. What moved into the envelope is the *contract* half — config, bindings, actions, versions, origin. Whether `ModelDashboardConfig` later becomes envelope-referencing placements is Phase 2/3 work and is gated by the persisted-layout migration (D6's hard precondition), not something to smuggle in here.

**2. `ModelWidgetConfigStatusGrid` is excluded from the fixtures, and why is a finding.** A status-grid config **cannot be JSON-serialised at all today**: `status_colors` defaults to a `MappingProxyType` of raw hex and `model_dump(mode="json")` raises `PydanticSerializationError: Unable to serialize unknown type: mappingproxy`. A status-grid widget therefore cannot cross the wire this envelope exists to cross. **OMN-16884 (Phase C3) removes that default**, and its test asserts the serialisation now succeeds. Recorded in the test module rather than left as a silent fixture choice.

## Gate GC.3 — proven end to end, not asserted

`test_emitted_schema_validates_a_discovered_widget` runs `scripts/emit_ts_types.py` as a subprocess, validates a sealed envelope against the emitted `$defs/ModelWidgetEnvelope` with `jsonschema`, then parses it and verifies the seal — the consumer's exact position, trusting no publisher at any step. A sibling test confirms an unknown `config_kind` is rejected by the emitted schema rather than tolerated as extra data.

## dod_evidence

- `uv run pytest tests/unit/models/dashboard/ -q` → **315 passed** (15 new in `test_widget_envelope.py`), run before push.
- Written test-first: the new module failed with `ModuleNotFoundError` before the models existed.
- `uv run ruff format` / `ruff check` clean on every changed file; `uv run mypy --strict` reports zero errors in the three new modules (repo-wide errors are pre-existing in unrelated files).
- Pre-push governed impacted-test selector (OMN-13973) escalated to the full suite and was allowed to run to completion — no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no bypass.
- Additive: no existing model, validator, or emitter symbol changes shape.

Phase C1 (OMN-16882) landed on `dev` at `f3cb4d72`. With C2 and C3, Phase 1B's envelope binding is unblocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned widget envelopes containing component configuration, provenance, and content integrity information.
  * Added widget provenance details, including publishing metadata and validated source revisions.
  * Added deterministic sealing and verification of widget content using SHA-256 digests.
  * Added public exports and JSON Schema support for the new widget models.

* **Bug Fixes**
  * Added validation to detect tampered content, invalid digests, mismatched component types, and malformed source revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Ticket: OMN-16883
Evidence-Source: OCC#7484
