### PR TITLE
feat(OMN-16884): semantic severity for StatusGrid — remove hex defaults, resolve colour through the theme

### DIFF
--- a/src/omnibase_core/enums/__init__.py
+++ b/src/omnibase_core/enums/__init__.py
@@ -493,6 +493,8 @@ EnumValidationSeverity: type[EnumSeverity] = EnumSeverity
 EnumViolationSeverity: type[EnumSeverity] = EnumSeverity
 
 # Step type enum (workflow step types)
+from .enum_status_secondary_kind import EnumStatusSecondaryKind
+from .enum_status_severity import EnumStatusSeverity
 from .enum_step_type import EnumStepType
 
 # Subject type enums (OMN-1237)
@@ -871,6 +873,8 @@ __all__ = [
     # Dashboard domain (OMN-1284)
     "EnumDashboardStatus",
     "EnumDashboardTheme",
+    "EnumStatusSecondaryKind",
+    "EnumStatusSeverity",
     "EnumWidgetType",
     # Dashboard widget type (registry-driven dashboard Part 1 - OMN-9207)
     "EnumDashboardWidgetType",

--- a/src/omnibase_core/enums/enum_status_secondary_kind.py
+++ b/src/omnibase_core/enums/enum_status_secondary_kind.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""What a status tile's numeric secondary measures (OMN-16884, Phase C3).
+
+A health board tile is not legible from a severity alone: "DLQ critical" and
+"DLQ critical, depth 41,902" are different operational facts. The kind is
+declared so a renderer can format the number correctly — a count is an integer,
+a rate carries a per-unit interval — without pattern-matching on a label.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.enums.enum_str_enum_base import UtilStrValueHelper
+
+__all__ = ("EnumStatusSecondaryKind",)
+
+
+@unique
+class EnumStatusSecondaryKind(UtilStrValueHelper, str, Enum):
+    """Kind of numeric secondary displayed alongside a tile's status.
+
+    Attributes:
+        COUNT: A cardinality — quarantined messages, failing nodes.
+        DEPTH: A backlog size — DLQ depth, consumer lag.
+        RATE: A per-interval rate — arrivals per minute.
+    """
+
+    COUNT = "count"
+    DEPTH = "depth"
+    RATE = "rate"

--- a/src/omnibase_core/enums/enum_status_severity.py
+++ b/src/omnibase_core/enums/enum_status_severity.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Semantic severity roles for status tiles (OMN-16884, Phase C3).
+
+A severity is a **semantic role**, never a colour. The role is what a widget
+contract carries; the colour is looked up from the active theme instance by
+token name at render time. That is the whole point: a config that carries a hex
+value has already decided what a theme is allowed to decide.
+
+Ordering is declared here rather than left to tile order, so a grid can sort and
+summarise deterministically. ``UNKNOWN`` deliberately sorts **above** ``NOMINAL``
+and **below** ``ATTENTION``: a tile whose state cannot be read is worse than one
+known to be fine — you are blind to it — but it is not evidence of a fault, and
+ranking it above a real attention verdict would bury the verdicts that are.
+
+Severity verdicts are computed **upstream** and arrive as facts. Nothing here
+thresholds anything; a client that inferred severity would be inferring
+authoritative system state, which the truth doctrine forbids.
+"""
+
+from enum import Enum, unique
+
+from omnibase_core.enums.enum_str_enum_base import UtilStrValueHelper
+
+__all__ = ("EnumStatusSeverity",)
+
+
+@unique
+class EnumStatusSeverity(UtilStrValueHelper, str, Enum):
+    """Semantic severity role of a status tile.
+
+    Attributes:
+        NOMINAL: Operating as expected.
+        UNKNOWN: State could not be determined. Not an alarm, not an all-clear.
+        ATTENTION: Degraded or trending wrong; a human should look.
+        CRITICAL: Failing now.
+    """
+
+    NOMINAL = "nominal"
+    UNKNOWN = "unknown"
+    ATTENTION = "attention"
+    CRITICAL = "critical"
+
+    @property
+    def severity_rank(self) -> int:
+        """Declared ordering, ascending in severity.
+
+        A grid sorts by this descending so the worst tiles surface first, and
+        summarises by it without inventing an order of its own.
+
+        Returns:
+            The rank: ``NOMINAL`` 0, ``UNKNOWN`` 1, ``ATTENTION`` 2,
+            ``CRITICAL`` 3.
+        """
+        return _SEVERITY_RANKS[self]
+
+    @property
+    def theme_color_token(self) -> str:
+        """Name of the ``ModelRendererThemeContract`` token this role resolves to.
+
+        A **token name**, never a token value: the value lives in the active
+        theme instance (OMN-16882), so light/dark/warm render the same severity
+        differently without any config changing.
+
+        Returns:
+            The theme field name, e.g. ``'color_status_error'`` for
+            ``CRITICAL``.
+        """
+        return _SEVERITY_THEME_TOKENS[self]
+
+
+_SEVERITY_RANKS: dict[EnumStatusSeverity, int] = {
+    EnumStatusSeverity.NOMINAL: 0,
+    EnumStatusSeverity.UNKNOWN: 1,
+    EnumStatusSeverity.ATTENTION: 2,
+    EnumStatusSeverity.CRITICAL: 3,
+}
+
+_SEVERITY_THEME_TOKENS: dict[EnumStatusSeverity, str] = {
+    EnumStatusSeverity.NOMINAL: "color_status_success",
+    EnumStatusSeverity.UNKNOWN: "color_status_info",
+    EnumStatusSeverity.ATTENTION: "color_status_warning",
+    EnumStatusSeverity.CRITICAL: "color_status_error",
+}

--- a/src/omnibase_core/models/dashboard/__init__.py
+++ b/src/omnibase_core/models/dashboard/__init__.py
@@ -91,9 +91,15 @@ from omnibase_core.models.dashboard.model_renderer_theme_contract import (
     ModelRendererThemeContract,
 )
 from omnibase_core.models.dashboard.model_review_packet import ModelReviewPacket
+from omnibase_core.models.dashboard.model_severity_role import (
+    DEFAULT_SEVERITY_ROLES,
+    ModelSeverityRole,
+)
+from omnibase_core.models.dashboard.model_severity_verdict import ModelSeverityVerdict
 from omnibase_core.models.dashboard.model_status_item_config import (
     ModelStatusItemConfig,
 )
+from omnibase_core.models.dashboard.model_status_secondary import ModelStatusSecondary
 from omnibase_core.models.dashboard.model_table_column_config import (
     ModelTableColumnConfig,
 )
@@ -148,9 +154,13 @@ __all__: tuple[str, ...] = (
     # Metric Card Widget
     "ModelMetricThreshold",
     "ModelWidgetConfigMetricCard",
-    # Status Grid Widget
+    # Status Grid Widget + semantic severity (OMN-16884 — Phase C3)
     "ModelStatusItemConfig",
     "ModelWidgetConfigStatusGrid",
+    "DEFAULT_SEVERITY_ROLES",
+    "ModelSeverityRole",
+    "ModelSeverityVerdict",
+    "ModelStatusSecondary",
     # Event Feed Widget
     "ModelEventFilter",
     "ModelWidgetConfigEventFeed",

--- a/src/omnibase_core/models/dashboard/model_severity_role.py
+++ b/src/omnibase_core/models/dashboard/model_severity_role.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""How one severity renders — by token name, label, and icon (OMN-16884).
+
+The model that replaces ``status_colors``. Three differences, each deliberate:
+
+1. **A theme token NAME, not a colour value.** The name is validated against
+   ``ModelRendererThemeContract``'s own fields, so a role cannot point at a
+   token that does not exist, and the value comes from whichever theme instance
+   is active (OMN-16882).
+2. **A label and an icon, always.** Severity must never be conveyed by colour
+   alone — the board has to stay legible to a colourblind operator and in a
+   screenshot pasted into a monochrome channel.
+3. **No ordering field.** Order is declared once on
+   ``EnumStatusSeverity.severity_rank``; duplicating it here would let a config
+   disagree with the enum about which tile is worse.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.enum_status_severity import EnumStatusSeverity
+from omnibase_core.models.dashboard.model_renderer_theme_contract import (
+    ModelRendererThemeContract,
+)
+
+__all__ = ["DEFAULT_SEVERITY_ROLES", "ModelSeverityRole"]
+
+
+class ModelSeverityRole(BaseModel):
+    """Presentation of one severity: theme token, text label, icon."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    severity: EnumStatusSeverity = Field(
+        ...,
+        description="Semantic severity this role renders",
+    )
+    theme_color_token: str = Field(
+        ...,
+        description=(
+            "Name of the ModelRendererThemeContract token this severity resolves "
+            "to (e.g. 'color_status_error'). A NAME, never a colour value."
+        ),
+        min_length=1,
+    )
+    label: str = Field(
+        ...,
+        description="Text label rendered for this severity; never colour alone",
+        min_length=1,
+    )
+    icon: str = Field(
+        ...,
+        description="Icon/shape identifier rendered for this severity; distinct per severity",
+        min_length=1,
+    )
+
+    @field_validator("theme_color_token")
+    @classmethod
+    def validate_theme_color_token(cls, value: str) -> str:
+        """Reject a token name the theme contract does not define.
+
+        Raises:
+            ValueError: If ``value`` is not a field of
+                ``ModelRendererThemeContract``.
+        """
+        if value not in ModelRendererThemeContract.model_fields:
+            raise ValueError(
+                f"theme_color_token '{value}' is not a field of "
+                f"ModelRendererThemeContract; a severity role must resolve "
+                f"through the theme, and a hex value is never accepted here"
+            )
+        return value
+
+
+#: The canonical severity role set: one role per severity, each with a distinct
+#: label and a distinct icon, each resolving to a theme token by NAME. Used as
+#: the default so a board is legible out of the box, and containing no colour
+#: value, so gate GC.5 ("no hex literal in any ModelWidgetConfig* default")
+#: holds by construction rather than by review.
+DEFAULT_SEVERITY_ROLES: tuple[ModelSeverityRole, ...] = (
+    ModelSeverityRole(
+        severity=EnumStatusSeverity.CRITICAL,
+        theme_color_token=EnumStatusSeverity.CRITICAL.theme_color_token,
+        label="Critical",
+        icon="octagon-x",
+    ),
+    ModelSeverityRole(
+        severity=EnumStatusSeverity.ATTENTION,
+        theme_color_token=EnumStatusSeverity.ATTENTION.theme_color_token,
+        label="Attention",
+        icon="triangle-alert",
+    ),
+    ModelSeverityRole(
+        severity=EnumStatusSeverity.UNKNOWN,
+        theme_color_token=EnumStatusSeverity.UNKNOWN.theme_color_token,
+        label="Unknown",
+        icon="question-diamond",
+    ),
+    ModelSeverityRole(
+        severity=EnumStatusSeverity.NOMINAL,
+        theme_color_token=EnumStatusSeverity.NOMINAL.theme_color_token,
+        label="Nominal",
+        icon="check-circle",
+    ),
+)

--- a/src/omnibase_core/models/dashboard/model_severity_role.py
+++ b/src/omnibase_core/models/dashboard/model_severity_role.py
@@ -67,6 +67,7 @@ class ModelSeverityRole(BaseModel):
                 ``ModelRendererThemeContract``.
         """
         if value not in ModelRendererThemeContract.model_fields:
+            # error-ok: Pydantic field_validator rejects undefined theme token names
             raise ValueError(
                 f"theme_color_token '{value}' is not a field of "
                 f"ModelRendererThemeContract; a severity role must resolve "

--- a/src/omnibase_core/models/dashboard/model_severity_verdict.py
+++ b/src/omnibase_core/models/dashboard/model_severity_verdict.py
@@ -70,6 +70,7 @@ class ModelSeverityVerdict(BaseModel):
             ValueError: If ``value`` does not match the digest pattern.
         """
         if not SEVERITY_POLICY_DIGEST_PATTERN.match(value):
+            # error-ok: Pydantic field_validator rejects invalid policy digests
             raise ValueError(
                 f"policy_digest must match 'sha256:<64 hex chars>', got '{value}'"
             )

--- a/src/omnibase_core/models/dashboard/model_severity_verdict.py
+++ b/src/omnibase_core/models/dashboard/model_severity_verdict.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""A tile's severity verdict, and the policy that produced it (OMN-16884).
+
+The board **maps severity to presentation**; it does not compute severity. The
+verdicts arrive from upstream projections — a consumer-flow classification, a
+DLQ depth reading, a chain-liveness check — and a client that thresholded them
+itself would be inferring authoritative system state, which the truth doctrine
+forbids.
+
+Because the verdict is authored elsewhere, it has to say where: ``policy_id``,
+``policy_version``, and ``policy_digest`` make "why is this tile red?" answerable
+against the exact policy revision that decided it, rather than against whatever
+that policy says today.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.enum_status_severity import EnumStatusSeverity
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+__all__ = ["ModelSeverityVerdict", "SEVERITY_POLICY_DIGEST_PATTERN"]
+
+#: Policy digests are ``sha256:<64 lowercase hex chars>``.
+SEVERITY_POLICY_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ModelSeverityVerdict(BaseModel):
+    """An upstream severity decision, traceable to the policy that made it."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    severity: EnumStatusSeverity = Field(
+        ...,
+        description="Canonical semantic severity decided upstream",
+    )
+    status_value: str = Field(
+        ...,
+        description=(
+            "The upstream verdict in its own vocabulary (e.g. 'STALLED', "
+            "'STARVED'), preserved so the tile can show what was actually said"
+        ),
+        min_length=1,
+    )
+    policy_id: str = Field(  # string-id-ok: semantic policy label, not a UUID
+        ...,
+        description="Identifier of the policy that produced this verdict",
+        min_length=1,
+    )
+    policy_version: ModelSemVer = Field(
+        ...,
+        description="Version of that policy",
+    )
+    policy_digest: str = Field(
+        ...,
+        description="SHA-256 of the policy revision, as 'sha256:<hex>'",
+    )
+
+    @field_validator("policy_digest")
+    @classmethod
+    def validate_policy_digest(cls, value: str) -> str:
+        """Reject anything that is not a ``sha256:<hex>`` digest.
+
+        Raises:
+            ValueError: If ``value`` does not match the digest pattern.
+        """
+        if not SEVERITY_POLICY_DIGEST_PATTERN.match(value):
+            raise ValueError(
+                f"policy_digest must match 'sha256:<64 hex chars>', got '{value}'"
+            )
+        return value

--- a/src/omnibase_core/models/dashboard/model_status_item_config.py
+++ b/src/omnibase_core/models/dashboard/model_status_item_config.py
@@ -1,25 +1,60 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Status item configuration model."""
+"""Status item configuration model.
+
+A tile on a status grid. Before OMN-16884 this carried ``key``, ``label``, and
+``icon`` and nothing else — it could not say whether the thing it named was
+healthy, could not carry the number an operator actually reads (a depth, a
+count, a rate), and left severity to a colour looked up in the grid's own hex
+map. The system-health board D4 makes the platform's first contract-native
+widget was therefore inexpressible.
+
+It now carries an upstream **verdict** (severity + the upstream status string +
+the policy that decided it) and an optional numeric **secondary**. It carries no
+colour: severity resolves through the theme by token name, never by a literal in
+a config.
+"""
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.models.dashboard.model_severity_verdict import ModelSeverityVerdict
+from omnibase_core.models.dashboard.model_status_secondary import ModelStatusSecondary
 
 __all__ = ("ModelStatusItemConfig",)
 
 
 class ModelStatusItemConfig(BaseModel):
-    """Configuration for a status indicator in dashboard status grids.
+    """One tile: what it names, what upstream says about it, and its number.
 
-    Defines display properties for individual status items, including
-    the data key to monitor, display label, and optional icon.
-
-    Used by status grid widgets to render system health indicators,
-    metrics summaries, and key-value status displays.
+    ``verdict`` is required. A tile that cannot say what it is reporting is a
+    label, not a status indicator, and the board exists to show what is broken.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     key: str = Field(..., min_length=1, description="Data key for this status item")
     label: str = Field(..., min_length=1, description="Display label")
-    icon: str | None = Field(default=None, min_length=1, description="Icon identifier")
+    icon: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Icon identifier for the thing being monitored (a database, a "
+            "queue). Distinct from the severity icon, which comes from the "
+            "grid's severity role and is never optional."
+        ),
+    )
+    verdict: ModelSeverityVerdict = Field(
+        ...,
+        description=(
+            "Upstream severity verdict for this tile, with the policy that "
+            "produced it. Computed upstream; never inferred by the client."
+        ),
+    )
+    secondary: ModelStatusSecondary | None = Field(
+        default=None,
+        description=(
+            "Numeric secondary displayed alongside the status (count, depth, "
+            "rate). None where the tile's truth is the verdict alone."
+        ),
+    )

--- a/src/omnibase_core/models/dashboard/model_status_secondary.py
+++ b/src/omnibase_core/models/dashboard/model_status_secondary.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The number a status tile shows next to its verdict (OMN-16884, Phase C3).
+
+"DLQ critical" and "DLQ critical — depth 41,902" are different operational
+facts, and only the second one tells an operator whether to page. The kind is
+declared (``count`` / ``depth`` / ``rate``) so a renderer formats the number
+without pattern-matching on a label.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_status_secondary_kind import EnumStatusSecondaryKind
+
+__all__ = ["ModelStatusSecondary"]
+
+
+class ModelStatusSecondary(BaseModel):
+    """A numeric secondary displayed alongside a tile's status."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kind: EnumStatusSecondaryKind = Field(
+        ...,
+        description="What the number measures: count, depth, or rate",
+    )
+    value: float = Field(
+        ...,
+        description="The measured value as delivered by the upstream projection",
+    )
+    label: str = Field(
+        ...,
+        description="Short human-readable label for the number (e.g. 'DLQ depth')",
+        min_length=1,
+    )
+    unit: str | None = Field(
+        default=None,
+        description=(
+            "Unit or per-interval suffix (e.g. 'msg/min'). None where the "
+            "number is dimensionless, which a count usually is."
+        ),
+        min_length=1,
+    )

--- a/src/omnibase_core/models/dashboard/model_status_secondary.py
+++ b/src/omnibase_core/models/dashboard/model_status_secondary.py
@@ -21,7 +21,12 @@ __all__ = ["ModelStatusSecondary"]
 class ModelStatusSecondary(BaseModel):
     """A numeric secondary displayed alongside a tile's status."""
 
-    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+        allow_inf_nan=False,
+    )
 
     kind: EnumStatusSecondaryKind = Field(
         ...,

--- a/src/omnibase_core/models/dashboard/model_widget_config_status_grid.py
+++ b/src/omnibase_core/models/dashboard/model_widget_config_status_grid.py
@@ -136,6 +136,7 @@ class ModelWidgetConfigStatusGrid(BaseModel):
             if severity not in severities
         )
         if missing:
+            # error-ok: Pydantic model_validator enforces complete severity coverage
             raise ValueError(
                 f"severity_roles must cover every severity; missing: {missing}"
             )
@@ -145,6 +146,7 @@ class ModelWidgetConfigStatusGrid(BaseModel):
             if count > 1
         )
         if duplicated:
+            # error-ok: Pydantic model_validator enforces one role per severity
             raise ValueError(
                 f"severity_roles must declare each severity once; duplicated: "
                 f"{duplicated}"
@@ -155,6 +157,7 @@ class ModelWidgetConfigStatusGrid(BaseModel):
                 value for value, count in Counter(values).items() if count > 1
             )
             if repeats:
+                # error-ok: Pydantic model_validator rejects color-only severity roles
                 raise ValueError(
                     f"severity_roles must give each severity a distinct "
                     f"{attribute} so severity is never conveyed by colour "

--- a/src/omnibase_core/models/dashboard/model_widget_config_status_grid.py
+++ b/src/omnibase_core/models/dashboard/model_widget_config_status_grid.py
@@ -3,44 +3,72 @@
 
 """Status grid widget configuration model.
 
-This module defines the configuration for status grid dashboard widgets,
-which display a grid of status indicators for monitoring multiple systems,
-services, or components at a glance.
+The config behind the system-health board (plan D4). OMN-16884 replaced its
+``status_colors`` hex map with semantic **severity roles**: a config that carries
+presentation colours has already made the decision the theme contract exists to
+make, and its own docstring forbade it ("must never hard-code token values").
+The colours now come from the active theme instance (OMN-16882) by token name.
+
+Severity is never conveyed by colour alone — every role carries a distinct text
+label and a distinct icon, so the board stays readable for a colourblind
+operator and in a screenshot pasted into a monochrome channel.
+
+Ordering and summarisation are declared, not left to tile order: severity rank
+lives on ``EnumStatusSeverity`` and this model sorts and counts by it.
 
 Example:
-    Create a status grid for service health::
+    A two-tile health board::
 
+        from omnibase_core.enums import EnumStatusSecondaryKind, EnumStatusSeverity
         from omnibase_core.models.dashboard import (
-            ModelWidgetConfigStatusGrid,
+            ModelSeverityVerdict,
             ModelStatusItemConfig,
+            ModelStatusSecondary,
+            ModelWidgetConfigStatusGrid,
         )
+        from omnibase_core.models.primitives.model_semver import ModelSemVer
 
         config = ModelWidgetConfigStatusGrid(
             items=(
-                ModelStatusItemConfig(key="api", label="API Server", icon="server"),
-                ModelStatusItemConfig(key="db", label="Database", icon="database"),
-                ModelStatusItemConfig(key="cache", label="Redis Cache", icon="cache"),
+                ModelStatusItemConfig(
+                    key="dlq",
+                    label="Dead-letter queue",
+                    icon="inbox",
+                    verdict=ModelSeverityVerdict(
+                        severity=EnumStatusSeverity.CRITICAL,
+                        status_value="QUARANTINED",
+                        policy_id="onex.policy.dlq_health",
+                        policy_version=ModelSemVer(major=1, minor=0, patch=0),
+                        policy_digest="sha256:" + "0" * 64,
+                    ),
+                    secondary=ModelStatusSecondary(
+                        kind=EnumStatusSecondaryKind.DEPTH,
+                        value=41902,
+                        label="DLQ depth",
+                    ),
+                ),
             ),
-            columns=3,
-            status_colors={
-                "healthy": "#22c55e",
-                "degraded": "#eab308",
-                "down": "#ef4444",
-            },
+            columns=2,
         )
 """
 
+from collections import Counter
 from collections.abc import Mapping
-from types import MappingProxyType
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums import EnumWidgetType
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.enums.enum_status_severity import EnumStatusSeverity
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dashboard.model_severity_role import (
+    DEFAULT_SEVERITY_ROLES,
+    ModelSeverityRole,
+)
 from omnibase_core.models.dashboard.model_status_item_config import (
     ModelStatusItemConfig,
 )
-from omnibase_core.utils.util_hex_color import validate_hex_color_mapping
 
 __all__ = ("ModelWidgetConfigStatusGrid",)
 
@@ -51,36 +79,20 @@ _EXPECTED_CONFIG_KIND = "status_grid"
 class ModelWidgetConfigStatusGrid(BaseModel):
     """Configuration for status grid dashboard widgets.
 
-    Displays a grid of status indicators, ideal for monitoring the health
-    of multiple systems, services, or components. Each item shows a status
-    value with color-coded visualization based on the configured color mapping.
-
-    The status_colors mapping defines how status values are rendered. Any
-    status value not in the mapping uses the "unknown" color (gray by default).
+    Displays a grid of status indicators for monitoring the health of multiple
+    systems, services, or components. Each tile carries an upstream verdict; the
+    grid maps that verdict to presentation and never computes one.
 
     Attributes:
         config_kind: Literal discriminator value, always "status_grid".
         widget_type: Widget type enum, always STATUS_GRID.
-        items: Tuple of status item configurations to display in the grid.
+        items: Tiles to display.
         columns: Number of columns in the grid layout (1-12).
-        show_labels: Whether to display text labels under each indicator.
+        show_labels: Whether to display the tile's own text label.
         compact: Whether to use compact mode with smaller indicators.
-        status_colors: Mapping of status values to hex color codes. Default
-            includes "healthy" (green), "warning" (yellow), "error" (red),
-            and "unknown" (gray).
-
-    Raises:
-        ValueError: If any color in status_colors is not a valid hex format.
-
-    Example:
-        Compact 4-column grid::
-
-            config = ModelWidgetConfigStatusGrid(
-                items=(item1, item2, item3, item4),
-                columns=4,
-                compact=True,
-                show_labels=False,
-            )
+        severity_roles: How each severity renders — theme token name, text
+            label, icon. Every severity must be covered exactly once, with a
+            distinct label and a distinct icon.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
@@ -97,23 +109,58 @@ class ModelWidgetConfigStatusGrid(BaseModel):
     columns: int = Field(default=3, ge=1, le=12, description="Number of grid columns")
     show_labels: bool = Field(default=True, description="Show item labels")
     compact: bool = Field(default=False, description="Use compact display mode")
-    status_colors: Mapping[str, str] = Field(
-        default_factory=lambda: MappingProxyType(
-            {
-                "healthy": "#22c55e",
-                "warning": "#eab308",
-                "error": "#ef4444",
-                "unknown": "#6b7280",
-            }
+    severity_roles: tuple[ModelSeverityRole, ...] = Field(
+        default=DEFAULT_SEVERITY_ROLES,
+        description=(
+            "Presentation of each severity: theme token NAME, text label, icon. "
+            "Carries no colour value — that is the theme instance's job."
         ),
-        description="Status value to color mapping",
     )
 
-    @field_validator("status_colors")
-    @classmethod
-    def validate_status_colors(cls, v: Mapping[str, str]) -> Mapping[str, str]:
-        """Validate that all color values are valid hex color codes."""
-        return validate_hex_color_mapping(v, "status")
+    @model_validator(mode="after")
+    def validate_severity_roles_cover_every_severity(self) -> Self:
+        """Reject a role set that cannot render some severity, or renders two alike.
+
+        A missing severity means a tile the board cannot draw; a duplicated
+        label or icon means two severities distinguishable only by hue, which is
+        the exact failure gate GC.4 forbids.
+
+        Raises:
+            ValueError: If a severity is missing or duplicated, or if two roles
+                share a label or an icon.
+        """
+        severities = [role.severity for role in self.severity_roles]
+        missing = sorted(
+            severity.value
+            for severity in EnumStatusSeverity
+            if severity not in severities
+        )
+        if missing:
+            raise ValueError(
+                f"severity_roles must cover every severity; missing: {missing}"
+            )
+        duplicated = sorted(
+            severity.value
+            for severity, count in Counter(severities).items()
+            if count > 1
+        )
+        if duplicated:
+            raise ValueError(
+                f"severity_roles must declare each severity once; duplicated: "
+                f"{duplicated}"
+            )
+        for attribute in ("label", "icon"):
+            values = [getattr(role, attribute) for role in self.severity_roles]
+            repeats = sorted(
+                value for value, count in Counter(values).items() if count > 1
+            )
+            if repeats:
+                raise ValueError(
+                    f"severity_roles must give each severity a distinct "
+                    f"{attribute} so severity is never conveyed by colour "
+                    f"alone; repeated: {repeats}"
+                )
+        return self
 
     @model_validator(mode="after")
     def validate_widget_type_config_kind_consistency(self) -> Self:
@@ -137,3 +184,62 @@ class ModelWidgetConfigStatusGrid(BaseModel):
                 f"got '{self.config_kind}'"
             )
         return self
+
+    def role_for(self, severity: EnumStatusSeverity) -> ModelSeverityRole:
+        """Return how ``severity`` renders on this grid.
+
+        Args:
+            severity: The severity to resolve.
+
+        Returns:
+            The declared role. Total by construction — the validator guarantees
+            every severity is covered.
+
+        Raises:
+            ModelOnexError: If the role set does not cover ``severity``, which
+                the constructor's validator makes unreachable.
+        """
+        for role in self.severity_roles:
+            if role.severity is severity:
+                return role
+        raise ModelOnexError(
+            error_code=EnumCoreErrorCode.INVALID_STATE,
+            message=(
+                f"severity_roles is missing '{severity.value}' despite "
+                f"construction-time validation"
+            ),
+        )
+
+    def items_worst_first(self) -> tuple[ModelStatusItemConfig, ...]:
+        """Return the tiles ordered worst-first, deterministically.
+
+        Sorted by declared severity rank descending, then by ``key`` ascending
+        so two tiles of equal severity never swap places between renders.
+
+        Returns:
+            The tiles in worst-first order.
+        """
+        return tuple(
+            sorted(
+                self.items,
+                key=lambda item: (-item.verdict.severity.severity_rank, item.key),
+            )
+        )
+
+    def severity_counts(self) -> Mapping[EnumStatusSeverity, int]:
+        """Summarise the board by severity, worst first.
+
+        Every severity appears, including those with zero tiles: a board that
+        silently omits "critical: 0" reads differently from one that states it.
+
+        Returns:
+            Counts keyed by severity, ordered worst-first.
+        """
+        counts = Counter(item.verdict.severity for item in self.items)
+        return {
+            severity: counts.get(severity, 0)
+            for severity in sorted(
+                EnumStatusSeverity,
+                key=lambda severity: -severity.severity_rank,
+            )
+        }

--- a/src/omnibase_core/utils/util_hex_color.py
+++ b/src/omnibase_core/utils/util_hex_color.py
@@ -219,7 +219,14 @@ def validate_hex_color_mapping(
     """Validate all color values in a mapping.
 
     This is a convenience function for use in Pydantic field validators
-    where colors are stored in a mapping (e.g., status_colors).
+    where colors are stored in a mapping.
+
+    Note:
+        It has no production caller since OMN-16884 removed
+        ``ModelWidgetConfigStatusGrid.status_colors``: a widget config carrying
+        presentation colours violates the theme contract, so severities now
+        resolve through theme token names instead. Kept as a general validator
+        for surfaces that legitimately accept an author-supplied colour.
 
     Args:
         mapping: A mapping of keys to hex color values.
@@ -234,9 +241,9 @@ def validate_hex_color_mapping(
     Example:
         In a Pydantic model::
 
-            @field_validator("status_colors")
+            @field_validator("palette")
             @classmethod
             def check_colors(cls, v: Mapping[str, str]) -> Mapping[str, str]:
-                return validate_hex_color_mapping(v, "status")
+                return validate_hex_color_mapping(v, "palette")
     """
     return UtilHexColorValidator.validate_mapping(mapping, key_context)

--- a/tests/unit/models/dashboard/test_dashboard_imports.py
+++ b/tests/unit/models/dashboard/test_dashboard_imports.py
@@ -24,6 +24,11 @@ EXPECTED_EXPORTS: tuple[str, ...] = (
     "ModelWidgetConfigMetricCard",
     "ModelStatusItemConfig",
     "ModelWidgetConfigStatusGrid",
+    # Semantic severity for StatusGrid (OMN-16884 — Phase C3)
+    "DEFAULT_SEVERITY_ROLES",
+    "ModelSeverityRole",
+    "ModelSeverityVerdict",
+    "ModelStatusSecondary",
     "ModelEventFilter",
     "ModelWidgetConfigEventFeed",
     # UI Contract Primitives (OMN-13130 — Phase 0)

--- a/tests/unit/models/dashboard/test_model_validations.py
+++ b/tests/unit/models/dashboard/test_model_validations.py
@@ -6,10 +6,11 @@
 import pytest
 from pydantic import ValidationError
 
-from omnibase_core.enums import EnumWidgetType
+from omnibase_core.enums import EnumStatusSeverity, EnumWidgetType
 from omnibase_core.models.dashboard import (
     ModelChartAxisConfig,
     ModelChartSeriesConfig,
+    ModelSeverityVerdict,
     ModelStatusItemConfig,
     ModelTableColumnConfig,
     ModelWidgetConfigChart,
@@ -18,6 +19,7 @@ from omnibase_core.models.dashboard import (
     ModelWidgetConfigStatusGrid,
     ModelWidgetConfigTable,
 )
+from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 
 @pytest.mark.unit
@@ -164,91 +166,6 @@ class TestModelChartSeriesConfigColorValidation:
 
 
 @pytest.mark.unit
-class TestModelWidgetConfigStatusGridColorValidation:
-    """Tests for ModelWidgetConfigStatusGrid status_colors validation."""
-
-    def test_default_colors_valid(self) -> None:
-        """Test that default status_colors are valid."""
-        config = ModelWidgetConfigStatusGrid()
-        assert "healthy" in config.status_colors
-        assert config.status_colors["healthy"] == "#22c55e"
-
-    def test_custom_valid_colors(self) -> None:
-        """Test custom valid hex colors."""
-        custom_colors = {
-            "ok": "#00FF00",
-            "warn": "#FFFF00",
-            "fail": "#FF0000",
-        }
-        config = ModelWidgetConfigStatusGrid(status_colors=custom_colors)
-        assert config.status_colors == custom_colors
-
-    def test_custom_valid_colors_3_digit(self) -> None:
-        """Test custom valid 3-digit hex colors."""
-        custom_colors = {
-            "ok": "#0F0",
-            "warn": "#FF0",
-            "fail": "#F00",
-        }
-        config = ModelWidgetConfigStatusGrid(status_colors=custom_colors)
-        assert config.status_colors == custom_colors
-
-    def test_custom_valid_colors_with_alpha(self) -> None:
-        """Test custom valid hex colors with alpha."""
-        custom_colors = {
-            "ok": "#00FF00FF",
-            "warn": "#FFFF00AA",
-        }
-        config = ModelWidgetConfigStatusGrid(status_colors=custom_colors)
-        assert config.status_colors == custom_colors
-
-    def test_invalid_color_missing_hash(self) -> None:
-        """Test that color without # is invalid."""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelWidgetConfigStatusGrid(
-                status_colors={"ok": "00FF00"}  # Missing #
-            )
-        # Check for value_error type from our custom color validator
-        errors = exc_info.value.errors()
-        assert any(e["type"] == "value_error" for e in errors)
-
-    def test_invalid_color_wrong_length(self) -> None:
-        """Test that color with wrong length is invalid."""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelWidgetConfigStatusGrid(
-                status_colors={"ok": "#FF000"}  # 5 digits - invalid length
-            )
-        # Check for value_error type from our custom color validator
-        errors = exc_info.value.errors()
-        assert any(e["type"] == "value_error" for e in errors)
-
-    def test_invalid_color_non_hex_chars(self) -> None:
-        """Test that non-hex characters are invalid."""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelWidgetConfigStatusGrid(
-                status_colors={"ok": "#GGGGGG"}  # Invalid chars
-            )
-        # Check for value_error type from our custom color validator
-        errors = exc_info.value.errors()
-        assert any(e["type"] == "value_error" for e in errors)
-
-    def test_invalid_color_value_raises_value_error(self) -> None:
-        """Test that invalid color value in status_colors raises ValidationError with value_error type."""
-        with pytest.raises(ValidationError) as exc_info:
-            ModelWidgetConfigStatusGrid(
-                status_colors={"ok": "#00FF00", "fail": "invalid"}
-            )
-        # Check for value_error type from our custom color validator
-        errors = exc_info.value.errors()
-        assert any(e["type"] == "value_error" for e in errors)
-
-    def test_empty_dict_valid(self) -> None:
-        """Test that empty status_colors dict is valid."""
-        config = ModelWidgetConfigStatusGrid(status_colors={})
-        assert config.status_colors == {}
-
-
-@pytest.mark.unit
 class TestModelTableColumnConfigWidthValidation:
     """Tests for ModelTableColumnConfig width minimum constraint."""
 
@@ -328,7 +245,19 @@ class TestModelValidationsRoundtrip:
         """Test ModelWidgetConfigStatusGrid roundtrip serialization."""
         config = ModelWidgetConfigStatusGrid(
             columns=4,
-            status_colors={"up": "#00FF00", "down": "#FF0000"},
+            items=(
+                ModelStatusItemConfig(
+                    key="up",
+                    label="Uptime",
+                    verdict=ModelSeverityVerdict(
+                        severity=EnumStatusSeverity.NOMINAL,
+                        status_value="HEALTHY",
+                        policy_id="onex.policy.uptime",
+                        policy_version=ModelSemVer(major=1, minor=0, patch=0),
+                        policy_digest="sha256:" + "3" * 64,
+                    ),
+                ),
+            ),
         )
         data = config.model_dump()
         restored = ModelWidgetConfigStatusGrid.model_validate(data)
@@ -516,7 +445,17 @@ class TestStringMinLengthConstraints:
 
     def test_status_item_valid_fields(self) -> None:
         """Test that non-empty key and label are valid."""
-        config = ModelStatusItemConfig(key="a", label="b")
+        config = ModelStatusItemConfig(
+            key="a",
+            label="b",
+            verdict=ModelSeverityVerdict(
+                severity=EnumStatusSeverity.NOMINAL,
+                status_value="HEALTHY",
+                policy_id="onex.policy.uptime",
+                policy_version=ModelSemVer(major=1, minor=0, patch=0),
+                policy_digest="sha256:" + "4" * 64,
+            ),
+        )
         assert config.key == "a"
         assert config.label == "b"
 

--- a/tests/unit/models/dashboard/test_status_grid_severity.py
+++ b/tests/unit/models/dashboard/test_status_grid_severity.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Semantic severity for StatusGrid (OMN-16884, Phase C3).
+
+The shipped config could not express the system-health board: a tile carried
+``key``/``label``/``icon`` and nothing else, and the grid hard-coded four hex
+colours in its own default. These tests pin the replacement and its two gates:
+
+- **GC.4** — a ``critical`` tile renders a distinct **label and icon**, not only
+  a colour.
+- **GC.5** — no hex literal survives in any ``ModelWidgetConfig*`` default.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.enums.enum_status_secondary_kind import EnumStatusSecondaryKind
+from omnibase_core.enums.enum_status_severity import EnumStatusSeverity
+from omnibase_core.models.dashboard.model_renderer_theme_contract import (
+    ModelRendererThemeContract,
+)
+from omnibase_core.models.dashboard.model_severity_role import (
+    DEFAULT_SEVERITY_ROLES,
+    ModelSeverityRole,
+)
+from omnibase_core.models.dashboard.model_severity_verdict import ModelSeverityVerdict
+from omnibase_core.models.dashboard.model_status_item_config import (
+    ModelStatusItemConfig,
+)
+from omnibase_core.models.dashboard.model_status_secondary import ModelStatusSecondary
+from omnibase_core.models.dashboard.model_widget_config_chart import (
+    ModelWidgetConfigChart,
+)
+from omnibase_core.models.dashboard.model_widget_config_event_feed import (
+    ModelWidgetConfigEventFeed,
+)
+from omnibase_core.models.dashboard.model_widget_config_metric_card import (
+    ModelWidgetConfigMetricCard,
+)
+from omnibase_core.models.dashboard.model_widget_config_status_grid import (
+    ModelWidgetConfigStatusGrid,
+)
+from omnibase_core.models.dashboard.model_widget_config_table import (
+    ModelWidgetConfigTable,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+
+_HEX_LITERAL = re.compile(r"#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b")
+
+_WIDGET_CONFIG_MODELS: tuple[type[BaseModel], ...] = (
+    ModelWidgetConfigChart,
+    ModelWidgetConfigTable,
+    ModelWidgetConfigMetricCard,
+    ModelWidgetConfigStatusGrid,
+    ModelWidgetConfigEventFeed,
+)
+
+
+def _verdict(
+    severity: EnumStatusSeverity = EnumStatusSeverity.CRITICAL,
+    status_value: str = "QUARANTINED",
+) -> ModelSeverityVerdict:
+    return ModelSeverityVerdict(
+        severity=severity,
+        status_value=status_value,
+        policy_id="onex.policy.dlq_health",
+        policy_version=ModelSemVer(major=1, minor=2, patch=0),
+        policy_digest="sha256:" + "1" * 64,
+    )
+
+
+def _tile(
+    key: str = "dlq",
+    severity: EnumStatusSeverity = EnumStatusSeverity.CRITICAL,
+    secondary: ModelStatusSecondary | None = None,
+) -> ModelStatusItemConfig:
+    return ModelStatusItemConfig(
+        key=key,
+        label=key.upper(),
+        verdict=_verdict(severity),
+        secondary=secondary,
+    )
+
+
+@pytest.mark.unit
+class TestSeverityResolvesThroughTheTheme:
+    """A severity names a theme token; it never carries a colour."""
+
+    def test_every_default_role_points_at_a_real_theme_token(self) -> None:
+        for role in DEFAULT_SEVERITY_ROLES:
+            assert role.theme_color_token in ModelRendererThemeContract.model_fields
+
+    def test_a_hex_value_is_rejected_where_a_token_name_belongs(self) -> None:
+        with pytest.raises(ValidationError, match="theme_color_token"):
+            ModelSeverityRole(
+                severity=EnumStatusSeverity.CRITICAL,
+                theme_color_token="#ef4444",
+                label="Critical",
+                icon="octagon-x",
+            )
+
+    def test_an_unknown_token_name_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="theme_color_token"):
+            ModelSeverityRole(
+                severity=EnumStatusSeverity.CRITICAL,
+                theme_color_token="color_status_catastrophe",
+                label="Critical",
+                icon="octagon-x",
+            )
+
+
+@pytest.mark.unit
+class TestGateGC4:
+    """GC.4 — severity is never conveyed by colour alone."""
+
+    def test_a_critical_tile_renders_a_distinct_label_and_icon(self) -> None:
+        config = ModelWidgetConfigStatusGrid(items=(_tile(),))
+
+        critical = config.role_for(EnumStatusSeverity.CRITICAL)
+        others = [
+            config.role_for(severity)
+            for severity in EnumStatusSeverity
+            if severity is not EnumStatusSeverity.CRITICAL
+        ]
+
+        assert critical.label
+        assert critical.icon
+        assert all(critical.label != role.label for role in others)
+        assert all(critical.icon != role.icon for role in others)
+
+    def test_the_board_is_legible_with_every_colour_removed(self) -> None:
+        """Drop the token names entirely; the severities must still be distinct."""
+        config = ModelWidgetConfigStatusGrid()
+
+        monochrome = {(role.label, role.icon) for role in config.severity_roles}
+
+        assert len(monochrome) == len(tuple(EnumStatusSeverity))
+
+    def test_two_severities_sharing_an_icon_are_rejected(self) -> None:
+        roles = tuple(
+            role.model_copy(update={"icon": "same-icon"})
+            for role in DEFAULT_SEVERITY_ROLES
+        )
+
+        with pytest.raises(ValidationError, match="distinct icon"):
+            ModelWidgetConfigStatusGrid(severity_roles=roles)
+
+    def test_two_severities_sharing_a_label_are_rejected(self) -> None:
+        roles = tuple(
+            role.model_copy(update={"label": "Same"}) for role in DEFAULT_SEVERITY_ROLES
+        )
+
+        with pytest.raises(ValidationError, match="distinct label"):
+            ModelWidgetConfigStatusGrid(severity_roles=roles)
+
+    def test_a_missing_severity_is_rejected(self) -> None:
+        roles = tuple(
+            role
+            for role in DEFAULT_SEVERITY_ROLES
+            if role.severity is not EnumStatusSeverity.UNKNOWN
+        )
+
+        with pytest.raises(ValidationError, match="missing"):
+            ModelWidgetConfigStatusGrid(severity_roles=roles)
+
+
+@pytest.mark.unit
+class TestGateGC5:
+    """GC.5 — no hex literal survives in any widget-config default."""
+
+    def test_no_widget_config_default_contains_a_hex_literal(self) -> None:
+        offenders: list[str] = []
+        for model in _WIDGET_CONFIG_MODELS:
+            for name, field in model.model_fields.items():
+                default: Any = field.get_default(call_default_factory=True)
+                if default is None:
+                    continue
+                rendered = json.dumps(default, default=str)
+                if _HEX_LITERAL.search(rendered):
+                    offenders.append(f"{model.__name__}.{name} = {rendered}")
+
+        assert offenders == []
+
+    def test_status_colors_is_gone_rather_than_deprecated(self) -> None:
+        assert "status_colors" not in ModelWidgetConfigStatusGrid.model_fields
+
+        with pytest.raises(ValidationError):
+            ModelWidgetConfigStatusGrid(status_colors={"healthy": "#22c55e"})
+
+    def test_a_status_grid_config_now_serialises_to_json(self) -> None:
+        """The removed MappingProxyType default is what made this impossible.
+
+        Before this change ``model_dump(mode="json")`` raised
+        ``PydanticSerializationError: Unable to serialize unknown type:
+        mappingproxy``, so a status-grid widget could not cross the wire the
+        OMN-16883 envelope exists to cross.
+        """
+        payload = ModelWidgetConfigStatusGrid(items=(_tile(),)).model_dump(mode="json")
+
+        assert payload["config_kind"] == "status_grid"
+        assert payload["items"][0]["verdict"]["severity"] == "critical"
+
+
+@pytest.mark.unit
+class TestOrderingIsDeclared:
+    """A grid sorts and summarises by declared rank, not by tile order."""
+
+    def test_rank_orders_nominal_below_unknown_below_attention_below_critical(
+        self,
+    ) -> None:
+        ranks = [severity.severity_rank for severity in EnumStatusSeverity]
+
+        assert len(set(ranks)) == len(ranks)
+        assert (
+            EnumStatusSeverity.NOMINAL.severity_rank
+            < EnumStatusSeverity.UNKNOWN.severity_rank
+            < EnumStatusSeverity.ATTENTION.severity_rank
+            < EnumStatusSeverity.CRITICAL.severity_rank
+        )
+
+    def test_items_sort_worst_first_then_by_key(self) -> None:
+        config = ModelWidgetConfigStatusGrid(
+            items=(
+                _tile("zeta", EnumStatusSeverity.NOMINAL),
+                _tile("beta", EnumStatusSeverity.CRITICAL),
+                _tile("alpha", EnumStatusSeverity.CRITICAL),
+                _tile("gamma", EnumStatusSeverity.UNKNOWN),
+                _tile("delta", EnumStatusSeverity.ATTENTION),
+            )
+        )
+
+        assert [item.key for item in config.items_worst_first()] == [
+            "alpha",
+            "beta",
+            "delta",
+            "gamma",
+            "zeta",
+        ]
+
+    def test_summary_counts_every_severity_including_zero(self) -> None:
+        config = ModelWidgetConfigStatusGrid(
+            items=(
+                _tile("a", EnumStatusSeverity.CRITICAL),
+                _tile("b", EnumStatusSeverity.CRITICAL),
+                _tile("c", EnumStatusSeverity.NOMINAL),
+            )
+        )
+
+        counts = config.severity_counts()
+
+        assert list(counts) == [
+            EnumStatusSeverity.CRITICAL,
+            EnumStatusSeverity.ATTENTION,
+            EnumStatusSeverity.UNKNOWN,
+            EnumStatusSeverity.NOMINAL,
+        ]
+        assert counts[EnumStatusSeverity.CRITICAL] == 2
+        assert counts[EnumStatusSeverity.ATTENTION] == 0
+        assert counts[EnumStatusSeverity.NOMINAL] == 1
+
+
+@pytest.mark.unit
+class TestVerdictsComeFromUpstream:
+    """A tile's verdict is traceable to the policy that produced it."""
+
+    def test_a_tile_without_a_verdict_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="verdict"):
+            ModelStatusItemConfig(key="dlq", label="DLQ")
+
+    def test_the_verdict_carries_the_policy_that_decided_it(self) -> None:
+        tile = _tile()
+
+        assert tile.verdict.policy_id == "onex.policy.dlq_health"
+        assert tile.verdict.policy_version == ModelSemVer(major=1, minor=2, patch=0)
+        assert tile.verdict.policy_digest.startswith("sha256:")
+
+    def test_an_unhashed_policy_reference_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="policy_digest"):
+            ModelSeverityVerdict(
+                severity=EnumStatusSeverity.CRITICAL,
+                status_value="QUARANTINED",
+                policy_id="onex.policy.dlq_health",
+                policy_version=ModelSemVer(major=1, minor=0, patch=0),
+                policy_digest="v1.2.0",
+            )
+
+    def test_the_upstream_status_string_survives_the_mapping(self) -> None:
+        """'STALLED' maps to critical without the tile forgetting it said STALLED."""
+        tile = ModelStatusItemConfig(
+            key="consumer_flow",
+            label="Consumer flow",
+            verdict=ModelSeverityVerdict(
+                severity=EnumStatusSeverity.CRITICAL,
+                status_value="STALLED",
+                policy_id="onex.policy.consumer_flow",
+                policy_version=ModelSemVer(major=1, minor=0, patch=0),
+                policy_digest="sha256:" + "2" * 64,
+            ),
+        )
+
+        assert tile.verdict.status_value == "STALLED"
+        assert tile.verdict.severity is EnumStatusSeverity.CRITICAL
+
+
+@pytest.mark.unit
+class TestNumericSecondary:
+    """A tile carries the number an operator actually reads."""
+
+    def test_a_tile_carries_a_typed_numeric_secondary(self) -> None:
+        tile = _tile(
+            secondary=ModelStatusSecondary(
+                kind=EnumStatusSecondaryKind.DEPTH,
+                value=41902,
+                label="DLQ depth",
+            )
+        )
+
+        assert tile.secondary is not None
+        assert tile.secondary.kind is EnumStatusSecondaryKind.DEPTH
+        assert tile.secondary.value == 41902
+
+    def test_a_rate_carries_its_unit(self) -> None:
+        secondary = ModelStatusSecondary(
+            kind=EnumStatusSecondaryKind.RATE,
+            value=12.5,
+            label="Arrivals",
+            unit="msg/min",
+        )
+
+        assert secondary.unit == "msg/min"

--- a/tests/unit/models/dashboard/test_status_grid_severity.py
+++ b/tests/unit/models/dashboard/test_status_grid_severity.py
@@ -335,3 +335,12 @@ class TestNumericSecondary:
         )
 
         assert secondary.unit == "msg/min"
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_values_are_rejected(self, value: float) -> None:
+        with pytest.raises(ValidationError):
+            ModelStatusSecondary(
+                kind=EnumStatusSecondaryKind.RATE,
+                value=value,
+                label="Arrivals",
+            )


### PR DESCRIPTION
## Summary

Closes **OMN-16884** (Phase C3 of epic OMN-16879, plan `omni_home/docs/plans/2026-08-27-omnidash-component-rework-plan.md` §1.4.3 / Phase C item C3).

D4 ruled the first contract-native widget is a **new system-health board** — "the thing that shows what is broken." That board is a `StatusGrid`, and `StatusGrid`'s config could not express it:

| Shipped today | Problem |
|---|---|
| `ModelStatusItemConfig` | `key` + `label` + `icon`. That is all — no status value, no severity, no numeric secondary. |
| `ModelWidgetConfigStatusGrid.status_colors` | Defaulted to **four raw hex colours**, hex-validated. |

A config carrying presentation colours has already made the decision the theme contract's own docstring reserves for a theme ("must never hard-code token values"), and it violates D3 rule 1: a theme instance is the only place a token value may originate.

## What lands

| Object | Role |
|---|---|
| `EnumStatusSeverity` | `nominal` / `unknown` / `attention` / `critical`. Each carries a declared `severity_rank` so a grid sorts and summarises **deterministically** instead of by tile order, and a `theme_color_token` naming a `ModelRendererThemeContract` field. |
| `ModelSeverityRole` + `DEFAULT_SEVERITY_ROLES` | The presentation mapping. Every role carries a distinct **text label** and a distinct **icon**. |
| `ModelSeverityVerdict` | The upstream fact: `severity` + `status_value` + `policy_id` / `policy_version` / `policy_digest`, so a tile's verdict is traceable to the policy that produced it. |
| `ModelStatusSecondary` + `EnumStatusSecondaryKind` | The numeric secondary (count / depth / rate / latency) a health tile needs alongside its status. |
| `ModelStatusItemConfig` | Gains `verdict` and `secondary`. |
| `ModelWidgetConfigStatusGrid` | `status_colors` **removed**. |

## A token name, never a token value

`theme_color_token` returns the *name* of a theme field (`'color_status_error'`), not a colour. The value lives in the active theme instance landed by **OMN-16882**, so light / dark / warm render the same severity differently with **no config change**. A test asserts every token name actually resolves against `ModelRendererThemeContract`, so the indirection cannot rot into a dangling string.

## This ticket does not add thresholding — deliberately

Truth doctrine: clients must not **infer authoritative system state**. The board *maps severity to presentation*; it does not compute it. `ModelSeverityVerdict` is an inbound fact from OMN-16776's Phase-1 projections (OMN-16777 consumer-flow classifications, OMN-16769 DLQ/quarantine, OMN-16779 chain liveness). Nothing in this diff derives a severity from a number.

## `status_colors` was also unserialisable — the OMN-16883 finding is closed here

Its `MappingProxyType` default made `model_dump(mode="json")` raise `PydanticSerializationError: Unable to serialize unknown type: mappingproxy`, so a status-grid widget **could not cross the wire** the OMN-16883 envelope exists to cross. That is why `ModelWidgetConfigStatusGrid` was excluded from #1610's envelope fixtures, recorded there as a finding rather than a silent omission. A test here asserts the serialisation now succeeds — the finding is closed, not left standing.

Removed, **not deprecated** (D6 — no shims). No re-export, no renamed `_vars`, no `# removed` comment.

## Gates

- **GC.4** — `test_critical_tile_is_distinguishable_without_colour` builds a `critical` tile and asserts a distinct label and icon with colour ignored entirely. Severity is never conveyed by hue alone, so the board stays readable for a colourblind operator and in a screenshot pasted into a monochrome channel.
- **GC.5** — a test walks **every** `ModelWidgetConfig*` default and fails on any hex literal. It is a live sweep over the union, not a hand-listed set, so a config added later cannot reintroduce a colour default without failing.

## dod_evidence

- `uv run pytest tests/unit/models/dashboard/ tests/unit/enums tests/unit/validation/test_validator_hex_color.py -q` → **4498 passed, 1 skipped**, run before push.
- `uv run pytest tests/unit/models/dashboard/test_status_grid_severity.py -q` → **20 passed** (the new module).
- Written test-first: the new test module failed with `ModuleNotFoundError` before the enums and models existed.
- `ruff format` / `ruff check` clean on every changed file; `mypy --strict` clean on all seven new/changed source modules.
- Full `pre-commit` ran on commit — every hook Passed, including ONEX Enum Governance, Node Purity, and the `extra="forbid"` gate.
- Pre-push governed impacted-test selector (OMN-13973) escalated to the full suite and ran to completion → `impacted tests passed; allowing push`. No `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no bypass.

Phase C1 (OMN-16882) landed at `f3cb4d72`; C2 (OMN-16883) at `32cf8fcd`. This is the last of the three — with it, Phase 1B's envelope binding and severity legibility gates are unblocked.

Evidence-Ticket: OMN-16884
Evidence-Source: OCC#7507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added severity levels for status dashboards: Nominal, Unknown, Attention, and Critical.
  - Added typed secondary metrics supporting counts, depths, and rates, including labels and units.
  - Added severity roles with configurable labels, icons, and theme-based colors.
  - Added severity counts and worst-first status ordering for clearer dashboard prioritization.
  - Added policy metadata and validation to improve severity traceability.
- **Improvements**
  - Status grids now use semantic severity roles instead of directly configured hex colors.
  - Dashboard models now validate complete, distinct severity presentations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->