### PR TITLE
fix(OMN-16917): apply the OMN-16745 CI-contract ruling to core's own import-graph selector

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -145,6 +145,44 @@ SEPARATELY_GATED_TEST_ROOTS = frozenset({"integration"})  # own unconditional jo
 # than silently dropping a newly-collectable family from the narrowed path.
 TEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
 
+# --- CI-contract test class for `.github/**` diffs (OMN-16917) --------------
+# Applies the OMN-16745 ruling — written up in omnibase_infra
+# `docs/reference/selector-workflow-diff-ruling.md`, landed as
+# omnibase_infra#2988 (95fb95837) — to THIS repo's selector, which is a
+# different design (the OMN-14921 import-graph closure, not infra's static
+# reverse-dependency map) and was not touched by that PR.
+#
+# The ruling: for a `.github/**` diff the necessary and sufficient proof is the
+# CI-contract class — the tests that read `.github/**` off disk and assert its
+# contents — plus any test module the diff itself touches. The unit suite is
+# neither necessary nor sufficient: no test under `tests/unit/` that never reads
+# `.github/**` has an outcome a workflow YAML edit can change, so escalating to
+# it is cost without proof.
+#
+# What it cost here, measured live: the real OMN-16625 diff in this repo
+# (.github/required-checks.yaml + .github/workflows/ci.yml + three
+# tests/unit/validation modules) resolved to `split_count=39` with
+# `selected_paths` containing the whole `tests/unit/` tree (1,478 collectable
+# files). `.github/**` is unresolvable to `resolve_changed_src_modules`, and any
+# unresolvable path fails the WHOLE selection closed to the `["tests/unit/"]`
+# sentinel — a whole-suite-equivalent selection carrying `is_full_suite=False`,
+# exactly the shape the pre-push hook's OMN-15408 `selection_is_whole_suite`
+# predicate routes into the OMN-15059 / OMN-16295 host-load guard. That is how
+# OMN-16346 and OMN-16625 got stranded in omnibase_infra.
+#
+# The class may never select NOTHING (OMN-15541): a workflow edit breaks the
+# ENFORCEMENT of tests rather than the tests themselves — there, `ci.yml`
+# hardcoded a pytest root the selector and pyproject did not name, so full-suite
+# escalation itself collected ZERO of the top-level `tests/` tree and no Python
+# test failed to say so. An empty or unenumerable class therefore escalates.
+#
+# The membership is DERIVED from the tree, never hand-listed — the same posture
+# as `unnarrowable_test_paths` above: a new workflow-shape test joins the class
+# the day it lands, with nobody having to remember a list.
+CI_CONTRACT_TEST_ROOT = "tests/ci/"
+CI_CONTRACT_MARKER = ".github"
+GITHUB_DIR_PREFIX = ".github/"
+
 
 def is_test_file_name(name: str) -> bool:
     """True when pytest would collect a file with this name (``python_files``)."""
@@ -201,6 +239,63 @@ def unnarrowable_test_paths(repo_root: Path) -> list[str]:
 def _with_unnarrowable(selected: list[str], unnarrowable: list[str]) -> list[str]:
     """Union a narrowed selection with the always-run paths, order-stable."""
     return [*selected, *[path for path in unnarrowable if path not in selected]]
+
+
+def _dedup(paths: list[str]) -> list[str]:
+    """Order-stable de-duplication."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            out.append(path)
+    return out
+
+
+def ci_contract_test_paths(repo_root: Path) -> list[str]:
+    """The CI-contract class: tests whose outcome depends on ``.github/**``.
+
+    Two positively-evidenced sources, both derived from the tree (see the block
+    comment on :data:`CI_CONTRACT_TEST_ROOT`):
+
+    * ``tests/ci/`` — the positively-named CI-contract root, included whenever
+      it holds at least one collectable test.
+    * every collectable test module under ``tests/unit/`` whose source
+      references ``.github`` — i.e. reads the workflow / required-check files
+      off disk and asserts their contents. These are the only ``tests/unit/``
+      modules a ``.github/**`` edit can change the outcome of, and the closure
+      cannot find them because the edge is a filesystem read, not an import.
+
+    A candidate that cannot be read is KEPT, not dropped: the class never
+    shrinks on an unproven negative. ``OSError`` propagates when the tree itself
+    cannot be enumerated — the caller escalates rather than emit a class it
+    cannot prove is complete.
+
+    Returns ``[]`` only when this tree genuinely holds no CI-contract proof; the
+    caller must then escalate (OMN-15541 — the class may never select nothing).
+    """
+    paths: list[str] = []
+
+    ci_root = repo_root / CI_CONTRACT_TEST_ROOT.rstrip("/")
+    if ci_root.is_dir() and _contains_collectable_test(ci_root):
+        paths.append(CI_CONTRACT_TEST_ROOT)
+
+    unit_root = repo_root / TEST_UNIT_PREFIX.rstrip("/")
+    if unit_root.is_dir():
+        for dirpath, _dirs, files in os.walk(unit_root, onerror=_raise_walk_error):
+            for name in sorted(files):
+                if not is_test_file_name(name):
+                    continue
+                candidate = Path(dirpath) / name
+                try:
+                    source = candidate.read_text(encoding="utf-8")
+                except (OSError, ValueError):  # boundary-ok: unreadable → keep
+                    paths.append(candidate.relative_to(repo_root).as_posix())
+                    continue
+                if CI_CONTRACT_MARKER in source:
+                    paths.append(candidate.relative_to(repo_root).as_posix())
+
+    return sorted(set(paths))
 
 
 def compute_selection(
@@ -311,6 +406,68 @@ def compute_selection(
     # reconciliations.
     if changed_files and set(changed_files) == {REQUIRED_CHECKS_MANIFEST_PATH}:
         selected = _with_unnarrowable([REQUIRED_CHECKS_MANIFEST_TEST], unnarrowable)
+        split_count = _split_count_for(selected, repo_root=closure_root)
+        return ModelTestSelection(
+            selected_paths=selected,
+            split_count=split_count,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=list(range(1, split_count + 1)),
+        )
+
+    # 5c. CI-contract classification for `.github/**` diffs (OMN-16917, applying
+    # the OMN-16745 ruling — see the block comment on CI_CONTRACT_TEST_ROOT).
+    # Placed AFTER every escalation above, so a `.github/**` edit paired with a
+    # shared module (step 3), a dependency-bearing pyproject.toml or any
+    # `test_infrastructure_paths` entry including the selector itself (step 2),
+    # or >= 8 changed modules (step 4) still escalates on that path's own rules.
+    # `.md` under `.github/` stays documentation and is handled by step 5.
+    github_ci_files = [
+        path
+        for path in changed_files
+        if path.startswith(GITHUB_DIR_PREFIX) and not _is_docs_only_path(path)
+    ]
+    if github_ci_files:
+        try:
+            ci_contract = ci_contract_test_paths(closure_root)
+        except OSError:
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+        if not ci_contract:
+            # OMN-15541: the class may never select NOTHING. With no CI-contract
+            # proof resolvable in this tree there is no substitute for the
+            # escalation, so take it rather than narrow on absence of evidence.
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
+        residual = [path for path in changed_files if path not in set(github_ci_files)]
+        # A directly-touched unit-test module narrows to ITSELF, at file grain —
+        # strictly narrower than the containing directory the closure's
+        # forced-keep would emit, and strictly covering the changed module
+        # (the OMN-16745 grain lesson). A non-collectable file under tests/unit/
+        # (a helper, a conftest) is NOT narrowable this way and falls through to
+        # the closure below, which still forces its directory.
+        touched_tests = [
+            path
+            for path in residual
+            if path.startswith(TEST_UNIT_PREFIX) and is_test_file_name(Path(path).name)
+        ]
+        # Documentation is positively inert (step 5's own premise), so it is not
+        # a closure input. Everything else still goes through the closure and
+        # still fails closed there to the ["tests/unit/"] sentinel.
+        closure_inputs = [
+            path
+            for path in residual
+            if path not in set(touched_tests) and not _is_docs_only_path(path)
+        ]
+        closure_files: list[str] = []
+        if closure_inputs:
+            closure_files = list(
+                compute_closure_selection(
+                    closure_inputs, repo_root=closure_root
+                ).selected_files
+            )
+        selected = _with_unnarrowable(
+            _dedup([*closure_files, *touched_tests, *ci_contract]), unnarrowable
+        )
         split_count = _split_count_for(selected, repo_root=closure_root)
         return ModelTestSelection(
             selected_paths=selected,

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -48,10 +48,22 @@ thresholds:
 #     requires-python), not on a bare `version` bump, entry-point registration,
 #     lint-only [tool.ruff.*] edit, or metadata edit. Fail-closed:
 #     unparseable/unavailable TOML still escalates.
-#   * .github/workflows/ — removed to align with omnibase_infra (which omits it).
-#     A workflow-only change carries zero test-code delta, is exercised by the PR's
-#     own CI run, and is backstopped by the unconditional merge_group -> main full
-#     suite (root CLAUDE.md Rule #4).
+#   * .github/ — removed to align with omnibase_infra (which omits it), so a
+#     workflow change does not force the distributed full suite.
+#     CORRECTED (OMN-16917): the old rationale here — "a workflow-only change
+#     carries zero test-code delta" — was wrong in the direction that matters.
+#     A workflow edit carries zero test-code delta but it CAN break the
+#     ENFORCEMENT of tests, which is worse and invisible: OMN-15541 is the live
+#     proof, where ci.yml hardcoded a pytest root the selector and pyproject did
+#     not name and full-suite escalation itself collected ZERO of the top-level
+#     tests/ tree. Per the OMN-16745 ruling (omnibase_infra#2988,
+#     docs/reference/selector-workflow-diff-ruling.md), .github/** non-.md paths
+#     are now classified CONTENT-AWARE in detect_test_paths.py step 5c: they
+#     select the CI-contract class (`ci_contract_test_paths` — tests/ci/ plus the
+#     tests/unit/ modules that read .github/** off disk), plus any test module
+#     the diff itself touches, at file grain. The class may never be empty; an
+#     empty or unenumerable class escalates. Absence from this list is therefore
+#     NOT "no proof required" — the proof was substituted, not removed.
 #
 # scripts/ci/ NARROWED to the SELECTOR'S OWN FILES ONLY (OMN-14910, CI-C1 #1).
 # OMN-14081 kept the whole `scripts/ci/` directory here as a "conservative — it

--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -25,6 +25,24 @@
 # remediation message and a non-zero exit. It never degrades to a green skip -- a
 # gate that cannot run must be indistinguishable from a failing gate.
 #
+# CI-CONTRACT CLASS for `.github/**` diffs (OMN-16917, applying the OMN-16745
+# ruling -- omnibase_infra#2988, docs/reference/selector-workflow-diff-ruling.md).
+# A `.github/**` diff used to be unresolvable to the import graph, which failed
+# the WHOLE selection closed to the `["tests/unit/"]` sentinel: a
+# whole-suite-equivalent selection (split_count=39, 1,478 files) carrying
+# `is_full_suite=false`, which the OMN-15408 predicate below then correctly
+# routed into the OMN-15059 host-load guard. That escalation proved nothing --
+# no test under tests/unit/ that never reads `.github/**` has an outcome a
+# workflow YAML edit can change -- while consuming exactly the capacity the
+# guard refuses pushes over. It is how OMN-16346 / OMN-16625 got stranded.
+# The selector now resolves those paths to the CI-contract class instead: the
+# tests that read `.github/**` off disk and assert its contents, plus any test
+# module the diff itself touches. This is a SUBSTITUTION of proof, not a
+# removal: the class may never select nothing (OMN-15541 -- a workflow edit can
+# turn full-suite escalation itself fail-OPEN), and an empty or unenumerable
+# class escalates. No env override, no allowlist to zero tests, no bypass token;
+# the vars below are untouched and can still only make this hook run MORE tests.
+#
 # Env overrides (all optional):
 #   PREPUSH_BASE_REF     git ref to diff against            (default: origin/dev)
 #   PREPUSH_ADJACENCY    adjacency yaml path            (default: selector built-in)

--- a/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py
@@ -382,3 +382,51 @@ def test_parity_mixins_change_produces_multiple_splits_on_real_tree(
     assert sel.is_full_suite is False
     assert sel.split_count >= 1
     assert sel.matrix == list(range(1, sel.split_count + 1))
+
+
+# =============================================================================
+# OMN-16917: a NAMED, asserted divergence — the `.github/**` CI-contract class
+# =============================================================================
+
+
+def test_github_ci_contract_class_is_oracle_only_named_divergence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CI-contract class (OMN-16917) lives in the oracle ONLY, on purpose.
+
+    ``scripts/ci/detect_test_paths.py`` is the sole selector CI (`ci.yml`) and
+    the pre-push hook invoke, so it is where the OMN-16745 ruling was applied:
+    a ``.github/**`` diff selects the CI-contract class rather than escalating
+    to the whole ``tests/unit/`` tree.
+
+    The pure node cannot reproduce that yet. Its EFFECT boundary
+    (``runtime_test_selector.py``) does not compute a closure at all — the
+    pre-existing, documented OMN-14921 fast-follow gap (``closure_selected_files
+    = None``) — and the class additionally needs the closure computed over the
+    diff's NON-``.github`` residual, which is a second injected input the
+    request contract does not carry. Porting it is a change to the node's
+    pure/EFFECT contract, deliberately not folded into a governed-selector fix.
+
+    This test exists so the divergence is a NAMED, asserted fact rather than a
+    silent one: it fails the moment either surface moves, so the node cannot be
+    promoted into CI while still escalating this class.
+    """
+    changed = [".github/workflows/receipt-gate.yml"]
+    monkeypatch.setattr(detect, "REPO_ROOT", REPO_ROOT)
+
+    oracle = compute_selection(
+        changed_files=changed, adjacency_path=ADJ, ref_name="pr-branch"
+    )
+    node = _node_selection(changed, "pr-branch", REPO_ROOT)
+
+    # Oracle: the CI-contract class, narrow.
+    assert "tests/unit/" not in oracle.selected_paths
+    assert "tests/ci/" in oracle.selected_paths
+    assert (
+        "tests/unit/validation/test_receipt_gate_workflow_shape.py"
+        in oracle.selected_paths
+    )
+
+    # Node: still the fail-closed whole-tree answer. Wrong, but never fail-OPEN.
+    assert node.selected_paths == _narrowed("tests/unit/")
+    assert node.model_dump_json() != oracle.model_dump_json()

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -70,10 +70,19 @@ def test_test_infrastructure_change_escalates_to_full_suite() -> None:
 
 def test_workflow_only_change_no_longer_escalates() -> None:
     # OMN-14081: .github/workflows/ was removed from test_infrastructure_paths to
-    # align with omnibase_infra. A workflow-only change carries zero test-code delta,
-    # is exercised on the PR's own CI run, and is backstopped by the unconditional
-    # merge_group -> main full suite (root CLAUDE.md Rule #4). It now falls to the
-    # conservative tests/unit/ fallback instead of forcing the distributed full suite.
+    # align with omnibase_infra, so a workflow-only change no longer forces the
+    # distributed full suite.
+    #
+    # OMN-16917 (applying the OMN-16745 ruling, omnibase_infra#2988): it no
+    # longer takes the conservative tests/unit/ fallback either. That fallback
+    # was cost without proof — no test under tests/unit/ that never reads
+    # .github/** has an outcome a workflow YAML edit can change, and the
+    # resulting selection was whole-suite-equivalent (split_count=39) while
+    # carrying is_full_suite=False. A workflow-only diff now selects the
+    # CI-contract class: the tests that read .github/** off disk and assert its
+    # contents. This is a SUBSTITUTION of proof, never a removal — the class may
+    # never be empty (the OMN-15541 fail-OPEN counterexample), which
+    # test_detect_test_paths_ci_contract_omn16917.py asserts directly.
     selection = compute_selection(
         changed_files=[".github/workflows/receipt-gate.yml"],
         adjacency_path=ADJ,
@@ -81,7 +90,13 @@ def test_workflow_only_change_no_longer_escalates() -> None:
     )
     assert selection.is_full_suite is False
     assert selection.full_suite_reason is None
-    assert selection.selected_paths == _narrowed("tests/unit/")
+    assert selection.selected_paths != []
+    assert "tests/unit/" not in selection.selected_paths
+    assert "tests/ci/" in selection.selected_paths
+    assert (
+        "tests/unit/validation/test_receipt_gate_workflow_shape.py"
+        in selection.selected_paths
+    )
 
 
 def test_required_checks_manifest_uses_focused_guard_test() -> None:
@@ -718,14 +733,29 @@ def test_mixed_docs_and_code_does_not_take_the_exemption() -> None:
 def test_github_precommit_hooks_are_not_docs_exempt(non_doc_only: list[str]) -> None:
     # core has workflow-shape unit tests (test_occ_preflight_workflow_shape.py,
     # test_receipt_gate_workflow_shape.py) whose outcome depends on these files, so
-    # they must run the conservative fallback, NOT the empty docs-only selection.
+    # they must never take the empty docs-only selection.
+    #
+    # OMN-16917: the SHAPE of the non-empty answer now differs by class.
+    # `.github/**` resolves to the CI-contract class (the tests that read those
+    # files off disk) — a substitution of proof, not a removal.
+    # `.pre-commit-config.yaml` and `scripts/hooks/` are deliberately unchanged:
+    # they remain unresolvable to the import graph and still fail closed to the
+    # conservative tests/unit/ fallback.
     selection = compute_selection(
         changed_files=non_doc_only,
         adjacency_path=ADJ,
         ref_name="pr-branch",
     )
     assert selection.is_full_suite is False
-    assert selection.selected_paths == _narrowed("tests/unit/")
+    assert selection.selected_paths != []
+    if non_doc_only[0].startswith(".github/"):
+        assert "tests/unit/" not in selection.selected_paths
+        assert (
+            "tests/unit/validation/test_receipt_gate_workflow_shape.py"
+            in selection.selected_paths
+        )
+    else:
+        assert selection.selected_paths == _narrowed("tests/unit/")
 
 
 def test_docs_only_does_not_suppress_shared_module_escalation() -> None:

--- a/tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""The CI-contract test class for ``.github/**`` diffs (OMN-16917).
+
+Applies the OMN-16745 ruling — recorded in omnibase_infra
+``docs/reference/selector-workflow-diff-ruling.md``, landed as omnibase_infra#2988
+(``95fb95837``) — to omnibase_core's OWN selector, which is a different design
+(the OMN-14921 import-graph closure, not infra's static reverse-dependency map)
+and was never fixed by that PR.
+
+Ruling, restated for this repo: for a ``.github/**`` diff the necessary and
+sufficient proof is the **CI-contract class** — the tests that read ``.github/**``
+off disk and assert its contents — plus any test module the diff itself touches.
+The class may never select NOTHING (OMN-15541: a workflow edit can turn
+full-suite escalation itself fail-OPEN), and everything outside ``.github/**``
+keeps its existing fail-closed behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.detect_test_paths import (
+    CI_CONTRACT_TEST_ROOT,
+    ci_contract_test_paths,
+    compute_selection,
+    unnarrowable_test_paths,
+)
+from scripts.ci.test_selection_closure import compute_closure_selection
+from scripts.ci.test_selection_models import EnumFullSuiteReason
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+ALWAYS_RUN = unnarrowable_test_paths(REPO_ROOT)
+
+# The real, merged OMN-16625 diff in this repo (commit a88cff22). This exact
+# five-file list measured `split_count=39` with `selected_paths` containing the
+# whole `tests/unit/` tree (1,478 collectable files) before OMN-16917 — a
+# whole-suite-equivalent selection with `is_full_suite=False`, which is the
+# shape the pre-push hook's OMN-15408 `selection_is_whole_suite` predicate
+# routes into the OMN-15059 / OMN-16295 host-load guard.
+OMN_16625_DIFF = [
+    ".github/required-checks.yaml",
+    ".github/workflows/ci.yml",
+    "tests/unit/validation/test_ci_workflow_shape.py",
+    "tests/unit/validation/test_draft_state_admission_gate_omn16215.py",
+    "tests/unit/validation/test_quality_gate_docs_only_short_circuit_omn16625.py",
+]
+
+# Named members of the class, asserted BY NAME (OMN-16745 AC2: assert the class,
+# not merely a smaller test count). Each of these reads `.github/**` off disk.
+NAMED_CI_CONTRACT_MODULES = (
+    "tests/unit/validation/test_ci_workflow_shape.py",
+    "tests/unit/validation/test_receipt_gate_workflow_shape.py",
+    "tests/unit/validation/test_occ_preflight_workflow_shape.py",
+    "tests/unit/validation/test_release_workflow_shape.py",
+    "tests/unit/validation/test_auto_merge_workflow_shape.py",
+    "tests/unit/validation/test_required_check_skip_guard.py",
+)
+
+
+# ---------------------------------------------------------------------------
+# The class itself: derived, non-empty, workflow-aware
+# ---------------------------------------------------------------------------
+
+
+def test_ci_contract_class_is_non_empty_and_workflow_aware() -> None:
+    """OMN-15541: the class may never be empty, and must actually read .github."""
+    paths = ci_contract_test_paths(REPO_ROOT)
+
+    assert paths, "the CI-contract class may never select nothing"
+    assert CI_CONTRACT_TEST_ROOT in paths
+    for module in NAMED_CI_CONTRACT_MODULES:
+        assert module in paths, (
+            f"{module} reads .github/** off disk but is not in the class"
+        )
+
+
+def test_ci_contract_class_is_derived_not_hand_listed() -> None:
+    """Every non-root member is a real, collectable test file in this tree."""
+    paths = ci_contract_test_paths(REPO_ROOT)
+    for path in paths:
+        if path == CI_CONTRACT_TEST_ROOT:
+            assert (REPO_ROOT / path).is_dir()
+            continue
+        resolved = REPO_ROOT / path
+        assert resolved.is_file(), f"{path} is not a file in this tree"
+        assert ".github" in resolved.read_text(encoding="utf-8")
+
+
+def test_ci_contract_class_is_a_strict_subset_of_the_unit_tree() -> None:
+    """The class is proof, not an escalation in disguise."""
+    paths = ci_contract_test_paths(REPO_ROOT)
+    unit_files = list((REPO_ROOT / "tests/unit").rglob("test_*.py"))
+    assert "tests/unit/" not in paths
+    assert len(paths) < len(unit_files) / 10
+
+
+# ---------------------------------------------------------------------------
+# The stranded shape: the real OMN-16625 diff
+# ---------------------------------------------------------------------------
+
+
+def test_omn16625_diff_selects_the_ci_contract_class_not_the_unit_tree() -> None:
+    selection = compute_selection(
+        changed_files=OMN_16625_DIFF,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    # RED before OMN-16917: this was `["tests/unit/", ...]` at split_count=39.
+    assert "tests/unit/" not in selection.selected_paths
+    assert CI_CONTRACT_TEST_ROOT in selection.selected_paths
+    for module in NAMED_CI_CONTRACT_MODULES:
+        assert module in selection.selected_paths
+    assert selection.split_count < 39
+    assert selection.matrix == list(range(1, selection.split_count + 1))
+
+
+def test_omn16625_diff_selects_its_own_touched_test_modules_at_file_grain() -> None:
+    """The OMN-16745 grain lesson: a touched test module narrows to ITSELF."""
+    selection = compute_selection(
+        changed_files=OMN_16625_DIFF,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    # This module carries no `.github` literal, so it is NOT in the derived
+    # class — it is selected purely because the diff touches it.
+    touched = (
+        "tests/unit/validation/test_quality_gate_docs_only_short_circuit_omn16625.py"
+    )
+    assert touched not in ci_contract_test_paths(REPO_ROOT)
+    assert touched in selection.selected_paths
+    # ...and it is NOT widened to its containing directory.
+    assert "tests/unit/validation/" not in selection.selected_paths
+
+
+def test_workflow_only_diff_selects_the_ci_contract_class() -> None:
+    selection = compute_selection(
+        changed_files=[".github/workflows/receipt-gate.yml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is False
+    assert "tests/unit/" not in selection.selected_paths
+    assert CI_CONTRACT_TEST_ROOT in selection.selected_paths
+    assert selection.selected_paths == [
+        *ci_contract_test_paths(REPO_ROOT),
+        *[p for p in ALWAYS_RUN if p not in ci_contract_test_paths(REPO_ROOT)],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed properties preserved
+# ---------------------------------------------------------------------------
+
+
+def test_unresolvable_file_alongside_a_workflow_still_fails_closed() -> None:
+    """A genuinely unresolvable path still collapses the run to the unit tree."""
+    selection = compute_selection(
+        changed_files=[".github/workflows/ci.yml", "Makefile"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is False
+    assert "tests/unit/" in selection.selected_paths
+
+
+def test_workflow_plus_shared_module_still_escalates() -> None:
+    selection = compute_selection(
+        changed_files=[".github/workflows/ci.yml", "src/omnibase_core/models/foo.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+
+
+def test_workflow_plus_test_infrastructure_still_escalates() -> None:
+    selection = compute_selection(
+        changed_files=[".github/workflows/ci.yml", "tests/conftest.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_workflow_plus_selector_change_still_escalates() -> None:
+    """A selector that narrowed on a change to ITSELF is fail-open."""
+    selection = compute_selection(
+        changed_files=[".github/workflows/ci.yml", "scripts/ci/detect_test_paths.py"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+def test_empty_ci_contract_class_escalates_rather_than_selecting_nothing(
+    tmp_path: Path,
+) -> None:
+    """OMN-15541 counterexample, mechanised: no class -> no narrowing."""
+    (tmp_path / "tests" / "unit").mkdir(parents=True)
+    (tmp_path / "tests" / "unit" / "test_inert.py").write_text(
+        "def test_x() -> None:\n    assert True\n", encoding="utf-8"
+    )
+
+    assert ci_contract_test_paths(tmp_path) == []
+
+    selection = compute_selection(
+        changed_files=[".github/workflows/ci.yml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=tmp_path,
+    )
+
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+    assert selection.split_count == 40
+
+
+def test_unreadable_unit_test_is_kept_in_the_class_not_dropped(
+    tmp_path: Path,
+) -> None:
+    """The class never shrinks on an unproven negative."""
+    unit = tmp_path / "tests" / "unit"
+    unit.mkdir(parents=True)
+    (unit / "test_binary.py").write_bytes(b"\xff\xfe not utf-8 \x00")
+
+    assert "tests/unit/test_binary.py" in ci_contract_test_paths(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Everything outside .github/** is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_docs_only_github_markdown_stays_docs_exempt() -> None:
+    selection = compute_selection(
+        changed_files=[".github/PULL_REQUEST_TEMPLATE.md"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is False
+    assert selection.selected_paths == []
+
+
+def test_required_checks_manifest_only_is_byte_for_byte_unchanged() -> None:
+    """Step 5b's exact-match special case is strictly narrower and stays put."""
+    selection = compute_selection(
+        changed_files=[".github/required-checks.yaml"],
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.selected_paths == [
+        "tests/unit/validation/test_required_check_skip_guard.py",
+        *[
+            p
+            for p in ALWAYS_RUN
+            if p != "tests/unit/validation/test_required_check_skip_guard.py"
+        ],
+    ]
+
+
+def test_source_only_diff_is_byte_for_byte_the_pre_existing_closure_path() -> None:
+    """No `.github` path in the diff -> the new classification is inert.
+
+    The expected value is built from the SAME primitives step 6 has always used
+    (``compute_closure_selection`` unioned with the OMN-15661 always-run set),
+    so this fails if the new branch leaks into a non-``.github`` diff.
+    """
+    changed = ["src/omnibase_core/cli/cli_main.py"]
+    closure = compute_closure_selection(changed, repo_root=REPO_ROOT)
+    expected = [
+        *closure.selected_files,
+        *[p for p in ALWAYS_RUN if p not in closure.selected_files],
+    ]
+
+    selection = compute_selection(
+        changed_files=changed,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        repo_root=REPO_ROOT,
+    )
+
+    assert selection.is_full_suite is False
+    assert selection.selected_paths == expected


### PR DESCRIPTION
## OMN-16917 — the OMN-16745 ruling, applied to omnibase_core's *own* selector

OMN-16745 landed the CI-contract ruling and fixed **omnibase_infra's** selector (omnibase_infra#2988, `95fb95837`; ruling written up at `docs/reference/selector-workflow-diff-ruling.md`). That is infra's *static reverse-dependency map*. **omnibase_core runs a different selector** — the OMN-14921 **import-graph closure** (`scripts/ci/test_selection_closure.py` + `scripts/ci/detect_test_paths.py`) — and was never touched by that PR. It strands core PRs the same way OMN-16346 / OMN-16625 were stranded in infra.

## Measured, live, before this change

The real OMN-16625 diff in this repo (core commit `a88cff22`) — 5 files:

```
.github/required-checks.yaml
.github/workflows/ci.yml
tests/unit/validation/test_ci_workflow_shape.py
tests/unit/validation/test_draft_state_admission_gate_omn16215.py
tests/unit/validation/test_quality_gate_docs_only_short_circuit_omn16625.py
```

`uv run python -m scripts.ci.detect_test_paths --changed-files-from <list>` →

```
split_count: 39   selected_paths: ["tests/unit/", "tests/agents/", ..., "tests/validators/"]
```

`tests/unit/` alone is **1,478 collectable test files**. That is a whole-suite-equivalent selection carrying `is_full_suite=false` — exactly the shape the pre-push hook's OMN-15408 `selection_is_whole_suite` predicate routes into the OMN-15059 / OMN-16295 host-load guard, which then refuses the push. Cost without proof: no test under `tests/unit/` that never reads `.github/**` has an outcome a workflow YAML edit can change.

## Root cause (core-specific, NOT the infra bug)

`resolve_changed_src_modules` resolves only `src/**.py`, `tests/unit/**`, `tests/integration/**`, `pyproject.toml`, and `.md`/`docs/`. `.github/workflows/ci.yml` and `.github/required-checks.yaml` hit the final `else`:

```
changed file outside src/tests cannot be resolved by the import graph: .github/workflows/ci.yml
```

Any such reason fails the **whole** selection closed to the conservative sentinel `["tests/unit/"]`, unioned with the OMN-15661 always-run set → 39/40 splits.

Core's own design comment already stated the intent (`scripts/ci/test_selection_adjacency.yaml`: "`.github/workflows/` — removed to align with omnibase_infra … a workflow-only change carries zero test-code delta"). The intent existed; the implementation did not. That rationale is also **corrected** in this PR — a workflow edit carries zero test-code delta but it *can* break the **enforcement** of tests, which is worse and invisible.

## Change — `detect_test_paths.py` step 5c

* `.github/**` non-`.md` paths resolve to the **CI-contract class**, `ci_contract_test_paths()`: `tests/ci/` plus every collectable `tests/unit/` module whose source reads `.github/**` off disk (`test_ci_workflow_shape.py`, `test_receipt_gate_workflow_shape.py`, `test_occ_preflight_workflow_shape.py`, `test_release_workflow_shape.py`, `test_auto_merge_workflow_shape.py`, `test_required_check_skip_guard.py`, …). That edge is a **filesystem read, not an import**, which is precisely why the closure cannot find it.
* **Derived from the tree, never hand-listed** — the same posture as `unnarrowable_test_paths` (OMN-15661). A new workflow-shape test joins the class the day it lands.
* A test module the diff itself touches is added at **file grain**, not widened to its directory (the OMN-16745 grain lesson). A non-collectable file under `tests/unit/` (a helper, a conftest) is *not* narrowable this way and falls through to the closure, which still forces its directory.
* An unreadable candidate is **kept, not dropped** — the class never shrinks on an unproven negative.
* Placed **after** every escalation, so `.github` + a shared module still escalates `shared_module`, and `.github` + any `test_infrastructure_paths` entry (including the selector itself) still escalates `test_infrastructure`.

## The class may never select nothing (OMN-15541)

OMN-15541 is the live fail-**OPEN** counterexample: `ci.yml` hardcoded a pytest root the selector and `pyproject.toml` did not name, so full-suite escalation itself collected **zero** of the top-level `tests/` tree and no Python test said so. So here: an **empty** class, or one whose tree cannot be enumerated (`OSError`), **escalates to the full suite**. This is a *substitution* of proof, not a removal.

## Readback (the acceptance number)

Same OMN-16625 file list, after the change:

```
split_count: 5   is_full_suite: false
selected_paths: tests/unit/validation/test_ci_workflow_shape.py,
                tests/unit/validation/test_draft_state_admission_gate_omn16215.py,
                tests/unit/validation/test_quality_gate_docs_only_short_circuit_omn16625.py,
                tests/ci/, + 19 CI-contract modules, + the OMN-15661 always-run roots
```

**39 → 5 splits; `tests/unit/` absent.** The three directly-touched test modules appear at file grain, by name.

## Fail-closed preserved — all asserted

| Diff | Outcome | Test |
|------|---------|------|
| the real OMN-16625 5-file diff | CI-contract class, narrow, `tests/unit/` absent, class asserted **by name** | `test_omn16625_diff_selects_the_ci_contract_class_not_the_unit_suite` |
| `.github/**` + `Makefile` (genuinely unresolvable) | still collapses to `["tests/unit/"]` | `test_unresolvable_non_github_path_still_fails_closed` |
| `.github/**` + a `shared_modules` source file | full suite `shared_module` | `test_github_plus_shared_module_still_escalates` |
| `.github/**` + `tests/conftest.py` / the selector itself | full suite `test_infrastructure` | `test_github_plus_test_infrastructure_still_escalates` |
| class empty / tree unenumerable | full suite `test_infrastructure` | `test_empty_ci_contract_class_escalates` |
| every non-`.github` diff | byte-for-byte unchanged | the existing selector battery, unmodified |

The class is asserted **non-empty and workflow-aware against the real tree** — it can never select nothing.

## Node-parity divergence, named rather than hidden

The pure node (`selector_core.py`) is deliberately **not** changed: its EFFECT boundary has a pre-existing documented OMN-14921 closure gap and the class needs a second injected input. The divergence is now a **named, asserted fact** in `test_node_test_selector_compute.py`, so the node cannot be promoted into CI while still escalating this class.

## No bypass anywhere

No `[skip-*` token, no `ENABLE_SMART_TESTS=off`, no `PREPUSH_FULL_SUITE`, **no new environment variable of any kind**, no allowlist mapping `.github` paths to zero tests. The two pre-existing knobs are untouched and can still only make the hook run *more* tests.

## dod_evidence

* **TDD red-first**: the new battery failed on `ImportError: cannot import name 'ci_contract_test_paths' from 'scripts.ci.detect_test_paths'` before the classifier existed; the 39-split shape is pinned as the RED case and the narrow selection as GREEN, asserted **by class name**, not merely by a smaller count.
* `uv run pytest tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py tests/unit/scripts/ci/test_detect_test_paths.py tests/unit/nodes/node_test_selector_compute/test_node_test_selector_compute.py` → **140 passed** in 79s.
* Live selector readback on the real OMN-16625 file list: **`split_count: 39` → `split_count: 5`**, `is_full_suite=false`, `tests/unit/` absent from `selected_paths`.
* **Governed pre-push selector on this branch**: correctly escalated `is_full_suite=true, full_suite_reason=test_infrastructure` (this PR changes `scripts/ci/detect_test_paths.py`, a `test_infrastructure_paths` entry) → the hook ran the **full suite** (`pytest tests/ --ignore=tests/integration -n4 --dist=loadgroup`) and allowed the push. No override grant minted, no knob set, no `--no-verify`.
* `pre-commit run --files <the six changed files>` → **clean, exit 0**.
* `uv run ruff format --check` / `uv run ruff check` on the changed scripts and tests → clean. `mypy` reports no error in `detect_test_paths.py` (the three `scripts.ci` errors are pre-existing in `test_selection_closure.py`, `effect_golden.py`, `verify_flip_bundle.py`, untouched here).

Ticket: OMN-16917

Evidence-Ticket: OMN-16745
Evidence-Ticket: OMN-16917
Evidence-Source: OCC#7531


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automated test selection for changes to CI and workflow configuration.
  - Workflow-related updates now run focused contract tests instead of the full unit-test suite when safely identifiable.
  - Touched tests are included alongside relevant workflow checks.

- **Bug Fixes**
  - Added fail-safe escalation to broader test coverage when affected tests cannot be reliably determined.
  - Documentation-only changes remain excluded from unnecessary test selection.

- **Documentation**
  - Updated test-selection guidance to reflect the new workflow validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->