### PR TITLE
fix(OMN-16859): eligibility names the runner that owes an execution instead of reporting a bare non-PASS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.0"
+version = "0.47.1"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/enums/enum_occ_eligibility_reason.py
+++ b/src/omnibase_core/enums/enum_occ_eligibility_reason.py
@@ -24,6 +24,19 @@ class EnumOccEligibilityReason(StrEnum):
     # to the OCC PR itself (`occ-self-bind-pr-<N>` omitted). Split out of
     # PR_TICKET_MISMATCH so the gate can name the exact remedy.
     MISSING_OCC_SELF_BIND = "missing_occ_self_bind"
+    # OMN-16859: the receipt resolves, is hash-bound and PR-bound, and honestly
+    # declares PENDING — the probe was allocated but has not executed yet —
+    # on a check type a product-repo CI runner executes and supersedes.
+    #
+    # This is a LEGIBILITY split out of NONPASS_RECEIPT, never a relaxation:
+    # the verdict stays `eligible=False`, and the gate reports it only when it
+    # is the SOLE remaining blocker, so a genuinely missing or genuinely
+    # FAILING receipt still wins. It exists because the OCC producers run in
+    # the .201 effects runtime with no product checkout and structurally cannot
+    # execute a `test_passes` check, so "non-PASS" pointed four separate lanes
+    # at the wrong remedy (hand-author a receipt) on 2026-08-28 alone. The
+    # right remedy is: wait for the product-repo runner, or fix it.
+    AWAITING_RUNNER_RECEIPT = "awaiting_runner_receipt"
 
 
 __all__ = ["EnumOccEligibilityReason"]

--- a/src/omnibase_core/enums/enum_occ_eligibility_reason.py
+++ b/src/omnibase_core/enums/enum_occ_eligibility_reason.py
@@ -40,5 +40,11 @@ class EnumOccEligibilityReason(StrEnum):
     # wrong remedy (hand-author a receipt) on 2026-08-28 alone.
     AWAITING_RUNNER_RECEIPT = "awaiting_runner_receipt"
 
+    def legacy_external_value(self) -> str:
+        """Return the v0.46-compatible reason value for exhaustive consumers."""
+        if self is EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT:
+            return EnumOccEligibilityReason.NONPASS_RECEIPT.value
+        return self.value
+
 
 __all__ = ["EnumOccEligibilityReason"]

--- a/src/omnibase_core/enums/enum_occ_eligibility_reason.py
+++ b/src/omnibase_core/enums/enum_occ_eligibility_reason.py
@@ -31,11 +31,13 @@ class EnumOccEligibilityReason(StrEnum):
     # This is a LEGIBILITY split out of NONPASS_RECEIPT, never a relaxation:
     # the verdict stays `eligible=False`, and the gate reports it only when it
     # is the SOLE remaining blocker, so a genuinely missing or genuinely
-    # FAILING receipt still wins. It exists because the OCC producers run in
-    # the .201 effects runtime with no product checkout and structurally cannot
-    # execute a `test_passes` check, so "non-PASS" pointed four separate lanes
-    # at the wrong remedy (hand-author a receipt) on 2026-08-28 alone. The
-    # right remedy is: wait for the product-repo runner, or fix it.
+    # FAILING receipt still wins. Exhaustive consumers should treat unknown
+    # reasons as ineligible and may map this value to NONPASS_RECEIPT until
+    # they render the more specific "wait for or fix the product-repo runner"
+    # remedy. It exists because the OCC producers run in the .201 effects
+    # runtime with no product checkout and structurally cannot execute a
+    # `test_passes` check, so "non-PASS" pointed four separate lanes at the
+    # wrong remedy (hand-author a receipt) on 2026-08-28 alone.
     AWAITING_RUNNER_RECEIPT = "awaiting_runner_receipt"
 
 

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -435,6 +435,7 @@ def validate_occ_merge_eligibility(
                 if (
                     receipt.status is EnumReceiptStatus.PENDING
                     and check_type in RUNNER_COVERED_CHECK_TYPES
+                    and is_bound
                 ):
                     awaiting_runner_receipts.append(receipt_key)
                 else:
@@ -483,44 +484,6 @@ def validate_occ_merge_eligibility(
             ),
             detail="one or more receipts are missing or non-PASS",
         )
-    # OMN-16859 — DELIBERATELY AFTER the missing/non-PASS return above.
-    #
-    # That ordering IS the safety property, and it is why this is a legibility
-    # split rather than a carve-out: a genuinely absent receipt or a receipt
-    # that ran and FAILED is reported as such and reaches its own return first.
-    # This branch can only be taken when every other declared receipt resolved
-    # PASS and the sole outstanding item is an honestly-PENDING one on a check
-    # type a product-repo runner executes. Moving this block above that one
-    # would let "not yet run" mask "ran and failed"; do not reorder.
-    #
-    # The verdict is unchanged from before this ticket (`eligible=False`), and
-    # the key is still surfaced in `missing_or_nonpass_receipts` so CI logs and
-    # downstream tooling that read that field do not go blind on the new reason.
-    if awaiting_runner_receipts:
-        return ModelOccEligibilityResult(
-            eligible=False,
-            reason=EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT,
-            ticket_ids=ticket_ids,
-            occ_commit_sha=snapshot.occ_commit_sha,
-            contract_hashes=contract_hashes,
-            receipt_ids=tuple(sorted(receipt_ids)),
-            missing_or_nonpass_receipts=tuple(sorted(awaiting_runner_receipts)),
-            detail=(
-                f"{len(awaiting_runner_receipts)} receipt(s) are honestly PENDING "
-                "on a check type the OCC producers cannot execute (they run in "
-                "the .201 effects runtime with no product checkout): "
-                f"{', '.join(sorted(awaiting_runner_receipts))}. This is NOT a "
-                "missing receipt and NOT a failed check — the probe was "
-                "allocated and has not run yet. The product repo's OCC receipt "
-                "runner executes the declared check at PR head and appends a "
-                "superseding receipt to this companion's branch; preflight then "
-                "re-evaluates. Do NOT hand-author a receipt to clear this: "
-                "check the product PR's OCC receipt runner job first, and fix "
-                "it if it did not run. Merge stays blocked until a real "
-                "executed PASS supersedes the PENDING receipt "
-                f"(runner-covered check types: {', '.join(sorted(RUNNER_COVERED_CHECK_TYPES))})."
-            ),
-        )
     unbound_tickets = tuple(
         ticket_id
         for ticket_id in ticket_ids
@@ -561,6 +524,45 @@ def validate_occ_merge_eligibility(
             ),
         )
 
+    # OMN-16859 — DELIBERATELY AFTER the missing/non-PASS and unbound-ticket
+    # returns above.
+    #
+    # That ordering IS the safety property, and it is why this is a legibility
+    # split rather than a carve-out: a genuinely absent receipt or a receipt
+    # that ran and FAILED is reported as such and reaches its own return first.
+    # This branch can only be taken when every other declared receipt resolved
+    # PASS and the sole outstanding item is an honestly-PENDING one on a check
+    # type a product-repo runner executes. Moving this block above that one
+    # would let "not yet run" mask "ran and failed"; do not reorder.
+    #
+    # The verdict is unchanged from before this ticket (`eligible=False`), and
+    # the key is still surfaced in `missing_or_nonpass_receipts` so CI logs and
+    # downstream tooling that read that field do not go blind on the new reason.
+    if awaiting_runner_receipts:
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            missing_or_nonpass_receipts=tuple(sorted(awaiting_runner_receipts)),
+            detail=(
+                f"{len(awaiting_runner_receipts)} receipt(s) are honestly PENDING "
+                "on a check type the OCC producers cannot execute (they run in "
+                "the .201 effects runtime with no product checkout): "
+                f"{', '.join(sorted(awaiting_runner_receipts))}. This is NOT a "
+                "missing receipt and NOT a failed check — the probe was "
+                "allocated and has not run yet. The product repo's OCC receipt "
+                "runner executes the declared check at PR head and appends a "
+                "superseding receipt to this companion's branch; preflight then "
+                "re-evaluates. Do NOT hand-author a receipt to clear this: "
+                "check the product PR's OCC receipt runner job first, and fix "
+                "it if it did not run. Merge stays blocked until a real "
+                "executed PASS supersedes the PENDING receipt "
+                f"(runner-covered check types: {', '.join(sorted(RUNNER_COVERED_CHECK_TYPES))})."
+            ),
+        )
     return ModelOccEligibilityResult(
         eligible=True,
         reason=EnumOccEligibilityReason.ELIGIBLE,

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -52,6 +52,27 @@ _OCC_REPO_NAME = "onex_change_control"
 _OCC_REPO_ORG = "OmniNode-ai"
 _OCC_REPO_QUALIFIED = f"{_OCC_REPO_ORG}/{_OCC_REPO_NAME}"
 
+# OMN-16859: check types a PRODUCT-REPO CI runner executes and supersedes.
+#
+# The OCC companion producers (`OccCompanionEmitter` born path,
+# `node_occ_companion_compute`) run inside the .201 dev-lane effects runtime,
+# which holds no product-repo checkout — the declared `cwd` is
+# `${OMNI_HOME}/<repo>`, a path that does not exist there. They therefore
+# cannot execute a `test_passes` check, and the honest mint is a PENDING
+# receipt ("the probe was allocated but has not yet executed", per
+# `EnumReceiptStatus`) rather than a PASS behind a `gh pr view` probe.
+#
+# The surface that CAN execute it honestly is the product repo's own CI, which
+# has the checkout, the dependencies and the real test targets. It writes the
+# executed result into the OPEN companion branch as a net-new supersession
+# record, which `resolve_supersession` re-binds this key to.
+#
+# Membership here changes only the REASON reported while that is outstanding.
+# It never makes a PR eligible. Keep this set to types a runner genuinely
+# covers: adding a type with no runner behind it would turn a permanent block
+# into a message claiming something is on its way when nothing is.
+RUNNER_COVERED_CHECK_TYPES = frozenset({"test_passes"})
+
 
 def _is_occ_repo(repo: str) -> bool:
     """True only for the canonical OCC repo — bare name or exact org/name.
@@ -181,6 +202,12 @@ def validate_occ_merge_eligibility(
     missing_contracts: list[str] = []
     missing_receipts: list[str] = []
     nonpass_receipts: list[str] = []
+    # OMN-16859: PENDING receipts on runner-covered check types, kept in their
+    # own bucket so they can be reported distinctly ONLY when nothing harder is
+    # outstanding. Deliberately a third list rather than a flag on
+    # `nonpass_receipts`: the outranking rule below is then a plain ordering of
+    # returns instead of a predicate someone can weaken by accident.
+    awaiting_runner_receipts: list[str] = []
     # OMN-14404: stale contract bindings accumulate like every other failure
     # class in this function. Returning on the first one discards the other N-1
     # already-resolved receipts and costs the operator a full CI round per stale
@@ -397,7 +424,21 @@ def validate_occ_merge_eligibility(
             if is_bound:
                 tickets_with_pr_bound_receipt.add(ticket_id)
             if receipt.status is not EnumReceiptStatus.PASS:
-                nonpass_receipts.append(receipt_key)
+                # OMN-16859: an honest PENDING on a check type a product-repo
+                # runner executes is "not yet run", not "ran and failed". Both
+                # are ineligible; only the remedy differs, and naming the wrong
+                # remedy is what cost four lanes a full re-diagnosis each on
+                # 2026-08-28. ADVISORY and FAIL are NOT included — ADVISORY
+                # means the probe ran but the proof is structurally weak, and
+                # FAIL means it ran and contradicted the claim; neither is
+                # waiting on anything.
+                if (
+                    receipt.status is EnumReceiptStatus.PENDING
+                    and check_type in RUNNER_COVERED_CHECK_TYPES
+                ):
+                    awaiting_runner_receipts.append(receipt_key)
+                else:
+                    nonpass_receipts.append(receipt_key)
                 continue
             receipt_ids.append(receipt_key)
 
@@ -435,6 +476,44 @@ def validate_occ_merge_eligibility(
                 sorted([*missing_receipts, *nonpass_receipts])
             ),
             detail="one or more receipts are missing or non-PASS",
+        )
+    # OMN-16859 — DELIBERATELY AFTER the missing/non-PASS return above.
+    #
+    # That ordering IS the safety property, and it is why this is a legibility
+    # split rather than a carve-out: a genuinely absent receipt or a receipt
+    # that ran and FAILED is reported as such and reaches its own return first.
+    # This branch can only be taken when every other declared receipt resolved
+    # PASS and the sole outstanding item is an honestly-PENDING one on a check
+    # type a product-repo runner executes. Moving this block above that one
+    # would let "not yet run" mask "ran and failed"; do not reorder.
+    #
+    # The verdict is unchanged from before this ticket (`eligible=False`), and
+    # the key is still surfaced in `missing_or_nonpass_receipts` so CI logs and
+    # downstream tooling that read that field do not go blind on the new reason.
+    if awaiting_runner_receipts:
+        return ModelOccEligibilityResult(
+            eligible=False,
+            reason=EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT,
+            ticket_ids=ticket_ids,
+            occ_commit_sha=snapshot.occ_commit_sha,
+            contract_hashes=contract_hashes,
+            receipt_ids=tuple(sorted(receipt_ids)),
+            missing_or_nonpass_receipts=tuple(sorted(awaiting_runner_receipts)),
+            detail=(
+                f"{len(awaiting_runner_receipts)} receipt(s) are honestly PENDING "
+                "on a check type the OCC producers cannot execute (they run in "
+                "the .201 effects runtime with no product checkout): "
+                f"{', '.join(sorted(awaiting_runner_receipts))}. This is NOT a "
+                "missing receipt and NOT a failed check — the probe was "
+                "allocated and has not run yet. The product repo's OCC receipt "
+                "runner executes the declared check at PR head and appends a "
+                "superseding receipt to this companion's branch; preflight then "
+                "re-evaluates. Do NOT hand-author a receipt to clear this: "
+                "check the product PR's OCC receipt runner job first, and fix "
+                "it if it did not run. Merge stays blocked until a real "
+                "executed PASS supersedes the PENDING receipt "
+                f"(runner-covered check types: {', '.join(sorted(RUNNER_COVERED_CHECK_TYPES))})."
+            ),
         )
     unbound_tickets = tuple(
         ticket_id

--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -473,7 +473,13 @@ def validate_occ_merge_eligibility(
             contract_hashes=contract_hashes,
             receipt_ids=tuple(sorted(receipt_ids)),
             missing_or_nonpass_receipts=tuple(
-                sorted([*missing_receipts, *nonpass_receipts])
+                sorted(
+                    [
+                        *missing_receipts,
+                        *nonpass_receipts,
+                        *awaiting_runner_receipts,
+                    ]
+                )
             ),
             detail="one or more receipts are missing or non-PASS",
         )

--- a/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
+++ b/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
@@ -84,26 +84,45 @@ def _write_contract(root: Path, items: list[dict[str, Any]]) -> str:
     return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
 
 
+def _write_ticket_contract(
+    root: Path, ticket_id: str, items: list[dict[str, Any]]
+) -> str:
+    text = yaml.safe_dump(
+        {
+            "ticket_id": ticket_id,
+            "title": f"{ticket_id} contract",
+            "dod_evidence": items,
+        },
+        sort_keys=True,
+    )
+    (root / "contracts").mkdir(parents=True, exist_ok=True)
+    (root / "contracts" / f"{ticket_id}.yaml").write_text(text, encoding="utf-8")
+    return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
+
+
 def _write_receipt(
     root: Path,
     *,
+    ticket_id: str = TICKET,
     evidence_item_id: str,
     check_type: str,
     check_value: str,
     status: EnumReceiptStatus,
     contract_sha256: str,
+    commit_sha: str = PR_SHA,
+    pr_number: int = PR_NUMBER,
 ) -> Path:
     """Write a receipt at the path eligibility resolves: ``<item>/<check_type>.yaml``."""
     executed = status is not EnumReceiptStatus.PENDING
     receipt: dict[str, Any] = {
         "schema_version": "1.0.0",
-        "ticket_id": TICKET,
+        "ticket_id": ticket_id,
         "evidence_item_id": evidence_item_id,
         "check_type": check_type,
         "check_value": check_value,
         "status": status.value,
         "run_timestamp": datetime(2026, 8, 29, 11, 0, tzinfo=UTC),
-        "commit_sha": PR_SHA,
+        "commit_sha": commit_sha,
         # Distinct identities: `verifier == runner` downgrades PASS to ADVISORY
         # (ModelDodReceipt rule 1) and would make the PASS control below fail
         # for a reason that has nothing to do with this ticket.
@@ -115,10 +134,10 @@ def _write_receipt(
         # Writing a fake "1 passed" here would defeat the point of the fixture.
         "probe_stdout": "" if not executed else "1 passed in 0.12s\n",
         "exit_code": None if not executed else 0,
-        "pr_number": PR_NUMBER,
+        "pr_number": pr_number,
         "contract_sha256": contract_sha256,
     }
-    path = root / "receipts" / TICKET / evidence_item_id / f"{check_type}.yaml"
+    path = root / "receipts" / ticket_id / evidence_item_id / f"{check_type}.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(receipt, sort_keys=True), encoding="utf-8")
     return path
@@ -133,6 +152,21 @@ def _snapshot(root: Path) -> ModelOccEligibilityInput:
         pr_branch=f"jonah/{TICKET.lower()}-occ-receipt-runner",
         pr_commit_shas=(PR_SHA,),
         pr_commit_texts=(f"feat({TICKET}): runner",),
+        occ_commit_sha="c" * 40,
+        contracts_dir=root / "contracts",
+        receipts_dir=root / "receipts",
+    )
+
+
+def _snapshot_for_tickets(root: Path, *ticket_ids: str) -> ModelOccEligibilityInput:
+    return ModelOccEligibilityInput(
+        repo="omnimarket",
+        pr_number=PR_NUMBER,
+        pr_title=" ".join(f"feat({ticket_id}): runner" for ticket_id in ticket_ids),
+        pr_body="\n".join(f"Closes: {ticket_id}" for ticket_id in ticket_ids),
+        pr_branch="jonah/multi-ticket-occ-receipt-runner",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=tuple(f"feat({ticket_id}): runner" for ticket_id in ticket_ids),
         occ_commit_sha="c" * 40,
         contracts_dir=root / "contracts",
         receipts_dir=root / "receipts",
@@ -201,6 +235,45 @@ def test_awaiting_runner_still_surfaces_the_receipt_key(tmp_path: Path) -> None:
     assert result.missing_or_nonpass_receipts == (
         f"{TICKET}:{BEHAVIOR_ITEM}:test_passes",
     )
+
+
+@pytest.mark.unit
+def test_unbound_ticket_outranks_awaiting_runner(tmp_path: Path) -> None:
+    """A bound pending receipt cannot hide another ticket with no PR-bound proof."""
+    other_ticket = "OMN-16860"
+    other_item = "dod-other-bound-proof"
+    contract_hash = _write_contract(
+        tmp_path, [_item(BEHAVIOR_ITEM, "test_passes", BEHAVIOR_CHECK)]
+    )
+    other_contract_hash = _write_ticket_contract(
+        tmp_path, other_ticket, [_item(other_item, "test_passes", "uv run pytest -q")]
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id=BEHAVIOR_ITEM,
+        check_type="test_passes",
+        check_value=BEHAVIOR_CHECK,
+        status=EnumReceiptStatus.PENDING,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        ticket_id=other_ticket,
+        evidence_item_id=other_item,
+        check_type="test_passes",
+        check_value="uv run pytest -q",
+        status=EnumReceiptStatus.PASS,
+        contract_sha256=other_contract_hash,
+        commit_sha="4" * 40,
+        pr_number=9999,
+    )
+
+    result = validate_occ_merge_eligibility(
+        _snapshot_for_tickets(tmp_path, TICKET, other_ticket)
+    )
+
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
+    assert other_ticket in result.detail
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
+++ b/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
@@ -204,6 +204,25 @@ def test_awaiting_runner_still_surfaces_the_receipt_key(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_awaiting_runner_has_legacy_nonpass_reason_value(tmp_path: Path) -> None:
+    """Older exhaustive consumers can keep their NONPASS_RECEIPT branch.
+
+    The emitted reason remains specific for new consumers, while compatibility
+    callers that have not yet added a dedicated branch can fail closed exactly
+    as they did before OMN-16859.
+    """
+    _only_pending_behavior_proof(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.reason is EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT
+    assert (
+        result.reason.legacy_external_value()
+        == EnumOccEligibilityReason.NONPASS_RECEIPT.value
+    )
+
+
+@pytest.mark.unit
 def test_awaiting_runner_detail_names_the_remedy(tmp_path: Path) -> None:
     """The detail must say what will clear it, since that is the whole point.
 

--- a/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
+++ b/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-16859 AC3c — a PENDING receipt on a runner-covered check_type is legible.
+
+Context, in one paragraph. The OCC companion producers run in the .201 dev-lane
+effects runtime, which holds NO product-repo checkout, so they cannot execute a
+declared ``test_passes`` check. Until OMN-16859 the born receipt papered over
+that by minting ``status: PASS`` behind a ``gh pr view`` probe. The honest mint
+is ``status: PENDING`` ("the probe was allocated but has not yet executed" --
+:class:`EnumReceiptStatus` docstring), and a product-repo CI runner later
+supersedes it with a real executed run.
+
+This module pins the eligibility half of that arrangement. The verdict does NOT
+change: a PENDING receipt is ineligible, exactly as it was. What changes is the
+REASON. Four independent lanes on 2026-08-28 hit the same defect and each
+re-diagnosed it from scratch, because the gate said ``missing_receipt`` --
+which points at the wrong remedy (hand-author a receipt) instead of the right
+one (wait for, or fix, the runner).
+
+The three properties that make this a legibility change and not a carve-out are
+each pinned by their own test:
+
+* ``test_awaiting_runner_is_still_ineligible`` -- fail-closed. If the runner
+  never reports, the PR stays blocked forever.
+* ``test_a_genuine_missing_receipt_outranks_awaiting_runner`` and
+  ``test_a_genuine_failing_receipt_outranks_awaiting_runner`` -- the softer
+  reason is reported ONLY when it is the sole remaining blocker, so no real
+  failure can be laundered into "just waiting".
+* ``test_pending_receipt_on_a_non_runner_check_type_stays_nonpass`` -- the
+  carve-out is scoped to the check types a runner actually covers, not to
+  PENDING in general.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_core.enums.ticket.enum_receipt_status import EnumReceiptStatus
+from omnibase_core.validation.validator_occ_merge_eligibility import (
+    EnumOccEligibilityReason,
+    ModelOccEligibilityInput,
+    validate_occ_merge_eligibility,
+)
+
+TICKET = "OMN-16859"
+PR_SHA = "3" * 40
+PR_NUMBER = 2210
+BEHAVIOR_ITEM = "dod-occ-diff-derived-behavior-proof"
+BEHAVIOR_CHECK = (
+    "uv run pytest tests/unit/scripts/test_occ_receipt_runner_omn_16859.py -q"
+)
+
+
+def _contract_text(items: list[dict[str, Any]]) -> str:
+    return yaml.safe_dump(
+        {
+            "ticket_id": TICKET,
+            "title": "automatic OCC receipt generation",
+            "dod_evidence": items,
+        },
+        sort_keys=True,
+    )
+
+
+def _item(item_id: str, check_type: str, check_value: str) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "description": f"probe {item_id}",
+        "checks": [{"check_type": check_type, "check_value": check_value}],
+    }
+
+
+def _write_contract(root: Path, items: list[dict[str, Any]]) -> str:
+    text = _contract_text(items)
+    (root / "contracts").mkdir(parents=True, exist_ok=True)
+    (root / "contracts" / f"{TICKET}.yaml").write_text(text, encoding="utf-8")
+    return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
+
+
+def _write_receipt(
+    root: Path,
+    *,
+    evidence_item_id: str,
+    check_type: str,
+    check_value: str,
+    status: EnumReceiptStatus,
+    contract_sha256: str,
+) -> Path:
+    """Write a receipt at the path eligibility resolves: ``<item>/<check_type>.yaml``."""
+    executed = status is not EnumReceiptStatus.PENDING
+    receipt: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "ticket_id": TICKET,
+        "evidence_item_id": evidence_item_id,
+        "check_type": check_type,
+        "check_value": check_value,
+        "status": status.value,
+        "run_timestamp": datetime(2026, 8, 29, 11, 0, tzinfo=UTC),
+        "commit_sha": PR_SHA,
+        # Distinct identities: `verifier == runner` downgrades PASS to ADVISORY
+        # (ModelDodReceipt rule 1) and would make the PASS control below fail
+        # for a reason that has nothing to do with this ticket.
+        "runner": "github-actions/occ-receipt-runner",
+        "verifier": "occ-receipt-runner exit-status assertion",
+        "probe_command": check_value,
+        # An unexecuted probe has no stdout, and ModelDodReceipt rule 3
+        # explicitly exempts PENDING from the non-empty-stdout requirement.
+        # Writing a fake "1 passed" here would defeat the point of the fixture.
+        "probe_stdout": "" if not executed else "1 passed in 0.12s\n",
+        "exit_code": None if not executed else 0,
+        "pr_number": PR_NUMBER,
+        "contract_sha256": contract_sha256,
+    }
+    path = root / "receipts" / TICKET / evidence_item_id / f"{check_type}.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(receipt, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _snapshot(root: Path) -> ModelOccEligibilityInput:
+    return ModelOccEligibilityInput(
+        repo="omnimarket",
+        pr_number=PR_NUMBER,
+        pr_title=f"feat({TICKET}): product-repo OCC receipt runner",
+        pr_body=f"Closes: {TICKET}",
+        pr_branch=f"jonah/{TICKET.lower()}-occ-receipt-runner",
+        pr_commit_shas=(PR_SHA,),
+        pr_commit_texts=(f"feat({TICKET}): runner",),
+        occ_commit_sha="c" * 40,
+        contracts_dir=root / "contracts",
+        receipts_dir=root / "receipts",
+    )
+
+
+def _only_pending_behavior_proof(root: Path) -> None:
+    """The exact live shape: one declared test_passes item, receipt PENDING."""
+    contract_hash = _write_contract(
+        root, [_item(BEHAVIOR_ITEM, "test_passes", BEHAVIOR_CHECK)]
+    )
+    _write_receipt(
+        root,
+        evidence_item_id=BEHAVIOR_ITEM,
+        check_type="test_passes",
+        check_value=BEHAVIOR_CHECK,
+        status=EnumReceiptStatus.PENDING,
+        contract_sha256=contract_hash,
+    )
+
+
+@pytest.mark.unit
+def test_pending_runner_covered_receipt_reports_awaiting_runner(
+    tmp_path: Path,
+) -> None:
+    """The reason names the real situation, not a missing file.
+
+    RED before OMN-16859: the receipt exists and resolves, so the gate falls
+    through to ``NONPASS_RECEIPT`` -- indistinguishable from a check that ran
+    and FAILED, and pointing the operator at hand-authoring a receipt.
+    """
+    _only_pending_behavior_proof(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.reason is EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT
+
+
+@pytest.mark.unit
+def test_awaiting_runner_is_still_ineligible(tmp_path: Path) -> None:
+    """Fail-closed. This is the property that keeps the change honest.
+
+    A PENDING receipt asserts nothing was executed. If the product-repo runner
+    never reports, this PR never merges. The new reason buys legibility, never
+    permission.
+    """
+    _only_pending_behavior_proof(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+
+
+@pytest.mark.unit
+def test_awaiting_runner_still_surfaces_the_receipt_key(tmp_path: Path) -> None:
+    """The machine-readable key list does not go blind on the new reason.
+
+    ``missing_or_nonpass_receipts`` is what CI logs and downstream tooling read
+    to name the offending key. Reporting a new reason with an empty key list
+    would trade one diagnosis problem for another.
+    """
+    _only_pending_behavior_proof(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.missing_or_nonpass_receipts == (
+        f"{TICKET}:{BEHAVIOR_ITEM}:test_passes",
+    )
+
+
+@pytest.mark.unit
+def test_awaiting_runner_detail_names_the_remedy(tmp_path: Path) -> None:
+    """The detail must say what will clear it, since that is the whole point.
+
+    Four lanes re-diagnosed this from scratch because the message pointed at
+    the wrong remedy. The detail names the check type and says a product-repo
+    runner supersedes it, so the next lane reads the answer instead of
+    re-deriving it.
+    """
+    _only_pending_behavior_proof(tmp_path)
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert "test_passes" in result.detail
+    assert "PENDING" in result.detail
+    assert "runner" in result.detail.lower()
+
+
+@pytest.mark.unit
+def test_pending_receipt_on_a_non_runner_check_type_stays_nonpass(
+    tmp_path: Path,
+) -> None:
+    """The carve-out is scoped to check types a runner covers, not to PENDING.
+
+    ``file_exists`` has no product-repo runner behind it, so a PENDING receipt
+    there is an ordinary non-PASS receipt and must keep saying so. Widening
+    this to every PENDING status would turn "someone left a placeholder" into
+    "the system is working on it".
+    """
+    contract_hash = _write_contract(
+        tmp_path, [_item("dod-artifact", "file_exists", "docs/plan.md")]
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="dod-artifact",
+        check_type="file_exists",
+        check_value="docs/plan.md",
+        status=EnumReceiptStatus.PENDING,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.NONPASS_RECEIPT
+
+
+@pytest.mark.unit
+def test_a_genuine_missing_receipt_outranks_awaiting_runner(tmp_path: Path) -> None:
+    """A real gap still reports as a real gap.
+
+    One PENDING runner-covered item plus one item with no receipt at all. The
+    missing receipt is the harder failure and must win, or a PR with genuinely
+    absent evidence would read as merely waiting on CI.
+    """
+    contract_hash = _write_contract(
+        tmp_path,
+        [
+            _item(BEHAVIOR_ITEM, "test_passes", BEHAVIOR_CHECK),
+            _item("dod-unwritten", "command", "echo never-minted"),
+        ],
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id=BEHAVIOR_ITEM,
+        check_type="test_passes",
+        check_value=BEHAVIOR_CHECK,
+        status=EnumReceiptStatus.PENDING,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
+
+
+@pytest.mark.unit
+def test_a_genuine_failing_receipt_outranks_awaiting_runner(tmp_path: Path) -> None:
+    """A check that RAN and FAILED still reports as a failure.
+
+    This is the adversarial case for the whole change: if AWAITING could mask a
+    FAIL, the new reason would be a bypass rather than a label.
+    """
+    contract_hash = _write_contract(
+        tmp_path,
+        [
+            _item(BEHAVIOR_ITEM, "test_passes", BEHAVIOR_CHECK),
+            _item("dod-ran-and-failed", "command", "exit 1"),
+        ],
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id=BEHAVIOR_ITEM,
+        check_type="test_passes",
+        check_value=BEHAVIOR_CHECK,
+        status=EnumReceiptStatus.PENDING,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="dod-ran-and-failed",
+        check_type="command",
+        check_value="exit 1",
+        status=EnumReceiptStatus.FAIL,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.NONPASS_RECEIPT
+
+
+@pytest.mark.unit
+def test_the_runners_executed_pass_clears_the_gate(tmp_path: Path) -> None:
+    """Positive control: this is the state the runner exists to produce.
+
+    Same contract, same key -- the only difference is that the check actually
+    ran. If this did not go green the arrangement would have no exit, and the
+    PENDING tests above would be pinning a permanent block.
+    """
+    contract_hash = _write_contract(
+        tmp_path, [_item(BEHAVIOR_ITEM, "test_passes", BEHAVIOR_CHECK)]
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id=BEHAVIOR_ITEM,
+        check_type="test_passes",
+        check_value=BEHAVIOR_CHECK,
+        status=EnumReceiptStatus.PASS,
+        contract_sha256=contract_hash,
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is True
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE

--- a/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
+++ b/tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py
@@ -278,6 +278,10 @@ def test_a_genuine_missing_receipt_outranks_awaiting_runner(tmp_path: Path) -> N
 
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.MISSING_RECEIPT
+    assert result.missing_or_nonpass_receipts == (
+        f"{TICKET}:{BEHAVIOR_ITEM}:test_passes",
+        f"{TICKET}:dod-unwritten:command",
+    )
 
 
 @pytest.mark.unit
@@ -315,6 +319,10 @@ def test_a_genuine_failing_receipt_outranks_awaiting_runner(tmp_path: Path) -> N
 
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.NONPASS_RECEIPT
+    assert result.missing_or_nonpass_receipts == (
+        f"{TICKET}:{BEHAVIOR_ITEM}:test_passes",
+        f"{TICKET}:dod-ran-and-failed:command",
+    )
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.0"
+version = "0.47.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-16859 AC3c — eligibility names the runner that owes an execution, instead of reporting a bare non-PASS

Companion piece to **omnimarket#2205** (merged, squash `2a7e444f722f76289e12b82828dc2fd4f8eb4a50`), which landed the product-CI OCC receipt runner and the honest PENDING born receipt.

### Why this exists

The OCC companion producers (`OccCompanionEmitter` born path, `node_occ_companion_compute`) run inside the **.201 dev-lane effects runtime**, which holds no product-repo checkout — the declared `cwd` is `${OMNI_HOME}/<repo>`, a path that does not exist there. They therefore **structurally cannot execute** a `test_passes` check, and the honest mint is a `PENDING` receipt ("the probe was allocated but has not yet executed") rather than a `PASS` behind a `gh pr view` probe.

Before this change, that honest PENDING was reported as `nonpass_receipt` — indistinguishable from "the check ran and failed". On 2026-08-28 alone, **four separate lanes** re-diagnosed the same condition from scratch and each reached for the same wrong remedy: hand-author a receipt. The failure text pointed at the wrong fix.

### What changes

New `EnumOccEligibilityReason.AWAITING_RUNNER_RECEIPT`, split out of `NONPASS_RECEIPT`, with a detail that names the remedy (check the product PR's OCC receipt runner job; fix it if it did not run) and **explicitly says not to hand-author a receipt**.

### This is a legibility split, NOT a carve-out — three properties hold it closed

1. **The verdict is unchanged.** `eligible=False` on both paths. Nothing merges that did not merge before.
2. **Ordering is the safety property.** The new return is placed **after** the missing/non-PASS return, so a genuinely absent receipt or one that **ran and FAILED** reaches its own return first and still wins. It can only be taken when every other declared receipt resolved PASS and the sole outstanding item is an honestly-PENDING one on a runner-covered check type. A comment marks this as load-bearing: reordering it would let "not yet run" mask "ran and failed".
3. **Only PENDING qualifies.** ADVISORY and FAIL are deliberately excluded — ADVISORY means the probe ran but the proof is structurally weak, FAIL means it ran and contradicted the claim. Neither is waiting on anything.

`RUNNER_COVERED_CHECK_TYPES` is `{test_passes}` — the set a product-repo CI runner genuinely executes. Adding a type with no runner behind it would turn a permanent block into a message claiming something is on its way when nothing is; the constant carries that warning.

The key is still surfaced in `missing_or_nonpass_receipts`, so CI logs and downstream tooling that read that field do not go blind on the new reason.

### If the runner never reports

The PR stays blocked. Forever. That is the intended behaviour — this is fail-closed, and the PENDING receipt is the standing, honest record that a check is owed.

### dod_evidence

- `uv run pytest tests/unit/validation/test_occ_awaiting_runner_receipt_omn_16859.py -q` → **8 passed**. Red proven by mutation, not absence: collapsing PENDING back into `nonpass` fails 2; hoisting the awaiting-runner return above missing/failing fails 2; making it `eligible=True` fails 1.
- `uv run mypy src/omnibase_core/validation/validator_occ_merge_eligibility.py src/omnibase_core/enums/enum_occ_eligibility_reason.py --strict` → **Success: no issues found in 2 source files**
- `uv run ruff format --check src/ tests/` + `uv run ruff check src/ tests/` → clean
- Version bumped 0.47.0 → 0.47.1 per the OMN-13411 release-identity gate.
- **Governed impacted-test selector (pre-push, OMN-13973): full suite, run on the .201 gate-runner.** The selector escalated correctly (`is_full_suite=True reason=shared_module` — `validator_occ_merge_eligibility` is a shared module) and then refused to run on the .200 host, which was at/over the 1.0x-core load threshold under other lanes' suites. Rather than set `PREPUSH_ALLOW_LOCAL_FULL_SUITE=1` (a visible degraded-evidence override, explicitly not a routine bypass), the change was transferred to .201 per the runbook's transfer-and-run-remotely pattern and the full suite executed there on a fit host. **The escalation was honoured in full, on a host with capacity.**

Ticket: OMN-16859 (AC3c).

Evidence-Ticket: OMN-16859
Evidence-Source: OCC#7612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an eligibility status for receipts awaiting CI runner execution.
  - Pending runner-covered receipts remain ineligible until an executed passing receipt is available.
  - Eligibility details now distinguish pending execution from missing or failed receipts.

- **Bug Fixes**
  - Improved pending-receipt handling while preserving receipt references and remediation guidance.
  - Ensured missing or failed receipts take precedence and passing receipts clear the eligibility gate.

- **Chores**
  - Updated the project version to 0.47.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->