### PR TITLE
chore(OMN-16914): add omninode_infra to dependency-cascade downstream matrix

### DIFF
--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -8,7 +8,7 @@
 # to pick up the new version.
 #
 # Downstream mapping:
-#   omnibase_core  -> omnibase_infra, omniintelligence, omnimemory, omniclaude, onex_change_control
+#   omnibase_core  -> omnibase_infra, omniintelligence, omnimemory, omniclaude, onex_change_control, omninode_infra
 #   omnibase_spi   -> omnibase_infra, omniintelligence, omnimemory, omniclaude
 #   omnibase_infra -> omniintelligence, omnimemory, omniclaude
 #
@@ -105,7 +105,7 @@ jobs:
 
           case "$PACKAGE" in
             omnibase_core)
-              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude", "onex_change_control"]'
+              REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude", "onex_change_control", "omninode_infra"]'
               ;;
             omnibase_spi)
               REPOS='["omnibase_infra", "omniintelligence", "omnimemory", "omniclaude"]'


### PR DESCRIPTION
## Summary

`omninode_infra` pins `omnibase-core` as a dev-only dependency
(`pyproject.toml`) but was never in
`.github/workflows/dependency-cascade.yml`'s `omnibase_core` downstream
matrix. Every other core-consuming repo gets an automated bump PR on
each core release; `omninode_infra` never did, which is exactly why its
pin sat 4 minors stale with nothing to catch it -- confirmed live: it
was pinned `>=0.42.0,<0.43.0` against a released `0.46.13`. Companion
pin-bump PR: `omninode_infra#1058` (merged), same ticket.

## Change

Add `"omninode_infra"` to the `omnibase_core` case's `REPOS` list in
`compute-matrix`, and to the docstring's downstream-mapping comment.
Scoped to the `omnibase_core` case only -- `omninode_infra` does not
depend on `omnibase-spi` or `omnibase-infra`, so those cases are
untouched (mirrors the existing `onex_change_control` precedent, which
is core-only for the same reason).

The `onexbot-occ-writer` GitHub App (used by `open-bump-pr` to push/PR
into each downstream repo) has `repository_selection: "all"` on the
`OmniNode-ai` org -- verified live via
`gh api orgs/OmniNode-ai/installations`, confirming it already has
write access to `omninode_infra` with no additional App wiring needed.

## Verification

- `tests/scripts/test_dependency_cascade_matrix.py`: 15/15 pass (parses
  the case-mapping and asserts non-empty/unique/expected downstream
  sets -- no hardcoded assertion on the `omnibase_core` list's exact
  membership breaks from this addition)
- `ruff format --check` / `ruff check`: clean
- `pre-commit run --files .github/workflows/dependency-cascade.yml`:
  all hooks pass
- Governed pre-push impacted-test selector (`scripts/hooks/prepush_smart_tests.sh`,
  OMN-13973): 44256 passed, 53 skipped, 3 xpassed, 0 failed

Evidence-Ticket: OMN-16914

Evidence-Source: OCC#7515