### PR TITLE
fix(OMN-16321): structural additive-enum proportionality in governed test selector

### DIFF
--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -14,6 +14,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from scripts.ci.enum_additive_diff import classify_enum_diff_additive
 from scripts.ci.test_selection_closure import compute_closure_selection
 from scripts.ci.test_selection_loader import (
     load_adjacency_map,
@@ -58,6 +59,12 @@ def _is_docs_only_path(path: str) -> bool:
 # pyproject.toml is handled content-aware (not as a bare path-prefix trigger).
 # See classify_pyproject_dependency_relevant / step 2 in compute_selection.
 PYPROJECT_PATH = "pyproject.toml"
+
+# OMN-16321. The one `shared_modules` entry whose escalation can be discharged by
+# structural proof instead of a path-prefix match. See scripts/ci/enum_additive_diff.py
+# for why "only ADDS members" is the exact boundary, and why nothing else narrows.
+ENUMS_MODULE = "enums"
+ENUMS_PREFIX = f"{SRC_PREFIX}{ENUMS_MODULE}/"
 
 # Keys under [project] whose change is metadata-only — it cannot alter dependency
 # resolution, build inputs, or test behavior, so a diff confined to these must NOT
@@ -298,6 +305,36 @@ def ci_contract_test_paths(repo_root: Path) -> list[str]:
     return sorted(set(paths))
 
 
+def _enums_escalation_discharged(
+    shared_hits: set[str],
+    changed_files: list[str],
+    enums_diff_additive: bool | None,
+) -> bool:
+    """True only when the ONLY shared module touched is a provably-additive ``enums``.
+
+    OMN-16321. Three conditions, all required, all positive:
+
+    1. ``enums`` is the sole ``shared_modules`` entry in the diff. A diff that
+       also touches ``models``/``runtime``/``contracts``/``validation``/
+       ``event_bus`` escalates on those, untouched by this rule.
+    2. The classifier proved every changed ``enums/`` file only APPENDS members
+       (``True``, never ``None``). ``None`` — no base ref, unreadable revision,
+       unparseable source — escalates, so ambiguity keeps the old behaviour.
+    3. The diff actually contains an ``enums/`` file. Guards against discharging
+       an escalation on a stale or mis-supplied classification.
+
+    Discharging the escalation does not select fewer tests than the closure can
+    prove: the caller still unions ``unnarrowable_test_paths`` into the result,
+    so every always-run root (``tests/enums/``, ``tests/gates/``,
+    ``tests/validation/``, ``tests/models/``, ``tests/ci/`` …) still runs.
+    """
+    if shared_hits != {ENUMS_MODULE}:
+        return False
+    if enums_diff_additive is not True:
+        return False
+    return any(path.startswith(ENUMS_PREFIX) for path in changed_files)
+
+
 def compute_selection(
     changed_files: list[str],
     adjacency_path: Path,
@@ -306,6 +343,7 @@ def compute_selection(
     feature_flag_enabled: bool = True,
     pyproject_dependency_relevant: bool | None = None,
     repo_root: Path | None = None,
+    enums_diff_additive: bool | None = None,
 ) -> ModelTestSelection:
     """Resolve the test selection for a change set.
 
@@ -315,6 +353,14 @@ def compute_selection(
     is metadata-only (do not escalate on ``pyproject.toml`` alone), ``None`` = not
     classified. When ``pyproject.toml`` is in the change set and this is not
     ``False`` (i.e. ``True`` or ``None``), the selector fails closed and escalates.
+
+    ``enums_diff_additive`` carries the structural classification of an
+    ``src/omnibase_core/enums/`` change (OMN-16321, computed by the CLI via a
+    base-vs-head AST diff): ``True`` = every enums hunk only APPENDS members and
+    edits nothing else, ``False`` = it does more than that, ``None`` = not
+    classified. Only ``True`` discharges the ``enums`` shared-module escalation;
+    ``False`` and ``None`` both escalate, so an unclassified or unparseable diff
+    fails closed exactly as before this parameter existed.
 
     ``repo_root`` is the tree the file-grain import-graph closure (OMN-14921) is
     computed over — defaults to :data:`REPO_ROOT` (this checkout). Tests inject a
@@ -364,7 +410,10 @@ def compute_selection(
         for path in changed_files
         if path.startswith(SRC_PREFIX)
     }
-    if changed_modules & set(config.shared_modules):
+    shared_hits = changed_modules & set(config.shared_modules)
+    if shared_hits and not _enums_escalation_discharged(
+        shared_hits, changed_files, enums_diff_additive
+    ):
         return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
 
     # 4. Threshold escalation: too many distinct modules.
@@ -643,6 +692,28 @@ def classify_pyproject_dependency_relevant(
     )
 
 
+# OMN-14891 / OMN-16321. Git exports these into EVERY hook environment, and they
+# OVERRIDE both `git -C` and `cwd=`. This selector runs from the pre-push hook and
+# resolves a base revision to decide whether it may NARROW the suite, so an
+# inherited GIT_DIR pointing at a different repository would let it answer that
+# safety question against the wrong tree. Every git read below is scrubbed.
+# Duplicated (not imported from omnibase_core.validators) so the selector stays
+# runnable without the package importable.
+_GIT_LOCATION_ENV_VARS = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_WORK_TREE",
+)
+
+
+def _scrubbed_git_env() -> dict[str, str]:
+    """The ambient environment with every git location variable removed."""
+    return {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_ENV_VARS}
+
+
 def _git_show(ref: str, rel_path: str, repo_root: Path) -> str | None:
     """Return the content of ``rel_path`` at ``ref`` via ``git show``, or None.
 
@@ -655,6 +726,7 @@ def _git_show(ref: str, rel_path: str, repo_root: Path) -> str | None:
             capture_output=True,
             text=True,
             check=False,
+            env=_scrubbed_git_env(),
         )
     except OSError:
         return None
@@ -681,6 +753,94 @@ def _resolve_pyproject_dependency_relevant(
         return None
     old_content = _git_show(base_ref, PYPROJECT_PATH, repo_root)
     return classify_pyproject_dependency_relevant(old_content, new_content)
+
+
+def _git_ref_resolves(ref: str, repo_root: Path) -> bool:
+    """True when ``ref`` names a commit that exists in ``repo_root``.
+
+    Needed because :func:`_git_show` returns ``None`` for BOTH "this path did
+    not exist at the base revision" and "this ref cannot be read at all", and
+    those two must not be treated alike: the first is a genuinely new file
+    (additive), the second is an unusable base (never provable). Conflating
+    them made an unfetched base ref narrow — caught by
+    ``test_resolver_refuses_an_unreadable_base_revision``.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                f"{ref}^{{commit}}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_scrubbed_git_env(),
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def _git_path_exists_at_ref(ref: str, rel_path: str, repo_root: Path) -> bool:
+    """True when ``rel_path`` is present in the tree at ``ref``."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{rel_path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_scrubbed_git_env(),
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def _resolve_enums_diff_additive(
+    base_ref: str | None,
+    repo_root: Path,
+    changed_files: list[str],
+) -> bool | None:
+    """Classify every changed ``enums/`` file against its ``base_ref`` revision.
+
+    Returns ``None`` (caller escalates as "unclassified") when no base ref was
+    supplied or no ``enums/`` file is in the diff. Returns ``False`` (caller
+    escalates as "classified unprovable") when the base ref does not resolve, a
+    revision cannot be read, or any single changed ``enums/`` file is not
+    provably additive — there is no per-file partial credit. ``True`` only when
+    EVERY changed ``enums/`` file is proven additive.
+
+    A head file that cannot be read is passed to the classifier as ``None``,
+    which it treats as a deletion and refuses.
+    """
+    if not base_ref:
+        return None
+    enums_files = [p for p in changed_files if p.startswith(ENUMS_PREFIX)]
+    if not enums_files:
+        return None
+    if not _git_ref_resolves(base_ref, repo_root):
+        # An unfetched, garbage, or shallow-truncated base proves nothing.
+        return False
+    for rel_path in enums_files:
+        try:
+            new_content: str | None = (repo_root / rel_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            new_content = None
+        if _git_path_exists_at_ref(base_ref, rel_path, repo_root):
+            old_content = _git_show(base_ref, rel_path, repo_root)
+            if old_content is None:
+                # Present in the tree but unreadable — an error, not a new file.
+                return False
+        else:
+            old_content = None  # genuinely new file at this base
+        if not classify_enum_diff_additive(old_content, new_content):
+            return False
+    return True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -751,6 +911,11 @@ def main(argv: list[str] | None = None) -> int:
         pyproject_dependency_relevant = _resolve_pyproject_dependency_relevant(
             args.base_ref, args.repo_root
         )
+    # Structural enums/ classification (OMN-16321). None -> compute_selection
+    # fails closed and escalates exactly as it did before this existed.
+    enums_diff_additive = _resolve_enums_diff_additive(
+        args.base_ref, args.repo_root, changed
+    )
     selection = compute_selection(
         changed_files=changed,
         adjacency_path=args.adjacency,
@@ -759,6 +924,7 @@ def main(argv: list[str] | None = None) -> int:
         feature_flag_enabled=(args.feature_flag == "on"),
         pyproject_dependency_relevant=pyproject_dependency_relevant,
         repo_root=args.repo_root,
+        enums_diff_additive=enums_diff_additive,
     )
     if args.shadow_closure == "on":
         # SHADOW MODE (OMN-14921): now vestigial post-promotion — compute_selection's

--- a/scripts/ci/enum_additive_diff.py
+++ b/scripts/ci/enum_additive_diff.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Prove — or refuse to prove — that an ``enums/`` diff is purely ADDITIVE.
+
+OMN-16321. ``enums`` is a ``shared_modules`` entry, so step 3 of
+``detect_test_paths.compute_selection`` escalates ANY diff touching it to the
+40-shard full suite on a bare path-prefix match. Measured cost: a two-member
+addition plus ten tests (OMN-16998, external contributor) selected all 44,495
+tests, ~10h on the contributor's hardware.
+
+The escalation is a proxy for a real hazard: an enum member that is RENAMED,
+REMOVED, or has its VALUE changed can break any consumer — persisted rows,
+wire payloads, ``match`` arms, dict lookups keyed by value — arbitrarily far
+from the import graph. That hazard is real and this module does not narrow it.
+
+But a diff that only APPENDS members is a different fact. A new member cannot
+change the meaning of an existing one; it can only break code that enumerates
+the type exhaustively. Exhaustive consumers must reference the enum to
+enumerate it, so they are reachable through the reverse-import closure — and
+the dynamically-discovering ones (schema/registry/contract sweeps) live under
+the always-run ``unnarrowable_test_paths`` roots, which
+``_with_unnarrowable`` unions into every narrowed selection unconditionally.
+
+So this module answers exactly one question, structurally rather than
+textually: *is every enums/ hunk in this diff a pure addition?* It is a
+governed safety classifier and narrows ONLY on positive proof:
+
+* AST-parsed both revisions. A ``SyntaxError`` on either side → NOT provable.
+* Every pre-existing ``(class, member, value-literal)`` triple must survive
+  byte-identical. A rename, a removal, or a value edit → NOT provable.
+* Everything in the module that is NOT an enum member assignment — imports,
+  decorators, base classes, methods, module-level statements, docstrings — is
+  fingerprinted and must be UNCHANGED. A new method, an edited ``__str__``, a
+  changed base class → NOT provable.
+* A deleted file, an unreadable base revision, a non-UTF-8 blob → NOT provable.
+
+There is deliberately NO override env var, and no way to assert additivity from
+outside: the only input is the two revisions of the file.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+__all__ = [
+    "ModelEnumModuleShape",
+    "classify_enum_diff_additive",
+    "enum_module_shape",
+]
+
+# Assignment values that are member DEFINITIONS rather than machinery. An enum
+# member is a plain class-body assignment; everything else in the body (methods,
+# nested classes, dunder config like `_ignore_`) is captured as structure.
+_MEMBER_EXCLUDED_PREFIX = "_"
+
+
+@dataclass(frozen=True)
+class ModelEnumModuleShape:
+    """The structural fingerprint of one Python module, split two ways.
+
+    ``members`` maps ``"ClassName.MEMBER"`` to the unparsed source of its value
+    expression, so a value edit is visible even when it is a call or an f-string.
+    ``structure`` is the unparsed AST of the SAME module with every member
+    assignment stripped out — so any non-member edit changes it.
+    """
+
+    members: dict[str, str]
+    structure: str
+
+
+def _member_assignment(node: ast.stmt) -> tuple[str, ast.expr] | None:
+    """Return ``(member_name, value_expr)`` when ``node`` defines an enum member.
+
+    A member is a plain class-body assignment — ``NAME = <expr>`` or
+    ``NAME: ann = <expr>`` — with a single ``Name`` target that does not start
+    with an underscore. Everything else (tuple targets, ``_ignore_``/``_order_``
+    machinery, augmented assignment, methods, nested classes) is STRUCTURE, and
+    is fingerprinted rather than treated as an addable member.
+    """
+    if isinstance(node, ast.Assign):
+        if len(node.targets) != 1:
+            return None
+        target: ast.expr = node.targets[0]
+        value: ast.expr | None = node.value
+    elif isinstance(node, ast.AnnAssign):
+        target = node.target
+        value = node.value
+    else:
+        return None
+    if value is None:
+        return None
+    if not isinstance(target, ast.Name):
+        return None
+    if target.id.startswith(_MEMBER_EXCLUDED_PREFIX):
+        return None
+    return target.id, value
+
+
+def enum_module_shape(source: str) -> ModelEnumModuleShape | None:
+    """Fingerprint ``source``, or ``None`` when it cannot be parsed.
+
+    ``None`` is the fail-closed signal: an unparseable revision is never
+    classified additive.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+
+    members: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        surviving: list[ast.stmt] = []
+        for stmt in node.body:
+            member = _member_assignment(stmt)
+            if member is None:
+                surviving.append(stmt)
+            else:
+                name, value = member
+                members[f"{node.name}.{name}"] = ast.unparse(value)
+        # A class body cannot be empty; keep it syntactically valid so the
+        # stripped tree still unparses.
+        node.body = surviving or [ast.Pass()]
+
+    try:
+        structure = ast.unparse(tree)
+    except (AttributeError, ValueError):  # pragma: no cover - defensive
+        return None
+    return ModelEnumModuleShape(members=members, structure=structure)
+
+
+def classify_enum_diff_additive(
+    old_source: str | None,
+    new_source: str | None,
+) -> bool:
+    """True ONLY when ``new_source`` provably just ADDS members to ``old_source``.
+
+    ``old_source is None`` means the file did not exist at the base revision —
+    a brand-new enum module, which adds members and removes none, so it is
+    additive. ``new_source is None`` means the file was DELETED (or is
+    unreadable) at head, which removes members and is never additive.
+    """
+    if new_source is None:
+        return False
+    new_shape = enum_module_shape(new_source)
+    if new_shape is None:
+        return False
+    if old_source is None:
+        # New file: nothing pre-existing can have been renamed or removed.
+        return True
+    old_shape = enum_module_shape(old_source)
+    if old_shape is None:
+        return False
+
+    # Any non-member edit anywhere in the module disqualifies the diff.
+    if old_shape.structure != new_shape.structure:
+        return False
+
+    # Every pre-existing member must survive with an identical value literal.
+    for key, old_value in old_shape.members.items():
+        if new_shape.members.get(key) != old_value:
+            return False
+    return True

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -24,6 +24,17 @@ schema_version: 1
 # to a permanent layering invariant. Curate based on operational risk + import fan-out.
 # Removing a module from this list is allowed once we have shadow data showing its
 # changes don't surface broad regressions.
+#
+# `enums` carries a NARROW, STRUCTURALLY-PROVEN discharge (OMN-16321) and is
+# otherwise unchanged: a diff whose ONLY shared_modules entry is `enums`, and
+# whose every changed enums/ file provably just APPENDS members (AST-compared
+# base-vs-head by scripts/ci/enum_additive_diff.py — no rename, no removal, no
+# value edit, no non-member edit anywhere in the module), falls through to the
+# import-graph closure instead of escalating. Everything else about `enums`
+# still escalates, including a diff this classifier cannot parse or has no
+# --base-ref to compare against. The entry STAYS in this list: the discharge is
+# conditional and evidence-bearing, not a demotion. Do not delete it thinking
+# the rule is dead.
 shared_modules:
   - models
   - contracts

--- a/tests/unit/scripts/ci/test_enum_additive_diff.py
+++ b/tests/unit/scripts/ci/test_enum_additive_diff.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-16321: structural proof that an ``enums/`` diff only APPENDS members.
+
+The classifier is a governed safety surface: it must answer ``True`` for the
+exact shape that motivated the ticket (OMN-16998 — two members appended to an
+existing enum) and ``False`` for every shape that can change the meaning of an
+existing member, plus every shape it cannot parse.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci.enum_additive_diff import (
+    classify_enum_diff_additive,
+    enum_module_shape,
+)
+
+BASE = '''"""Terminal failure causes."""
+
+from enum import StrEnum
+
+
+class EnumTerminalFailureCause(StrEnum):
+    """Why a delegation terminated."""
+
+    PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+    PROVIDER_TIMEOUT = "provider_timeout"
+
+    def is_retryable(self) -> bool:
+        return self is EnumTerminalFailureCause.PROVIDER_TIMEOUT
+'''
+
+
+def _mutate(old: str, new: str) -> str:
+    assert old in BASE, f"fixture drift: {old!r} not in BASE"
+    return BASE.replace(old, new)
+
+
+# --- the shape this ticket exists for -------------------------------------
+
+
+def test_appending_two_members_is_additive() -> None:
+    """OMN-16998's exact diff shape: two members appended, nothing else edited."""
+    head = _mutate(
+        '    PROVIDER_TIMEOUT = "provider_timeout"\n',
+        '    PROVIDER_TIMEOUT = "provider_timeout"\n'
+        '    AUTH_FAILED = "auth_failed"\n'
+        '    PROVIDER_UNAVAILABLE = "provider_unavailable"\n',
+    )
+    assert classify_enum_diff_additive(BASE, head) is True
+
+
+def test_unchanged_file_is_additive() -> None:
+    """The empty addition is still an addition — never a reason to escalate."""
+    assert classify_enum_diff_additive(BASE, BASE) is True
+
+
+def test_brand_new_enum_module_is_additive() -> None:
+    """No base revision means nothing pre-existing can have been broken."""
+    assert classify_enum_diff_additive(None, BASE) is True
+
+
+# --- every shape that must still escalate ---------------------------------
+
+
+def test_member_rename_escalates() -> None:
+    head = _mutate("PROVIDER_TIMEOUT = ", "PROVIDER_TIMED_OUT = ")
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_member_removal_escalates() -> None:
+    head = _mutate('    PROVIDER_TIMEOUT = "provider_timeout"\n', "")
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_member_value_change_escalates() -> None:
+    """The persisted-value hazard: same name, different wire value."""
+    head = _mutate('"provider_timeout"', '"timeout"')
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_value_change_plus_addition_escalates() -> None:
+    """An addition does not launder a value edit made in the same diff."""
+    head = _mutate(
+        '    PROVIDER_TIMEOUT = "provider_timeout"\n',
+        '    PROVIDER_TIMEOUT = "timeout"\n    AUTH_FAILED = "auth_failed"\n',
+    )
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_method_body_change_escalates() -> None:
+    """Non-member edits are structure; behaviour can change without any member."""
+    head = _mutate(
+        "return self is EnumTerminalFailureCause.PROVIDER_TIMEOUT",
+        "return True",
+    )
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_new_method_escalates() -> None:
+    head = _mutate(
+        "    def is_retryable(self) -> bool:",
+        "    def is_fatal(self) -> bool:\n        return True\n\n"
+        "    def is_retryable(self) -> bool:",
+    )
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_base_class_change_escalates() -> None:
+    head = _mutate("(StrEnum)", "(str, Enum)")
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_import_change_escalates() -> None:
+    head = _mutate("from enum import StrEnum", "from enum import Enum, StrEnum")
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_class_removal_escalates() -> None:
+    head = "from enum import StrEnum\n"
+    assert classify_enum_diff_additive(BASE, head) is False
+
+
+def test_file_deletion_escalates() -> None:
+    assert classify_enum_diff_additive(BASE, None) is False
+
+
+@pytest.mark.parametrize("broken", ["class Enum(:\n", "    return 1\n", "'"])
+def test_unparseable_head_escalates(broken: str) -> None:
+    assert classify_enum_diff_additive(BASE, broken) is False
+
+
+@pytest.mark.parametrize("broken", ["class Enum(:\n", "def (\n"])
+def test_unparseable_base_escalates(broken: str) -> None:
+    """A base we cannot parse cannot be proven a subset of head."""
+    assert classify_enum_diff_additive(broken, BASE) is False
+
+
+def test_both_none_escalates() -> None:
+    assert classify_enum_diff_additive(None, None) is False
+
+
+# --- shape helper ---------------------------------------------------------
+
+
+def test_shape_separates_members_from_structure() -> None:
+    shape = enum_module_shape(BASE)
+    assert shape is not None
+    assert shape.members == {
+        "EnumTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED": "'provider_quota_exhausted'",
+        "EnumTerminalFailureCause.PROVIDER_TIMEOUT": "'provider_timeout'",
+    }
+    # Members are stripped from the structural fingerprint, the method is not.
+    assert "provider_timeout" not in shape.structure
+    assert "is_retryable" in shape.structure
+
+
+def test_shape_returns_none_on_syntax_error() -> None:
+    assert enum_module_shape("class (:") is None
+
+
+def test_underscore_names_are_structure_not_members() -> None:
+    """``_ignore_``/``_order_`` are enum machinery — editing them must escalate."""
+    source = "from enum import StrEnum\n\n\nclass E(StrEnum):\n    _order_ = 'A'\n    A = 'a'\n"
+    shape = enum_module_shape(source)
+    assert shape is not None
+    assert set(shape.members) == {"E.A"}
+    assert "_order_" in shape.structure

--- a/tests/unit/scripts/ci/test_omn16321_enums_proportionality.py
+++ b/tests/unit/scripts/ci/test_omn16321_enums_proportionality.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-16321: a provably-additive ``enums/`` diff must not select 44,495 tests.
+
+``enums`` is a ``shared_modules`` entry, so before this change step 3 of
+``compute_selection`` escalated on a bare path-prefix match. Measured on
+OMN-16998: two appended members plus ten tests -> ``is_full_suite=True``,
+``full_suite_reason=shared_module``, 40 shards, ~10h on the contributor's
+laptop.
+
+These tests pin BOTH directions. The narrowing case is one test; the rest are
+the fail-closed cases, because the only way this change can be wrong is by
+narrowing something it should not.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+from scripts.ci.detect_test_paths import (
+    REPO_ROOT,
+    _resolve_enums_diff_additive,
+    compute_selection,
+    unnarrowable_test_paths,
+)
+from scripts.ci.test_selection_models import EnumFullSuiteReason
+
+# A real enums module, so the import-graph closure has something to resolve.
+ADJ = REPO_ROOT / "scripts/ci/test_selection_adjacency.yaml"
+
+ENUMS_FILE = "src/omnibase_core/enums/enum_agent_state.py"
+MODELS_FILE = "src/omnibase_core/models/model_node_metadata.py"
+
+
+def _select(changed: list[str], additive: bool | None):
+    return compute_selection(
+        changed_files=changed,
+        adjacency_path=ADJ,
+        ref_name="pr-branch",
+        enums_diff_additive=additive,
+    )
+
+
+# --- the narrowing case ----------------------------------------------------
+
+
+def test_additive_enums_diff_does_not_escalate() -> None:
+    """RED before OMN-16321: this returned SHARED_MODULE / 40 shards."""
+    selection = _select([ENUMS_FILE], additive=True)
+    assert selection.is_full_suite is False
+    assert selection.full_suite_reason is None
+    assert selection.split_count < 40
+
+
+def test_narrowed_selection_still_runs_every_always_run_root() -> None:
+    """The narrowing is safe only because nothing leaves the always-run set.
+
+    Exhaustiveness checks that find enum members dynamically (schema sweeps,
+    contract validation, registry gates) do not sit on an import edge, so they
+    are covered by ``unnarrowable_test_paths`` rather than by the closure.
+    """
+    selection = _select([ENUMS_FILE], additive=True)
+    always_run = unnarrowable_test_paths(REPO_ROOT)
+    assert always_run, "fixture drift: the always-run set must not be empty"
+    missing = [p for p in always_run if p not in selection.selected_paths]
+    assert missing == [], f"narrowed selection dropped always-run roots: {missing}"
+
+
+# --- fail-closed cases -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "additive",
+    [False, None],
+    ids=["not-provably-additive", "unclassified"],
+)
+def test_non_additive_or_unclassified_enums_diff_escalates(
+    additive: bool | None,
+) -> None:
+    """A rename/removal/value-change (False) and an unclassifiable diff (None).
+
+    ``None`` is the shape produced by a missing ``--base-ref`` or an unreadable
+    base revision, so this is the guarantee that the pre-OMN-16321 behaviour is
+    what ambiguity still gets.
+    """
+    selection = _select([ENUMS_FILE], additive=additive)
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+    assert selection.split_count == 40
+
+
+def test_additive_enums_plus_another_shared_module_still_escalates() -> None:
+    """The discharge is scoped to ``enums`` alone — ``models`` escalates on its own."""
+    selection = _select([ENUMS_FILE, MODELS_FILE], additive=True)
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+
+
+def test_additive_claim_without_an_enums_file_cannot_discharge() -> None:
+    """A stale/mis-supplied ``True`` must not discharge some other module's escalation."""
+    selection = _select([MODELS_FILE], additive=True)
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+
+
+def test_test_infrastructure_still_wins_over_an_additive_enums_diff() -> None:
+    """Step 2 runs before step 3 and is untouched by this change."""
+    selection = _select([ENUMS_FILE, "tests/conftest.py"], additive=True)
+    assert selection.is_full_suite is True
+    assert selection.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+
+# --- the CLI resolver, against a real git repository -----------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run git against ``repo`` with the ambient git location env SCRUBBED.
+
+    OMN-14891: git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE /
+    GIT_COMMON_DIR into every hook environment, and those OVERRIDE both ``-C``
+    and ``cwd=``. Without the scrub, this fixture would mutate the REAL
+    invoking worktree when the suite runs under a pre-push hook.
+    """
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=scrub_git_location_env(os.environ),
+    ).stdout
+
+
+@pytest.fixture
+def enums_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """A git repo with one committed enums module. Returns (root, rel_path, base_sha)."""
+    repo = tmp_path / "repo"
+    (repo / "src/omnibase_core/enums").mkdir(parents=True)
+    rel = "src/omnibase_core/enums/enum_thing.py"
+    (repo / rel).write_text(
+        "from enum import StrEnum\n\n\nclass EnumThing(StrEnum):\n    A = 'a'\n",
+        encoding="utf-8",
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD").strip()
+    return repo, rel, base
+
+
+def test_resolver_proves_a_real_appended_member(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    repo, rel, base = enums_repo
+    (repo / rel).write_text(
+        "from enum import StrEnum\n\n\nclass EnumThing(StrEnum):\n    A = 'a'\n    B = 'b'\n",
+        encoding="utf-8",
+    )
+    assert _resolve_enums_diff_additive(base, repo, [rel]) is True
+
+
+def test_resolver_refuses_a_real_value_change(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    repo, rel, base = enums_repo
+    (repo / rel).write_text(
+        "from enum import StrEnum\n\n\nclass EnumThing(StrEnum):\n    A = 'z'\n",
+        encoding="utf-8",
+    )
+    assert _resolve_enums_diff_additive(base, repo, [rel]) is False
+
+
+def test_resolver_refuses_a_deleted_enums_file(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    repo, rel, base = enums_repo
+    (repo / rel).unlink()
+    assert _resolve_enums_diff_additive(base, repo, [rel]) is False
+
+
+def test_resolver_refuses_when_one_of_several_files_is_not_additive(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    """One unprovable file poisons the whole diff — no per-file partial credit."""
+    repo, rel, base = enums_repo
+    (repo / rel).write_text(
+        "from enum import StrEnum\n\n\nclass EnumThing(StrEnum):\n    A = 'a'\n    B = 'b'\n",
+        encoding="utf-8",
+    )
+    other = "src/omnibase_core/enums/enum_new.py"
+    (repo / other).write_text("class Broken(:\n", encoding="utf-8")
+    assert _resolve_enums_diff_additive(base, repo, [rel, other]) is False
+
+
+def test_resolver_returns_none_without_a_base_ref(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    """No base ref -> unclassified -> the caller escalates."""
+    repo, rel, _ = enums_repo
+    assert _resolve_enums_diff_additive(None, repo, [rel]) is None
+    assert _resolve_enums_diff_additive("", repo, [rel]) is None
+
+
+def test_resolver_returns_none_when_the_diff_has_no_enums_file(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    repo, _, base = enums_repo
+    assert (
+        _resolve_enums_diff_additive(base, repo, ["src/omnibase_core/models/m.py"])
+        is None
+    )
+
+
+def test_resolver_refuses_an_unreadable_base_revision(
+    enums_repo: tuple[Path, str, str],
+) -> None:
+    """An unfetched/garbage base ref cannot prove anything."""
+    repo, rel, _ = enums_repo
+    assert _resolve_enums_diff_additive("0" * 40, repo, [rel]) is False
+
+
+def test_resolver_ignores_an_inherited_git_dir(
+    enums_repo: tuple[Path, str, str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OMN-14891: an inherited ``GIT_DIR`` must not retarget the base-revision read.
+
+    The selector runs FROM the pre-push hook, where git exports ``GIT_DIR`` /
+    ``GIT_WORK_TREE`` into the environment, and those override ``git -C``.
+    Unscrubbed, this classifier would answer "is this diff additive?" against
+    whatever repository the hook happened to be running for — and a wrong answer
+    in the narrowing direction silently under-tests. With the scrub, the decoy
+    is ignored and the real base still proves the appended member.
+    """
+    repo, rel, base = enums_repo
+    (repo / rel).write_text(
+        "from enum import StrEnum\n\n\nclass EnumThing(StrEnum):\n    A = 'a'\n    B = 'b'\n",
+        encoding="utf-8",
+    )
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    _git(decoy, "init", "-q")
+    monkeypatch.setenv("GIT_DIR", str(decoy / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(decoy))
+
+    assert _resolve_enums_diff_additive(base, repo, [rel]) is True


### PR DESCRIPTION
## OMN-16321: structural additive-enum proportionality in the governed test selector

Fixes the governed impacted-test selector (`scripts/ci/detect_test_paths.py`) over-escalating on enum diffs to a shared module. A 2-member additive enum change (new members appended, nothing renamed/removed/edited) no longer forces the full-suite escalation path.

### Measured before/after

- **Before**: `shared_module` classification for any diff touching an enum-bearing shared module -> 40 shards / 44,495 tests.
- **After**: structural proof that the diff is a pure additive enum change (new member(s) appended, no rename/removal/value edit) discharges the shared-module escalation -> 5 splits / 72 paths for a 2-member additive enum diff.
- **Still escalates** (unchanged, verified): enum member rename, enum member removal, enum value edit, and any unresolvable/ambiguous ref in the diff.

### Gate-caught defects fixed in this pass

1. Fail-open `_git_show` on an unreadable ref — a ref that could not be read was previously treated as "no prior enum state", which would have discharged the escalation on missing evidence instead of failing closed.
2. `GIT_DIR` / `GIT_WORK_TREE` env scrub before the internal git-show invocation, so a caller's ambient git env cannot redirect the structural diff read to the wrong tree.

### Test evidence

- 37 new tests added under `tests/unit/scripts/ci/` (`test_enum_additive_diff.py`, `test_omn16321_enums_proportionality.py`).
- 470 tests passing in `tests/unit/scripts/ci/`.
- Governed pre-push full-suite escalation (this diff touches `scripts/ci/detect_test_paths.py` + `scripts/ci/test_selection_adjacency.yaml`, both selector-infrastructure paths, so the selector escalates on a change to itself by design): routed to the `.201` queue-runner offload lane (`omnibase_core` has no OMN-16991 lab-dispatch seam yet, tracked as OMN-17159) — **44438 passed, 55 skipped, 3 xpassed, 0 failed** in 11081.75s (3h04m41s). Governed push then completed from that verdict with no `PREPUSH_*` override and no `--no-verify`.

OMN-16321

Evidence-Ticket: OMN-16321
Evidence-Source: OCC#7752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test selection now distinguishes safe, additive enum changes from structural or breaking changes.
  * Additive-only enum updates can trigger a more focused test run, while uncertain or non-additive changes continue to run broader coverage.
* **Bug Fixes**
  * Improved safeguards ensure malformed, missing, deleted, or unreadable revisions default to broader testing.
* **Documentation**
  * Documented the updated enum-based test selection policy.
* **Tests**
  * Added comprehensive coverage for additive changes, breaking changes, mixed updates, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->