### PR TITLE
fix(OMN-16998): terminal_failure_cause names the observed provider status class

### DIFF
--- a/src/omnibase_core/enums/enum_delegation_terminal_failure_cause.py
+++ b/src/omnibase_core/enums/enum_delegation_terminal_failure_cause.py
@@ -10,9 +10,27 @@ from enum import Enum, unique
 
 @unique
 class EnumDelegationTerminalFailureCause(str, Enum):
-    """Machine-readable cause of a terminal delegation failure."""
+    """Machine-readable cause of a terminal delegation failure.
+
+    Members name the failure class the provider actually reported, never an
+    inference drawn from it. The distinction is load-bearing: the over-quota
+    refusal metric is measured from this field, so an authentication failure
+    recorded as a quota event overstates capacity pressure that never happened
+    (OMN-16998).
+    """
 
     PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+    """The provider refused on capacity: HTTP 429 with a recognised quota body."""
+
+    AUTH_FAILED = "auth_failed"
+    """The provider rejected the credential: HTTP 401 or 403. Never capacity."""
+
+    PROVIDER_ERROR = "provider_error"
+    """Any other provider-side failure, once one has been observed.
+
+    Distinct from a null cause, which means no classification was attempted --
+    an unobserved failure and an unrecognised one are not the same fact.
+    """
 
 
 __all__: list[str] = ["EnumDelegationTerminalFailureCause"]

--- a/tests/unit/enums/test_enum_delegation_terminal_failure_cause.py
+++ b/tests/unit/enums/test_enum_delegation_terminal_failure_cause.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for EnumDelegationTerminalFailureCause.
+
+Part of OMN-16998: a terminal delegation failure must name the provider status
+class it actually observed. Before this ticket the enum carried a single member,
+so a live HTTP 401 had no cause it could resolve to and was recorded as
+``provider_quota_exhausted`` -- corrupting the over-quota refusal metric, which
+is measured from this field.
+
+These tests pin the wire vocabulary. The status-to-cause mapping itself is
+asserted in omnimarket, where the classifier lives.
+"""
+
+import json
+from enum import Enum
+
+import pytest
+
+from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
+    EnumDelegationTerminalFailureCause,
+)
+
+# Every member and the exact wire string it serialises to. Adding a member here
+# is deliberate: this constant is what makes a silent vocabulary change fail.
+EXPECTED_MEMBERS: dict[EnumDelegationTerminalFailureCause, str] = {
+    EnumDelegationTerminalFailureCause.PROVIDER_QUOTA_EXHAUSTED: "provider_quota_exhausted",
+    EnumDelegationTerminalFailureCause.AUTH_FAILED: "auth_failed",
+    EnumDelegationTerminalFailureCause.PROVIDER_ERROR: "provider_error",
+}
+
+
+@pytest.mark.unit
+class TestEnumDelegationTerminalFailureCause:
+    """Wire-contract tests for the terminal failure cause vocabulary."""
+
+    @pytest.mark.parametrize(("member", "wire_value"), list(EXPECTED_MEMBERS.items()))
+    def test_member_serialises_to_its_pinned_wire_value(
+        self,
+        member: EnumDelegationTerminalFailureCause,
+        wire_value: str,
+    ) -> None:
+        """Each member's wire string is pinned to an exact value.
+
+        These strings cross a process boundary into the terminal payload, so a
+        rename is a breaking contract change and must fail here first.
+        """
+        assert member.value == wire_value
+        assert json.dumps(member) == f'"{wire_value}"'
+
+    @pytest.mark.parametrize(("member", "wire_value"), list(EXPECTED_MEMBERS.items()))
+    def test_member_round_trips_from_its_wire_value(
+        self,
+        member: EnumDelegationTerminalFailureCause,
+        wire_value: str,
+    ) -> None:
+        """A wire string deserialises back to the member that produced it."""
+        assert EnumDelegationTerminalFailureCause(wire_value) is member
+
+    def test_vocabulary_is_exactly_the_pinned_set(self) -> None:
+        """No member exists that this suite does not know about.
+
+        Guards the direction the parametrized tests cannot: they prove every
+        expected member is present, this proves no unexpected one is.
+        """
+        assert set(EnumDelegationTerminalFailureCause) == set(EXPECTED_MEMBERS)
+
+    def test_causes_are_mutually_distinct(self) -> None:
+        """Auth, quota and generic provider failures are three separate facts.
+
+        The OMN-16998 defect was an auth failure wearing the quota label. If any
+        two of these ever compare equal, that defect becomes unobservable.
+        """
+        values = [member.value for member in EnumDelegationTerminalFailureCause]
+        assert len(values) == len(set(values))
+
+    def test_enum_is_a_string_enum(self) -> None:
+        """Members must be ``str`` so they serialise without a custom encoder."""
+        assert issubclass(EnumDelegationTerminalFailureCause, str)
+        assert issubclass(EnumDelegationTerminalFailureCause, Enum)
+
+    def test_unrecognised_wire_value_is_rejected(self) -> None:
+        """An unknown cause fails loudly rather than coercing to a member.
+
+        A terminal carrying a cause this build cannot express must surface as an
+        error, not silently degrade to the nearest label -- which is the failure
+        shape this ticket exists to remove.
+        """
+        with pytest.raises(ValueError):
+            EnumDelegationTerminalFailureCause("rate_limited")


### PR DESCRIPTION
Closes OMN-16998 (core half).

`EnumDelegationTerminalFailureCause` carried exactly ONE member, `PROVIDER_QUOTA_EXHAUSTED`. So a live HTTP 401 had no cause it could resolve to and was recorded as a quota event — an auth failure wearing the quota label. The over-quota refusal metric is measured from this field, so that overstates capacity pressure that never happened.

## What this adds

- `AUTH_FAILED` — the provider rejected the credential: HTTP 401 or 403. Never capacity.
- `PROVIDER_ERROR` — any other provider-side failure, once one has been observed. Deliberately distinct from a null cause: an unobserved failure and an unrecognised one are not the same fact.

Purely additive. No existing member renamed, no wire value changed.

## Tests

10 new, in `tests/unit/enums/test_enum_delegation_terminal_failure_cause.py`:

- Each member's wire string is pinned to an exact value and asserted to round-trip from it. These cross a process boundary into the terminal payload, so a rename is a breaking contract change and must fail here first.
- The vocabulary is asserted to be exactly the pinned set. This guards the direction the parametrized tests cannot: they prove every expected member is present, this proves no unexpected one is.
- The three causes are mutually distinct. If any two ever compare equal, the defect this ticket exists to remove becomes unobservable.
- An unrecognised wire value raises rather than coercing to the nearest label — a terminal carrying a cause this build cannot express must surface as an error, not silently degrade.

## Version

No bump in this diff. `dev` reached `0.47.2` independently while this branch waited, and PyPI is still at `0.47.1` — so `0.47.2` is unreleased and this change lands inside that pending release. The OMN-13411 release-identity gate is satisfied by the bump already on `dev`.

Governed pre-push on `.201`. No `PREPUSH_*` override, no `--no-verify`, no skip token, no override grant.

```
selection: is_full_suite=True reason=shared_module paths=[ tests/ ] (feature-flag=on)
44464 passed, 56 skipped, 3 xpassed in 10678.17s (2:57:58)
[prepush-smart-tests] impacted tests passed; allowing push.
```

Zero failures. An earlier run of this branch reported 4 failed / 44448 passed. Two were `test_verify_flip_bundle` twin-baseline-shrink, since root-caused and fixed as OMN-17324 (a sibling clone owned by another uid, refused by git `safe.directory`). Two were the load-dependent `test_cli_stdout_parity` `split_count` 39-vs-40 cases, which pass on a quiet box — this run confirms that.

## Selector note for OMN-16321

This diff is two files — the enum and its test — purely additive, with no `pyproject.toml` or `uv.lock` change. It still escalates with `reason=shared_module`.

That rules out the hypothesis raised when this branch first escalated, that the version bump riding in the same commit might be the disqualifier. The bump became a no-op after the rebase and the escalation is unchanged, so `enums/` being a shared module is sufficient on its own.

## Not in this PR

The omnimarket half — the `resolve_terminal_failure_cause` rewrite, where status and quota body must corroborate within one reported failure — is committed and held until this lands and the infra pin advances.

The live-401 done-proof (wrong key → one delegation → `terminal_failure_cause == "auth_failed"` while `quality_gates_failed[0]` contains HTTP 401) needs the `.201` lane, which is currently blocked on OMN-17150 defect 3: the runtime cannot find a Bifrost lane overlay of its own.

Evidence-Ticket: OMN-16998
Evidence-Source: OCC#7923
