### PR TITLE
fix(OMN-16346): Contract Compliance Check resolves push commit's PR instead of failing closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3550,11 +3550,16 @@ jobs:
     # `reject-required-check-skip-vector` pre-commit hook (OMN-14863) exists
     # to catch (confirmed live: it rejected an earlier draft of this fix that
     # narrowed the `if:`). Keeping `if:` unconditional means the job always
-    # runs to completion; the fix is entirely in the step below, which now
-    # `exit 1`s instead of `exit 0` on merge_group/push -- a `failure`
-    # conclusion is caught by the default-deny sweep regardless of GATE_JOBS/
-    # STRICT_SUCCESS_JOBS membership, so this fails closed without ever
-    # relying on an `if:`-driven skip.
+    # runs to completion; the step below fails closed (`exit 1`, caught by
+    # the default-deny sweep regardless of GATE_JOBS/STRICT_SUCCESS_JOBS
+    # membership) whenever it cannot resolve a PR number to validate against
+    # -- never an `if:`-driven skip. OMN-16346: on `push` that used to be
+    # EVERY event (permanently reddening dev's post-merge signal, since push
+    # never populates github.event.pull_request.number); the step now
+    # resolves the merge commit's originating PR via the associated-PR API
+    # first and only falls through to fail-closed if that resolution itself
+    # comes up empty. `merge_group` is unchanged (still fails closed) -- no
+    # live dev merge queue exercises it today.
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v7
@@ -3673,14 +3678,43 @@ jobs:
         working-directory: onex_change_control
         run: |
           set -euo pipefail
+          # OMN-16346: the job-level `if:` above deliberately admits
+          # pull_request, merge_group, AND push (it cannot be narrowed to
+          # pull_request -- see that comment), so this branch is NOT an
+          # invariant-broke escape hatch, it is the normal path on every dev
+          # push. Prior text here claimed the job "now only runs on
+          # pull_request" and unconditionally exited 1; that made
+          # push-event runs (i.e. every post-merge dev commit) fail closed
+          # by construction, permanently reddening dev's post-merge signal
+          # (OMN-16013 / OMN-16055 / OMN-16346).
+          #
+          # Push-path fix: resolve the PR that produced this push's commit
+          # and validate against IT, instead of failing blind. GitHub
+          # associates a squash-merge commit with its originating PR (the
+          # documented "List pull requests associated with a commit" API),
+          # so for the ordinary squash-merge-to-dev case this evaluates the
+          # exact same check_values the PR's own pull_request run already
+          # evaluated -- not a vacuous pass, not a skip, and not a second
+          # independent judgment that could disagree with the PR verdict.
+          if [ -z "${PR_NUMBER:-}" ] && [ "${{ github.event_name }}" = "push" ]; then
+            RESOLVED_PR="$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+              --jq '[.[] | select(.merged_at != null)] | sort_by(.merged_at) | last | .number // empty' \
+              2>/dev/null || true)"
+            if [ -n "$RESOLVED_PR" ]; then
+              echo "::notice::event=push, no PR in event payload -- resolved merged PR #${RESOLVED_PR} from commit ${{ github.sha }} via the associated-PR API"
+              PR_NUMBER="$RESOLVED_PR"
+            fi
+          fi
           if [ -z "${PR_NUMBER:-}" ]; then
-            # enforce-everything gate audit (fail-closed, not fail-open): this
-            # job now only runs `if: github.event_name == 'pull_request'`
-            # (see the job-level `if:` above), which always populates
-            # PR_NUMBER. Reaching this branch means that invariant broke some
-            # other way -- fail closed (exit 1), never vacuously pass a DoD
-            # check that did not actually run a single check_value.
-            echo "::error::No PR number (event=${{ github.event_name }}); DoD check_values are PR-scoped and this job should only run on pull_request. Failing closed."
+            # Still unresolved: a pull_request run missing PR_NUMBER (the
+            # invariant above broke some other way), a merge_group run (no
+            # live dev merge queue today; this repo has no merge_group
+            # associated-PR resolution yet -- see OMN-16346 follow-up if one
+            # is ever enabled), or a push whose commit genuinely has no
+            # associated PR (direct push, rebase merge, force push). Fail
+            # closed (exit 1), never vacuously pass a DoD check that did not
+            # actually run a single check_value.
+            echo "::error::No PR number (event=${{ github.event_name }}); DoD check_values are PR-scoped and could not be resolved for this event. Failing closed."
             exit 1
           fi
           uv run python scripts/ci/run_contract_compliance_check.py \

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -556,7 +556,15 @@ class TestContractComplianceFailClosed:
         text = CI_YML.read_text(encoding="utf-8")
         marker = 'if [ -z "${PR_NUMBER:-}" ]; then'
         idx = text.index(marker)
-        branch = text[idx : idx + 400].split("\n          fi", 1)[0]
+        # OMN-16346: bound the branch by its own terminator only. This used to
+        # slice a fixed `text[idx : idx + 400]` window first, which silently
+        # made the pin depend on how many COMMENT characters happen to sit
+        # between the `if` and the `exit 1` -- adding an explanatory comment
+        # inside the branch pushed `exit 1` past offset 400 and failed this
+        # test while the fail-closed property it guards was fully intact. The
+        # `\n          fi` split already bounds the branch exactly, so the
+        # character cap was never load-bearing, only brittle.
+        branch = text[idx:].split("\n          fi", 1)[0]
         assert "exit 1" in branch, branch
         assert "exit 0" not in branch, branch
 


### PR DESCRIPTION
## OMN-16346 — dev push CI is structurally red since #1556

`Contract Compliance Check` (and, behind it, `CI Summary`) fail by design on
**every** `dev` push. `#1556` widened the job's `if:` to admit
`pull_request`, `merge_group`, **and** `push`, but the DoD `check_values` it
evaluates are PR-scoped (`github.event.pull_request.number`) — a field
`push` never populates. `OMN-16055` closed the `dod_verify` *consumer* half
of this but never the `ci.yml` push-path half, so every dev push since has
hard-failed with:

```
##[error]No PR number (event=push); DoD check_values are PR-scoped and this job
should only run on pull_request. Failing closed.
##[error]Process completed with exit code 1.
```

Live confirmation (re-checked before this PR, not carried over from an
earlier triage pass): the most recent `push`-event `ci.yml` run on `dev`
(`2a5ac713`, run `33080008271`, 2026-08-27T14:02Z) shows both
`Contract Compliance Check` and `CI Summary` = `failure`.

## Fix

On `push`, resolve the merge commit's originating PR via
`gh api repos/{repo}/commits/{sha}/pulls` (GitHub associates a squash-merge
commit with its source PR) and validate against **that** PR number — the
exact same `check_values` the PR's own `pull_request` run already evaluated.
Not a vacuous pass, not a skip:

- `pull_request` path is byte-identical (`PR_NUMBER` already populated from
  the event payload; the new branch never executes).
- `merge_group` is unchanged — still fails closed, since there is no live
  `dev` merge queue to exercise it today.
- If the associated-PR lookup itself comes up empty (direct push, rebase
  merge, force push, or the invariant breaking some other way), the job
  still fails closed with `exit 1` — never a vacuous pass.

Also corrected two stale inline comments claiming the job "only runs on
`pull_request`" — the job-level `if:` has admitted `push`/`merge_group`
since `#1556`; the comments were never updated to match.

## Scope check (other repos calling `run_contract_compliance_check.py`)

- `omnibase_infra` — exit-0 vacuous skip on empty `PR_NUMBER`, a *different*
  fail-open risk, out of scope here.
- `omnibase_compat` — step-level `if:` skip, job reports success, out of
  scope.
- `onex_change_control` — job `if:` never admits `push`, unaffected.

Only `omnibase_core` exhibits the fail-closed dev-push red this ticket
targets.

Governed pre-push selector escalated to a full-suite-equivalent run (a
`.github/workflows/`-only diff cannot be resolved via the import graph) and
ran to completion clean: **44120 passed, 55 skipped, 3 xpassed** in
2:49:36 (`.201` gate-runner lane, `PREPUSH_201_GATE_RUNNER_HOSTNAME` only —
no `--no-verify`, no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS`, no
`PREPUSH_ALLOW_*`). Branch was then rebased onto current `dev` (clean, zero
conflicts, diffstat unchanged) and re-pushed through the same governed hook.

Not deploy-gate scoped: the diff touches only `.github/workflows/ci.yml`
and `tests/unit/scripts/ci/test_ci_summary_gate.py`, zero matches against
`RUNTIME_PATH_PATTERNS`.

Ticket: OMN-16346

Evidence-Ticket: OMN-16346
Evidence-Source: OCC#7568
