### PR TITLE
chore(OMN-17241): de-register SEA from omnibase_core governance

### DIFF
--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -43,7 +43,6 @@ known_repos:
   # validators added per-repo below based on repo language and content.
   - omnibase  # meta/registry repo (repos.yaml + docs); no Python src
   - omnicursor  # Python repo: cursor AI plugin
-  - onex-self-extending-agent  # Python repo: ONEX self-extending agent
   - knowledge-base  # Python tooling + documentation; doc-content-scan applies
 
 # Scopes:
@@ -191,10 +190,8 @@ required_validators:
       - omniintelligence
       - omninode_infra
       - onex_change_control
-      # OMN-13579: these repos have hardcoded topic strings in source
-      # (omnicursor: _TOPIC_MAP dict; onex-self-extending-agent: TOPIC_* constants)
+      # OMN-13579: this repo has hardcoded topic strings in source (omnicursor: _TOPIC_MAP dict)
       - omnicursor
-      - onex-self-extending-agent
       # knowledge-base is doc-only; no contract.yaml / Kafka coupling — excluded
 
   stub-implementations:
@@ -224,7 +221,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos with non-test source code
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   enum-governance:
@@ -255,7 +251,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos using enums
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   naming-conventions:
@@ -287,7 +282,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos with src/
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   self-gating-workflows:
@@ -357,7 +351,6 @@ required_validators:
       - omninode_infra
       # OMN-13579: Python repos with src/
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   mypy-type-check:
@@ -387,7 +380,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos with src/ + pyproject.toml
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   ruff-format-check:
@@ -420,7 +412,6 @@ required_validators:
       - onex_change_control
       # OMN-13579: Python repos — ruff applies to all with pyproject.toml
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   aislop-patterns:
@@ -471,7 +462,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos that use pydantic models
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   single-class-per-file:
@@ -502,7 +492,6 @@ required_validators:
       - omniintelligence
       # OMN-13579: Python repos with src/
       - omnicursor
-      - onex-self-extending-agent
       - knowledge-base
 
   detect-secrets:
@@ -649,8 +638,8 @@ required_validators:
       ENFORCEMENT SCOPE: wired + required on omnibase_core (pre-commit hook
       check-doc-content-scan + the doc-content-scan CI job that feeds the airtight
       CI Summary rollup, registered in model_b_rollup_enforcement).
-      OMN-13579 extends applies_to_repos to knowledge-base, omnibase, omnicursor,
-      and onex-self-extending-agent (all have docs/ with .md content). Wiring the
+      OMN-13579 extends applies_to_repos to knowledge-base, omnibase, and omnicursor
+      (all have docs/ with .md content). Wiring the
       pre-commit hook + CI job in those repos is tracked under OMN-13576 (fleet
       rollout) — adding them here surfaces MISSING_PRE_COMMIT / MISSING_CI_WORKFLOW
       gaps in the consumer, which is the correct ratchet posture before wiring lands.
@@ -682,7 +671,6 @@ required_validators:
       - knowledge-base
       - omnibase
       - omnicursor
-      - onex-self-extending-agent
 
   no-new-os-environ:
     description: |

--- a/tests/validation/test_validator_requirements_spec.py
+++ b/tests/validation/test_validator_requirements_spec.py
@@ -75,7 +75,6 @@ KNOWN_REPOS = {
     # OMN-13579: ungoverned public repos onboarded
     "omnibase",
     "omnicursor",
-    "onex-self-extending-agent",
     "knowledge-base",
 }
 
@@ -83,7 +82,6 @@ KNOWN_REPOS = {
 NEW_ONBOARDED_REPOS = {
     "omnibase",
     "omnicursor",
-    "onex-self-extending-agent",
     "knowledge-base",
 }
 
@@ -233,11 +231,13 @@ def test_critical_validators_present(spec: dict[str, Any]) -> None:
 
 
 def test_new_public_repos_in_known_repos(spec: dict[str, Any]) -> None:
-    """OMN-13579: the four previously ungoverned public repos must appear in
-    known_repos so the consumer can validate against them.
+    """OMN-13579: the three previously ungoverned public repos must appear in
+    known_repos so the consumer can validate against them. (A fourth,
+    onex-self-extending-agent, was onboarded under OMN-13579 and de-registered
+    under OMN-17241.)
 
-    Repos: omnibase (meta/registry), omnicursor (Python), onex-self-extending-agent
-    (Python), knowledge-base (Python + docs).
+    Repos: omnibase (meta/registry), omnicursor (Python), knowledge-base
+    (Python + docs).
     """
     known = set(spec.get("known_repos", []))
     missing = NEW_ONBOARDED_REPOS - known
@@ -247,13 +247,13 @@ def test_new_public_repos_in_known_repos(spec: dict[str, Any]) -> None:
 
 
 def test_new_public_repos_covered_by_universal_validators(spec: dict[str, Any]) -> None:
-    """OMN-13579: the four onboarded repos must be covered by the known universal
+    """OMN-13579: the three onboarded repos must be covered by the known universal
     validators (applies_to_repos: 'all'). Locking the expected universal validator
     names prevents a silent narrowing (converting 'all' to a list) from removing
     coverage without a test failure.
     """
     # These validators were 'all' when OMN-13579 was authored. Narrowing any of
-    # them to a list silently drops the four onboarded repos unless this test fails.
+    # them to a list silently drops the three onboarded repos unless this test fails.
     expected_universal = {
         "hardcoded-local-paths",
         "hardcoded-private-ip",
@@ -284,16 +284,15 @@ def test_new_public_repos_covered_by_universal_validators(spec: dict[str, Any]) 
 def test_doc_content_scan_applies_to_all_omn13579_doc_repos(
     spec: dict[str, Any],
 ) -> None:
-    """OMN-13579: doc_content_scan must apply to all four onboarded repos — they
+    """OMN-13579: doc_content_scan must apply to all three onboarded repos — they
     all have docs/ directories. The ticket DoD says 'doc_content_scan applies to
     these repos too where docs exist'. Protecting only knowledge-base leaves the
-    other three silently unprotected.
+    other two silently unprotected.
     """
     doc_repos = {
         "knowledge-base",
         "omnibase",
         "omnicursor",
-        "onex-self-extending-agent",
     }
     validators = spec["required_validators"]
     dcs = validators.get("doc-content-scan")


### PR DESCRIPTION
## OMN-17241 — de-register SEA from omnibase_core governance

Final governance site (9 of 9) in the SEA de-registration sweep. `onex-self-extending-agent` was archived (all 5 verdicts DEAD, project memory `project_sea_is_temporary_absorb_to_canonical`), but omnibase_core's validator-requirements handshake still declared it a governed repo — which kept the OCC autobind wedge class alive by minting requirements against a repo that no longer exists.

### Change

`architecture-handshakes/validator-requirements.yaml`:
- removed the `known_repos` entry for `onex-self-extending-agent`
- removed all **10** `applies_to_repos` entries across the validator blocks (topic-compliance, stub-implementations, enum-governance, naming-conventions, self-gating-workflows, mypy-type-check, and the rest)
- rewrote the OMN-13579 topic-compliance comment so it no longer names SEA (omnicursor is now the only repo that comment covers)

`tests/validation/test_validator_requirements_spec.py`: updated the spec assertions to match the de-registered set.

The single surviving mention is the **line-828 lineage comment** (`- OMN-13579  # onboard ungoverned public repos (omnibase, omnicursor, onex-self-extending-agent, knowledge-base)`). That is a historical record of which ticket onboarded which repos, not a governance binding — deliberately retained.

### dod_evidence

- Governed pre-push selector (OMN-13973) ran on the designated `.200` host under the load gate. It escalated fail-closed to the **full suite** (`is_full_suite=True reason=shared_module paths=[ tests/ ]`) and then ran the impacted subset; both passed — `[prepush-smart-tests] impacted tests passed; allowing push.` Wall time 1h53m; no `PREPUSH_*` override and no `--no-verify` was used at any point.
- Targeted spec suite `tests/validation/test_validator_requirements_spec.py`: 14/14 green.
- `pre-commit run --all-files`: green.
- Post-change grep of `architecture-handshakes/validator-requirements.yaml` for `onex-self-extending-agent` returns exactly one line — 828, the lineage comment.
- Sibling governance sites already verified clean on merged dev/main: onex_change_control#7746, omniclaude#2086, omni_home#240.

Closes the last of the 9 governance sites tracked by OMN-17241.

Evidence-Ticket: OMN-17241
Evidence-Source: OCC#7778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository validation registry to reflect the current set of onboarded repositories.
  * Removed one repository from applicable architecture, security, quality, formatting, typing, and documentation validation checks.
  * Updated validation expectations and coverage checks to account for three onboarded repositories.
  * Documentation-scan coverage and related validation metadata now reflect the revised repository scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->