### PR TITLE
fix(OMN-16917): count every configured test filename pattern when sizing selector splits

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -557,18 +557,29 @@ def _volume_split_count(selected_paths: list[str], repo_root: Path | None) -> in
 
 
 def _count_test_files(selected_paths: list[str], repo_root: Path) -> int:
-    """Count ``test_*.py`` files a selection covers.
+    """Count the collectable test files a selection covers.
 
     ``selected_paths`` entries are either a directory (module-grain sentinel,
     e.g. ``tests/unit/`` or ``tests/unit/cli/`` — walked recursively) or an
     individual test FILE (OMN-14921 file-grain closure output, e.g.
     ``tests/unit/cli/test_foo.py`` — counted directly, no walk needed).
+
+    Directory walks count every name :func:`is_test_file_name` accepts — i.e.
+    the whole of ``TEST_FILE_PATTERNS``, which mirrors pytest's ``python_files``
+    — not just the ``test_*.py`` half. Counting only one pattern here while
+    ``_contains_collectable_test`` admits both would let a directory be SELECTED
+    on the strength of files this function then does not count, undercounting
+    the volume and emitting too few matrix splits (OMN-16917 review finding).
     """
     total = 0
     for rel in selected_paths:
         target = repo_root / rel
         if target.is_dir():
-            total += sum(1 for _ in target.rglob("test_*.py"))
+            total += sum(
+                1
+                for candidate in target.rglob("*.py")
+                if is_test_file_name(candidate.name)
+            )
         elif target.is_file():
             total += 1
     return total

--- a/tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py
@@ -24,8 +24,10 @@ import pytest
 
 from scripts.ci.detect_test_paths import (
     CI_CONTRACT_TEST_ROOT,
+    _count_test_files,
     ci_contract_test_paths,
     compute_selection,
+    is_test_file_name,
     unnarrowable_test_paths,
 )
 from scripts.ci.test_selection_closure import compute_closure_selection
@@ -309,3 +311,28 @@ def test_source_only_diff_is_byte_for_byte_the_pre_existing_closure_path() -> No
 
     assert selection.is_full_suite is False
     assert selection.selected_paths == expected
+
+
+def test_split_count_counts_every_configured_test_filename_pattern(
+    tmp_path: Path,
+) -> None:
+    """Volume counting honours ALL of ``TEST_FILE_PATTERNS``, not just half.
+
+    ``_contains_collectable_test`` admits a directory on either pattern, so a
+    directory can be SELECTED on the strength of ``*_test.py`` files. If the
+    volume counter only globbed ``test_*.py`` it would not count the files that
+    justified the selection, undercount the volume, and emit too few matrix
+    splits — a selection whose own proof is invisible to its sizing.
+
+    Asserted against the counter directly so the invariant holds regardless of
+    which patterns happen to be populated in the live tree today.
+    """
+    suite = tmp_path / "tests" / "suite"
+    suite.mkdir(parents=True)
+    (suite / "test_prefix_style.py").write_text("def test_a() -> None: ...\n")
+    (suite / "suffix_style_test.py").write_text("def test_b() -> None: ...\n")
+    (suite / "helper.py").write_text("VALUE = 1\n")
+
+    assert _count_test_files(["tests/suite/"], tmp_path) == 2
+    assert is_test_file_name("suffix_style_test.py") is True
+    assert is_test_file_name("helper.py") is False


### PR DESCRIPTION
## OMN-16917 follow-up — the selection predicate and the sizing predicate are now the same predicate

Follow-up to **omnibase_core#1614** (merged to `dev` as `22adaa83`), landing a **valid CodeRabbit review finding** on that PR that was orphaned: the repo's auto-squash bot merged #1614 on its first commit while the second commit's governed full-suite pre-push was still running, so the fix never reached `dev`. This PR is that commit, cherry-picked onto post-merge `dev`.

## The defect

`TEST_FILE_PATTERNS` mirrors pytest's `python_files` and holds **two** patterns:

```python
TEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
```

`is_test_file_name` honours both. `_contains_collectable_test` therefore admits a directory on **either** pattern — and `ci_contract_test_paths` (added in #1614) selects `tests/ci/` on exactly that predicate.

But `_count_test_files` globbed only one half:

```python
total += sum(1 for _ in target.rglob("test_*.py"))
```

So a directory could be **selected** on the strength of files the volume counter then did **not count**. The consequence runs through `_split_count_for` → `VOLUME_THRESHOLD_FILES` / `VOLUME_TARGET_FILES_PER_SPLIT`: undercounted volume, too few matrix splits, each split carrying more than the sizing intended. A selection whose own justification was invisible to its sizing.

## The change

`_count_test_files` now counts every name `is_test_file_name` accepts, so the predicate that decides *whether a directory is selected* and the predicate that decides *how big that selection is* are the same predicate. One function, one source of truth, no second copy of the pattern list to drift.

## Behavior on the current tree

**Unchanged.** The live tree holds **0** `*_test.py` files against **1,586** `test_*.py`, so no selection is sized differently today. This closes a latent divergence rather than reacting to a live miscount — which is precisely why it needed a test that does not depend on the live tree's population.

`test_split_count_counts_every_configured_test_filename_pattern` asserts the counter **directly**, against a synthetic tree holding one file of each pattern plus a non-test helper:

```
tests/suite/test_prefix_style.py      -> counted
tests/suite/suffix_style_test.py      -> counted   (would have been missed)
tests/suite/helper.py                 -> not counted
```

so the invariant holds regardless of which patterns happen to be populated in the repo later.

## Readback unchanged

Same real OMN-16625 5-file diff that #1614 was measured on:

```
split_count: 5   is_full_suite: false   tests/unit/ absent
```

Identical to the post-merge readback on `22adaa83`. This PR narrows nothing and widens nothing on today's tree.

## No bypass

No `[skip-*` token, no `ENABLE_SMART_TESTS=off`, no `PREPUSH_FULL_SUITE`, no new environment variable. The pre-existing knobs are untouched.

## dod_evidence

* `uv run pytest tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py` → **16 passed** (15 from #1614 plus the new counter test).
* Live selector readback on the real OMN-16625 file list after this change: `split_count: 5`, `is_full_suite=false`, `tests/unit/` absent — byte-identical to the merged `22adaa83` readback.
* **Governed pre-push selector on this branch**: correctly escalated `is_full_suite=true, full_suite_reason=test_infrastructure` (this PR changes `scripts/ci/detect_test_paths.py`, a `test_infrastructure_paths` entry) → the hook ran the **full suite** and allowed the push. No knob set, no override grant, no `--no-verify`.
* `uv run ruff format --check` / `uv run ruff check` on both changed files → clean. Full pre-commit ran as part of the push.
* Review thread on #1614 replied to and resolved with this reasoning.

Ticket: OMN-16917

Evidence-Ticket: OMN-16917
Evidence-Source: OCC#7544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test discovery for directory selections by recognizing both supported pytest filename patterns.
  * Non-test files are now excluded from test counts as expected.

* **Tests**
  * Added coverage to verify accurate counting across multiple test filename patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->