### PR TITLE
chore(OMN-16831): bump omnibase_core 0.46.14 -> 0.47.0 and cut the release the fleet re-pin is gated on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 <!-- onex-allow-file-todo-marker reason="historical changelog entries include literal TODO marker tokens" -->
 
+## v0.47.0 (2026-08-29)
+
+### Breaking Changes
+- bump omnibase_core to v0.47.0 — `ModelWidgetConfigStatusGrid.status_colors` is **removed** (#1612). The field carried a `Mapping[str, str]` of raw hex colours in the config's own default, which is the decision the theme contract exists to make; it is replaced by `severity_roles: tuple[ModelSeverityRole, ...]` naming theme tokens, and colours now resolve through the active theme instance. The model is `extra="forbid"`, so any caller still passing `status_colors=` raises. Minor bump per pre-1.0 semver convention for a breaking public-API deletion.
+
+### Features
+- feat theme instances + theme catalog — `ModelThemeInstance`, `ModelThemeCatalog`, `ModelThemeCatalogEntry`, `ModelThemeActivation`, `util_theme_catalog`, and the `onex.theme.{light,dark,warm}` 1.0.0 theme contracts (#1608)
+- feat one versioned widget envelope — `ModelWidgetEnvelope`, `ModelWidgetProvenance`, `util_widget_envelope` (#1610)
+- feat semantic severity for StatusGrid — `EnumStatusSeverity`, `EnumStatusSecondaryKind`, `ModelSeverityRole` + `DEFAULT_SEVERITY_ROLES`, `ModelSeverityVerdict`, `ModelStatusSecondary` (#1612)
+- feat the transport envelope carries the tenant dimension — an OPTIONAL `tenant` field on `ModelEventEnvelope` (additive; the model stays `extra="forbid"`) (#1611)
+- feat `onex user-config` CLI surface + `ModelCliUserConfig` family, unifying the `~/.onex/config.yaml` schema across all CLI writers (#1604)
+
+### Changes
+- chore make `.onex_state` disposable-by-default with two named durable subtrees (#1609)
+- fix make a freshly scaffolded ONEX project pass `onex validate` (#1607)
+- fix pass commits into the receipt-gate workflow (#1605)
+- fix retry Enable Auto-Merge with `--squash` when no queue is active (#1606)
+- chore add omninode_infra to the dependency-cascade downstream matrix (#1613)
+
 ## v0.46.0 (2026-06-25)
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.46.14"
+version = "0.47.0"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.46.14"
+version = "0.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Cuts **v0.47.0** — the omnibase_core release that OMN-16831 item 2 (runtime tenant stamping) is explicitly gated on. Both omnibase_infra#2976 and omnimarket#2199 record the precondition as "omnibase_core releases + fleet re-pins". Ten PRs have merged to `dev` since `v0.46.13` and **none of them is on PyPI**, so no downstream repo can bind against any of them today. omniui Phase 1A binds against the Phase C models and needs a published version for the same reason.

## Why MINOR (0.47.0), not the 0.46.14 currently in `pyproject`

`CHANGELOG.md` states this repo's convention twice, in its own words:

- v0.45.0 — *"Minor bump per pre-1.0 semver convention for a breaking public-API deletion."*
- v0.46.0 — *"Minor bump per pre-1.0 semver convention for breaking surface relocations..."*

The delta contains exactly such a deletion. #1612 **removed `status_colors`** from `ModelWidgetConfigStatusGrid` — a model published since #363, carrying `ConfigDict(extra="forbid")`. Any caller still passing `status_colors=` now raises `ValidationError`. It is replaced by `severity_roles: tuple[ModelSeverityRole, ...]`, which names theme tokens instead of carrying hex values.

`pyproject` sat at 0.46.14 only because an unrelated fix PR (`d89b1076`) bumped it inline. **0.46.14 was never tagged and never published**, so nothing is skipped by going straight to 0.47.0. Shipping this delta as a patch would publish a breaking public-API deletion under a version that five downstream repos' `<0.47.0` caps were written to accept — the precise failure those caps exist to prevent.

## Delta since v0.46.13 (10 PRs, 43 src files, +2638 / -226)

| commit | PR | what |
| --- | --- | --- |
| `872beef0` | #1613 | add omninode_infra to the dependency-cascade downstream matrix |
| `c8050400` | #1612 | semantic severity for StatusGrid — **breaking**, see above |
| `ae6a19d6` | #1611 | transport envelope carries the tenant dimension (OPTIONAL field, model stays `extra="forbid"` — additive) |
| `32cf8fcd` | #1610 | one versioned widget envelope |
| `f3cb4d72` | #1608 | theme instances + theme catalog |
| `f8eef25e` | #1609 | `.onex_state` disposable-by-default with two named durable subtrees |
| `8c41a3ca` | #1607 | a freshly scaffolded ONEX project passes `onex validate` |
| `d89b1076` | #1604 | unified `~/.onex/config.yaml` schema across all CLI writers |
| `bb48dffc` | #1605 | pass commits into the receipt-gate workflow |
| `c454c68a` | #1606 | retry Enable Auto-Merge with `--squash` when no queue is active |

All ten merged with required checks green. Zero open PRs on omnibase_core at the time this was cut — no concurrent release work.

## Verification

- **Release-identity gate (OMN-13411) passes both modes:** `--base origin/dev` → `OK: no packaged src/** change in this diff — version bump not required (pyproject 0.47.0, latest published 0.46.13).`; strict → `OK: version 0.47.0 is ahead of latest published 0.46.13.`
- **Fast-forward precondition checked:** `git merge-base --is-ancestor origin/main origin/dev` → TRUE, so `release.yml`'s Sync-main step (OMN-16289) can actually fast-forward. `origin/main` is currently `2a5ac713` == the `v0.46.13` tag commit, so the release-synced-main policy is holding mechanically.
- **No tag protection / no protected environment** on this repo — `gh api repos/OmniNode-ai/omnibase_core/tags/protection` → 404; the only ruleset is `Merge Queue` (id 13269695, `enforcement=disabled`). The release needs no operator approval step.
- **Governed pre-push selector: full escalated suite green** — `44298 passed, 53 skipped, 3 xpassed, 155 warnings in 6643.49s (1:50:43)`, then `[prepush-smart-tests] impacted tests passed; allowing push.` The selector escalated to the whole non-integration tree because `pyproject.toml` changed. No `PREPUSH_FULL_SUITE` / `ENABLE_SMART_TESTS=off` override was set and no escalation was bypassed.
- `uv.lock` regenerated in the same commit (`Updated omnibase-core v0.46.14 -> v0.47.0`).
- CHANGELOG entry follows the existing file's convention (PR numbers, no ticket tokens — the Doc-Content Scan Gate, OMN-13572, rejects `OMN-<digits>` in docs on this public repo).

## Known cascade consequence — stated up front, not discovered later

`dependency-cascade.yml` bumps six downstream repos. Only **omnibase_infra** pins core exactly (`omnibase-core==0.46.13`), which the cascade's "Update pyproject.toml pin" step rewrites via its `==X.Y.Z` regex. The other five cap core **below** this release:

| repo | current constraint | cascade leg on 0.47.0 |
| --- | --- | --- |
| omnibase_infra | `==0.46.13` | moves — exact pin is rewritten |
| omniintelligence | `>=0.46.3,<0.47.0` | **SKIP** — cap excludes 0.47.0 |
| omnimemory | `>=0.46.13,<0.47.0` | **SKIP** |
| omniclaude | `>=0.46.5,<0.47.0` | **SKIP** |
| onex_change_control | `>=0.46.8,<0.47.0` | **SKIP** |
| omninode_infra | `>=0.46.13,<0.47.0` | **SKIP** |

`uv lock --upgrade-package` cannot cross a range cap, so those five legs will resolve to the same version they already have, see no diff, and report *"already on latest"* — a false statement of the same class OMN-15604 / OMN-16286 hardened against for `[tool.uv.sources]` git overrides. The existing guard (`check_dep_provenance.py --check-movable`) only detects the git-override channel, **not** a range cap. That gap is real and is being filed separately; it is not introduced by this PR.

The caps are safe to widen: no Python consumer in the fleet references `status_colors` or `ModelWidgetConfigStatusGrid` (grep across omnibase_infra, omniintelligence, omnimemory, omniclaude, onex_change_control, omninode_infra, omnimarket → zero hits). The only fleet reference is omnidash's generated TypeScript types, which regenerate from core rather than resolving a Python pin. Cap-widening + re-pin PRs follow this release, per repo.

## Test plan

- [x] Release-identity gate passes (both modes)
- [x] `main` is an ancestor of `dev` (post-release FF can succeed)
- [x] Full escalated local suite green (44298 passed)
- [x] `uv.lock` in sync with the bumped `pyproject.toml`
- [ ] `gh pr checks` green in CI (confirmed post-open)

## After this merges

Push lightweight tag `v0.47.0` at the merge commit (this repo's tags are lightweight `commit` refs — `v0.46.11/12/13` all are; `auto-tag-on-merge.yml` fires only on a `release:` / `chore: release` / `chore(release)` title prefix or a `release` label, which no recent release used). `release.yml` then builds, publishes to PyPI, cuts the GitHub Release, fast-forwards `main`, and fires the dependency cascade — including the omninode_infra leg added by #1613, whose first live exercise this will be.

Evidence-Ticket: OMN-16831
Evidence-Source: OCC#7534
