### PR TITLE
fix(OMN-17189): drop nested occ-preflight from core's cr-thread-gate fork — the caller has been startup_failure since #1621

### DIFF
--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -36,17 +36,16 @@ on:
         default: ""
 
 jobs:
-  occ-preflight:
-    uses: ./.github/workflows/occ-preflight.yml
-    permissions:
-      contents: read
-      pull-requests: read
-    with:
-      contracts-dir: contracts
-      receipts-dir: drift/dod_receipts
-
+  # OMN-17146: the nested `occ-preflight` job is REMOVED. omnibase_core#1621
+  # (31e44e9db, 2026-08-30T02:41Z) converted cr-thread-gate-caller.yml from the
+  # remote reusable to this local fork; from that commit on, EVERY run of
+  # cr-thread-gate-caller.yml concluded `startup_failure` (dev and feature
+  # branches alike) — the composed check run was never created at all, which is
+  # the OMN-14856/OMN-15120 vector-3 wedge in its worst form. The caller already
+  # runs its own `occ-preflight` job and `gate` already `needs:` it, so this
+  # copy was redundant nesting (caller -> this fork -> occ-preflight). A no-op
+  # gate needs no preflight at all.
   gate:
-    needs: occ-preflight
     name: CodeRabbit Thread Check
     runs-on: >-
       ${{


### PR DESCRIPTION
Refs OMN-17189

## Summary

Removes the nested `occ-preflight` job from omnibase_core's local fork of `.github/workflows/cr-thread-gate.yml`. Nothing else changes: the `workflow_call` interface, the job key `gate`, and the job name `CodeRabbit Thread Check` are untouched, so the composed context `gate / CodeRabbit Thread Check` keeps its exact name.

## Why — the gate has not merely been failing, it has not been *starting*

omnibase_core#1621 (`31e44e9db`, 2026-08-30T02:41:02Z, OMN-16967) converted `cr-thread-gate-caller.yml` from the remote reusable to this local fork:

```diff
-    uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
+    uses: ./.github/workflows/cr-thread-gate.yml
```

The local fork it now points at *also* declared `uses: ./.github/workflows/occ-preflight.yml`, while the caller already ran its own `occ-preflight` job that `gate` `needs:`. From that commit onward **every** run of `cr-thread-gate-caller.yml` concluded `startup_failure` — on `dev` and on feature branches alike:

```
$ gh api "repos/OmniNode-ai/omnibase_core/actions/workflows/cr-thread-gate-caller.yml/runs?per_page=15" \
    --jq '.workflow_runs[]|"\(.created_at) \(.conclusion) \(.head_branch)"'
2026-08-30T13:47:19Z startup_failure dev
2026-08-30T13:47:04Z startup_failure jonah/omn-16619-docs-only-ci-proof
2026-08-30T13:42:24Z startup_failure dev
2026-08-30T13:00:51Z startup_failure dev
2026-08-30T08:47:18Z startup_failure jonah/omn-13902-receipt-gate-commit-text
2026-08-30T02:06:11Z failure         dev      <-- last run that actually STARTED
```

`startup_failure` means GitHub never created the workflow run's jobs, so **no check run named `gate / CodeRabbit Thread Check` is produced at all** — strictly worse than a red check. Confirmed by absence rather than by `gh pr checks`:

```
$ gh api repos/OmniNode-ai/omnibase_core/commits/235c01ba6b77729e3600aa55bf6c39cb638d75f4/check-runs?per_page=100 \
    --jq '.check_runs[]|select(.name|test("CodeRabbit"))'
(empty)
```

That is the OMN-14856 / OMN-15120 vector-3 wedge in its worst form — the class already documented in `docs/diagnoses/2026-08-06-omnibase-core-1548-missing-required-contexts.md` — except caused by an unresolvable nested `uses:` rather than a skipped job.

## Why removing the job is the right fix, not adding one

The `gate` job has been a no-op since #1623 (OMN-17146: CodeRabbit is retired org-wide, OMN-16933). A no-op has nothing to preflight. The caller keeps its own `occ-preflight` job and `gate` still `needs:` it there, so OCC preflight coverage on this PR path is unchanged — this only deletes the redundant second copy and the `caller → fork → occ-preflight` nesting that came with it.

## Not blocking merges today (but latent)

`gate / CodeRabbit Thread Check` is in neither `dev`'s `required_status_checks` nor `scripts/ci/ci_summary_gate.py`'s `EXPECTED_EXTERNAL_CONTEXTS` (`("DB ownership CI twin (B1)", "LLM refs drift check (OMN-11932)")`), both read live 2026-08-30. It wedges the moment either surface re-adds the context.

## Verification

- `python3 -c "import yaml; d = yaml.safe_load(open('.github/workflows/cr-thread-gate.yml'))"` → `jobs` = `['gate']`, `jobs.gate.name == 'CodeRabbit Thread Check'`.
- `pre-commit run --files .github/workflows/cr-thread-gate.yml` → exit 0.
- Governed pre-push selector (`scripts/hooks/prepush_smart_tests.sh`) ran on push; no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no `--no-verify`.
- **This PR is its own proof.** On head `8df815706680b50d2aba67149ee9b11b7e8e997c` the caller reached `completed` and the context is present and green: [run 33315973134 / job 99269484135](https://github.com/OmniNode-ai/omnibase_core/actions/runs/33315973134/job/99269484135) → `gate / CodeRabbit Thread Check | completed | success`. Re-confirmed on the later head `43e05e3d`.

## Relationship to OMN-17146

OMN-17146 fixed a different failure (`chmod: cannot access 'scripts/check-unresolved-threads.sh'`) via omniclaude#2078 (merged to `main`, `0452f946e`) and omnibase_core#1623 (merged to `dev`, `4a4c5e3d1`). This `startup_failure` is a distinct defect with a distinct cause, found while verifying that work and split out to OMN-17189 so it carries its own evidence.

Related: OMN-17146, OMN-16933, OMN-16389, OMN-16967, OMN-14856, OMN-15120

Evidence-Ticket: OMN-17189
Evidence-Source: OCC#7701
