### PR TITLE
ci(OMN-16619): md-only short-circuit — stage the zone classifier so it actually fires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3105,11 +3105,36 @@ jobs:
           fi
           echo "changed_files=$FILES" >> "$GITHUB_OUTPUT"
 
+      - name: Stage classifier as standalone module
+        # OMN-16619: this step was missing from this inline job while the
+        # reusable .github/workflows/zone-filter.yml (used by every OTHER repo)
+        # has had it all along -- so the docs-only short-circuit worked for
+        # consumers and was inert here, in the repo that owns it.
+        #
+        # src/omnibase_core/__init__.py runs importlib.metadata.version(
+        # "omnibase-core") at import time. This job intentionally does NOT
+        # `uv sync` (the classifier is pure stdlib and must stay cheap), so the
+        # distribution has no metadata on the runner and that call raised
+        # PackageNotFoundError. The traceback exited 1, which the verdict
+        # branch below read as "production/mixed diff" -- a confident, wrong
+        # answer that ran the entire matrix on every docs-only PR while
+        # reporting nothing unusual. Staging the two pure-stdlib modules under
+        # empty __init__.py files bypasses the heavy package init entirely.
+        run: |
+          set -eu
+          mkdir -p .zone-pkg/omnibase_core/enums .zone-pkg/omnibase_core/validation
+          : > .zone-pkg/omnibase_core/__init__.py
+          : > .zone-pkg/omnibase_core/enums/__init__.py
+          : > .zone-pkg/omnibase_core/validation/__init__.py
+          cp src/omnibase_core/enums/enum_file_zone.py .zone-pkg/omnibase_core/enums/
+          cp src/omnibase_core/validation/zone_classifier.py .zone-pkg/omnibase_core/validation/
+          cp scripts/zone_diff_filter.py .zone-pkg/zone_diff_filter.py
+
       - name: Run zone-diff filter
         id: zone
         env:
           ZONE_DIFF_FILTER_FAKE_DIFF: ${{ steps.diff.outputs.changed_files }}
-          PYTHONPATH: src
+          PYTHONPATH: .zone-pkg
         run: |
           if [ -z "$ZONE_DIFF_FILTER_FAKE_DIFF" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
@@ -3117,7 +3142,7 @@ jobs:
             exit 0
           fi
           set +e
-          python scripts/zone_diff_filter.py --check docs-only
+          python .zone-pkg/zone_diff_filter.py --check docs-only
           RC=$?
           if [ $RC -eq 0 ]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.1"
+version = "0.47.2"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/scripts/zone_diff_filter.py
+++ b/scripts/zone_diff_filter.py
@@ -9,6 +9,14 @@ Exit codes:
     0  — all changed files are in the DOCS zone (CI matrix may be skipped)
     1  — at least one changed file is outside the DOCS zone (run full matrix)
     2  — bad usage / unknown mode
+    3  — internal error (classifier unimportable, git diff failed, ...).
+         Callers MUST treat 3 as "no verdict" and run the full matrix. It is
+         deliberately distinct from 1: an uncaught exception exits 1, which a
+         caller reads as the confident verdict "production/mixed diff". That
+         conflation silently disabled the omnibase_core docs-only
+         short-circuit for every PR (OMN-16619) — the classifier crashed on
+         import and CI reported a normal non-docs verdict, so the failure was
+         invisible in the step summary.
 """
 
 from __future__ import annotations
@@ -16,6 +24,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 
@@ -29,22 +38,39 @@ def _diff_files() -> list[Path]:
     return [Path(line) for line in out.splitlines() if line]
 
 
+def _classify(files: list[Path]) -> int:
+    # Imported here so the script fails fast on bad usage before requiring the
+    # classifier. NOTE: this import path goes through omnibase_core/__init__.py
+    # unless the caller stages the two pure-stdlib modules into a package tree
+    # with empty __init__.py files. The real package init calls
+    # importlib.metadata.version("omnibase-core"), which raises on a CI runner
+    # that has not installed the distribution. Both the reusable
+    # .github/workflows/zone-filter.yml and omnibase_core's own inline
+    # zone-filter job stage the modules for exactly that reason (OMN-16619).
+    from omnibase_core.enums.enum_file_zone import EnumFileZone
+    from omnibase_core.validation.zone_classifier import classify_path
+
+    zones = {classify_path(p) for p in files}
+    return 0 if zones <= {EnumFileZone.DOCS} else 1
+
+
 def main() -> int:
     if len(sys.argv) != 3 or sys.argv[1] != "--check" or sys.argv[2] != "docs-only":
         sys.stderr.write("usage: zone_diff_filter --check docs-only\n")
         return 2
 
-    # Import after arg parse so the script fails fast on bad usage without
-    # requiring omnibase_core to be installed.
-    from omnibase_core.enums.enum_file_zone import EnumFileZone
-    from omnibase_core.validation.zone_classifier import classify_path
-
-    files = _diff_files()
-    if not files:
-        return 0
-
-    zones = {classify_path(p) for p in files}
-    return 0 if zones <= {EnumFileZone.DOCS} else 1
+    try:
+        files = _diff_files()
+        if not files:
+            return 0
+        return _classify(files)
+    except Exception:  # noqa: BLE001  # boundary-ok: any classifier failure must fail closed as 'no verdict', never as verdict 1
+        # Not a swallow: the full traceback is surfaced on stderr and the
+        # distinct exit code 3 forces the caller onto the full matrix. The
+        # alternative — letting the exception propagate — exits 1 and is
+        # indistinguishable from a real "not docs-only" verdict.
+        traceback.print_exc()
+        return 3
 
 
 if __name__ == "__main__":

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -85,24 +85,41 @@ def _load_adjacency(path: Path) -> ModelAdjacencyMap:
 
 
 def _count_test_files(rel_path: str, repo_root: Path) -> int:
-    """Recursive test-file count beneath ``repo_root / rel_path`` (0 if absent).
+    """Test-file count for one ``selected_paths`` entry (0 if absent).
 
-    Matches BOTH ``_TEST_FILE_PATTERNS`` (``test_*.py`` and ``*_test.py``), not
-    just the ``test_*.py`` half -- mirrors the oracle's own
-    ``scripts.ci.detect_test_paths._count_test_files`` exactly. Counting only
-    one pattern here while ``_contains_collectable_test`` admits both would let
-    a directory be SELECTED on the strength of files this function then does
-    not count, undercounting the volume and emitting too few matrix splits
-    (the OMN-16917 oracle-side finding; that fix was never ported to this node
-    twin, so the two "byte-for-byte" copies silently diverged on real trees
-    large enough for the miscount to cross a split-count boundary -- OMN-16619
-    companion fix, caught by the CLI stdout parity battery this module exists
-    to hold honest).
+    ``rel_path`` is either a directory (module-grain sentinel, e.g.
+    ``tests/unit/`` -- walked recursively, matching BOTH
+    ``_TEST_FILE_PATTERNS``: ``test_*.py`` and ``*_test.py``) or an individual
+    test FILE (OMN-14921 file-grain closure output, e.g.
+    ``tests/test_foo.py`` -- counted directly as 1, no walk needed). Mirrors
+    the oracle's own ``scripts.ci.detect_test_paths._count_test_files``
+    exactly, including its file branch.
+
+    Two prior undercounts, both caught by the CLI stdout parity battery this
+    module exists to hold honest:
+
+    - Counting only the ``test_*.py`` half of the patterns while
+      ``_contains_collectable_test`` admits both would let a directory be
+      SELECTED on the strength of ``*_test.py`` files this function then
+      does not count (the OMN-16917 oracle-side finding).
+    - Checking only ``directory.is_dir()`` and returning 0 otherwise silently
+      dropped every individual-file selection to 0 instead of 1 -- this repo
+      has real top-level test files that are never inside a directory
+      sentinel (``tests/test_db_ownership_subcontract.py`` and siblings),
+      each undercounted by exactly 1 (OMN-16619).
+
+    Both crossed the ``VOLUME_TARGET_FILES_PER_SPLIT`` rounding boundary on
+    the real tree, emitting a ``split_count`` one lower than the oracle's for
+    an identical selection -- reproducible only against CI's actual
+    ``pull_request`` merge-ref tree (dev merged into the branch), not the
+    branch tip alone.
     """
-    directory = repo_root / rel_path
-    if not directory.is_dir():
-        return 0
-    return sum(1 for f in directory.rglob("*.py") if _is_test_file_name(f.name))
+    target = repo_root / rel_path
+    if target.is_dir():
+        return sum(1 for f in target.rglob("*.py") if _is_test_file_name(f.name))
+    if target.is_file():
+        return 1
+    return 0
 
 
 def _is_test_file_name(name: str) -> bool:

--- a/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
+++ b/src/omnibase_core/nodes/node_test_selector_compute/runtime_test_selector.py
@@ -85,11 +85,24 @@ def _load_adjacency(path: Path) -> ModelAdjacencyMap:
 
 
 def _count_test_files(rel_path: str, repo_root: Path) -> int:
-    """Recursive ``test_*.py`` count beneath ``repo_root / rel_path`` (0 if absent)."""
+    """Recursive test-file count beneath ``repo_root / rel_path`` (0 if absent).
+
+    Matches BOTH ``_TEST_FILE_PATTERNS`` (``test_*.py`` and ``*_test.py``), not
+    just the ``test_*.py`` half -- mirrors the oracle's own
+    ``scripts.ci.detect_test_paths._count_test_files`` exactly. Counting only
+    one pattern here while ``_contains_collectable_test`` admits both would let
+    a directory be SELECTED on the strength of files this function then does
+    not count, undercounting the volume and emitting too few matrix splits
+    (the OMN-16917 oracle-side finding; that fix was never ported to this node
+    twin, so the two "byte-for-byte" copies silently diverged on real trees
+    large enough for the miscount to cross a split-count boundary -- OMN-16619
+    companion fix, caught by the CLI stdout parity battery this module exists
+    to hold honest).
+    """
     directory = repo_root / rel_path
     if not directory.is_dir():
         return 0
-    return sum(1 for _ in directory.rglob("test_*.py"))
+    return sum(1 for f in directory.rglob("*.py") if _is_test_file_name(f.name))
 
 
 def _is_test_file_name(name: str) -> bool:

--- a/tests/ci/test_zone_filter_job_omn16619.py
+++ b/tests/ci/test_zone_filter_job_omn16619.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""ci.yml's inline zone-filter job must stage the classifier (OMN-16619).
+
+omnibase_core runs its own copy of the docs-only detector inline in ci.yml
+rather than calling the reusable .github/workflows/zone-filter.yml. The
+reusable workflow stages the two pure-stdlib classifier modules under empty
+__init__.py files before running them; the inline job did not, so it imported
+the real src/omnibase_core/__init__.py, which calls
+importlib.metadata.version("omnibase-core") and raises on a runner that never
+installed the distribution. The resulting exit code 1 was read as the verdict
+"production/mixed diff", so the docs-only short-circuit never fired in the repo
+that owns it, silently, on every PR.
+
+These tests pin the staged shape so the inline job cannot regress to importing
+the installed-package path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _zone_filter_steps() -> list[dict[str, Any]]:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    job = workflow["jobs"]["zone-filter"]
+    return list(job["steps"])
+
+
+def _run_step() -> dict[str, Any]:
+    for step in _zone_filter_steps():
+        if step.get("id") == "zone":
+            return step
+    raise AssertionError("ci.yml zone-filter job has no step with id 'zone'")
+
+
+def test_zone_filter_stages_classifier_before_running_it() -> None:
+    names = [str(step.get("name", "")) for step in _zone_filter_steps()]
+    staging = [n for n in names if "Stage classifier" in n]
+    assert staging, (
+        "ci.yml zone-filter job must stage the classifier as a standalone "
+        f"module before running it; steps were {names}"
+    )
+    assert names.index(staging[0]) < names.index("Run zone-diff filter")
+
+
+def test_zone_filter_does_not_import_the_installed_package_path() -> None:
+    """PYTHONPATH must point at the staged tree, never at src/.
+
+    PYTHONPATH: src imports src/omnibase_core/__init__.py, whose
+    importlib.metadata.version call raises when the distribution is not
+    installed — which it is not, because this job deliberately skips uv sync.
+    """
+    pythonpath = str(_run_step().get("env", {}).get("PYTHONPATH", ""))
+    assert pythonpath == ".zone-pkg", (
+        f"zone-filter PYTHONPATH is {pythonpath!r}; expected '.zone-pkg' so the "
+        "staged stdlib-only classifier is used instead of the real package init"
+    )
+
+
+def test_zone_filter_runs_the_staged_copy_of_the_script() -> None:
+    run_block = str(_run_step().get("run", ""))
+    assert ".zone-pkg/zone_diff_filter.py" in run_block
+    assert "python scripts/zone_diff_filter.py" not in run_block
+
+
+def test_zone_filter_treats_a_non_verdict_exit_code_as_full_matrix() -> None:
+    """Only 0 and 1 are verdicts; anything else must fall back to full CI."""
+    run_block = str(_run_step().get("run", ""))
+    assert "RC -eq 0" in run_block and "RC -eq 1" in run_block
+    tail = run_block.split("RC -eq 1", 1)[1]
+    assert "else" in tail and "docs_only=false" in tail, (
+        "the zone-filter verdict branch must end in an else that forces "
+        "docs_only=false for any exit code that is not a verdict"
+    )

--- a/tests/scripts/test_prepush_hook_host_identity_guard.py
+++ b/tests/scripts/test_prepush_hook_host_identity_guard.py
@@ -62,7 +62,7 @@ from scripts.ci.test_selection_closure import TEST_UNIT_PREFIX
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh"
 
-_GUARANTEED_NON_MATCHING_HOSTNAME = "definitely-not-the-200-host-omn15059"
+_GUARANTEED_NON_MATCHING_HOSTNAME = "definitely-not-a-gate-host-omn15059"
 
 _FULL_SUITE_BRANCH_RE = re.compile(
     r'if \[ "\$IS_FULL" = "True" \].*?\n(.*?\n)(?=elif|else|fi)',
@@ -138,6 +138,7 @@ def test_guard_refuses_full_suite_escalation_on_non_200_host() -> None:
     env["PREPUSH_FULL_SUITE"] = "1"
     env["PREPUSH_BASE_REF"] = "HEAD"
     env["PREPUSH_200_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
+    env["PREPUSH_201_GATE_RUNNER_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
     # OMN-16425: PREPUSH_ALLOW_LOCAL_FULL_SUITE leaking in from the outer
     # process's ambient env (e.g. an operator's own degraded-host `git push`
     # override) defeats this test's own assertion -- the hook takes the
@@ -320,6 +321,7 @@ def _run_hook_with_stubbed_selection(
     env["PREPUSH_TEST_SELECTION_JSON"] = str(selection_file)
     env["PREPUSH_BASE_REF"] = "HEAD"
     env["PREPUSH_200_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
+    env["PREPUSH_201_GATE_RUNNER_HOSTNAME"] = _GUARANTEED_NON_MATCHING_HOSTNAME
     for leaky in (
         "PREPUSH_FULL_SUITE",
         "PREPUSH_ALLOW_LOCAL_FULL_SUITE",

--- a/tests/scripts/test_zone_diff_filter.py
+++ b/tests/scripts/test_zone_diff_filter.py
@@ -60,3 +60,85 @@ def test_empty_diff_exits_0() -> None:
 def test_bad_usage_exits_2() -> None:
     rc = _run({}, "--check", "unknown-mode")
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# OMN-16619: the classifier must stay loadable on a CI runner that has NOT
+# installed the omnibase-core distribution, and a crash must never be reported
+# as the verdict "not docs-only".
+#
+# The tests above all pass trivially in a synced dev venv (omnibase-core IS
+# installed, so omnibase_core/__init__.py's importlib.metadata.version call
+# succeeds). They therefore never exercised the CI condition, which is how the
+# short-circuit shipped inert: on the runner the package init raised
+# PackageNotFoundError, the traceback exited 1, and the workflow read 1 as a
+# confident "production/mixed diff".
+# ---------------------------------------------------------------------------
+
+_ABSENT_DIST = "omnibase-core-deliberately-absent-omn16619"
+
+
+def _staged_pkg(tmp_path: Path, *, init_body: str) -> Path:
+    """Build a package tree mirroring what the CI job stages on disk."""
+    pkg = tmp_path / "omnibase_core"
+    (pkg / "enums").mkdir(parents=True)
+    (pkg / "validation").mkdir(parents=True)
+    (pkg / "__init__.py").write_text(init_body)
+    (pkg / "enums" / "__init__.py").write_text("")
+    (pkg / "validation" / "__init__.py").write_text("")
+    src = REPO_ROOT / "src" / "omnibase_core"
+    (pkg / "enums" / "enum_file_zone.py").write_text(
+        (src / "enums" / "enum_file_zone.py").read_text()
+    )
+    (pkg / "validation" / "zone_classifier.py").write_text(
+        (src / "validation" / "zone_classifier.py").read_text()
+    )
+    return tmp_path
+
+
+def _run_with_pkg_root(pkg_root: Path, diff: str) -> int:
+    import os
+
+    env = os.environ.copy()
+    # Shadow BOTH src/ and site-packages so the subprocess resolves
+    # omnibase_core from pkg_root only — this is what the runner sees.
+    env["PYTHONPATH"] = str(pkg_root)
+    env["ZONE_DIFF_FILTER_FAKE_DIFF"] = diff
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--check", "docs-only"],
+        env=env,
+        check=False,
+    ).returncode
+
+
+def test_uninstalled_distribution_exits_3_not_a_verdict(tmp_path: Path) -> None:
+    """A package init that cannot resolve its distribution must exit 3, not 1.
+
+    Reproduces the live failure: on the runner the real
+    src/omnibase_core/__init__.py raised PackageNotFoundError and the uncaught
+    traceback exited 1 — indistinguishable from a genuine non-docs verdict.
+    """
+    pkg_root = _staged_pkg(
+        tmp_path,
+        init_body=(
+            "from importlib.metadata import version\n"
+            f'__version__ = version("{_ABSENT_DIST}")\n'
+        ),
+    )
+    rc = _run_with_pkg_root(pkg_root, "README.md")
+    assert rc == 3, (
+        f"expected internal-error code 3, got {rc}; "
+        "code 1 would be read by CI as a confident 'production/mixed' verdict"
+    )
+
+
+def test_staged_standalone_package_classifies_docs_only(tmp_path: Path) -> None:
+    """The staged layout the CI job builds must classify a README-only diff."""
+    pkg_root = _staged_pkg(tmp_path, init_body="")
+    assert _run_with_pkg_root(pkg_root, "README.md") == 0
+
+
+def test_staged_standalone_package_still_rejects_production(tmp_path: Path) -> None:
+    """Staging must not weaken the verdict — mixed diffs still exit 1."""
+    pkg_root = _staged_pkg(tmp_path, init_body="")
+    assert _run_with_pkg_root(pkg_root, "README.md,src/omnibase_core/x.py") == 1

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -212,3 +212,41 @@ def test_always_run_derivations_agree_between_the_two_surfaces() -> None:
     derived = _unnarrowable_test_paths(REPO_ROOT)
     assert derived == unnarrowable_test_paths(REPO_ROOT)
     assert "tests/gates/" in derived
+
+
+def test_node_split_count_counts_every_configured_test_filename_pattern(
+    tmp_path: Path,
+) -> None:
+    """OMN-16619: this node's volume counter must match the oracle's fix.
+
+    OMN-16917 fixed ``scripts.ci.detect_test_paths._count_test_files`` to count
+    BOTH ``TEST_FILE_PATTERNS`` (``test_*.py`` and ``*_test.py``), not just the
+    ``test_*.py`` half — see
+    ``tests/unit/scripts/ci/test_detect_test_paths_ci_contract_omn16917.py::
+    test_split_count_counts_every_configured_test_filename_pattern``, which this
+    test mirrors. That fix was never ported to this node's own
+    ``_count_test_files`` copy, so the two "byte-for-byte" implementations
+    silently diverged: on a real tree large enough for the undercount to cross
+    a split-count rounding boundary, ``node_main`` and ``oracle_main`` emit
+    different ``split_count`` values for the identical selection — caught by
+    ``test_cli_stdout_parity`` failing on CI's checked-out tree (39 vs 40) while
+    passing locally (below the boundary on a smaller/differently-shaped local
+    tree). Asserted against the counter directly so the invariant holds
+    regardless of which patterns happen to be populated in the live tree today.
+    """
+    from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+        _count_test_files as node_count_test_files,
+    )
+    from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+        _is_test_file_name,
+    )
+
+    suite = tmp_path / "tests" / "suite"
+    suite.mkdir(parents=True)
+    (suite / "test_prefix_style.py").write_text("def test_a() -> None: ...\n")
+    (suite / "suffix_style_test.py").write_text("def test_b() -> None: ...\n")
+    (suite / "helper.py").write_text("VALUE = 1\n")
+
+    assert node_count_test_files("tests/suite", tmp_path) == 2
+    assert _is_test_file_name("suffix_style_test.py") is True
+    assert _is_test_file_name("helper.py") is False

--- a/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
+++ b/tests/unit/nodes/node_test_selector_compute/test_runtime_test_selector.py
@@ -250,3 +250,40 @@ def test_node_split_count_counts_every_configured_test_filename_pattern(
     assert node_count_test_files("tests/suite", tmp_path) == 2
     assert _is_test_file_name("suffix_style_test.py") is True
     assert _is_test_file_name("helper.py") is False
+
+
+def test_node_count_test_files_counts_an_individual_file_path(
+    tmp_path: Path,
+) -> None:
+    """OMN-16619: a ``selected_paths`` entry can be a single FILE, not just a
+    directory — the OMN-14921 file-grain closure selects individual test files
+    directly (e.g. ``tests/test_foo.py``), and this repo has real top-level
+    test files that are never inside a directory sentinel (measured live:
+    ``tests/test_db_ownership_subcontract.py``,
+    ``tests/test_direct_instantiation_danger.py``,
+    ``tests/test_json_serialization_crash.py``).
+
+    The oracle's ``scripts.ci.detect_test_paths._count_test_files`` handles
+    this explicitly (``elif target.is_file(): total += 1``). This node's
+    per-path twin only ever checked ``directory.is_dir()`` and returned 0 for
+    anything else — silently undercounting every individual-file selection by
+    1. On the real tree this crossed the ``VOLUME_TARGET_FILES_PER_SPLIT``
+    rounding boundary by exactly the 3 top-level test files above (oracle
+    total 1561 -> split_count 40, node total 1558 -> split_count 39),
+    reproduced via a scratch merge of this branch with ``origin/dev`` (the
+    actual tree CI's ``pull_request`` merge-ref checks out) — this unit test
+    pins the underlying per-path defect directly, independent of which files
+    happen to sit at the tree's rounding boundary today.
+
+    Verified failing pre-fix: ``node_count_test_files(...) == 0``.
+    """
+    from omnibase_core.nodes.node_test_selector_compute.runtime_test_selector import (
+        _count_test_files as node_count_test_files,
+    )
+
+    lone_file = tmp_path / "tests" / "test_lone.py"
+    lone_file.parent.mkdir(parents=True)
+    lone_file.write_text("def test_a() -> None: ...\n")
+
+    assert node_count_test_files("tests/test_lone.py", tmp_path) == 1
+    assert node_count_test_files("tests/does_not_exist.py", tmp_path) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.1"
+version = "0.47.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Fixes the reason OMN-16619's md-only CI short-circuit was silently inert in
`omnibase_core` itself, even after OMN-16625 (merged, PR #1618) built the
mechanism: this repo's own **inline** `zone-filter` job never staged the
docs-only classifier as a standalone stdlib-only module the way the reusable
`.github/workflows/zone-filter.yml` (which every OTHER repo calls) has always
done.

## Root cause

`zone-filter`'s `Run zone-diff filter` step ran with `PYTHONPATH=src`, which
imports the real `src/omnibase_core/__init__.py`. That module calls
`importlib.metadata.version("omnibase-core")` at import time, and this job
deliberately does not `uv sync` (the classifier is pure stdlib and must stay
cheap), so the distribution has no metadata on the runner and the call raises
`PackageNotFoundError`.

The uncaught traceback exited `1`, and `zone_diff_filter.py`'s exit-code
contract read `1` as the confident verdict "production/mixed diff" — there was
no distinct "internal error" code. So the short-circuit reported a normal,
non-anomalous non-docs verdict on every PR, and the entire `quality-gate`
matrix ran on every docs-only PR in this repo, with nothing unusual in the
step summary to flag it. Measured on a README-only probe PR (#1624, closed
unmerged): `docs_only=false`, and all ~50 quality-gate leaves ran including
Code Quality (mypy), Pyright and Import Layering Oracle.

## Fix

- `ci.yml`: port the reusable workflow's "Stage classifier as standalone
  module" step into the inline `zone-filter` job (`PYTHONPATH: src` ->
  `PYTHONPATH: .zone-pkg`, running the staged copy of the script instead of
  `scripts/zone_diff_filter.py` directly).
- `zone_diff_filter.py`: distinct exit code `3` for internal errors
  (classifier unimportable, git diff failed, ...), never conflated with the
  real verdict `1`. Callers treat `3` as "no verdict" and run the full
  matrix — fail-closed is unchanged, but a crash can no longer masquerade as
  a real verdict.

Mixed diffs still exit `1` and run full CI — verified against the staged
tree (`test_staged_standalone_package_still_rejects_production`).

## RED-first

- `tests/ci/test_zone_filter_job_omn16619.py` (new) — pins the staged
  workflow shape: staging step present and ordered before the run step,
  `PYTHONPATH` points at `.zone-pkg` not `src`, the run step invokes the
  staged copy, and a non-0/1 exit code falls back to `docs_only=false`.
- `tests/scripts/test_zone_diff_filter.py` — added
  `test_uninstalled_distribution_exits_3_not_a_verdict` (reproduces the live
  `PackageNotFoundError` and asserts it is not reported as verdict `1`),
  `test_staged_standalone_package_classifies_docs_only`, and
  `test_staged_standalone_package_still_rejects_production`. The pre-existing
  tests all passed trivially in a synced dev venv (omnibase-core IS
  installed there), which is exactly how this shipped inert — they never
  exercised the uninstalled-distribution CI condition.

12/12 new+updated tests pass locally.

## Relationship to OMN-16625

OMN-16625 (Done, merged PR #1618, 2026-08-29) built the docs-only
short-circuit mechanism org-wide-pattern-correctly (detach `zone-filter`,
skip-gate the 16 non-spec-required `quality-gate` leaves, skip-tolerant
aggregation). That work is correct and unchanged by this PR. This PR fixes a
separate, narrower defect: the classifier the mechanism depends on was
inert specifically in the repo that owns it, because its inline job
(unlike every consumer's reusable-workflow call) never staged the module.

Ticket: OMN-16619

dod_evidence: governed pre-push selector escalated to the whole-suite-
equivalent path on this diff (a `ci.yml` + classifier-script change touches
enough workflow-shape/CI-contract tests to trip the OMN-13973 "covers an
entire heavyweight target" guard). Host `Stickybeatz-Studio` (.200, the
designated gate host) was repeatedly over the 1.0x-core load threshold from
concurrent lab activity; per this repo's own hook this is a real fail-closed
refusal, not a bypassable one — no `PREPUSH_ALLOW_LOCAL_FULL_SUITE`, no
`--no-verify`. Waited out the load with bounded polling; the push was
retried once load cleared and the escalated full local suite
(`tests/unit/` + `tests/ci/` + the allowlisted service-free integration
paths, `-n4`) ran for real and passed
(`[prepush-smart-tests] impacted tests passed; allowing push`) before this
branch reached origin.

Evidence-Ticket: OMN-16619
Evidence-Source: OCC#7780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test discovery to recognize both `test_*.py` and `*_test.py` filename patterns.
  - Improved CI change classification so setup or execution failures are reported distinctly from valid classification results.
  - Preserved correct handling of documentation-only and mixed changes, including environments without the package installed.

- **Chores**
  - Updated the package version to 0.47.2.

- **Tests**
  - Added regression coverage for test discovery, CI classification, and supported host-guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->