### PR TITLE
fix(OMN-17167): pre-commit sibling-resolution hooks fail fast on OMNI_HOME

### DIFF
--- a/scripts/pre_commit_validate_deterministic_skills.sh
+++ b/scripts/pre_commit_validate_deterministic_skills.sh
@@ -13,12 +13,45 @@
 # WS7 fail-loud parity (OMN-14671 / OMN-14655): this hook used to ``exit 0``
 # when no sibling resolved -- green locally while the same gate was RED on CI (a
 # skipped gate byte-indistinguishable from a passing one, DRIFT-2). A gate that
-# cannot run must FAIL LOUD, not silently pass. It now exits 1 with an
+# cannot run must FAIL LOUD, not silently pass. It now exits non-zero with an
 # actionable message. In the canonical omni_home layout OMNI_HOME is set and the
 # sibling exists, so this resolves; a contributor without the registry sets
 # DETERMINISTIC_SKILL_ROOT or clones the omniclaude sibling.
+#
+# OMN-17167: the fail-loud message used to be generic -- it never printed the
+# ``$OMNI_HOME``-derived path it actually probed, so a STALE OMNI_HOME (set, but
+# pointing at the wrong directory) was byte-indistinguishable from an UNSET one.
+# The shared preflight below distinguishes the two and names the variable and
+# the full missing path in both. Doctrine: omni_home CLAUDE.md rule 8 (fail fast
+# on missing env, never a silent default) and rule 6 (no absolute paths -- the
+# remediation is an ``export`` line, not a machine path).
 
 set -euo pipefail
+
+# --- OMN-17167 shared preflight ------------------------------------------------
+# Deliberately duplicated verbatim in omnimarket/scripts/validation/run_topic_lint.sh
+# and omnimarket/scripts/ci/check_subscriber_dispatcher_resolution.sh rather than
+# factored into a cross-repo shim library: a hook whose job is to diagnose a broken
+# sibling layout must not itself be loaded from that sibling layout. Repo-local,
+# identical wording.
+#
+#   $1     human list of the sibling clones THIS hook needs
+#   $2...  the full $OMNI_HOME-derived paths this hook needed and did not find
+omni_home_preflight_fail() {
+  local siblings="$1"
+  shift
+  if [ -z "${OMNI_HOME:-}" ]; then
+    echo "OMNI_HOME is not set. It must be the directory containing the sibling clones (${siblings}). Example: export OMNI_HOME=\$HOME/omninode" >&2
+  else
+    echo "OMNI_HOME is set to ${OMNI_HOME}, but the sibling clones this hook needs (${siblings}) are not there. Missing:" >&2
+    for missing_path in "$@"; do
+      echo "  ${missing_path}" >&2
+    done
+    echo "OMNI_HOME must be the directory containing the sibling clones (${siblings}). Example: export OMNI_HOME=\$HOME/omninode" >&2
+  fi
+  exit 2
+}
+# --- end shared preflight ------------------------------------------------------
 
 SKILL_ROOT=""
 if [ -n "${DETERMINISTIC_SKILL_ROOT:-}" ]; then
@@ -34,11 +67,8 @@ fi
 if [ -z "${SKILL_ROOT}" ]; then
   echo "ERROR: OMN-8765 deterministic-skill gate cannot run: omniclaude skills root not found." >&2
   echo "  This gate runs unconditionally in CI; a silent local skip is a false-green (WS7/OMN-14671)." >&2
-  echo "  Resolve by one of:" >&2
-  echo "    - export OMNI_HOME=<omni_home root> (so \$OMNI_HOME/omniclaude/plugins/onex/skills resolves), or" >&2
-  echo "    - export DETERMINISTIC_SKILL_ROOT=<path to omniclaude/plugins/onex/skills>, or" >&2
-  echo "    - clone the omniclaude sibling next to this repo (../omniclaude)." >&2
-  exit 1
+  echo "  Override with: export DETERMINISTIC_SKILL_ROOT=<path to omniclaude/plugins/onex/skills>" >&2
+  omni_home_preflight_fail "omniclaude" "${OMNI_HOME:-}/omniclaude/plugins/onex/skills"
 fi
 
 exec uv run python scripts/validate_deterministic_skill_routing.py \

--- a/tests/scripts/test_deterministic_skills_hook_omni_home_preflight.py
+++ b/tests/scripts/test_deterministic_skills_hook_omni_home_preflight.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMNI_HOME fail-fast preflight for the deterministic-skill-routing hook (OMN-17167).
+
+``scripts/pre_commit_validate_deterministic_skills.sh`` resolves an ``omniclaude``
+sibling clone. Reported by a contractor 2026-08-30: with a stale or unset
+``OMNI_HOME`` the hook failed with a generic "skills root not found" line that
+never printed the ``$OMNI_HOME``-derived path it actually probed, so a STALE
+OMNI_HOME (set, wrong directory) was byte-indistinguishable from an UNSET one.
+
+Doctrine under test: omni_home CLAUDE.md rule 8 (fail fast on missing env, never
+a silent default), rule 6 (no absolute paths -- the remediation is an ``export``
+line), and memory ``feedback_own_errors_give_full_paths`` (name the variable AND
+the full missing path).
+
+These tests drive THE real hook script end-to-end via subprocess from an isolated
+tmp cwd where no sibling can resolve, with a stubbed ``uv`` on PATH so the passing
+case proves resolution without running the real gate -- the same harness shape as
+``tests/scripts/test_prepush_hook_host_identity_guard.py``. Git env vars are
+stripped from the child per the OMN-14746/14744 worktree-safety lesson.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "pre_commit_validate_deterministic_skills.sh"
+
+# The literal remediation the operator must be able to copy. Asserting on its
+# PRESENCE (not merely a non-zero exit) is the point of the ticket: an opaque
+# non-zero exit is the defect, not the fix.
+_UNSET_MESSAGE = "OMNI_HOME is not set."
+_SIBLING_LAYOUT = "It must be the directory containing the sibling clones (omniclaude)."
+_EXPORT_EXAMPLE = "export OMNI_HOME=$HOME/omninode"
+_STALE_MESSAGE = "OMNI_HOME is set to"
+
+_STUB_UV = """#!/usr/bin/env bash
+echo "STUB_UV_INVOKED $*"
+exit 0
+"""
+
+
+def _clean_env(stub_bin: Path) -> dict[str, str]:
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in {
+            "OMNI_HOME",
+            "DETERMINISTIC_SKILL_ROOT",
+            "GIT_DIR",
+            "GIT_INDEX_FILE",
+            "GIT_WORK_TREE",
+        }
+    }
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+@pytest.fixture
+def stub_bin(tmp_path: Path) -> Path:
+    """A PATH entry whose ``uv`` records its argv instead of running the gate."""
+    bin_dir = tmp_path / "stub_bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "uv"
+    stub.write_text(_STUB_UV)
+    stub.chmod(0o755)
+    return bin_dir
+
+
+@pytest.fixture
+def isolated_hook(tmp_path: Path) -> Path:
+    """The real hook, copied where NO sibling candidate can resolve.
+
+    ``_external/omniclaude/...`` and ``../omniclaude/...`` are both relative to the
+    cwd, so the isolated tree is deliberately nested one level down with no
+    ``omniclaude`` anywhere above it.
+    """
+    workdir = tmp_path / "isolated" / "scripts"
+    workdir.mkdir(parents=True)
+    dest = workdir / HOOK_SCRIPT.name
+    shutil.copy2(HOOK_SCRIPT, dest)
+    dest.chmod(0o755)
+    return dest
+
+
+def _run(
+    hook: Path, env: dict[str, str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(hook)],
+        env=env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+def test_hook_script_exists_and_is_executable() -> None:
+    assert HOOK_SCRIPT.is_file(), f"missing hook script: {HOOK_SCRIPT}"
+    assert os.access(HOOK_SCRIPT, os.X_OK), "hook script must be executable"
+
+
+@pytest.mark.unit
+def test_no_hardcoded_absolute_paths() -> None:
+    """Rule #6: the remediation is an ``export`` line, never a machine path."""
+    text = HOOK_SCRIPT.read_text()
+    for prefix in ("/" + "Users/", "/" + "Volumes/"):
+        assert prefix not in text, f"hardcoded local absolute path in hook: {prefix}"
+
+
+@pytest.mark.unit
+def test_unset_omni_home_names_the_variable_and_the_expected_layout(
+    isolated_hook: Path, stub_bin: Path
+) -> None:
+    """UNSET -> exit 2, naming the variable, the layout, and a copyable export."""
+    result = _run(isolated_hook, _clean_env(stub_bin), isolated_hook.parent.parent)
+
+    assert result.returncode == 2, (
+        f"expected exit 2 on unset OMNI_HOME, got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert _UNSET_MESSAGE in result.stderr, (
+        f"stderr must name the unset variable; got:\n{result.stderr}"
+    )
+    assert _SIBLING_LAYOUT in result.stderr, (
+        f"stderr must state what OMNI_HOME points at; got:\n{result.stderr}"
+    )
+    assert _EXPORT_EXAMPLE in result.stderr, (
+        f"stderr must carry the copyable export example; got:\n{result.stderr}"
+    )
+    assert "STUB_UV_INVOKED" not in result.stdout, (
+        "the gate must not run when its skills root cannot be resolved"
+    )
+
+
+@pytest.mark.unit
+def test_stale_omni_home_prints_the_full_missing_path(
+    isolated_hook: Path, stub_bin: Path, tmp_path: Path
+) -> None:
+    """STALE -> exit 2 naming the FULL expanded missing path AND the variable.
+
+    This is the case the pre-OMN-17167 hook could not express: it emitted the same
+    generic line as the unset case, so the operator could not tell that OMNI_HOME
+    was set-but-wrong.
+    """
+    stale_root = tmp_path / "stale_registry"
+    stale_root.mkdir()
+    env = _clean_env(stub_bin)
+    env["OMNI_HOME"] = str(stale_root)
+
+    result = _run(isolated_hook, env, isolated_hook.parent.parent)
+
+    expected_missing = str(stale_root / "omniclaude" / "plugins" / "onex" / "skills")
+    assert result.returncode == 2, (
+        f"expected exit 2 on stale OMNI_HOME, got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert expected_missing in result.stderr, (
+        f"stderr must print the full expanded missing path {expected_missing!r}; "
+        f"got:\n{result.stderr}"
+    )
+    assert _STALE_MESSAGE in result.stderr, (
+        f"stderr must say OMNI_HOME is set (not unset); got:\n{result.stderr}"
+    )
+    assert _UNSET_MESSAGE not in result.stderr, (
+        "a stale OMNI_HOME must not be reported as unset -- that is the reported "
+        f"defect; got:\n{result.stderr}"
+    )
+    assert _EXPORT_EXAMPLE in result.stderr, (
+        f"stderr must carry the copyable export example; got:\n{result.stderr}"
+    )
+
+
+@pytest.mark.unit
+def test_correct_omni_home_resolves_and_does_not_preflight_fail(
+    isolated_hook: Path, stub_bin: Path, tmp_path: Path
+) -> None:
+    """CORRECT -> the preflight stays silent and the gate runs against the sibling."""
+    registry = tmp_path / "registry"
+    skills = registry / "omniclaude" / "plugins" / "onex" / "skills"
+    skills.mkdir(parents=True)
+    env = _clean_env(stub_bin)
+    env["OMNI_HOME"] = str(registry)
+
+    result = _run(isolated_hook, env, isolated_hook.parent.parent)
+
+    assert result.returncode == 0, (
+        f"expected the gate to run, got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert _UNSET_MESSAGE not in result.stderr
+    assert _STALE_MESSAGE not in result.stderr
+    assert "STUB_UV_INVOKED" in result.stdout, (
+        f"the gate must actually be invoked; got stdout:\n{result.stdout}"
+    )
+    assert str(skills) in result.stdout, (
+        f"--skills-root must resolve to the OMNI_HOME sibling; got:\n{result.stdout}"
+    )


### PR DESCRIPTION
## OMN-17167 — pre-commit sibling-resolution hooks fail fast on OMNI_HOME

Contractor report (Lakshman, 2026-08-30): with a stale or unset `OMNI_HOME`, `scripts/pre_commit_validate_deterministic_skills.sh` (hook `validate-deterministic-skill-routing`) failed with a generic `ERROR: OMN-8765 deterministic-skill gate cannot run: omniclaude skills root not found.` It never printed the `$OMNI_HOME`-derived path it actually probed, so a **stale** `OMNI_HOME` (set, pointing at the wrong directory) was byte-indistinguishable from an **unset** one and the operator had nothing to act on.

### What changed

One shared-shape preflight, `omni_home_preflight_fail()`:

- `OMNI_HOME` unset → **exit 2**: `OMNI_HOME is not set. It must be the directory containing the sibling clones (omniclaude). Example: export OMNI_HOME=$HOME/omninode`
- `OMNI_HOME` set but the sibling missing → **exit 2**, naming the **full expanded missing path** (`<OMNI_HOME>/omniclaude/plugins/onex/skills`) AND the variable.

No default path, no fallback. The `DETERMINISTIC_SKILL_ROOT` escape hatch is still printed.

### What did NOT change

**What the gate validates is untouched.** The preflight fires only where the existing four-candidate resolution (`DETERMINISTIC_SKILL_ROOT` → `_external/omniclaude` → `../omniclaude` → `$OMNI_HOME/omniclaude`) has already failed, so the CI `_external` checkout path that `ci.yml`'s `check-deterministic-skills` job relies on is not disturbed. The WS7/OMN-14671 fail-loud posture is preserved — the exit code moves 1 → 2, still non-zero, still never a silent skip.

The same preflight lands in `omnimarket/scripts/validation/run_topic_lint.sh` and `omnimarket/scripts/ci/check_subscriber_dispatcher_resolution.sh` (OmniNode-ai/omnimarket#2221, **merged** `4025105cf0f164067ff0e07b2e310264ff59c17e`). The three function bodies are **byte-identical** — `awk '/^omni_home_preflight_fail\(\) \{/,/^\}/' <file> | md5` returns `42515f151ebe6b39304392afcb02a883` for all three. It is deliberately **duplicated verbatim** rather than factored into a cross-repo shim library: a hook whose job is to diagnose a broken sibling layout must not itself be loaded from that layout.

### Doctrine

omni_home `CLAUDE.md` rule 8 (fail fast on missing env, never a silent default), rule 6 (no absolute paths — the remediation is an `export` line, not a machine path); memory `feedback_no_defensive_no_defaults`, `feedback_own_errors_give_full_paths`.

### dod_evidence

**RED-first.** `tests/scripts/test_deterministic_skills_hook_omni_home_preflight.py` drives the REAL hook script via `subprocess` from an isolated tmp cwd where no sibling can resolve, with a stubbed `uv` on PATH so the passing case proves resolution without running the real gate — the harness shape established by `tests/scripts/test_prepush_hook_host_identity_guard.py`. Git env vars stripped from the child (OMN-14746/14744).

- Against the pre-fix script (`git checkout origin/dev -- scripts/pre_commit_validate_deterministic_skills.sh`): **2 failed, 3 passed** — `unset` and `stale` both exited 1 with the identical generic message.
- Post-fix: **5 passed**.
- omnimarket side of the same ticket: 5 failed, 6 passed → 11 passed.

**Live hook still green against the real registry**, run from this worktree with the real `OMNI_HOME`:
`validate_deterministic_skill_routing: OK — 18 Tier 1 skill(s) scanned, 0 violations.` exit 0.

**Governed pre-push: full run, no override.** The local selector escalated to a whole-suite-equivalent impacted set and refused on this Mac — `triggered on 'Stickybeatz-Studio' (the designated host by identity), but its load is at/over the 1.0x-core threshold` (measured load1 49.0 / 24 cores = 2.04x). Followed the hook's own remediation, **not** `PREPUSH_ALLOW_LOCAL_FULL_SUITE`: routed to the `.201` gate-runner queue per `~/push-lanes/README-QUEUE.md`. Branch mirrored SHA-exact by `git bundle` (md5 `284194f13896a7d15130cc9f4a8d1cac` byte-identical on both hosts, HEAD `43ee631d661b0630f6f7c78131adaa11ec46f48a` on both), lane `SLOT ACQUIRED (no other heavy prepush, ratio 0.107)` at `14:05:50Z`, result:

```
44406 passed, 55 skipped, 3 xpassed, 151 warnings in 11140.29s (3:05:40)
[prepush-smart-tests] impacted tests passed; allowing push.
```

The only env var the queue runner sets is `PREPUSH_201_GATE_RUNNER_HOSTNAME=omninode-pc`, the hook's own sanctioned host-identity override. No `--no-verify`, no skip token, no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS`, no `PREPUSH_ALLOW_*`.

`pre-commit run --files scripts/pre_commit_validate_deterministic_skills.sh tests/scripts/test_deterministic_skills_hook_omni_home_preflight.py` exit 0. `ruff format` + `ruff check` clean. `shellcheck -S error` clean.

Related: OMN-14444 (the omnimarket half closes that hook's worktree-unrunnability), OMN-14462 (`scripts/merge-proof`, same defect class), OMN-16849 (OMNIBASE_PATH rename epic — this preflight is a call site that rename will touch).

Ticket: OMN-17167

Evidence-Ticket: OMN-17167
Evidence-Source: OCC#7726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup validation when the configured home path is missing, unset, or outdated.
  * Error messages now identify the missing location and provide clearer remediation guidance.
  * The validation now stops immediately when required skill paths cannot be found.

* **Tests**
  * Added coverage for valid, missing, stale, and incorrectly configured home paths.
  * Verified executable availability and successful resolution of related skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->