### PR TITLE
fix(OMN-17146): make omnibase_core's cr-thread-gate fork a no-op — unbreak gate / CodeRabbit Thread Check on dev

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -1,4 +1,15 @@
 name: CR Thread Gate
+# OMN-17146: NO-OP. CodeRabbit is being retired org-wide (OMN-16933).
+# This is a local fork of omniclaude's reusable (OMN-16389). It used to
+# sparse-check-out omniclaude's scripts/check-unresolved-threads.sh at
+# ref: dev; omniclaude#2069 (051f96da6, OMN-16933) deleted that script from
+# omniclaude dev, so the gate hard-failed on every omnibase_core PR.
+# Re-pointing at ref: main would reintroduce the CodeRabbit dependency the
+# retirement exists to remove; deleting the workflow would strand a required
+# context that can never report. So the job succeeds with a notice until
+# OMN-16933 removes the context and the caller.
+# The workflow_call interface and the job key/name are UNCHANGED so the
+# composed context "gate / CodeRabbit Thread Check" keeps reporting.
 # Reusable workflow — call via:
 #   uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
 # Required status check string: "gate / CodeRabbit Thread Check"
@@ -44,54 +55,16 @@ jobs:
         || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
-      - name: Checkout omniclaude scripts
-        uses: actions/checkout@v7
-        with:
-          repository: OmniNode-ai/omniclaude
-          ref: dev
-          path: _external/omniclaude-cr-thread-gate
-          sparse-checkout: scripts/check-unresolved-threads.sh
-          sparse-checkout-cone-mode: false
-
-      - name: Resolve repo name
-        id: resolve-repo
+      - name: CodeRabbit retired — gate is a no-op
         run: |
-          REPO="${{ inputs.repo }}"
-          [ -z "$REPO" ] && REPO="${{ github.repository }}"
-          # Strip owner prefix if present (owner/repo -> repo)
-          echo "repo=${REPO##*/}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve PR number
-        id: resolve-pr
-        run: |
-          PR="${{ inputs.pr-number }}"
-          if [ -z "$PR" ]; then
-            PR="${{ github.event.pull_request.number }}"
-          fi
-          if [ -z "$PR" ]; then
-            PR="${{ github.event.issue.number }}"
-          fi
-          echo "pr=$PR" >> "$GITHUB_OUTPUT"
-
-      - name: Check unresolved CodeRabbit threads
-        env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT || secrets.github-token || secrets.GITHUB_TOKEN }}
-        run: |
-          PR="${{ steps.resolve-pr.outputs.pr }}"
-          if [ -z "$PR" ] || [ "$PR" = "0" ]; then
-            echo "No PR number — skipping (merge_group context)."
-            exit 0
-          fi
-          SCRIPT="_external/omniclaude-cr-thread-gate/scripts/check-unresolved-threads.sh"
-          test -f "$SCRIPT"
-          chmod +x "$SCRIPT"
-          COUNT=$(bash "$SCRIPT" \
-            "${{ github.repository_owner }}" \
-            "${{ steps.resolve-repo.outputs.repo }}" \
-            "$PR")
-          echo "Unresolved CodeRabbit threads: $COUNT"
-          if [ "$COUNT" -gt 0 ]; then
-            echo "::error::$COUNT unresolved CodeRabbit thread(s). Resolve all CR threads before merging."
-            exit 1
-          fi
-          echo "All CodeRabbit threads resolved."
+          echo "::notice::CodeRabbit retired (OMN-16933); gate is a no-op pending removal from required contexts."
+          echo "OMN-17146: this workflow no longer checks out or executes"
+          echo "omniclaude's scripts/check-unresolved-threads.sh. That script was"
+          echo "deleted from omniclaude dev by omniclaude#2069 (051f96da6, OMN-16933),"
+          echo "and this fork pinned ref: dev, so the gate failed with"
+          echo "\"chmod: cannot access ... No such file or directory\" on every PR."
+          echo "The CodeRabbit dependency is deliberately not being reintroduced."
+          echo "Removal of this workflow, its caller, and the composed context"
+          echo "\"gate / CodeRabbit Thread Check\" from required_status_checks /"
+          echo "EXPECTED_EXTERNAL_CONTEXTS is tracked by OMN-16933."
+          exit 0


### PR DESCRIPTION
Refs OMN-17146

## Summary

Makes omnibase_core's **local fork** of `.github/workflows/cr-thread-gate.yml` a no-op. It no longer sparse-checks-out or executes omniclaude's `scripts/check-unresolved-threads.sh`; the `gate` job prints a notice and exits 0.

## Why (root cause)

omnibase_core does not consume omniclaude's reusable — it carries its own copy (one of the five disconnected local forks tracked by OMN-16389). That copy pinned the script checkout at `ref: dev`:

```yaml
# .github/workflows/cr-thread-gate.yml (before)
- name: Checkout omniclaude scripts
  uses: actions/checkout@v7
  with:
    repository: OmniNode-ai/omniclaude
    ref: dev
    path: _external/omniclaude-cr-thread-gate
    sparse-checkout: scripts/check-unresolved-threads.sh
```

omniclaude#2069 / `051f96da6` (2026-08-29, OMN-16933, CodeRabbit retirement) deleted that script from omniclaude `dev`. The step's own `test -f "$SCRIPT"` then fails, so `gate / CodeRabbit Thread Check` fails on **every** omnibase_core PR — including ordinary in-flight work on `dev`, which is this repo's PR landing branch.

The OMN-17146 census listed `omnibase_core@dev` as consuming the reusable `@main`. That row is wrong: live readback shows `cr-thread-gate-caller.yml` uses `./.github/workflows/cr-thread-gate.yml` (local). Fixing omniclaude `main` therefore does **not** fix this repo; this PR is required.

## Why a no-op and not a re-point

- Re-pointing to `ref: main` would restore the gate but reintroduce the CodeRabbit dependency OMN-16933 exists to remove.
- Restoring the script on omniclaude `dev` would reverse omniclaude#2069.
- Deleting the workflow now would strand the required/asserted context `gate / CodeRabbit Thread Check`, which can then never report.

Removal of the workflow, its caller, and the context from `required_status_checks` / `EXPECTED_EXTERNAL_CONTEXTS` is tracked by OMN-16933.

## Deliberately unchanged

- `workflow_call` inputs and secrets — so `cr-thread-gate-caller.yml` resolves without edits.
- The `occ-preflight` job and the `gate` job's `needs: occ-preflight`.
- Job key `gate` / job name `CodeRabbit Thread Check` — so the composed context `gate / CodeRabbit Thread Check` keeps reporting.
- No job-level `if:` was added (OMN-14856/OMN-15120 vector-3: a skipped `uses:` caller job produces zero check runs).

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses; `jobs` = `['occ-preflight', 'gate']`, `jobs.gate.name == "CodeRabbit Thread Check"`.
- `pre-commit run --files .github/workflows/cr-thread-gate.yml` — exit 0, all hooks pass (incl. `Reject skip vectors on required-check workflows (OMN-14863)` and `Pull-request workflow-file ratchet (OMN-14907)`).
- Governed pre-push selector (`scripts/hooks/prepush_smart_tests.sh`) ran on push; no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no `--no-verify`.
- **This PR is its own proof**: `cr-thread-gate-caller.yml` uses the local `./.github/workflows/cr-thread-gate.yml`, resolved from this PR head — a green `gate / CodeRabbit Thread Check` here is direct evidence of the fix.

## Companion

- omniclaude#2078 — same fix for the cross-repo reusable on omniclaude `main` (unblocks `onex_change_control@main`, `omnidash@main`, `omniclaude@main`).

Related: OMN-16933, OMN-16389, OMN-16934

Evidence-Ticket: OMN-17146
Evidence-Source: OCC#7679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Retired the automated CodeRabbit thread check.
  * Existing workflow checks now complete successfully without validating unresolved review threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->